### PR TITLE
Stirling 0.33.1 -> 0.43.1 and minor improvments

### DIFF
--- a/nixos/modules/services/web-apps/stirling-pdf.nix
+++ b/nixos/modules/services/web-apps/stirling-pdf.nix
@@ -75,7 +75,12 @@ in
           # See https://github.com/Stirling-Tools/Stirling-PDF/blob/main/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java#L42
           which
           unpaper
-          libreoffice
+          # Before any invocation to LibreOffice ended up in trying to mkdir
+          # /run/user/<uid>/libreoffice-dbus. Since the user is not a logged one and
+          # the user not a lingering one, it always failed with a permission denied
+          # error.
+          # Thus, we use a libreoffice version not verifying Dbus.
+          (libreoffice.override { dbusVerify = false; })
           qpdf
           ocrmypdf
           poppler-utils
@@ -112,7 +117,7 @@ in
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateUsers = true;
-        ProcSubset = "pid";
+        ProcSubset = "all"; # for libreoffice to work
         ProtectClock = true;
         ProtectControlGroups = true;
         ProtectHome = true;

--- a/nixos/modules/services/web-apps/stirling-pdf.nix
+++ b/nixos/modules/services/web-apps/stirling-pdf.nix
@@ -135,7 +135,7 @@ in
         RestrictRealtime = true;
         SystemCallArchitectures = "native";
         SystemCallFilter = [
-          "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @clock @setuid @chown"
+          "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid"
         ];
         UMask = "0077";
       };

--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -88,23 +88,23 @@
    "module": "sha256-IFNqlfL+sr9DBRKMaq7Lb9idxFeYqchfJgK4qAnXUNs=",
    "pom": "sha256-Q1z/VXiZht7arXF/aPuo1UgklHhWLc2EsirU1lZvRAs="
   },
-  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/7.0.2": {
-   "pom": "sha256-7R3td6KWpv4hpQJ5ySbAe+FK98CMJDfTaFxw/Pa7oC0="
+  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/7.0.3": {
+   "pom": "sha256-G25I1Qmw5W6lqm5g/WrjWt1JWO7i6UOFt6ggVSS9Dy4="
   },
-  "com/diffplug/spotless#spotless-lib-extra/3.0.2": {
-   "jar": "sha256-sOd3RtYz1EXnhImsPQitLqGzU3xNBk5KvkbMQtYjA+s=",
-   "module": "sha256-vSVeQkQbWRehU8U9z5fP08IEevN2zF3Yu1Z/aEAWtFk=",
-   "pom": "sha256-IVesGayscKzQRQH8WbvJZNsZD1tx5O1e/s6o5c9o7Os="
+  "com/diffplug/spotless#spotless-lib-extra/3.1.1": {
+   "jar": "sha256-fN3VetBQax5U7QpxutM3/+ufG0DOKUWMexiDjp4pey0=",
+   "module": "sha256-p3l5JAxQdzDGHS0+7xZaEO9OXualIZWEaqqnF1dIa8M=",
+   "pom": "sha256-LVoH4iU7AEVspY6ZAG+e7i6JsYLnU8sXaRvfFbUVjuA="
   },
-  "com/diffplug/spotless#spotless-lib/3.0.2": {
-   "jar": "sha256-P5p/38WwOsIIlINBcJEMFcTyuE7UzjZ3iYowetWJg3w=",
-   "module": "sha256-E1WLrsCR6gDxYmXNNSOBePT+ejv61zXel214XUF/ss0=",
-   "pom": "sha256-jxtFo4m6Jeel8DvZ8KS9BKp+dHXgku6C1VUJYrLPdV8="
+  "com/diffplug/spotless#spotless-lib/3.1.1": {
+   "jar": "sha256-3sJyfKfWFxAKI6RFlB/fopWAAITGjefM9aPHtuczBpE=",
+   "module": "sha256-hkpe+SmvEsSkbReM7WJo6SM9gcokkBnuwAVnfs8fHnc=",
+   "pom": "sha256-1y1Ix+INJRUU9dewaUAGVOTNRd6F95RewhUoWAJcMZc="
   },
-  "com/diffplug/spotless#spotless-plugin-gradle/7.0.2": {
-   "jar": "sha256-WaNMT4SkjUyNkp4viZBjaeZUduwEmaQ96Hw+QSeXfNU=",
-   "module": "sha256-rxC8mydsNqlNcRh+kVhwJ1yyRVZTntzqGYpYL30Tsws=",
-   "pom": "sha256-JyVoPfbvTNSIr+sgANqJIpQcqQ513D49uFIupxWKaMQ="
+  "com/diffplug/spotless#spotless-plugin-gradle/7.0.3": {
+   "jar": "sha256-spmAT2Wh/Lmud1f9bi42mIaR8lcCr4a9Vga2uv5SBsg=",
+   "module": "sha256-jRMTSN3tGgWeJucFYNHkNwdBCPtJ3X31wgN3FMWl/Ys=",
+   "pom": "sha256-bzyta24QTa6vcWJXgb1NtawmYhbkZHaTHUw5AkcrCJ8="
   },
   "com/fasterxml#oss-parent/61": {
    "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
@@ -345,23 +345,23 @@
   "org/apache/httpcomponents#httpcomponents-parent/13": {
    "pom": "sha256-5Ch4ZwNYVsc3QgNo3VhuXlfnAgmBNYQM89c+nINj17M="
   },
-  "org/apache/httpcomponents/client5#httpclient5-parent/5.4.2": {
-   "pom": "sha256-d2r5CnR0EULt8vvx+XpMAwrl+QT8PW2H6PNOilmb4Ug="
+  "org/apache/httpcomponents/client5#httpclient5-parent/5.4.3": {
+   "pom": "sha256-5jResynLh+7FgrEPKWsZh5O9FrW1QfTHsf/tnF8UDdg="
   },
-  "org/apache/httpcomponents/client5#httpclient5/5.4.2": {
-   "jar": "sha256-oKnc02lqYoH4LjktOapnS/lmJJZgVBHeKgDURDWn+yY=",
-   "pom": "sha256-Uzeacw5Oy6ug1EvSqXPlqxtjI958xHxPEAmmZmjiPmU="
+  "org/apache/httpcomponents/client5#httpclient5/5.4.3": {
+   "jar": "sha256-c54DVnnGjhXvqTtEyAikU7yY6qwXIuWoDKsVwCYiMCI=",
+   "pom": "sha256-mVG7RlyhWOb6UEtR4GGe2JTMjQwjL0YKftYVBiiY4S0="
   },
-  "org/apache/httpcomponents/core5#httpcore5-h2/5.3.3": {
-   "jar": "sha256-oSH0sU7FJeVOKbn123uT9Kl+CId06BxxQ7UZj2fYG+w=",
-   "pom": "sha256-DG+UMCpWYarEjlb6GiyYSNTYyEqTgBa5lvV11y5lyP8="
+  "org/apache/httpcomponents/core5#httpcore5-h2/5.3.4": {
+   "jar": "sha256-H7TzTkthLnwSetaTM1WDWHhQsXzpscNm+d4cpJ/ix4E=",
+   "pom": "sha256-zsGQjdjoavkI22E/I6CTt1lgvEpcaI5X9u9BmYtsUos="
   },
-  "org/apache/httpcomponents/core5#httpcore5-parent/5.3.3": {
-   "pom": "sha256-GpQSCJ6gfk/7CvecgWsepVXpx/aoYZvhCajdGWUVQJA="
+  "org/apache/httpcomponents/core5#httpcore5-parent/5.3.4": {
+   "pom": "sha256-Iyuj6AizQJPByLh2XNvqSQ4FrLfK9KQTbh9HDIykrOw="
   },
-  "org/apache/httpcomponents/core5#httpcore5/5.3.3": {
-   "jar": "sha256-CHt66b3p01GLS10G81YNf9DbBAmGVedrZOeRdzhH1QM=",
-   "pom": "sha256-23qZ78VZF+iY4vdeZAbqWhpMyMcQPoo5zdyFsdPzFCk="
+  "org/apache/httpcomponents/core5#httpcore5/5.3.4": {
+   "jar": "sha256-8rL9egFk6MMSDNhDe8n+pDkjnhZcFyYrPpB9qn6Xn4A=",
+   "pom": "sha256-NMsQqf+CzT+yBfasdsfpHrazHyL4wnSJUtvbm2ZXpbc="
   },
   "org/awaitility#awaitility-kotlin/4.0.3": {
    "jar": "sha256-66iiOFFxL0WzGvZ/gwbHYC/0TaAh0UZwl/41LeVlo9s=",
@@ -385,9 +385,17 @@
    "jar": "sha256-Q/kvOttoGl8wBrl56NNBwSqM/YAp8ofEK88KgDd1Za4=",
    "pom": "sha256-BVlUQr62ogYQi2c6qcZpLIPkHfGDF33GcROxzD9Sgd0="
   },
-  "org/eclipse/platform#org.eclipse.osgi/3.18.500": {
-   "jar": "sha256-gLJ11YN5cjspHqZQJJzDgJyPELNPeKr5iBMs1tQ0q04=",
-   "pom": "sha256-4o9b4Azk7Sx+SAnsrQW5UwfzWhflhWAHhri97juk2Wg="
+  "org/eclipse/platform#org.eclipse.osgi/3.23.0": {
+   "jar": "sha256-GsETVBoZ8McsBCH7JAWN78p+PG8oLl7nPxTSdoqa5lM=",
+   "pom": "sha256-tbuXndaxJrjJ1cDVe3aQyhZ0Bz0oQQk7lsWxz0QHEyk="
+  },
+  "org/gradle/toolchains#foojay-resolver/1.0.0": {
+   "jar": "sha256-eLhqR9/fdpfJvRXaeJg/2A2nJH1uAvwQa98H4DiLYKg=",
+   "module": "sha256-YZDPDkLmZMEeGsCnhWmasCtUnOo0OSxnnzbYosVQ/Lk=",
+   "pom": "sha256-m8SLSeQi2e2rw5asGNiwQd/CIhLX+ujjVmfShdSBApo="
+  },
+  "org/gradle/toolchains/foojay-resolver-convention#org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/1.0.0": {
+   "pom": "sha256-8TMkmhh1Suah0nAdANhJsa+6ewaD3bX8GxinAHHOwvo="
   },
   "org/hamcrest#hamcrest/2.1": {
    "jar": "sha256-upOy46ViMiukMvChtTrdzFXLGIJTMZoCDtd/gk5pIFA=",
@@ -457,6 +465,10 @@
    "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
    "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
   },
+  "org/junit#junit-bom/5.11.3": {
+   "module": "sha256-S/D1PO6nx5D9+9JNujyeBM3FGGQnnuv8V6qkc+vKA4A=",
+   "pom": "sha256-8T3y5Mrx/rzlZ2Z+fDeBAaAzHVPRMk1uLf467Psfd3Q="
+  },
   "org/junit#junit-bom/5.11.4": {
    "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
    "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
@@ -489,27 +501,27 @@
   "org/slf4j#slf4j-parent/2.0.13": {
    "pom": "sha256-Z/rP1R8Gk1zqhWFaBHddcNgL/QOtDzdnA1H5IO0LtYo="
   },
-  "org/sonarqube#org.sonarqube.gradle.plugin/6.0.1.5171": {
-   "pom": "sha256-eg0FryT8MszWBHJh5skpCifsX++1GlIyfpym74oMhWc="
+  "org/sonarqube#org.sonarqube.gradle.plugin/6.2.0.5505": {
+   "pom": "sha256-rRX6asDkCqfgmJL045PDyIR67586wRdnC3CBNitu7wI="
   },
-  "org/sonarsource/parent#parent/77.0.0.2082": {
-   "pom": "sha256-AoNvJjQJkX0VZT1dJniuCCEz7G3+fXheQdM9Dx03v3g="
+  "org/sonarsource/parent#parent/83.0.0.2369": {
+   "pom": "sha256-01GmWHGSs8N+88VSW4MZ/vE4M7YwCZCBwCfiHWMzfv0="
   },
-  "org/sonarsource/scanner/gradle#sonarqube-gradle-plugin/6.0.1.5171": {
-   "jar": "sha256-0ic2EjWZ4BV583ltQ1kRUI5ksYvcUfekJWMugGeJa5w=",
-   "module": "sha256-5iB4o4Vu/5xtSdeEkaNYTHWUw79cE0u3sabj1u/UY1Y=",
-   "pom": "sha256-f5IoG31hCjhmAF/vB/bai7j2zI9zx1zK8YfNqlhm7rQ="
+  "org/sonarsource/scanner/gradle#sonarqube-gradle-plugin/6.2.0.5505": {
+   "jar": "sha256-AASeHrIg9xk201Rd0miPz/fcOGHrrA/xUXzb/Adfzsw=",
+   "module": "sha256-aleCEUMj0+oH72M1erpslMqtXufC0aXpEyZVlC0qOe0=",
+   "pom": "sha256-JjZuG1SxZHGRM3542RDMTfJZ5e/95pBmfZgxuGXWgPM="
   },
-  "org/sonarsource/scanner/lib#sonar-scanner-java-library-batch-interface/3.1.1.261": {
-   "jar": "sha256-Kzsy65groOpyre0pM4/hghMvtMZXJW67ojpSaqQLWP8=",
-   "pom": "sha256-YKHCePJLFAgY+D/igBguXnxLLqs4Y44hBtFmDRF/3Nk="
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-batch-interface/3.3.1.450": {
+   "jar": "sha256-rb/vIFOVek6WOdtpcwuoOgkKX4+hzDQkoSLCxmYyl9k=",
+   "pom": "sha256-s9e6R9/C3hzJ5M8GLfxQF6Oy40ZtNgmOYc6fVBR7hfQ="
   },
-  "org/sonarsource/scanner/lib#sonar-scanner-java-library-parent/3.1.1.261": {
-   "pom": "sha256-07k6IFpgASkDSN0GdDU9rWJpcISUQnco1XeBf4hkDC4="
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-parent/3.3.1.450": {
+   "pom": "sha256-fXPto/IKWRpHm2VuTG1WI6N0BWcqw+LL9QsaD+s3TEk="
   },
-  "org/sonarsource/scanner/lib#sonar-scanner-java-library/3.1.1.261": {
-   "jar": "sha256-rbL/v1VCslYOIxk2df7MiNkJlfzFM7CFHK2j4ia9aOY=",
-   "pom": "sha256-ocE4+H7xU+rf1+zQqiKFjyM1iXAtW/Zig9/bTZytD18="
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library/3.3.1.450": {
+   "jar": "sha256-zSlBpxpwWpbBgeEJA/Lk94cIfrfknZm22tpAjcXdkXY=",
+   "pom": "sha256-Aj134k5b/jwVDgAleeVoTBAdXB3HqGAXPtL+3L1hUic="
   },
   "org/sonatype/oss#oss-parent/5": {
    "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
@@ -528,33 +540,33 @@
   "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.9.0": {
    "pom": "sha256-tl5WbBE1MB1a3ZBIt2+eSkYygpKKJ27CMFDL64QIWd0="
   },
-  "org/springframework#spring-core/6.2.5": {
-   "jar": "sha256-TO4Czy0CJ8Hxv7l8Ltwp06+DuTyD0Is45Zh8P6D+Tx4=",
-   "module": "sha256-L8IU0itA9AB9/adE+FHn755yjRgoYFfw9ZTrlUvIriA=",
-   "pom": "sha256-K2lVoWZQfbOAVQK84ifbJ4+s37ynyqM6cThHhw4B8oI="
+  "org/springframework#spring-core/6.2.6": {
+   "jar": "sha256-d2KPuou40Fm+D7NVqXFv77gItcfZ7ZxXSkomQUBAQ1I=",
+   "module": "sha256-EsBGMpbwEoFrgvTpOXqkdHrj3g6KE6ksNGLARgwd3Jc=",
+   "pom": "sha256-8Au6GX8JRAUsuQARNpJBaibtMMMUNkbqXJujXkNCcBw="
   },
-  "org/springframework#spring-jcl/6.2.5": {
-   "jar": "sha256-T5ORX6sQwU3zuQBUz9XRwBop3vWbbiXA8z2erE/+wHk=",
-   "module": "sha256-XmoAS9bTzk9i7in2ByXOmGmn9q3uqHiA6oGj/CPCPRI=",
-   "pom": "sha256-8t98qvowo7Ku34ViqGh0RsJUMviNNvGwt3+keA7nxr0="
+  "org/springframework#spring-jcl/6.2.6": {
+   "jar": "sha256-0XNXrA0/CNibeABNZr0t34oI1Ej/8mmBuvMk55GoU5I=",
+   "module": "sha256-Y+dV4bYsm+Tlb72iR9r4A9xZnCVX0f8EKHO+DJohR6I=",
+   "pom": "sha256-t7p5PSCaef8RU2+h2kBVBHU6vZT/rJRy2R+0lAiv66s="
   },
-  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.4.4": {
-   "pom": "sha256-Hf1lJt1GlYHQ1jrd1225jKD1knmiINxApZsRvNHJEkM="
+  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.4.5": {
+   "pom": "sha256-7j5NXuzpqOwV3mGiT8s6pkrm+rs0zvQBWZCvx5j80HQ="
   },
-  "org/springframework/boot#spring-boot-buildpack-platform/3.4.4": {
-   "jar": "sha256-lmDNqob4rSIKcIJFcjsOKGBQyITOKv9hhdpFOUZZw/w=",
-   "module": "sha256-JyTPS5Ubyju6vPNNHeh+U1U866OasPJ42TVbZ/wah8g=",
-   "pom": "sha256-1ezt4zuJ/xGImOuYeR5a86QUwvJKJOKAR7bgKrC55RM="
+  "org/springframework/boot#spring-boot-buildpack-platform/3.4.5": {
+   "jar": "sha256-oeYrEsDa+XZZAQzuU+nSmdfnHbHt3kJym5zXga7hkOQ=",
+   "module": "sha256-FDeoWiIVMOenXkAoqxRr/YZV/GKOqQmM+ijL3qmUxzw=",
+   "pom": "sha256-QP2gmZt5lPqzf40yQB7XU4QuX5J2QNKyd3KHgQYKrf4="
   },
-  "org/springframework/boot#spring-boot-gradle-plugin/3.4.4": {
-   "jar": "sha256-aHbhy0xWekvrAtGDH6rxe0G4gfX2acarshLU1VHGOCQ=",
-   "module": "sha256-G4T/5dOIbasfYuJmtHF5PNhlxLYOpDUuJlMD+qtCoq4=",
-   "pom": "sha256-dqoxfADGPFeHN7oKh/kE7Dsc89RTCRaRVd7okJYI/1w="
+  "org/springframework/boot#spring-boot-gradle-plugin/3.4.5": {
+   "jar": "sha256-pjD8mJEbGsIhEPhujNJSYMZ1E8+hKpxJRQBVFb7fbbA=",
+   "module": "sha256-t6uXeyREh23wkIUfFo6YJT85XLQk239kTLtQJ0O6dL8=",
+   "pom": "sha256-H9Y2y7i8zd2sMQNbZNeWmopGws1UuU7OtrdlkYQwQAg="
   },
-  "org/springframework/boot#spring-boot-loader-tools/3.4.4": {
-   "jar": "sha256-Ww0fHB1gD3AMbSC3TAT26CWz8Wbd0huV0ZMMBN+a9fc=",
-   "module": "sha256-q0vSs/CphMZBlCmxK18WzgmkASjM7omFWWf8VriUKso=",
-   "pom": "sha256-t1a6bsjKt7SaRvCPn13Htd7hIEmKyM0TATdF0poG2XI="
+  "org/springframework/boot#spring-boot-loader-tools/3.4.5": {
+   "jar": "sha256-S6kGh8gc2CSUMoRuQtC2rtfEQktG0sa7Xx0WhuIR668=",
+   "module": "sha256-fWPwx8TMlzrocHK6c7Wh/NP3mMBlLLzQDRyGKFPvmM8=",
+   "pom": "sha256-O6D+wGKN0JCbBh3Z0mrsSYRyF/bkJvZo+8LxCJdDZ9A="
   },
   "org/tomlj#tomlj/1.0.0": {
    "jar": "sha256-Mml8dWeykhxHNnioILE/xkcAqoe7FFdu60jQ7VhHz9Q=",
@@ -593,9 +605,6 @@
    "jar": "sha256-cgI4UPOCtJ2FbfvKbBKym87l6gmJQEQleG4UbkuUXIo=",
    "pom": "sha256-rGVzfL3JyqjoTXZ4A1TVHUPAsV6oF7HOXAlr/4wMR7Q="
   },
-  "com/datastax/oss#java-driver-bom/4.15.0": {
-   "pom": "sha256-XJ4x7/lc83XFvf/4XOKCh9Wa/PUTS05qJKdj2xcaXmc="
-  },
   "com/drewnoakes#metadata-extractor/2.19.0": {
    "jar": "sha256-5Ru0VO0I6iv8w60UfQiK0apzqZngByVj+K5QAhovyts=",
    "pom": "sha256-fqXDxPtl2ERBve2oMsDprgToozurEcr4J6tOWXtjsu0="
@@ -603,9 +612,6 @@
   "com/fasterxml#classmate/1.7.0": {
    "jar": "sha256-y4aPIxxczrideV6gDm4bepO49Kwc4di+dt3jIt/0oEY=",
    "pom": "sha256-ZHEa3vDskvH2zap7LqwGsuVmekppkez7i/rEZoHVuTE="
-  },
-  "com/fasterxml#oss-parent/50": {
-   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
   },
   "com/fasterxml#oss-parent/56": {
    "pom": "sha256-/UkfeIV0JBBtLj1gW815m1PTGlZc3IaEY8p+h120WlA="
@@ -619,9 +625,6 @@
   "com/fasterxml/jackson#jackson-base/2.18.3": {
    "pom": "sha256-1bv9PIRFIw5Ji2CS3oCa/WXPUE0BOTLat7Pf1unzpP0="
   },
-  "com/fasterxml/jackson#jackson-bom/2.15.2": {
-   "pom": "sha256-Hq1jAlXEiMUbXgq1YMdsI3GtJq422t8JKcUmVy6ls4s="
-  },
   "com/fasterxml/jackson#jackson-bom/2.17.2": {
    "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
   },
@@ -633,9 +636,6 @@
   },
   "com/fasterxml/jackson#jackson-bom/2.18.3": {
    "pom": "sha256-8dTGrrMhGGUMgF/pu8XulA+o8s19DwT6Q2BVHponspA="
-  },
-  "com/fasterxml/jackson#jackson-parent/2.15": {
-   "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
   },
   "com/fasterxml/jackson#jackson-parent/2.17": {
    "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
@@ -708,9 +708,9 @@
   "com/fathzer#javaluator-parent-pom/1.0.1": {
    "pom": "sha256-YRV0qFwGU9vwoDS7iJ9LrCZr0oZz6EZ2w2o6TNqWLfg="
   },
-  "com/fathzer#javaluator/3.0.5": {
-   "jar": "sha256-kRfz3GEP5z7oe7YtQRjxjpK4+lfj6U+sa+vDVL3aTJk=",
-   "pom": "sha256-y1S3+s1i4tvFhS2gx773uFnMeK+5Q3lTRiC2bxzLpr0="
+  "com/fathzer#javaluator/3.0.6": {
+   "jar": "sha256-8tKeGgIJWzL83AfdwzO+mKAQ0SlmrexmxdxJ6IhMwkQ=",
+   "pom": "sha256-QffAJLgEtmsGR52DyISaWvk73AnuDNxnkdCkr0HGJhE="
   },
   "com/fathzer#parent-pom/1.0.8": {
    "pom": "sha256-zRQ6tSZOnHOx0gQmT1GKVaAZpmgdV/J5C+s9s90sPCA="
@@ -818,26 +818,16 @@
    "jar": "sha256-/ulOrlxDiOHef7qE462iuS0Xu7soxjDUJYpvBhXB8wM=",
    "pom": "sha256-lusqwKOmi0Q3mu+oa2yc+RSDQI7OAafKUbbUL0NTE2k="
   },
-  "com/opencsv#opencsv/5.10": {
-   "jar": "sha256-55J+uabU+KNIpSCQfbsI2mKDpESKu5vZ7y+VDXu5ULA=",
-   "pom": "sha256-gMuqtG1lfpLy4dGjVqENl0bc2VTVgBsLVRa2W6WF3Oc="
-  },
-  "com/oracle/database/jdbc#ojdbc-bom/21.9.0.0": {
-   "pom": "sha256-YWOUxaVc9n/ygO1pdup/MxarCdRMDin6ILZqyykKyaU="
+  "com/opencsv#opencsv/5.11": {
+   "jar": "sha256-XnD1PzBexFgvEObxuyAnBIxbHzJGod4Yx4mSYOTO78M=",
+   "pom": "sha256-TqrhhtZS3k8xIRPHKosdQipKiG+gdoLIaPcJsbG7uF8="
   },
   "com/posthog/java#posthog/1.2.0": {
    "jar": "sha256-gnEBAD2F9li1yqwPI4IQ/ySEhjR+qVSd6kvBPHWfYao=",
    "pom": "sha256-YIqAJ1xuFdnIJ7i/5RZw0LCqjy6jsgd5xT2vokFoTLo="
   },
-  "com/querydsl#querydsl-bom/5.0.0": {
-   "pom": "sha256-M9iKwC/Iwb2sEp3BGP/aOxf+lr9c+DVB3cAUoptiexs="
-  },
   "com/querydsl#querydsl-bom/5.1.0": {
    "pom": "sha256-iFPc4TLJ7OTClcf01PPCgy7uDX1EkwhwwGZvpyBDylY="
-  },
-  "com/squareup/okhttp3#okhttp-bom/4.10.0": {
-   "module": "sha256-NLNP75zu3d2ihMXxVoc4lg0qU9VuHvz/jK6tPmZSpcM=",
-   "pom": "sha256-vmLpNvEMNmU+XpGVrwBVq4bMugi4/sKo773exKzu71g="
   },
   "com/sun/activation#all/1.2.0": {
    "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
@@ -1032,18 +1022,15 @@
    "jar": "sha256-7urpF5FxRKaKdB1MDf9mqlxcX9hVk/8he87T/Iyng7g=",
    "pom": "sha256-1dgfzCiMDYxxHDAgB8raSqmiJu0aES1LqmTLHWMiFws="
   },
-  "commons-io#commons-io/2.18.0": {
-   "jar": "sha256-88oPjWPEDiOlbVQQHGDV7e4Ta0LYS/uFvHljCTEJz4s=",
-   "pom": "sha256-Y9lpQetE35yQ0q2yrYw/aZwuBl5wcEXF2vcT/KUrz8o="
+  "commons-io#commons-io/2.19.0": {
+   "jar": "sha256-gkJokZtLYvn0DwjFQ4HeWZOwePWGZ+My0XNIrgGdcrk=",
+   "pom": "sha256-VCt6UC7WGVDRuDEStRsWF9NAfjpN9atWqY12Dg+MWVA="
   },
-  "commons-logging#commons-logging/1.3.4": {
-   "pom": "sha256-1L2jSJKqzL9PrTP8MjqKqQfvnXmYRlnaJJRMCoa/CGU="
+  "commons-logging#commons-logging/1.3.5": {
+   "pom": "sha256-zPSjA0b1AnuUlqvVYpCsJtFZq/K+ZN8SZWEdyUALnWg="
   },
   "io/dropwizard/metrics#metrics-bom/4.2.15": {
    "pom": "sha256-jeCq6KvWprh1x3JJoC2oHVFOTaKIBG/6+OFYEaPywp8="
-  },
-  "io/dropwizard/metrics#metrics-bom/4.2.19": {
-   "pom": "sha256-+G9/Vev/HwNOTVHbypTh18FykokM79GdBDDugjrFxDo="
   },
   "io/dropwizard/metrics#metrics-bom/4.2.25": {
    "pom": "sha256-glrTe4OA+ZK1FQULvZVFL4VGb+rnuFbVwVDU5fcWqOk="
@@ -1055,9 +1042,6 @@
   "io/dropwizard/metrics#metrics-parent/4.2.15": {
    "pom": "sha256-R5JYxO8ApkgjX/xVwl+KHSO4d6pX9dOSO1fUZ35AKKc="
   },
-  "io/dropwizard/metrics#metrics-parent/4.2.19": {
-   "pom": "sha256-lm7hDMMMk2UClsipjkFs11IpEj1WItPcHqV+UgjVgLY="
-  },
   "io/dropwizard/metrics#metrics-parent/4.2.25": {
    "pom": "sha256-33tjcfmxVpjhI9mGHyCZyjLJ7JZtnwxgdVoqNMy/q8I="
   },
@@ -1066,37 +1050,34 @@
    "module": "sha256-yVtRSvUY7z3hT8u/D7x+a9qWbz2GKAbAUGw4VLAGASo=",
    "pom": "sha256-QS8qIbNob7S9/im6e26f3p/zjHkgX3dd4i+ixGkIAVw="
   },
-  "io/micrometer#micrometer-bom/1.11.2": {
-   "pom": "sha256-2qo2vb6vKmnTVi6A92D+f4bU02uUGsBbqhjPpGtkvhA="
+  "io/micrometer#micrometer-bom/1.14.6": {
+   "pom": "sha256-KblvkVvI3UyBLDCza1ZVtqtL4CcuC5Np9ypi2CYyKh8="
   },
-  "io/micrometer#micrometer-bom/1.14.5": {
-   "pom": "sha256-paLdeg1baH99SzFS2qClo2ru4cqyRiR1lyRFEbAwwuU="
+  "io/micrometer#micrometer-commons/1.14.6": {
+   "jar": "sha256-GLdCkjchxblxjXWNQiFsXnonN3nt/ILJPup8UKMPhjc=",
+   "pom": "sha256-mZ5FxWZh0VxnJBM05X3rJhFb00tk/Q5adlhq3VJrUlk="
   },
-  "io/micrometer#micrometer-commons/1.14.5": {
-   "jar": "sha256-6YSF/+y32Mya9Hz+Yn6ovziXkV3Q80s+OhkNaJaHW0s=",
-   "pom": "sha256-eJLWtZpradwyeterbZIJJHDLc2OgNlLpaA1B/c7pMOI="
+  "io/micrometer#micrometer-core/1.14.6": {
+   "pom": "sha256-jQAIXgppS0ViXTWAdt8jx3H9Km1pciiCFoSlosOZjpE="
   },
-  "io/micrometer#micrometer-core/1.14.5": {
-   "jar": "sha256-fAxV73/hvvW4lFNlXnaO4F/TWzgb1n+dQs/kg2IXTKU=",
-   "pom": "sha256-YHq1TfGdsoInclmotrvcP7Yg/An0rJYtLZoMiDm+EZw="
+  "io/micrometer#micrometer-core/1.15.0": {
+   "jar": "sha256-Z6cyMfGC2cIYIDZDq5FggGn4mfS4z/7/bljqvwpsaYo=",
+   "pom": "sha256-F6xWcIid2th9kE6EKRY7ZUYFOA5EwLkmeNT05e9NQT0="
   },
-  "io/micrometer#micrometer-jakarta9/1.14.5": {
-   "jar": "sha256-CMDgYd9YWDrhG0sOxmTwIF5D27FszUFXHPBoJpgjgDo=",
-   "pom": "sha256-O8WW7DAedEQ1Mpqo6rLoW0zbq+Wwo8at8eJOsGJ53bU="
+  "io/micrometer#micrometer-jakarta9/1.14.6": {
+   "jar": "sha256-siHQ04nGmhHP5BzLCSSCR/mei0giIOfh4loLbJQOgAY=",
+   "pom": "sha256-ABsUW+p+zCbQpBGOCzxHu3d9ZMvqEHEBjN/NpkgH3l8="
   },
-  "io/micrometer#micrometer-observation/1.14.5": {
-   "jar": "sha256-fPv3FKvfN3nIIP8ZcSGZrJuuA9Lw6Am6jnTDZjwSEoo=",
-   "pom": "sha256-ni5FvQMZiF4btrvQdJAEXZttynip0gLyzbzHP4ISXfI="
+  "io/micrometer#micrometer-observation/1.14.6": {
+   "jar": "sha256-o3usHDaHvMQNBXs3Rj0MDTrYwfzERWAD7xIY4YkOWAw=",
+   "pom": "sha256-7dBmn0Mb6rXvJVnzvmhOt66RioSoVaExSSNVpd4sbfI="
   },
-  "io/micrometer#micrometer-registry-prometheus/1.14.5": {
-   "jar": "sha256-d8dzJVPiNGRJIhQxIbfSfMI2ht72A0i41ohvzT7a4kc=",
-   "pom": "sha256-Y6OeLDAlmF+/7uhXTbtEimjivkxtfCtg0CWa3dbzK7Q="
+  "io/micrometer#micrometer-registry-prometheus/1.14.6": {
+   "jar": "sha256-a22xBbMd7sLmUHUWoAES4FYskpe9x14Aaq58RKX0hu4=",
+   "pom": "sha256-2VLDhOQFbPdGy2zdKYXUUXxYljpl74HNqBeHQeYDPhA="
   },
-  "io/micrometer#micrometer-tracing-bom/1.1.3": {
-   "pom": "sha256-fprbb3oR0grb8tb/f7NMCJ9FGvQdM7uRjr17kcXszJk="
-  },
-  "io/micrometer#micrometer-tracing-bom/1.4.4": {
-   "pom": "sha256-VlJh6zMDaInlrv3Q9IvH8JvV9gLmQ5/teEiIwxBGqOo="
+  "io/micrometer#micrometer-tracing-bom/1.4.5": {
+   "pom": "sha256-z2dhoUKsmUMICpM1RiJ4bcqkBcoW2YjTkFAXgaKkWsI="
   },
   "io/netty#netty-bom/4.1.115.Final": {
    "pom": "sha256-JdyLuDN9/BhsSfyM9PaltsfPQUY2L19EDaytzQ35dhs="
@@ -1104,16 +1085,9 @@
   "io/netty#netty-bom/4.1.119.Final": {
    "pom": "sha256-CDVn40YWM4soNBpaCUdd7HKmcnlppsR6JCs9Z08TW38="
   },
-  "io/netty#netty-bom/4.1.94.Final": {
-   "pom": "sha256-FLsEPt93HvaT1f9ezBRm913JFpjwSn+oIrMJPT0COdE="
-  },
   "io/opentelemetry#opentelemetry-bom-alpha/1.46.0-alpha": {
    "module": "sha256-GjQNa9goWJPXYfeHLPEsGTdswKmIW2BKC7QMAJBkD7o=",
    "pom": "sha256-e7+pLXcsgFkhRIUyfrJaoHHCjttvyp9uDWiVJNAWdYc="
-  },
-  "io/opentelemetry#opentelemetry-bom/1.25.0": {
-   "module": "sha256-RHe55WRW2h7ZM64ig4bOAbusBl2bVLSZ7cKI4rumzLk=",
-   "pom": "sha256-VsipemuNS6DjaRVWdCMISrVTq++a+XTaGTXcIeXjCR8="
   },
   "io/opentelemetry#opentelemetry-bom/1.43.0": {
    "module": "sha256-FihOwxKoOYVg114KpIBTwXZNFk6w13f8BEC5s2xOtKE=",
@@ -1131,17 +1105,13 @@
    "module": "sha256-pqUY8hXgvQljDZxFxSd8CrvWJ3zyMHqzkLbOFy4de4o=",
    "pom": "sha256-PiwIbtrhgrPCBlKsnuPECT2tobh5mwyQvJOZmaCEPrE="
   },
-  "io/projectreactor#reactor-bom/2022.0.9": {
-   "module": "sha256-BfI8ABvRI1lpnqe+Y6bRi03YWoqRZ/PxehkRrwI9t7k=",
-   "pom": "sha256-agI/PfE5yap6gWUR1YSSnd0PXrhIeb+i46VRTFsXYJI="
-  },
   "io/projectreactor#reactor-bom/2024.0.0": {
    "module": "sha256-q9+I0toctizFQ+OgBJvN0/40JvOfqIH6/38OEifY1S8=",
    "pom": "sha256-sPfCTHH0Hlqqku03Pm1SI6HTXuKRMDgNhehmSnhPpRY="
   },
-  "io/projectreactor#reactor-bom/2024.0.4": {
-   "module": "sha256-uG6hW/aErIvj81kWEPceNkKHJVTAh15/uPRBTA83Eww=",
-   "pom": "sha256-682HMXgOY9D7D6+jMNS1fNzcNMUKSimrdzssQv0gn88="
+  "io/projectreactor#reactor-bom/2024.0.5": {
+   "module": "sha256-2/uVz8Y5SkznrPG/Zom+QNbcC6jPybdBBhYlnWa6nsk=",
+   "pom": "sha256-XkmymStq9Z8cN7NNTHf9SFnmgYjeOIPXdpd5wSNarc0="
   },
   "io/prometheus#client_java/1.3.6": {
    "pom": "sha256-n/AOSQfYUE9Rt6u2o9wns7fLZQmOWb7Nt14TjjPHR0I="
@@ -1182,14 +1152,8 @@
   "io/prometheus#simpleclient_bom/0.16.0": {
    "pom": "sha256-r0QdMpXeEacONf6+s9kZui7RdVJ1MWMyW5VNU1lNVcM="
   },
-  "io/rest-assured#rest-assured-bom/5.3.1": {
-   "pom": "sha256-Tg5ZUuRY6U+3dZ3nFM6hy9ru/ZFSJ4Z1if6R1EKJBUg="
-  },
   "io/rest-assured#rest-assured-bom/5.5.1": {
    "pom": "sha256-LKG6f3hk22p9WQLKWlwogHp2g5upZiP+fLjoihMe6Es="
-  },
-  "io/rsocket#rsocket-bom/1.1.3": {
-   "pom": "sha256-5czY/tNBW7Q4Xk0Hh+PjNiTLLHwALSVQw5eI8rubD64="
   },
   "io/rsocket#rsocket-bom/1.1.5": {
    "pom": "sha256-Ck4TdcyMFOz+MSIZQGgXmO+Ke4r26JaONj8VwO1HjD8="
@@ -1204,29 +1168,23 @@
   "io/smallrye#smallrye-build-parent/42": {
    "pom": "sha256-FBJFawNFSQ+NC00L5SnQSh1Y0Z1a2FvzHDdAwT+Q1t4="
   },
-  "io/swagger/core/v3#swagger-annotations-jakarta/2.2.15": {
-   "jar": "sha256-2RvQjd92HA2zTvao4Ftf4/7cJrt2h4ti/aEwJLhP7Qw=",
-   "pom": "sha256-O0+45xZK8IyJMqLESv5jv2Hgc+oF/64iHNxCs3izL68="
+  "io/swagger/core/v3#swagger-annotations-jakarta/2.2.30": {
+   "jar": "sha256-Kj8W8gxlZ+Pl6aFGrO+Naqccq2i66mIVVqwtN5eOBuI=",
+   "pom": "sha256-zkarwk7RoI41icv+ZIoG6siRdcUSKr2KMAN1xMFGwqI="
   },
-  "io/swagger/core/v3#swagger-core-jakarta/2.2.15": {
-   "jar": "sha256-P+NWP4qRp84f60pqgVlN3PcJHNtPMJ6tjaNPNbezY+Q=",
-   "pom": "sha256-KqQIInyuhFI7Ey892SGRZA4Hh7gNvMCvshm9qYEV+6A="
+  "io/swagger/core/v3#swagger-core-jakarta/2.2.30": {
+   "jar": "sha256-r25tXOLOhloCK6ucyGUr37yy3EV5Y4e8sfPFwq0/oS0=",
+   "pom": "sha256-N2XJGY3xaAAipHZkBV/UhMJeEBj+lBhm9tlpdk36ri8="
   },
-  "io/swagger/core/v3#swagger-models-jakarta/2.2.15": {
-   "jar": "sha256-nsdvb7bqw4X3wJGU9aOGTXb6qDyvtBLcciaZcIvIXeo=",
-   "pom": "sha256-lYxl0r9XBqnmkVQ7CLl34MMBQfzFzEHuEYlflZ3WJqg="
+  "io/swagger/core/v3#swagger-models-jakarta/2.2.30": {
+   "jar": "sha256-6W0DFIPL2iLe6qUVe8c9bUa/zKLS6VWrVqGYsq5VaT4=",
+   "pom": "sha256-r1mbT8wHHfALCtSzZox964H8eq7Q9x4UtMC8eUo2uuI="
   },
-  "io/swagger/core/v3#swagger-project-jakarta/2.2.15": {
-   "pom": "sha256-DuEGCUZxQIy4MPJj6NidCVKzXT8oiqY6Mh6CtA9Uugg="
-  },
-  "io/zipkin/brave#brave-bom/5.15.1": {
-   "pom": "sha256-HX6AYLG4a9DsxU3Hv99gp9bgAHYaTL0zLCry1W9vvZs="
+  "io/swagger/core/v3#swagger-project-jakarta/2.2.30": {
+   "pom": "sha256-kOQyeN56U2nxatUzv+fF9NK/tLUShQdsgZIlBWFN0eE="
   },
   "io/zipkin/brave#brave-bom/6.0.3": {
    "pom": "sha256-PRo+v/lZfRbomYoQU9/MWy5fEHc+XaZhYcQ9KIymFPE="
-  },
-  "io/zipkin/reporter2#zipkin-reporter-bom/2.16.3": {
-   "pom": "sha256-3hWmaeME4kB8d2agw6vuCKTsAf+JOoBJoJFo5kPFpvw="
   },
   "io/zipkin/reporter2#zipkin-reporter-bom/3.4.3": {
    "pom": "sha256-gNbEmFeGJ2Awx5+Zt+ElDe7sob+Z0zDbXcOKh6bpkZ8="
@@ -1387,14 +1345,11 @@
   "org/apache#apache/30": {
    "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
   },
-  "org/apache#apache/32": {
-   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
-  },
   "org/apache#apache/33": {
    "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
   },
-  "org/apache#apache/7": {
-   "pom": "sha256-E5fOHbQzrcnyI9vwdJbRM2gUSHUfSuKeWPaOePtLbCU="
+  "org/apache#apache/34": {
+   "pom": "sha256-NnGunU0GKuO7mFcxx2CIuy9vfXJU4tME7p9pC5dlEyg="
   },
   "org/apache/activemq#activemq-bom/6.1.6": {
    "pom": "sha256-FcLWnzVyE9bjsHEq+H31cfDY21mE0RSwoiD/LnSdxUQ="
@@ -1448,16 +1403,15 @@
   "org/apache/commons#commons-parent/78": {
    "pom": "sha256-Ai0gLmVe3QTyoQ7L5FPZKXeSTTg4Ckyow1nxgXqAMg4="
   },
+  "org/apache/commons#commons-parent/81": {
+   "pom": "sha256-NI1OfBMb5hFMhUpxnOekQwenw5vTZghJd7JP0prQ7bQ="
+  },
   "org/apache/commons#commons-text/1.10.0": {
    "pom": "sha256-OI3VI0i6GEKqOK64l8kdJwsUZh64daIP2YAxU1qydWc="
   },
   "org/apache/commons#commons-text/1.13.0": {
    "jar": "sha256-HjI6UBEn33jtCYfzRdadZdDqf6PU+1s/hKrro6iyDzg=",
    "pom": "sha256-1GYUvcptEZXDM7qfcwzQhYXE8zKkPqe5C2A1rYBIcdg="
-  },
-  "org/apache/groovy#groovy-bom/4.0.13": {
-   "module": "sha256-UMvUHEPhbMJKIJ7i2pNdeV1rN8VnNQlmtJJusxQwM6M=",
-   "pom": "sha256-M5j/NPIIMkDWY0erSnMzudi3nTqVrN8vz03DAn2B5qs="
   },
   "org/apache/groovy#groovy-bom/4.0.22": {
    "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
@@ -1487,15 +1441,9 @@
   "org/apache/logging#logging-parent/11.3.0": {
    "pom": "sha256-pcmFtW/hxYQzOTtQkabznlufeFGN2PySE0aQWZtk19A="
   },
-  "org/apache/logging#logging-parent/7": {
-   "pom": "sha256-5YkR3J/GsXOhDlqp7bk8eZStBmAnBd0Gftz8bh6eFys="
-  },
   "org/apache/logging/log4j#log4j-api/2.24.3": {
    "jar": "sha256-W0oKDNDnUd7UMcFiRCvb3VMyjR+Lsrrl/Bu+7g9m2A8=",
    "pom": "sha256-vAXeM1M6Elmtusv8yCbNZjdqLZxO5T+4NgCfRKRbgjk="
-  },
-  "org/apache/logging/log4j#log4j-bom/2.20.0": {
-   "pom": "sha256-+LtpLpWmt72mAehxAJWOg9AGG38SMlC2gSiUOhlenaE="
   },
   "org/apache/logging/log4j#log4j-bom/2.24.2": {
    "pom": "sha256-NQKIlCeybxfvStgWgCxJtJQ/DJOXJoYdEmPlenKiMEY="
@@ -1510,49 +1458,55 @@
   "org/apache/logging/log4j#log4j/2.24.3": {
    "pom": "sha256-wUG0hj/AzqtYOJShPh+eUsAfwtdYcn1nR/a5nVBA87E="
   },
-  "org/apache/pdfbox#fontbox/3.0.4": {
-   "jar": "sha256-Le7GIy9dbTsxJ2WS0xaArpcir1fSTLD3bacOK6DpnhI=",
-   "pom": "sha256-8MzDMOmyDYlXigqHArR6OZvNYojCOG10/6uPjjAoROg="
+  "org/apache/maven#maven-parent/33": {
+   "pom": "sha256-OFbj/NFpUC1fEv4kUmBOv2x8Al8VZWv6VY6pntKdc+o="
+  },
+  "org/apache/maven#maven/3.6.3": {
+   "pom": "sha256-0thiRepmFJvBTS3XK7uWH5ZN1li4CaBXMlLAZTHu7BY="
+  },
+  "org/apache/pdfbox#fontbox/3.0.5": {
+   "jar": "sha256-6KYr4t8noNRBkbZmnAsY327+UnEjLbjcuHRdXZd0dVs=",
+   "pom": "sha256-I/bas9ldDvUDM8n3ZZp0ChCwYZ3eEXbqYtyLSTU4jr4="
   },
   "org/apache/pdfbox#jbig2-imageio/3.0.4": {
    "jar": "sha256-KcspUWIvEKz2H9BlbE5vpVYhlKkJX3odJqpCbi9rF+s=",
    "pom": "sha256-KOp8SskuCYX3lqi8aJCnvviSZwetrf0eLIVsmwvho4s="
   },
-  "org/apache/pdfbox#pdfbox-io/3.0.4": {
-   "jar": "sha256-ep1HRvLhOh4i9O/kf7r5mXY8rqQXSFNa+ToB7txQ9VQ=",
-   "pom": "sha256-YLURdX737TBIv4LH2ClvcdC8RwAgEYQzqzs+OEC/jqU="
+  "org/apache/pdfbox#pdfbox-io/3.0.5": {
+   "jar": "sha256-bfPztNtP1V71AoR+pOTrxY4okIgA6G6rAxNF7+IZtwU=",
+   "pom": "sha256-NVvL5DdA/CEouNwRUQsTutOrPcet1Cnjt0q72WA3iVc="
   },
-  "org/apache/pdfbox#pdfbox-parent/3.0.4": {
-   "pom": "sha256-w5j++zUez/mTEYCNftU0bnHzVrETS9c6JQTLgXB9tFE="
+  "org/apache/pdfbox#pdfbox-parent/3.0.5": {
+   "pom": "sha256-HKnfIMk56uhgJQonn+oCoRzdK0DkJa2Q0M5Ma3d8gpY="
   },
-  "org/apache/pdfbox#pdfbox/3.0.4": {
-   "jar": "sha256-CaD/J9b4Sh3EAGDLCgHezyrU75HDa8kbmDbCVL6KrkU=",
-   "pom": "sha256-098DLfK90jT+NwMO+sNXa6Yj/Jf1ERNUxMUq13dfkOQ="
+  "org/apache/pdfbox#pdfbox/3.0.5": {
+   "jar": "sha256-8OXToeVzxwfk+8wu6OQuqModUmG9yzoFoI0hGFU8Hlo=",
+   "pom": "sha256-oFmNxJdGm9W/HEjFubAmcqJlaQG435sfG6pJy3huZYM="
   },
-  "org/apache/pdfbox#preflight/3.0.4": {
-   "jar": "sha256-v0aR1HNN9JFO1TzGjt6i/Z6ppo0Iyhh7oHTiqA2GDm4=",
-   "pom": "sha256-uzcdkEROYENB5n+78GM+ZBFO+zi4yQV3mmrF5L5XBKw="
+  "org/apache/pdfbox#preflight/3.0.5": {
+   "jar": "sha256-VbjnOQq1pEH+KHsXwB1m/dyHzo9aLyB8ALnyR/xgHoo=",
+   "pom": "sha256-CQ41b52f7RJ7CwpC9IVOMxx0lh/p/Za15G58Mds2ozg="
   },
-  "org/apache/pdfbox#xmpbox/3.0.4": {
-   "jar": "sha256-0K8/1yIvs+GDcqKO96mFlaP31F4M9a0w+RethhLB3bs=",
-   "pom": "sha256-Di6ucXVvw1IVGAhuAxd7qKFthU2nuEK0VWQx3bletr4="
+  "org/apache/pdfbox#xmpbox/3.0.5": {
+   "jar": "sha256-AXiZsvtcKvcU0wxSzKks3o8SmZq/MUDU8NXxEzT2L90=",
+   "pom": "sha256-E6MTEo+lkzyjcj8gwYKO5oJUHRRqX7BK5JtXoqYFC4s="
   },
-  "org/apache/pulsar#pulsar-bom/3.3.5": {
-   "pom": "sha256-CZnz78BPOm5NpFyV1uc0LelPTEhagT7UL7254buDixI="
+  "org/apache/pulsar#pulsar-bom/3.3.6": {
+   "pom": "sha256-DOd0NzWp3O33lLhz6idKYQYWfU/rhoRX3IPlUwMa58s="
   },
   "org/apache/santuario#xmlsec/2.3.4": {
    "jar": "sha256-VRPnQX7cHrcYitxN4DEukxVr18ptbB5gctPgAG3v/yM=",
    "pom": "sha256-Ez/s/gIYho799ZY03YaS9/Ke5uLeQynWdwDJF6OE7kA="
   },
-  "org/apache/tomcat/embed#tomcat-embed-core/10.1.39": {
-   "pom": "sha256-JtS19rDnpU3wkmk/Slw70gThqLeGLb7AYCCNI9usmMU="
+  "org/apache/tomcat/embed#tomcat-embed-core/10.1.40": {
+   "pom": "sha256-2Vldhm4WnGXh/myP3daF96n0RREhl3Exfc4yC6ynD7Y="
   },
-  "org/apache/tomcat/embed#tomcat-embed-el/10.1.39": {
-   "jar": "sha256-3pk6Worwtspkc7pZuVAm197ZPeOhaD2ft3U7e3bTjuc=",
-   "pom": "sha256-uFrOeQ2wGObr4e2pJ244LxYDJijX1Kz+zVKAlgkzPKk="
+  "org/apache/tomcat/embed#tomcat-embed-el/10.1.40": {
+   "jar": "sha256-E44bi8sGiQs4QIsIAdL0wqWjdZR6qNP8EqwvmFc9U4U=",
+   "pom": "sha256-EbOcfUagP0I80M/PUv5ndyHTwELiyYlJQ0DafMfjXsc="
   },
-  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.39": {
-   "pom": "sha256-SGMUZiaKsLBcFLJSswgd7MkhLGRaLTTjmWKiyGMdFEg="
+  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.40": {
+   "pom": "sha256-+0Ug4VaOKUhYDjcsFG0SFsbgzmsm3ctF72XtTEtGbJs="
   },
   "org/apache/velocity#velocity-engine-core/2.3": {
    "jar": "sha256-sIbO6P2Bg+JAtK/PVP447DPdjrDaQUY25b96pNmFZik=",
@@ -1564,28 +1518,25 @@
   "org/apache/velocity#velocity-master/4": {
    "pom": "sha256-eirHPJDdEEtaB+bizQPpXsKNKfO4ME891//87LBJcS4="
   },
-  "org/apache/xmlgraphics#batik-all/1.18": {
-   "jar": "sha256-5rmcnOZVmwrAVxc/EeAVcr0ImKo4i2WWN2rocbw/yE8=",
-   "pom": "sha256-ZTf86ANuf0G7iheJN2w1Vs2KlNEyrxa7KYlDMqSoSJg="
+  "org/apache/xmlgraphics#batik-all/1.19": {
+   "jar": "sha256-XcMtc9WGsStsSlRbg+tTfl48LNggqHNzCwc7LpTc9SU=",
+   "pom": "sha256-xo20Pw5lXMpnatNyaffr2V5zFtyc3vv65PKNkXbGW4s="
   },
-  "org/apache/xmlgraphics#batik/1.18": {
-   "pom": "sha256-xaC/+m0aTRYFs5xhIsy/8ImD0qdF+q9hwMi/V9u8xTg="
+  "org/apache/xmlgraphics#batik/1.19": {
+   "pom": "sha256-HRpNXZF4DjRChBp5DhBYeAVGiC6uX4NSiLEJjGhvKY4="
   },
-  "org/apache/xmlgraphics#xmlgraphics-commons/2.10": {
-   "jar": "sha256-hXry0G0ALOIXUyUEJE6o7oMa6wlP6wpHsml/GUlnEeo=",
-   "pom": "sha256-mD18XYcB8GYOiVw7TET0ORjDGaOi/Tas+TNwEJnTUgk="
+  "org/apache/xmlgraphics#xmlgraphics-commons/2.11": {
+   "jar": "sha256-GjeUjr/tqwzSks/FAH5lwvoWpwG5TCBhUnINOnOFYbw=",
+   "pom": "sha256-nK3V48G4PKnsuW32YD269E3mqblhqdqHDasG2ghYMLk="
   },
   "org/apiguardian#apiguardian-api/1.1.2": {
    "jar": "sha256-tQlEisUG1gcxnxglN/CzXXEAdYLsdBgyofER5bW3Czg=",
    "module": "sha256-4IAoExN1s1fR0oc06aT7QhbahLJAZByz7358fWKCI/w=",
    "pom": "sha256-MjVQgdEJCVw9XTdNWkO09MG3XVSemD71ByPidy5TAqA="
   },
-  "org/aspectj#aspectjweaver/1.9.23": {
-   "jar": "sha256-LxSxL6e6EJdl72yAioo8rC7uWUByP6Wp0qmUNfRAv98=",
-   "pom": "sha256-ASeiTmBszQFtN9ZDU/tYBnorIjP0HXzqYzsZ8AArzd8="
-  },
-  "org/assertj#assertj-bom/3.24.2": {
-   "pom": "sha256-EqxGrmTTYl80S79kKrVvoC4Vuu/lPvX1sGHhJLSEYgA="
+  "org/aspectj#aspectjweaver/1.9.24": {
+   "jar": "sha256-deQif7fcX5fD1Gic0cJDn02wvRjOovokLEZWzZPFmao=",
+   "pom": "sha256-JExiUSK8NBpYUYRPIvhY0Kl1WYrk3M47h/H9VIF5BkU="
   },
   "org/assertj#assertj-bom/3.26.3": {
    "pom": "sha256-4UJ5BJyPgMRzFwzVCpaD51xmjgDdNdBGX4/Y7GO0XkY="
@@ -1658,12 +1609,19 @@
    "jar": "sha256-xgDRrmG1sP8TkeAOtvs5AgHkYSw6ry3BuUBQyHhIQL4=",
    "pom": "sha256-RnLsWVmf6Yu0Gr0VJtn1KJcmr/sj/XCeNru8umM056E="
   },
+  "org/eclipse/angus#all/2.0.3": {
+   "pom": "sha256-EoyjtvoISnQ8pRwgKxqfxHCjdzm5PI9OcoVM4m+gBnI="
+  },
   "org/eclipse/angus#angus-activation-project/2.0.2": {
    "pom": "sha256-r5GIoQy4qk61/+bTkfHuIVnx6kp/2JDuaYYj5vN52PY="
   },
   "org/eclipse/angus#angus-activation/2.0.2": {
    "jar": "sha256-bdO8/8IrzoOwc3ag4uCU5JZKMZXUEY+0PjgO81Q2zB4=",
    "pom": "sha256-deViGn3IWMmW7nDGtNiE2QHRh4Ns5sZxIMr5VH5vxXE="
+  },
+  "org/eclipse/angus#jakarta.mail/2.0.3": {
+   "jar": "sha256-77lGQkkzgGvG+BNnUtIv2zuoh+oFJ/+EnEdOUfezcV4=",
+   "pom": "sha256-Z5luZL2/8GcHrUq6eDp5do1iFRs2jFpbITnFuZE0vSg="
   },
   "org/eclipse/ee4j#project/1.0.6": {
    "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
@@ -1677,139 +1635,133 @@
   "org/eclipse/ee4j#project/1.0.9": {
    "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
   },
-  "org/eclipse/jetty#jetty-alpn-client/12.0.18": {
-   "jar": "sha256-5Dx8Wky7YFCJg1tNc8CUdor5Zeukv/cC+QX+F1C8OEY=",
-   "pom": "sha256-mGZ/R0Cth7iUaorC/nyIIcD3merBgN5G37fIgQMoxwY="
+  "org/eclipse/jetty#jetty-alpn-client/12.0.19": {
+   "jar": "sha256-r9MPFRE2WILWbcWs9bDfmoECs43iW46booa9TRdBK0Y=",
+   "pom": "sha256-3naFZ6ub32C/WPzWdCeIyVfUoyKWgaYFofk9wrgBjYo="
   },
-  "org/eclipse/jetty#jetty-alpn/12.0.18": {
-   "pom": "sha256-uRHosPQLvq3gTDcqYufCiNCHd4lMg9Bso+y/80Qpe88="
+  "org/eclipse/jetty#jetty-alpn/12.0.19": {
+   "pom": "sha256-al7aZ/TqCXZtTLOPDg6nO6zQkmxl8WNISIzLlOelNqI="
   },
-  "org/eclipse/jetty#jetty-bom/11.0.15": {
-   "pom": "sha256-+ksNDeuvyR9Q++wI7+RkInAzTzeOg562o1+jdqoaLPg="
+  "org/eclipse/jetty#jetty-bom/12.0.19": {
+   "pom": "sha256-hwwbW+ywl65hpgzkWwgsf9lgO4BFvgiPf4oclclAKnU="
   },
-  "org/eclipse/jetty#jetty-bom/12.0.18": {
-   "pom": "sha256-lEijD9eZ6wpUZCTuAmTWdQuFahMpXxtm+l7BZz88cBM="
+  "org/eclipse/jetty#jetty-client/12.0.19": {
+   "jar": "sha256-mnulTSq6abNAidJss6fr7JxcRSXokOVm6cJKcEGHhC4=",
+   "pom": "sha256-VCO6LLgLITR71BwbINnDmPpM56aU2ZeMOpCo4CCN+nM="
   },
-  "org/eclipse/jetty#jetty-client/12.0.18": {
-   "jar": "sha256-8GHqCQR0RaeRd1kfAQPe/w4L3zUgJ0YvCUz+SG8O0w8=",
-   "pom": "sha256-jYsWmldqS368kElY4TIwfHOZB2ntM2oqnxddy9nwYi8="
+  "org/eclipse/jetty#jetty-core/12.0.19": {
+   "pom": "sha256-WlnJIoSqiWT9xOKQweakAaySfXmabfw3/eQ7GZ19ajk="
   },
-  "org/eclipse/jetty#jetty-core/12.0.18": {
-   "pom": "sha256-m0qJW6rnHuJ8TrP9J+iQNiqB5lqOXqJDw3/6QaBJez0="
+  "org/eclipse/jetty#jetty-ee/12.0.19": {
+   "jar": "sha256-+20XDpLFzifyeepbL5l4VrY7ZVDCNiufE3h9R+qTAvA=",
+   "pom": "sha256-EL5fw7ya0xe/vImnGUjdjdiEJBqt3uQppoFNYg6IrKs="
   },
-  "org/eclipse/jetty#jetty-ee/12.0.18": {
-   "jar": "sha256-wmmLkpzVotASLVyca+Xarrvj+7iYTpJYguJ3cWoUgG8=",
-   "pom": "sha256-OL1elncT/MDZra1KUc4DHtMBKV4189Sld8FPtIcpFb8="
+  "org/eclipse/jetty#jetty-http/12.0.19": {
+   "jar": "sha256-BSICiO7RSRZ9pQbSFBMamI8wuVZS7ZKSBhTBWDPGSaU=",
+   "pom": "sha256-dIGCV/cZF26ofN91AXQkAQTDMGjYCxFDr601C7TeG4E="
   },
-  "org/eclipse/jetty#jetty-http/12.0.18": {
-   "jar": "sha256-ZAz5UOutH4jVqW5GVIo0/42kGLYXHivC4w5z9JERsGg=",
-   "pom": "sha256-ugkOUMVGzQh1twAKz2/QzMPki82VcU284q+9BVLhzTw="
+  "org/eclipse/jetty#jetty-io/12.0.19": {
+   "jar": "sha256-xs9Rz7QhmIpR0e3tAFzAabzpwqe/YcdNO5d+PFtekpc=",
+   "pom": "sha256-NGjexy5gMl01t5CFPx/CzL9r2/OPVtHxb9vyrERDZCs="
   },
-  "org/eclipse/jetty#jetty-io/12.0.18": {
-   "jar": "sha256-JSjDJAsGFf1zXvZ4Je5816L0MOQF/Vfu11Y3fS0HAqc=",
-   "pom": "sha256-rXTNc+C7Vk7631bMUBjMzl3y2zIlU0jmB4P81MGNUXQ="
+  "org/eclipse/jetty#jetty-plus/12.0.19": {
+   "jar": "sha256-ZyIb0BlXwbcA6QO/Rz321NsRqkdj4jmFExAnL4cobko=",
+   "pom": "sha256-ddIJYmb+LwY57Omc0xvKzs5bh9WnARCad4RJ+gZ3oOM="
   },
-  "org/eclipse/jetty#jetty-plus/12.0.18": {
-   "jar": "sha256-re2+4lQU1PK3b2QbNGyXmUlOOEsuFPVd+Cc/SPkLa+A=",
-   "pom": "sha256-GkPHKbDvK3tfHrn9y6m032a0D5msXWWE/ZNj1bVxv3Y="
+  "org/eclipse/jetty#jetty-project/12.0.19": {
+   "pom": "sha256-4+ZN8tcwhMyChBtFyR3rZnkI9GIKLliMIvORKGCfxuI="
   },
-  "org/eclipse/jetty#jetty-project/12.0.18": {
-   "pom": "sha256-PzY38CDKMWMCrkwGh45p66AbkarZMQ7iKS/H1e5qrYw="
+  "org/eclipse/jetty#jetty-security/12.0.19": {
+   "jar": "sha256-NxOrBXh4etewjObIEJrL0+ne+Z4F3aD7OqdwEymme+c=",
+   "pom": "sha256-x/lnUYg9Stf9QGpYk6H8U7FXxcKzH2FC9+AbAYH8kPA="
   },
-  "org/eclipse/jetty#jetty-security/12.0.18": {
-   "jar": "sha256-6YUHv0wnOyKte/VJEAMtCUipuoOFKSYPG5Go1gx2t0k=",
-   "pom": "sha256-XXPWb6k+qBC2WcDsFXiv5cmJHjC+lhqyU57lPuCAPGk="
+  "org/eclipse/jetty#jetty-server/12.0.19": {
+   "jar": "sha256-rXPzXFuYbvpNpQCvhkeyxVbSPiTDZFs3sG/YfQqecXA=",
+   "pom": "sha256-5sj3pEpmUzDh6PYZeIHSJp+6lpLHsBes/t/QQS6vzw4="
   },
-  "org/eclipse/jetty#jetty-server/12.0.18": {
-   "jar": "sha256-EYyPeE/8v0pp4QGLhx/Tls1OxjH8b3ZP6Vi+sJHlBWg=",
-   "pom": "sha256-YpS+SZdLQx6r+HKJr3pp/W+O3o5UDBBFMnsWfmdabFw="
+  "org/eclipse/jetty#jetty-session/12.0.19": {
+   "jar": "sha256-vdYjUPrtOVBhivUPs3kkYrv6qUg24IUEVO5zZU5wulA=",
+   "pom": "sha256-cJT4uwG5bQL+YBcupTCkSxlDOG2n0wz64VtFtF9qAFU="
   },
-  "org/eclipse/jetty#jetty-session/12.0.18": {
-   "jar": "sha256-tpgAZB8emtwVlA278iZQb0FU9UOlKgNiaOXimPq4X4c=",
-   "pom": "sha256-TKx1ZJX/Gj7G8imAW6Mtg4XxkJBmGuuEWAzLtQmWKu4="
+  "org/eclipse/jetty#jetty-util/12.0.19": {
+   "jar": "sha256-kBuDmdZHU9jEjWyGV251jPfgLzaCR1XcIjqRCrXLxSU=",
+   "pom": "sha256-+3BLTg7ELNmVEgTn0I+XAqfoxrjn8QESYowyFxRqXW0="
   },
-  "org/eclipse/jetty#jetty-util/12.0.18": {
-   "jar": "sha256-xMnnQ19/AFp090bZSVLhSOyAM1biDJnm1GpS+Jbh5BM=",
-   "pom": "sha256-oKk+PMa8REc5a5esU0q/zVBaXjzykXeplG6MlV+1ycw="
+  "org/eclipse/jetty#jetty-xml/12.0.19": {
+   "jar": "sha256-RlkcGdrC+4aDXIiaU+o2VnmHBq9DE87fb46XHUpRwVk=",
+   "pom": "sha256-h4avshZI+HdQ6fEHHhveo0InUf7200tELXEPA2bjc9E="
   },
-  "org/eclipse/jetty#jetty-xml/12.0.18": {
-   "jar": "sha256-TCKAUNag4P/yKES6uWB9L5CTw59vrqaN7FMCREirRBw=",
-   "pom": "sha256-xVFoYaKy83hwWpiJTKC8iwVxHUsltPJ74QGMxgeWOz4="
+  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.19": {
+   "jar": "sha256-Zzm+FaC5h76dwAC0R1T9+s9BK1dNXMABSiRKHY5zsbw=",
+   "pom": "sha256-973qQnnikSzbcH95oZq5qQhqJPweWwkSmxW5NmM4p8g="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.18": {
-   "jar": "sha256-bd/ghhR+tkhWDDnMbsLaoqohqXg6UhzCQhRamlsN3js=",
-   "pom": "sha256-3odv/SXW3ht3BxVv+0BVEKP2J+T7mCZ7vTz+K7bD8QI="
+  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.19": {
+   "pom": "sha256-kw+WXKp0sfkikTzicqCYbB2Y5iorlqx8WWu87G4VjDM="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.18": {
-   "pom": "sha256-sPU4NYiv//iVCgRyxA/4I0oKfP74z1SkwtOuD3iax6M="
+  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.19": {
+   "jar": "sha256-/P5aEBlhqXnomrtO4VptypcpI1gXUaCVYu0DRAcrNUA=",
+   "pom": "sha256-PXjHGRPtNmOig27/TKftKJ8JGXaao8A+imh8eWrdxHs="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.18": {
-   "jar": "sha256-IOdLhOf1hHldHfJGAHu/EimzXm4yMbdnhwe1lp6e9VA=",
-   "pom": "sha256-5IFAwkhVHc+lG6FGTKqAOgkxELZa0HXS69XZ5VnJj3E="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.19": {
+   "jar": "sha256-unkQYcra4mm6jlFDZu+anv+MSpZDbxgwIOtHYkpZte0=",
+   "pom": "sha256-8nOgRAMEk3coOm+1AtX/XSEHBwkWqI2YEk5IaAw6pKo="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.18": {
-   "jar": "sha256-6qmY/YVNZP4WHIItIfB0WYaVTbXIF657g8OxPpSqPgY=",
-   "pom": "sha256-8OGv7q6bfIHYN5R78W48nEemB9/P5hW0pUTMlY7cSXM="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.19": {
+   "jar": "sha256-222Xs4NWGa8F/pM/aKzkm0t4FHjoIN7tBeIc8FRsxfQ=",
+   "pom": "sha256-otLijb2I4xW5lJclCXcbffLUboT0czLW0P6J0w15k6Y="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.18": {
-   "jar": "sha256-Styu2zpd11xV40WwTEV+JNopMxJWPNCEdO+NWgsBnQ0=",
-   "pom": "sha256-EwdCGE8xfk5rbkA6PlUizGw25oaz4G0f2LPrMiqqzoQ="
+  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.19": {
+   "jar": "sha256-QHkYikQ4dJJjhhsXcCWVPUKVjOagwXz8yfSbvk6rQ40=",
+   "pom": "sha256-3lpZ+RNfiQra5xsTV27QkA/+coiV00IdjXoQglkpEkc="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.18": {
-   "jar": "sha256-wDEV7bSmgr20nsgkXwrNfs0lgFyvL73VDurDQtVq8lA=",
-   "pom": "sha256-A3Zjd8xsEhRJ5/2Q+3EVkylVp/sw+8lYsod99WkWCjk="
+  "org/eclipse/jetty/ee10#jetty-ee10/12.0.19": {
+   "pom": "sha256-g0v8BRMOoPBy9Yq/2YyKKLu8RYNqPi7bMXAQvFfkm+I="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10/12.0.18": {
-   "pom": "sha256-R7SD8458sfXw2IMRgShtA5fVxoXEnyT5zwGffbllnYk="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.19": {
+   "jar": "sha256-p58WPlkLIaxLev9PghLsjCiwmUuPkxy5u9AerRDVcY4=",
+   "pom": "sha256-vaQWeTiryS24eHxbtCPrJnacLWABNEGzz5YW8Z/Rxyo="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.18": {
-   "jar": "sha256-Oa44yVV/58qqHxvE0XzrI3HCwi4EFC4rag+4hSVsf1E=",
-   "pom": "sha256-H8iMnxBsPw8Dtm1Kmi9/4SOIFbbxAymnuSDl7/jfV3Q="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.19": {
+   "jar": "sha256-U83Oh1FojaaYQVtl+LAjsXnpoWWi798r6ketXIcDpfY=",
+   "pom": "sha256-TZApD2scgRTBYp23816QHsfp2xDOlqhhb6vmPMcD91I="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.18": {
-   "jar": "sha256-IL+cS89DzkD28ieaZ4kakwLE7pWNibMkpnWqjClhqgI=",
-   "pom": "sha256-upUKLD7ayY2ViPISAVUNWSsNufYihYODgE3h6aVGoXk="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.19": {
+   "jar": "sha256-lQhibl0gVktsB3Tzxx04dgAl28WyhGpmP4QY/hpMIGs=",
+   "pom": "sha256-z0LX/c7JlnUkaG661J6RdOwt7W+9ttRFNqrkkvUR9E4="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.18": {
-   "jar": "sha256-opUxgkIkjRa3777/md4s57loryuUAy2zscVlhqx47PQ=",
-   "pom": "sha256-F+x/0DMObuuqnmsPXAYbX36pstF7ViweXx+7xRX8x3Q="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.19": {
+   "jar": "sha256-zuJeEes1iAKOjPkN9abzXuxW2d6M7RKDPfidkopyKHM=",
+   "pom": "sha256-ZBpUuxqv/AR2V3f783H4FvVJ2rluib3hnSRo9nAFyhQ="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.18": {
-   "jar": "sha256-cguolyzpCLtvM0bnY1M3tzsj8bHJa/7W2L+fTy/NGwI=",
-   "pom": "sha256-NlnjfQULr9NbmrZ/P0IcfN/x4Y6a5y3KdYLrADKT4r8="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.19": {
+   "jar": "sha256-L65cskTTadPUyRjS9RlP1K5G1A0Zv/iIZVYqL/rWpJA=",
+   "pom": "sha256-ixXx0CeX07fT7pEhiRzdGkWsDoP05kY0DUBFjITvVzE="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.18": {
-   "jar": "sha256-wQv9NLQEL96hZ3FSCirHoB4zlLSDMW6DQyyOpsZsf0U=",
-   "pom": "sha256-B+XgbkM/y8xzWT8y3c7vSLUjyshmxI4g95LjeeC8x9k="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.19": {
+   "pom": "sha256-URXrdE5JVIr17RavFvv7btUbhs+IWaiDJl9yxYIvpPQ="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.18": {
-   "pom": "sha256-FJuGgFyTecjCuiXDc2Qt28TrbqPzEMkT+Op3HxxVDKI="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.19": {
+   "jar": "sha256-GMJESvNCFCiTu47q0RZqaBnYNnk1zBuEO/GAwkdNt3k=",
+   "pom": "sha256-fXXPUgs0auYizK93IdlEcvlRmbzTbFo9I0mdQzcOW5k="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.18": {
-   "jar": "sha256-1n05bNy2c9YHQvgOQoELkZPdnyruwmknFKzeyn375jQ=",
-   "pom": "sha256-owj8h3nOG6trI7LgVPywCabhziY7giO/feTnjuRqdCo="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.19": {
+   "jar": "sha256-ojdRYh81QAAwOTGH2qZJU6SyMjewBXlLqWxBOuQ+cKY=",
+   "pom": "sha256-GnHiA0V1LGVoiJfO65MRgaYa/Hy9FDzgtdsJWxCs7DM="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.18": {
-   "jar": "sha256-Qn7CQrxXwCY43RnCyNS/ZuvupSrlitbWqbQBOviLsgE=",
-   "pom": "sha256-uE3iWImyc8RSCPUc57WihEJ8R5jpMA10AkcMRdARIzI="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.19": {
+   "jar": "sha256-ABfXZ/wTWXGL8yNE/GQwcbrdT0JKgYEFC4+uuyK4Ax4=",
+   "pom": "sha256-L/fpu5obNXSBJ3kytgO6paJ+gbi2ltXScnruZ9Okc7o="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.18": {
-   "jar": "sha256-aYFjpUXiHeDWozDwoIL4HU6WmIcDvqSIGCX8pL0h1vQ=",
-   "pom": "sha256-vHc35FPruSa1wnLw1LnNANoZ15LdfdDzWjrKRbtkO7Q="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.19": {
+   "jar": "sha256-zp1dld4KBQb98ZfWYtbkpXYxoqdkxwNmnjq1v9DRSv8=",
+   "pom": "sha256-F9SrNvaQvGFNq055X4aG5kQJ84dt6JaEUkG1+pn9DBs="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.18": {
-   "jar": "sha256-ndwN5HS8wGW1y7RoK7LzoD8hTncmh1LHHwgqJmg0Mco=",
-   "pom": "sha256-VgPHA2ssyUodwAHPJpzAoRa3EP476BHpBUHHGamjEF4="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.19": {
+   "jar": "sha256-fH6lCUkBpPxFvrPm3h56TnPv/BC0nNzmIeOyEXfQoiw=",
+   "pom": "sha256-gmz3GqQhq9LJ5t3HZ8rBdWknPeUfMPQthdOMzradI2Y="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.18": {
-   "jar": "sha256-Cgtx3a7XK49xxH/jfM7aHrrPquaQIAONEux14nkbFc4=",
-   "pom": "sha256-b8BWGKaXp82u6kYuHzahV6r3TJQsysIaz4YHeKt1caE="
-  },
-  "org/eclipse/jetty/websocket#jetty-websocket/12.0.18": {
-   "pom": "sha256-etesYt8KvkGmxpodrxukOJWJafVLWb/KzTuV7w3gOhg="
-  },
-  "org/glassfish/jaxb#jaxb-bom/4.0.3": {
-   "pom": "sha256-Zg8EhAYlliYXiumpcrA86VFmXDPDM8q0U7EXi40NJBU="
+  "org/eclipse/jetty/websocket#jetty-websocket/12.0.19": {
+   "pom": "sha256-+1xH2AtXWR8RPFBeKzOUlVY4aIJ4S+DVxIITazfTiUw="
   },
   "org/glassfish/jaxb#jaxb-bom/4.0.5": {
    "pom": "sha256-7JfsQtk308iVGXl+RCRvgN4IUIGax6euZ1xEl7cHXDk="
@@ -1829,9 +1781,6 @@
   "org/glassfish/jersey#jersey-bom/3.1.10": {
    "pom": "sha256-KYl09Itfm23mIvJFApLexNuZs5vjJF9WVqbJpEtd67Q="
   },
-  "org/glassfish/jersey#jersey-bom/3.1.2": {
-   "pom": "sha256-WmsvkyguMAlcrhRpCiqrWpxTa1f/MuiQ6giu/4qEwT4="
-  },
   "org/hamcrest#hamcrest/2.2": {
    "jar": "sha256-XmKEaonwXNeM2cGlU/NA0AJFg4DDIEVd0fj8VJeoocE=",
    "pom": "sha256-s2E3N2xLP8923DN+KhvFtpGirBqpZqtdJiCak4EvpX0="
@@ -1845,15 +1794,19 @@
    "module": "sha256-sapyAvw/Z9IgZpA9Ph63BS7hD0cyKhy5JfovRJ8lruM=",
    "pom": "sha256-ZvbmB7MHQOORmJglpa4HamyHepm3jrBUqBRmUKr/cus="
   },
-  "org/hibernate/orm#hibernate-core/6.6.11.Final": {
-   "jar": "sha256-8PjzZCXoGRngEHTEDys3P6huOtweXm7XkrBLZofgdmA=",
-   "pom": "sha256-mTGR3tnzybF+L6SqcV4yx18KE4mie5vssjLqOy9Z3gU="
+  "org/hibernate/orm#hibernate-core/6.6.13.Final": {
+   "jar": "sha256-vV92VTNmBIX3Uz0Xwm1ZjqUELJDb9S5lApGb7DNAYas=",
+   "pom": "sha256-pB+FTJZnR1EhFdkGgDtuVhRYlp1/5TC3ncFGKtzpDFk="
   },
   "org/hibernate/search#hibernate-search-bom/7.1.2.Final": {
    "pom": "sha256-BAbGloTq1BCta0E1tShrtggnsLWiEdXl0T0iM1lATPA="
   },
-  "org/infinispan#infinispan-bom/14.0.12.Final": {
-   "pom": "sha256-morEX54P+bvW3iEsHdCHIrxPrmuhC/vN7zaL8jroDh4="
+  "org/hibernate/validator#hibernate-validator-parent/8.0.2.Final": {
+   "pom": "sha256-4IrtGYZCWE/kJxF/EYP1MEBxrMyRzJFjH/atokeNKoY="
+  },
+  "org/hibernate/validator#hibernate-validator/8.0.2.Final": {
+   "jar": "sha256-LyIkpaGb3PpzVA6f9clxtsQlrYBBWHbzBSWf6HOhWy8=",
+   "pom": "sha256-Gorr9UkAgnTLf81gjEiSLyk/LhK5qQF8J+342CHMOro="
   },
   "org/infinispan#infinispan-bom/15.0.11.Final": {
    "pom": "sha256-l1ZGl2WLzh5IwN06lHdoxhNyMtYVGVhBQhz8Q7GE6Cw="
@@ -1861,23 +1814,39 @@
   "org/infinispan#infinispan-bom/15.0.14.Final": {
    "pom": "sha256-Zf+BVhyv+gTTu4z0zZvKxlo92YG19ayVu/gEYns362E="
   },
-  "org/infinispan#infinispan-build-configuration-parent/14.0.12.Final": {
-   "pom": "sha256-WTir5k+BZwjr5C5mlla+UltuhfxMyAh3OkVqnp6ne6I="
-  },
   "org/infinispan#infinispan-build-configuration-parent/15.0.11.Final": {
    "pom": "sha256-utwbV7pKcUvVQfHty5kdfpBpDLJCNO8kd4ju3eO3jgo="
   },
   "org/infinispan#infinispan-build-configuration-parent/15.0.14.Final": {
    "pom": "sha256-Q164DFInvsRbB1WBQUrJ9Fz5gJ4lY+HIUeWlSTFnTG4="
   },
-  "org/jboss#jboss-parent/39": {
-   "pom": "sha256-BN/wdaAAlLYwYa9AfSgW2c3mZ5WsrjdqBUvf6Lox5mQ="
+  "org/jacoco#org.jacoco.agent/0.8.13": {
+   "jar": "sha256-nbPJ1ddPqHCyYbZKMIJBLhvW4i6fqY9HN7G/+K+cxk0=",
+   "pom": "sha256-auuUf988z1Qlydq41oPWu+MPCSjEWnAuYlWMblXmRLc="
+  },
+  "org/jacoco#org.jacoco.ant/0.8.13": {
+   "jar": "sha256-ZDS4VS/z0OSi+70Tpu+xJODJykU4F8YsA96DkNh//RE=",
+   "pom": "sha256-I4tCPVxuZQ9LQPF1T42iYQDHpzYz5d1RKIxzgHRj744="
+  },
+  "org/jacoco#org.jacoco.build/0.8.13": {
+   "pom": "sha256-mUw64c/KZ2WWj+Pt5PN5mGrrLn61GiAUyqSgnXGo9KM="
+  },
+  "org/jacoco#org.jacoco.core/0.8.13": {
+   "jar": "sha256-UUwj32z9AV19g8EKeS41q2int+gvPWo6RIF2LBMuM6k=",
+   "pom": "sha256-73/2F3zZcB1QXv6C9N1P6l5fcssEesK088qitBbaD08="
+  },
+  "org/jacoco#org.jacoco.report/0.8.13": {
+   "jar": "sha256-gTMoCgqkQ1i+nRNrUjcDQvRVzLlEquB0OCIKd2YleKI=",
+   "pom": "sha256-EBBlOpAAx+qoVqJx+E0HH/Rt6nojdbhKitmiOz5lPOg="
   },
   "org/jboss#jboss-parent/42": {
    "pom": "sha256-5BJ27+NQkFTLpBl7PWNgxR3Ve8ZA3eSM832vqkWgnDs="
   },
   "org/jboss#jboss-parent/43": {
    "pom": "sha256-PDredvuIOs25qKAzVdHfQGb/ucjHjwmyGenA/Co/Qxc="
+  },
+  "org/jboss/arquillian#arquillian-bom/1.7.0.Alpha10": {
+   "pom": "sha256-C/LOORlX466CMFpMzc3sBHzDEnr5Tq6Acwc72BnsHh0="
   },
   "org/jboss/logging#jboss-logging/3.6.1.Final": {
    "jar": "sha256-XgiksJLchbM38JEKdAVx2HIM+lZfq9iAqMr5SmV8pBY=",
@@ -1886,18 +1855,21 @@
   "org/jboss/logging#logging-parent/1.0.3.Final": {
    "pom": "sha256-mXLIlHSc2jVXZiF9Q97XAJse6ybgMBwwkUotslPdaFs="
   },
+  "org/jboss/shrinkwrap#shrinkwrap-bom/1.2.6": {
+   "pom": "sha256-HArIAaoxJb3l6IFrqHijJDJZw5bS845nbihSqcxVADY="
+  },
+  "org/jboss/shrinkwrap/descriptors#shrinkwrap-descriptors-bom/2.0.0": {
+   "pom": "sha256-h46wca0fSwyBVoU2sqOk996FqBSvxbGW2ambXjwKZYM="
+  },
+  "org/jboss/shrinkwrap/resolver#shrinkwrap-resolver-bom/3.1.4": {
+   "pom": "sha256-U9Rd91c4i2k6N0k7dODXqTjFc0wV+CYp1Aop3qnOt08="
+  },
   "org/jetbrains#annotations/24.0.1": {
    "jar": "sha256-YWZtvOfkLmyFtDwE/PuCk6Idy1WzyA6GknDOQsAaazU=",
    "pom": "sha256-mb7eKcAzHBlS7uBL+ZeN5TWpDJfi3v/6XgCTNRcZJbA="
   },
-  "org/jetbrains/kotlin#kotlin-bom/1.8.22": {
-   "pom": "sha256-yNeU63YYiNNDaeZ33o6roLAfnop1bPv/UyFcz6XFjD8="
-  },
   "org/jetbrains/kotlin#kotlin-bom/1.9.25": {
    "pom": "sha256-GZrnpYnroWgYRqlUmmlc87CkLB2SEZpQqDD/Erq7oCM="
-  },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
-   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.1": {
    "pom": "sha256-Vj5Kop+o/gmm4XRtCltRMI98fe3EaNxaDKgQpIWHcDA="
@@ -1911,6 +1883,11 @@
   "org/jsoup#jsoup/1.15.4": {
    "jar": "sha256-AGgw0Hl3EECN5VicGNhkNDwO8aOgxgPJyxOMlDtn2aQ=",
    "pom": "sha256-chKJC3LAuGDgIlhWvnQT5469Ps0+y4Vn3eaqxic9+4k="
+  },
+  "org/jspecify#jspecify/1.0.0": {
+   "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
+   "module": "sha256-0wfKd6VOGKwe8artTlu+AUvS9J8p4dL4E+R8J4KDGVs=",
+   "pom": "sha256-zauSmjuVIR9D0gkMXi0N/oRllg43i8MrNYQdqzJEM6Y="
   },
   "org/junit#junit-bom/5.10.2": {
    "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
@@ -1940,6 +1917,10 @@
    "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
    "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
+  "org/junit#junit-bom/5.12.0": {
+   "module": "sha256-v/EC0wjRgUHrv+gdhjsFmaMPe7rK291WmKnUNpL9pi8=",
+   "pom": "sha256-rhFA2ksa+nWxxD/+oO8MreDDR/r1mWO1xJk/RzJwCNQ="
+  },
   "org/junit#junit-bom/5.9.0": {
    "module": "sha256-oFTq9QFrWLvN6GZgREp8DdPiyvhNKhrV/Ey1JZecGbk=",
    "pom": "sha256-2D6H8Wds3kQZHuxc2mkEkjkvJpI7HkmBSMpznf7XUpU="
@@ -1947,10 +1928,6 @@
   "org/junit#junit-bom/5.9.1": {
    "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
    "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
-  },
-  "org/junit#junit-bom/5.9.3": {
-   "module": "sha256-tAH9JZAeWCpSSqU0PEs54ovFbiSWHBBpvytLv87ka5M=",
-   "pom": "sha256-TQMpzZ5y8kIOXKFXJMv+b/puX9KIg2FRYnEZD9w0Ltc="
   },
   "org/junit/jupiter#junit-jupiter-api/5.11.4": {
    "jar": "sha256-q4PvnlGsRZfVnSa0tYgSEpVQ4vV5pATIr30J9c5bQpM=",
@@ -2007,12 +1984,12 @@
   "org/mockito#mockito-bom/5.14.2": {
    "pom": "sha256-b9MRNhOpcvzRz6u9lpSP3OlDYH7PmpzBl1imA7mmMH4="
   },
-  "org/mockito#mockito-bom/5.3.1": {
-   "pom": "sha256-F8lglCSkwzBWhOTlZS9VQRAyV1wafKPXhZZiEEafJTU="
-  },
   "org/mockito#mockito-core/5.14.2": {
-   "jar": "sha256-IpYUHB4fLhrjXAjTapq0Vj7NZuA1M/6CYwp2TnqkkYI=",
    "pom": "sha256-Y45Wpo9JaHm8ig9Tz735xMw5pFtuQ4ozOl6oPAnunP0="
+  },
+  "org/mockito#mockito-core/5.17.0": {
+   "jar": "sha256-3/Wa2MYbAm74bMET+U8jAesGyq+B3sMMeKlqGmVZXF4=",
+   "pom": "sha256-0BzBTnZhxjBHlApC9Qc9Sg7L4qDqXS6jQgS0zAgeFqU="
   },
   "org/mockito#mockito-inline/5.2.0": {
    "jar": "sha256-7lLhwpmmMhhPuidKk3CZPgkUBCn15RbmxVcP1ldLKX8=",
@@ -2059,31 +2036,43 @@
   "org/ow2/asm#asm-bom/9.7.1": {
    "pom": "sha256-qNMCypF0b46grZBx9i/zoNq9Ov5h2hTMgMHIdc9hi0I="
   },
+  "org/ow2/asm#asm-bom/9.8": {
+   "pom": "sha256-DaHcsibmzf2ttNrFkZFruRe1c3RnTZG9LxMAMTe0FSA="
+  },
   "org/ow2/asm#asm-commons/9.7.1": {
    "jar": "sha256-mlebVNKSrZvhcdQxP9RznGNVksK1rDpFm70QSc3exqA=",
    "pom": "sha256-C/HTHaDJ+djtwvJ9u/279z8acVtyzS+ijz8ZWZTXStE="
+  },
+  "org/ow2/asm#asm-commons/9.8": {
+   "jar": "sha256-MwGhwctMWfzFKSZI2sHXxa7UwPBn376IhzuM3+d0BPQ=",
+   "pom": "sha256-95PnjwH3A3F9CUcuVs3yEv4piXDIguIRbo5Un7bRQMI="
   },
   "org/ow2/asm#asm-tree/9.7.1": {
    "jar": "sha256-mSmIH1nra4QOhtVFcMd7Wc5yHRBObf16QJeJkcLTtB8=",
    "pom": "sha256-E7kF9l5/1DynZ09Azao3Z5ukhYxsnZ+48Xp6/ZuqvJ4="
   },
+  "org/ow2/asm#asm-tree/9.8": {
+   "jar": "sha256-FLeIDLfIXu0QHicQQy/D/7gydVMqaolNxMQJXUmtWfE=",
+   "pom": "sha256-cUnn+qDhkSlvh5ru2SCciULTmPBpjSzKGpxijy4qj3c="
+  },
   "org/ow2/asm#asm/9.7.1": {
    "jar": "sha256-jK3UOsXrbQneBfrsyji5F6BAu5E5x+3rTMgcdAtxMoE=",
    "pom": "sha256-cimwOzCnPukQCActnkVppR2FR/roxQ9SeEGu9MGwuqg="
+  },
+  "org/ow2/asm#asm/9.8": {
+   "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
+   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
   },
   "org/postgresql#postgresql/42.7.5": {
    "jar": "sha256-aQILO9IJhFQ+gXOT8ubAGokO8uN6d90R1thQgYHQeas=",
    "pom": "sha256-FB6pP8GF3rFdKPz+P+qAivQBic9pEtaPMW6GjXzq/kg="
   },
-  "org/projectlombok#lombok/1.18.36": {
-   "jar": "sha256-c7awW2otNltwC6sI0w+U3p0zZJC8Cszlthgf70jL8Y4=",
-   "pom": "sha256-iaIdJYdshWLBShDxsh77/M6dU7BYaGuChf6iJ2xTKQ4="
+  "org/projectlombok#lombok/1.18.38": {
+   "jar": "sha256-Hh5CfDb/Y8RP0w7yktnnc+oxVEYKtiZdP+1+b1vFD7k=",
+   "pom": "sha256-gWXuhymafa8GmnyYG3u4YENCE7mvyqurC0abO6v0jm0="
   },
   "org/seleniumhq/selenium#selenium-bom/4.25.0": {
    "pom": "sha256-WWonHEIBciy0qtEP9MnOu2+J/AixL2vjSxwMFz+R+m8="
-  },
-  "org/seleniumhq/selenium#selenium-bom/4.8.3": {
-   "pom": "sha256-VjKTeC4Y0PLA1r3M6+vjQUjw7LuSuBjbCLhAXtOuCB4="
   },
   "org/skyscreamer#jsonassert/1.5.3": {
    "jar": "sha256-cZCVwH1CA5YTINpZNEHYs7ZDwY6x2Bqpjqkzu36zUbo=",
@@ -2113,50 +2102,55 @@
   "org/sonatype/oss#oss-parent/9": {
    "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
   },
-  "org/springdoc#springdoc-openapi-starter-common/2.2.0": {
-   "jar": "sha256-zEr8QIcXzwP6tvVFrZZ1eDy6+D18h04LrnLLWPh2OG8=",
-   "pom": "sha256-ispBYN10vlujiirctgHGPFZ/ezLy1oY9/d2hkAX1yu0="
+  "org/springdoc#springdoc-openapi-starter-common/2.8.8": {
+   "jar": "sha256-1hoKqKBCy1pugrWXy0Kt5/gpQ1BSuW3Ks86w7unXjvY=",
+   "pom": "sha256-Roplh09HFBcVRLfUBKUYX+rIgOlis6x5iKWAUkPKXUY="
   },
-  "org/springdoc#springdoc-openapi-starter-webmvc-api/2.2.0": {
-   "jar": "sha256-0LKlyYo07K2f0Mwo2mz5sH37yHeOJlMZAF0sSvI2+jI=",
-   "pom": "sha256-ZPUNQT5EKWrYbXRpe2WRlpLRoZ8kuR5yqDA25VQXKqo="
+  "org/springdoc#springdoc-openapi-starter-webmvc-api/2.8.8": {
+   "jar": "sha256-HB1c8/n0BZe5LJxhWLcKGH7Bn5B4fytLXMZzqojdbuA=",
+   "pom": "sha256-tQJvlidK4lkkR8fGpHAdrDxojWwunrVPQVttWDftAwk="
   },
-  "org/springdoc#springdoc-openapi-starter-webmvc-ui/2.2.0": {
-   "jar": "sha256-2+lkQpxHn/vJKynrfLO8cRNuGzShifnOk0pxX2Uje9g=",
-   "pom": "sha256-Cv9w4vNuOl5Zgq2nnSbUxIiN4Umoiqya9fVdJ9ukizo="
+  "org/springdoc#springdoc-openapi-starter-webmvc-ui/2.8.8": {
+   "jar": "sha256-yV5d/9HLDEanOhaKXzpNxYxwD0avgPrrw2WjWj/2rak=",
+   "pom": "sha256-iLo+WReLVXaDPCpt/XZNW43HBahiXoQwWU7AnCLchxw="
   },
-  "org/springdoc#springdoc-openapi/2.2.0": {
-   "pom": "sha256-Los3sS+E+doEZrqeLfbA2nneG1cyCSPFNW/oXbE0d2w="
+  "org/springdoc#springdoc-openapi/2.8.8": {
+   "pom": "sha256-blFe2YX6GlNIY1v2U5ju+DoulRzS0qqJmsoPL0cp60M="
   },
-  "org/springframework#spring-aop/6.2.5": {
-   "jar": "sha256-395Y5bJ34S5GTV8NfWDEnOEMltqUqjKhlqhxFGevfdg=",
-   "module": "sha256-f6Dxb2n+7LNO34y3IH1gjPpX915HPteyldfPup6/pzE=",
-   "pom": "sha256-gztBWu9TrsbeBwyLPxbR2Oe5s05u3iITZqkgUeDr464="
+  "org/springframework#spring-aop/6.2.6": {
+   "jar": "sha256-AoTRVciHiRY2cMhQKqTyZTfLIBEpGs+FDNvxf0m+xQg=",
+   "module": "sha256-nYelsI8z/XKXoUy5uFAXZIkLnzgfZ4mfRzEHkiu3DjU=",
+   "pom": "sha256-Vt7M8p64xvH8pkI5oOemRxkkJde/nOMreHHl+EpQp4I="
   },
-  "org/springframework#spring-aspects/6.2.5": {
-   "jar": "sha256-T472n/xMs9ZRWWoA9Tsp3IE+QOdVI+1SE1R+ILR9jY0=",
-   "module": "sha256-m2Mfr9pqsDBYvRgWKNuqmpCmdoPr/XG8VR7QiuO8A0c=",
-   "pom": "sha256-/f3/3OATylEIH3FHjCJL5MV3Sp9xaAhFtxGi0ngb4io="
+  "org/springframework#spring-aspects/6.2.6": {
+   "jar": "sha256-ALFuK1Aa9mHf8g6/VZ5ZWEE9WENVUf84/Ou6Wtv0yeY=",
+   "module": "sha256-vAs56alu3EWPnnDfwx9MA65hZDCXNzoNbOHjmPLxEQw=",
+   "pom": "sha256-MYyyy8N6qAzdlIZd/zbx6dwigbaoh0oaS+w3jcNVCmU="
   },
-  "org/springframework#spring-beans/6.2.5": {
-   "jar": "sha256-Y/f/ZKchh9ccQC+Md8X+a6nTjgNGXk+aYBw1IiZQUdQ=",
-   "module": "sha256-5F34QHwHIM870oc5E3wmxlPAUrg+TIenuT93XsVACbM=",
-   "pom": "sha256-ljzIyX+2b5jjYtGyMAfO/yy5ptvQcm7LWMNyS5YsxJE="
+  "org/springframework#spring-beans/6.2.6": {
+   "jar": "sha256-cj6OaHCf98h1nOrbpt9Hc756Rt7kOHRaSoXQAZ6KA7I=",
+   "module": "sha256-ZG1QmamO9qx4SMG85d/NR5LWgEKf4oS9iERG70WxWeg=",
+   "pom": "sha256-2lmNjVTTgVLzE2rP1STpkz3wxEFG+gH3nWgf1Og2Lh4="
   },
-  "org/springframework#spring-context/6.2.5": {
-   "jar": "sha256-IZQeDJ8jMQx4QD81piSyfzoTAfHM9d4lDXR4lW57q1E=",
-   "module": "sha256-XMaESKC/guHdXkrE+UwDutYJCsjV78j405IIwZT+H+k=",
-   "pom": "sha256-E2zENI5nYWgl3gvzfj/nSx4fGaisOd8Pqs4p8ZK0syM="
+  "org/springframework#spring-context-support/6.2.6": {
+   "jar": "sha256-T+tKHPs6GEvPXxmeIJk13plEsYto0MD0PmBqrJ3lH78=",
+   "module": "sha256-t5AQSQ5WbJxMjWA3KirzapN8kC29/ff0+vBTnQ3G+2Y=",
+   "pom": "sha256-C//XeRgUpDMybyw6E+MdaGpgcOWgo7Pa8y/jHB1cW5o="
   },
-  "org/springframework#spring-core/6.2.5": {
-   "jar": "sha256-TO4Czy0CJ8Hxv7l8Ltwp06+DuTyD0Is45Zh8P6D+Tx4=",
-   "module": "sha256-L8IU0itA9AB9/adE+FHn755yjRgoYFfw9ZTrlUvIriA=",
-   "pom": "sha256-K2lVoWZQfbOAVQK84ifbJ4+s37ynyqM6cThHhw4B8oI="
+  "org/springframework#spring-context/6.2.6": {
+   "jar": "sha256-wLFq6mk7a45TUMPzrb7SG4jZ6E7A2Ls63qVXXppRX/s=",
+   "module": "sha256-sXjq2/g0srdqhEZ/Ed0xlNA/CZtvgQD4YVfhftQXB+E=",
+   "pom": "sha256-LY4tFF+RzdG+3COzDsr9amsttgrmGkE1YM07ANefCGc="
   },
-  "org/springframework#spring-expression/6.2.5": {
-   "jar": "sha256-7HbEHU5Fd5tIrhACAyKzLssuL08tkwsNk4RKREkNdsU=",
-   "module": "sha256-TE8PHZ7MMmFpCaLKjP5X7wl7KWospGVbaSvca7jiWqQ=",
-   "pom": "sha256-XEmjLJcqg+VTBOnDV+EWgF6yFkavvHoXSEAgRXPLpmM="
+  "org/springframework#spring-core/6.2.6": {
+   "jar": "sha256-d2KPuou40Fm+D7NVqXFv77gItcfZ7ZxXSkomQUBAQ1I=",
+   "module": "sha256-EsBGMpbwEoFrgvTpOXqkdHrj3g6KE6ksNGLARgwd3Jc=",
+   "pom": "sha256-8Au6GX8JRAUsuQARNpJBaibtMMMUNkbqXJujXkNCcBw="
+  },
+  "org/springframework#spring-expression/6.2.6": {
+   "jar": "sha256-/fNVgWviFHTt96hT7Apux/xcnKvLW8ROmzr7F6dOXzM=",
+   "module": "sha256-jY930XK2pOfVg3qd3QH9uBMAg0+zeVjqRzZGKdCHK98=",
+   "pom": "sha256-qEYrMZ1BNVXAQbCnfeNhG5bdKa/nVKXrvveoLF8xK58="
   },
   "org/springframework#spring-framework-bom/5.3.25": {
    "module": "sha256-bPPIDzsrxVO0LptyC/9x/bBxUmy4kMVwkz2deAd2JQ4=",
@@ -2170,214 +2164,212 @@
    "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
    "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
   },
-  "org/springframework#spring-framework-bom/6.0.11": {
-   "module": "sha256-CV5xI53YkWkSRMjWvm19o05nC2UYaUeexdJBXZmrYZI=",
-   "pom": "sha256-SK3yYlH1WiPKJZbVBuBZEdmnZ3fm0CxSgMGhd4wUMGc="
-  },
   "org/springframework#spring-framework-bom/6.2.0": {
    "module": "sha256-8KnavGjttkVgoh3q0GDDB1D8qckDYQYgonMZs4oewCA=",
    "pom": "sha256-c9YvN2lzSpSUY+hXhSoVS6qroJ0Mdm40QQZs/q46fsQ="
   },
-  "org/springframework#spring-framework-bom/6.2.4": {
-   "module": "sha256-AsGZBljD+XSn/kaO10kF5mAnMW2xP0LfAtkPvLd6Qbg=",
-   "pom": "sha256-4FloFPbXFJP9SFVPOqTQ5XG0SWOWs61IfsLljw7saUA="
+  "org/springframework#spring-framework-bom/6.2.6": {
+   "module": "sha256-Jn2C9ozgsPmgTvw6laORJ0u8UosqVJ2+m9AExjTwa2A=",
+   "pom": "sha256-kMAgfqwMHP6EJr+gdzjROnv9xBy9sf+wyYzP7RnEn84="
   },
-  "org/springframework#spring-framework-bom/6.2.5": {
-   "module": "sha256-cGjuMW7K/Caddl57c+LX/cK2kvwtPMeB2uiPspDF2OY=",
-   "pom": "sha256-fyh8p+xN0cZuM13PyktIXJILcYVK2VTadN7UInPyW2s="
+  "org/springframework#spring-jcl/6.2.6": {
+   "jar": "sha256-0XNXrA0/CNibeABNZr0t34oI1Ej/8mmBuvMk55GoU5I=",
+   "module": "sha256-Y+dV4bYsm+Tlb72iR9r4A9xZnCVX0f8EKHO+DJohR6I=",
+   "pom": "sha256-t7p5PSCaef8RU2+h2kBVBHU6vZT/rJRy2R+0lAiv66s="
   },
-  "org/springframework#spring-jcl/6.2.5": {
-   "jar": "sha256-T5ORX6sQwU3zuQBUz9XRwBop3vWbbiXA8z2erE/+wHk=",
-   "module": "sha256-XmoAS9bTzk9i7in2ByXOmGmn9q3uqHiA6oGj/CPCPRI=",
-   "pom": "sha256-8t98qvowo7Ku34ViqGh0RsJUMviNNvGwt3+keA7nxr0="
+  "org/springframework#spring-jdbc/6.2.6": {
+   "module": "sha256-rP3SmNfJEz5KNxfjG8Vu2LpoWtAJ2r4xNh6vrcpWLbw=",
+   "pom": "sha256-0l4CigQ0mD/Nxwge+UkfKk1ZCXxSOwDx9CLRdfW+mt4="
   },
-  "org/springframework#spring-jdbc/6.2.5": {
-   "jar": "sha256-ImiwovsId/R2d/bqZ/KD2XK5WR9M0o1jcZo9+6vNCi0=",
-   "module": "sha256-K4G/JP/SmxlnnDJ8o+A5YpO6eHzYcmrDINxH/hkuqSY=",
-   "pom": "sha256-7sBqbI/Klbvud5iWqhquoDj5UbLHCBw3X2BiCh5YksM="
+  "org/springframework#spring-jdbc/6.2.7": {
+   "jar": "sha256-yqxRF8AKVsArN/yzAPXgIG8rd6LPznnIhx6mZMLPWUo=",
+   "module": "sha256-mToXDQZIGR75ixWe6K5Omyr7BSbzjT2c0Wo00LJP0qM=",
+   "pom": "sha256-ihj2+Az2Wzkw3dYhnjoZc7WAxfO1rsSuBC7+oaJhIHk="
   },
-  "org/springframework#spring-orm/6.2.5": {
-   "jar": "sha256-CMVMIusCIhhOBvvq1qjCBwmpsflNYYJYJF/gHvtgJEs=",
-   "module": "sha256-brvzlRbCRfEqMBqxIdPYhbxwRsrhwqRGM2jdUclxeQI=",
-   "pom": "sha256-6u3ZSb3Fmcz0Pl51Ud4YQtL1zy4ioHKLmYpqkVf8f74="
+  "org/springframework#spring-orm/6.2.6": {
+   "jar": "sha256-YFFJi2F2Po4cRJt9tUBDPy268VK/XtR6kPB65d9x5vc=",
+   "module": "sha256-LZIVP5wvbWrBYPPPnfsZoNgCZql1YQLVjM4M+J2RB0w=",
+   "pom": "sha256-E4+xlYD3nZUnMpYls6eujoy5LVAPji0DHG87mcI16v4="
   },
-  "org/springframework#spring-test/6.2.5": {
-   "jar": "sha256-VYVYYpbPl3jY0CeXG1KXRlYeDZspU9AJVrJ6H1sfDX4=",
-   "module": "sha256-K0bkH/tj15DGnUfq/EX/SPa+nQIuyTHIHJJP18bB7uM=",
-   "pom": "sha256-8VFyp2/mWduThqY9IJaa/zeeYpjtx/IC/DaJ+Np8paU="
+  "org/springframework#spring-test/6.2.6": {
+   "jar": "sha256-u+uIBphdyhaJLmlEW55SfBUl7VqbZsOY2rl4/1QCyaU=",
+   "module": "sha256-Ihxh78H51GU6QNuM9eotXDzv2bIlF7MFnLJKlMMIHAk=",
+   "pom": "sha256-G9qkptxIhvvmjxubmVHL1KSLWMgOeed1MJ+lEahFS6E="
   },
-  "org/springframework#spring-tx/6.2.5": {
-   "jar": "sha256-oPxPJ14Ezxsx3ei1NI4Q7QM3LNc0xuPRTghjJjeUqeA=",
-   "module": "sha256-EgVuBdYr9YBe8u2K1iMDs+92xorwqGYpju0nvmZH7+A=",
-   "pom": "sha256-QIUxUoXgMOOw/bQaghZnhxxwyZiOaP1BrUre6nt16uA="
+  "org/springframework#spring-tx/6.2.6": {
+   "jar": "sha256-mMi1mi9ZtXXhZldzFtbQYIxj1ZWSxQJSj/aFPvY53+0=",
+   "module": "sha256-dEKK3F5aRz1GwpZKMuel4Pqudj7VS7lR/s2qgoH27VA=",
+   "pom": "sha256-b3gFFVmg91AdOgrBWHwslcfsGbyRaA9vJCDVZq5iSM4="
   },
-  "org/springframework#spring-web/6.2.5": {
-   "jar": "sha256-hfDBrK8DOl96vcrzSPHdLOvh93aH7nfwXoy2a/vG/s8=",
-   "module": "sha256-yEX4BsUU3Z2Kjc1bq0+1fTi6IaAB7m1vfjDwsszJ7Zo=",
-   "pom": "sha256-QJ3SB/YroB93ofMB8PpbendWZU2lcrXpPXw4qoqDIik="
+  "org/springframework#spring-web/6.2.6": {
+   "jar": "sha256-g0GuRIgP5BfRvJhW0Ba7GCaXazCSqKq32fJCr2CltwI=",
+   "module": "sha256-HzxUl6NQ5QcBPKOKiVDP8yG4lb4c/a4rqcHy851g5sc=",
+   "pom": "sha256-ogIJkFy3wQ4wM6eJYVYkhQQ0D6WhoW1aS7arkLmVu28="
   },
-  "org/springframework#spring-webmvc/6.2.5": {
-   "jar": "sha256-uNKBrt8enL9zuyxs9y0+r4Efkpiy3FAX6cQLPLkoS0Y=",
-   "module": "sha256-pvMa5KRyE+iNlZnYvLdMYL9oAvbXurMsbi74oXJmHCA=",
-   "pom": "sha256-32UTRYMZFI7c/ZkZiXoc0l7EUD/XcRTqe3ac3QEf0nU="
+  "org/springframework#spring-webmvc/6.2.6": {
+   "module": "sha256-mtxLQ+aQXghg7OB/K8gQRyu1pudULyXArZt7anNMpCM=",
+   "pom": "sha256-Hd9xGoscjVCQuyUSl+kswkXV0vb3Pbi4zqLr1gzCgCI="
   },
-  "org/springframework/amqp#spring-amqp-bom/3.0.6": {
-   "pom": "sha256-sch8n8omH3LZPz+tDWBfn6FQECv1fU6eT9Ga0ltYvB4="
+  "org/springframework#spring-webmvc/6.2.7": {
+   "jar": "sha256-UMgBdo5J/EjI6S4tlKgDryCeofXjEmvY1zcLXFm55xo=",
+   "module": "sha256-2+6Y+/e7QWK+6xOOjfKUtVeuDVU/1WFKgm0+YCSHTws=",
+   "pom": "sha256-YWQ2iJhLpa+LY4L7EYW9fjm+zEZ5Bwto2Gqk1uS3dqI="
   },
-  "org/springframework/amqp#spring-amqp-bom/3.2.4": {
-   "module": "sha256-6GajudWTyzW9is6za3K6oNenSrtg/izG5fkN0nqmgGs=",
-   "pom": "sha256-16+mzir5n+3pJ+EyyGq3N9gTZKDwyzHF3sAFLx6UsKI="
-  },
-  "org/springframework/batch#spring-batch-bom/5.0.2": {
-   "pom": "sha256-aDpeNRsQ0aR8gkN/CtTnhmTUICWhpXBtaPpDhCHt1uw="
+  "org/springframework/amqp#spring-amqp-bom/3.2.5": {
+   "module": "sha256-L+YuO5sm66R7/4yjIwTfwCf15Gtnn3mrXgu5HhnY8Yg=",
+   "pom": "sha256-BGTRVbnvEgFUAEEC2/tuYXPfdf0md8db8NESNUU+Nqk="
   },
   "org/springframework/batch#spring-batch-bom/5.2.2": {
    "pom": "sha256-SJs2UNjohLCPgk5pY7T9M/GIrgTewdAIIP4Ap939nsE="
   },
-  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.4.4": {
-   "jar": "sha256-vtL6GJeJuV1RHOGDjf+cBBo0yT2sb5A8OoaVnbAzt6w=",
-   "module": "sha256-/cS/xtYp8OhC0TTdpxBeo+A0pzCGtDMdbWTQl6DBJIY=",
-   "pom": "sha256-KWiDSGfOQEdgqdAFG2kdJhgr8qDzmntixSy5E1bQ15Y="
+  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.4.5": {
+   "jar": "sha256-EHML0GA1vzpUbYW84NIg1Tqx6CQHwpir4QGoCnVIqzM=",
+   "module": "sha256-R+2kmOtTQ9kpXvtBz+v6aruKe4WWMg64vyzVU53RT2Q=",
+   "pom": "sha256-uxd4qxgTmxMMymT9u4KCvjeXS8MDqijfs2+6ks8Fw2o="
   },
-  "org/springframework/boot#spring-boot-actuator/3.4.4": {
-   "jar": "sha256-lMHGya+W1NLKSvVbgMd4uXUPzGOjeIk/WHMSKzucDfw=",
-   "module": "sha256-Zj8ORbOC7Bem+WXDUoaiwZ4DPhWrTXCqdyCtsrzpbV8=",
-   "pom": "sha256-mQ3SrTASowMCG0NkWxC+1yg/nSO8J8AsMgyopr+psaw="
+  "org/springframework/boot#spring-boot-actuator/3.4.5": {
+   "jar": "sha256-QH3YfIlm4an0vTLNhOvuAZKPENHmAknYhLMrHQCijes=",
+   "module": "sha256-/+mDmdt8brLFw00VBSSgUqwLy+qyd8+ny7mNPBlFf5g=",
+   "pom": "sha256-meBJcm2foegwM4o8a9BFqaj71aPXO5RkxcLFiW+D24c="
   },
-  "org/springframework/boot#spring-boot-autoconfigure/3.4.4": {
-   "jar": "sha256-BKO098Tgqzn7i03XeiCS7VwDaWETPSeAYK8URV3FXTk=",
-   "module": "sha256-IcDgeQGfH0VlygVqmP8m+abKJ2BqHV1u6ky6IlU/d20=",
-   "pom": "sha256-AdJdJ6o3eAfpMWPgjZcIQKwN9gBDTUgwb78pbrVWLf4="
+  "org/springframework/boot#spring-boot-autoconfigure/3.4.5": {
+   "jar": "sha256-0hvBzHog0EmICoUQFoVu4NGi41xVA9xhj929jUr6NkM=",
+   "module": "sha256-ksuEMVzI10yfhujFv4USMFE/YNivToPeuqrzbYosX1Q=",
+   "pom": "sha256-RfP7LoODEY8pmL7yjruw21P/o7A8rffhQBalD4pVpAk="
   },
-  "org/springframework/boot#spring-boot-dependencies/3.1.2": {
-   "pom": "sha256-DIaB6QfO2iWOWU6lt8/aByuKxHDamKrAGEqO62lQV9o="
+  "org/springframework/boot#spring-boot-dependencies/3.4.5": {
+   "pom": "sha256-EOAJspHTC/IW92Dp3lQwFoTIXhL2vNKTmo3zxZmkmEU="
   },
-  "org/springframework/boot#spring-boot-dependencies/3.4.4": {
-   "pom": "sha256-6ptKw3zUDVMf33fO3yIIrSrmhN5FQ4kfDDJyCYFp4Bo="
+  "org/springframework/boot#spring-boot-devtools/3.4.5": {
+   "jar": "sha256-xkYQPHYfUE1NA66eyiwU8uWdPxTeLTdyAARVep991xA=",
+   "module": "sha256-ifsz+DqyilVJwMRnmSczA+v1ROkxS7iXPD5xboLNljY=",
+   "pom": "sha256-56jQVBSRov8CU42GqAw+h9mz9CoyF1NtkM1Fl9GcrtM="
   },
-  "org/springframework/boot#spring-boot-devtools/3.4.4": {
-   "jar": "sha256-o73D3co6U8KwF5c3bqvbcYrT+5qzAboEI9OG/5X8ARU=",
-   "module": "sha256-+w/feE+rwolwt/jHnNN66tVSqAbqzKps/cqcZZlL3ro=",
-   "pom": "sha256-Q+9kcSYqi1KE64ZYMAslgujy6bVO+J37LeIUdGmvWnQ="
+  "org/springframework/boot#spring-boot-starter-actuator/3.4.5": {
+   "jar": "sha256-xEI+dtiVFdz7daQ7qcU0hJgtpe+XrTXNoj8K81P2feU=",
+   "module": "sha256-L/MPa742leBdkzqmr+8FlgBydOf5BXDxhWxHVvnqpRI=",
+   "pom": "sha256-v0pirgI+9/J0hUUJIL1NlZE7YX/Y7xZqSLuej+coDak="
   },
-  "org/springframework/boot#spring-boot-starter-actuator/3.4.4": {
-   "jar": "sha256-c4501nr76yKerWHT4jNHfum0XwB3iQeaWv1/g5ukF88=",
-   "module": "sha256-hCSxu+We4S+wKH8fohf4CYYXS8Fj84SzyCDMc/XwGq0=",
-   "pom": "sha256-myBG2TnIK/cH2rpzNkY1OW2mPnc5X4nlxEpzeWD+MsI="
+  "org/springframework/boot#spring-boot-starter-data-jpa/3.4.5": {
+   "jar": "sha256-Lxox3ZpHWldQ7lium91Q51/3Lhz7/lpnq4zU2fnKN+M=",
+   "module": "sha256-0fLQu2p5MkjCdLQmjzRtRXte6pcXeHE3ILHBzCM3B9Y=",
+   "pom": "sha256-0kexa7follZMF55YRtbqB7mHlQhXYLnnjXglPjT3/zA="
   },
-  "org/springframework/boot#spring-boot-starter-data-jpa/3.4.4": {
-   "jar": "sha256-skBAVJ48JRWWGJTeUaL9Kqw//DGSmDDnDkNAvpv2Tbw=",
-   "module": "sha256-H/DOoNICiZXVNUcAjougxyTr/WUK1omOfFaoXnR5TyE=",
-   "pom": "sha256-OOG9qSGt+LtW8TVAknHeoaQQCG5izZx6QyFefAVKW/E="
+  "org/springframework/boot#spring-boot-starter-jdbc/3.4.5": {
+   "jar": "sha256-TWaB+c2HRPYTWuQ1Ozpx5jql7NdnsaEEH4JZJ1wgJ8Y=",
+   "module": "sha256-iNN5pbb5tChh7OjDwjBpxqOXPYzGLvFK13YkaabrOn8=",
+   "pom": "sha256-oA9Z+iGWNi5jRnoKvc7MZb6kqYULTez9IbSsDv2xxc4="
   },
-  "org/springframework/boot#spring-boot-starter-jdbc/3.4.4": {
-   "jar": "sha256-Fwq7oCy0t9W72pZYctVNWH7B+nzQSUM3umopRAt0Tlg=",
-   "module": "sha256-KwQs8INnguLfp81ejxhYSN/4B6YlKpMn+Y3nDecfDi4=",
-   "pom": "sha256-NP45Tc7DfcNS22b/m9hu3n1zyyzKOprB7umwWJpKCJs="
+  "org/springframework/boot#spring-boot-starter-jetty/3.4.5": {
+   "jar": "sha256-nWiRyQS9t7Jxpbe8pUI8+b33AbUUaj0VKY8fWOxWAMA=",
+   "module": "sha256-9gnl+RMzFE/qAPJJaxCq9JPBK4+7tJOigQsYD1SVJaA=",
+   "pom": "sha256-JaYQzB/d8M8owDn+3vU7a2CdI0xE9jdGXsmAWhQvJhw="
   },
-  "org/springframework/boot#spring-boot-starter-jetty/3.4.4": {
-   "jar": "sha256-iZahtQOPlQUlFf4zDmdpwPS95N6LhNSzpAOXcv8TT6I=",
-   "module": "sha256-hIf1ZE7PjN+OuT6vsJ66eqy71qLZFpxb/VFK4GHRBrc=",
-   "pom": "sha256-XZqnFLOmdOrZ+a9Kyv12/soP0r3bjsEfyMswA3Cl/BM="
+  "org/springframework/boot#spring-boot-starter-json/3.4.5": {
+   "jar": "sha256-x9OCKcxOlgqUS8Cm0Q4egXMbA7CICS0VQA9njzsAzLM=",
+   "module": "sha256-h8xJpgbldNYb/ZD4SfIG+SYaUvwK9HNfUSKpv4Dm8Gw=",
+   "pom": "sha256-Qpa7UVjcQBp1wvKO54h9zPx5ZYU9ZU9PzuZDxc8hjbU="
   },
-  "org/springframework/boot#spring-boot-starter-json/3.4.4": {
-   "jar": "sha256-yS3db30QmlFzkaWcDZ1PAlbVxbqNtdGvRxDgyhf98sI=",
-   "module": "sha256-Zuu/iZ4e4fy0k8FPBuUvlri8ukkyvegnCcXuSpupR/g=",
-   "pom": "sha256-FtGm0ENM4DCz0BmII1NlzhBrOTCgt6bOhckzZcL68Tk="
+  "org/springframework/boot#spring-boot-starter-logging/3.4.5": {
+   "jar": "sha256-0ZRJuqXaw33Xy9m4iJB+oxYg2LPbXe9xAuAJocxoxLU=",
+   "module": "sha256-co58/APEtOa4ZmBGMuu0fQzP5dp07G8VfykOnSCC92w=",
+   "pom": "sha256-KhkrknD/nmU/ZPNPfuDHJkg8ytGO3fK25JDK6Rx/iXk="
   },
-  "org/springframework/boot#spring-boot-starter-logging/3.4.4": {
-   "jar": "sha256-H80SNqOLXuvDV1J8BYBwZpJyt7YMg5T4h9uIK0tHokA=",
-   "module": "sha256-nppuvQXs+pb6EM8UamLBDQxUP6mvwC3ii7VAwp6prj0=",
-   "pom": "sha256-4GxccC+sEHw2beJEAQEwyGogewHcLXnNi0b96ngYIok="
+  "org/springframework/boot#spring-boot-starter-mail/3.4.5": {
+   "jar": "sha256-573SFf7+sQJaG6t15Y8ebksq8FRMTAUS6aHjEHKUc74=",
+   "module": "sha256-R36TwBKj/VWPTIhYejL6TeBCu1IHOwuMe+qExesV5zk=",
+   "pom": "sha256-5vVXZFpvYGBBVFgsVN+r/NAEhiUu8WhXqkiaj81DvKw="
   },
-  "org/springframework/boot#spring-boot-starter-oauth2-client/3.4.4": {
-   "jar": "sha256-vCtxAsJkixgBiBPA/5p24DyIUTv+u/fgvQeHfgpn6Ik=",
-   "module": "sha256-BGYau4OFMgpJTF2H8vyw79qWCXfyAeYE3/KBKzu37mU=",
-   "pom": "sha256-0h5c9iowmm0mkIlbRTh8gEAxBOGaIXDRSWhMWQy4hPg="
+  "org/springframework/boot#spring-boot-starter-oauth2-client/3.4.5": {
+   "jar": "sha256-K/0SWxS1H7+ARRvtFjeEf+Yzy6ZtFTv5XXZIH8tqozc=",
+   "module": "sha256-WzFPFndGoHNTbqCQRRAY2tXR0+4JNOF+gRT2eqK9rSs=",
+   "pom": "sha256-Cuq0L9MmlNvWuuSXAWC4do64+8uq4OtUJ09CjxOaTxw="
   },
-  "org/springframework/boot#spring-boot-starter-parent/3.1.2": {
-   "pom": "sha256-TB9NCfr9cgJEhZCDvfx7VytHF22Bil965q1m0ZOODO4="
+  "org/springframework/boot#spring-boot-starter-parent/3.4.5": {
+   "pom": "sha256-Fos7OtVWRcT+MC9tnWEDE2GhqJEBqH+ZhDPdlSLS3FQ="
   },
-  "org/springframework/boot#spring-boot-starter-security/3.4.4": {
-   "jar": "sha256-eWRSwgqaC0btch1vMv012vhAdOjjRc7IMYrRIX0I5/E=",
-   "module": "sha256-CC3hd2cjAqqwSgqbeIue3kmFYlETplmC7jJBaEtcVzk=",
-   "pom": "sha256-w9zMpiZeWDAbC07uiSG/IM49etts8svVlA8Zs4k02MQ="
+  "org/springframework/boot#spring-boot-starter-security/3.4.5": {
+   "jar": "sha256-W63D0LX96YJY3L8RytfapWuGF2uBF38vEb8qnSpEHt8=",
+   "module": "sha256-AfALf7b1UsYCbAifSijZicHIJnia71w1xnhN+5OSbLY=",
+   "pom": "sha256-/7YtRp0z5K4JUjBMsLg78U3wD2d82e5/b89VHG3w1m8="
   },
-  "org/springframework/boot#spring-boot-starter-test/3.4.4": {
-   "jar": "sha256-7z4g9cxwRspOefXHVv9qKz0QSs1D+s8+fP7+x6FejAg=",
-   "module": "sha256-WWkQeS6C2rHBnOT9iAzbIt74WZQGYSxNAYKHyMDf5sk=",
-   "pom": "sha256-Mh7cErHbGEV2excLV1Oj/iOl+Ld9HS89vagkAO4omis="
+  "org/springframework/boot#spring-boot-starter-test/3.4.5": {
+   "jar": "sha256-Tvo4g++TSPifMNN8LvNkjCtzSBGLegp281C15xh9ipY=",
+   "module": "sha256-/MvSuZhpE/g+/DT3xQ9hs8p9S5g69X1Tuj/yNyFOVKM=",
+   "pom": "sha256-imsMoLeVEMa7LtAJae+MXH/el7J+P3e8/Mav40tRogk="
   },
-  "org/springframework/boot#spring-boot-starter-thymeleaf/3.4.4": {
-   "jar": "sha256-y2zT/kOStQv1jsisILEDu/FaP8wf2kiR+ymOJpuowe4=",
-   "module": "sha256-MUOlQxu7uudG4qOEeB+gWO2/UJpEpwswkWB4ax719pk=",
-   "pom": "sha256-viYp+eY8MexI2bzbqgP/mDwKKejLk4U94jNgKjwKaik="
+  "org/springframework/boot#spring-boot-starter-thymeleaf/3.4.5": {
+   "jar": "sha256-wpcbOUtw+PLRhSB7jmt73QxZcajM4FNRaoPP1KMR604=",
+   "module": "sha256-9Cq5utjGAWDWpf+o+ZTkttfx/aL1pAWqBc2/pvCOPsE=",
+   "pom": "sha256-gFHZkV8lZzjwYFtDC3nOUtla7Lap2ytnpJ5dy/9kxnc="
   },
-  "org/springframework/boot#spring-boot-starter-tomcat/3.4.4": {
-   "module": "sha256-MoqFXUkkPdJtdm8llVGWcs8tLm1AErxMqL4ztw2qYho=",
-   "pom": "sha256-i+/NL8lM5FoAgBio/O8HCaJ3IOQdQEnj2iv8cTM/iO4="
+  "org/springframework/boot#spring-boot-starter-tomcat/3.4.5": {
+   "module": "sha256-dc/XrX7EVU7s8Tjhgz8yIAo+mNz8sBJKcC7nJvMwbmE=",
+   "pom": "sha256-4CAMpBZn/guJWYcXAAtK6pEDhuKsI2XpLXrRswwlP5M="
   },
-  "org/springframework/boot#spring-boot-starter-web/3.4.4": {
-   "jar": "sha256-xii40NfIMMfqO8EllQ4RMyt843eevW1lXxg+RW/+RIE=",
-   "module": "sha256-brhwwPlZ2AOxm09SSvEMqazIlKbl804kkVL52DGQI/M=",
-   "pom": "sha256-kNNNh039JtkHpq7L6ohn6aCmEaqXjTlaij9W1GKzVDg="
+  "org/springframework/boot#spring-boot-starter-validation/3.4.5": {
+   "jar": "sha256-GnfcbnTkM0OttIL07QoA5U8DqlsOFaaG+Gb/FIwEh+Y=",
+   "module": "sha256-CGLM372Z6dRptD0TzmxxMfaG1AavHzdZPM/aZ2itoA8=",
+   "pom": "sha256-OiTVV3OfRlB8yx0nZZPqsIGdTQwBlL8qS0BYoTn4AGI="
   },
-  "org/springframework/boot#spring-boot-starter/3.4.4": {
-   "jar": "sha256-L83AA3/RwKzrtLHvcAgYyX2EV/q8bVvrw4ePWEwccn8=",
-   "module": "sha256-6+eaKOIivSRmYBaa5xJmstSO3hYfdvpHKxvI+bjBey0=",
-   "pom": "sha256-MZ6iobSR8Tk8UQZVmfLjZ1HK+0+QD7MaveDHaLw7p4s="
+  "org/springframework/boot#spring-boot-starter-web/3.4.5": {
+   "jar": "sha256-otVlZ9ArCQQDLbBMeDAzM+aMC3VZqU5Uy3NPelbSoTI=",
+   "module": "sha256-RlF98t/gauj/HQiw57/XOYSpnI4J9Sq0BlQ9E3uKUfw=",
+   "pom": "sha256-A6hhiZ+JUNtM4km4oGf80jDDK/dTKgJLJrQWxT2dDvE="
   },
-  "org/springframework/boot#spring-boot-test-autoconfigure/3.4.4": {
-   "jar": "sha256-iWJsqo7ffUfeWotpiMILiav01zoEZA1A+6OtlEOZETo=",
-   "module": "sha256-TYIZZ+u5QVZO9cyXgnb/bGQIFi67EsENhGNx4ewFbBE=",
-   "pom": "sha256-G4xBG/jarW2I41axYCf9kx59t/PD8gmSwr/Z2IDjeSU="
+  "org/springframework/boot#spring-boot-starter/3.4.5": {
+   "jar": "sha256-L3xxixCmRkd2cF1P6oMgTw0g257rcST4hX/0KxScTzc=",
+   "module": "sha256-RK+16b7OaPuRPoRo1HnXuyjYwsj3KS1+dOu/5YxZMSM=",
+   "pom": "sha256-a9hK2PBSsnRoPQ+2/gt6hYgI+XyX2zs/BFuBmbI6cRU="
   },
-  "org/springframework/boot#spring-boot-test/3.4.4": {
-   "jar": "sha256-vGlYSIYAXFYH2JEg+6N1C8aJOWwSWGtrkX4hvVu5KxU=",
-   "module": "sha256-SZekaJmYRLS7D4twxt5Pqz/6fRznI8Jz26D94PDUiYY=",
-   "pom": "sha256-/ivGB4/3vjc3xCBFFl0i8bDZ8p8ksiA2df6aZyE64ds="
+  "org/springframework/boot#spring-boot-test-autoconfigure/3.4.5": {
+   "jar": "sha256-tPKifHUyd9HEmrzD2HT1AqzwwtzSVoQWYXqnnE8e34E=",
+   "module": "sha256-NJpPiFe5W4y1XTA5oNyKnPdmvKakqdeuDz/fY0KDRco=",
+   "pom": "sha256-6wTd5yXDJVs4Qvrbldxqt5nTRpfC/vPk1PlXPRjxnT0="
   },
-  "org/springframework/boot#spring-boot/3.4.4": {
-   "jar": "sha256-8TTULRnB9wdAjizmrOjViHqefD5Qo1GnWtqAr7vW7K8=",
-   "module": "sha256-lGUna66QcisNzKFdPXIvC86w5UBRYMoTriVyjzoPX3s=",
-   "pom": "sha256-89A19FDWaGe58oqGQzMhiMzioFWXnb0ACASiQ3ySCfs="
+  "org/springframework/boot#spring-boot-test/3.4.5": {
+   "jar": "sha256-XSBg2SPaMwy8Be3TF0SWpRRO4+3aQkx4UzjYjHs7ARQ=",
+   "module": "sha256-fXwJl30nJMw8B3Ugh7CopG23MHCWf9413lRzjuom1Zk=",
+   "pom": "sha256-oZvMdRsvRNHii/TyYG2ew2XZQBfpUD6oTLkcc/UdjZo="
   },
-  "org/springframework/data#spring-data-bom/2023.0.2": {
-   "pom": "sha256-r5JYFO1beGWJH9CGEGBVcLS7hFCi9Rv55bhjXNNoHgQ="
+  "org/springframework/boot#spring-boot/3.4.5": {
+   "jar": "sha256-CaxpBuLQOMLihrZxtKMMr7ugajrezd1N7UJvyhErl+4=",
+   "module": "sha256-2rp5y6Ryb5yTNDZ5FF6ogyIRco/WMi4bxaorRvetf9c=",
+   "pom": "sha256-NEnV4z6/N5Yc9K6Mm1BQnLHQHz2HuCa+1+F5uw6j4e4="
   },
-  "org/springframework/data#spring-data-bom/2024.1.4": {
-   "pom": "sha256-sBmDPBXeOQFuZm5MHIyqQfHmbEAv2Op0k8e+e6PPuT8="
+  "org/springframework/cloud#spring-cloud-dependencies-parent/4.2.1": {
+   "pom": "sha256-ktuXOlcqL1nZIAYhy4EPPShvPfaG4nGCHzgAQgApjk0="
   },
-  "org/springframework/data#spring-data-commons/3.4.4": {
-   "jar": "sha256-Nreu2b8d4YCABFQyc69Zw1VtCxXDG8PJFPdq/8thSGY=",
-   "pom": "sha256-6u3bs8j7PFfLa29rvLNb3zFX3pQzGN/JaX1E1698XGM="
+  "org/springframework/cloud#spring-cloud-function-dependencies/4.2.2": {
+   "pom": "sha256-JdZFU6d/QWigqkVELGYwQ5V50WBK79Ba66F37gdhE3g="
   },
-  "org/springframework/data#spring-data-jpa-parent/3.4.4": {
-   "pom": "sha256-5ENpbkQx2iLDRLqqnOOQxmAwJWwFmNUDDGFYrFvxni4="
+  "org/springframework/data#spring-data-bom/2024.1.5": {
+   "pom": "sha256-bHj3zLo/vj0oCm6zvMujJ7pSgEFKV+5Wp92smkU6NHA="
   },
-  "org/springframework/data#spring-data-jpa/3.4.4": {
-   "jar": "sha256-FOHxgWUopL6VWYGQKuWSPWK5dOnW81Tn4l7KP3dLA9g=",
-   "pom": "sha256-4WoQ3RojDP8LCtbwOSDLuUM8hVN7jCujJhnTJcoMmIA="
+  "org/springframework/data#spring-data-commons/3.4.5": {
+   "jar": "sha256-eQuos6oIgwG4z6etb/EfEyb8YVdc7+Fj4zgXpHHiKuM=",
+   "pom": "sha256-gRKQcd10pN90MKpO9m0yp//k/WIQ/cwjh9x1YuQ+xE0="
   },
-  "org/springframework/data/build#spring-data-build/3.4.4": {
-   "pom": "sha256-FpQ4zLn6cUyRWbPcR0LZN4xNJ9r6HBO/mH0K9mFCHrw="
+  "org/springframework/data#spring-data-jpa-parent/3.4.5": {
+   "pom": "sha256-74pPEtQCX3ErbqSYzg79bfrVuESWwXJ5moKdyyTlgbs="
   },
-  "org/springframework/data/build#spring-data-parent/3.4.4": {
-   "pom": "sha256-xNKwHEdypqLrMSWbOcpccmVZgMUgv/3Wq6+W185MhfI="
+  "org/springframework/data#spring-data-jpa/3.4.5": {
+   "jar": "sha256-l4XVoCUgcpjBi1wXFmX0lZ1kKjj3R0EqUAwxBBJmgB0=",
+   "pom": "sha256-FmkqkhfA55ORuJsc4dFFP10e8GxOTDNfv0OxUkapN4M="
   },
-  "org/springframework/integration#spring-integration-bom/6.1.2": {
-   "pom": "sha256-0mxOaZYUSD15O82BeZxUTtpYlXYrSzGXFX7tAo7GL+c="
+  "org/springframework/data/build#spring-data-build/3.4.5": {
+   "pom": "sha256-mhxk1lFiSQxBH3//Mfde6bidl6nbLk/pz50LnmysZYs="
   },
-  "org/springframework/integration#spring-integration-bom/6.4.3": {
-   "module": "sha256-eKT7QrIcbMErc1cvlWR2qYvYJztf8WLl9vsxt6qUolk=",
-   "pom": "sha256-CAzdoKJKOILsGygPsvoGw7Ck8ibqJxMOsJih3jWnoJg="
+  "org/springframework/data/build#spring-data-parent/3.4.5": {
+   "pom": "sha256-sGCQrJhCmgLZErec9C6Ttl3Vxh5u3tFfl5LbDSy5Y8o="
   },
-  "org/springframework/pulsar#spring-pulsar-bom/1.2.4": {
-   "module": "sha256-11oIRNX4om9A6ZagK+qeCifczpf5AovyGGK3+3UIWJU=",
-   "pom": "sha256-eANokQLSMKDWAyyRQn8t7BGfa3abYbIWLhG3XkwOV/Q="
+  "org/springframework/integration#spring-integration-bom/6.4.4": {
+   "module": "sha256-D6CLhB/i8mhTuNOlg2fTtuzljR1ILi2URVZBBrvygQE=",
+   "pom": "sha256-ovWQl7eLrRKBfP08iWazgRCGz18hsalZwTkgQOIDxrs="
   },
-  "org/springframework/restdocs#spring-restdocs-bom/3.0.0": {
-   "pom": "sha256-/8nEe+Wo60iO3pJozgiaeZyT6JT7G9P5QPYsRnpmEyM="
+  "org/springframework/pulsar#spring-pulsar-bom/1.2.5": {
+   "module": "sha256-KUMO4wI07swPESLzedtY1gRxayhCc9Ld6pLscu8XqI0=",
+   "pom": "sha256-hUNszF1lL+2CJ9JXtx1gtbW1BDjxcoLAGfEA9suIuKg="
   },
   "org/springframework/restdocs#spring-restdocs-bom/3.0.3": {
    "pom": "sha256-BqUY6ZcWnX7d821cOtwAQOKThnvfofFo3al4QL0Pb3Y="
@@ -2386,75 +2378,65 @@
    "module": "sha256-eRpwg4XuOGguCJQeRFffivCdxuZWxUVhF91pH9DvNW4=",
    "pom": "sha256-kcopmCCxmXYQcGDwwsagsPRftd8MuZOvC31Opd4x6hY="
   },
-  "org/springframework/security#spring-security-bom/6.1.2": {
-   "module": "sha256-HMJ40imEfP7hLpBd9w5W5W4eo2m+LKd3S/u60EtbMos=",
-   "pom": "sha256-P0nGqe8bTNCnKRAzAyshnLkmzIPX3KlutclyzSQnI44="
+  "org/springframework/security#spring-security-bom/6.4.5": {
+   "module": "sha256-4bGUPRNCiO4GUEPbsXrQ6NoPAH9jpfhbyUPtkkTILpE=",
+   "pom": "sha256-yI3hiaFUzHFGAuF3B35AcdPIkCYoZDUXzRJIq1pTkOo="
   },
-  "org/springframework/security#spring-security-bom/6.4.4": {
-   "module": "sha256-qOtMz9NfTa56PwqReln3SCjniYenROdD0GnOVX3FTmQ=",
-   "pom": "sha256-gv5qePWLA683DDc2NN0a3USD7tw4ELhGpPlJaGl9X5o="
+  "org/springframework/security#spring-security-config/6.4.5": {
+   "jar": "sha256-6SbePQ+rOmE48+X5XRP/gi3L0aLQkGeHd4cQvKogpSc=",
+   "module": "sha256-XnKHizKEv3ghJ8N9OhfhQO6HcoRruhK0qMLBsKstOx4=",
+   "pom": "sha256-XZaqw8rjhuhHwIocZ2OXINMXaBh6iE0gXoiUtgeEDlE="
   },
-  "org/springframework/security#spring-security-config/6.4.4": {
-   "jar": "sha256-8T8jZbSvQbM+QK9lcBTbdz3oWNhMdPNMmtpHHJb5wWk=",
-   "module": "sha256-A5Fel4GjWAuBxkuTNzI5Ba5HKmthZWWq6SEQd1Z25GM=",
-   "pom": "sha256-VaDxS3ukEE/lmVGCN9B+zVqxUHCFB1UYj57lX7OJ3WE="
+  "org/springframework/security#spring-security-core/6.4.5": {
+   "jar": "sha256-aecfKiEq5I/iP2aMi47d4oMLJHvN4xjY5DmX5eECBYY=",
+   "module": "sha256-1s6csBUmUo5TolWna14OuNZ8AwvOL+vLISqPAm5iz1c=",
+   "pom": "sha256-swp8RuFRvS/aYcNqFGworiay0Eq+6QNRo9WjAHtckUs="
   },
-  "org/springframework/security#spring-security-core/6.4.4": {
-   "jar": "sha256-2ffKVZ7K3AcAVV/BbL1Mi9+77dJHT1/R8MQpvtlGZY0=",
-   "module": "sha256-kD4+6mRHlchaZc3k/BPIuow2fqJCUsaKUvkt3Qp2HQc=",
-   "pom": "sha256-8gIi/vESbaPnKf3dIFU1WtlJhl3XAbHDPM7C/7eK57I="
+  "org/springframework/security#spring-security-crypto/6.4.5": {
+   "jar": "sha256-gYd3YQypJbnZjqmy2aEcAcsPin4szyejDZQ0B2jQ09c=",
+   "module": "sha256-HgMuGan43xRJ4y6oh9vG0c9hprtfX6TAHueB1ekb0YU=",
+   "pom": "sha256-jzttZK5xwTUzRX35OGWU00/vw/8iami9Ma7reSTR9v0="
   },
-  "org/springframework/security#spring-security-crypto/6.4.4": {
-   "jar": "sha256-YrNCS+Yg5FcUalGj2pqoeO6YdGZ80kmNcwhag5TTaUA=",
-   "module": "sha256-204pLvMQAIHc2TOLCcs+lKE71vqV3t/gIy9olsksvXg=",
-   "pom": "sha256-ebual+pdPEX9xHMepqxpssL//0wTwjQfWFA6S2ojsc4="
+  "org/springframework/security#spring-security-oauth2-client/6.4.5": {
+   "jar": "sha256-lxYl8VQQeX6YAlcYJb34EWum3HSeYhQc8iDdi2XaxAc=",
+   "module": "sha256-Z3BVg+TFleCG98ABoQLrlyC5UpsuieJn4QR0R26jpQA=",
+   "pom": "sha256-1j7IdYBqbKnGPohlayBCaJWJS0GdXZMADb1I/hVh5b0="
   },
-  "org/springframework/security#spring-security-oauth2-client/6.4.4": {
-   "jar": "sha256-K71c0xh7cLOS2SgIwmbMJJDQb+mkyQodarNn+6zhELg=",
-   "module": "sha256-gwD0FCVeqGmZ5fIwxIzHG58bH4j77x1vb/zCe823YAs=",
-   "pom": "sha256-EM/PVBFACsmFaADcUIP4oaYTbOENCTZCCWzPb1vcatc="
+  "org/springframework/security#spring-security-oauth2-core/6.4.5": {
+   "jar": "sha256-xiJWLLv5mP44W2EwiExhCtrG8bk17hIODQktn2vX7Z0=",
+   "module": "sha256-Ph88ImZMWaEJhzZSkG/rn5YVepqDSpA8YWZXXqub4l0=",
+   "pom": "sha256-fl2LJsP0bMxofUv6PMiljHy+eQmzjO8Bp8cDVThXpjg="
   },
-  "org/springframework/security#spring-security-oauth2-core/6.4.4": {
-   "jar": "sha256-cLfRUUKU8Ni16gZ4JTA7yZS/iw/DmiUEb6UWBYfoa3U=",
-   "module": "sha256-RlW0afpNdYzzIU2JUYxF5A8q9rHQTN6Eh558Xj4nzFY=",
-   "pom": "sha256-u3hbA6cUq7bMNlhcWoBdSx6xmDKIYMrECM+zcpWHreo="
+  "org/springframework/security#spring-security-oauth2-jose/6.4.5": {
+   "jar": "sha256-PrS5JZbk2eTlf5aHRHGzAuvfcq7fD6GZHMYSIgutBZ4=",
+   "module": "sha256-YmqZsnVMPzeWkCwDvJvTgH71Eyjq+jYO3si/5BG0aUo=",
+   "pom": "sha256-+yLFhwHa6nPWSvstJTGZwaPmcD1g/grq6+HM6O99l+o="
   },
-  "org/springframework/security#spring-security-oauth2-jose/6.4.4": {
-   "jar": "sha256-vGXW6EYjUj7mtTNK6uuUBPm9aUuL5eSfkfgJN2Pa+jw=",
-   "module": "sha256-HRq3Bw2lHv4sPZVGoo9hibLGuYTdpA5aD1AtdbvcN8E=",
-   "pom": "sha256-3g7o1az46wXuqbD7IvcLgDrH0aVdGERx3lcgB3m3G0U="
+  "org/springframework/security#spring-security-saml2-service-provider/6.4.5": {
+   "module": "sha256-0ZTZJW5P4MaTG/L01Jag9ZZOamwnzhgvmZEaE2oFAks=",
+   "pom": "sha256-RJQgjevYVM1soIyhJZGZeF42J7S1iCRp/Z32EsVtiO8="
   },
-  "org/springframework/security#spring-security-saml2-service-provider/6.4.4": {
-   "jar": "sha256-s0NAkF+aWL1xqAWiyk9O0zHjzPbEFlaLSzzTI5Lk0bA=",
-   "module": "sha256-9/AoBxl7+u4OrrDk5VsmgaoPowXjFulAV+22NW8QOO4=",
-   "pom": "sha256-cfS6/m2dsuoxZGq3BuIQuu7cNElJWtanmQ5jOs9O9WI="
+  "org/springframework/security#spring-security-saml2-service-provider/6.5.0": {
+   "jar": "sha256-B4jz+3r60wvcHGl3P6wtUvCtI331yVCsCyFneLjCsoU=",
+   "module": "sha256-AUnPhM2gSLlrNd2Lf0Vz28C1NeDc/8k3RTM4qGViO1U=",
+   "pom": "sha256-Fk+iW7upOpMuGdjx1vJQaqePhbJe+OWao7FXZYOi1Ws="
   },
-  "org/springframework/security#spring-security-web/6.4.4": {
-   "jar": "sha256-dwXuw0yGYH0+LIGWXSBYT6RoGbrzEao+k4He677OuaQ=",
-   "module": "sha256-9WsRnHRd70ctreao+y/RVMd1X4Etk4CQ0j60f2eJdYc=",
-   "pom": "sha256-+uhgUYPsCNRbZj6xaILBLahuLROhNisEiKuX5ZU6Z3s="
+  "org/springframework/security#spring-security-web/6.4.5": {
+   "jar": "sha256-BjHLVaLD/FEhxeMyoPcI2fjUuixTqYyWTTqwTa692jE=",
+   "module": "sha256-LrIW7uCvCo2OsRXlJWHFoG9JvI4G5rkrhT1kFzIL+f4=",
+   "pom": "sha256-ZcxvY3ZHm3vwnf275PreADy8YVW6fB8iZMGFqavZdWE="
   },
-  "org/springframework/session#spring-session-bom/3.1.1": {
-   "module": "sha256-1pUWyPsAHxEYTRTC/WPXiiXTt3H27w40+UMFo+/cYyc=",
-   "pom": "sha256-yKH2TVmHtfeggnybjVe/dSegTYM/7o7EXlKD7kKTwV0="
+  "org/springframework/session#spring-session-bom/3.4.3": {
+   "module": "sha256-zn7fQg1Kkebfrg8P6Ld/jKq3pCa3ErH5hyTjiVvQ5KQ=",
+   "pom": "sha256-cJfeozK7onrcP2k0pzIJOS/zznH/VcQEyhI1TffA2CM="
   },
-  "org/springframework/session#spring-session-bom/3.4.2": {
-   "module": "sha256-3AEv25HkBdv3qVLsLS0D4iZ7pEhT0QvFjDjejTLnLU4=",
-   "pom": "sha256-a8HJfa9sj0A18oPW84lXkmEWWl17PfcxjYduB/iTEco="
+  "org/springframework/session#spring-session-core/3.4.3": {
+   "jar": "sha256-nEZXJ1sR849z6/PFP0yj8Vq0HqvZIV7dEj04hL4dUaY=",
+   "module": "sha256-WagEDUvRYpnJLqLxVxH4gfJccoqvlGAqnHl+Fg1i2SQ=",
+   "pom": "sha256-YeRcqQ3pMx8rXLTtU5qYkUfKLL9kTuyz+uiAlaxyLsM="
   },
-  "org/springframework/session#spring-session-core/3.4.2": {
-   "jar": "sha256-oGS3BNzAq8kkctm9LJgVlXdkfjn749VRLLtykANULyw=",
-   "module": "sha256-A02zA9rMLOu/2//SCtgR4CxzfElHx9A3Ja9HLPO/jkY=",
-   "pom": "sha256-3kg0+gkVeP2a5IGlrK2oqirJc1a30A30y4txM22z+IA="
-  },
-  "org/springframework/ws#spring-ws-bom/4.0.12": {
-   "pom": "sha256-z4sPmYxvuuDkUByT8WuEXLoTqsVZNA8RF7j5K8+G6RI="
-  },
-  "org/springframework/ws#spring-ws-bom/4.0.5": {
-   "pom": "sha256-8OjPCyFD18APnTYVoZy7cPI+Qy+B8OcCi91a0/KBo/w="
-  },
-  "org/testcontainers#testcontainers-bom/1.18.3": {
-   "pom": "sha256-l0dtYsuLXM/NHLrmkmHEk3v36BtWUw2oKmZJ4w3DHMw="
+  "org/springframework/ws#spring-ws-bom/4.0.13": {
+   "pom": "sha256-DJwCm7nt2NrMGCCZAxjkju+/6htETbhyF0Wr3QFJFQ8="
   },
   "org/testcontainers#testcontainers-bom/1.20.4": {
    "pom": "sha256-oVFHwtqO3sE0AdHT5qCgG2Gea2e2bBA1ks7zpwzB7Ik="
@@ -2488,9 +2470,13 @@
    "jar": "sha256-WXz4fVsaTzhbnRzsl0t7SDq7PuhfxbP4tir45L7JXCw=",
    "pom": "sha256-AgOVYrsyfVQcDwUHZ+kYmPo4l0eSZojMITvRG8dRJ9E="
   },
-  "org/webjars#swagger-ui/5.2.0": {
-   "jar": "sha256-x7hZO4W+yIujqoGQudsk2a7a8CyVmqOMMu3WpkO8k9Q=",
-   "pom": "sha256-n0iJORwtkGWjTpc9CURMnMycPMASGDNgQ8Umuqe5BgA="
+  "org/webjars#swagger-ui/5.21.0": {
+   "jar": "sha256-/yhIgGQBi5iAkvyQB2+cHvFbHthcz9qD7XrJHV3INa4=",
+   "pom": "sha256-SzvAAKRPzOtAwwVa1WaRatRBBF2IBEADltUkcLgOOEw="
+  },
+  "org/webjars#webjars-locator-lite/1.0.1": {
+   "jar": "sha256-ohbBATefZlS9ZeUL8snYo1dbx9bo3iiYKGrEnFbZrpk=",
+   "pom": "sha256-AOcjdg/XYrWY0FFyTpNK9xRfrontoVNnHIk06BG0Cyw="
   },
   "org/xmlunit#xmlunit-core/2.10.0": {
    "jar": "sha256-P4mwpinT2cymbhX43eXglHhS+kQXK8d+om7fluPk/Pg=",

--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -1,7 +1,7 @@
 {
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
- "https://build.shibboleth.net/nexus/content/repositories/releases": {
+ "https://build.shibboleth.net/maven/releases": {
   "net/shibboleth#parent/11.3.5": {
    "pom": "sha256-eiTicASF7qCHNw8dym/gKR14k9OMEaq/6Xd4T9k7gIw="
   },
@@ -70,19 +70,6 @@
    "pom": "sha256-p8Qr8gu9VKhifsK5FPj6f2jQ1dP4JXeNhNKndCZMdEs="
   }
  },
- "https://jitpack.io/com/github/Carleslc": {
-  "Simple-YAML#Simple-Configuration/1.8.4": {
-   "jar": "sha256-K5YPSECsaLsYFdk3yi1Y65sEwF5qm3aaTocMUqRygVY=",
-   "pom": "sha256-aY43joFqIg7fy3VP1MT32aj9OHFrkIH2P5h41LvzzdU="
-  },
-  "Simple-YAML#Simple-YAML-Parent/1.8.4": {
-   "pom": "sha256-uSmLh1GFvRO04wEYfusjTToaSxqHHdSnRh8ud3USE1c="
-  },
-  "Simple-YAML#Simple-Yaml/1.8.4": {
-   "jar": "sha256-1VjKV5J9S8OT6VIqrAz2DMYyqfb2DNZySqlLcAXh/Rg=",
-   "pom": "sha256-R/EAPNketsEbLJQb+J5yQortkua/7zJ7GJNd2ijrQHI="
-  }
- },
  "https://plugins.gradle.org/m2": {
   "com/diffplug/durian#durian-collect/1.2.0": {
    "jar": "sha256-sZTAuIAhzBFsIcHcdvScLB/hda9by3TIume527+aSMw=",
@@ -96,63 +83,63 @@
    "jar": "sha256-CV/R3HeIjAc/C+OaAYFW7lJnInmLCd6eKF7yE14W6sQ=",
    "pom": "sha256-NQkZQkMk4nUKPdwvobzmqQrIziklaYpgqbTR1uSSL/4="
   },
-  "com/diffplug/durian#durian-swt.os/4.2.2": {
-   "jar": "sha256-a1Mca0vlgaizLq2GHdwVwsk7IMZl+00z4DgUg8JERfQ=",
-   "module": "sha256-rVlQLGknZu48M0vkliigDctNka4aSPJjLitxUStDXPk=",
-   "pom": "sha256-GzxJFP1eLM4pZq1wdWY5ZBFFwdNCB3CTV4Py3yY2kIU="
+  "com/diffplug/durian#durian-swt.os/4.3.0": {
+   "jar": "sha256-geK2Oafkvm3JtyRXE88G9cq1HynbLha5tXZFyW/eKIQ=",
+   "module": "sha256-IFNqlfL+sr9DBRKMaq7Lb9idxFeYqchfJgK4qAnXUNs=",
+   "pom": "sha256-Q1z/VXiZht7arXF/aPuo1UgklHhWLc2EsirU1lZvRAs="
   },
-  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/6.25.0": {
-   "pom": "sha256-9FyCsS+qzYWs1HTrppkyL6XeqIQIskfQ5L3pQSkIIjo="
+  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/7.0.2": {
+   "pom": "sha256-7R3td6KWpv4hpQJ5ySbAe+FK98CMJDfTaFxw/Pa7oC0="
   },
-  "com/diffplug/spotless#spotless-lib-extra/2.45.0": {
-   "jar": "sha256-YCy7zTgo7pz7LjCn+bMDNcaScTB3FBTUzdKU0h/ly2c=",
-   "module": "sha256-9pnkNfTlzgPbYJpHaO6wNj1uB8ZfvPrx/GKcTnbuf7A=",
-   "pom": "sha256-5x2LkRDdSNLn9KVLi/uozlWpbmteu9T0OpJGZJz1b7A="
+  "com/diffplug/spotless#spotless-lib-extra/3.0.2": {
+   "jar": "sha256-sOd3RtYz1EXnhImsPQitLqGzU3xNBk5KvkbMQtYjA+s=",
+   "module": "sha256-vSVeQkQbWRehU8U9z5fP08IEevN2zF3Yu1Z/aEAWtFk=",
+   "pom": "sha256-IVesGayscKzQRQH8WbvJZNsZD1tx5O1e/s6o5c9o7Os="
   },
-  "com/diffplug/spotless#spotless-lib/2.45.0": {
-   "jar": "sha256-sllply4dmAKAyirlKRl+2bMWCq5ItQbPGTXwG9Exhmc=",
-   "module": "sha256-+x+8+TUAczrHWcp99E8P9mVTEze0LaAS4on/CINNiQ8=",
-   "pom": "sha256-WKd8IsQLIc8m29tCEwFu9HrM9bBwchfHkyqQ9D+PMNw="
+  "com/diffplug/spotless#spotless-lib/3.0.2": {
+   "jar": "sha256-P5p/38WwOsIIlINBcJEMFcTyuE7UzjZ3iYowetWJg3w=",
+   "module": "sha256-E1WLrsCR6gDxYmXNNSOBePT+ejv61zXel214XUF/ss0=",
+   "pom": "sha256-jxtFo4m6Jeel8DvZ8KS9BKp+dHXgku6C1VUJYrLPdV8="
   },
-  "com/diffplug/spotless#spotless-plugin-gradle/6.25.0": {
-   "jar": "sha256-9euQikxdpGKZ51Q/qtoEAtLEt31Yx7Qy1Lblk0mygKM=",
-   "module": "sha256-RoHRe/PJIF2DeOynBcAAywzJjcx40DATy2iJjGvSx0Q=",
-   "pom": "sha256-q1ZuPYS2w/rHqPySXy279TzZdZywOvPAfQ3EN9OXqNo="
+  "com/diffplug/spotless#spotless-plugin-gradle/7.0.2": {
+   "jar": "sha256-WaNMT4SkjUyNkp4viZBjaeZUduwEmaQ96Hw+QSeXfNU=",
+   "module": "sha256-rxC8mydsNqlNcRh+kVhwJ1yyRVZTntzqGYpYL30Tsws=",
+   "pom": "sha256-JyVoPfbvTNSIr+sgANqJIpQcqQ513D49uFIupxWKaMQ="
   },
-  "com/fasterxml#oss-parent/48": {
-   "pom": "sha256-EbuiLYYxgW4JtiOiAHR0U9ZJGmbqyPXAicc9ordJAU8="
+  "com/fasterxml#oss-parent/61": {
+   "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
-  "com/fasterxml/jackson#jackson-base/2.14.2": {
-   "pom": "sha256-OuJFud+VEnMh8fkF9wO9MndP5VcVip06nlB9grK8TtQ="
+  "com/fasterxml/jackson#jackson-base/2.18.2": {
+   "pom": "sha256-71dLcvW0iUgET2g3a4dMiK4JoCncjgX2Shwwvftt4Uo="
   },
-  "com/fasterxml/jackson#jackson-bom/2.14.2": {
-   "pom": "sha256-mqIJuzI5HL9fG9Pn+hGQFnYWms0ZDZiWtcHod8mZ/rw="
+  "com/fasterxml/jackson#jackson-bom/2.18.2": {
+   "pom": "sha256-UkfNwwFyXT9n9+8EkDconVr3CdaXK89LFwluRUjSlWs="
   },
-  "com/fasterxml/jackson#jackson-parent/2.14": {
-   "pom": "sha256-CQat2FWuOfkjV9Y/SFiJsI/KTEOl/kM1ItdTROB1exk="
+  "com/fasterxml/jackson#jackson-parent/2.18.1": {
+   "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.14.2": {
-   "jar": "sha256-LGhp1QXPYNwGZzS31QM5+XW9OtxjXianirtxrLRHPA0=",
-   "module": "sha256-sBSmTMGESUn4JNNGcSk1Qfq3IyI6yLgyIrV3IRO97Bc=",
-   "pom": "sha256-hK4DQYN9dpamEEPYCeQyYKXrB3Iy0dyqRkyNpUnNnqA="
+  "com/fasterxml/jackson/core#jackson-annotations/2.18.2": {
+   "jar": "sha256-WBvWEADvdkiUP3gcoFaJ5W0D9gUnSDZajis6m10/oy8=",
+   "module": "sha256-4Ruvm1NubflNqmNaEBPsPgabhmuOES3cKqBEahVQUNw=",
+   "pom": "sha256-CyvWlOqJJn7qSBJqilskplI0xkM4dULSRGnRlb+6HPg="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.14.2": {
-   "jar": "sha256-tdN6d8iCd7l+NZPIdAklIWwG345BcrveBYUo3wStPno=",
-   "module": "sha256-knOeO8vgmyZJ4YfrftJawlK1h3B82SKrlbrc3orqEtw=",
-   "pom": "sha256-9EzGPWEvA7Hb/IKJLc2zL9t1vxYEn9hZVWHnx6M7xFE="
+  "com/fasterxml/jackson/core#jackson-core/2.18.2": {
+   "jar": "sha256-2AVK58DRwtL1XSjkYCbr5YkogfP6tfQ5IzGEOBw7Sh8=",
+   "module": "sha256-ynjGBDZ2f8w2zhRrd05PUKnLn2MtExcsRLrojgwDz6I=",
+   "pom": "sha256-4GWwA50h9N/ORr1DEEx9dtWFa9cy4qqGDMWkonDtct4="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.14.2": {
-   "jar": "sha256-UB06vOTRjcw4EFjsWTxblEd5Brum77rBTa5ApkL3dCQ=",
-   "module": "sha256-YTDKm5VwfM1PgPYlhWmZCnzkADmqNTxGNckA02vuxwU=",
-   "pom": "sha256-IoCOu0t12MQDfZzuEgitxlvHgqmIVzIjSjG3tXTF2Qw="
+  "com/fasterxml/jackson/core#jackson-databind/2.18.2": {
+   "jar": "sha256-SzZOaFDciRcvzx1N0muP9UiO2kT/RlfiLdJlID3Vqzw=",
+   "module": "sha256-jH2sL3J4GNiEeoKqTqxrAXTXnPBN+Q3iJGBy5t005wA=",
+   "pom": "sha256-STo9tkR7eo7Ls3JCNMbOZ31y20sE9roAjw6+rqe+Wp0="
   },
-  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.14.2": {
-   "jar": "sha256-tOP76lRaFVoU3LimXEa1etjQ+5YnyE94mFgmPwUpkzA=",
-   "module": "sha256-FS+gHfdRXJqmhk0hmHjx1RDMxU6RSkRuwWhoSQeHNjY=",
-   "pom": "sha256-ZJQDWanJpVdkpMbeM0eZUJBL0JJtKKHWj2sNQdp1fJc="
+  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.2": {
+   "jar": "sha256-Z6aktrkfPUUN8h53QX9AC+Zjvgz1KOSDSczDgc90s7A=",
+   "module": "sha256-LBXqycqNl7Q4LNOEMlHIrH7uIlbPfcPknsydE2t2z04=",
+   "pom": "sha256-IBZ1+nWRQy+yYIuQ0hgiPncyqU0BNG/ip1/GqbrLRNE="
   },
-  "com/fasterxml/jackson/module#jackson-modules-java8/2.14.2": {
-   "pom": "sha256-Nup9rcsQxxU+9lp14Wmxt/k33tCaGEUODxD+IC3yrc0="
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.2": {
+   "pom": "sha256-s6z7kQ0CPpOkGZr8zeH/nsX6sMVQ3E+WilBXEXrLCzY="
   },
   "com/github/jk1#gradle-license-report/2.9": {
    "jar": "sha256-6/1tqFFlTFMhbuqe2hSFwS4M1t5amRm/XalzWgIfMq8=",
@@ -171,12 +158,25 @@
    "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
    "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
   },
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
+  },
   "com/google/code/gson#gson-parent/2.8.9": {
    "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
   },
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
+  },
   "com/google/code/gson#gson/2.8.9": {
-   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
    "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  },
+  "com/google/errorprone#error_prone_annotations/2.27.0": {
+   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
+   "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
+  },
+  "com/google/errorprone#error_prone_parent/2.27.0": {
+   "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
   "com/googlecode/concurrent-trees#concurrent-trees/2.6.1": {
    "jar": "sha256-BONySYTipcv1VgbPo3KlvT08XSohUzpwBOPN5Tl2H6U=",
@@ -185,6 +185,16 @@
   "com/googlecode/javaewah#JavaEWAH/1.2.3": {
    "jar": "sha256-1lImlJcTxMYaeE9BxRFn57Axb5N2Q5jrup5DNrPZVMI=",
    "pom": "sha256-5O1sZpYgNm+ZOSBln+CsfLyD11PbwNwOseUplzr5byM="
+  },
+  "com/squareup/okhttp3#logging-interceptor/4.12.0": {
+   "jar": "sha256-8+jV8JA8JQwrVdL0f8/gCOgGNDhdqDhRYcemOq7Qx0w=",
+   "module": "sha256-LiFIzSE7T49U1m0FSKIoBX4fe2czLg+Xmxoc42sidqc=",
+   "pom": "sha256-MVkkh9X6euW87fZ4Bqy93Eh9zPROH9t/z3zlNkrPyFw="
+  },
+  "com/squareup/okhttp3#okhttp-urlconnection/4.12.0": {
+   "jar": "sha256-dMDj+MPfCx0yq52DlEjJFFhtPoR5YR5Dhv7PprPwoms=",
+   "module": "sha256-qQHvrIuBpvn+bJcHCONTvUvR2gO5Kd+sAadhey1P6jE=",
+   "pom": "sha256-qZz5k4JeWi/xL1CXM5jnyfxXAFU2i98QJqee/PtebXI="
   },
   "com/squareup/okhttp3#okhttp/4.12.0": {
    "jar": "sha256-sQUAgbFLt6On5VpNPvAbXc+rxFO0VzpPwBl2cZHV9OA=",
@@ -207,14 +217,21 @@
    "jar": "sha256-h98PC+V8kgN9ARD7siWjC2UXAtwnVlPSha/P7zG8LoE=",
    "pom": "sha256-c9gezjnpSh0tf80BhGYqo9QQa/6XCbeTlkiS4+f0/cQ="
   },
-  "commons-codec#commons-codec/1.16.0": {
-   "jar": "sha256-VllfsgsLhbyR0NUD2tULt/G5r8Du1d/6bLslkpAASE0=",
-   "pom": "sha256-bLWVeBnfOTlW/TEaOgw/XuwevEm6Wy0J8/ROYWf6PnQ="
+  "commons-codec#commons-codec/1.17.0": {
+   "pom": "sha256-wBxM2l5Aj0HtHYPkoKFwz1OAG2M4q6SfD5BHhrwSFPw="
   },
-  "dev/equo/ide#solstice/1.7.5": {
-   "jar": "sha256-BuFLxDrMMx2ra16iAfxnNk7RI/mCyF+lEx8IF+1lrk8=",
-   "module": "sha256-eYp7cGdyE27iijLt2GOx6fgWE6NJhAXXS+ilyb6/9U8=",
-   "pom": "sha256-20U7urXn2opDE5sNzTuuZykzIfKcTZH1p5XZ/2xS3d8="
+  "commons-codec#commons-codec/1.17.1": {
+   "jar": "sha256-+fbLED8t3DyZqdgK2irnvwaFER/Wv/zLcgM9HaTm/yM=",
+   "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "dev/equo/ide#solstice/1.8.1": {
+   "jar": "sha256-bluizOgTvh1xzNwuzz5JJxsU5pG/u7GhFM86MOdzsQ0=",
+   "module": "sha256-pnYDnqavCPJXtG4Hwr8VcaRqTUtbnMuGw/yY0H+v6hs=",
+   "pom": "sha256-arSo7K4qu9NrkZ0Lm5+yTBdxSPE+U2TJegxu4Ro/xCY="
   },
   "edu/sc/seis/launch4j#edu.sc.seis.launch4j.gradle.plugin/3.0.6": {
    "pom": "sha256-YqT2dSGQuevzCGngkuQVTkGixc2WBIrpigGRbyaERlo="
@@ -224,17 +241,27 @@
    "module": "sha256-Cjjh2qt5oytWeQ20WAiBSMl74CF2Ti0tziWbmof+wEg=",
    "pom": "sha256-MhJ0+5apc3nprkdy0A7DMlBOPS/dQxlLUpQBlSzxcZY="
   },
+  "io/github/hakky54#sslcontext-kickstart-bom/8.3.6": {
+   "pom": "sha256-vRw5cU+BlPtQbphtvneTcWRGaHhs4pdUPcLkj64hJA4="
+  },
+  "io/github/hakky54#sslcontext-kickstart-parent/8.3.6": {
+   "pom": "sha256-Wh4MIe5Y9AuzGppFkK6TnDMz/oH0wDD8wYXXFh4JLYo="
+  },
+  "io/github/hakky54#sslcontext-kickstart/8.3.6": {
+   "jar": "sha256-5fpoinAmZ2+XCTODj2A1IzR9hAR9Iee3v+z0IrMvJ/A=",
+   "pom": "sha256-AMzuBEbKPCrxdkzXP2jiIkGy39TyeHLjii8IBfiafb4="
+  },
   "io/github/x-stream#mxparser/1.2.2": {
    "jar": "sha256-ru7iOjMD2BG8qHkOp/JbU0MUhhwDz/Ntr9zCGAlp65c=",
    "pom": "sha256-I1AiQk4S8zGB9iraGcxEKAGbaXZXw8OSzjVxYKQi+qg="
   },
-  "io/spring/dependency-management#io.spring.dependency-management.gradle.plugin/1.1.6": {
-   "pom": "sha256-CFq9cXivKRAHeHfvZcf75G9tqj6KlBLnm3+ROMd+vCI="
+  "io/spring/dependency-management#io.spring.dependency-management.gradle.plugin/1.1.7": {
+   "pom": "sha256-GbsWq11jWb/4jOlcgLAefjRFFX+qHXSuXPA6RnzqHgQ="
   },
-  "io/spring/gradle#dependency-management-plugin/1.1.6": {
-   "jar": "sha256-V2HXOkK3PAiFyXkzZz95G+1IXpZRGP/LMzu4tKodZHo=",
-   "module": "sha256-o0vXlzMjdIhpE8YYG16S/R3Bfd5iziAE3nSSuOg54tk=",
-   "pom": "sha256-/GVloBfXrODoCaOOuaGfKRfQZCMDDKEl0gvca9yGP34="
+  "io/spring/gradle#dependency-management-plugin/1.1.7": {
+   "jar": "sha256-nohe7E/AtxUqe7oWZABAhcZmOjyTsKYkY75zCLAFvkw=",
+   "module": "sha256-MnseqM8InsEvY9Xgh/8ZyMzmaIVtSY/gjRD34VwSzHc=",
+   "pom": "sha256-ge5zHnvYkuwZQyEhgKaE1lrH0329PkPlyDMkCuQXOKw="
   },
   "io/swagger#swaggerhub/1.3.2": {
    "jar": "sha256-cDph6Wsjr4GyzuukoIG7MhLsACEa4wB0iz58yx8zvTI=",
@@ -274,13 +301,28 @@
   "org/apache#apache/30": {
    "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
   },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/32": {
+   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
   "org/apache/commons#commons-compress/1.25.0": {
-   "jar": "sha256-0OyAFOu7B0n0cYAxIrIXlq/d8umOGU5DdGIuX7r2n0k=",
    "pom": "sha256-ulzaSWZDqQb8t3sfE8XH3oFxM8l3pBfoqDX+KKZRjs4="
   },
+  "org/apache/commons#commons-compress/1.27.1": {
+   "jar": "sha256-KT2A9UtTa3QJXc1+o88KKbv8NAJRkoEzJJX0Qg03DRY=",
+   "pom": "sha256-34zBqDh9TOhCNjtyCf3G0135djg5/T/KtVig+D+dhBw="
+  },
   "org/apache/commons#commons-lang3/3.13.0": {
-   "jar": "sha256-gvUoz3GMejwvMPxbx4TjxqChCxdgXa254WyC7eEeYGQ=",
    "pom": "sha256-/3zqTrI53WIRdRDavlGo1fDJ5MxCa8PowsIhpxj4ZIQ="
+  },
+  "org/apache/commons#commons-lang3/3.17.0": {
+   "jar": "sha256-bucx31yOWil2ocoCO2uzIOqNNTn75kyKHVy3ZRJ8M7Q=",
+   "pom": "sha256-NRxuSUDpObHzMN9H9g8Tujg9uB7gCBga9UHzoqbSpWw="
   },
   "org/apache/commons#commons-parent/58": {
    "pom": "sha256-LUsS4YiZBjq9fHUni1+pejcp2Ah4zuy2pA2UbpwNVZA="
@@ -288,26 +330,38 @@
   "org/apache/commons#commons-parent/64": {
    "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
   },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/commons#commons-parent/71": {
+   "pom": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+  },
+  "org/apache/commons#commons-parent/72": {
+   "pom": "sha256-Q0Xev8dnsa6saKvdcvxn0YtSHUs5A3KhG2P/DFhrIyA="
+  },
+  "org/apache/commons#commons-parent/73": {
+   "pom": "sha256-TtRFYLB/hEhHnf0eg6Qiuk6D5gs25RsocaxQKm1cG+o="
+  },
   "org/apache/httpcomponents#httpcomponents-parent/13": {
    "pom": "sha256-5Ch4ZwNYVsc3QgNo3VhuXlfnAgmBNYQM89c+nINj17M="
   },
-  "org/apache/httpcomponents/client5#httpclient5-parent/5.3.1": {
-   "pom": "sha256-NoiUNOqs3KRwF0BreUEgOze895YkeN74+UiSlCQt7uQ="
+  "org/apache/httpcomponents/client5#httpclient5-parent/5.4.2": {
+   "pom": "sha256-d2r5CnR0EULt8vvx+XpMAwrl+QT8PW2H6PNOilmb4Ug="
   },
-  "org/apache/httpcomponents/client5#httpclient5/5.3.1": {
-   "jar": "sha256-CDRqdXxhf27MZq+fCZJgrd4fOhNR+oHLIvwXSCsx+CM=",
-   "pom": "sha256-fuGd8eK2dpxAzXkwLISRYJXhz67EoxDAbVjkFQuIHyA="
+  "org/apache/httpcomponents/client5#httpclient5/5.4.2": {
+   "jar": "sha256-oKnc02lqYoH4LjktOapnS/lmJJZgVBHeKgDURDWn+yY=",
+   "pom": "sha256-Uzeacw5Oy6ug1EvSqXPlqxtjI958xHxPEAmmZmjiPmU="
   },
-  "org/apache/httpcomponents/core5#httpcore5-h2/5.2.4": {
-   "jar": "sha256-3BqV5z6wTbk0UVM9OQzgLFOzAaENw0PQjIYvKTSz0w4=",
-   "pom": "sha256-TRZ2hcCpo5jMJEpzqQhuKs9jUWCAGgpOuM/T4ycc+dM="
+  "org/apache/httpcomponents/core5#httpcore5-h2/5.3.3": {
+   "jar": "sha256-oSH0sU7FJeVOKbn123uT9Kl+CId06BxxQ7UZj2fYG+w=",
+   "pom": "sha256-DG+UMCpWYarEjlb6GiyYSNTYyEqTgBa5lvV11y5lyP8="
   },
-  "org/apache/httpcomponents/core5#httpcore5-parent/5.2.4": {
-   "pom": "sha256-g/3u2xolBJtf5+AK/NNXQ/eon5kED7mjpRNfuSaaWko="
+  "org/apache/httpcomponents/core5#httpcore5-parent/5.3.3": {
+   "pom": "sha256-GpQSCJ6gfk/7CvecgWsepVXpx/aoYZvhCajdGWUVQJA="
   },
-  "org/apache/httpcomponents/core5#httpcore5/5.2.4": {
-   "jar": "sha256-p/YklhE/ZvnifCa4TET1zkVVxicAg83y1F8lUzbNUq8=",
-   "pom": "sha256-Abq2p2771NJoSf1FDqrofK75ocHAzF9g/k87kY8HcWQ="
+  "org/apache/httpcomponents/core5#httpcore5/5.3.3": {
+   "jar": "sha256-CHt66b3p01GLS10G81YNf9DbBAmGVedrZOeRdzhH1QM=",
+   "pom": "sha256-23qZ78VZF+iY4vdeZAbqWhpMyMcQPoo5zdyFsdPzFCk="
   },
   "org/awaitility#awaitility-kotlin/4.0.3": {
    "jar": "sha256-66iiOFFxL0WzGvZ/gwbHYC/0TaAh0UZwl/41LeVlo9s=",
@@ -320,16 +374,20 @@
    "jar": "sha256-G8JCQg80krW4xo8Ujk5BAfbqglUnznk74iwMb/o7USE=",
    "pom": "sha256-P8iCHmLEEy5xfNk1wB0dOTTov7sPklphhPj2oo2jasY="
   },
-  "org/eclipse/jgit#org.eclipse.jgit-parent/6.7.0.202309050840-r": {
-   "pom": "sha256-u56FQW2Y0HMfx2f41w6EaAQWAdZnKuItsqx5n3qjkR8="
+  "org/bouncycastle#bcprov-jdk18on/1.78.1": {
+   "jar": "sha256-rdWRXmrPxqtYNuH9il4hxkiFNqjB8h84bus78oC3Atc=",
+   "pom": "sha256-KJEtE5+e7RQcOUNx++W6b//5HnjxycuDSPlEok0gTtI="
   },
-  "org/eclipse/jgit#org.eclipse.jgit/6.7.0.202309050840-r": {
-   "jar": "sha256-tWRHfQkiQaqrUMhKxd0aw3XAGCBE1+VlnTpgqQ4ugBo=",
-   "pom": "sha256-BNB83b8ZjfpuRIuan7lA94HAEq2T2eqCBv4KTTplwZI="
+  "org/eclipse/jgit#org.eclipse.jgit-parent/6.10.0.202406032230-r": {
+   "pom": "sha256-8tNTmgp5Iv15RwgsGQHSCQ2uB0mGsi2r2XO0OYzR6i4="
   },
-  "org/eclipse/platform#org.eclipse.osgi/3.18.300": {
-   "jar": "sha256-urlD5Y7dFzCSOGctunpFrsni2svd24GKjPF3I+oT+iI=",
-   "pom": "sha256-4nl2N1mZxUJ/y8//PzvCD77a+tiqRRArN59cL5fI/rQ="
+  "org/eclipse/jgit#org.eclipse.jgit/6.10.0.202406032230-r": {
+   "jar": "sha256-Q/kvOttoGl8wBrl56NNBwSqM/YAp8ofEK88KgDd1Za4=",
+   "pom": "sha256-BVlUQr62ogYQi2c6qcZpLIPkHfGDF33GcROxzD9Sgd0="
+  },
+  "org/eclipse/platform#org.eclipse.osgi/3.18.500": {
+   "jar": "sha256-gLJ11YN5cjspHqZQJJzDgJyPELNPeKr5iBMs1tQ0q04=",
+   "pom": "sha256-4o9b4Azk7Sx+SAnsrQW5UwfzWhflhWAHhri97juk2Wg="
   },
   "org/hamcrest#hamcrest/2.1": {
    "jar": "sha256-upOy46ViMiukMvChtTrdzFXLGIJTMZoCDtd/gk5pIFA=",
@@ -387,20 +445,71 @@
    "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
    "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
   },
-  "org/junit#junit-bom/5.10.1": {
-   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
-   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.11.0": {
+   "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
+   "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
+  },
+  "org/junit#junit-bom/5.11.0-M2": {
+   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
+   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+  },
+  "org/junit#junit-bom/5.11.4": {
+   "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
+   "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
   "org/junit#junit-bom/5.9.3": {
    "module": "sha256-tAH9JZAeWCpSSqU0PEs54ovFbiSWHBBpvytLv87ka5M=",
    "pom": "sha256-TQMpzZ5y8kIOXKFXJMv+b/puX9KIg2FRYnEZD9w0Ltc="
   },
+  "org/panteleyev#jpackage-gradle-plugin/1.6.1": {
+   "jar": "sha256-uD0LN8jmT+Aem1Bgt+QNW9FWwt4yocesxS7zEzJXS/8=",
+   "module": "sha256-zvCM8QHHDB13wt7Q7sg8uXKdFvKONHrg05yS+PZReyU=",
+   "pom": "sha256-q9MYynbDkpe3k9zgnumw5FUgsd2J/MmZleUB5BwKWYA="
+  },
+  "org/panteleyev/jpackageplugin#org.panteleyev.jpackageplugin.gradle.plugin/1.6.1": {
+   "pom": "sha256-TpxSuZS/oDivd5ZLP5OiZJLYLjV9ttxp0Fd9eJ4Rxgs="
+  },
   "org/slf4j#slf4j-api/1.7.36": {
-   "jar": "sha256-0+9XXj5JeWeNwBvx3M5RAhSTtNEft/G+itmCh3wWocA=",
    "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
+  },
+  "org/slf4j#slf4j-api/2.0.13": {
+   "jar": "sha256-58KkjoUVuh9J+mN9V7Ti9ZCz9b2XQHrGmcOqXvsSBKk=",
+   "pom": "sha256-UYBc/agMoqyCBBuQbZhl056YI+NYoO62I3nf7UdcFXE="
+  },
+  "org/slf4j#slf4j-bom/2.0.13": {
+   "pom": "sha256-evJy16c44rmHY3kf/diWBA6L6ymKiP1gYhRAeXbNMQo="
   },
   "org/slf4j#slf4j-parent/1.7.36": {
    "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  },
+  "org/slf4j#slf4j-parent/2.0.13": {
+   "pom": "sha256-Z/rP1R8Gk1zqhWFaBHddcNgL/QOtDzdnA1H5IO0LtYo="
+  },
+  "org/sonarqube#org.sonarqube.gradle.plugin/6.0.1.5171": {
+   "pom": "sha256-eg0FryT8MszWBHJh5skpCifsX++1GlIyfpym74oMhWc="
+  },
+  "org/sonarsource/parent#parent/77.0.0.2082": {
+   "pom": "sha256-AoNvJjQJkX0VZT1dJniuCCEz7G3+fXheQdM9Dx03v3g="
+  },
+  "org/sonarsource/scanner/gradle#sonarqube-gradle-plugin/6.0.1.5171": {
+   "jar": "sha256-0ic2EjWZ4BV583ltQ1kRUI5ksYvcUfekJWMugGeJa5w=",
+   "module": "sha256-5iB4o4Vu/5xtSdeEkaNYTHWUw79cE0u3sabj1u/UY1Y=",
+   "pom": "sha256-f5IoG31hCjhmAF/vB/bai7j2zI9zx1zK8YfNqlhm7rQ="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-batch-interface/3.1.1.261": {
+   "jar": "sha256-Kzsy65groOpyre0pM4/hghMvtMZXJW67ojpSaqQLWP8=",
+   "pom": "sha256-YKHCePJLFAgY+D/igBguXnxLLqs4Y44hBtFmDRF/3Nk="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-parent/3.1.1.261": {
+   "pom": "sha256-07k6IFpgASkDSN0GdDU9rWJpcISUQnco1XeBf4hkDC4="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library/3.1.1.261": {
+   "jar": "sha256-rbL/v1VCslYOIxk2df7MiNkJlfzFM7CFHK2j4ia9aOY=",
+   "pom": "sha256-ocE4+H7xU+rf1+zQqiKFjyM1iXAtW/Zig9/bTZytD18="
   },
   "org/sonatype/oss#oss-parent/5": {
    "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
@@ -419,33 +528,33 @@
   "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.8.0": {
    "pom": "sha256-LRFzQyMeKb4i5Im8H0gl4dS771RZBeeTJE6VIhlXFU8="
   },
-  "org/springframework#spring-core/6.1.14": {
-   "jar": "sha256-4VoRefyWQv/tE8pV4oY+LaUkzNEIO3xvG1z9VzPzssU=",
-   "module": "sha256-c5SoxHoyHbg43H3wtb7F9prMPMu7D4jn57eCdEpaahE=",
-   "pom": "sha256-7YrAnxeoq79chQmBgDdU1CSx2jYytN37Kl7K5Com1pE="
+  "org/springframework#spring-core/6.2.3": {
+   "jar": "sha256-SVMWhN8jBPDmEfd1+rp5Jzx3UE632FZZLYMOI4np6xQ=",
+   "module": "sha256-qn+EiEW+ahEMm9rPFRSfnp4wTaRS/oHqEbcb0uQbxtk=",
+   "pom": "sha256-iiURsdM4PfstvI0mmPlzR4LvZ8wg4e26hKEYrRFERvI="
   },
-  "org/springframework#spring-jcl/6.1.14": {
-   "jar": "sha256-mXXEYrrO56DBqnnlWqT67QK9KNx40SUkBNqH9ff7TLE=",
-   "module": "sha256-eVuSx7ppHm1vSPMy/IoKELVkJx1A/luRYEsT89XeBFo=",
-   "pom": "sha256-XS7hByyO0HjD5QkJVXnPKujOMBMFhthMz2q2LACN9WM="
+  "org/springframework#spring-jcl/6.2.3": {
+   "jar": "sha256-jGXsXtZIlmpHDmtIsny+v18fQSvUayQ+ARHF1dlu/oY=",
+   "module": "sha256-PxqK+qC2Yi3g2S/4zTFpBoB1CGXpSJSu7DCf7kmqDEs=",
+   "pom": "sha256-BSEm2SxKXGAHZjYcxATm4AR7V6VjfQKI0CTvb5IAPn8="
   },
-  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.3.5": {
-   "pom": "sha256-yGsKKmHOFuW2MK0UYJ3nS9dOFAX23odkPptBsbEojnc="
+  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.4.3": {
+   "pom": "sha256-TBxFUSwamoj+TrMITcNZuUmtJWM5qmydh1W3fVzLUS8="
   },
-  "org/springframework/boot#spring-boot-buildpack-platform/3.3.5": {
-   "jar": "sha256-ZvIYiRuxn8WI1nKG8nFVkjKxH25Gm0krlCTEcGdl6zU=",
-   "module": "sha256-xDXSJ0/EYh6RRdYcneiAIXZ6AWCIZOOBvRAeCy0cIpU=",
-   "pom": "sha256-zWTEONdO19uYUB7rGrAFJoVcOnD+pNiko4phk6tPPWA="
+  "org/springframework/boot#spring-boot-buildpack-platform/3.4.3": {
+   "jar": "sha256-9Fz2SHx7VThwClT26KIcvwQ9MJM09qDM1K3wGPAO3w8=",
+   "module": "sha256-uMfbOuB5Z4htPZjwFygahjwCV8jhdzxAGR8TQyQm598=",
+   "pom": "sha256-pW0pQxL9lL4GQixjMoczP5ZCxiIrxPJXqL07ptBW+jU="
   },
-  "org/springframework/boot#spring-boot-gradle-plugin/3.3.5": {
-   "jar": "sha256-P8Ujr/n8qpo376cG8FSS09xTlcH8h0uCcppsIjKHocQ=",
-   "module": "sha256-gQDJC0ty8kFj0ansMJNzw7LfKBaJDcMe8bTRFEXGkUw=",
-   "pom": "sha256-vjdd2LFqHY0zfQs7RKkOiPr5bADFDVFBNgC/85ibdwg="
+  "org/springframework/boot#spring-boot-gradle-plugin/3.4.3": {
+   "jar": "sha256-L/upm2ru6tgT7U6iHt/S49n1C2d7b5PxixHqUnzv0Cw=",
+   "module": "sha256-11HDMtbZ129uiJyTON/Wi3s1XA+hDsbDVjY8yyil/LM=",
+   "pom": "sha256-+FLbfAT1AmxT3gkQRMRzLvZUbbxZa+kRzBuPViMjhWw="
   },
-  "org/springframework/boot#spring-boot-loader-tools/3.3.5": {
-   "jar": "sha256-PqQC09miNf0jpgds3NfEiMYfR53Sx6PylBdhM7DHP9I=",
-   "module": "sha256-goTrVE/BdaUAWRApnqXVoQNFHpqFaKY7ZUy0IK349Ac=",
-   "pom": "sha256-XeUrEYYU6jy2CxzjlfnqQGLzkWNDLruniC6yKz0cGLY="
+  "org/springframework/boot#spring-boot-loader-tools/3.4.3": {
+   "jar": "sha256-RqvmIrmVLdyuyOCf2eQINZM4l+y2fSlDDSNYaFpQ1p0=",
+   "module": "sha256-s9b/bSe/6RbZu0yl4qclapOc443AmcVcDbd/IzJfIMc=",
+   "pom": "sha256-D3SaPL0ST/V7o0/KlCaemtfs8oybxcOvlR8s8BUnlO8="
   },
   "org/tomlj#tomlj/1.0.0": {
    "jar": "sha256-Mml8dWeykhxHNnioILE/xkcAqoe7FFdu60jQ7VhHz9Q=",
@@ -461,16 +570,16 @@
   }
  },
  "https://repo.maven.apache.org/maven2": {
-  "ch/qos/logback#logback-classic/1.5.11": {
-   "jar": "sha256-4iPM4yHMtDXSPh2t/GzuzNhi4tq7GipWdTGEJvf6GXg=",
-   "pom": "sha256-7u7Y46CAy0JpTgHWFBsxWu9VW4Sn4GF5zpI51VVMeu0="
+  "ch/qos/logback#logback-classic/1.5.16": {
+   "jar": "sha256-+YWjOmjZALrexbDDxhOrnbZkFdLPN4mHNX3tnaU3DjI=",
+   "pom": "sha256-y7yWslAAjVh6BnN3xzawF6fBqCxSgGh8KpCGDB4uuYc="
   },
-  "ch/qos/logback#logback-core/1.5.11": {
-   "jar": "sha256-4PJCqjxEEc6MfsMEpa/qp1IkaAiQ9fgTFT74B8u5VC4=",
-   "pom": "sha256-rtgUfEhrQnBK8C1fAF8MZI2/TbTH1/6y8YH4ZVhWD7Q="
+  "ch/qos/logback#logback-core/1.5.16": {
+   "jar": "sha256-8V4ga5jKJSlFBtLa3+XOKm2p35z3yF2OcZH5mkIt88k=",
+   "pom": "sha256-Z6n5D3mGkdzVd2xRk6b/QSa6lFsDRiv67dZXoUZ2IZU="
   },
-  "ch/qos/logback#logback-parent/1.5.11": {
-   "pom": "sha256-dkYxxGeLEOfDyUokzzjmN1Vyhd9gyQQJAn0vbep2JiI="
+  "ch/qos/logback#logback-parent/1.5.16": {
+   "pom": "sha256-PrpFA3BWtKOwfxEwviXXpd1NRpH+uTlGbzFs7PlmTmg="
   },
   "com/adobe/xmp#xmpcore/6.1.11": {
    "jar": "sha256-j3AzxXm5n6DZ1t3LlEiHW15LV3w1AAInjORpl9Z4tzc=",
@@ -504,91 +613,94 @@
   "com/fasterxml#oss-parent/58": {
    "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
   },
-  "com/fasterxml/jackson#jackson-base/2.17.2": {
-   "pom": "sha256-fPnFn70UyQVnRxN7kNcKleh3YN/huCRWufAjF9W1b68="
+  "com/fasterxml#oss-parent/61": {
+   "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
+  },
+  "com/fasterxml/jackson#jackson-base/2.18.2": {
+   "pom": "sha256-71dLcvW0iUgET2g3a4dMiK4JoCncjgX2Shwwvftt4Uo="
   },
   "com/fasterxml/jackson#jackson-bom/2.15.2": {
    "pom": "sha256-Hq1jAlXEiMUbXgq1YMdsI3GtJq422t8JKcUmVy6ls4s="
   },
-  "com/fasterxml/jackson#jackson-bom/2.16.1": {
-   "pom": "sha256-adi/myp9QsnPHXCtgr5C9qxv14iRim4ddXkuzcwRegs="
-  },
-  "com/fasterxml/jackson#jackson-bom/2.17.1": {
-   "pom": "sha256-n0RhIo4SkQPu16MC3BABqy5Mgt086pFcKn27jMYe/SU="
-  },
   "com/fasterxml/jackson#jackson-bom/2.17.2": {
    "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.18.1": {
+   "pom": "sha256-84SrzK8Mb712GDdi9yVv1nkBLtgdt/KiZofouWWgFKc="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.18.2": {
+   "pom": "sha256-UkfNwwFyXT9n9+8EkDconVr3CdaXK89LFwluRUjSlWs="
   },
   "com/fasterxml/jackson#jackson-parent/2.15": {
    "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
   },
-  "com/fasterxml/jackson#jackson-parent/2.16": {
-   "pom": "sha256-i/YUKBIUiiq/aFCycvCvTD2P8RIe1gTEAvPzjJ5lRqs="
-  },
   "com/fasterxml/jackson#jackson-parent/2.17": {
    "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.17.2": {
-   "jar": "sha256-hzpgbiNQeWn5u76pOdXhknSoh3XqWhabp+LXlapRVuE=",
-   "module": "sha256-KMxD6Y54gYA+HoKFIeOKt67S+XejbCVR3ReQ9DDz688=",
-   "pom": "sha256-Q3gYTWCK3Nu7BKd4vGRmhj8HpFUqcgREZckQQD+ewLs="
+  "com/fasterxml/jackson#jackson-parent/2.18.1": {
+   "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.17.2": {
-   "jar": "sha256-choYkkHasFJdnoWOXLYE0+zA7eCB4t531vNPpXeaW0Y=",
-   "module": "sha256-OCgvt1xzPSOV3TTcC1nsy7Q6p8wxohomFrqqivy38jY=",
-   "pom": "sha256-F4IeGYjoMnB6tHGvGjBvSl7lATTyLY0nF7WNqFnrNbs="
+  "com/fasterxml/jackson/core#jackson-annotations/2.18.2": {
+   "jar": "sha256-WBvWEADvdkiUP3gcoFaJ5W0D9gUnSDZajis6m10/oy8=",
+   "module": "sha256-4Ruvm1NubflNqmNaEBPsPgabhmuOES3cKqBEahVQUNw=",
+   "pom": "sha256-CyvWlOqJJn7qSBJqilskplI0xkM4dULSRGnRlb+6HPg="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.17.2": {
-   "jar": "sha256-wEmT8zwPhFNCZTeE8U84Nz0AUoDmNZ21+AhwHPrnPAw=",
-   "module": "sha256-9HC96JRNV9axUMqov1O7mCqZ6x1lkecxr8uXKrPddx8=",
-   "pom": "sha256-0kUGmLrpC+M48rmfrtppTNRQrbUhJCE+elO0Ehm1QGI="
+  "com/fasterxml/jackson/core#jackson-core/2.18.2": {
+   "jar": "sha256-2AVK58DRwtL1XSjkYCbr5YkogfP6tfQ5IzGEOBw7Sh8=",
+   "module": "sha256-ynjGBDZ2f8w2zhRrd05PUKnLn2MtExcsRLrojgwDz6I=",
+   "pom": "sha256-4GWwA50h9N/ORr1DEEx9dtWFa9cy4qqGDMWkonDtct4="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.17.2": {
-   "jar": "sha256-lBvNixOBuzsNcm+rQWJPqOzg7nts8oYK2V6BV85nM3Y=",
-   "module": "sha256-snbSUVf4i+6mnT9ENGWFZLcfMazeHUsaFPiYS+lTw0M=",
-   "pom": "sha256-7eVVk8YoXTmdlgc6GQy5v/QlZ5WqjWO5AXcrsxI+SDs="
+  "com/fasterxml/jackson/core#jackson-databind/2.18.2": {
+   "jar": "sha256-SzZOaFDciRcvzx1N0muP9UiO2kT/RlfiLdJlID3Vqzw=",
+   "module": "sha256-jH2sL3J4GNiEeoKqTqxrAXTXnPBN+Q3iJGBy5t005wA=",
+   "pom": "sha256-STo9tkR7eo7Ls3JCNMbOZ31y20sE9roAjw6+rqe+Wp0="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.17.2": {
-   "pom": "sha256-5pgyMzCpqCySDlqJtlsPciXI5zPBIqGPeWoEpuMfpcs="
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.18.2": {
+   "jar": "sha256-OBocBxHku4hWGmwACLWpRUZWKMoHdkzNZqDZfuB61hI=",
+   "module": "sha256-evxmQXLDpubGw1hHZaAyncb+q7/mu6ibrq2L0un77Hs=",
+   "pom": "sha256-9W9UNh5DSV7TuiShoG8OO3QZA+Q+0TLxpq086QErhBU="
   },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.17.2": {
-   "jar": "sha256-qqmNPtq/UEJr2CL60UQvva2m5HCWkybLyrXCeY8XONk=",
-   "module": "sha256-eG+CJvp0Tkyw3/M7pt+MLv8kd2PixpwhkP1SesSrrmw=",
-   "pom": "sha256-3fwpGHlF2jpkLCK4cP1keg30smJYIK/DXLeldGkWjsQ="
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.18.2": {
+   "pom": "sha256-4h1diLBHShG3H+lBAMT1KVv6F08u5q5LCtArdhZHhkg="
   },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.17.2": {
-   "jar": "sha256-m4ACSpgi5wsH9rsTgkx2wTfBBkobXrUYN0qxQYcP28w=",
-   "module": "sha256-hQ6bLt+rFU0bQVAbAZc1GtZ6K69+SCmmVmISIAJSpo0=",
-   "pom": "sha256-P1yG5fexCv31YydS8TV769ngDLNQmiB04NfnUqU04eg="
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.18.2": {
+   "jar": "sha256-8w139YJrnpgTNC6Eq0Egle1O1c9P72+TzruEjLD9ApQ=",
+   "module": "sha256-QRhvKEmAd1gdVKfhHydHr6u3vklp21tiwEsfuJs0sAA=",
+   "pom": "sha256-Zd4yKbqOtpnZSDT8dd3S7elk6Lp2y7F/VlU2YCcoIio="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-base/2.17.2": {
-   "jar": "sha256-/d9Kn+CAWTZ4whYYGFkt1bb1klZhHyoVqPRdA1xLGpg=",
-   "module": "sha256-I5CmPWivkbGztBTy03yIoWo3bfVIGeHYdNKJ57Fva8A=",
-   "pom": "sha256-MbpqN3YlxoP1mF2lnAfMn/WWlCdU1o1XTESc962wKDc="
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.18.2": {
+   "jar": "sha256-4tIC1GBuI66vilqWMtsG9f79W2PSUcP1A/n6qnhTDlw=",
+   "module": "sha256-Jd8o9WC1kI6hAYUATV/Bkyk0hHBj5mcpJID2dbOx7eQ=",
+   "pom": "sha256-FivnrZea9eDHOc1+0BiJ+Br0ggDJ+RJ5lqElrFGzSkc="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-json-provider/2.17.2": {
-   "jar": "sha256-bmDyqsam49x9BxS3vdeHnlKqRT6VyS/UmttWbl+6vi8=",
-   "module": "sha256-RUwENWSZOzY6HDKhc+fXdSb9b6eaYZfDR5nxbQXAlDg=",
-   "pom": "sha256-f+eMtFxkHwGYgwLMc5FvJ7DJEkuYHKskD8QJlqbNVUA="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-base/2.18.2": {
+   "jar": "sha256-Ir2kpF97vD3fBB1hX1H/rZw8/xwEb9cPgOsUT3vWlyI=",
+   "module": "sha256-gblJEkjbxaEkgxS+YQ6EPinyvhDRzb2oSVeG92NIJPc=",
+   "pom": "sha256-oF8ul4+JYiveopQitZ1kRrYk4jQOtFzoGws7MqaSiqc="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-providers/2.17.2": {
-   "pom": "sha256-eWGhuH0xwGqyrgr3Nn/A8bCrnBFnNRHvMiWJcQ69wrU="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-json-provider/2.18.2": {
+   "jar": "sha256-43QlZIDa+3EHDcOFrnDjeCRwENsVTI8pMUHCiHRzT1U=",
+   "module": "sha256-G0+pJqx2NfoSPRypjBJNhiCbFwKk6xGVnqi7tHAxOEY=",
+   "pom": "sha256-N1b7GWMJDrmTKRBR98SS2WQnHosV+g58+0HgiJWGPew="
   },
-  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.17.2": {
-   "jar": "sha256-hVYckOm941aaaI9XQQvelGFAs1Wr3XCuwFP+yVTjAaY=",
-   "module": "sha256-JR4jRcce8k2uUpe84BAk2ESa3L6IJimArNCt1fiTil4=",
-   "pom": "sha256-L4BbIPMNTBlqQV+9HljEE1p71xh9LhnFae9Eo2dKjTs="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-providers/2.18.2": {
+   "pom": "sha256-NJBwwUCuHb7rwq/7yFGy6xViWVKjAwa/vVazE0aeXcg="
   },
-  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.17.2": {
-   "jar": "sha256-HuXi81k9RHJrkAhoxvZNGlBjalaD1tQEJ/WYSmHeU8A=",
-   "module": "sha256-crBsxJRu9LXdDMpqDT6byf2rFxlTGOF1OOGfzj9lNng=",
-   "pom": "sha256-sm0FFho+BOejiIIRecARtkFXKrr4DiNdBOoRgTLQaDo="
+  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.18.2": {
+   "jar": "sha256-ZFyk3imYBHPxmubAjXws4OP9JzJE0xVbXao7yC+hPUE=",
+   "module": "sha256-wRlrUgwa7RJ88R3ka0l9gbxPNVquWqvIFwcwfX6x30U=",
+   "pom": "sha256-T2FGzIFi5nDA1ERI8q1Iqf9WSeQHFmhM+gSua2Bm+fA="
   },
-  "com/fasterxml/jackson/module#jackson-modules-base/2.17.2": {
-   "pom": "sha256-rrMBBVHhN9CeuDhPO4PCQSXcOSwqmHIexorT/4TlWSU="
+  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.2": {
+   "jar": "sha256-Z6aktrkfPUUN8h53QX9AC+Zjvgz1KOSDSczDgc90s7A=",
+   "module": "sha256-LBXqycqNl7Q4LNOEMlHIrH7uIlbPfcPknsydE2t2z04=",
+   "pom": "sha256-IBZ1+nWRQy+yYIuQ0hgiPncyqU0BNG/ip1/GqbrLRNE="
   },
-  "com/fasterxml/jackson/module#jackson-modules-java8/2.17.2": {
-   "pom": "sha256-PznFUQn1GiKIF7SxheQ1G57wUBwJ/B4aMHWulUfMLQM="
+  "com/fasterxml/jackson/module#jackson-modules-base/2.18.2": {
+   "pom": "sha256-wVCoPSPNizMiqqSYmEh0J5vi3I1f4qN5B9P1arYOJpw="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.2": {
+   "pom": "sha256-s6z7kQ0CPpOkGZr8zeH/nsX6sMVQ3E+WilBXEXrLCzY="
   },
   "com/fathzer#javaluator-parent-pom/1.0.1": {
    "pom": "sha256-YRV0qFwGU9vwoDS7iJ9LrCZr0oZz6EZ2w2o6TNqWLfg="
@@ -600,6 +712,14 @@
   "com/fathzer#parent-pom/1.0.8": {
    "pom": "sha256-zRQ6tSZOnHOx0gQmT1GKVaAZpmgdV/J5C+s9s90sPCA="
   },
+  "com/github/jai-imageio#jai-imageio-core/1.4.0": {
+   "jar": "sha256-itPGjp7/+xCsh/+LxYmt9ksEpynFGUwHnv0GQ2B/1yo=",
+   "pom": "sha256-Ac0LjPRGoe4kVuyeg8Q11gRH0G6fVJBMTm/sCPfO8qw="
+  },
+  "com/github/jai-imageio#jai-imageio-jpeg2000/1.4.0": {
+   "jar": "sha256-B/tuOjBAEiuEbF5SUgAzF1wyUeLsiDDfgvh8sh84i7E=",
+   "pom": "sha256-jQd0KBAHliclrx93swfN6BbP1+4loQxTI3nW41ZMvh4="
+  },
   "com/github/stephenc/jcip#jcip-annotations/1.0-1": {
    "jar": "sha256-T8z/g4Kq/FiZYsTtsmL2qlleNPHhHmEFfRxqluj8cyM=",
    "pom": "sha256-aMKlqm6PNFdDCT5StbngGQuk1aUhXApZtNfTNkcgjLs="
@@ -608,12 +728,19 @@
    "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
    "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
   },
-  "com/google/errorprone#error_prone_annotations/2.11.0": {
-   "jar": "sha256-chy5GEK0b6BWhH0QTVIlyLjh6LYiY7mTBR4eWgE3t+w=",
-   "pom": "sha256-AmHKAfLS6awq4uznXULFYyOzhfspS2vJQ/Yu9Okt3wg="
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
   },
-  "com/google/errorprone#error_prone_parent/2.11.0": {
-   "pom": "sha256-goPwy0TGJKedMwtv2AuLinFaaLNoXJqVHD3oN9RUBVE="
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
+  },
+  "com/google/errorprone#error_prone_annotations/2.27.0": {
+   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
+   "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
+  },
+  "com/google/errorprone#error_prone_parent/2.27.0": {
+   "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
   "com/google/guava#failureaccess/1.0.1": {
    "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
@@ -659,12 +786,9 @@
   "com/googlecode/owasp-java-html-sanitizer#parent/20240325.1": {
    "pom": "sha256-OXpFf8kcCbT+HBtvZuVkF3oBtpwQQxU/d3K4D0wfFcE="
   },
-  "com/h2database#h2/2.1.214": {
-   "jar": "sha256-1iPNwPYdIYz1SajQnxw5H/kQlhFrIuJHVHX85PvnK9A=",
-   "pom": "sha256-UX4aBXKZSVISML9WJlvaxaI5/bkOrWyqhfDGppzX+AM="
-  },
-  "com/h2database#h2/2.2.224": {
-   "pom": "sha256-DUUDoBpMemL5GuGmJxM5z4BvKkYt7+C+/17/1aYR45g="
+  "com/h2database#h2/2.3.232": {
+   "jar": "sha256-ja5i0i24mCw9yzgm7bnHJ8XTAgY6Z+731j2C3kAfB9M=",
+   "pom": "sha256-7O2yquV8vtuMAhfSC5O9Ld6IAxGYwgQlGoEHu4Mr+fA="
   },
   "com/jayway/jsonpath#json-path/2.9.0": {
    "jar": "sha256-Eanub4i7MfFFAQjRz2RBN33shKygdetrsjQ74VdXW+o=",
@@ -687,20 +811,20 @@
    "jar": "sha256-Eq5KOiYAldeuuirep645bouVcNuLe0CeCagkwhnMBEQ=",
    "pom": "sha256-r8Y7aJ2IFDm5XzQ7Hcp1A5HtrGO4c5K+TZDRnJTMr74="
   },
-  "com/nimbusds#oauth2-oidc-sdk/9.43.4": {
-   "jar": "sha256-qq6G2BhiRNvDVm+qHw9nzjgKz3d3QwLO0g1SL8YTsK0=",
-   "pom": "sha256-RnCDbjnZ0P3CDuGqpf8bk3WYOptPlDzxipNYaktjH1U="
+  "com/nimbusds#oauth2-oidc-sdk/9.43.6": {
+   "jar": "sha256-/ulOrlxDiOHef7qE462iuS0Xu7soxjDUJYpvBhXB8wM=",
+   "pom": "sha256-lusqwKOmi0Q3mu+oa2yc+RSDQI7OAafKUbbUL0NTE2k="
   },
-  "com/opencsv#opencsv/5.9": {
-   "jar": "sha256-ICOWm4bOlorYrlSWSKxYfRQcGa5oSppcZ8kQXzerDRw=",
-   "pom": "sha256-l+UC78Xmwt0VZiGynKy8D0dEIowAmPaxafV/eukwMGA="
+  "com/opencsv#opencsv/5.10": {
+   "jar": "sha256-55J+uabU+KNIpSCQfbsI2mKDpESKu5vZ7y+VDXu5ULA=",
+   "pom": "sha256-gMuqtG1lfpLy4dGjVqENl0bc2VTVgBsLVRa2W6WF3Oc="
   },
   "com/oracle/database/jdbc#ojdbc-bom/21.9.0.0": {
    "pom": "sha256-YWOUxaVc9n/ygO1pdup/MxarCdRMDin6ILZqyykKyaU="
   },
-  "com/posthog/java#posthog/1.1.1": {
-   "jar": "sha256-ZR4qhzaFTtXc1+gG6tltR9kqGErcIK0XscISECKMdRk=",
-   "pom": "sha256-oj6QZKWCJMpuy3kF2wMVDncE0xcZ/yNscRxUq81j080="
+  "com/posthog/java#posthog/1.2.0": {
+   "jar": "sha256-gnEBAD2F9li1yqwPI4IQ/ySEhjR+qVSd6kvBPHWfYao=",
+   "pom": "sha256-YIqAJ1xuFdnIJ7i/5RZw0LCqjy6jsgd5xT2vokFoTLo="
   },
   "com/querydsl#querydsl-bom/5.0.0": {
    "pom": "sha256-M9iKwC/Iwb2sEp3BGP/aOxf+lr9c+DVB3cAUoptiexs="
@@ -711,10 +835,6 @@
   "com/squareup/okhttp3#okhttp-bom/4.10.0": {
    "module": "sha256-NLNP75zu3d2ihMXxVoc4lg0qU9VuHvz/jK6tPmZSpcM=",
    "pom": "sha256-vmLpNvEMNmU+XpGVrwBVq4bMugi4/sKo773exKzu71g="
-  },
-  "com/squareup/okhttp3#okhttp-bom/4.12.0": {
-   "module": "sha256-fg4vNHsbY22SsEMZnlFAPhXwn7SsRujBY1UaWCt7Brw=",
-   "pom": "sha256-eAg47mfyoe5YCIfeinSOWyWfnoFULhxCRNUEJlmSLhQ="
   },
   "com/sun/activation#all/1.2.0": {
    "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
@@ -802,29 +922,120 @@
    "jar": "sha256-37e64vQEz+C3K00jlEaYy3FrdmUXGBKgpND1kmwPrHk=",
    "pom": "sha256-L/bBfZwGC4nNfvGPpICuJEbrqGhVpjPziSg3/DuEj+8="
   },
+  "com/vladsch/flexmark#flexmark-ext-emoji/0.64.8": {
+   "jar": "sha256-AS0ttRRjr9hHAmJ+ST/tzkLrfesbrjCd3O/RgasoPL4=",
+   "pom": "sha256-N1dSYA7KUGOae9HyFnK282sDFbYCoOcKDzoGRZZxQKk="
+  },
+  "com/vladsch/flexmark#flexmark-ext-gfm-strikethrough/0.64.8": {
+   "jar": "sha256-/GytAm+9A2s//QRIJkNgpfG1cnVu80J/8CJxW3/F8cM=",
+   "pom": "sha256-29iSNA0WNyOaf2bF5SGSELfNQX0f13HOk6llsD9xgog="
+  },
+  "com/vladsch/flexmark#flexmark-ext-ins/0.64.8": {
+   "jar": "sha256-W2G4PDHLC9MnPL8SrtOIe2O4vcbfoXsD7PR5zxzhdr0=",
+   "pom": "sha256-TPZAzDnlBtzCvF7Sk0ZOiet9u3X8chhlgre2M8ziWyE="
+  },
+  "com/vladsch/flexmark#flexmark-ext-superscript/0.64.8": {
+   "jar": "sha256-RXkzMk0cqfKDvBWhhCd3xt8DhfMY/M6t5N5BYhOV5AI=",
+   "pom": "sha256-+JfvOutkMsN/uIgBcgUxFtEa84rkcJyQiqcBVM0mGh4="
+  },
+  "com/vladsch/flexmark#flexmark-ext-tables/0.64.8": {
+   "jar": "sha256-zfgtJuES6WrefjcBOK6xaSC34tQR0gxsFcsaz6zR7x8=",
+   "pom": "sha256-+Lnuh0FZExL8I1PkfMjMbZIud2RInYOrrX0V8zU33PU="
+  },
+  "com/vladsch/flexmark#flexmark-ext-wikilink/0.64.8": {
+   "jar": "sha256-8y73ee77TDuA1b6/PEt61yBvxG4IOlkBz1Hbe0U1/3k=",
+   "pom": "sha256-Vr+s6mEz9k+F30Ir6iY/9USKNWCxfSIXw8LSvJRPtbo="
+  },
+  "com/vladsch/flexmark#flexmark-html2md-converter/0.64.8": {
+   "jar": "sha256-PySpCo/t1nCPBr5yu8n19SEavEnDXulZGM57C0FlHmI=",
+   "pom": "sha256-UrrKRFXJePTvC0NK2oOfmHQy9JaQFS7yDkxvHmYb7TA="
+  },
+  "com/vladsch/flexmark#flexmark-java/0.64.8": {
+   "pom": "sha256-QHv3UvN2KqkIxfxNZkuJOZTRt4OqIKKWakP4bBVetDM="
+  },
+  "com/vladsch/flexmark#flexmark-jira-converter/0.64.8": {
+   "jar": "sha256-zMHDqWWaEEt1pTojIenB1M7bBazYZ9Q2bYuOFke9N90=",
+   "pom": "sha256-aO668VQ27ex78DMIQgcN0iOqcXQcaX17yQKVEdlG4II="
+  },
+  "com/vladsch/flexmark#flexmark-util-ast/0.64.8": {
+   "jar": "sha256-pTQvZExqXzfVAvIlw6DLaZwmNiHILnINnAjrpanzuNM=",
+   "pom": "sha256-M5IPcD8naQ/qq7CKQ07O8g073bpMbcF9m1EYACUHITM="
+  },
+  "com/vladsch/flexmark#flexmark-util-builder/0.64.8": {
+   "jar": "sha256-r7nIjZ9lJFHnXxqwaa193XkdcS6yEcUdjSqDSUJAh10=",
+   "pom": "sha256-ERKthdmLh0tJeVT6eySR9AXb4B2kso0x9XVMzFtqL6E="
+  },
+  "com/vladsch/flexmark#flexmark-util-collection/0.64.8": {
+   "jar": "sha256-Ax/wFAjQ9UxiNdsY1FHcbmsVuFmw7B5A/zQpqCN1CCo=",
+   "pom": "sha256-xHLCQN7mFbkqISQcG0Lzm/44ZYlcMChulWI82UBecms="
+  },
+  "com/vladsch/flexmark#flexmark-util-data/0.64.8": {
+   "jar": "sha256-g861mJqwIFBUvxtCRG9Vy22hTBCqfCvaBdaiUEZw81M=",
+   "pom": "sha256-26l1Ca96vWwSBNwLP2K0hpzxqON8np1mNW4QqyTkhfE="
+  },
+  "com/vladsch/flexmark#flexmark-util-dependency/0.64.8": {
+   "jar": "sha256-5BrbXoFEaZtht41Q6wBO633oT5DExjYmYJ5s7l6ii0I=",
+   "pom": "sha256-0EkP+0Tt80pQprn6nrXD3XPT9weOH03oruUhmyIURVY="
+  },
+  "com/vladsch/flexmark#flexmark-util-format/0.64.8": {
+   "jar": "sha256-bJrIdoZHTt8BF7P4ONncs7ll+nK+SZjSF3tZgBNnn3M=",
+   "pom": "sha256-q+B6AP/rbr+L6DoCzOTSdpHnRUlRvnatteV9qmJiSOE="
+  },
+  "com/vladsch/flexmark#flexmark-util-html/0.64.8": {
+   "jar": "sha256-WxnmUGr/eRPHStclr3wrip8jlY5jJL8HEMWmRaRmMBc=",
+   "pom": "sha256-QSOT8DUt+GmWg4KaaRDOIX7RtSyaucYZIg1OM9W0n7o="
+  },
+  "com/vladsch/flexmark#flexmark-util-misc/0.64.8": {
+   "jar": "sha256-dEcsqBqQgOUeoaTxHCcImOPWwkLJInX6tH65k4Bsjys=",
+   "pom": "sha256-7kzBaZZgo0M+YJAy20ar+0yTTlGmP3pYOewfi2qVwOE="
+  },
+  "com/vladsch/flexmark#flexmark-util-options/0.64.8": {
+   "jar": "sha256-JIn0HpyvHZ+AYYM7MRslQDkly7Yx//K4wGkZKATW/Ig=",
+   "pom": "sha256-GA5DN4dxzcVhlDhgQ8XX9Dsq7EW9N9CJwmYV0As5i2A="
+  },
+  "com/vladsch/flexmark#flexmark-util-sequence/0.64.8": {
+   "jar": "sha256-biKXb+TpuN6U/VKZkeyy15zEgqrZSYU2dHCpO+HYJjE=",
+   "pom": "sha256-bOq0Eg9oVbt9IeVyDhVuogqWkeURN9ZGj0uQZzUvg+8="
+  },
+  "com/vladsch/flexmark#flexmark-util-visitor/0.64.8": {
+   "jar": "sha256-2bMAKoM6B4xF4TlWizBtqwrBF/+QRsah+eGAwBVFY/w=",
+   "pom": "sha256-+kWiyg+uR7+nw6GXwiuhe2QiNZhZTDimzlknPlOQwXY="
+  },
+  "com/vladsch/flexmark#flexmark-util/0.64.8": {
+   "jar": "sha256-HiTIkdrJUyu3Ir5xIscCb7R4aMPeNsAkAO7Y6a1TVyc=",
+   "pom": "sha256-g4Eg9qTozQub7BiGcCnXjxFNV3zcvOppRr65fsmM5/g="
+  },
+  "com/vladsch/flexmark#flexmark/0.64.8": {
+   "jar": "sha256-MTOHjRCPDhlk19Qn83mnQz4bcaRfnzwfq37QrAMB07A=",
+   "pom": "sha256-wwO7cco5tSiAann47wLaSpTxklt11Bh3ojRNsbwiWpI="
+  },
   "com/zaxxer#HikariCP/5.1.0": {
    "jar": "sha256-pHpu5iN5aU7lLDADbwkxty+a7iqAHVkDQe2CvYOeITQ=",
    "pom": "sha256-M0sOCm5lucZJw/6Wc5ZjpEEOGpF2ZTgC5ZVJO4YYLyw="
   },
-  "commons-beanutils#commons-beanutils/1.9.4": {
-   "jar": "sha256-fZOMgXiQKARcCMBl6UvnX8KAUnYg1b1itRnVg4UyNoo=",
-   "pom": "sha256-w1zKe2HUZ42VeMvAuQG4cXtTmr+SVEQdp4uP5g3gZNA="
+  "commons-beanutils#commons-beanutils/1.10.0": {
+   "jar": "sha256-tujb9dSn/WbtvHEGiGkJwJfcfgdoynjMEFWVXW/4d6E=",
+   "pom": "sha256-znPbgRwgsbDBHqjST4j0angkPhmWR+CCRgnlDPge9Gk="
   },
-  "commons-codec#commons-codec/1.16.1": {
-   "jar": "sha256-7Ie/tV8iy9GyHiGQ7toosrMS7SpDHuSfvcwBgS0EpeQ=",
-   "pom": "sha256-uCbd2S+dfMZDcaAvoIMMFU1nyYNw6lSi0ZbnLrWQrSg="
+  "commons-cli#commons-cli/1.4": {
+   "jar": "sha256-/Tx8lUWpzbIFHR+RVcT3ax5KxaVzBEBKbu21eP+6cyg=",
+   "pom": "sha256-9Ym/MKmNx0l0ELjrjYahZ2N1d6xVzV3TDMS1fbvG+JM="
+  },
+  "commons-codec#commons-codec/1.17.2": {
+   "jar": "sha256-QUgzJyhJDO8Ssp2sTDhfRpgvBChRMsb6Ua1yZ9fceos=",
+   "pom": "sha256-4kAvuaYGA4TzK9T8aQKxBr/3r8e5UpuDGoUMrKqjJG4="
   },
   "commons-collections#commons-collections/3.2.2": {
    "jar": "sha256-7urpF5FxRKaKdB1MDf9mqlxcX9hVk/8he87T/Iyng7g=",
    "pom": "sha256-1dgfzCiMDYxxHDAgB8raSqmiJu0aES1LqmTLHWMiFws="
   },
-  "commons-io#commons-io/2.17.0": {
-   "jar": "sha256-SqTKSPPf0wt4Igt4gdjLk+rECT7JQ2G2vvqUh5mKVQs=",
-   "pom": "sha256-SEqTn/9TELjLXGuQKcLc8VXT+TuLjWKF8/VrsroJ/Ek="
+  "commons-io#commons-io/2.18.0": {
+   "jar": "sha256-88oPjWPEDiOlbVQQHGDV7e4Ta0LYS/uFvHljCTEJz4s=",
+   "pom": "sha256-Y9lpQetE35yQ0q2yrYw/aZwuBl5wcEXF2vcT/KUrz8o="
   },
-  "commons-logging#commons-logging/1.0.4": {
-   "jar": "sha256-6Ur0l0k4TBH1qlDo0PX+Z5vncSlbUgMDONMoQ8mANR4=",
-   "pom": "sha256-ZdMQUJNStUJRGCJe5gCgH4O6chQtA1AUtdFkvASy0oQ="
+  "commons-logging#commons-logging/1.3.4": {
+   "jar": "sha256-vC3+MvHvBlCeagZRRMGt97Qg6r8RqH8wvRJ/j6ozIBY=",
+   "pom": "sha256-1L2jSJKqzL9PrTP8MjqKqQfvnXmYRlnaJJRMCoa/CGU="
   },
   "io/dropwizard/metrics#metrics-bom/4.2.15": {
    "pom": "sha256-jeCq6KvWprh1x3JJoC2oHVFOTaKIBG/6+OFYEaPywp8="
@@ -848,50 +1059,44 @@
   "io/dropwizard/metrics#metrics-parent/4.2.25": {
    "pom": "sha256-33tjcfmxVpjhI9mGHyCZyjLJ7JZtnwxgdVoqNMy/q8I="
   },
-  "io/fabric8#kubernetes-client-bom/5.12.4": {
-   "pom": "sha256-0jI5KonD79yFqymcWpToud01vALzQM6ERv9lmqFZE6A="
-  },
-  "io/github/pixee#java-security-toolkit/1.2.0": {
-   "jar": "sha256-53T/9SmHY4UGG382VNyr8ef15Z/ctoFqvlPQtjydkJA=",
-   "module": "sha256-tTocVLs16ou6XTHb8tyimtPJKT1fg37aIWEtvnFrQ0c=",
-   "pom": "sha256-Bc4BBr4BbcQe9VbatoW157GwdSGi/NtTNaHqn8+E6mk="
+  "io/github/pixee#java-security-toolkit/1.2.1": {
+   "jar": "sha256-tp2fp0URFahxtgp2C2T4eqhFxtMdYHHNXxLG+kz8wiI=",
+   "module": "sha256-yVtRSvUY7z3hT8u/D7x+a9qWbz2GKAbAUGw4VLAGASo=",
+   "pom": "sha256-QS8qIbNob7S9/im6e26f3p/zjHkgX3dd4i+ixGkIAVw="
   },
   "io/micrometer#micrometer-bom/1.11.2": {
    "pom": "sha256-2qo2vb6vKmnTVi6A92D+f4bU02uUGsBbqhjPpGtkvhA="
   },
-  "io/micrometer#micrometer-bom/1.13.6": {
-   "pom": "sha256-2tjiAeDzTg/l2Yt/gtoO+ul8ftDUZZK6XRTRT80HNvU="
+  "io/micrometer#micrometer-bom/1.14.4": {
+   "pom": "sha256-nXV+Ip4mskymMo1BAHTVPvIgI+kpW+gxTPa+KnOvQ5U="
   },
-  "io/micrometer#micrometer-commons/1.13.6": {
-   "jar": "sha256-plvl38w8eCvwyijOpTXBiyJg4kp3Pd/wU7hfxqk8cG4=",
-   "pom": "sha256-9mQw515c3+W4vsOkaKkty/gqi+o5B9ftD7UvGCHbCiY="
+  "io/micrometer#micrometer-commons/1.14.4": {
+   "jar": "sha256-a7D1b7iPZd20sIDj2AFl7rF0DyInuguKw4YQmWn36b8=",
+   "pom": "sha256-Iopw0QbpWwk7ZFDeCdjAL0A0WVJG53sjHHXD7BTef+E="
   },
-  "io/micrometer#micrometer-core/1.13.6": {
-   "jar": "sha256-NZZvvc1VKGRymiwTbg3/I2g7XDvF/3ARRsPp8gmPKOc=",
-   "pom": "sha256-ha9r28IZiHD5AcDuRviBuqetNs946/rIKU2LV0ipICA="
+  "io/micrometer#micrometer-core/1.14.4": {
+   "jar": "sha256-0WPGmzji+fmhSz0bNuWonXuM8kekH8RK/VByw81k5RY=",
+   "pom": "sha256-szYrcvIx6yPw6tXDUwns7YVFwqoH3kbi67KGprBq3Ak="
   },
-  "io/micrometer#micrometer-jakarta9/1.13.6": {
-   "jar": "sha256-msjvflNwxTA50GJbW3GvU1BkxbFNdVSdoLn2fjOfrdc=",
-   "pom": "sha256-4CjAF/bPfSHyLfVxEvdqO8yE7AV2gR9813DdpK9Zfu8="
+  "io/micrometer#micrometer-jakarta9/1.14.4": {
+   "jar": "sha256-jJj/s9G5SZJaxQyiWqyBDZWtddUVhftf6eDyVAYMW7s=",
+   "pom": "sha256-+VsGTGIBUZIznFycf5xchLc4SN0WdXNQ2uv+QpHMtxQ="
   },
-  "io/micrometer#micrometer-observation/1.13.6": {
-   "jar": "sha256-c/Xb0IWwqa7tQU6mwMG6RXM3A24OS2ik+11EmGg9Dt0=",
-   "pom": "sha256-U3NxWc6jerjuWYKSZw7npfY6eBpe/aOt+x9yisBRFL4="
+  "io/micrometer#micrometer-observation/1.14.4": {
+   "jar": "sha256-KN1LABwU/BOwvEhTViEhSRZRiJWSTjzlKKYEIFsf8KE=",
+   "pom": "sha256-QbnNkGZsx11dw/SpucmoiXvE7eodOxvPpaKhsfa1GXg="
   },
   "io/micrometer#micrometer-tracing-bom/1.1.3": {
    "pom": "sha256-fprbb3oR0grb8tb/f7NMCJ9FGvQdM7uRjr17kcXszJk="
   },
-  "io/micrometer#micrometer-tracing-bom/1.3.5": {
-   "pom": "sha256-wWJpo3Y690kICbHJGs8qt4a+J9gq9d+pwJohAPg6KQM="
+  "io/micrometer#micrometer-tracing-bom/1.4.3": {
+   "pom": "sha256-Kt0beCbiDPKM7J5vT+n00sjBl+PqXZQ1cVcQtlhu77Y="
   },
-  "io/netty#netty-bom/4.1.107.Final": {
-   "pom": "sha256-w2mXVYv7ThHyAN2m7i5BpF8t+eGu9njtoI553Yk4whA="
+  "io/netty#netty-bom/4.1.115.Final": {
+   "pom": "sha256-JdyLuDN9/BhsSfyM9PaltsfPQUY2L19EDaytzQ35dhs="
   },
-  "io/netty#netty-bom/4.1.109.Final": {
-   "pom": "sha256-ZjFy46WwvVMEUtlhTVh9KtU6Pdp+9CPaJbc0KSIqNJE="
-  },
-  "io/netty#netty-bom/4.1.114.Final": {
-   "pom": "sha256-Df0Iq8EG9iW+HW60mPqZPeZci1WAcN+xGvqaM5S7ZhI="
+  "io/netty#netty-bom/4.1.118.Final": {
+   "pom": "sha256-kA94/W64xqZ7TJo52eXNlvnsonCxLXCQvFBX7+foKGo="
   },
   "io/netty#netty-bom/4.1.94.Final": {
    "pom": "sha256-FLsEPt93HvaT1f9ezBRm913JFpjwSn+oIrMJPT0COdE="
@@ -900,26 +1105,30 @@
    "module": "sha256-RHe55WRW2h7ZM64ig4bOAbusBl2bVLSZ7cKI4rumzLk=",
    "pom": "sha256-VsipemuNS6DjaRVWdCMISrVTq++a+XTaGTXcIeXjCR8="
   },
-  "io/opentelemetry#opentelemetry-bom/1.37.0": {
-   "module": "sha256-0Kr0RXnLl0xznMMlPGOH6NzDYMP3FIJvrpIWdvPvoPQ=",
-   "pom": "sha256-wUCREcWoWtiQVjDhyk6q7qk3nyx4o6GTmIPACeb/JAk="
+  "io/opentelemetry#opentelemetry-bom/1.43.0": {
+   "module": "sha256-FihOwxKoOYVg114KpIBTwXZNFk6w13f8BEC5s2xOtKE=",
+   "pom": "sha256-oSv8/iZgecXMvL785RIts/mbE6u6KvrSKkztn+/oxHk="
   },
   "io/projectreactor#reactor-bom/2022.0.9": {
    "module": "sha256-BfI8ABvRI1lpnqe+Y6bRi03YWoqRZ/PxehkRrwI9t7k=",
    "pom": "sha256-agI/PfE5yap6gWUR1YSSnd0PXrhIeb+i46VRTFsXYJI="
   },
-  "io/projectreactor#reactor-bom/2023.0.11": {
-   "module": "sha256-Zt09jzLY1v2J+TmdJu8N50mGspuxAgklbMQJniQkgvA=",
-   "pom": "sha256-J7VhRa1PO2xW4GtXSSqVVPtP4vXRMgHPAZB3xvNfQyg="
+  "io/projectreactor#reactor-bom/2024.0.0": {
+   "module": "sha256-q9+I0toctizFQ+OgBJvN0/40JvOfqIH6/38OEifY1S8=",
+   "pom": "sha256-sPfCTHH0Hlqqku03Pm1SI6HTXuKRMDgNhehmSnhPpRY="
   },
-  "io/prometheus#client_java/1.2.1": {
-   "pom": "sha256-/I9/4rTvDO7chDk7iQCpPWSxnJg/+CFmyEozZnBwun0="
+  "io/projectreactor#reactor-bom/2024.0.3": {
+   "module": "sha256-DaIfB9EoPt7t/OVqll5tkgZ2bt39CjWr9oKLv1J/x5c=",
+   "pom": "sha256-LHuu9g6FJLrKuaFDYzev+SEVjYzukNw+AJAIZcGH4Fk="
+  },
+  "io/prometheus#client_java/1.3.6": {
+   "pom": "sha256-n/AOSQfYUE9Rt6u2o9wns7fLZQmOWb7Nt14TjjPHR0I="
   },
   "io/prometheus#parent/0.16.0": {
    "pom": "sha256-citVEZCXsE1xFHnftg3VSye1kgoa63cCAnxEohX/xZY="
   },
-  "io/prometheus#prometheus-metrics-bom/1.2.1": {
-   "pom": "sha256-jad6fZgGP0gVLr6LX1p+CnFj5Jn90iBI8ZZnVgIOans="
+  "io/prometheus#prometheus-metrics-bom/1.3.6": {
+   "pom": "sha256-7F7SHKoBR1WFBiSTeY7gQUX7wUmkUNXFMWnASxUCg2A="
   },
   "io/prometheus#simpleclient_bom/0.16.0": {
    "pom": "sha256-r0QdMpXeEacONf6+s9kZui7RdVJ1MWMyW5VNU1lNVcM="
@@ -927,21 +1136,24 @@
   "io/rest-assured#rest-assured-bom/5.3.1": {
    "pom": "sha256-Tg5ZUuRY6U+3dZ3nFM6hy9ru/ZFSJ4Z1if6R1EKJBUg="
   },
-  "io/rest-assured#rest-assured-bom/5.4.0": {
-   "pom": "sha256-PwPaOF0/x5zMpbMiNuK9IORcgElQHNAxfn+NlmCC1qs="
+  "io/rest-assured#rest-assured-bom/5.5.1": {
+   "pom": "sha256-LKG6f3hk22p9WQLKWlwogHp2g5upZiP+fLjoihMe6Es="
   },
   "io/rsocket#rsocket-bom/1.1.3": {
    "pom": "sha256-5czY/tNBW7Q4Xk0Hh+PjNiTLLHwALSVQw5eI8rubD64="
   },
-  "io/smallrye#jandex-parent/3.1.2": {
-   "pom": "sha256-fkYFO0xKyz2eo+8LDLLRqWvriSRanlsriuSEzXX4Its="
+  "io/rsocket#rsocket-bom/1.1.5": {
+   "pom": "sha256-Ck4TdcyMFOz+MSIZQGgXmO+Ke4r26JaONj8VwO1HjD8="
   },
-  "io/smallrye#jandex/3.1.2": {
-   "jar": "sha256-3uEvoXh9VSPtGgLWxjsZ5672rFYPfG1wWV2wGqN+BB4=",
-   "pom": "sha256-HFK+SK0hc8V9n7gVhdW/WriGO1jz8sd6/zIL7zINP7o="
+  "io/smallrye#jandex-parent/3.2.0": {
+   "pom": "sha256-WPnpF9Q4ZNeG22JKATOyij4tYEptqETHIBeiqNiuO14="
   },
-  "io/smallrye#smallrye-build-parent/39": {
-   "pom": "sha256-NtHAKKxxhuPvCc0h603rb8RGdU0Mubl6NVGkwePGzwI="
+  "io/smallrye#jandex/3.2.0": {
+   "jar": "sha256-baPpzo0MCkM/PnzmEKPGasywDHH+5nqg/z5ahBOVrBU=",
+   "pom": "sha256-veRmaZ/UPVT1uLonERXRUT2fMW34CyZeGctNyTzsCWI="
+  },
+  "io/smallrye#smallrye-build-parent/42": {
+   "pom": "sha256-FBJFawNFSQ+NC00L5SnQSh1Y0Z1a2FvzHDdAwT+Q1t4="
   },
   "io/swagger/core/v3#swagger-annotations-jakarta/2.2.15": {
    "jar": "sha256-2RvQjd92HA2zTvao4Ftf4/7cJrt2h4ti/aEwJLhP7Qw=",
@@ -967,8 +1179,8 @@
   "io/zipkin/reporter2#zipkin-reporter-bom/2.16.3": {
    "pom": "sha256-3hWmaeME4kB8d2agw6vuCKTsAf+JOoBJoJFo5kPFpvw="
   },
-  "io/zipkin/reporter2#zipkin-reporter-bom/3.4.2": {
-   "pom": "sha256-2dVs6krrwqS03rb53fIefVTa2ppqEyvicjXBFTDU9Rg="
+  "io/zipkin/reporter2#zipkin-reporter-bom/3.4.3": {
+   "pom": "sha256-gNbEmFeGJ2Awx5+Zt+ElDe7sob+Z0zDbXcOKh6bpkZ8="
   },
   "jakarta/activation#jakarta.activation-api/2.1.3": {
    "jar": "sha256-AbF21xihaSY+eCkGkfxHmXcYa8xrMzSHMlCE1lhvRic=",
@@ -1048,16 +1260,32 @@
    "jar": "sha256-iLlVoN9XiAomp0cIvDT3Tcr46/TniEOii1Dq6UVzKwY=",
    "pom": "sha256-ErIM+SJ3NEXDRFwog8v2cfqYIRHpv5+HUCD5MTs4FLE="
   },
-  "net/bytebuddy#byte-buddy-agent/1.14.19": {
-   "jar": "sha256-nzOGemHnJhrw/kt46NhDQoS1dylZeFJNFoHlv7z96E0=",
-   "pom": "sha256-61VgCGre00h7uCvIw7/GVJoonQpBGOJAUSOryZ2dBdw="
+  "me/friwi#gluegen-rt/v2.4.0-rc-20210111": {
+   "jar": "sha256-4UwfKiQ4Q0k11th8aBqCtWI9t8R8o84f9M1wIwqxqlE=",
+   "pom": "sha256-6Z7+XtgkagItsy0Q0JZuBzNAW9QZx5CBgwYDe7RRZss="
   },
-  "net/bytebuddy#byte-buddy-parent/1.14.19": {
-   "pom": "sha256-Swuyl9Wz4gov5jLlorCt8Qoy27CdUuaeMbGtumfemm0="
+  "me/friwi#jcef-api/jcef-1770317+cef-132.3.1+g144febe+chromium-132.0.6834.83": {
+   "jar": "sha256-51h4/1InqDBfRA1YIbQp0MptO3Ie/yyOidILAB9W6Ew=",
+   "pom": "sha256-VlV/Q4s8D4BrHqbK2kjzkImWfxvZJ/9dRMj0xhVlfVA="
   },
-  "net/bytebuddy#byte-buddy/1.14.19": {
-   "jar": "sha256-hBWkTYQbLN7N9dc6BcKajPktwrYPyn/3s/Ic1DG1pOw=",
-   "pom": "sha256-fEn+DXvCCenqFWsqmFUbCJzxOTI1zNr9O7cr8NTaodg="
+  "me/friwi#jcefmaven/132.3.1": {
+   "jar": "sha256-6Fe3hk8pnaX9NMcKds7y09I3G4tUQbF1u1VGNRc8+eY=",
+   "pom": "sha256-nGbMtYQ4cUwVVGdvlSqsYRXJxtjfI7UCV9DHOAKA8TI="
+  },
+  "me/friwi#jogl-all/v2.4.0-rc-20210111": {
+   "jar": "sha256-gZ5InHXMoqwyjBwEuTvt5QyzJxY6ipqbToexd80zmLI=",
+   "pom": "sha256-Lp2imccXNFIkVvsUOO+t3OoOabyOwX+mqPfwa3dSEh8="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.15.11": {
+   "jar": "sha256-MW0sB5XCpNTEdW8ub5NJg3x0MKw04Ed+rYdNBfXMGeU=",
+   "pom": "sha256-tfoTlvFHl7jYCIJ+d0O6il8gO0iJvjLklj1EvV7XWag="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.15.11": {
+   "pom": "sha256-jcUZ16PnkhEqfNhB6vvsTwDbxjPQha3SDEXwq0dspJY="
+  },
+  "net/bytebuddy#byte-buddy/1.15.11": {
+   "jar": "sha256-+giZiq4ee9roO94HEsUOhETXHA4MGWuyJHrejUrQ65A=",
+   "pom": "sha256-IFuLJUGWcX6B2tZyu4aacZr8lt8pf5fYEe/+H0NlPa4="
   },
   "net/java#jvnet-parent/1": {
    "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
@@ -1065,19 +1293,19 @@
   "net/java#jvnet-parent/5": {
    "pom": "sha256-GvaZ+Nndq2f5oNIC+9eRXrA2Klpt/V/8VMr6NGXJywo="
   },
-  "net/minidev#accessors-smart/2.5.1": {
-   "jar": "sha256-J5auhX0Me+S8NYDapNOCjVVSEjVfTIPTjdCvB0KzyBI=",
-   "pom": "sha256-SH53qNvZrDhEGRbIMFAYXDoeSGnOl1N3r+o5Mr9ire4="
+  "net/minidev#accessors-smart/2.5.2": {
+   "jar": "sha256-m4p7xDhh1hVsAhFm2UH7fd2+RGPi+l7ogHfksBRSqDY=",
+   "pom": "sha256-/SIDhF6kN2wTbSdgrqXyBp+W/2gIcaQwhl4CWjD9h5g="
   },
-  "net/minidev#json-smart/2.5.1": {
-   "jar": "sha256-hsDBiVgbebV7Bxn0Q6ck6fYo/7ue72Rc95GU9Zc6EAE=",
-   "pom": "sha256-9GfdUfaGnmaD0QWmcop0I9oReTsIFevTK1DDq/QyH20="
+  "net/minidev#json-smart/2.5.2": {
+   "jar": "sha256-T73tsBBc7cf3ZrlcKX0uiPtqVg2kjzu6oMxTjqi3v3E=",
+   "pom": "sha256-Qhs8AMg8LTCtjiUHG/qMTPRaxHunWLX0NkYUsKuLoPQ="
   },
   "net/sf/launch4j#launch4j/3.50": {
    "pom": "sha256-1716EuPm1bR/Ou0p/4g89cTKnie3GWkQZnkzH6N+xy0="
   },
-  "net/sf/launch4j#launch4j/3.50/workdir-linux": {
-   "jar": "sha256-lIYQ+neeFs1zX+wI+d+NfIZmWsbND1Kobh1QYW/msdo="
+  "net/sf/launch4j#launch4j/3.50/workdir-linux64": {
+   "jar": "sha256-/uvoOrT+Q5F+qn3/Jy3uDvP6hUvWgzRDRDDgjjoS8zA="
   },
   "org/antlr#antlr4-master/4.13.0": {
    "pom": "sha256-IiBv17pJUVLlJvUO/sn8j03QX8tD38+PJk6Dffa2Qk8="
@@ -1091,9 +1319,6 @@
   },
   "org/apache#apache/18": {
    "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
-  },
-  "org/apache#apache/19": {
-   "pom": "sha256-kfejMJbqabrCy69tAf65NMrAAsSNjIz6nCQLQPHsId8="
   },
   "org/apache#apache/21": {
    "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
@@ -1113,9 +1338,6 @@
   "org/apache#apache/30": {
    "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
   },
-  "org/apache#apache/31": {
-   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
-  },
   "org/apache#apache/32": {
    "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
   },
@@ -1125,14 +1347,14 @@
   "org/apache#apache/7": {
    "pom": "sha256-E5fOHbQzrcnyI9vwdJbRM2gUSHUfSuKeWPaOePtLbCU="
   },
-  "org/apache/activemq#activemq-bom/6.1.3": {
-   "pom": "sha256-9psWXzrwS+S91wLXDv3brT3AMh0XlUhN05WKYndB03I="
+  "org/apache/activemq#activemq-bom/6.1.5": {
+   "pom": "sha256-fk/4LeeGcLrZD74VrPdpaxQXhx1tzOcEh81dEDOPb/0="
   },
-  "org/apache/activemq#artemis-bom/2.33.0": {
-   "pom": "sha256-AsD+oOjmq5RmO0Lv87cWE74rlBxUoKrY9dB8E3ICQvI="
+  "org/apache/activemq#artemis-bom/2.37.0": {
+   "pom": "sha256-3PCTU3B4SWQQBNVOxUE9OagScmm+OB9SVzkece6A3oQ="
   },
-  "org/apache/activemq#artemis-project/2.33.0": {
-   "pom": "sha256-oezNKJD2HwdLoChQ5aelOs8w+ikOWC4TZceLrjgp0Wc="
+  "org/apache/activemq#artemis-project/2.37.0": {
+   "pom": "sha256-UesqjnhSc4tdLSVGIGdkcyZXg/LY3ZwdycrGycGtqF4="
   },
   "org/apache/cassandra#java-driver-bom/4.18.1": {
    "pom": "sha256-hMhkOw8BrkR2LyLLeYIMSWHOWL21F0Myn28gOHE8m2U="
@@ -1141,45 +1363,60 @@
    "jar": "sha256-Hfi5QwtcjtFD14FeQD4z71NxskAKrb6b2giDdi4IRtE=",
    "pom": "sha256-JxvWc4Oa9G5zr/lX4pGNS/lvWsT2xs9NW+k/0fEnHE0="
   },
-  "org/apache/commons#commons-lang3/3.14.0": {
-   "jar": "sha256-e5a/PuaJSau1vEZVWawnDgVRWW+jRSP934kOxBjd4Tw=",
-   "pom": "sha256-EQQ4hjutN8KPkGv4cBbjjHqMdYujIeCdEdxaI2Oo554="
+  "org/apache/commons#commons-compress/1.27.1": {
+   "jar": "sha256-KT2A9UtTa3QJXc1+o88KKbv8NAJRkoEzJJX0Qg03DRY=",
+   "pom": "sha256-34zBqDh9TOhCNjtyCf3G0135djg5/T/KtVig+D+dhBw="
+  },
+  "org/apache/commons#commons-csv/1.9.0": {
+   "jar": "sha256-xBjWqrTbTx9wmD01XejXwedVx1SCCpIpTaLl9QgQIsw=",
+   "pom": "sha256-jTVvs6AAg7oYnQBDgFuL0FsMx/0eFAyz+A9WTgeBT0Y="
+  },
+  "org/apache/commons#commons-lang3/3.17.0": {
+   "jar": "sha256-bucx31yOWil2ocoCO2uzIOqNNTn75kyKHVy3ZRJ8M7Q=",
+   "pom": "sha256-NRxuSUDpObHzMN9H9g8Tujg9uB7gCBga9UHzoqbSpWw="
   },
   "org/apache/commons#commons-parent/39": {
    "pom": "sha256-h80n4aAqXD622FBZzphpa7G0TCuLZQ8FZ8ht9g+mHac="
   },
-  "org/apache/commons#commons-parent/47": {
-   "pom": "sha256-io7LVwVTv58f+uIRqNTKnuYwwXr+WSkzaPunvZtC/Lc="
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
   },
   "org/apache/commons#commons-parent/48": {
    "pom": "sha256-Hh996TcKe3kB8Sjx2s0UIr504/R/lViw954EwGN8oLQ="
   },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
   "org/apache/commons#commons-parent/54": {
    "pom": "sha256-AA2Bh5UrIjcC/eKW33mVY/Nd6CznKttOe/FXNCN4++M="
   },
-  "org/apache/commons#commons-parent/64": {
-   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  "org/apache/commons#commons-parent/72": {
+   "pom": "sha256-Q0Xev8dnsa6saKvdcvxn0YtSHUs5A3KhG2P/DFhrIyA="
   },
-  "org/apache/commons#commons-parent/66": {
-   "pom": "sha256-SP1tyEblax9AhmDRY+dTAPnjhLtjvkgqgIKiHXKo25w="
+  "org/apache/commons#commons-parent/73": {
+   "pom": "sha256-TtRFYLB/hEhHnf0eg6Qiuk6D5gs25RsocaxQKm1cG+o="
   },
-  "org/apache/commons#commons-parent/74": {
-   "pom": "sha256-gOthsMh/3YJqBpMTsotnLaPxiFgy2kR7Uebophl+fss="
+  "org/apache/commons#commons-parent/78": {
+   "pom": "sha256-Ai0gLmVe3QTyoQ7L5FPZKXeSTTg4Ckyow1nxgXqAMg4="
   },
   "org/apache/commons#commons-text/1.10.0": {
    "pom": "sha256-OI3VI0i6GEKqOK64l8kdJwsUZh64daIP2YAxU1qydWc="
   },
-  "org/apache/commons#commons-text/1.11.0": {
-   "jar": "sha256-Ks8woHCxkWPVpIDq5BGigTQehwAg41NMbV1MhHJznjA=",
-   "pom": "sha256-O0AZecBkEoXYUM8Ri04Y8EmsIj3Hherk0LNXKPxTTRE="
+  "org/apache/commons#commons-text/1.13.0": {
+   "jar": "sha256-HjI6UBEn33jtCYfzRdadZdDqf6PU+1s/hKrro6iyDzg=",
+   "pom": "sha256-1GYUvcptEZXDM7qfcwzQhYXE8zKkPqe5C2A1rYBIcdg="
   },
   "org/apache/groovy#groovy-bom/4.0.13": {
    "module": "sha256-UMvUHEPhbMJKIJ7i2pNdeV1rN8VnNQlmtJJusxQwM6M=",
    "pom": "sha256-M5j/NPIIMkDWY0erSnMzudi3nTqVrN8vz03DAn2B5qs="
   },
-  "org/apache/groovy#groovy-bom/4.0.23": {
-   "module": "sha256-hKLVj9vLqhYHW25d82DnxJbP7Q8XRrG9Cz+rCY0+ZrU=",
-   "pom": "sha256-+HaQcnrSGjDHQJeRopw7Wl1b6pYah9E52JnTCrQlIag="
+  "org/apache/groovy#groovy-bom/4.0.22": {
+   "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
+   "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
+  },
+  "org/apache/groovy#groovy-bom/4.0.25": {
+   "module": "sha256-dG8kZ2e5HjnAyjqGJ6sAbrN6UeJ4CZaxfdzYPtbgKAU=",
+   "pom": "sha256-/Jvxy9DlMd68PjZIc//LIk7Wrvp8bnA8Ze3Uqlsd7ps="
   },
   "org/apache/httpcomponents#httpclient/4.5.14": {
    "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
@@ -1198,68 +1435,75 @@
    "jar": "sha256-bJs90UKgncRo4jrTmq1vdaDyuFElEERp8CblKkdORk8=",
    "pom": "sha256-PLrYSbNdrP5s7DGtraLGI8AmwyYRQbDSbux+OZxs1/o="
   },
-  "org/apache/logging#logging-parent/10.6.0": {
-   "pom": "sha256-+CdHWECmQIO1heyNu/cJO2/QJiQpPOw31W7fn8NUEJ4="
+  "org/apache/logging#logging-parent/11.3.0": {
+   "pom": "sha256-pcmFtW/hxYQzOTtQkabznlufeFGN2PySE0aQWZtk19A="
   },
   "org/apache/logging#logging-parent/7": {
    "pom": "sha256-5YkR3J/GsXOhDlqp7bk8eZStBmAnBd0Gftz8bh6eFys="
   },
-  "org/apache/logging/log4j#log4j-api/2.23.1": {
-   "jar": "sha256-kuwf02qzvAneYZjS18CRRoXA9xJ+qTGswy/S7N2C6ok=",
-   "pom": "sha256-tnzD0JgJJwSaO+sA1Qbs4oh0ZzKw3sgSJFxZ9FP7HKE="
+  "org/apache/logging/log4j#log4j-api/2.24.3": {
+   "jar": "sha256-W0oKDNDnUd7UMcFiRCvb3VMyjR+Lsrrl/Bu+7g9m2A8=",
+   "pom": "sha256-vAXeM1M6Elmtusv8yCbNZjdqLZxO5T+4NgCfRKRbgjk="
   },
   "org/apache/logging/log4j#log4j-bom/2.20.0": {
    "pom": "sha256-+LtpLpWmt72mAehxAJWOg9AGG38SMlC2gSiUOhlenaE="
   },
-  "org/apache/logging/log4j#log4j-bom/2.23.1": {
-   "pom": "sha256-NyOW4EWNTNMsCWytq+DMkzDsEPT1f6O+LnT3m14XijU="
+  "org/apache/logging/log4j#log4j-bom/2.24.2": {
+   "pom": "sha256-NQKIlCeybxfvStgWgCxJtJQ/DJOXJoYdEmPlenKiMEY="
   },
-  "org/apache/logging/log4j#log4j-to-slf4j/2.23.1": {
-   "jar": "sha256-eTeoQFUVaRAjTjtCho9V5o/0t77Ltv/RAUb3L1v1TdU=",
-   "pom": "sha256-BVZJuX0nP8asOjx61a/Y3tPA/OAEeyur7RKZ3Bpzk4I="
+  "org/apache/logging/log4j#log4j-bom/2.24.3": {
+   "pom": "sha256-sXq38yj0WGt+cfjJT8NaXaK86AcFpdYwBAIsGSiDNVg="
   },
-  "org/apache/logging/log4j#log4j/2.23.1": {
-   "pom": "sha256-bOFUBFU2S1PqIqGDQssSamOBYz9lPwlUZ/KqGYURps4="
+  "org/apache/logging/log4j#log4j-to-slf4j/2.24.3": {
+   "jar": "sha256-x/KwxhKk6wWxWH0ciA60z19PU4UGdqjt6Norj6u09z8=",
+   "pom": "sha256-Y15S40dOf03DDSzLy2ihY4iDlePCUpYSddBOPbX24jA="
   },
-  "org/apache/pdfbox#fontbox/3.0.3": {
-   "jar": "sha256-ZWkMPzmwShTRLBf0mYwVGGzod9Pi7CIscIV348wCgDA=",
-   "pom": "sha256-sik+UDqncEMGEVD4hGg9f2FMz1Fjvi0PBSyinzx2d+I="
+  "org/apache/logging/log4j#log4j/2.24.3": {
+   "pom": "sha256-wUG0hj/AzqtYOJShPh+eUsAfwtdYcn1nR/a5nVBA87E="
+  },
+  "org/apache/pdfbox#fontbox/3.0.4": {
+   "jar": "sha256-Le7GIy9dbTsxJ2WS0xaArpcir1fSTLD3bacOK6DpnhI=",
+   "pom": "sha256-8MzDMOmyDYlXigqHArR6OZvNYojCOG10/6uPjjAoROg="
   },
   "org/apache/pdfbox#jbig2-imageio/3.0.4": {
    "jar": "sha256-KcspUWIvEKz2H9BlbE5vpVYhlKkJX3odJqpCbi9rF+s=",
    "pom": "sha256-KOp8SskuCYX3lqi8aJCnvviSZwetrf0eLIVsmwvho4s="
   },
-  "org/apache/pdfbox#pdfbox-io/3.0.3": {
-   "jar": "sha256-Ej6jGHtJfFTmYdUMPIZ0eb93Zo/0UOUHEMZY8rtGh7o=",
-   "pom": "sha256-EXAbuMWnNaSzFA9zroM6KBzqCeO8P583kbmpenRekNQ="
+  "org/apache/pdfbox#pdfbox-io/3.0.4": {
+   "jar": "sha256-ep1HRvLhOh4i9O/kf7r5mXY8rqQXSFNa+ToB7txQ9VQ=",
+   "pom": "sha256-YLURdX737TBIv4LH2ClvcdC8RwAgEYQzqzs+OEC/jqU="
   },
-  "org/apache/pdfbox#pdfbox-parent/3.0.3": {
-   "pom": "sha256-yGXhzv8Jq1Kwh+cmDE8V025bW4vk/+IERvqkCiygvcw="
+  "org/apache/pdfbox#pdfbox-parent/3.0.4": {
+   "pom": "sha256-w5j++zUez/mTEYCNftU0bnHzVrETS9c6JQTLgXB9tFE="
   },
-  "org/apache/pdfbox#pdfbox/3.0.3": {
-   "jar": "sha256-W+ONLsgWkbBdU163IN5NxWbF0H5aBHMfoAZo0VOotKY=",
-   "pom": "sha256-vgiV9rLCDzEdYjXJam/SqsECsxkE0/TDnqUll3WwcAg="
+  "org/apache/pdfbox#pdfbox/3.0.4": {
+   "jar": "sha256-CaD/J9b4Sh3EAGDLCgHezyrU75HDa8kbmDbCVL6KrkU=",
+   "pom": "sha256-098DLfK90jT+NwMO+sNXa6Yj/Jf1ERNUxMUq13dfkOQ="
   },
-  "org/apache/pdfbox#xmpbox/3.0.3": {
-   "jar": "sha256-X7o5sziM5KOnf6ALCcQpY+Zw4IIE+qfsvzYeVrQ/TAg=",
-   "pom": "sha256-0QoW58RKxMdKydm1gPBz+Vds5DxXnyS0VQcW0Ha2Chc="
+  "org/apache/pdfbox#preflight/3.0.4": {
+   "jar": "sha256-v0aR1HNN9JFO1TzGjt6i/Z6ppo0Iyhh7oHTiqA2GDm4=",
+   "pom": "sha256-uzcdkEROYENB5n+78GM+ZBFO+zi4yQV3mmrF5L5XBKw="
   },
-  "org/apache/pulsar#pulsar-bom/3.2.4": {
-   "pom": "sha256-tYnjUUDRq5YAR+TVHhioOwdpbqhZxtBizQpmFH91NP0="
+  "org/apache/pdfbox#xmpbox/3.0.4": {
+   "jar": "sha256-0K8/1yIvs+GDcqKO96mFlaP31F4M9a0w+RethhLB3bs=",
+   "pom": "sha256-Di6ucXVvw1IVGAhuAxd7qKFthU2nuEK0VWQx3bletr4="
+  },
+  "org/apache/pulsar#pulsar-bom/3.3.4": {
+   "pom": "sha256-Lq9yAYYXgnT0vEDDExOqjFRQ5490emTfZGgy/mlSyGA="
   },
   "org/apache/santuario#xmlsec/2.3.4": {
    "jar": "sha256-VRPnQX7cHrcYitxN4DEukxVr18ptbB5gctPgAG3v/yM=",
    "pom": "sha256-Ez/s/gIYho799ZY03YaS9/Ke5uLeQynWdwDJF6OE7kA="
   },
-  "org/apache/tomcat/embed#tomcat-embed-core/10.1.31": {
-   "pom": "sha256-mTZ3y3ZLAn/nmqMglxgvvRlNhheVAWk4aHew/vFmMHg="
+  "org/apache/tomcat/embed#tomcat-embed-core/10.1.36": {
+   "pom": "sha256-VkZBy59xw+7w2I9eoyg1mmLvdtvXBkK1Vec/O+fWPfQ="
   },
-  "org/apache/tomcat/embed#tomcat-embed-el/10.1.31": {
-   "jar": "sha256-DhIKltMzrPDlj7S3RYToX+QTWCJUQMxMLe6Vj3ONB7k=",
-   "pom": "sha256-s8oIhz0JS2Cah6Rva6cbbqtakwgldzLrWjHUxf+UPPc="
+  "org/apache/tomcat/embed#tomcat-embed-el/10.1.36": {
+   "jar": "sha256-0V18O4kS0SAIl9BhnOP39dVhlTTuKMIEmvvegj5dHSI=",
+   "pom": "sha256-RlthOHJQAnNzFighiyiycwiPakYRKXgIuXIgrZ8RTKE="
   },
-  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.31": {
-   "pom": "sha256-U+ag5RatKyRVEiIV49TYRVP6h+nyBcRGG51/H3WcmyE="
+  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.36": {
+   "pom": "sha256-8ud7PokSdimZj6W67TkClpkMfMO1HH0navA/CHzoP50="
   },
   "org/apache/velocity#velocity-engine-core/2.3": {
    "jar": "sha256-sIbO6P2Bg+JAtK/PVP447DPdjrDaQUY25b96pNmFZik=",
@@ -1294,12 +1538,12 @@
   "org/assertj#assertj-bom/3.24.2": {
    "pom": "sha256-EqxGrmTTYl80S79kKrVvoC4Vuu/lPvX1sGHhJLSEYgA="
   },
-  "org/assertj#assertj-bom/3.25.3": {
-   "pom": "sha256-kbehm3evVGLHKQuRrHxyxE1kg6/qC2JTaBbpj41T8lc="
+  "org/assertj#assertj-bom/3.26.3": {
+   "pom": "sha256-4UJ5BJyPgMRzFwzVCpaD51xmjgDdNdBGX4/Y7GO0XkY="
   },
-  "org/assertj#assertj-core/3.25.3": {
-   "jar": "sha256-f73/oZltQ8wI4lduAQCLB+V7utK0dBqmw6tzzoUREw4=",
-   "pom": "sha256-ORcjDqozvPE+oz3TN6yvqdMmxzlmC/S2/FbIjXj+ufI="
+  "org/assertj#assertj-core/3.26.3": {
+   "jar": "sha256-TC+GQY/0fua2f7xq2xlOgCGbeTKBs72ih5nUQlvJoL0=",
+   "pom": "sha256-fXXFEKu7fcuR+zXOLxQG6AAP+rnuGPqpqt8xXxlzgWY="
   },
   "org/attoparser#attoparser/2.0.7.RELEASE": {
    "jar": "sha256-dd0cBFSSv/jhljqrsov+kDwgZOEeJ/4vDwr/GtPYRHY=",
@@ -1312,25 +1556,43 @@
    "jar": "sha256-6DH+4w7UAeIgjxvVoO+a3VONnLEQPA5DIWaRtke96cY=",
    "pom": "sha256-huWduqlfl1kBmysOurS8nW4Mqgtp++oPwFPA0gbOyFk="
   },
-  "org/bouncycastle#bcpkix-jdk18on/1.78.1": {
-   "jar": "sha256-S0jqCE5SMrnXnryhiHud4DexJJMYB81gcQdIwq7gjMk=",
-   "pom": "sha256-CVIrr36Zuqk6JRXRbPHLlT+iJ41+PEbIvv8n3AQXKDE="
+  "org/bouncycastle#bcmail-jdk15on/1.69": {
+   "pom": "sha256-fWl5LshLpoLSSajkm4IU5Aq+TlsKhbRiOqmAK6p/kto="
   },
-  "org/bouncycastle#bcprov-jdk18on/1.78.1": {
-   "jar": "sha256-rdWRXmrPxqtYNuH9il4hxkiFNqjB8h84bus78oC3Atc=",
-   "pom": "sha256-KJEtE5+e7RQcOUNx++W6b//5HnjxycuDSPlEok0gTtI="
+  "org/bouncycastle#bcpkix-jdk15on/1.69": {
+   "pom": "sha256-WrvkytLCMJR0ZvsgmiJn48xqDTgKajGRWVnTqtm4F2w="
   },
-  "org/bouncycastle#bcutil-jdk18on/1.78.1": {
-   "jar": "sha256-2fpW+XsPdhzjvI2ddMXXE3qYe/W9Or/hAD+br6RaHS8=",
-   "pom": "sha256-dB1Vy0XEwsiJtaQ2t0fcIVKSMTLkJr5u9VUA7uf6UxI="
+  "org/bouncycastle#bcpkix-jdk18on/1.80": {
+   "jar": "sha256-T0umqSYX6hncGD8PpdtJLu5Cb93ioKLWyUd3/9GvZBM=",
+   "pom": "sha256-pKEiETRntyjhjyb7DP1X8LGg18SlO4Zxis5wv4uG7Uc="
+  },
+  "org/bouncycastle#bcprov-jdk18on/1.80": {
+   "jar": "sha256-6K0gn4xY0pGjfKl1Dp6frGBZaVbJg+Sd2Cgjgd2LMkk=",
+   "pom": "sha256-oKdcdtkcQh7qVtD2Bi+49j7ff6x+xyT9QgzNytcYHUM="
+  },
+  "org/bouncycastle#bcutil-jdk15on/1.69": {
+   "pom": "sha256-p2e8fzQtGTKJfso8i6zHAEygOAv6dSnyOpc0VJZcffw="
+  },
+  "org/bouncycastle#bcutil-jdk18on/1.80": {
+   "jar": "sha256-Iuymh/eVVBH0Vq8z5uqOaPxzzYDLizKqX3qLGCfXxng=",
+   "pom": "sha256-Qhp95L/rnFs4sfxHxCagh9kIeJVdQQf1t6gusde3R7Y="
+  },
+  "org/bouncycastle/bcutil-jdk18on/maven-metadata": {
+   "xml": {
+    "groupId": "org.bouncycastle",
+    "lastUpdated": "20250114201150",
+    "release": "1.80"
+   }
   },
   "org/checkerframework#checker-qual/3.12.0": {
    "jar": "sha256-/xB4WsKjV+xd6cKTy5gqLLtgXAMJ6kzBy5ubxtvn88s=",
    "module": "sha256-0EeUnBuBCRwsORN3H6wvMqL6VJuj1dVIzIwLbfpJN3c=",
    "pom": "sha256-d1t6425iggs7htwao5rzfArEuF/0j3/khakionkPRrk="
   },
-  "org/codehaus/groovy#groovy-bom/3.0.21": {
-   "pom": "sha256-ksw2r/0g9Wi1CSwLlOz1hd3rCigbbIunJWVwuxhdZTQ="
+  "org/checkerframework#checker-qual/3.48.3": {
+   "jar": "sha256-RDaFsbIygDuq+APBXW9aQlRzxve4HF8nbfz5MojjiaU=",
+   "module": "sha256-Enu8VRPkHM/ms8tvqngBQjNJqVQUNnrLfPdil2dUnlk=",
+   "pom": "sha256-te+ROQIjzafQKelrKwwcZPVVu0Ad9lfqLLm7fElrqbE="
   },
   "org/commonmark#commonmark-ext-gfm-tables/0.24.0": {
    "jar": "sha256-tU3DMvkx5tB8J2YUTAh7CPNpNnfjaBUaZwILTpW7S5k=",
@@ -1366,139 +1628,136 @@
   "org/eclipse/ee4j#project/1.0.9": {
    "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
   },
-  "org/eclipse/jetty#jetty-alpn-client/12.0.14": {
-   "jar": "sha256-EAiuY40D3oSPTK59S3+YKPGFjrUbbf5zChorD3oC4Ns=",
-   "pom": "sha256-aoi39kY0BhUBEjvi08+DuSOzY+pQ1LTNrwKy5nWD8TI="
+  "org/eclipse/jetty#jetty-alpn-client/12.0.16": {
+   "jar": "sha256-KP+VaFNkg6+YRLBqhAr5D/Ia1FSa7ihAcOxhQGAwVTE=",
+   "pom": "sha256-4LpkYiL441FqKT2aXWnFVwbvwzKoQDxEfAlkRmVTPh4="
   },
-  "org/eclipse/jetty#jetty-alpn/12.0.14": {
-   "pom": "sha256-pEEFBLkmOfO2YRt1YrFgno6F1bc/oBbzV5reZrgUgIw="
+  "org/eclipse/jetty#jetty-alpn/12.0.16": {
+   "pom": "sha256-64A+e2Tf3wbzNi2CBhDQ2Zu9T1vouZcpOpGvAO9aYGQ="
   },
   "org/eclipse/jetty#jetty-bom/11.0.15": {
    "pom": "sha256-+ksNDeuvyR9Q++wI7+RkInAzTzeOg562o1+jdqoaLPg="
   },
-  "org/eclipse/jetty#jetty-bom/12.0.14": {
-   "pom": "sha256-faofSV6ifE90KWkp/eNwSrOTohlNes2IcgN4CRDx8zY="
+  "org/eclipse/jetty#jetty-bom/12.0.16": {
+   "pom": "sha256-3Ncg/gv7BC5d+ZiHcy0n2DFRxe4G7JnA1AAgUMEUKE4="
   },
-  "org/eclipse/jetty#jetty-bom/9.4.54.v20240208": {
-   "pom": "sha256-00QQSm7mGdplmEA8JdA6qqrw9U6WRv01EkWN9Xyarrg="
+  "org/eclipse/jetty#jetty-client/12.0.16": {
+   "jar": "sha256-DVN1yDpgNi8iJa4G1IN0Y5QvOcW8a9gxcrStKu8o3yk=",
+   "pom": "sha256-vzBGxtBCkQ8ybVyKHNyJItzV5Z7MJ133VDei6YXofZQ="
   },
-  "org/eclipse/jetty#jetty-client/12.0.14": {
-   "jar": "sha256-MFaB/nRpUAvlq2zA4zd+7lskukKZp73zjWsoNCPtwdU=",
-   "pom": "sha256-tNc36xUx4gXHANaC6x8C1ZTHlkRbn4+wqhgEPzPM9/E="
+  "org/eclipse/jetty#jetty-core/12.0.16": {
+   "pom": "sha256-lBeb2laCzcfJRHH1iNuu1Nsaq8CxDQwsZLEGRaGnFdk="
   },
-  "org/eclipse/jetty#jetty-core/12.0.14": {
-   "pom": "sha256-4dOlsQCYYR7A0FxvSD1ihC2CHWoNozLUoCGl06THUK8="
+  "org/eclipse/jetty#jetty-ee/12.0.16": {
+   "jar": "sha256-G3lfQ+DCi01peVcqGwpxntVgBSvqIKPj3FLMdeRWH38=",
+   "pom": "sha256-gFBXdu2iQj+3XvPfp0XhMuRrpbM8cnuhTIaZHZ0F6TU="
   },
-  "org/eclipse/jetty#jetty-ee/12.0.14": {
-   "jar": "sha256-uhh/lWdwlMJAtKUSqU0TTO3Q53gZDZfengb0WfUOaXM=",
-   "pom": "sha256-0jh1d/5/YaTyt0etL19e0rflB6MNgM5M2XXJXhs34yk="
+  "org/eclipse/jetty#jetty-http/12.0.16": {
+   "jar": "sha256-sHUbPdmoq8eboMUGFhOEPbodLOIxBX9TrT0DjKiI37A=",
+   "pom": "sha256-FyG2zUtSiTXUhC88/3xKzRZlCh+D96wdxmcRYwLvtXs="
   },
-  "org/eclipse/jetty#jetty-http/12.0.14": {
-   "jar": "sha256-wBNaaCFLdMRd4RjFKos1SgLxOGIqEjrnj0tO5jGsxiU=",
-   "pom": "sha256-RQz0nJdpeu4s4aQ7J73oFww5b9Vottb0Ru0aSJ0X8gg="
+  "org/eclipse/jetty#jetty-io/12.0.16": {
+   "jar": "sha256-yN/S2I00vlRhQX8iVr4MyGiGXEWBX37g5And2HLw6E8=",
+   "pom": "sha256-Uk4TYvU78k2el7i921Z33qPaWHLUaUizTY/DDNvtaGM="
   },
-  "org/eclipse/jetty#jetty-io/12.0.14": {
-   "jar": "sha256-fkMx4G9vA6NwrTNR9h1TkGU0I7WH5AkR2Wafjc/xdQk=",
-   "pom": "sha256-vNBqlYU5LwJlpXjYH/E06vRE7fkVgVLDobS6NxgmOdU="
+  "org/eclipse/jetty#jetty-plus/12.0.16": {
+   "jar": "sha256-nNw/BQqSr4qipgH6hG5kmztg6Bo0UOlwp8zC2m9kv4o=",
+   "pom": "sha256-zszauTmhsSOjFB7LF+ihOahpJMjIom3BlzAXua3BNxI="
   },
-  "org/eclipse/jetty#jetty-plus/12.0.14": {
-   "jar": "sha256-yUczr5vDB6RtEmgqLKzUaKPW/6gRUk4FI2GFmXSYZ8s=",
-   "pom": "sha256-UIj+5bz6RklAysowp+GBA0nOrIQRZ6KLciQMTOeswnQ="
+  "org/eclipse/jetty#jetty-project/12.0.16": {
+   "pom": "sha256-ZxSrN8Z8cMCyfFrYlcWMtvBuEUTxkbWwqv0FZwWvRkE="
   },
-  "org/eclipse/jetty#jetty-project/12.0.14": {
-   "pom": "sha256-azCsL8WKBo9V5mAeUI7RKAOFfFUg2h5FhPy9adq5Th8="
+  "org/eclipse/jetty#jetty-security/12.0.16": {
+   "jar": "sha256-em1bLQ7bG1AStVEKgEEcf7S5hEs4eZONO26azjubaHY=",
+   "pom": "sha256-v/ySNWOLTWpxRJ58jFJO1tCnF3xeykfRePgpaJ5Q88c="
   },
-  "org/eclipse/jetty#jetty-security/12.0.14": {
-   "jar": "sha256-sK79Pqwf8ls/pmhNRNat5IU7GgDpb8BvEa0ffMvl7Ew=",
-   "pom": "sha256-VlvFhQurTu5mhNx4A6K5xUTaArolXSgpzjDRFLrsnZk="
+  "org/eclipse/jetty#jetty-server/12.0.16": {
+   "jar": "sha256-nj8XynMhVO4sZ8wrw0DzIrKTNfdNZffMAQTC6c3GZA4=",
+   "pom": "sha256-Cy0QsdTqB7YWxfOaXpCt/IdXZlKZLzyEjL9FB8XOHSM="
   },
-  "org/eclipse/jetty#jetty-server/12.0.14": {
-   "jar": "sha256-ktUGKRn+SlYkKhyV/gtTOtTMqxIvjMFjLWVnEg4WRF8=",
-   "pom": "sha256-EnBf4JhImEyED8bCLk+eaweHYRZJxQvdJQHMsAcztLg="
+  "org/eclipse/jetty#jetty-session/12.0.16": {
+   "jar": "sha256-XX39JMlEcsNoRBSIeRQSox6kdq1PHZKGtPWALF2FUUs=",
+   "pom": "sha256-I6B5lpaZEspv7ZQ55nvlC0VGxsfXaQLnXRS7jbqUjNM="
   },
-  "org/eclipse/jetty#jetty-session/12.0.14": {
-   "jar": "sha256-i8VyATAQ54iI8tzm/R93J1wC37/Iz22B1TtbuxpPsrk=",
-   "pom": "sha256-H4vqNy4DZvOPKzikGT9IWoDuckmWyi3wiM9yIVGRctI="
+  "org/eclipse/jetty#jetty-util/12.0.16": {
+   "jar": "sha256-oD1DwZSZPrtNUfv+f+KRNNeGOyhwg4Du7dEXl8g1Q88=",
+   "pom": "sha256-bl7WF83htpxIgRzJNh7A3/elQTHfAWIj8bOS0x6GJFk="
   },
-  "org/eclipse/jetty#jetty-util/12.0.14": {
-   "jar": "sha256-q51pzPUe6Eo5zZ15zq8M2X1wcQBcOEJG5Xflc6gp9iI=",
-   "pom": "sha256-NN4icp8XaRPQjTa8BASD3FyNYn1yTpaLFBbkcqp4ab8="
+  "org/eclipse/jetty#jetty-xml/12.0.16": {
+   "jar": "sha256-qDT0DhfHg6n1m7fuCigGJsfaz25+4+k9wLaSemqr39k=",
+   "pom": "sha256-zu/+SzcPZ/v6xXEDEIaZqqAQnMSj9uWaP4bIL5Kw+iU="
   },
-  "org/eclipse/jetty#jetty-xml/12.0.14": {
-   "jar": "sha256-caM0wYHGh+VDq72Df955wgy6LNK+yZlUxibdtgELUCA=",
-   "pom": "sha256-UYLwY6kC5XO7aLfNhY0MwoiVyqLbQuVgI0cf++wmsQo="
+  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.16": {
+   "jar": "sha256-CK2WowcdYWHyO1oAx2Vizko0qDswAO1tVycHh57bi0Q=",
+   "pom": "sha256-9IK0qqZXa3RmKFMxzx9OGbVKAp/98Bq6/9ac1vsOyLA="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.14": {
-   "jar": "sha256-AFNnvsQAFrKGhKGowWliGMyIeFFPpHbKHCGNeoISj3A=",
-   "pom": "sha256-xJHv7vMXf4JwpSc/toCZUkWvZkVSdz1kKaza/K8O2us="
+  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.16": {
+   "pom": "sha256-OVZOMc7Xe7BSEXqSJsfdeq+bZj48hw6MhrrVC9El5sc="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.14": {
-   "pom": "sha256-pb5/xzUIfkJ/uYYjJqfcpAA4QTqxqWJ9PQaZEQxluqM="
+  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.16": {
+   "jar": "sha256-c+dEGiTi16t57QkHua1z5AFacm5/Jqm1TDK0BUFXYOY=",
+   "pom": "sha256-NskjRadmzN/Z6siw0vmbXPpE6dzQTTnIWu+zCq/VKBY="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.14": {
-   "jar": "sha256-3QQSUViYmMakWzPqNxBp5CErK8z476uNeZFa2Bs8jZw=",
-   "pom": "sha256-6IxQS5/gfW+O7KaU1jW5Nag0yRItXYn9zlV8u/yrZqg="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.16": {
+   "jar": "sha256-GKbEEHQGGg/0QNYYtD56syjoEibsIcTWpNU7kLLJSlU=",
+   "pom": "sha256-5OA3uGqQOgMbMqU4PKeqUMPoyMl+En/XjGnpnIv1KJw="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.14": {
-   "jar": "sha256-dPhecG2qS/NbbhqR1nrKH8UMA1U2AvkxCnMMGZfKnhk=",
-   "pom": "sha256-GkTOaxgBm4ndsTjd/fAIypuzdc9fvOry3qHqCoVMoB0="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.16": {
+   "jar": "sha256-xadQJp9mMAGD3E6nrhWKILkz53M/dxjUs7fQN8COVvE=",
+   "pom": "sha256-X8lSKyISayHKzJ3yqI06aQTUxmeF7r9HinVkUfqyeOk="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.14": {
-   "jar": "sha256-thmOz6vN+hz5GQs0xq4LcbOGAiWJglzsMk2PJvKdv6s=",
-   "pom": "sha256-EYYfkXQ3oWNpbhD64aYmH88D5CVmAtMMwx6rH28+9bk="
+  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.16": {
+   "jar": "sha256-dD3+SAVuYzgXHKWsBdef3hOJFINo2XZOhdrB0bym7eI=",
+   "pom": "sha256-GlqaFt4h9jIaWR/B+QxiZ/eXNNv3d+5R33jZUTCwLOw="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.14": {
-   "jar": "sha256-MwnXI5PJ4hQqhzrF/F5oqZWTEin7BO607j35Ngqgz7o=",
-   "pom": "sha256-2bYuxOI+H7WkgAppKOW8ipoQLvaOpxfsLrePd6LwEvQ="
+  "org/eclipse/jetty/ee10#jetty-ee10/12.0.16": {
+   "pom": "sha256-+Lp55YwQldbCd66Yr3Y5KSo7s3hVn+iptO4MFKr64PM="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10/12.0.14": {
-   "pom": "sha256-gZdYD3gL8Z6ZzlLEelBlG2Ae4HqsOvHzX66AMRPZPOY="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.16": {
+   "jar": "sha256-LPLk5FCiimS0lnML3GWuaq1BQH+0qxvxlcS4KdGLHc0=",
+   "pom": "sha256-gM/VzBEwr0Z4MuAc5iZ+X8IzPUz483lEZ4+MlgnflQ0="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.14": {
-   "jar": "sha256-+o4KZ71Zy05lfRKip55YHxIaDn9qr3o2QMIrPjwSm8I=",
-   "pom": "sha256-gtkpq397jDkyAE2vjxuzxvSR8i2JcxQe7CnFXBa3TWc="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.16": {
+   "jar": "sha256-sBWjKECHarWncsLbFL1qbH5WjuvO/T4MbF2E5r+aPKI=",
+   "pom": "sha256-x1H2CBdEnOk1ea1fhKGO+i+3S5RZa/22pgSZnjlNlRw="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.14": {
-   "jar": "sha256-Z1F8wKX8nePNXU2KgpPIXbEqTC0gdp6vMZrHJ7MeqrM=",
-   "pom": "sha256-pkSSecGqBduAM8Yep5bi4VYbnQjfqGlBxfUj22Io7mM="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.16": {
+   "jar": "sha256-uRgs1XH8+oPlXFyeoulewkRyo5YbvrUw8DzMKPSs0ro=",
+   "pom": "sha256-VCSz+PJHUZusjLyGvIOXATzzVr/ds3eE5uhCusjAGsc="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.14": {
-   "jar": "sha256-QbkNVGAHAutms6pkUlCu9PKQW58ml6VQfxA/TXqWRO8=",
-   "pom": "sha256-kZoi8vTA+NOWWsvotvtwvQu1Nb3abre7gP1zpOcqM+E="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.16": {
+   "jar": "sha256-C0AfdYY4Ig7xt/iYxcjI3JaczCvzkY4IaxzJrha/cjk=",
+   "pom": "sha256-266XXEc9+FWvzqC5ovDkwaPsvexWcQ8INHGS32yKJiM="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.14": {
-   "jar": "sha256-qwY9b6XcBQJ4vPcySeFzcMi1lBDt3cXV4wcw1rJZS94=",
-   "pom": "sha256-f08kMR9BlaCXXn+bKReGjG9dDm3gUoXshO8RG4v607g="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.16": {
+   "jar": "sha256-l5N2trxYP6ZwvSAL538E9rzglF0uYTeMBPT5FjYk7eI=",
+   "pom": "sha256-Tm0M2gO/ogZV8IFD3WznYqqfMp/3p0UcvBkuOoQZ7JE="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.14": {
-   "jar": "sha256-6OW1Gx/ITuVk+od+HcFlFoh8GeH7kSh9SGXlrFv2Acc=",
-   "pom": "sha256-qompwkgjVIIeh5U3ciRSz/Sw4JZXUrhwp61oF8Sr2VE="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.16": {
+   "pom": "sha256-fcFWMu3wU0kLeweOScDiYJHxbEuNqTvlEOgYccTKE5Q="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.14": {
-   "pom": "sha256-PNAypj2sH3YMPDdsw+arkCxTwjTp4I4jZ/iFSPdUp6c="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.16": {
+   "jar": "sha256-DuBPMGrAdZmA+LgeJYWtHKpK6tffIvGlJ3JkstWtZDE=",
+   "pom": "sha256-4P099As8ptFU0umiqWyX963bz7kIzKbBjoIdj4D8Bdg="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.14": {
-   "jar": "sha256-m87A0vFtBqKfLtIsATjFZhWGy6yZ1rKgS9tjwbjTNkM=",
-   "pom": "sha256-5YqrqNTeYw+5J3WF+5zLnREfRA/bwxfnqdfupZR3Qjs="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.16": {
+   "jar": "sha256-vr5vrG3dQEe9czS/QzYsf10UBCgu+GbKawkpUPbB+pE=",
+   "pom": "sha256-sFLjOQiQxL4pHsmj7ccZE5AgziSY4lWOPvcRyKBWIvU="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.14": {
-   "jar": "sha256-Ma1LCmHpk4nYQNpogU8xZIDKErbYijzyhgqY9S7ZyUc=",
-   "pom": "sha256-W0+ff7XqGvAQeZP5k/e8YcNO1u5lDEIbonmEzC421iY="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.16": {
+   "jar": "sha256-A64u73um3byZBqVwp9bLrJvyQ6oYnweT7PHdQnEbLJE=",
+   "pom": "sha256-qacaU3C2MIlj/qhHbuasocJW2Afsb47aEKrU+taBDYQ="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.14": {
-   "jar": "sha256-ox549uCpPngTGkw7wORycLATLRCr/pccqYJ7zqkJyMM=",
-   "pom": "sha256-0/2oKVgID871uE1enstG+1ows9QXGyGT+C8ReSNDDbE="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.16": {
+   "jar": "sha256-TUt/CghIvl31XJn+ySMgLVwRe2DXudlkKwlTTjJ0R30=",
+   "pom": "sha256-h5BtC8qe/E9K/onx38KwTcfxnUpfvDLxCQexwPm5YIw="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.14": {
-   "jar": "sha256-1yni+/xz7IHcMV4GuB6hmWIcD/483kJLtjGeuQxalKg=",
-   "pom": "sha256-peEZPTkIPI9n8ouRc3gE4z6cIz7lbVlmuns7Kek5W/Q="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.16": {
+   "jar": "sha256-i+xAy3tWtmoYcClzTyiEpBkXSqHjOw6NeLgsmBxtRZo=",
+   "pom": "sha256-kjtaWh27dwZxxdVm7RzxBHUp5P3RkR1YZy/lmSLk4aI="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.14": {
-   "jar": "sha256-NH5P7P9XkR3/9eYiA0s9+y/Nj1sN6pAnaPUnUhHWkR4=",
-   "pom": "sha256-/O+zIINydA+POE4Sk66o5KewQ3YXQYJnRjLJZpXlO2U="
-  },
-  "org/eclipse/jetty/websocket#jetty-websocket/12.0.14": {
-   "pom": "sha256-VwDT6c3DfAksJj2H2kL1rrkr2gETYICsh7Fp+AzZ418="
+  "org/eclipse/jetty/websocket#jetty-websocket/12.0.16": {
+   "pom": "sha256-WYu9Bbw1dqT/RHIulEAvIinmaQ2xDkLQPvLPggNOad8="
   },
   "org/glassfish/jaxb#jaxb-bom/4.0.3": {
    "pom": "sha256-Zg8EhAYlliYXiumpcrA86VFmXDPDM8q0U7EXi40NJBU="
@@ -1518,11 +1777,11 @@
    "jar": "sha256-kXNVvEUUgfMNBDsk0SMRBReWavNDg5AXc4goENykgOU=",
    "pom": "sha256-a2gzdWAy4YOaQBRoFaWY7IsFg6Lv+9Rd311UMB9Ky6s="
   },
+  "org/glassfish/jersey#jersey-bom/3.1.10": {
+   "pom": "sha256-KYl09Itfm23mIvJFApLexNuZs5vjJF9WVqbJpEtd67Q="
+  },
   "org/glassfish/jersey#jersey-bom/3.1.2": {
    "pom": "sha256-WmsvkyguMAlcrhRpCiqrWpxTa1f/MuiQ6giu/4qEwT4="
-  },
-  "org/glassfish/jersey#jersey-bom/3.1.9": {
-   "pom": "sha256-zjcapN28dH2/4lRRAeB2MlLCM1w8qD3VFioE6MyCxdk="
   },
   "org/hamcrest#hamcrest/2.2": {
    "jar": "sha256-XmKEaonwXNeM2cGlU/NA0AJFg4DDIEVd0fj8VJeoocE=",
@@ -1532,48 +1791,55 @@
    "jar": "sha256-ItHUMWxOwTpotVnpjIJW1pBxWTcx2pYTZkD4ZPoU+tg=",
    "pom": "sha256-JiM0ZTf3BvIgWbkRcgnLBoGwJBFFs1x10sXj7EGCZ2Y="
   },
-  "org/hibernate/common#hibernate-commons-annotations/6.0.6.Final": {
-   "jar": "sha256-zZdOCoSB+v26+bSg8Iu1pslpsDZUgnY+7fd+b9f0k7c=",
-   "module": "sha256-WvzxkaqDNZY3NlnlROW1BnQmwbF0Hg3jcc6+K6wYOLs=",
-   "pom": "sha256-hzhyRO2hjBgdDvEwH4zyeQ8HTO2LXrFl1qW9TtIH5MQ="
+  "org/hibernate/common#hibernate-commons-annotations/7.0.3.Final": {
+   "jar": "sha256-DbL9V9XkNoisbtXN823q8F2ENA3MJMLdKiEU3jjlF10=",
+   "module": "sha256-sapyAvw/Z9IgZpA9Ph63BS7hD0cyKhy5JfovRJ8lruM=",
+   "pom": "sha256-ZvbmB7MHQOORmJglpa4HamyHepm3jrBUqBRmUKr/cus="
   },
-  "org/hibernate/orm#hibernate-core/6.5.3.Final": {
-   "jar": "sha256-95teUCmnLi8Lp1QlkfuoMFye28Db3JdFQfI3b/EgNCI=",
-   "pom": "sha256-HJFMGnd3FAciRvUQAxlf+f8+/DYFS93bTsowGgSFhck="
+  "org/hibernate/orm#hibernate-core/6.6.8.Final": {
+   "jar": "sha256-CXGQkRcgKJZPRK5XxyaxKthHOC8m7wIZgJcsSFhgko4=",
+   "pom": "sha256-f+FpWnl5ExvuPi9Fm5BqWnRyQJwmHTV7NaSixh1BeJ4="
   },
-  "org/hibernate/search#hibernate-search-bom/7.1.1.Final": {
-   "pom": "sha256-WO2Xg6v4mdqIAbTa++A39hdSeBklEdgXxuu6tiWc0/Q="
+  "org/hibernate/search#hibernate-search-bom/7.1.2.Final": {
+   "pom": "sha256-BAbGloTq1BCta0E1tShrtggnsLWiEdXl0T0iM1lATPA="
   },
   "org/infinispan#infinispan-bom/14.0.12.Final": {
    "pom": "sha256-morEX54P+bvW3iEsHdCHIrxPrmuhC/vN7zaL8jroDh4="
   },
-  "org/infinispan#infinispan-bom/15.0.10.Final": {
-   "pom": "sha256-Uiq97eejO3nEf68dV7Zv8/D7ZcTbX77Fb2W7gNaOroE="
+  "org/infinispan#infinispan-bom/15.0.11.Final": {
+   "pom": "sha256-l1ZGl2WLzh5IwN06lHdoxhNyMtYVGVhBQhz8Q7GE6Cw="
   },
-  "org/infinispan#infinispan-bom/15.0.5.Final": {
-   "pom": "sha256-1qTKkMta/plIFuxQ2jX3GG5PG835+2eNC8ggZpvj9tk="
+  "org/infinispan#infinispan-bom/15.0.13.Final": {
+   "pom": "sha256-r9hOQe61uJa8KR6xgf6RwISZx72ZAShlUQhScQPjpkE="
   },
   "org/infinispan#infinispan-build-configuration-parent/14.0.12.Final": {
    "pom": "sha256-WTir5k+BZwjr5C5mlla+UltuhfxMyAh3OkVqnp6ne6I="
   },
-  "org/infinispan#infinispan-build-configuration-parent/15.0.10.Final": {
-   "pom": "sha256-m3tR40j13wGonBe7c77n0hEuJ6ZPXCsgd63x1JoZsac="
+  "org/infinispan#infinispan-build-configuration-parent/15.0.11.Final": {
+   "pom": "sha256-utwbV7pKcUvVQfHty5kdfpBpDLJCNO8kd4ju3eO3jgo="
   },
-  "org/infinispan#infinispan-build-configuration-parent/15.0.5.Final": {
-   "pom": "sha256-DAglqIiuar5Z8TLIQEnnXpNY9m8jXB+VFNR4V8wz5KE="
+  "org/infinispan#infinispan-build-configuration-parent/15.0.13.Final": {
+   "pom": "sha256-XzR8kQ11k2IhmsWXDyJVwiIAXJnIjwjRVffqpSznad8="
   },
   "org/jboss#jboss-parent/39": {
    "pom": "sha256-BN/wdaAAlLYwYa9AfSgW2c3mZ5WsrjdqBUvf6Lox5mQ="
   },
+  "org/jboss#jboss-parent/42": {
+   "pom": "sha256-5BJ27+NQkFTLpBl7PWNgxR3Ve8ZA3eSM832vqkWgnDs="
+  },
   "org/jboss#jboss-parent/43": {
    "pom": "sha256-PDredvuIOs25qKAzVdHfQGb/ucjHjwmyGenA/Co/Qxc="
   },
-  "org/jboss/logging#jboss-logging/3.5.3.Final": {
-   "jar": "sha256-exGUYN4XQZWspBLf7VLKC77w7OJsLXQwG2Fyz630/1k=",
-   "pom": "sha256-GGFMhJXpXxL+1s8lR5syQwhTnRSUjmAoGLhH1Bld1Oo="
+  "org/jboss/logging#jboss-logging/3.6.1.Final": {
+   "jar": "sha256-XgiksJLchbM38JEKdAVx2HIM+lZfq9iAqMr5SmV8pBY=",
+   "pom": "sha256-J82Iq45ZRrinqpJkTrNzLjW+KBQ5qwevcfiYRT7nVA0="
   },
-  "org/jboss/logging#logging-parent/1.0.1.Final": {
-   "pom": "sha256-e2CEZRKTW9dYnba5e57G3W7zlUmesUEYULL00hDcDZM="
+  "org/jboss/logging#logging-parent/1.0.3.Final": {
+   "pom": "sha256-mXLIlHSc2jVXZiF9Q97XAJse6ybgMBwwkUotslPdaFs="
+  },
+  "org/jetbrains#annotations/24.0.1": {
+   "jar": "sha256-YWZtvOfkLmyFtDwE/PuCk6Idy1WzyA6GknDOQsAaazU=",
+   "pom": "sha256-mb7eKcAzHBlS7uBL+ZeN5TWpDJfi3v/6XgCTNRcZJbA="
   },
   "org/jetbrains/kotlin#kotlin-bom/1.8.22": {
    "pom": "sha256-yNeU63YYiNNDaeZ33o6roLAfnop1bPv/UyFcz6XFjD8="
@@ -1587,16 +1853,15 @@
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.1": {
    "pom": "sha256-Vj5Kop+o/gmm4XRtCltRMI98fe3EaNxaDKgQpIWHcDA="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.9.0": {
+   "pom": "sha256-vqVRHpAB8sWTq1CA3xMbIZq14ghcxZec5YPqzUlG/Xg="
+  },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.6.3": {
    "pom": "sha256-KdaYQrt9RJviqkreakp85qpVgn0KsT0Wh0X+bZVzkzI="
   },
-  "org/junit#junit-bom/5.10.0": {
-   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
-   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
-  },
-  "org/junit#junit-bom/5.10.1": {
-   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
-   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  "org/jsoup#jsoup/1.15.4": {
+   "jar": "sha256-AGgw0Hl3EECN5VicGNhkNDwO8aOgxgPJyxOMlDtn2aQ=",
+   "pom": "sha256-chKJC3LAuGDgIlhWvnQT5469Ps0+y4Vn3eaqxic9+4k="
   },
   "org/junit#junit-bom/5.10.2": {
    "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
@@ -1606,13 +1871,25 @@
    "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
    "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
   },
-  "org/junit#junit-bom/5.10.5": {
-   "module": "sha256-hXsWv6Q5P1aoQJN8Z01TbeTiPFxjRpYgp3m1BcCowak=",
-   "pom": "sha256-g+QFzK2rN7rfIrfdZ6LS90vPLmgB+1W7LV1+eUI3Lho="
-  },
   "org/junit#junit-bom/5.11.0": {
    "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
    "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
+  },
+  "org/junit#junit-bom/5.11.0-M2": {
+   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
+   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+  },
+  "org/junit#junit-bom/5.11.2": {
+   "module": "sha256-iDoFuJLxGFnzg23nm3IH4kfhQSVYPMuKO+9Ni8D1jyw=",
+   "pom": "sha256-9I6IU4qsFF6zrgNFqevQVbKPMpo13OjR6SgTJcqbDqI="
+  },
+  "org/junit#junit-bom/5.11.3": {
+   "module": "sha256-S/D1PO6nx5D9+9JNujyeBM3FGGQnnuv8V6qkc+vKA4A=",
+   "pom": "sha256-8T3y5Mrx/rzlZ2Z+fDeBAaAzHVPRMk1uLf467Psfd3Q="
+  },
+  "org/junit#junit-bom/5.11.4": {
+   "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
+   "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
   "org/junit#junit-bom/5.9.0": {
    "module": "sha256-oFTq9QFrWLvN6GZgREp8DdPiyvhNKhrV/Ey1JZecGbk=",
@@ -1626,60 +1903,75 @@
    "module": "sha256-tAH9JZAeWCpSSqU0PEs54ovFbiSWHBBpvytLv87ka5M=",
    "pom": "sha256-TQMpzZ5y8kIOXKFXJMv+b/puX9KIg2FRYnEZD9w0Ltc="
   },
-  "org/junit/jupiter#junit-jupiter-api/5.10.5": {
-   "jar": "sha256-QiUcLxwpZYwVbKDz2WcFiKBR6bbdBPUqgt4Z6jI0Pkw=",
-   "module": "sha256-a/C8bplb9VYa+VZF1gzksLgXJFGeFKAHY8cmxkTsKcY=",
-   "pom": "sha256-94Utddu7iKjt2zu15l3HNwzA1+8SHHaQs+CEDGL9eV0="
+  "org/junit/jupiter#junit-jupiter-api/5.11.4": {
+   "jar": "sha256-q4PvnlGsRZfVnSa0tYgSEpVQ4vV5pATIr30J9c5bQpM=",
+   "module": "sha256-puov77OqWGj9engK4doRYudt2jdgtIAVwqQZ0jcv88s=",
+   "pom": "sha256-US0j/znHZmWho2RVJiMLz4ib1JiEME9/6+BHsBjuszk="
   },
-  "org/junit/jupiter#junit-jupiter-engine/5.10.5": {
-   "jar": "sha256-Ea9i07CAa13kVQsew4TpuXsIdXxGj8vcuNVtiOfhhHA=",
-   "module": "sha256-GgTVCG5rjuWsGl/ImmxD1RFE1X4B29crr16lrcotecg=",
-   "pom": "sha256-dvg/i0jIV17B03DOQRRVNrGBat+wAyaMW4yv4q6AT5c="
+  "org/junit/jupiter#junit-jupiter-engine/5.11.4": {
+   "jar": "sha256-zfisWfP613TKc4rQOJCVDuuRgz7w6JCHUxd+3SbxWBw=",
+   "module": "sha256-25EWOorwBaMnmFZd1nU3clGJWQ3qttoDsx292kVoahg=",
+   "pom": "sha256-sKMjsNA0REQdE9RjC0DbXvhBYNLC9YXU1kbcOIL5kgc="
   },
-  "org/junit/jupiter#junit-jupiter-params/5.10.5": {
-   "jar": "sha256-nwC/Vyw+fxlgkSNOCOIdMvrMR60qRGv0RNwnIDNLqvQ=",
-   "module": "sha256-KiSo+ih5+Q0LZMGtn43TwfiJV1/keozUDsTfvxlCBEc=",
-   "pom": "sha256-ZkrSX+qr0F2Ck1umhE+kVhpcJdb/dCpSCrd22d9UmY0="
+  "org/junit/jupiter#junit-jupiter-params/5.11.4": {
+   "jar": "sha256-AqbgFd586UrH8lbn+gW4CR3qhh/nmlVaeZMxPQ9sfZY=",
+   "module": "sha256-WIZbi0uZi5qxnBP45BO34dSBk3TdXfaXYMTAsLxOmJU=",
+   "pom": "sha256-jDWbvqB8ZKas3YweE7T3cFiyQys16G6ald3GMkmgrVQ="
   },
-  "org/junit/jupiter#junit-jupiter/5.10.5": {
-   "jar": "sha256-MIxvl5ahfr47XMfb3/e0XZFgdqQKb71vpTzdyzBvM1o=",
-   "module": "sha256-QW5hEe/1Cc1NtvGHTLzxI/pE/juGMan2IoF+hzi28q0=",
-   "pom": "sha256-vcusuIIYym22pLSD1URKFFYl59ABF2/pUYpA7Edai0c="
+  "org/junit/jupiter#junit-jupiter/5.11.4": {
+   "jar": "sha256-qogOSvuofURzV+TB/AmMXLHSAMuUA0lsANOzWlvQ6Ns=",
+   "module": "sha256-o8NT7XUWrhg16rlaCH9PCaWwzH0LiwOf53oDm4q1IQM=",
+   "pom": "sha256-qGLfEe5TmYLvyxQdnArecDe7oCZdC1idX7hNsNIS8dk="
   },
-  "org/junit/platform#junit-platform-commons/1.10.5": {
-   "jar": "sha256-q9rqr0zr0SGrmnSY7XhhaT0rsKxZdrJsAGCjCJIu9J0=",
-   "module": "sha256-8TMlkasuyk/Kzd0IV6vJ/3tXPbK4wFBwOkuc84Cy+Gs=",
-   "pom": "sha256-EPUlEitUEBGT3TcIQm3EaMJFII3HIOE4DUFsFa2zQ1c="
+  "org/junit/platform#junit-platform-commons/1.11.4": {
+   "jar": "sha256-nt2Wmw0GcMVBBbyRrnm9HG9QPhIRX6uoIHO4TIa7wzQ=",
+   "module": "sha256-C54mJcj0aLPNQTLMCoBfif5B+FLRrf/3Xz6xRlyhy2s=",
+   "pom": "sha256-zRLSt8JC8WVUjtnJQGFg3O22CAkltHz3MeD9rl+0vOI="
   },
-  "org/junit/platform#junit-platform-engine/1.10.5": {
-   "jar": "sha256-v9cfV9/+/ulOPwz9VTvl5d17j58nOrolFQdeKLjI52o=",
-   "module": "sha256-PqH2nOcbtZhfoRYziyKUovBupEBJuzclip6T3RrWFRA=",
-   "pom": "sha256-eMUE5IyG4Im3dFqa6CL7W5ryDvvTIxHshDeJlDnJNtE="
+  "org/junit/platform#junit-platform-engine/1.11.4": {
+   "jar": "sha256-sd2Zj2T5rK3BWWbZzT0IB0ZiZ3s+OQ8KOPy/C7THIzA=",
+   "module": "sha256-v2zh+1lR3Gx942re72rq9474LWODHFzOvOOI2p/F/iU=",
+   "pom": "sha256-lDRxV5mEIS++adA+3sfC/0+6sYiL4LgMJl6nCGn9ir0="
+  },
+  "org/junit/platform#junit-platform-launcher/1.11.4": {
+   "jar": "sha256-10ML0Cnn/M7VPuRF5NLRqKHgQ+pMTfQ7YzWoV/eXYa4=",
+   "module": "sha256-YMRTMgm6WHsc2n1ywIfzUaMjH5uRyU8/djlLDiI0HMQ=",
+   "pom": "sha256-tnzVOALgaqgqpZZumftCkX0iBFeEnlwIDINgdT7WfDE="
   },
   "org/latencyutils#LatencyUtils/2.0.3": {
    "jar": "sha256-oyqf+gay9OAcU2D4+d97xdlFSl03PNjzYTR/paVxZew=",
    "pom": "sha256-jwwBU3kLhK9sCTFtVpvRBu4PAIuTk+gLpHj1v2Vziig="
   },
+  "org/locationtech/jts#jts-core/1.18.1": {
+   "jar": "sha256-cirDq+rqhKlJa2MqIn0JxhLPIAadMfjr8l/1gQN50jU=",
+   "pom": "sha256-kwjEHx1YgWYDo1sXcI5AS0IOyP0Mzgnph9kG/8kQkzI="
+  },
+  "org/locationtech/jts#jts-modules/1.18.1": {
+   "pom": "sha256-5yC/+lSbUVBhJPjmyDAO5EejOzAARFKsvC46qezJ4kE="
+  },
+  "org/locationtech/jts#jts/1.18.1": {
+   "pom": "sha256-45baKUcMQeHLY9Mfb22CXGAo863AlbKhfe8lAjFuJ48="
+  },
   "org/mockito#mockito-bom/4.11.0": {
    "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
   },
-  "org/mockito#mockito-bom/5.11.0": {
-   "pom": "sha256-nS9GsUwh/8yOt/ApAeN9ncVJfmWEMFAYTRohNAcdVrM="
+  "org/mockito#mockito-bom/5.14.2": {
+   "pom": "sha256-b9MRNhOpcvzRz6u9lpSP3OlDYH7PmpzBl1imA7mmMH4="
   },
   "org/mockito#mockito-bom/5.3.1": {
    "pom": "sha256-F8lglCSkwzBWhOTlZS9VQRAyV1wafKPXhZZiEEafJTU="
   },
-  "org/mockito#mockito-core/5.11.0": {
-   "jar": "sha256-8HbJax9JuNm8QuRrCWmq9WhMQMi1tnnUAOXYgAc6DgA=",
-   "pom": "sha256-ugsbXXA1CUlPmo5EWCIjh54zSKTElmfwx35odG5IHHg="
+  "org/mockito#mockito-core/5.14.2": {
+   "jar": "sha256-IpYUHB4fLhrjXAjTapq0Vj7NZuA1M/6CYwp2TnqkkYI=",
+   "pom": "sha256-Y45Wpo9JaHm8ig9Tz735xMw5pFtuQ4ozOl6oPAnunP0="
   },
   "org/mockito#mockito-inline/5.2.0": {
    "jar": "sha256-7lLhwpmmMhhPuidKk3CZPgkUBCn15RbmxVcP1ldLKX8=",
    "pom": "sha256-cG00cOVtMaO1YwaY0Qeb79uYMUWwGE5LorhNo4eo9oQ="
   },
-  "org/mockito#mockito-junit-jupiter/5.11.0": {
-   "jar": "sha256-ow6k/gSE5U9kzcFSaabG/xvYm8JqDUHkwny5HLeNxUg=",
-   "pom": "sha256-bmmXepSLvkTQn3UPXos2i3VFwy5JeJgrs0luiJQELl4="
+  "org/mockito#mockito-junit-jupiter/5.14.2": {
+   "jar": "sha256-mhJuO/bdMYJqE4UjwX9J3hKzJD87Vha56pd1QuSkegk=",
+   "pom": "sha256-INayO/PQvGZuJAVwBiKH1JlHGAV2JSirxQOV4JHAR98="
   },
   "org/objenesis#objenesis-parent/3.3": {
    "pom": "sha256-MFw4SqLx4cf+U6ltpBw+w1JDuX1CjSSo93mBjMEL5P8="
@@ -1687,6 +1979,25 @@
   "org/objenesis#objenesis/3.3": {
    "jar": "sha256-At/QsEOaVZHjW3CO0vVHTrCUj1Or90Y36Vm45O9pv+s=",
    "pom": "sha256-ugxA2iZpoEi24k73BmpHHw+8v8xQnmo+hWyk3fphStM="
+  },
+  "org/openjfx#javafx-base/21": {
+   "jar": "sha256-Vf2BMMTI0arWL8sNoVTX5XvDaaafW0BFTnxMEcoTVys=",
+   "pom": "sha256-55O+wT72uWDvlqi7n+xCtmxu6Xi3hHIRbdQQqvrXxAI="
+  },
+  "org/openjfx#javafx-controls/21": {
+   "jar": "sha256-g/sh712bKpeWNVuZlHtIZK6HrgNn7fExUmTTmPzsCH4=",
+   "pom": "sha256-c/JBHyrDOyi6kTGBS9uJ1V6+HMOt7ybpzk6UxMQ0GUk="
+  },
+  "org/openjfx#javafx-graphics/21": {
+   "jar": "sha256-DGVSPsJ4ELRWqC6ht3MXitAAS7RXDmgSWtYMp/cu6sU=",
+   "pom": "sha256-E6Brj8cyw2qKmSb5hVttzPAH2AfcVfkKqdMVVS35ovY="
+  },
+  "org/openjfx#javafx-swing/21": {
+   "jar": "sha256-h39crkAoBObLI28hYPK6qk+nU7uNeVOoP6YM3GT/0Ng=",
+   "pom": "sha256-3DPoBXmhZN2hYGt/AfcSioKMt963tUw0huzIeyqjoD0="
+  },
+  "org/openjfx#javafx/21": {
+   "pom": "sha256-5/mWncVyN6U3NPUSt5d1g9L7WL1pA5SJ4wXfR1LDhmw="
   },
   "org/opentest4j#opentest4j/1.3.0": {
    "jar": "sha256-SOLfY2yrZWPO1k3N/4q7I1VifLI27wvzdZhoLd90Lxs=",
@@ -1696,30 +2007,31 @@
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
   },
-  "org/ow2/asm#asm-bom/9.7": {
-   "pom": "sha256-jIZR874EOzV43SihXAFhhhsV6wObf1JHZ5wMwNvwd4c="
+  "org/ow2/asm#asm-bom/9.7.1": {
+   "pom": "sha256-qNMCypF0b46grZBx9i/zoNq9Ov5h2hTMgMHIdc9hi0I="
   },
-  "org/ow2/asm#asm-commons/9.7": {
-   "jar": "sha256-OJvCR5WOBJ/JoECNOYySxtNwwYA1EgOV1Muh2dkwS3o=",
-   "pom": "sha256-Ws7j7nJS7ZC4B0x1XQInh0malfr/+YrEpoUQfE2kCbQ="
+  "org/ow2/asm#asm-commons/9.7.1": {
+   "jar": "sha256-mlebVNKSrZvhcdQxP9RznGNVksK1rDpFm70QSc3exqA=",
+   "pom": "sha256-C/HTHaDJ+djtwvJ9u/279z8acVtyzS+ijz8ZWZTXStE="
   },
-  "org/ow2/asm#asm-tree/9.7": {
-   "jar": "sha256-YvSzvENgRcGstcO6LY7FVuwzaQk9f10Gx0frBLVtUrE=",
-   "pom": "sha256-o06h4+QSjAEDjbQ8aXbojHec9a+EsFBdombf5pZWaOw="
+  "org/ow2/asm#asm-tree/9.7.1": {
+   "jar": "sha256-mSmIH1nra4QOhtVFcMd7Wc5yHRBObf16QJeJkcLTtB8=",
+   "pom": "sha256-E7kF9l5/1DynZ09Azao3Z5ukhYxsnZ+48Xp6/ZuqvJ4="
   },
-  "org/ow2/asm#asm/9.6": {
-   "pom": "sha256-ku7iS8PIQ+SIHUbB3WUFRx7jFC+s+0ZrQoz+paVsa2A="
+  "org/ow2/asm#asm/9.7.1": {
+   "jar": "sha256-jK3UOsXrbQneBfrsyji5F6BAu5E5x+3rTMgcdAtxMoE=",
+   "pom": "sha256-cimwOzCnPukQCActnkVppR2FR/roxQ9SeEGu9MGwuqg="
   },
-  "org/ow2/asm#asm/9.7": {
-   "jar": "sha256-rfRtXjSUC98Ujs3Sap7o7qlElqcgNP9xQQZrPupcTp0=",
-   "pom": "sha256-3gARXx2E86Cy7jpLb2GS0Gb4bRhdZ7nRUi8sgP6sXwA="
+  "org/postgresql#postgresql/42.7.5": {
+   "jar": "sha256-aQILO9IJhFQ+gXOT8ubAGokO8uN6d90R1thQgYHQeas=",
+   "pom": "sha256-FB6pP8GF3rFdKPz+P+qAivQBic9pEtaPMW6GjXzq/kg="
   },
-  "org/projectlombok#lombok/1.18.34": {
-   "jar": "sha256-wn1rKv9WJB0bB/y8xrGDcJ5rQyyA9zdO6x2CPobUuBo=",
-   "pom": "sha256-4ZCf4nLP/In/KJsTIeibZB/vc5ghZhu2k6b5ZqF+2eU="
+  "org/projectlombok#lombok/1.18.36": {
+   "jar": "sha256-c7awW2otNltwC6sI0w+U3p0zZJC8Cszlthgf70jL8Y4=",
+   "pom": "sha256-iaIdJYdshWLBShDxsh77/M6dU7BYaGuChf6iJ2xTKQ4="
   },
-  "org/seleniumhq/selenium#selenium-bom/4.19.1": {
-   "pom": "sha256-8QH5+xtuCznTc5SZoA6CHTXh8/boF2GRNzaCYJZM2mg="
+  "org/seleniumhq/selenium#selenium-bom/4.25.0": {
+   "pom": "sha256-WWonHEIBciy0qtEP9MnOu2+J/AixL2vjSxwMFz+R+m8="
   },
   "org/seleniumhq/selenium#selenium-bom/4.8.3": {
    "pom": "sha256-VjKTeC4Y0PLA1r3M6+vjQUjw7LuSuBjbCLhAXtOuCB4="
@@ -1742,6 +2054,10 @@
   "org/slf4j#slf4j-parent/2.0.16": {
    "pom": "sha256-CaC0zIFNcnRhbJsW1MD9mq8ezIEzNN5RMeVHJxsZguU="
   },
+  "org/snakeyaml#snakeyaml-engine/2.9": {
+   "jar": "sha256-L3qVdGG21wwABeLDW3ihyXvvbERnBMDuk5POmOSVi6g=",
+   "pom": "sha256-9toG5chpkBVwSG0VOlKn/y1iHc93AIG5MkUxCEUl9to="
+  },
   "org/sonatype/oss#oss-parent/7": {
    "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
   },
@@ -1763,320 +2079,320 @@
   "org/springdoc#springdoc-openapi/2.2.0": {
    "pom": "sha256-Los3sS+E+doEZrqeLfbA2nneG1cyCSPFNW/oXbE0d2w="
   },
-  "org/springframework#spring-aop/6.1.14": {
-   "jar": "sha256-FVlpOabbzKWBLe4auaizb2lTa/2AZyeYkn1fGsDThOU=",
-   "module": "sha256-AMqes2YcEWugHr7KSagPXF8vexXwNhpz/IF8IRyrAls=",
-   "pom": "sha256-tc03D1Ei9Lh6mEqCGrPc77MV5IJBaPUR3412oHrqrm4="
+  "org/springframework#spring-aop/6.2.3": {
+   "jar": "sha256-Xm/D2pDBlD8vzl8G7wTVhhh84AYv4YbYCs1TEJBlIF0=",
+   "module": "sha256-d+iEAqslnThkE8TPOXkCkwMZi5obLUu2rimqtNK2CCo=",
+   "pom": "sha256-VRti3MYad6IXIblFh7Y9WEH7+muksnjvys0Y9iftLsg="
   },
-  "org/springframework#spring-aspects/6.1.14": {
-   "jar": "sha256-IvubzJBl4b6WjEnNQcy9nGFUxRLxPgj9xnd+i3VtVwQ=",
-   "module": "sha256-DnOLl4Ctcf/rK79j6ZpLFVcz/sqp55aPaRWWa66BtH4=",
-   "pom": "sha256-zanChYT2IkY72DjdH3hLC4Gho4hdP+UBO8lRA79dzm4="
+  "org/springframework#spring-aspects/6.2.3": {
+   "jar": "sha256-7xt1sh9maSeZ+wQX8h2aZrzNrVwoTfp7GpFPJDVLbMc=",
+   "module": "sha256-cgMckfU9noGTXWnxa4LsMMuEHDlQhHcxbgv17METSC8=",
+   "pom": "sha256-ndJ4A29IgPM4IVfnx3LVukovzr9LM+eyshgEG5z8QFk="
   },
-  "org/springframework#spring-beans/6.1.14": {
-   "jar": "sha256-bK2EsqNaM6haMToZRFpD5UMraOTwu/bCv8Sohak91yc=",
-   "module": "sha256-uhYuQEZAPyaoXmyHIiwiI6UUATmW+KG39hU4W1hjwRk=",
-   "pom": "sha256-gH0dr6YVMCN6EzloITdtpYakHkySLLJuYM1vaohcFzc="
+  "org/springframework#spring-beans/6.2.3": {
+   "jar": "sha256-TiidbAqj6nRjMAXa4G18yCdRDluEDWi/zr3PC902P0Q=",
+   "module": "sha256-EWFFWz8fdZBPyJkJ1i5EVsRpnowfy4YNgUuxRNk3ufQ=",
+   "pom": "sha256-SmG8k1Xjh6DOqeaYtqdBZy9fnb3iNclhq4pe6B0tGoY="
   },
-  "org/springframework#spring-context/6.1.14": {
-   "jar": "sha256-2na1P2og8Js4BSowBDXzJFeA0w3rRuxd11MUzaBv02U=",
-   "module": "sha256-6DOB1Xv4kKR+X6UAisMDLZCCPDPvzX0hq/W//mA9Kak=",
-   "pom": "sha256-A+O/xXgJ0mwgv02c4WJJU7Vl4aF0LuNhPWk4G/WPVw8="
+  "org/springframework#spring-context/6.2.3": {
+   "jar": "sha256-U/7qbYxholCJ2MR0xPkuvSTw7361Ls2vRvEemiU/204=",
+   "module": "sha256-L0yecr5CWZq6HY9cs7fpCZP5nTTRGKP7Uk5g0sxSTJA=",
+   "pom": "sha256-zOZ14OTcExzMcrFc55sCCloeZOs5mPKw9qeWV1xdGHk="
   },
-  "org/springframework#spring-core/6.1.14": {
-   "jar": "sha256-4VoRefyWQv/tE8pV4oY+LaUkzNEIO3xvG1z9VzPzssU=",
-   "module": "sha256-c5SoxHoyHbg43H3wtb7F9prMPMu7D4jn57eCdEpaahE=",
-   "pom": "sha256-7YrAnxeoq79chQmBgDdU1CSx2jYytN37Kl7K5Com1pE="
+  "org/springframework#spring-core/6.2.3": {
+   "jar": "sha256-SVMWhN8jBPDmEfd1+rp5Jzx3UE632FZZLYMOI4np6xQ=",
+   "module": "sha256-qn+EiEW+ahEMm9rPFRSfnp4wTaRS/oHqEbcb0uQbxtk=",
+   "pom": "sha256-iiURsdM4PfstvI0mmPlzR4LvZ8wg4e26hKEYrRFERvI="
   },
-  "org/springframework#spring-expression/6.1.14": {
-   "jar": "sha256-ae1rBSOXqSmg5MRS9j8smj0i4EbYuA2HgZAgXdsllRg=",
-   "module": "sha256-hQ87N9nGHWqJyRG/U697Cj2aUgweuOtQj9tdhEZxFWc=",
-   "pom": "sha256-LrrFfljGyuqvjkQz8GTqM7a0OKe07ja8tEbyysqFdzo="
+  "org/springframework#spring-expression/6.2.3": {
+   "jar": "sha256-6QHia6qg4zPOLMTynZENYwwfemxsuZrHo8QRpQa1t4A=",
+   "module": "sha256-nf0phyL0WOlTbwmnspsHo080ysZLMIAQTJ5Bhh/H0yw=",
+   "pom": "sha256-pw0SUlcJwndW3sDGe8RVir0Lx1JwTUtdS7xA1vYMDZ4="
   },
   "org/springframework#spring-framework-bom/5.3.25": {
    "module": "sha256-bPPIDzsrxVO0LptyC/9x/bBxUmy4kMVwkz2deAd2JQ4=",
    "pom": "sha256-XMA2phbyoFlZZtPbyZ2uY1rJsY4VOLX+rXsqPL/mgog="
   },
-  "org/springframework#spring-framework-bom/5.3.29": {
-   "module": "sha256-pslWW9lncgrg50PCMmUst9yai4GAjvFDWv1/aJICE78=",
-   "pom": "sha256-Bald+izdhQdNkd3pYqk/KW2v3tf6l9Eu2+jQ/21hMys="
-  },
-  "org/springframework#spring-framework-bom/5.3.32": {
-   "module": "sha256-R6cJH2l8pjEYXtQY8Morhu7wyCqhbRdx3exLLDu3s70=",
-   "pom": "sha256-glr3ES49kupDa7DfeMGVFIhfXAFtD8YMiyTUdjoBWhA="
-  },
   "org/springframework#spring-framework-bom/5.3.34": {
    "module": "sha256-Xd1Euil/Pd6tp4FeR2aFMYvYh1WdN5mqcLdZM7Uf1QQ=",
    "pom": "sha256-bQYW4lRNcRXcJJgX3XWKNN+mdzKRgrQuF1QuEz5Vcy0="
+  },
+  "org/springframework#spring-framework-bom/5.3.39": {
+   "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
+   "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
   },
   "org/springframework#spring-framework-bom/6.0.11": {
    "module": "sha256-CV5xI53YkWkSRMjWvm19o05nC2UYaUeexdJBXZmrYZI=",
    "pom": "sha256-SK3yYlH1WiPKJZbVBuBZEdmnZ3fm0CxSgMGhd4wUMGc="
   },
-  "org/springframework#spring-framework-bom/6.1.14": {
-   "module": "sha256-mgk0smfR5fyez9tc0/7W9PYPeGppexZsyXieRv21jzo=",
-   "pom": "sha256-BOLo/oESIB1r4RFtdLATmOPD6sVr8L63NnNGF8Rqq4Q="
+  "org/springframework#spring-framework-bom/6.2.0": {
+   "module": "sha256-8KnavGjttkVgoh3q0GDDB1D8qckDYQYgonMZs4oewCA=",
+   "pom": "sha256-c9YvN2lzSpSUY+hXhSoVS6qroJ0Mdm40QQZs/q46fsQ="
   },
-  "org/springframework#spring-jcl/6.1.14": {
-   "jar": "sha256-mXXEYrrO56DBqnnlWqT67QK9KNx40SUkBNqH9ff7TLE=",
-   "module": "sha256-eVuSx7ppHm1vSPMy/IoKELVkJx1A/luRYEsT89XeBFo=",
-   "pom": "sha256-XS7hByyO0HjD5QkJVXnPKujOMBMFhthMz2q2LACN9WM="
+  "org/springframework#spring-framework-bom/6.2.3": {
+   "module": "sha256-jGhP2oDvHnxxmqfkMwEeMv4VMZvLItJ03rzEbqOSvig=",
+   "pom": "sha256-Zw6Er/sjG18ww+cCrlQiLyHHIy8wxUAbOl+AGv8GFo4="
   },
-  "org/springframework#spring-jdbc/6.1.14": {
-   "jar": "sha256-EeI+atc/Y3SYeGVC6iYBhcUZwKCS8ITxxU7A5evrhN8=",
-   "module": "sha256-s3fVKuypLuPrbJhKHBfGMo6HtZdNmc4kM4n9YEbh/ak=",
-   "pom": "sha256-JX0aNaCSSdupyy018IVoGHefj7zNSo6oqAYzZRu6uDA="
+  "org/springframework#spring-jcl/6.2.3": {
+   "jar": "sha256-jGXsXtZIlmpHDmtIsny+v18fQSvUayQ+ARHF1dlu/oY=",
+   "module": "sha256-PxqK+qC2Yi3g2S/4zTFpBoB1CGXpSJSu7DCf7kmqDEs=",
+   "pom": "sha256-BSEm2SxKXGAHZjYcxATm4AR7V6VjfQKI0CTvb5IAPn8="
   },
-  "org/springframework#spring-orm/6.1.14": {
-   "jar": "sha256-1Tik8BILOiQWulW7qrq6RKFA87raxokNhgX2GAJ+QYI=",
-   "module": "sha256-7m/cR317+RtbrPkMPEEdM0S/Z+v7McO4sgVr7rbLs2Q=",
-   "pom": "sha256-BZZ8CoWW7Z7YqIOx4C1mhT4qo6vIJpHett93D56lT8Y="
+  "org/springframework#spring-jdbc/6.2.3": {
+   "jar": "sha256-cM1y3vgW8p0Qui6ICKVS9D4TIYUKLvV5O3mQHnStw8w=",
+   "module": "sha256-k+Y/mIrnZX1pO7X4ltvXnwa/JtvvzHzfGsAr2XLZPOw=",
+   "pom": "sha256-dQRppvGVOmPIhGHw2n//jhEgDoKsYy2H84srrSeNfTM="
   },
-  "org/springframework#spring-test/6.1.14": {
-   "jar": "sha256-SLpxtng1gWxju7XtOrGC/IN9aymI817oBhNGUBSB2Sg=",
-   "module": "sha256-rQfr7q/epAzIzorQu8J3UQbAhxMkXnnR5Nj5SLKvs+s=",
-   "pom": "sha256-H0QrTcklpU/HK9mWwCs8M1sOswAGjZXQ0nd4lYhVJcU="
+  "org/springframework#spring-orm/6.2.3": {
+   "jar": "sha256-VvEQqzpSODIktEOqCZbfcSgh3cwFRFQGVuvaQLJyJSE=",
+   "module": "sha256-e33Zj/sPHn6k9lwXJ+101v4EP1HdFqwUq/hLNz4fuUQ=",
+   "pom": "sha256-rzzkiCAaTkm4YiCHkxB+rbKdrSTTthlb1Ps4OQi4fGM="
   },
-  "org/springframework#spring-tx/6.1.14": {
-   "jar": "sha256-3rgmxROi+/p1aLWeNn+TFsYQn/p9MwuzH53vrZg06vs=",
-   "module": "sha256-ClvtswRrvUYGjUv7TodMcgs6XLhlPLAMQvuX3N6HhD4=",
-   "pom": "sha256-9Y7Bw5d0xPOIY9UW5MJ4XyuuI8CPIxRLsCkWdT/dU/0="
+  "org/springframework#spring-test/6.2.3": {
+   "jar": "sha256-NJ6qfY1JajtoSQzMci8Ey9cRzkMIMAxZIqE7sgdGm8Y=",
+   "module": "sha256-GMxC2lXQt+498HpBmHjhPSIiT558nyrkqi+BSM3p7ZU=",
+   "pom": "sha256-vlg4/nRULaOZETV8Sfnx+TZ66weVDOeIeUP8ZoKG/4E="
   },
-  "org/springframework#spring-web/6.1.14": {
-   "jar": "sha256-j7vZXic2Gqn2Vr7hjTK60GK0IQ1YSQmJPLyD3Zxk9HI=",
-   "module": "sha256-V2ggogeLR2AYaeaBkKWkplHqQB4Ukg100xXT2+38xsI=",
-   "pom": "sha256-mPmcPKgjz5ad4b/H1Y/uz2imiXUXwemsJGJ/rCy4Wbs="
+  "org/springframework#spring-tx/6.2.3": {
+   "jar": "sha256-7ThK4V3aMGD/jf54jtPtrDVOOqVY7lr+drt5nrTBYNs=",
+   "module": "sha256-KNcWUlaIIUe/TIL0nRmDO2BtlqXk4hdS8tlFHgGpthc=",
+   "pom": "sha256-O4SjuqAyYKv0uA1ev/9q2mp8U/IBkEOsfmVy6bP7UHo="
   },
-  "org/springframework#spring-webmvc/6.1.14": {
-   "jar": "sha256-nwlvdTDtOFNI0mndmtZC3/R/UMvHWPF9aUhJUs3Qy8A=",
-   "module": "sha256-xXlQIEPn+CUuQcL408AXlUFvZ0ihLF2QBUMwVSEILMw=",
-   "pom": "sha256-+4NjEeK8k4HIj5AF2vY9J3y0iVwtGZWkIa6y+w0wWgE="
+  "org/springframework#spring-web/6.2.3": {
+   "jar": "sha256-dz8cpN0moeu/zWog4+tSdF6q1wXisDF3NOoG2Jea/yA=",
+   "module": "sha256-0rxhKFwJudN4ET6LkFxJlMFDYOlWrIdTLdVuGSbGYYg=",
+   "pom": "sha256-jzK2ZmCmSCtaA4t1D5lnRk4Zu7+hZbOp5MKi5A80upQ="
+  },
+  "org/springframework#spring-webmvc/6.2.3": {
+   "jar": "sha256-ei5JzIkShsFNmVoMX/ocr7S1Xuv6HPo3M88SAU/dnwA=",
+   "module": "sha256-D4DegT3bAFeB4P4fIyC/2GwxEnk+GWFVLOgg9s+E9U4=",
+   "pom": "sha256-JRI2/pHBk9hEnmJMBz+mfuRtoru/rnXqx+NzEEp9AvM="
   },
   "org/springframework/amqp#spring-amqp-bom/3.0.6": {
    "pom": "sha256-sch8n8omH3LZPz+tDWBfn6FQECv1fU6eT9Ga0ltYvB4="
   },
-  "org/springframework/amqp#spring-amqp-bom/3.1.7": {
-   "module": "sha256-V4RBJN1QOg+8JPUIUkNMFcSAjMhCvicZBqU+D0Xrq1M=",
-   "pom": "sha256-+A8UHBSgtP2fT9njnZ1s41LUal2VhEmPZS9Haq6cfAw="
+  "org/springframework/amqp#spring-amqp-bom/3.2.3": {
+   "module": "sha256-9eSGj7HQVpOpf4+6OVkrLfMKbLQysTCX8BCXf6ZBAdE=",
+   "pom": "sha256-tRG87VNspJqsdf6UkHNXCG83RhBNu/xBv5ZHWePLD9w="
   },
   "org/springframework/batch#spring-batch-bom/5.0.2": {
    "pom": "sha256-aDpeNRsQ0aR8gkN/CtTnhmTUICWhpXBtaPpDhCHt1uw="
   },
-  "org/springframework/batch#spring-batch-bom/5.1.2": {
-   "pom": "sha256-sVvWVb7ESiLKe/VnhcpPfubUcAOBaqBwJtF0bbECwAg="
+  "org/springframework/batch#spring-batch-bom/5.2.1": {
+   "pom": "sha256-lQOF8+SgFyJyld6ACk14EiJtOhdEe8tCXSAUrcOTl/g="
   },
-  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.3.5": {
-   "jar": "sha256-bvpMs8I0Pc9Z+hsNrJ7Wn+PPuYx4cyFeGMQy89qAc1g=",
-   "module": "sha256-8SMzcdDfdltsY2Dku2mbssWVBP5IU5511Z+LYwmxzD8=",
-   "pom": "sha256-mes1uzC/6fmLYrkIgZPVbn1df/tiF/vMiCtWOtJDs9M="
+  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.4.3": {
+   "jar": "sha256-779BRL0hktvf7XBEZfJ2aqoJcjGYiFkeuSsGZraHYlo=",
+   "module": "sha256-XfsMhg8KiWNguoBCoH479QA/mGBgK8vNSoZfcwAJ7zY=",
+   "pom": "sha256-WOOd7mQObDWgwSRp8fUXfLxf7d28MtemFuVEq2JUJ74="
   },
-  "org/springframework/boot#spring-boot-actuator/3.3.5": {
-   "jar": "sha256-hb7IFt6v9Q0Ij2Mn9Hkjc75O+iTHFC93TrEMPi553EI=",
-   "module": "sha256-uTp2iR4gbeASh9usAWVJYYmBNUcFvZrEzqkof2U3h8U=",
-   "pom": "sha256-wyQvUF8Ob0s2RRUlX5Dhy9Zq3TL1tVM8cat5vRq7R14="
+  "org/springframework/boot#spring-boot-actuator/3.4.3": {
+   "jar": "sha256-VJOhr9BtiVAB6d6ME6Ui33CSYUWkJHNOIKMEI6+/mXc=",
+   "module": "sha256-SpeVwjti57YszLEAM/pC2BWDnH+lyvffKtQ+EOBaZoM=",
+   "pom": "sha256-pSlmhtJ9MMRPGKmR8I35EdTaVVdfNGrVeSM3oFqcJX4="
   },
-  "org/springframework/boot#spring-boot-autoconfigure/3.3.5": {
-   "jar": "sha256-Tp0NmEFNkswYRPhLiNWKDJaP3lHnMzvkjf/kJLq3eEQ=",
-   "module": "sha256-3PO7QyDmEG9/LcwuYQ2Kb+kntoiBIVTpn2aI4x9vKiM=",
-   "pom": "sha256-hKRGXTatdgE2Dr/cUzzocUmFUJdQStBdbF9qFA8juVI="
+  "org/springframework/boot#spring-boot-autoconfigure/3.4.3": {
+   "jar": "sha256-F/vUV0fyav9SO05IkZjOW8K0kN5Fm2YSUm+7y983N0c=",
+   "module": "sha256-YqvS8kI9ojpn90Qle/62as/0MsTfwZaM18u8rZc8MYs=",
+   "pom": "sha256-Aw+107YhiUomkNk0dLk1YM8ijLECjBxmfXA/f4MKhtE="
   },
   "org/springframework/boot#spring-boot-dependencies/3.1.2": {
    "pom": "sha256-DIaB6QfO2iWOWU6lt8/aByuKxHDamKrAGEqO62lQV9o="
   },
-  "org/springframework/boot#spring-boot-dependencies/3.3.5": {
-   "pom": "sha256-S7uHEUNMSi5gNo++NPtvU1JAS30HoQL9I/GD39dXRwY="
+  "org/springframework/boot#spring-boot-dependencies/3.4.3": {
+   "pom": "sha256-EwzZoLGErLnXfpcHo0AvVhwmhrd3olNcqIf+VrMAMqA="
   },
-  "org/springframework/boot#spring-boot-devtools/3.3.5": {
-   "jar": "sha256-0zJP1Bn7Eqsr55Lsllw4KhvtT+2XlAHvGqUvouj5wgY=",
-   "module": "sha256-ivSaFt7w0KyNmz2qMCULNfX09nEJk/ErxEtRwfoHo3g=",
-   "pom": "sha256-ozEmQ6WI/jl4o1RbJ9UwNj6T1+99KLxGntgJhjanK7w="
+  "org/springframework/boot#spring-boot-devtools/3.4.3": {
+   "jar": "sha256-uL1vjudEi2TM3P1N1JsJp3nEqdT9MjU3Zmwcos1X7As=",
+   "module": "sha256-fAijzkbz04ZpdS8uexmBLwW0ytVGdXmnuptPFHnqjzo=",
+   "pom": "sha256-jb3XksKStLGNT8IVjNJj/yTlFl1IDU+hL18bY9K18E0="
   },
-  "org/springframework/boot#spring-boot-starter-actuator/3.3.5": {
-   "jar": "sha256-dLYMH4fFWk3Srz6LE8FHqPKjnK0BXRYPJondkZXOx/A=",
-   "module": "sha256-EKOh3FGUDWjp7ueIsgqAMLol8OHa/cl19zCIlzhVHHE=",
-   "pom": "sha256-QvW0+YX6isJnkojehcgOKhn57MsvJNpVdQJLFndlMR0="
+  "org/springframework/boot#spring-boot-starter-actuator/3.4.3": {
+   "jar": "sha256-zIa5c9J9P3m4xR4wGvdb14uNDvqJz+K/TRqi+b4gQuk=",
+   "module": "sha256-wMSmwTKgvJPURscC9apTfnv1xG1E3FXOGXKfqo8nOzk=",
+   "pom": "sha256-t7zmB93aqDAwaDqQE6XItoxzcBQVFquw4wGUbSWakDg="
   },
-  "org/springframework/boot#spring-boot-starter-aop/3.3.5": {
-   "jar": "sha256-RSyVAyl/nzTBS8FUhLJq9qlELBc59t68sZw+GbWtzfQ=",
-   "module": "sha256-DkJs5MGVFzuZwonRpkm9OcdQhjRsi84E/rRe5DTzIj4=",
-   "pom": "sha256-nu4KfXuWGNTvdg1V3hAUgUy6UhwCQ/VIlqvDMCcqHQk="
+  "org/springframework/boot#spring-boot-starter-data-jpa/3.4.3": {
+   "jar": "sha256-YEAipoj2eHrdrPQXgHT2fHDpX0FCrXdzT957QTjw+KM=",
+   "module": "sha256-JC+Q0SkCWjuhxswscQXe6m5oVgVSbR/1NpmvQHZnjPo=",
+   "pom": "sha256-sIcbkCFwi5EUkp7KnwpwObueboZ1OWmQQJuhu1y54Oo="
   },
-  "org/springframework/boot#spring-boot-starter-data-jpa/3.3.5": {
-   "jar": "sha256-GrHbKAjl3oo4wxMvHVGE1p5lfu/BBkG/qaNp1cpVJqI=",
-   "module": "sha256-hL8Uu9zCam65KPSiiDBGh5/zlfr4TvRQlIS2XdwZhNA=",
-   "pom": "sha256-f3xHBijkbF/G4L0JFDBr06a/cVF2Y5Djb+89WwmBgN8="
+  "org/springframework/boot#spring-boot-starter-jdbc/3.4.3": {
+   "jar": "sha256-pkioQnt5Zt/rGs2fEyqPuxLwT2vBGSm0/8fsOsfZVC8=",
+   "module": "sha256-Oyge+t4WZjdaJUdlldkYAyy1eN55rohSR9ddtaLTgu8=",
+   "pom": "sha256-9nhimCgGKw82aPSiQraB1Aee5vM4Mt8a3BBDA1MlxF8="
   },
-  "org/springframework/boot#spring-boot-starter-jdbc/3.3.5": {
-   "jar": "sha256-sUXjhyzqVowHe7eZ3XPKYkmgKEoHaESxTyYiu4qwwVA=",
-   "module": "sha256-JEEWw9yYgwbelXzhrrjR57PoKAks2qoJXvi8rFgSByE=",
-   "pom": "sha256-0Xd2ggFTIN/lDKgaph0qiUiYh0Snhiz/RhROY2zz7F0="
+  "org/springframework/boot#spring-boot-starter-jetty/3.4.3": {
+   "jar": "sha256-xfTwqqH9CBUc4lSHKc7jMYGI99Ku3mEao9yobYsG6GU=",
+   "module": "sha256-CptRu25KA+bkzpJjON1hHWL69spJ8X3eM1IoLYqxpP0=",
+   "pom": "sha256-M/lRilpLBQebjWuWYXSsH1OpfhcPGXadi9j24P59Xn8="
   },
-  "org/springframework/boot#spring-boot-starter-jetty/3.3.5": {
-   "jar": "sha256-dXZ207xfZXS7FDejvSmSSK1XCPsQlXN6Zuv4JXqSZag=",
-   "module": "sha256-GjYt5okMZ69/Z3Wi6s+5F4ExXIOncWmKzpKkFlf7s6w=",
-   "pom": "sha256-N4ro5k7+CXHbO0rgzrbUMnaOC13suSit6pOxilX9A0I="
+  "org/springframework/boot#spring-boot-starter-json/3.4.3": {
+   "jar": "sha256-A/uEve/+cIdbJnp/mYQL/VcjQRPvlqjbrM4pXCP5lO8=",
+   "module": "sha256-h3gZa3wmkiDcUKthq1xRyTK5vEnLVBXKP/+XglP82tE=",
+   "pom": "sha256-k0pjQWlNz9EntXsqQ1+CHFzhnm0jolvKucnOW+51Z/o="
   },
-  "org/springframework/boot#spring-boot-starter-json/3.3.5": {
-   "jar": "sha256-otsbpb7I6ZxU7CL7dhVVfALILibeRtb27CDErTDiXyc=",
-   "module": "sha256-AW4ZrNh22O1vuur0lY5C/MhtmRaNoAb2jL8WHpAKcnU=",
-   "pom": "sha256-0zWNw0gljedx4w4yDg3cZTCCe80xJm9574+EEC6Ze9c="
+  "org/springframework/boot#spring-boot-starter-logging/3.4.3": {
+   "jar": "sha256-xl3ww6bdHMmS+b7SzPLgh7cr4KtQMdUIXkB51lPeTVI=",
+   "module": "sha256-9n2snuAUiNQceB9z3M2AF+57/EycZ3bq7z6raTebe20=",
+   "pom": "sha256-WTGytzxUdEMPEMi1woSbTXyMBbuXRSOft7ju3Y12Prc="
   },
-  "org/springframework/boot#spring-boot-starter-logging/3.3.5": {
-   "jar": "sha256-yAmeCD9RKAUpZXc216GGw3fp9+RYNj2PXQAo0xZvrCg=",
-   "module": "sha256-EnxJnA4hhERGwAjxjHaqOkobqIm7Y0pYzWqRpl6MzbE=",
-   "pom": "sha256-JGFbevQCW41Tdl3Z/ThSt36eKe/hjarh+s4s4M6WeOI="
-  },
-  "org/springframework/boot#spring-boot-starter-oauth2-client/3.3.5": {
-   "jar": "sha256-yWwDZKZKVWU592su5mZ1cc3/SlbXaUvjgeueuVatiwU=",
-   "module": "sha256-JPqPtr/6LcMQ1WN62Rf00agA5Oiw0R7cN0rI1DS53os=",
-   "pom": "sha256-sbro30iABI7HSiH4cvTMsAgOWDjoDX1DRmwAbpwNUJc="
+  "org/springframework/boot#spring-boot-starter-oauth2-client/3.4.3": {
+   "jar": "sha256-VfFS+hujHUuZdljexDMlJ26q12+s7o68Nljkrz45wq0=",
+   "module": "sha256-e2B8EnIDU2lilRC3wSs73V4Vq9TQisoHj57YPrDinrM=",
+   "pom": "sha256-+EDFSardW03f9CgxXMNI9RdFBMPUTtiqcQk8vXKvmAw="
   },
   "org/springframework/boot#spring-boot-starter-parent/3.1.2": {
    "pom": "sha256-TB9NCfr9cgJEhZCDvfx7VytHF22Bil965q1m0ZOODO4="
   },
-  "org/springframework/boot#spring-boot-starter-security/3.3.5": {
-   "jar": "sha256-jbKAzw3D0rEPFKeHwBoa3Yj3m5GKzByRfKx1vmboJZ4=",
-   "module": "sha256-ab8BxgkjdGaGdNvQR0Gjpg5sR69V46eaxkWnIvdvIzU=",
-   "pom": "sha256-SucdtxT/E8X9rCIfyzYYYAXJOVROhFCXnt6/SIVM9tc="
+  "org/springframework/boot#spring-boot-starter-security/3.4.3": {
+   "jar": "sha256-jA4Rik0gVX02V6x4R2jwWRN07E2W9eIWCJQiS/4r2KY=",
+   "module": "sha256-y6iIFbbOCKQOn6T/+8vER/dRCYVKGjzMeiLOXHl4FlI=",
+   "pom": "sha256-nzJbiep1ND5afKIrjKr7Co8KUuwlKyrUbGmCux8nwpQ="
   },
-  "org/springframework/boot#spring-boot-starter-test/3.3.5": {
-   "jar": "sha256-5bNxoza5AHEQC2Uqh+ooisqfzthE+ZNJigO5ZVmRffg=",
-   "module": "sha256-t+nz5yUdIcDHnrr5i3TB6jgWbTQCqJozAsz384jzL3s=",
-   "pom": "sha256-4Du/tK6qkV6ljBgcbOx7XTJRdXjmjbekOMvjN09G6p8="
+  "org/springframework/boot#spring-boot-starter-test/3.4.3": {
+   "jar": "sha256-F3xoASxNaUbPg/6AeTR7r9VHGfsw5HzzwgFBXsIog3s=",
+   "module": "sha256-XBwaDTnUR5tWq2cFoBzDiQzaYnrKuHWiOu71tCggSGk=",
+   "pom": "sha256-oY8jYvnn6mCrrgQ0b4dU60ZaaVMg/Uf1GD0yaqcmwwU="
   },
-  "org/springframework/boot#spring-boot-starter-thymeleaf/3.3.5": {
-   "jar": "sha256-4+o205RuZdlCZ2NONnYUJJmHa50MuK1GXKm13cOsffY=",
-   "module": "sha256-hSAw0uIg8N1iYMmfxXVfzOuWUXFqxDeT9QkfBMNDjEg=",
-   "pom": "sha256-XSK/KjKB97vQXe+rBgggFYrK7+Vs7KZCff+dauMWNVg="
+  "org/springframework/boot#spring-boot-starter-thymeleaf/3.4.3": {
+   "jar": "sha256-lMxGBKihVKZinwmmMHipWJh3oCusQrvhPznBgAIxdhw=",
+   "module": "sha256-qwzxFW5bIeZ0K1ebySgGOAydAegxpWXHxbb5WCIu69o=",
+   "pom": "sha256-sNb9RVc0CU07Rp5Xubi9MLB16s8PTGbX/dFcqhznSCw="
   },
-  "org/springframework/boot#spring-boot-starter-tomcat/3.3.5": {
-   "module": "sha256-LwwmMkO3r8O3w4yZbYuvZT3qKZWhP3NR+3hNsx4XVy0=",
-   "pom": "sha256-1ztMKXhHWytiATtIi+/S34Wd00omRc56fy/Qq6EE3LI="
+  "org/springframework/boot#spring-boot-starter-tomcat/3.4.3": {
+   "module": "sha256-aTHJpE4/Q9DwDTnZSmBfyrtWuxF5AgqiaAQT1Ni5M5U=",
+   "pom": "sha256-tvp16RbAM51BYqPExKYqB1HuvIz+YYF85Zm44AOpdRI="
   },
-  "org/springframework/boot#spring-boot-starter-web/3.3.5": {
-   "jar": "sha256-rgX5yxq+59KW35tmzhR62MjZpwhQvI0X3PivXVoeMbE=",
-   "module": "sha256-qR0BMgl5A8SPrES2u6Q57wuti3oBjWY9QOkFAmXJ3NE=",
-   "pom": "sha256-E8FiMBe45T6xISnimiXUnezUnBhdHxchQpeeJG2N264="
+  "org/springframework/boot#spring-boot-starter-web/3.4.3": {
+   "jar": "sha256-raJMFSbJog2P26tdTzvE13lJWjF8/zp9eJ+ofjNihoU=",
+   "module": "sha256-rzMsCpbLc0WNInWghBJZDDz5j3XneNzWiNc11+fDP1o=",
+   "pom": "sha256-g8FkECxnf+APWFSflfMPE8oINVqQXHY77sPoJehfiIY="
   },
-  "org/springframework/boot#spring-boot-starter/3.3.5": {
-   "jar": "sha256-uTKGV4VhwUXCVLYiPUAdcV3i+kpo6Tz93vTsFIXnj+U=",
-   "module": "sha256-d2qWi5dZbgHonj2P9SGjpS0R/kw/SgNBHFBRFZq7Shc=",
-   "pom": "sha256-ZsPiDg82UKgejfE+/5RN/EU5FWiwAGaXmzQbZzDK/j4="
+  "org/springframework/boot#spring-boot-starter/3.4.3": {
+   "jar": "sha256-c7SFJciK+2H2ZF143luwx7NmrCAWV9NvgUdYwVkbeT8=",
+   "module": "sha256-gfghsIQaMRdz574z7EtljzMLQSnBGIVi3LkPBUJmXzw=",
+   "pom": "sha256-Vbe/CCnxy1uCRgG1/s28NbXRoTg9b0PL9sOdfBg6mok="
   },
-  "org/springframework/boot#spring-boot-test-autoconfigure/3.3.5": {
-   "jar": "sha256-pMiwpQleenn+aQz2iGPuRi38hWnad1yFu0gg3K8Ag/U=",
-   "module": "sha256-DjW70DU/NOQIMeqxcDPHJlkAYm6MOIgimOL9lNV0DZ4=",
-   "pom": "sha256-eBlxePNeHkBI9wQS/IamiD9aWpWNPwAfF88wfCMzOXw="
+  "org/springframework/boot#spring-boot-test-autoconfigure/3.4.3": {
+   "jar": "sha256-p3IWX/JGiqN73NimbnWwQQEVzC0NFC0FV5Nch4rL9rg=",
+   "module": "sha256-VycMQkAMiJ4z6m+TZYVqj3hNekCS5zMAswCqz5lTsY0=",
+   "pom": "sha256-+DhcWbROFGHtwvZkChXkxVYK/q/G8CtV0QzqxeBqqg4="
   },
-  "org/springframework/boot#spring-boot-test/3.3.5": {
-   "jar": "sha256-LeK6rxGS5GPZuqy4UpnSu3qGBP/Cjdl6snKrB0Qlsbs=",
-   "module": "sha256-AwSn5ZjFZknrhb4EXjB4+WRs5UVu5lSiJwq1+ycOa6E=",
-   "pom": "sha256-E+eCY1dR4LCYzK7Jo3t9kPbjqDcJO6r7BcYyyl4eDlQ="
+  "org/springframework/boot#spring-boot-test/3.4.3": {
+   "jar": "sha256-c7lhTT8oKyxe7gVq/8rSQcmqYqLdeG+CR5cOhTKlrlA=",
+   "module": "sha256-Q26UnuWF/tHj+SsYF7l3GbJvtWQCamMOVlW8/lJAxtw=",
+   "pom": "sha256-kXNsfxk7e30iMnc4cMJC02xrAtw6YQSQe1cksVCxw3U="
   },
-  "org/springframework/boot#spring-boot/3.3.5": {
-   "jar": "sha256-akpciltYwglwWIHkh7SURWeatpyFhiP+9wD2NOJOucI=",
-   "module": "sha256-AqTMJo2on0OkLwh+X0TQRLYkM0iHX8MafKneQTIGInc=",
-   "pom": "sha256-wXOJ0KhXirYYaGaUDxH6KVLeKS/QYJ9Yt6R5EFjrUds="
+  "org/springframework/boot#spring-boot/3.4.3": {
+   "jar": "sha256-QYpq/Skgr+YvxcCcxGtIWnpv3QnhZ/Cu1aI0eAnrVgw=",
+   "module": "sha256-o67EOT2xuuPgcKoJU+zy4ImgDKq7XNvuwn/oGJ+WkOs=",
+   "pom": "sha256-LaJ6GNBSueVA4rwdA6oKU5xHT88M5mmjPPStM/IzMMI="
   },
   "org/springframework/data#spring-data-bom/2023.0.2": {
    "pom": "sha256-r5JYFO1beGWJH9CGEGBVcLS7hFCi9Rv55bhjXNNoHgQ="
   },
-  "org/springframework/data#spring-data-bom/2024.0.5": {
-   "pom": "sha256-T74vSlPI0KF3/wdPbEsFdTU4WUX5qLh/gWNijtUAQAI="
+  "org/springframework/data#spring-data-bom/2024.1.3": {
+   "pom": "sha256-jVIbBkHCz1WpZKiCyUtmQpRxOOhldjBsBY+jije5Smo="
   },
-  "org/springframework/data#spring-data-commons/3.3.5": {
-   "jar": "sha256-TSsh/zcvJ6HXTMTUxceI3nbYIkTUdEmVIiIfLanY8V0=",
-   "pom": "sha256-PUCirD2/PhztCVzxjHjw6cPYL0fVNk/j2DPeEQa1F2s="
+  "org/springframework/data#spring-data-commons/3.4.3": {
+   "jar": "sha256-bo3k4YhQPn1iR+EPsHeeIwYZMEqneqqHD6XtnJzeRgw=",
+   "pom": "sha256-zAZASufV1Depo4Glva0SnUKhFPOsvdxRoFLEQl50JeM="
   },
-  "org/springframework/data#spring-data-jpa-parent/3.3.5": {
-   "pom": "sha256-TYrJIFGZe+7Jg+WkqD3/JcluKI0xQE+jo2QTxyOAMgo="
+  "org/springframework/data#spring-data-jpa-parent/3.4.3": {
+   "pom": "sha256-RL6rGLGNlTUI39ExT1C+tAv44zQvcR+h4nMHv/objHc="
   },
-  "org/springframework/data#spring-data-jpa/3.3.5": {
-   "jar": "sha256-M5oPgDUs1wAEn1YKgdqhgrLV7WIBTNBWExEuJSwAvEk=",
-   "pom": "sha256-QCYK585I1IpdG5qAsq3OlbAEWrhtWHD92E0/P3f/eSo="
+  "org/springframework/data#spring-data-jpa/3.4.3": {
+   "jar": "sha256-vMERcu3I8b81JuiENhIF64r0G701DoilcxRfUDb5MPk=",
+   "pom": "sha256-CdId6Nf+SaKm4O3pep7TAU2cLja1ukllGiA8uHApGKI="
   },
-  "org/springframework/data/build#spring-data-build/3.3.5": {
-   "pom": "sha256-1cHojTyo8/8nB6Sc7JUCtMMDpGHRNGNXujX4NUrDXLA="
+  "org/springframework/data/build#spring-data-build/3.4.3": {
+   "pom": "sha256-ojJb5SAowdM/DsJ5rKpbaxvKby7S5c+2GvLqGQVyEpM="
   },
-  "org/springframework/data/build#spring-data-parent/3.3.5": {
-   "pom": "sha256-E0ETrbpQjk3heG4pxSTONPDinYryY0zthyfPAL7L5dA="
+  "org/springframework/data/build#spring-data-parent/3.4.3": {
+   "pom": "sha256-Ulh3zIcXyWH04IAmytx0mg68jqXonHR59UYebnMLHjs="
   },
   "org/springframework/integration#spring-integration-bom/6.1.2": {
    "pom": "sha256-0mxOaZYUSD15O82BeZxUTtpYlXYrSzGXFX7tAo7GL+c="
   },
-  "org/springframework/integration#spring-integration-bom/6.3.5": {
-   "module": "sha256-aCsKwIaxXSLAWv6P1LmtWBIbAqTyBUBFscHfl6o+FkA=",
-   "pom": "sha256-i2kHldjBjMjl4C3s5xXm8cCgz2majI43DhB00COQMZA="
+  "org/springframework/integration#spring-integration-bom/6.4.2": {
+   "module": "sha256-9d6pRUNT+kUOFie5X/9BAbXUuD0uE5UjISLVQO+QRJ8=",
+   "pom": "sha256-LqskSezM/plnbIrxlmoD60DNGcYq79eX7oX40fOw7Ok="
   },
-  "org/springframework/pulsar#spring-pulsar-bom/1.1.5": {
-   "module": "sha256-BM6anJV+aHSHhhEJGjGlEUAcYjlD7LmMn4xsD7Gc4Xg=",
-   "pom": "sha256-NhOS9MbincFWam8DXx5FSGBHfcjsV9X5szEPatYHD/o="
+  "org/springframework/pulsar#spring-pulsar-bom/1.2.3": {
+   "module": "sha256-kKJY0Et+aALU62ipbovDfNkgjj2fD36BllPk5RM8qDo=",
+   "pom": "sha256-XQHgYZtimzI6V89ByehHv/dxTxVCih54PdZhgQfU0a8="
   },
   "org/springframework/restdocs#spring-restdocs-bom/3.0.0": {
    "pom": "sha256-/8nEe+Wo60iO3pJozgiaeZyT6JT7G9P5QPYsRnpmEyM="
   },
-  "org/springframework/restdocs#spring-restdocs-bom/3.0.2": {
-   "pom": "sha256-fCqIW7xLUzlL111fOel8gd7s7PAH6uqkDsv6UY10XT0="
+  "org/springframework/restdocs#spring-restdocs-bom/3.0.3": {
+   "pom": "sha256-BqUY6ZcWnX7d821cOtwAQOKThnvfofFo3al4QL0Pb3Y="
   },
-  "org/springframework/security#spring-security-bom/5.8.5": {
-   "module": "sha256-ThRXe7Hs0qntCNqoNEe5HBK2pGX+1YqlqWoztXBZEVo=",
-   "pom": "sha256-NtcpSd0VViwUD/4Xbnf8sfc+GaTSwDNhE6oJbCNbW8s="
+  "org/springframework/security#spring-security-bom/5.8.16": {
+   "module": "sha256-eRpwg4XuOGguCJQeRFffivCdxuZWxUVhF91pH9DvNW4=",
+   "pom": "sha256-kcopmCCxmXYQcGDwwsagsPRftd8MuZOvC31Opd4x6hY="
   },
   "org/springframework/security#spring-security-bom/6.1.2": {
    "module": "sha256-HMJ40imEfP7hLpBd9w5W5W4eo2m+LKd3S/u60EtbMos=",
    "pom": "sha256-P0nGqe8bTNCnKRAzAyshnLkmzIPX3KlutclyzSQnI44="
   },
-  "org/springframework/security#spring-security-bom/6.3.4": {
-   "module": "sha256-EAFpuDWKBHs9SY/BPT6nPulAQafwJjL/JoWXxELQUkw=",
-   "pom": "sha256-RK0PCLvjoMWdkpm8VYRar5oM/h4svOFUV/PPyLJlk8g="
+  "org/springframework/security#spring-security-bom/6.4.3": {
+   "module": "sha256-TIpHk0q+SGYF9ZOhrFp1qylQ9kQMSvzffNBjzcyJzPI=",
+   "pom": "sha256-VvjOf8pjVlnMUHikZGh8zrwY5T/NX008rJldz+xEFII="
   },
-  "org/springframework/security#spring-security-config/6.3.4": {
-   "jar": "sha256-Op6KqHrDg8XEWK8JTSMfrwvULH71bpXubbyGIJx3hjw=",
-   "module": "sha256-1OWFsOOkMVp3TOu8YEpGjinYT1FyXt1q35vNPlnZXlw=",
-   "pom": "sha256-WmSvchi6bymMU6M0ERTNj4+50p2QdsEMA7KiBOZCXVw="
+  "org/springframework/security#spring-security-config/6.4.3": {
+   "jar": "sha256-gH1jbFh3txFUtPvi3Wx8I4AcowO5yxjjST+fRocAZ7I=",
+   "module": "sha256-nrBNAW38U20n9yXUmT4y5znRKYdLvcBN2jKyWD0c+DI=",
+   "pom": "sha256-wT0Zv9/hLOUaqseVxcfQM0KfzgblI9Qtk4dur2MH6p0="
   },
-  "org/springframework/security#spring-security-core/6.3.4": {
-   "jar": "sha256-gdgSVIGvgcZnqhnF9bu+ArTWXRa7DHiiZCwNKuTwViI=",
-   "module": "sha256-GPEgX9wvvNe3BSy2xFIhOv0h1wIeM0hXxzXlgC0RhJo=",
-   "pom": "sha256-Ao9sGzTJaFJ6zhVReD1hw6mcHek8PcDz7R3gCeq5aLg="
+  "org/springframework/security#spring-security-core/6.4.3": {
+   "jar": "sha256-X2GPUcX40ad0R/PLToyM9CABip/iVVrz8HC1hz87ELQ=",
+   "module": "sha256-kQdEWEeVZaRbGymMqQwVsZSjWmO6gq2jxfBkxct2rjQ=",
+   "pom": "sha256-XTxUZsTuHccAssoudONf1p3/j41GVTRRijKtrLfLu7U="
   },
-  "org/springframework/security#spring-security-crypto/6.3.4": {
-   "jar": "sha256-Rd4Rv/QQ5rADu/s9y/sI40wQLxBgdsBxsz7jc+mqb3I=",
-   "module": "sha256-FWQ4lGElqXnMMxkSkFqfj1lTF9vT8hs23EVgUrdOe5E=",
-   "pom": "sha256-RLSe9O6juW72Pm59q/Xja7sMmZxIjoFRrBrVeaZkCLE="
+  "org/springframework/security#spring-security-crypto/6.4.3": {
+   "jar": "sha256-PbETxWk6q8qHiV5VpDVaWRdJV1nHG1q7nT6FH3PJ1Bw=",
+   "module": "sha256-2zN0lhzqd0rU0usK+XWBpCNAzK20AGnhh91fuzTg+sg=",
+   "pom": "sha256-UtLMXNeYLmR4WW4FrPYGmcahli2Xyza3fr1i2WIvHNQ="
   },
-  "org/springframework/security#spring-security-oauth2-client/6.3.4": {
-   "jar": "sha256-JvmTPE1tkBoQVeaQR4nUgV07Q1qLg/IVMGCXd7Z7OPk=",
-   "module": "sha256-r/shECptD/tSb4/8z0Hkc35AuooormY9Aa+WY1+q2FY=",
-   "pom": "sha256-+GcSSzQ36H/Z2bWR1jacKjqp9uMtFw4ZnvMfsK4sKiQ="
+  "org/springframework/security#spring-security-oauth2-client/6.4.3": {
+   "jar": "sha256-72uf/dH5DBqmDEsIP1EGlGViMf3Ym8V/oROC0uE1+6Q=",
+   "module": "sha256-b0X3o554wIjoqEeUuGWocwPRABf75b2q6ZBqvA/JBQ8=",
+   "pom": "sha256-vtsMg8kHeKOZh2r+OTzkevDcCHKlDMHar4HiMxw35vU="
   },
-  "org/springframework/security#spring-security-oauth2-core/6.3.4": {
-   "jar": "sha256-/fsHfc5OczPU154doM3zIzEAAJ2Zt5HKkEh4Mr4LwcA=",
-   "module": "sha256-btvkgzKYVQAv9CSh4RKC+LEP04uJ1xldCDzdF7f1x2s=",
-   "pom": "sha256-wX5cRzGyH6Cu5Ewd1WV/iS+2Qj8w6/+bBTYcYsxk/+4="
+  "org/springframework/security#spring-security-oauth2-core/6.4.3": {
+   "jar": "sha256-x1N19G+oZ5RLWslTV1z2p8rg9h7xvhWVguTvXlFy7DA=",
+   "module": "sha256-apDWFB54kVUpvzUUYvZuuB66Z5Mp91Lt9TRGeK2XYKU=",
+   "pom": "sha256-N6qX9P4FC36hrv42ooiBSY792PhETu4ZQ74cB17my2M="
   },
-  "org/springframework/security#spring-security-oauth2-jose/6.3.4": {
-   "jar": "sha256-4gQKE0sYvZASg8Gdd5rAUQqB5F4UJFp/HZxoBNdaezY=",
-   "module": "sha256-ytHo4eMDgTwI30WsYWGJTYuNEmQq/ij4LEXvcYeGzzo=",
-   "pom": "sha256-ytjQ9KnN2gUKLa8enCw28mQA/EA+kOuz0ouud7BfZBU="
+  "org/springframework/security#spring-security-oauth2-jose/6.4.3": {
+   "jar": "sha256-WFOM7XQBe4A2WX+aNExdmcDBF7dXhbYI8/FUdl0dr4k=",
+   "module": "sha256-k+yyUDaTdOGlL09LORwBnRtLuFj5u0SZtioExMGMUJY=",
+   "pom": "sha256-Disd/Vcm2dz21vMzzydu4ue0qhy87thpw62T5Tb0R8o="
   },
-  "org/springframework/security#spring-security-saml2-service-provider/6.3.4": {
-   "jar": "sha256-/3Wl9Z4m1QW3ZMIrk4djaLiTR8KCjiYOnuxDRlyP/qQ=",
-   "module": "sha256-PLIx6bK7tN+uLCSjOHO7VzEg9x1feo8pfp6xhJNPgm0=",
-   "pom": "sha256-HriS/fN37BEszguvUvaze+g2WeY45kye9XD6H2qTqwM="
+  "org/springframework/security#spring-security-saml2-service-provider/6.4.3": {
+   "jar": "sha256-zNm5o8dcx93f4i0bgCEyd6sbMjEN7nMH7QDxBG43peQ=",
+   "module": "sha256-1YRoM+23Bzkqp3BppBgHdwedeZ3s3tjzEsq1dqFmsjI=",
+   "pom": "sha256-b3MqF4nav7mjRnu7S112vUPwHeZiX+fvw2mzca7cyXI="
   },
-  "org/springframework/security#spring-security-web/6.3.4": {
-   "jar": "sha256-sV5hOGZD6R6JUq/8M24xiAxXla3t6N6DZIFWvZZH7Lc=",
-   "module": "sha256-4b6wXUu5mvH+dH089vlsmYj22qcijsxRkmOpQqNArLs=",
-   "pom": "sha256-kZSRrphzBEMxVZaNko62eOfaDX9/ikbqeV3uzsi694A="
+  "org/springframework/security#spring-security-web/6.4.3": {
+   "jar": "sha256-9q8n+yPpNosgSP7h+5ovnH7SWVzU1xnoQOnIV4dJx/c=",
+   "module": "sha256-vp8tr6DVp3FrseBf+PCYP4JiPpwlCaa4SxVpl85CWA4=",
+   "pom": "sha256-SjsmEhgVndo7snw2Fwatcmbg/yl8Qj6YCVJC1V46BII="
   },
   "org/springframework/session#spring-session-bom/3.1.1": {
    "module": "sha256-1pUWyPsAHxEYTRTC/WPXiiXTt3H27w40+UMFo+/cYyc=",
    "pom": "sha256-yKH2TVmHtfeggnybjVe/dSegTYM/7o7EXlKD7kKTwV0="
   },
-  "org/springframework/session#spring-session-bom/3.3.3": {
-   "module": "sha256-NcV1S6JrYazj794KeEFGAIck9pAzPhU+ICPmCgnYD4c=",
-   "pom": "sha256-vQuBF/0ukuBMNM9Mtak3fxugb4T4CHSEaa1AMgbCNRI="
+  "org/springframework/session#spring-session-bom/3.4.2": {
+   "module": "sha256-3AEv25HkBdv3qVLsLS0D4iZ7pEhT0QvFjDjejTLnLU4=",
+   "pom": "sha256-a8HJfa9sj0A18oPW84lXkmEWWl17PfcxjYduB/iTEco="
+  },
+  "org/springframework/session#spring-session-core/3.4.2": {
+   "jar": "sha256-oGS3BNzAq8kkctm9LJgVlXdkfjn749VRLLtykANULyw=",
+   "module": "sha256-A02zA9rMLOu/2//SCtgR4CxzfElHx9A3Ja9HLPO/jkY=",
+   "pom": "sha256-3kg0+gkVeP2a5IGlrK2oqirJc1a30A30y4txM22z+IA="
   },
   "org/springframework/ws#spring-ws-bom/4.0.11": {
    "pom": "sha256-ebcaocK/ikSdMKx+g6qJOo0Ah5L8KUvIYCYVUvoQ7fA="
@@ -2087,30 +2403,33 @@
   "org/testcontainers#testcontainers-bom/1.18.3": {
    "pom": "sha256-l0dtYsuLXM/NHLrmkmHEk3v36BtWUw2oKmZJ4w3DHMw="
   },
-  "org/testcontainers#testcontainers-bom/1.19.8": {
-   "pom": "sha256-Nk8kRkvSboev9GTi1JF9PMTS9FNCwuMuupvmphk8lUs="
+  "org/testcontainers#testcontainers-bom/1.20.4": {
+   "pom": "sha256-oVFHwtqO3sE0AdHT5qCgG2Gea2e2bBA1ks7zpwzB7Ik="
   },
-  "org/thymeleaf#thymeleaf-lib/3.1.2.RELEASE": {
-   "pom": "sha256-+BG2hU0QZoLGjwYOUMk3ONhXOaq8UKOYiP3FnWZlu+Q="
+  "org/testcontainers#testcontainers-bom/1.20.5": {
+   "pom": "sha256-TeDLRzMSJ4A2o5d2MTacmtFylGTDIUfYfJ9cMvcmbfA="
   },
-  "org/thymeleaf#thymeleaf-parent/3.1.2.RELEASE": {
-   "pom": "sha256-yISd92GB/uypYinPsWHcJA7eQNtQUsnWjSyqd8r4Ujk="
+  "org/thymeleaf#thymeleaf-lib/3.1.3.RELEASE": {
+   "pom": "sha256-+UdIWb85tid8foaXGj9qfLtu8Jos9r6/D1XO8/GUgtw="
   },
-  "org/thymeleaf#thymeleaf-spring5/3.1.2.RELEASE": {
-   "jar": "sha256-DELJReKUFEYCy0R9NkExEjkktg/Y1PS28TN+R4qr3L8=",
-   "pom": "sha256-LYUlq7euSQPQGwB5TQhhoVfgXKwaJB6EY7DBeTZl82I="
+  "org/thymeleaf#thymeleaf-parent/3.1.3.RELEASE": {
+   "pom": "sha256-rXcDS/nWNQDMQeZ4PMJ4M5ay8m51odOjKXfg137CvVA="
   },
-  "org/thymeleaf#thymeleaf-spring6/3.1.2.RELEASE": {
-   "jar": "sha256-LS3THRJS03d7Uh22s3HemG76vS1bFdUcXK14t5zXeZw=",
-   "pom": "sha256-KoPIXHLDCamBMDIvJ6ycgqN2gkXmVxgrrnWDSM8g93Y="
+  "org/thymeleaf#thymeleaf-spring5/3.1.3.RELEASE": {
+   "jar": "sha256-HrSl+/OENUqgiCirTVq/pq7sL2D9Rt7VDSwJKENzM1g=",
+   "pom": "sha256-d+SsUHopKYh9s+YnjONTkpZ811xFK7Mrryvcc66i/nM="
   },
-  "org/thymeleaf#thymeleaf/3.1.2.RELEASE": {
-   "jar": "sha256-KzpxS+LeNJzLYMZWA65ei9cGDHpPiDNIVwdnHpqGKiQ=",
-   "pom": "sha256-yNg11KkpXvSZfjyK6eiUz4B1nNVpPoNukaSkY4cn3/w="
+  "org/thymeleaf#thymeleaf-spring6/3.1.3.RELEASE": {
+   "jar": "sha256-ecfwiXAIgx6c+HMVyMpFLl6pXTLL8EZI3BH55rrQpQ4=",
+   "pom": "sha256-5LGKFfElcH8Fxa8+gx1Kf5zXTKLwAPooX3SiSZlwmCc="
   },
-  "org/thymeleaf/extras#thymeleaf-extras-springsecurity5/3.1.2.RELEASE": {
-   "jar": "sha256-NANxlgdib0YRutYET9yB7WpDTxMOmtZG03JlaCWT5Ow=",
-   "pom": "sha256-gahhwPVVfRDoivS0opdkOwUlWgws+yLaORBtpTTAVWI="
+  "org/thymeleaf#thymeleaf/3.1.3.RELEASE": {
+   "jar": "sha256-Fl7xbNcQIMTVcud9c897r/1DHz8+jB2EtBDeI9x5+Sw=",
+   "pom": "sha256-7JfKeJ3rAW3QnoxBOer0Nvmo2s8TBYMZFIVTKsasMcE="
+  },
+  "org/thymeleaf/extras#thymeleaf-extras-springsecurity5/3.1.3.RELEASE": {
+   "jar": "sha256-SJrBXvvhBVllRPNtHBeNOqhmIbebu4+Z5Uqu7iAkljk=",
+   "pom": "sha256-tqsH7O66pD5/1a0DF7vEaeq8Uknk1tX6D0jaXJqpX9c="
   },
   "org/unbescape#unbescape/1.1.6.RELEASE": {
    "jar": "sha256-WXz4fVsaTzhbnRzsl0t7SDq7PuhfxbP4tir45L7JXCw=",
@@ -2120,16 +2439,20 @@
    "jar": "sha256-x7hZO4W+yIujqoGQudsk2a7a8CyVmqOMMu3WpkO8k9Q=",
    "pom": "sha256-n0iJORwtkGWjTpc9CURMnMycPMASGDNgQ8Umuqe5BgA="
   },
-  "org/xmlunit#xmlunit-core/2.9.1": {
-   "jar": "sha256-fnDyPU914F8O558Pa54Tts9R0082xfw6a4OUKd3h7+8=",
-   "pom": "sha256-0n5OKjEqIVR+82BcgS5+YMiuyWTn+WDlDU3Dy2azkBI="
+  "org/xmlunit#xmlunit-core/2.10.0": {
+   "jar": "sha256-P4mwpinT2cymbhX43eXglHhS+kQXK8d+om7fluPk/Pg=",
+   "pom": "sha256-dm2pvAtCrYEk6vJw6zEgRBdaZWCSkc8coSxXg3iemA0="
   },
-  "org/xmlunit#xmlunit-parent/2.9.1": {
-   "pom": "sha256-1+RY+9XGRFBIeOX7zglLHTB402mn/uF93ezj0Zn9qsA="
+  "org/xmlunit#xmlunit-parent/2.10.0": {
+   "pom": "sha256-XOnCkW1QdlQJ78IKgQf5jvF3BAzr4LG4VwSI4h0JYcc="
   },
-  "org/yaml#snakeyaml/2.2": {
-   "jar": "sha256-FGeTFEiggXaWrigFt7iyC/sIJlK/nE767VKJMNxJOJs=",
-   "pom": "sha256-6YLq3HiMac8uTeUKn2MrGCwx26UGEoMNNI/EtLqN19Y="
+  "org/yaml#snakeyaml/2.3": {
+   "jar": "sha256-Y6dv5mtlI2C9TCwQfm8CWNqn1LtJIAi6jCb80jD/kUY=",
+   "pom": "sha256-D1omWgYzGwBJ41K+MsoyLeGLF/PU27cGNdQNppLjWC8="
+  },
+  "technology/tabula#tabula/1.0.5": {
+   "jar": "sha256-0xB/NyGu3/bPO8Ob+XnVZLvQV75gVrNUsMcHSKN9O0I=",
+   "pom": "sha256-mGSPnQ0/apzUwEEAVK/5AHcjGAy2Mk0Xe9ULwUKF1iE="
   },
   "xml-apis#xml-apis-ext/1.3.04": {
    "jar": "sha256-0LSIfcNNV95JB0pYr/rUOaAT0Lr/oagDT47ypeoZFkY=",

--- a/pkgs/by-name/st/stirling-pdf/deps.json
+++ b/pkgs/by-name/st/stirling-pdf/deps.json
@@ -109,37 +109,37 @@
   "com/fasterxml#oss-parent/61": {
    "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
-  "com/fasterxml/jackson#jackson-base/2.18.2": {
-   "pom": "sha256-71dLcvW0iUgET2g3a4dMiK4JoCncjgX2Shwwvftt4Uo="
+  "com/fasterxml/jackson#jackson-base/2.18.3": {
+   "pom": "sha256-1bv9PIRFIw5Ji2CS3oCa/WXPUE0BOTLat7Pf1unzpP0="
   },
-  "com/fasterxml/jackson#jackson-bom/2.18.2": {
-   "pom": "sha256-UkfNwwFyXT9n9+8EkDconVr3CdaXK89LFwluRUjSlWs="
+  "com/fasterxml/jackson#jackson-bom/2.18.3": {
+   "pom": "sha256-8dTGrrMhGGUMgF/pu8XulA+o8s19DwT6Q2BVHponspA="
   },
   "com/fasterxml/jackson#jackson-parent/2.18.1": {
    "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.18.2": {
-   "jar": "sha256-WBvWEADvdkiUP3gcoFaJ5W0D9gUnSDZajis6m10/oy8=",
-   "module": "sha256-4Ruvm1NubflNqmNaEBPsPgabhmuOES3cKqBEahVQUNw=",
-   "pom": "sha256-CyvWlOqJJn7qSBJqilskplI0xkM4dULSRGnRlb+6HPg="
+  "com/fasterxml/jackson/core#jackson-annotations/2.18.3": {
+   "jar": "sha256-iqV0DYC1pQJVCLQbutuqH7N3ImfGKLLjBoGk9F+LiTE=",
+   "module": "sha256-RkWF2yH0irFZ6O9XnNfo5tMHoEdhGZZRw+zBf05ydF0=",
+   "pom": "sha256-ucmLqeKephtpPUyMgBlo/qriILKyACNkp7zsUkmYOEs="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.18.2": {
-   "jar": "sha256-2AVK58DRwtL1XSjkYCbr5YkogfP6tfQ5IzGEOBw7Sh8=",
-   "module": "sha256-ynjGBDZ2f8w2zhRrd05PUKnLn2MtExcsRLrojgwDz6I=",
-   "pom": "sha256-4GWwA50h9N/ORr1DEEx9dtWFa9cy4qqGDMWkonDtct4="
+  "com/fasterxml/jackson/core#jackson-core/2.18.3": {
+   "jar": "sha256-BWvE0+XlPOghRQ+pez+eD43eElz22miENTux8JWC4dk=",
+   "module": "sha256-mDbVp/Iba8VNfybeh8izBd3g5PGEsqyJUOmhsd9Hw0A=",
+   "pom": "sha256-N9xrj2ORpHCawhXKmPojQcbdZWE8InfZak/YKi9Q48k="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.18.2": {
-   "jar": "sha256-SzZOaFDciRcvzx1N0muP9UiO2kT/RlfiLdJlID3Vqzw=",
-   "module": "sha256-jH2sL3J4GNiEeoKqTqxrAXTXnPBN+Q3iJGBy5t005wA=",
-   "pom": "sha256-STo9tkR7eo7Ls3JCNMbOZ31y20sE9roAjw6+rqe+Wp0="
+  "com/fasterxml/jackson/core#jackson-databind/2.18.3": {
+   "jar": "sha256-UQvdp1p6YYbFvzO4USOUiKFFCQauV1cSHy4cxIp+EI8=",
+   "module": "sha256-ZCqggPhbIAV3ifrPKsaibhR4NbUDPidSDstpe8RD/Lo=",
+   "pom": "sha256-5Y9IrBTk29SFldaeILrTUBnsEoFRTvfvFV4YByraYX8="
   },
-  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.2": {
-   "jar": "sha256-Z6aktrkfPUUN8h53QX9AC+Zjvgz1KOSDSczDgc90s7A=",
-   "module": "sha256-LBXqycqNl7Q4LNOEMlHIrH7uIlbPfcPknsydE2t2z04=",
-   "pom": "sha256-IBZ1+nWRQy+yYIuQ0hgiPncyqU0BNG/ip1/GqbrLRNE="
+  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.3": {
+   "jar": "sha256-N5ckHimfzem+K/XzpSrGG2b3SecVdHj1skbrWX6WLCY=",
+   "module": "sha256-kRB76S9bch8VtwCtgfr9E+vfI2dRqSYHzldYuHXKwdo=",
+   "pom": "sha256-T6a2oB7BPGZAXWNIa6nurP/SS9xwUpeO4Im5YOSkI+Q="
   },
-  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.2": {
-   "pom": "sha256-s6z7kQ0CPpOkGZr8zeH/nsX6sMVQ3E+WilBXEXrLCzY="
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.3": {
+   "pom": "sha256-rehezbxjw22XyQcnNfQfeUGO+K0EA755gtr/9BxfruM="
   },
   "com/github/jk1#gradle-license-report/2.9": {
    "jar": "sha256-6/1tqFFlTFMhbuqe2hSFwS4M1t5amRm/XalzWgIfMq8=",
@@ -520,41 +520,41 @@
   "org/sonatype/oss#oss-parent/9": {
    "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
   },
-  "org/springdoc#springdoc-openapi-gradle-plugin/1.8.0": {
-   "jar": "sha256-lAdaoBdXoMHVc63pFFwJiWPwhP7v0x3JXWVgbFA1hfQ=",
-   "module": "sha256-by2CiAeWEWkpP09biX98PudtoG3Gu52UrLPV8kGOmYw=",
-   "pom": "sha256-4CMQC3oczVQmo9cPklZdW8Xdf/51f6TqYGOhkpBlCHM="
+  "org/springdoc#springdoc-openapi-gradle-plugin/1.9.0": {
+   "jar": "sha256-T+RZKiwmtTiSrLep0TSKnamOcnMp8vJRpfhvvVucH64=",
+   "module": "sha256-aJPg4AegxTFzaVUdt5lZYgr2Mx2k2S0DogS5X+00FNY=",
+   "pom": "sha256-B8u4VtyB/FGqakUr7VIKyw722mvJrUvO7+JSM/u6ml0="
   },
-  "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.8.0": {
-   "pom": "sha256-LRFzQyMeKb4i5Im8H0gl4dS771RZBeeTJE6VIhlXFU8="
+  "org/springdoc/openapi-gradle-plugin#org.springdoc.openapi-gradle-plugin.gradle.plugin/1.9.0": {
+   "pom": "sha256-tl5WbBE1MB1a3ZBIt2+eSkYygpKKJ27CMFDL64QIWd0="
   },
-  "org/springframework#spring-core/6.2.3": {
-   "jar": "sha256-SVMWhN8jBPDmEfd1+rp5Jzx3UE632FZZLYMOI4np6xQ=",
-   "module": "sha256-qn+EiEW+ahEMm9rPFRSfnp4wTaRS/oHqEbcb0uQbxtk=",
-   "pom": "sha256-iiURsdM4PfstvI0mmPlzR4LvZ8wg4e26hKEYrRFERvI="
+  "org/springframework#spring-core/6.2.5": {
+   "jar": "sha256-TO4Czy0CJ8Hxv7l8Ltwp06+DuTyD0Is45Zh8P6D+Tx4=",
+   "module": "sha256-L8IU0itA9AB9/adE+FHn755yjRgoYFfw9ZTrlUvIriA=",
+   "pom": "sha256-K2lVoWZQfbOAVQK84ifbJ4+s37ynyqM6cThHhw4B8oI="
   },
-  "org/springframework#spring-jcl/6.2.3": {
-   "jar": "sha256-jGXsXtZIlmpHDmtIsny+v18fQSvUayQ+ARHF1dlu/oY=",
-   "module": "sha256-PxqK+qC2Yi3g2S/4zTFpBoB1CGXpSJSu7DCf7kmqDEs=",
-   "pom": "sha256-BSEm2SxKXGAHZjYcxATm4AR7V6VjfQKI0CTvb5IAPn8="
+  "org/springframework#spring-jcl/6.2.5": {
+   "jar": "sha256-T5ORX6sQwU3zuQBUz9XRwBop3vWbbiXA8z2erE/+wHk=",
+   "module": "sha256-XmoAS9bTzk9i7in2ByXOmGmn9q3uqHiA6oGj/CPCPRI=",
+   "pom": "sha256-8t98qvowo7Ku34ViqGh0RsJUMviNNvGwt3+keA7nxr0="
   },
-  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.4.3": {
-   "pom": "sha256-TBxFUSwamoj+TrMITcNZuUmtJWM5qmydh1W3fVzLUS8="
+  "org/springframework/boot#org.springframework.boot.gradle.plugin/3.4.4": {
+   "pom": "sha256-Hf1lJt1GlYHQ1jrd1225jKD1knmiINxApZsRvNHJEkM="
   },
-  "org/springframework/boot#spring-boot-buildpack-platform/3.4.3": {
-   "jar": "sha256-9Fz2SHx7VThwClT26KIcvwQ9MJM09qDM1K3wGPAO3w8=",
-   "module": "sha256-uMfbOuB5Z4htPZjwFygahjwCV8jhdzxAGR8TQyQm598=",
-   "pom": "sha256-pW0pQxL9lL4GQixjMoczP5ZCxiIrxPJXqL07ptBW+jU="
+  "org/springframework/boot#spring-boot-buildpack-platform/3.4.4": {
+   "jar": "sha256-lmDNqob4rSIKcIJFcjsOKGBQyITOKv9hhdpFOUZZw/w=",
+   "module": "sha256-JyTPS5Ubyju6vPNNHeh+U1U866OasPJ42TVbZ/wah8g=",
+   "pom": "sha256-1ezt4zuJ/xGImOuYeR5a86QUwvJKJOKAR7bgKrC55RM="
   },
-  "org/springframework/boot#spring-boot-gradle-plugin/3.4.3": {
-   "jar": "sha256-L/upm2ru6tgT7U6iHt/S49n1C2d7b5PxixHqUnzv0Cw=",
-   "module": "sha256-11HDMtbZ129uiJyTON/Wi3s1XA+hDsbDVjY8yyil/LM=",
-   "pom": "sha256-+FLbfAT1AmxT3gkQRMRzLvZUbbxZa+kRzBuPViMjhWw="
+  "org/springframework/boot#spring-boot-gradle-plugin/3.4.4": {
+   "jar": "sha256-aHbhy0xWekvrAtGDH6rxe0G4gfX2acarshLU1VHGOCQ=",
+   "module": "sha256-G4T/5dOIbasfYuJmtHF5PNhlxLYOpDUuJlMD+qtCoq4=",
+   "pom": "sha256-dqoxfADGPFeHN7oKh/kE7Dsc89RTCRaRVd7okJYI/1w="
   },
-  "org/springframework/boot#spring-boot-loader-tools/3.4.3": {
-   "jar": "sha256-RqvmIrmVLdyuyOCf2eQINZM4l+y2fSlDDSNYaFpQ1p0=",
-   "module": "sha256-s9b/bSe/6RbZu0yl4qclapOc443AmcVcDbd/IzJfIMc=",
-   "pom": "sha256-D3SaPL0ST/V7o0/KlCaemtfs8oybxcOvlR8s8BUnlO8="
+  "org/springframework/boot#spring-boot-loader-tools/3.4.4": {
+   "jar": "sha256-Ww0fHB1gD3AMbSC3TAT26CWz8Wbd0huV0ZMMBN+a9fc=",
+   "module": "sha256-q0vSs/CphMZBlCmxK18WzgmkASjM7omFWWf8VriUKso=",
+   "pom": "sha256-t1a6bsjKt7SaRvCPn13Htd7hIEmKyM0TATdF0poG2XI="
   },
   "org/tomlj#tomlj/1.0.0": {
    "jar": "sha256-Mml8dWeykhxHNnioILE/xkcAqoe7FFdu60jQ7VhHz9Q=",
@@ -570,16 +570,16 @@
   }
  },
  "https://repo.maven.apache.org/maven2": {
-  "ch/qos/logback#logback-classic/1.5.16": {
-   "jar": "sha256-+YWjOmjZALrexbDDxhOrnbZkFdLPN4mHNX3tnaU3DjI=",
-   "pom": "sha256-y7yWslAAjVh6BnN3xzawF6fBqCxSgGh8KpCGDB4uuYc="
+  "ch/qos/logback#logback-classic/1.5.18": {
+   "jar": "sha256-PhUz0DIfiBXu9GdQruARG0FVT5pGRMPE0tQEdEsJ9g8=",
+   "pom": "sha256-1VfNKrI95KR+zocGQhYqn5Rzn80LHDE+J4MlFO4gODM="
   },
-  "ch/qos/logback#logback-core/1.5.16": {
-   "jar": "sha256-8V4ga5jKJSlFBtLa3+XOKm2p35z3yF2OcZH5mkIt88k=",
-   "pom": "sha256-Z6n5D3mGkdzVd2xRk6b/QSa6lFsDRiv67dZXoUZ2IZU="
+  "ch/qos/logback#logback-core/1.5.18": {
+   "jar": "sha256-hROee1e0ZPjl42Mm3YExdki+0ZnMxPmM1CWF+NdXECc=",
+   "pom": "sha256-x3JHKX1dm7ngTpLUyC51xujqviRUNokvkRQzW4t5DIM="
   },
-  "ch/qos/logback#logback-parent/1.5.16": {
-   "pom": "sha256-PrpFA3BWtKOwfxEwviXXpd1NRpH+uTlGbzFs7PlmTmg="
+  "ch/qos/logback#logback-parent/1.5.18": {
+   "pom": "sha256-U8PiGxI7vTijAbQNDYFAlOrUehAj0h1hPMdI1w57nGk="
   },
   "com/adobe/xmp#xmpcore/6.1.11": {
    "jar": "sha256-j3AzxXm5n6DZ1t3LlEiHW15LV3w1AAInjORpl9Z4tzc=",
@@ -616,8 +616,8 @@
   "com/fasterxml#oss-parent/61": {
    "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
-  "com/fasterxml/jackson#jackson-base/2.18.2": {
-   "pom": "sha256-71dLcvW0iUgET2g3a4dMiK4JoCncjgX2Shwwvftt4Uo="
+  "com/fasterxml/jackson#jackson-base/2.18.3": {
+   "pom": "sha256-1bv9PIRFIw5Ji2CS3oCa/WXPUE0BOTLat7Pf1unzpP0="
   },
   "com/fasterxml/jackson#jackson-bom/2.15.2": {
    "pom": "sha256-Hq1jAlXEiMUbXgq1YMdsI3GtJq422t8JKcUmVy6ls4s="
@@ -631,6 +631,9 @@
   "com/fasterxml/jackson#jackson-bom/2.18.2": {
    "pom": "sha256-UkfNwwFyXT9n9+8EkDconVr3CdaXK89LFwluRUjSlWs="
   },
+  "com/fasterxml/jackson#jackson-bom/2.18.3": {
+   "pom": "sha256-8dTGrrMhGGUMgF/pu8XulA+o8s19DwT6Q2BVHponspA="
+  },
   "com/fasterxml/jackson#jackson-parent/2.15": {
    "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
   },
@@ -640,67 +643,67 @@
   "com/fasterxml/jackson#jackson-parent/2.18.1": {
    "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.18.2": {
-   "jar": "sha256-WBvWEADvdkiUP3gcoFaJ5W0D9gUnSDZajis6m10/oy8=",
-   "module": "sha256-4Ruvm1NubflNqmNaEBPsPgabhmuOES3cKqBEahVQUNw=",
-   "pom": "sha256-CyvWlOqJJn7qSBJqilskplI0xkM4dULSRGnRlb+6HPg="
+  "com/fasterxml/jackson/core#jackson-annotations/2.18.3": {
+   "jar": "sha256-iqV0DYC1pQJVCLQbutuqH7N3ImfGKLLjBoGk9F+LiTE=",
+   "module": "sha256-RkWF2yH0irFZ6O9XnNfo5tMHoEdhGZZRw+zBf05ydF0=",
+   "pom": "sha256-ucmLqeKephtpPUyMgBlo/qriILKyACNkp7zsUkmYOEs="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.18.2": {
-   "jar": "sha256-2AVK58DRwtL1XSjkYCbr5YkogfP6tfQ5IzGEOBw7Sh8=",
-   "module": "sha256-ynjGBDZ2f8w2zhRrd05PUKnLn2MtExcsRLrojgwDz6I=",
-   "pom": "sha256-4GWwA50h9N/ORr1DEEx9dtWFa9cy4qqGDMWkonDtct4="
+  "com/fasterxml/jackson/core#jackson-core/2.18.3": {
+   "jar": "sha256-BWvE0+XlPOghRQ+pez+eD43eElz22miENTux8JWC4dk=",
+   "module": "sha256-mDbVp/Iba8VNfybeh8izBd3g5PGEsqyJUOmhsd9Hw0A=",
+   "pom": "sha256-N9xrj2ORpHCawhXKmPojQcbdZWE8InfZak/YKi9Q48k="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.18.2": {
-   "jar": "sha256-SzZOaFDciRcvzx1N0muP9UiO2kT/RlfiLdJlID3Vqzw=",
-   "module": "sha256-jH2sL3J4GNiEeoKqTqxrAXTXnPBN+Q3iJGBy5t005wA=",
-   "pom": "sha256-STo9tkR7eo7Ls3JCNMbOZ31y20sE9roAjw6+rqe+Wp0="
+  "com/fasterxml/jackson/core#jackson-databind/2.18.3": {
+   "jar": "sha256-UQvdp1p6YYbFvzO4USOUiKFFCQauV1cSHy4cxIp+EI8=",
+   "module": "sha256-ZCqggPhbIAV3ifrPKsaibhR4NbUDPidSDstpe8RD/Lo=",
+   "pom": "sha256-5Y9IrBTk29SFldaeILrTUBnsEoFRTvfvFV4YByraYX8="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.18.2": {
-   "jar": "sha256-OBocBxHku4hWGmwACLWpRUZWKMoHdkzNZqDZfuB61hI=",
-   "module": "sha256-evxmQXLDpubGw1hHZaAyncb+q7/mu6ibrq2L0un77Hs=",
-   "pom": "sha256-9W9UNh5DSV7TuiShoG8OO3QZA+Q+0TLxpq086QErhBU="
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.18.3": {
+   "jar": "sha256-PKAOR8/LQ+eUON3PyPxzXp66w4JPt3aROGCb5r1W5IM=",
+   "module": "sha256-v2AjrStgVyCsbaJ6K16Y7bGjJs0L9jfDpAtiH+jgk80=",
+   "pom": "sha256-a056nStXQq6hOMFcDJ3gRjLxotjebnYe3vizYJK0hko="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.18.2": {
-   "pom": "sha256-4h1diLBHShG3H+lBAMT1KVv6F08u5q5LCtArdhZHhkg="
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.18.3": {
+   "pom": "sha256-VnParMboVZdt7O3rRtxjOVprGsmkg+Zy8IMc9G/gbiU="
   },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.18.2": {
-   "jar": "sha256-8w139YJrnpgTNC6Eq0Egle1O1c9P72+TzruEjLD9ApQ=",
-   "module": "sha256-QRhvKEmAd1gdVKfhHydHr6u3vklp21tiwEsfuJs0sAA=",
-   "pom": "sha256-Zd4yKbqOtpnZSDT8dd3S7elk6Lp2y7F/VlU2YCcoIio="
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.18.3": {
+   "jar": "sha256-H1F6+RrOVBUFJc2zCgEvyhmlNhlFZHVvWAwhrPx+BKA=",
+   "module": "sha256-7QX+6N/FAwRMH4PwROBtcYwzYEK8FzqloevfdzQXyG8=",
+   "pom": "sha256-/14lbEPjXWUtZhVeVmqYYqWbuzCM3GNvSIi96PVq9Tw="
   },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.18.2": {
-   "jar": "sha256-4tIC1GBuI66vilqWMtsG9f79W2PSUcP1A/n6qnhTDlw=",
-   "module": "sha256-Jd8o9WC1kI6hAYUATV/Bkyk0hHBj5mcpJID2dbOx7eQ=",
-   "pom": "sha256-FivnrZea9eDHOc1+0BiJ+Br0ggDJ+RJ5lqElrFGzSkc="
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.18.3": {
+   "jar": "sha256-Lh3y/rk2g9N5lpzq94t2oKwRXGfQRnGVj9307tbmQB0=",
+   "module": "sha256-Kt37kDio5g8OlWOZLC3sdYpQxDvH8ECVnYXbbp1o04w=",
+   "pom": "sha256-LIA9pFO2CM4OQ6FscvAaWf5Dg++oV6jxszQhc2bqJk0="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-base/2.18.2": {
-   "jar": "sha256-Ir2kpF97vD3fBB1hX1H/rZw8/xwEb9cPgOsUT3vWlyI=",
-   "module": "sha256-gblJEkjbxaEkgxS+YQ6EPinyvhDRzb2oSVeG92NIJPc=",
-   "pom": "sha256-oF8ul4+JYiveopQitZ1kRrYk4jQOtFzoGws7MqaSiqc="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-base/2.18.3": {
+   "jar": "sha256-2IHLJn1S72vZMBlL6noZejGCS2y/n7kL0MVtOhQXqaQ=",
+   "module": "sha256-vDXtauZ38TSvDYNI+OE+3HsMZrzID9vtObw0Nty0NE0=",
+   "pom": "sha256-QkD9GCw9mhos/Dw1Sht4TP92UuDaEb7sRW/+8EHklUU="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-json-provider/2.18.2": {
-   "jar": "sha256-43QlZIDa+3EHDcOFrnDjeCRwENsVTI8pMUHCiHRzT1U=",
-   "module": "sha256-G0+pJqx2NfoSPRypjBJNhiCbFwKk6xGVnqi7tHAxOEY=",
-   "pom": "sha256-N1b7GWMJDrmTKRBR98SS2WQnHosV+g58+0HgiJWGPew="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-json-provider/2.18.3": {
+   "jar": "sha256-+Y2q3WXsdFSzEKkGeROQAg4aCUiEOOvJya5RrB5MKlU=",
+   "module": "sha256-tOVZdY/GWJNlQgbTcfnDStm08pvI+wHNzYyJK4tC+Pw=",
+   "pom": "sha256-LS6MY3T8hjds8zZV5KLMQsDNO/2yE9MkkU82g2foL9Y="
   },
-  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-providers/2.18.2": {
-   "pom": "sha256-NJBwwUCuHb7rwq/7yFGy6xViWVKjAwa/vVazE0aeXcg="
+  "com/fasterxml/jackson/jaxrs#jackson-jaxrs-providers/2.18.3": {
+   "pom": "sha256-B9ePaypXav7OC2De+BfH/sL9mv6JoWHRfGBeptYKuhw="
   },
-  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.18.2": {
-   "jar": "sha256-ZFyk3imYBHPxmubAjXws4OP9JzJE0xVbXao7yC+hPUE=",
-   "module": "sha256-wRlrUgwa7RJ88R3ka0l9gbxPNVquWqvIFwcwfX6x30U=",
-   "pom": "sha256-T2FGzIFi5nDA1ERI8q1Iqf9WSeQHFmhM+gSua2Bm+fA="
+  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.18.3": {
+   "jar": "sha256-aZymoQM6tTzXhQSndsPjX2sa9Bln5/w1C5wZ0L8m87A=",
+   "module": "sha256-576Qmss0xxLC6scGo8DIbc8GmlBA1UmMTHlrQ84zFBo=",
+   "pom": "sha256-J3x7fDLlnKF6STK3pk0xT7UE6zIskPoM2C3galzLhU4="
   },
-  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.2": {
-   "jar": "sha256-Z6aktrkfPUUN8h53QX9AC+Zjvgz1KOSDSczDgc90s7A=",
-   "module": "sha256-LBXqycqNl7Q4LNOEMlHIrH7uIlbPfcPknsydE2t2z04=",
-   "pom": "sha256-IBZ1+nWRQy+yYIuQ0hgiPncyqU0BNG/ip1/GqbrLRNE="
+  "com/fasterxml/jackson/module#jackson-module-parameter-names/2.18.3": {
+   "jar": "sha256-N5ckHimfzem+K/XzpSrGG2b3SecVdHj1skbrWX6WLCY=",
+   "module": "sha256-kRB76S9bch8VtwCtgfr9E+vfI2dRqSYHzldYuHXKwdo=",
+   "pom": "sha256-T6a2oB7BPGZAXWNIa6nurP/SS9xwUpeO4Im5YOSkI+Q="
   },
-  "com/fasterxml/jackson/module#jackson-modules-base/2.18.2": {
-   "pom": "sha256-wVCoPSPNizMiqqSYmEh0J5vi3I1f4qN5B9P1arYOJpw="
+  "com/fasterxml/jackson/module#jackson-modules-base/2.18.3": {
+   "pom": "sha256-xKm+97Oqh0vwx69XAkRs9JuwLlGZuKrgNRs3Tri+lrQ="
   },
-  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.2": {
-   "pom": "sha256-s6z7kQ0CPpOkGZr8zeH/nsX6sMVQ3E+WilBXEXrLCzY="
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.18.3": {
+   "pom": "sha256-rehezbxjw22XyQcnNfQfeUGO+K0EA755gtr/9BxfruM="
   },
   "com/fathzer#javaluator-parent-pom/1.0.1": {
    "pom": "sha256-YRV0qFwGU9vwoDS7iJ9LrCZr0oZz6EZ2w2o6TNqWLfg="
@@ -1034,7 +1037,6 @@
    "pom": "sha256-Y9lpQetE35yQ0q2yrYw/aZwuBl5wcEXF2vcT/KUrz8o="
   },
   "commons-logging#commons-logging/1.3.4": {
-   "jar": "sha256-vC3+MvHvBlCeagZRRMGt97Qg6r8RqH8wvRJ/j6ozIBY=",
    "pom": "sha256-1L2jSJKqzL9PrTP8MjqKqQfvnXmYRlnaJJRMCoa/CGU="
   },
   "io/dropwizard/metrics#metrics-bom/4.2.15": {
@@ -1067,39 +1069,47 @@
   "io/micrometer#micrometer-bom/1.11.2": {
    "pom": "sha256-2qo2vb6vKmnTVi6A92D+f4bU02uUGsBbqhjPpGtkvhA="
   },
-  "io/micrometer#micrometer-bom/1.14.4": {
-   "pom": "sha256-nXV+Ip4mskymMo1BAHTVPvIgI+kpW+gxTPa+KnOvQ5U="
+  "io/micrometer#micrometer-bom/1.14.5": {
+   "pom": "sha256-paLdeg1baH99SzFS2qClo2ru4cqyRiR1lyRFEbAwwuU="
   },
-  "io/micrometer#micrometer-commons/1.14.4": {
-   "jar": "sha256-a7D1b7iPZd20sIDj2AFl7rF0DyInuguKw4YQmWn36b8=",
-   "pom": "sha256-Iopw0QbpWwk7ZFDeCdjAL0A0WVJG53sjHHXD7BTef+E="
+  "io/micrometer#micrometer-commons/1.14.5": {
+   "jar": "sha256-6YSF/+y32Mya9Hz+Yn6ovziXkV3Q80s+OhkNaJaHW0s=",
+   "pom": "sha256-eJLWtZpradwyeterbZIJJHDLc2OgNlLpaA1B/c7pMOI="
   },
-  "io/micrometer#micrometer-core/1.14.4": {
-   "jar": "sha256-0WPGmzji+fmhSz0bNuWonXuM8kekH8RK/VByw81k5RY=",
-   "pom": "sha256-szYrcvIx6yPw6tXDUwns7YVFwqoH3kbi67KGprBq3Ak="
+  "io/micrometer#micrometer-core/1.14.5": {
+   "jar": "sha256-fAxV73/hvvW4lFNlXnaO4F/TWzgb1n+dQs/kg2IXTKU=",
+   "pom": "sha256-YHq1TfGdsoInclmotrvcP7Yg/An0rJYtLZoMiDm+EZw="
   },
-  "io/micrometer#micrometer-jakarta9/1.14.4": {
-   "jar": "sha256-jJj/s9G5SZJaxQyiWqyBDZWtddUVhftf6eDyVAYMW7s=",
-   "pom": "sha256-+VsGTGIBUZIznFycf5xchLc4SN0WdXNQ2uv+QpHMtxQ="
+  "io/micrometer#micrometer-jakarta9/1.14.5": {
+   "jar": "sha256-CMDgYd9YWDrhG0sOxmTwIF5D27FszUFXHPBoJpgjgDo=",
+   "pom": "sha256-O8WW7DAedEQ1Mpqo6rLoW0zbq+Wwo8at8eJOsGJ53bU="
   },
-  "io/micrometer#micrometer-observation/1.14.4": {
-   "jar": "sha256-KN1LABwU/BOwvEhTViEhSRZRiJWSTjzlKKYEIFsf8KE=",
-   "pom": "sha256-QbnNkGZsx11dw/SpucmoiXvE7eodOxvPpaKhsfa1GXg="
+  "io/micrometer#micrometer-observation/1.14.5": {
+   "jar": "sha256-fPv3FKvfN3nIIP8ZcSGZrJuuA9Lw6Am6jnTDZjwSEoo=",
+   "pom": "sha256-ni5FvQMZiF4btrvQdJAEXZttynip0gLyzbzHP4ISXfI="
+  },
+  "io/micrometer#micrometer-registry-prometheus/1.14.5": {
+   "jar": "sha256-d8dzJVPiNGRJIhQxIbfSfMI2ht72A0i41ohvzT7a4kc=",
+   "pom": "sha256-Y6OeLDAlmF+/7uhXTbtEimjivkxtfCtg0CWa3dbzK7Q="
   },
   "io/micrometer#micrometer-tracing-bom/1.1.3": {
    "pom": "sha256-fprbb3oR0grb8tb/f7NMCJ9FGvQdM7uRjr17kcXszJk="
   },
-  "io/micrometer#micrometer-tracing-bom/1.4.3": {
-   "pom": "sha256-Kt0beCbiDPKM7J5vT+n00sjBl+PqXZQ1cVcQtlhu77Y="
+  "io/micrometer#micrometer-tracing-bom/1.4.4": {
+   "pom": "sha256-VlJh6zMDaInlrv3Q9IvH8JvV9gLmQ5/teEiIwxBGqOo="
   },
   "io/netty#netty-bom/4.1.115.Final": {
    "pom": "sha256-JdyLuDN9/BhsSfyM9PaltsfPQUY2L19EDaytzQ35dhs="
   },
-  "io/netty#netty-bom/4.1.118.Final": {
-   "pom": "sha256-kA94/W64xqZ7TJo52eXNlvnsonCxLXCQvFBX7+foKGo="
+  "io/netty#netty-bom/4.1.119.Final": {
+   "pom": "sha256-CDVn40YWM4soNBpaCUdd7HKmcnlppsR6JCs9Z08TW38="
   },
   "io/netty#netty-bom/4.1.94.Final": {
    "pom": "sha256-FLsEPt93HvaT1f9ezBRm913JFpjwSn+oIrMJPT0COdE="
+  },
+  "io/opentelemetry#opentelemetry-bom-alpha/1.46.0-alpha": {
+   "module": "sha256-GjQNa9goWJPXYfeHLPEsGTdswKmIW2BKC7QMAJBkD7o=",
+   "pom": "sha256-e7+pLXcsgFkhRIUyfrJaoHHCjttvyp9uDWiVJNAWdYc="
   },
   "io/opentelemetry#opentelemetry-bom/1.25.0": {
    "module": "sha256-RHe55WRW2h7ZM64ig4bOAbusBl2bVLSZ7cKI4rumzLk=",
@@ -1109,6 +1119,18 @@
    "module": "sha256-FihOwxKoOYVg114KpIBTwXZNFk6w13f8BEC5s2xOtKE=",
    "pom": "sha256-oSv8/iZgecXMvL785RIts/mbE6u6KvrSKkztn+/oxHk="
   },
+  "io/opentelemetry#opentelemetry-bom/1.46.0": {
+   "module": "sha256-XOhJduf9T785pQun+mpctRmHwjsNRYVkL/RdlFfNJWE=",
+   "pom": "sha256-aJhHsqN67KZ6jySGrQWl8TEE2L35dv57YoJeb4y4KLw="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-bom-alpha/2.12.0-alpha": {
+   "module": "sha256-jn5+7wk+tYvTpbPqjEBU+djgAaSeKMgmja5bY/PdtK8=",
+   "pom": "sha256-CNbtDdftMSmWrbb20+e+Hn9oh7hAsNwMr1Iub6ut0lU="
+  },
+  "io/opentelemetry/instrumentation#opentelemetry-instrumentation-bom/2.12.0": {
+   "module": "sha256-pqUY8hXgvQljDZxFxSd8CrvWJ3zyMHqzkLbOFy4de4o=",
+   "pom": "sha256-PiwIbtrhgrPCBlKsnuPECT2tobh5mwyQvJOZmaCEPrE="
+  },
   "io/projectreactor#reactor-bom/2022.0.9": {
    "module": "sha256-BfI8ABvRI1lpnqe+Y6bRi03YWoqRZ/PxehkRrwI9t7k=",
    "pom": "sha256-agI/PfE5yap6gWUR1YSSnd0PXrhIeb+i46VRTFsXYJI="
@@ -1117,9 +1139,9 @@
    "module": "sha256-q9+I0toctizFQ+OgBJvN0/40JvOfqIH6/38OEifY1S8=",
    "pom": "sha256-sPfCTHH0Hlqqku03Pm1SI6HTXuKRMDgNhehmSnhPpRY="
   },
-  "io/projectreactor#reactor-bom/2024.0.3": {
-   "module": "sha256-DaIfB9EoPt7t/OVqll5tkgZ2bt39CjWr9oKLv1J/x5c=",
-   "pom": "sha256-LHuu9g6FJLrKuaFDYzev+SEVjYzukNw+AJAIZcGH4Fk="
+  "io/projectreactor#reactor-bom/2024.0.4": {
+   "module": "sha256-uG6hW/aErIvj81kWEPceNkKHJVTAh15/uPRBTA83Eww=",
+   "pom": "sha256-682HMXgOY9D7D6+jMNS1fNzcNMUKSimrdzssQv0gn88="
   },
   "io/prometheus#client_java/1.3.6": {
    "pom": "sha256-n/AOSQfYUE9Rt6u2o9wns7fLZQmOWb7Nt14TjjPHR0I="
@@ -1129,6 +1151,33 @@
   },
   "io/prometheus#prometheus-metrics-bom/1.3.6": {
    "pom": "sha256-7F7SHKoBR1WFBiSTeY7gQUX7wUmkUNXFMWnASxUCg2A="
+  },
+  "io/prometheus#prometheus-metrics-config/1.3.6": {
+   "jar": "sha256-Mubs8586t27ulO5pECeV+O2AAk0n/aC6QdVPJayIf60=",
+   "pom": "sha256-Ieq0w9C1LzeGO1glKJv/PrLPJN597MtEoB4fhtLlp2Q="
+  },
+  "io/prometheus#prometheus-metrics-core/1.3.6": {
+   "jar": "sha256-aB64+Qbb0w45a7abGu/3EaZS8UZOLIezaBP4ldEkrGc=",
+   "pom": "sha256-5kRcSCr+zm3m4zHT4MgjgPYSog2nLa+TDcCcEDFiu1c="
+  },
+  "io/prometheus#prometheus-metrics-exposition-formats/1.3.6": {
+   "jar": "sha256-UnxeIXZ5NPodf7D0WB9WAlT+Ff/1uGBG6z1mmuyK4AA=",
+   "pom": "sha256-kxpheprpV2McNvfkv7fctC+syYO9gs9G6bCStl5qC28="
+  },
+  "io/prometheus#prometheus-metrics-exposition-textformats/1.3.6": {
+   "jar": "sha256-LZ4DUDwrzRyRPypPgtLr74ud+XHG8i3nmT36vgHVdfk=",
+   "pom": "sha256-2lVnm4mHGy2y0TpOz3qlNDFl1NHaL1mGWrK4fXFmXHc="
+  },
+  "io/prometheus#prometheus-metrics-model/1.3.6": {
+   "jar": "sha256-UajadMA33dXJTda/yCjmC3SO/t4Nw/rm8YjU4Lvq3XU=",
+   "pom": "sha256-2Eb4QZjM2yLyVCM2EQQznUti+pPeLFkrOeZ1LfMYPPo="
+  },
+  "io/prometheus#prometheus-metrics-tracer-common/1.3.6": {
+   "jar": "sha256-904xijCq/inBaUiMRTX0FwcUYly1D8/VbChUw8X2bwk=",
+   "pom": "sha256-Q7HKkgPqveQdZHLlite5WjHBcRxDFERRtXft9zPchBk="
+  },
+  "io/prometheus#prometheus-metrics-tracer/1.3.6": {
+   "pom": "sha256-CftjJSvJmrLSzniTDwYrQ3q4F7eQ987qXdx4UQ946W8="
   },
   "io/prometheus#simpleclient_bom/0.16.0": {
    "pom": "sha256-r0QdMpXeEacONf6+s9kZui7RdVJ1MWMyW5VNU1lNVcM="
@@ -1347,8 +1396,8 @@
   "org/apache#apache/7": {
    "pom": "sha256-E5fOHbQzrcnyI9vwdJbRM2gUSHUfSuKeWPaOePtLbCU="
   },
-  "org/apache/activemq#activemq-bom/6.1.5": {
-   "pom": "sha256-fk/4LeeGcLrZD74VrPdpaxQXhx1tzOcEh81dEDOPb/0="
+  "org/apache/activemq#activemq-bom/6.1.6": {
+   "pom": "sha256-FcLWnzVyE9bjsHEq+H31cfDY21mE0RSwoiD/LnSdxUQ="
   },
   "org/apache/activemq#artemis-bom/2.37.0": {
    "pom": "sha256-3PCTU3B4SWQQBNVOxUE9OagScmm+OB9SVzkece6A3oQ="
@@ -1414,9 +1463,9 @@
    "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
    "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
   },
-  "org/apache/groovy#groovy-bom/4.0.25": {
-   "module": "sha256-dG8kZ2e5HjnAyjqGJ6sAbrN6UeJ4CZaxfdzYPtbgKAU=",
-   "pom": "sha256-/Jvxy9DlMd68PjZIc//LIk7Wrvp8bnA8Ze3Uqlsd7ps="
+  "org/apache/groovy#groovy-bom/4.0.26": {
+   "module": "sha256-b3I9IpHN+uqPpoZ/frp77Klvt4SQXfvikjG0eW7I6RE=",
+   "pom": "sha256-uJshtYixe2Q/ou7HxAbgoah541ctzuy9VU9aB+IfV4Y="
   },
   "org/apache/httpcomponents#httpclient/4.5.14": {
    "jar": "sha256-yLx+HFGm1M5y9A0uu6vxxLaL/nbnMhBLBDgbSTR46dY=",
@@ -1488,22 +1537,22 @@
    "jar": "sha256-0K8/1yIvs+GDcqKO96mFlaP31F4M9a0w+RethhLB3bs=",
    "pom": "sha256-Di6ucXVvw1IVGAhuAxd7qKFthU2nuEK0VWQx3bletr4="
   },
-  "org/apache/pulsar#pulsar-bom/3.3.4": {
-   "pom": "sha256-Lq9yAYYXgnT0vEDDExOqjFRQ5490emTfZGgy/mlSyGA="
+  "org/apache/pulsar#pulsar-bom/3.3.5": {
+   "pom": "sha256-CZnz78BPOm5NpFyV1uc0LelPTEhagT7UL7254buDixI="
   },
   "org/apache/santuario#xmlsec/2.3.4": {
    "jar": "sha256-VRPnQX7cHrcYitxN4DEukxVr18ptbB5gctPgAG3v/yM=",
    "pom": "sha256-Ez/s/gIYho799ZY03YaS9/Ke5uLeQynWdwDJF6OE7kA="
   },
-  "org/apache/tomcat/embed#tomcat-embed-core/10.1.36": {
-   "pom": "sha256-VkZBy59xw+7w2I9eoyg1mmLvdtvXBkK1Vec/O+fWPfQ="
+  "org/apache/tomcat/embed#tomcat-embed-core/10.1.39": {
+   "pom": "sha256-JtS19rDnpU3wkmk/Slw70gThqLeGLb7AYCCNI9usmMU="
   },
-  "org/apache/tomcat/embed#tomcat-embed-el/10.1.36": {
-   "jar": "sha256-0V18O4kS0SAIl9BhnOP39dVhlTTuKMIEmvvegj5dHSI=",
-   "pom": "sha256-RlthOHJQAnNzFighiyiycwiPakYRKXgIuXIgrZ8RTKE="
+  "org/apache/tomcat/embed#tomcat-embed-el/10.1.39": {
+   "jar": "sha256-3pk6Worwtspkc7pZuVAm197ZPeOhaD2ft3U7e3bTjuc=",
+   "pom": "sha256-uFrOeQ2wGObr4e2pJ244LxYDJijX1Kz+zVKAlgkzPKk="
   },
-  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.36": {
-   "pom": "sha256-8ud7PokSdimZj6W67TkClpkMfMO1HH0navA/CHzoP50="
+  "org/apache/tomcat/embed#tomcat-embed-websocket/10.1.39": {
+   "pom": "sha256-SGMUZiaKsLBcFLJSswgd7MkhLGRaLTTjmWKiyGMdFEg="
   },
   "org/apache/velocity#velocity-engine-core/2.3": {
    "jar": "sha256-sIbO6P2Bg+JAtK/PVP447DPdjrDaQUY25b96pNmFZik=",
@@ -1531,9 +1580,9 @@
    "module": "sha256-4IAoExN1s1fR0oc06aT7QhbahLJAZByz7358fWKCI/w=",
    "pom": "sha256-MjVQgdEJCVw9XTdNWkO09MG3XVSemD71ByPidy5TAqA="
   },
-  "org/aspectj#aspectjweaver/1.9.22.1": {
-   "jar": "sha256-zS3QHsJCTAVmnfTVV/bGzX7YewUlfuPIZrTFsRaxing=",
-   "pom": "sha256-+G594K2zLOtcEF+YOz0as0AWYTEpmwtfqz7ccCWaaog="
+  "org/aspectj#aspectjweaver/1.9.23": {
+   "jar": "sha256-LxSxL6e6EJdl72yAioo8rC7uWUByP6Wp0qmUNfRAv98=",
+   "pom": "sha256-ASeiTmBszQFtN9ZDU/tYBnorIjP0HXzqYzsZ8AArzd8="
   },
   "org/assertj#assertj-bom/3.24.2": {
    "pom": "sha256-EqxGrmTTYl80S79kKrVvoC4Vuu/lPvX1sGHhJLSEYgA="
@@ -1628,136 +1677,136 @@
   "org/eclipse/ee4j#project/1.0.9": {
    "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
   },
-  "org/eclipse/jetty#jetty-alpn-client/12.0.16": {
-   "jar": "sha256-KP+VaFNkg6+YRLBqhAr5D/Ia1FSa7ihAcOxhQGAwVTE=",
-   "pom": "sha256-4LpkYiL441FqKT2aXWnFVwbvwzKoQDxEfAlkRmVTPh4="
+  "org/eclipse/jetty#jetty-alpn-client/12.0.18": {
+   "jar": "sha256-5Dx8Wky7YFCJg1tNc8CUdor5Zeukv/cC+QX+F1C8OEY=",
+   "pom": "sha256-mGZ/R0Cth7iUaorC/nyIIcD3merBgN5G37fIgQMoxwY="
   },
-  "org/eclipse/jetty#jetty-alpn/12.0.16": {
-   "pom": "sha256-64A+e2Tf3wbzNi2CBhDQ2Zu9T1vouZcpOpGvAO9aYGQ="
+  "org/eclipse/jetty#jetty-alpn/12.0.18": {
+   "pom": "sha256-uRHosPQLvq3gTDcqYufCiNCHd4lMg9Bso+y/80Qpe88="
   },
   "org/eclipse/jetty#jetty-bom/11.0.15": {
    "pom": "sha256-+ksNDeuvyR9Q++wI7+RkInAzTzeOg562o1+jdqoaLPg="
   },
-  "org/eclipse/jetty#jetty-bom/12.0.16": {
-   "pom": "sha256-3Ncg/gv7BC5d+ZiHcy0n2DFRxe4G7JnA1AAgUMEUKE4="
+  "org/eclipse/jetty#jetty-bom/12.0.18": {
+   "pom": "sha256-lEijD9eZ6wpUZCTuAmTWdQuFahMpXxtm+l7BZz88cBM="
   },
-  "org/eclipse/jetty#jetty-client/12.0.16": {
-   "jar": "sha256-DVN1yDpgNi8iJa4G1IN0Y5QvOcW8a9gxcrStKu8o3yk=",
-   "pom": "sha256-vzBGxtBCkQ8ybVyKHNyJItzV5Z7MJ133VDei6YXofZQ="
+  "org/eclipse/jetty#jetty-client/12.0.18": {
+   "jar": "sha256-8GHqCQR0RaeRd1kfAQPe/w4L3zUgJ0YvCUz+SG8O0w8=",
+   "pom": "sha256-jYsWmldqS368kElY4TIwfHOZB2ntM2oqnxddy9nwYi8="
   },
-  "org/eclipse/jetty#jetty-core/12.0.16": {
-   "pom": "sha256-lBeb2laCzcfJRHH1iNuu1Nsaq8CxDQwsZLEGRaGnFdk="
+  "org/eclipse/jetty#jetty-core/12.0.18": {
+   "pom": "sha256-m0qJW6rnHuJ8TrP9J+iQNiqB5lqOXqJDw3/6QaBJez0="
   },
-  "org/eclipse/jetty#jetty-ee/12.0.16": {
-   "jar": "sha256-G3lfQ+DCi01peVcqGwpxntVgBSvqIKPj3FLMdeRWH38=",
-   "pom": "sha256-gFBXdu2iQj+3XvPfp0XhMuRrpbM8cnuhTIaZHZ0F6TU="
+  "org/eclipse/jetty#jetty-ee/12.0.18": {
+   "jar": "sha256-wmmLkpzVotASLVyca+Xarrvj+7iYTpJYguJ3cWoUgG8=",
+   "pom": "sha256-OL1elncT/MDZra1KUc4DHtMBKV4189Sld8FPtIcpFb8="
   },
-  "org/eclipse/jetty#jetty-http/12.0.16": {
-   "jar": "sha256-sHUbPdmoq8eboMUGFhOEPbodLOIxBX9TrT0DjKiI37A=",
-   "pom": "sha256-FyG2zUtSiTXUhC88/3xKzRZlCh+D96wdxmcRYwLvtXs="
+  "org/eclipse/jetty#jetty-http/12.0.18": {
+   "jar": "sha256-ZAz5UOutH4jVqW5GVIo0/42kGLYXHivC4w5z9JERsGg=",
+   "pom": "sha256-ugkOUMVGzQh1twAKz2/QzMPki82VcU284q+9BVLhzTw="
   },
-  "org/eclipse/jetty#jetty-io/12.0.16": {
-   "jar": "sha256-yN/S2I00vlRhQX8iVr4MyGiGXEWBX37g5And2HLw6E8=",
-   "pom": "sha256-Uk4TYvU78k2el7i921Z33qPaWHLUaUizTY/DDNvtaGM="
+  "org/eclipse/jetty#jetty-io/12.0.18": {
+   "jar": "sha256-JSjDJAsGFf1zXvZ4Je5816L0MOQF/Vfu11Y3fS0HAqc=",
+   "pom": "sha256-rXTNc+C7Vk7631bMUBjMzl3y2zIlU0jmB4P81MGNUXQ="
   },
-  "org/eclipse/jetty#jetty-plus/12.0.16": {
-   "jar": "sha256-nNw/BQqSr4qipgH6hG5kmztg6Bo0UOlwp8zC2m9kv4o=",
-   "pom": "sha256-zszauTmhsSOjFB7LF+ihOahpJMjIom3BlzAXua3BNxI="
+  "org/eclipse/jetty#jetty-plus/12.0.18": {
+   "jar": "sha256-re2+4lQU1PK3b2QbNGyXmUlOOEsuFPVd+Cc/SPkLa+A=",
+   "pom": "sha256-GkPHKbDvK3tfHrn9y6m032a0D5msXWWE/ZNj1bVxv3Y="
   },
-  "org/eclipse/jetty#jetty-project/12.0.16": {
-   "pom": "sha256-ZxSrN8Z8cMCyfFrYlcWMtvBuEUTxkbWwqv0FZwWvRkE="
+  "org/eclipse/jetty#jetty-project/12.0.18": {
+   "pom": "sha256-PzY38CDKMWMCrkwGh45p66AbkarZMQ7iKS/H1e5qrYw="
   },
-  "org/eclipse/jetty#jetty-security/12.0.16": {
-   "jar": "sha256-em1bLQ7bG1AStVEKgEEcf7S5hEs4eZONO26azjubaHY=",
-   "pom": "sha256-v/ySNWOLTWpxRJ58jFJO1tCnF3xeykfRePgpaJ5Q88c="
+  "org/eclipse/jetty#jetty-security/12.0.18": {
+   "jar": "sha256-6YUHv0wnOyKte/VJEAMtCUipuoOFKSYPG5Go1gx2t0k=",
+   "pom": "sha256-XXPWb6k+qBC2WcDsFXiv5cmJHjC+lhqyU57lPuCAPGk="
   },
-  "org/eclipse/jetty#jetty-server/12.0.16": {
-   "jar": "sha256-nj8XynMhVO4sZ8wrw0DzIrKTNfdNZffMAQTC6c3GZA4=",
-   "pom": "sha256-Cy0QsdTqB7YWxfOaXpCt/IdXZlKZLzyEjL9FB8XOHSM="
+  "org/eclipse/jetty#jetty-server/12.0.18": {
+   "jar": "sha256-EYyPeE/8v0pp4QGLhx/Tls1OxjH8b3ZP6Vi+sJHlBWg=",
+   "pom": "sha256-YpS+SZdLQx6r+HKJr3pp/W+O3o5UDBBFMnsWfmdabFw="
   },
-  "org/eclipse/jetty#jetty-session/12.0.16": {
-   "jar": "sha256-XX39JMlEcsNoRBSIeRQSox6kdq1PHZKGtPWALF2FUUs=",
-   "pom": "sha256-I6B5lpaZEspv7ZQ55nvlC0VGxsfXaQLnXRS7jbqUjNM="
+  "org/eclipse/jetty#jetty-session/12.0.18": {
+   "jar": "sha256-tpgAZB8emtwVlA278iZQb0FU9UOlKgNiaOXimPq4X4c=",
+   "pom": "sha256-TKx1ZJX/Gj7G8imAW6Mtg4XxkJBmGuuEWAzLtQmWKu4="
   },
-  "org/eclipse/jetty#jetty-util/12.0.16": {
-   "jar": "sha256-oD1DwZSZPrtNUfv+f+KRNNeGOyhwg4Du7dEXl8g1Q88=",
-   "pom": "sha256-bl7WF83htpxIgRzJNh7A3/elQTHfAWIj8bOS0x6GJFk="
+  "org/eclipse/jetty#jetty-util/12.0.18": {
+   "jar": "sha256-xMnnQ19/AFp090bZSVLhSOyAM1biDJnm1GpS+Jbh5BM=",
+   "pom": "sha256-oKk+PMa8REc5a5esU0q/zVBaXjzykXeplG6MlV+1ycw="
   },
-  "org/eclipse/jetty#jetty-xml/12.0.16": {
-   "jar": "sha256-qDT0DhfHg6n1m7fuCigGJsfaz25+4+k9wLaSemqr39k=",
-   "pom": "sha256-zu/+SzcPZ/v6xXEDEIaZqqAQnMSj9uWaP4bIL5Kw+iU="
+  "org/eclipse/jetty#jetty-xml/12.0.18": {
+   "jar": "sha256-TCKAUNag4P/yKES6uWB9L5CTw59vrqaN7FMCREirRBw=",
+   "pom": "sha256-xVFoYaKy83hwWpiJTKC8iwVxHUsltPJ74QGMxgeWOz4="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.16": {
-   "jar": "sha256-CK2WowcdYWHyO1oAx2Vizko0qDswAO1tVycHh57bi0Q=",
-   "pom": "sha256-9IK0qqZXa3RmKFMxzx9OGbVKAp/98Bq6/9ac1vsOyLA="
+  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.18": {
+   "jar": "sha256-bd/ghhR+tkhWDDnMbsLaoqohqXg6UhzCQhRamlsN3js=",
+   "pom": "sha256-3odv/SXW3ht3BxVv+0BVEKP2J+T7mCZ7vTz+K7bD8QI="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.16": {
-   "pom": "sha256-OVZOMc7Xe7BSEXqSJsfdeq+bZj48hw6MhrrVC9El5sc="
+  "org/eclipse/jetty/ee10#jetty-ee10-bom/12.0.18": {
+   "pom": "sha256-sPU4NYiv//iVCgRyxA/4I0oKfP74z1SkwtOuD3iax6M="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.16": {
-   "jar": "sha256-c+dEGiTi16t57QkHua1z5AFacm5/Jqm1TDK0BUFXYOY=",
-   "pom": "sha256-NskjRadmzN/Z6siw0vmbXPpE6dzQTTnIWu+zCq/VKBY="
+  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.18": {
+   "jar": "sha256-IOdLhOf1hHldHfJGAHu/EimzXm4yMbdnhwe1lp6e9VA=",
+   "pom": "sha256-5IFAwkhVHc+lG6FGTKqAOgkxELZa0HXS69XZ5VnJj3E="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.16": {
-   "jar": "sha256-GKbEEHQGGg/0QNYYtD56syjoEibsIcTWpNU7kLLJSlU=",
-   "pom": "sha256-5OA3uGqQOgMbMqU4PKeqUMPoyMl+En/XjGnpnIv1KJw="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.18": {
+   "jar": "sha256-6qmY/YVNZP4WHIItIfB0WYaVTbXIF657g8OxPpSqPgY=",
+   "pom": "sha256-8OGv7q6bfIHYN5R78W48nEemB9/P5hW0pUTMlY7cSXM="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.16": {
-   "jar": "sha256-xadQJp9mMAGD3E6nrhWKILkz53M/dxjUs7fQN8COVvE=",
-   "pom": "sha256-X8lSKyISayHKzJ3yqI06aQTUxmeF7r9HinVkUfqyeOk="
+  "org/eclipse/jetty/ee10#jetty-ee10-servlets/12.0.18": {
+   "jar": "sha256-Styu2zpd11xV40WwTEV+JNopMxJWPNCEdO+NWgsBnQ0=",
+   "pom": "sha256-EwdCGE8xfk5rbkA6PlUizGw25oaz4G0f2LPrMiqqzoQ="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.16": {
-   "jar": "sha256-dD3+SAVuYzgXHKWsBdef3hOJFINo2XZOhdrB0bym7eI=",
-   "pom": "sha256-GlqaFt4h9jIaWR/B+QxiZ/eXNNv3d+5R33jZUTCwLOw="
+  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.18": {
+   "jar": "sha256-wDEV7bSmgr20nsgkXwrNfs0lgFyvL73VDurDQtVq8lA=",
+   "pom": "sha256-A3Zjd8xsEhRJ5/2Q+3EVkylVp/sw+8lYsod99WkWCjk="
   },
-  "org/eclipse/jetty/ee10#jetty-ee10/12.0.16": {
-   "pom": "sha256-+Lp55YwQldbCd66Yr3Y5KSo7s3hVn+iptO4MFKr64PM="
+  "org/eclipse/jetty/ee10#jetty-ee10/12.0.18": {
+   "pom": "sha256-R7SD8458sfXw2IMRgShtA5fVxoXEnyT5zwGffbllnYk="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.16": {
-   "jar": "sha256-LPLk5FCiimS0lnML3GWuaq1BQH+0qxvxlcS4KdGLHc0=",
-   "pom": "sha256-gM/VzBEwr0Z4MuAc5iZ+X8IzPUz483lEZ4+MlgnflQ0="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.18": {
+   "jar": "sha256-Oa44yVV/58qqHxvE0XzrI3HCwi4EFC4rag+4hSVsf1E=",
+   "pom": "sha256-H8iMnxBsPw8Dtm1Kmi9/4SOIFbbxAymnuSDl7/jfV3Q="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.16": {
-   "jar": "sha256-sBWjKECHarWncsLbFL1qbH5WjuvO/T4MbF2E5r+aPKI=",
-   "pom": "sha256-x1H2CBdEnOk1ea1fhKGO+i+3S5RZa/22pgSZnjlNlRw="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.18": {
+   "jar": "sha256-IL+cS89DzkD28ieaZ4kakwLE7pWNibMkpnWqjClhqgI=",
+   "pom": "sha256-upUKLD7ayY2ViPISAVUNWSsNufYihYODgE3h6aVGoXk="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.16": {
-   "jar": "sha256-uRgs1XH8+oPlXFyeoulewkRyo5YbvrUw8DzMKPSs0ro=",
-   "pom": "sha256-VCSz+PJHUZusjLyGvIOXATzzVr/ds3eE5uhCusjAGsc="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.18": {
+   "jar": "sha256-opUxgkIkjRa3777/md4s57loryuUAy2zscVlhqx47PQ=",
+   "pom": "sha256-F+x/0DMObuuqnmsPXAYbX36pstF7ViweXx+7xRX8x3Q="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.16": {
-   "jar": "sha256-C0AfdYY4Ig7xt/iYxcjI3JaczCvzkY4IaxzJrha/cjk=",
-   "pom": "sha256-266XXEc9+FWvzqC5ovDkwaPsvexWcQ8INHGS32yKJiM="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.18": {
+   "jar": "sha256-cguolyzpCLtvM0bnY1M3tzsj8bHJa/7W2L+fTy/NGwI=",
+   "pom": "sha256-NlnjfQULr9NbmrZ/P0IcfN/x4Y6a5y3KdYLrADKT4r8="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.16": {
-   "jar": "sha256-l5N2trxYP6ZwvSAL538E9rzglF0uYTeMBPT5FjYk7eI=",
-   "pom": "sha256-Tm0M2gO/ogZV8IFD3WznYqqfMp/3p0UcvBkuOoQZ7JE="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.18": {
+   "jar": "sha256-wQv9NLQEL96hZ3FSCirHoB4zlLSDMW6DQyyOpsZsf0U=",
+   "pom": "sha256-B+XgbkM/y8xzWT8y3c7vSLUjyshmxI4g95LjeeC8x9k="
   },
-  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.16": {
-   "pom": "sha256-fcFWMu3wU0kLeweOScDiYJHxbEuNqTvlEOgYccTKE5Q="
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.18": {
+   "pom": "sha256-FJuGgFyTecjCuiXDc2Qt28TrbqPzEMkT+Op3HxxVDKI="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.16": {
-   "jar": "sha256-DuBPMGrAdZmA+LgeJYWtHKpK6tffIvGlJ3JkstWtZDE=",
-   "pom": "sha256-4P099As8ptFU0umiqWyX963bz7kIzKbBjoIdj4D8Bdg="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.18": {
+   "jar": "sha256-1n05bNy2c9YHQvgOQoELkZPdnyruwmknFKzeyn375jQ=",
+   "pom": "sha256-owj8h3nOG6trI7LgVPywCabhziY7giO/feTnjuRqdCo="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.16": {
-   "jar": "sha256-vr5vrG3dQEe9czS/QzYsf10UBCgu+GbKawkpUPbB+pE=",
-   "pom": "sha256-sFLjOQiQxL4pHsmj7ccZE5AgziSY4lWOPvcRyKBWIvU="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.18": {
+   "jar": "sha256-Qn7CQrxXwCY43RnCyNS/ZuvupSrlitbWqbQBOviLsgE=",
+   "pom": "sha256-uE3iWImyc8RSCPUc57WihEJ8R5jpMA10AkcMRdARIzI="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.16": {
-   "jar": "sha256-A64u73um3byZBqVwp9bLrJvyQ6oYnweT7PHdQnEbLJE=",
-   "pom": "sha256-qacaU3C2MIlj/qhHbuasocJW2Afsb47aEKrU+taBDYQ="
+  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.18": {
+   "jar": "sha256-aYFjpUXiHeDWozDwoIL4HU6WmIcDvqSIGCX8pL0h1vQ=",
+   "pom": "sha256-vHc35FPruSa1wnLw1LnNANoZ15LdfdDzWjrKRbtkO7Q="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.16": {
-   "jar": "sha256-TUt/CghIvl31XJn+ySMgLVwRe2DXudlkKwlTTjJ0R30=",
-   "pom": "sha256-h5BtC8qe/E9K/onx38KwTcfxnUpfvDLxCQexwPm5YIw="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.18": {
+   "jar": "sha256-ndwN5HS8wGW1y7RoK7LzoD8hTncmh1LHHwgqJmg0Mco=",
+   "pom": "sha256-VgPHA2ssyUodwAHPJpzAoRa3EP476BHpBUHHGamjEF4="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.16": {
-   "jar": "sha256-i+xAy3tWtmoYcClzTyiEpBkXSqHjOw6NeLgsmBxtRZo=",
-   "pom": "sha256-kjtaWh27dwZxxdVm7RzxBHUp5P3RkR1YZy/lmSLk4aI="
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.18": {
+   "jar": "sha256-Cgtx3a7XK49xxH/jfM7aHrrPquaQIAONEux14nkbFc4=",
+   "pom": "sha256-b8BWGKaXp82u6kYuHzahV6r3TJQsysIaz4YHeKt1caE="
   },
-  "org/eclipse/jetty/websocket#jetty-websocket/12.0.16": {
-   "pom": "sha256-WYu9Bbw1dqT/RHIulEAvIinmaQ2xDkLQPvLPggNOad8="
+  "org/eclipse/jetty/websocket#jetty-websocket/12.0.18": {
+   "pom": "sha256-etesYt8KvkGmxpodrxukOJWJafVLWb/KzTuV7w3gOhg="
   },
   "org/glassfish/jaxb#jaxb-bom/4.0.3": {
    "pom": "sha256-Zg8EhAYlliYXiumpcrA86VFmXDPDM8q0U7EXi40NJBU="
@@ -1796,9 +1845,9 @@
    "module": "sha256-sapyAvw/Z9IgZpA9Ph63BS7hD0cyKhy5JfovRJ8lruM=",
    "pom": "sha256-ZvbmB7MHQOORmJglpa4HamyHepm3jrBUqBRmUKr/cus="
   },
-  "org/hibernate/orm#hibernate-core/6.6.8.Final": {
-   "jar": "sha256-CXGQkRcgKJZPRK5XxyaxKthHOC8m7wIZgJcsSFhgko4=",
-   "pom": "sha256-f+FpWnl5ExvuPi9Fm5BqWnRyQJwmHTV7NaSixh1BeJ4="
+  "org/hibernate/orm#hibernate-core/6.6.11.Final": {
+   "jar": "sha256-8PjzZCXoGRngEHTEDys3P6huOtweXm7XkrBLZofgdmA=",
+   "pom": "sha256-mTGR3tnzybF+L6SqcV4yx18KE4mie5vssjLqOy9Z3gU="
   },
   "org/hibernate/search#hibernate-search-bom/7.1.2.Final": {
    "pom": "sha256-BAbGloTq1BCta0E1tShrtggnsLWiEdXl0T0iM1lATPA="
@@ -1809,8 +1858,8 @@
   "org/infinispan#infinispan-bom/15.0.11.Final": {
    "pom": "sha256-l1ZGl2WLzh5IwN06lHdoxhNyMtYVGVhBQhz8Q7GE6Cw="
   },
-  "org/infinispan#infinispan-bom/15.0.13.Final": {
-   "pom": "sha256-r9hOQe61uJa8KR6xgf6RwISZx72ZAShlUQhScQPjpkE="
+  "org/infinispan#infinispan-bom/15.0.14.Final": {
+   "pom": "sha256-Zf+BVhyv+gTTu4z0zZvKxlo92YG19ayVu/gEYns362E="
   },
   "org/infinispan#infinispan-build-configuration-parent/14.0.12.Final": {
    "pom": "sha256-WTir5k+BZwjr5C5mlla+UltuhfxMyAh3OkVqnp6ne6I="
@@ -1818,8 +1867,8 @@
   "org/infinispan#infinispan-build-configuration-parent/15.0.11.Final": {
    "pom": "sha256-utwbV7pKcUvVQfHty5kdfpBpDLJCNO8kd4ju3eO3jgo="
   },
-  "org/infinispan#infinispan-build-configuration-parent/15.0.13.Final": {
-   "pom": "sha256-XzR8kQ11k2IhmsWXDyJVwiIAXJnIjwjRVffqpSznad8="
+  "org/infinispan#infinispan-build-configuration-parent/15.0.14.Final": {
+   "pom": "sha256-Q164DFInvsRbB1WBQUrJ9Fz5gJ4lY+HIUeWlSTFnTG4="
   },
   "org/jboss#jboss-parent/39": {
    "pom": "sha256-BN/wdaAAlLYwYa9AfSgW2c3mZ5WsrjdqBUvf6Lox5mQ="
@@ -2040,19 +2089,19 @@
    "jar": "sha256-cZCVwH1CA5YTINpZNEHYs7ZDwY6x2Bqpjqkzu36zUbo=",
    "pom": "sha256-xqiAc3trPIon2aBcYEhTanpwuzUMuR3OIza2cQorpig="
   },
-  "org/slf4j#jul-to-slf4j/2.0.16": {
-   "jar": "sha256-Dy7DluopyaRAiQ0fCf24L91XS0eymENXZCNUUcGThh0=",
-   "pom": "sha256-ZrmCqPWdeK480y5UaMHUjn78wYZruIPYqYgE2E3rZn8="
+  "org/slf4j#jul-to-slf4j/2.0.17": {
+   "jar": "sha256-p6/NI7nP0UdeVclPlDuAjFkiA15+LCpcZaSHpBBrxTg=",
+   "pom": "sha256-OMMwoKtfCT5WK1L7Ya7GMK4cH5FAbjz1R3UEXlzPbAM="
   },
-  "org/slf4j#slf4j-api/2.0.16": {
-   "jar": "sha256-oSV43eG6AL2bgW04iguHmSjQC6s8g8JA9wE79BlsV5o=",
-   "pom": "sha256-saAPWxxNvmK4BdZdI5Eab3cGOInXyx6G/oOJ1hkEc/c="
+  "org/slf4j#slf4j-api/2.0.17": {
+   "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
+   "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
   },
-  "org/slf4j#slf4j-bom/2.0.16": {
-   "pom": "sha256-BWYEjsglzfKHWGIK9k2eFK44qc2HSN1vr6bfSkGUwnk="
+  "org/slf4j#slf4j-bom/2.0.17": {
+   "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
   },
-  "org/slf4j#slf4j-parent/2.0.16": {
-   "pom": "sha256-CaC0zIFNcnRhbJsW1MD9mq8ezIEzNN5RMeVHJxsZguU="
+  "org/slf4j#slf4j-parent/2.0.17": {
+   "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
   },
   "org/snakeyaml#snakeyaml-engine/2.9": {
    "jar": "sha256-L3qVdGG21wwABeLDW3ihyXvvbERnBMDuk5POmOSVi6g=",
@@ -2079,35 +2128,35 @@
   "org/springdoc#springdoc-openapi/2.2.0": {
    "pom": "sha256-Los3sS+E+doEZrqeLfbA2nneG1cyCSPFNW/oXbE0d2w="
   },
-  "org/springframework#spring-aop/6.2.3": {
-   "jar": "sha256-Xm/D2pDBlD8vzl8G7wTVhhh84AYv4YbYCs1TEJBlIF0=",
-   "module": "sha256-d+iEAqslnThkE8TPOXkCkwMZi5obLUu2rimqtNK2CCo=",
-   "pom": "sha256-VRti3MYad6IXIblFh7Y9WEH7+muksnjvys0Y9iftLsg="
+  "org/springframework#spring-aop/6.2.5": {
+   "jar": "sha256-395Y5bJ34S5GTV8NfWDEnOEMltqUqjKhlqhxFGevfdg=",
+   "module": "sha256-f6Dxb2n+7LNO34y3IH1gjPpX915HPteyldfPup6/pzE=",
+   "pom": "sha256-gztBWu9TrsbeBwyLPxbR2Oe5s05u3iITZqkgUeDr464="
   },
-  "org/springframework#spring-aspects/6.2.3": {
-   "jar": "sha256-7xt1sh9maSeZ+wQX8h2aZrzNrVwoTfp7GpFPJDVLbMc=",
-   "module": "sha256-cgMckfU9noGTXWnxa4LsMMuEHDlQhHcxbgv17METSC8=",
-   "pom": "sha256-ndJ4A29IgPM4IVfnx3LVukovzr9LM+eyshgEG5z8QFk="
+  "org/springframework#spring-aspects/6.2.5": {
+   "jar": "sha256-T472n/xMs9ZRWWoA9Tsp3IE+QOdVI+1SE1R+ILR9jY0=",
+   "module": "sha256-m2Mfr9pqsDBYvRgWKNuqmpCmdoPr/XG8VR7QiuO8A0c=",
+   "pom": "sha256-/f3/3OATylEIH3FHjCJL5MV3Sp9xaAhFtxGi0ngb4io="
   },
-  "org/springframework#spring-beans/6.2.3": {
-   "jar": "sha256-TiidbAqj6nRjMAXa4G18yCdRDluEDWi/zr3PC902P0Q=",
-   "module": "sha256-EWFFWz8fdZBPyJkJ1i5EVsRpnowfy4YNgUuxRNk3ufQ=",
-   "pom": "sha256-SmG8k1Xjh6DOqeaYtqdBZy9fnb3iNclhq4pe6B0tGoY="
+  "org/springframework#spring-beans/6.2.5": {
+   "jar": "sha256-Y/f/ZKchh9ccQC+Md8X+a6nTjgNGXk+aYBw1IiZQUdQ=",
+   "module": "sha256-5F34QHwHIM870oc5E3wmxlPAUrg+TIenuT93XsVACbM=",
+   "pom": "sha256-ljzIyX+2b5jjYtGyMAfO/yy5ptvQcm7LWMNyS5YsxJE="
   },
-  "org/springframework#spring-context/6.2.3": {
-   "jar": "sha256-U/7qbYxholCJ2MR0xPkuvSTw7361Ls2vRvEemiU/204=",
-   "module": "sha256-L0yecr5CWZq6HY9cs7fpCZP5nTTRGKP7Uk5g0sxSTJA=",
-   "pom": "sha256-zOZ14OTcExzMcrFc55sCCloeZOs5mPKw9qeWV1xdGHk="
+  "org/springframework#spring-context/6.2.5": {
+   "jar": "sha256-IZQeDJ8jMQx4QD81piSyfzoTAfHM9d4lDXR4lW57q1E=",
+   "module": "sha256-XMaESKC/guHdXkrE+UwDutYJCsjV78j405IIwZT+H+k=",
+   "pom": "sha256-E2zENI5nYWgl3gvzfj/nSx4fGaisOd8Pqs4p8ZK0syM="
   },
-  "org/springframework#spring-core/6.2.3": {
-   "jar": "sha256-SVMWhN8jBPDmEfd1+rp5Jzx3UE632FZZLYMOI4np6xQ=",
-   "module": "sha256-qn+EiEW+ahEMm9rPFRSfnp4wTaRS/oHqEbcb0uQbxtk=",
-   "pom": "sha256-iiURsdM4PfstvI0mmPlzR4LvZ8wg4e26hKEYrRFERvI="
+  "org/springframework#spring-core/6.2.5": {
+   "jar": "sha256-TO4Czy0CJ8Hxv7l8Ltwp06+DuTyD0Is45Zh8P6D+Tx4=",
+   "module": "sha256-L8IU0itA9AB9/adE+FHn755yjRgoYFfw9ZTrlUvIriA=",
+   "pom": "sha256-K2lVoWZQfbOAVQK84ifbJ4+s37ynyqM6cThHhw4B8oI="
   },
-  "org/springframework#spring-expression/6.2.3": {
-   "jar": "sha256-6QHia6qg4zPOLMTynZENYwwfemxsuZrHo8QRpQa1t4A=",
-   "module": "sha256-nf0phyL0WOlTbwmnspsHo080ysZLMIAQTJ5Bhh/H0yw=",
-   "pom": "sha256-pw0SUlcJwndW3sDGe8RVir0Lx1JwTUtdS7xA1vYMDZ4="
+  "org/springframework#spring-expression/6.2.5": {
+   "jar": "sha256-7HbEHU5Fd5tIrhACAyKzLssuL08tkwsNk4RKREkNdsU=",
+   "module": "sha256-TE8PHZ7MMmFpCaLKjP5X7wl7KWospGVbaSvca7jiWqQ=",
+   "pom": "sha256-XEmjLJcqg+VTBOnDV+EWgF6yFkavvHoXSEAgRXPLpmM="
   },
   "org/springframework#spring-framework-bom/5.3.25": {
    "module": "sha256-bPPIDzsrxVO0LptyC/9x/bBxUmy4kMVwkz2deAd2JQ4=",
@@ -2129,199 +2178,203 @@
    "module": "sha256-8KnavGjttkVgoh3q0GDDB1D8qckDYQYgonMZs4oewCA=",
    "pom": "sha256-c9YvN2lzSpSUY+hXhSoVS6qroJ0Mdm40QQZs/q46fsQ="
   },
-  "org/springframework#spring-framework-bom/6.2.3": {
-   "module": "sha256-jGhP2oDvHnxxmqfkMwEeMv4VMZvLItJ03rzEbqOSvig=",
-   "pom": "sha256-Zw6Er/sjG18ww+cCrlQiLyHHIy8wxUAbOl+AGv8GFo4="
+  "org/springframework#spring-framework-bom/6.2.4": {
+   "module": "sha256-AsGZBljD+XSn/kaO10kF5mAnMW2xP0LfAtkPvLd6Qbg=",
+   "pom": "sha256-4FloFPbXFJP9SFVPOqTQ5XG0SWOWs61IfsLljw7saUA="
   },
-  "org/springframework#spring-jcl/6.2.3": {
-   "jar": "sha256-jGXsXtZIlmpHDmtIsny+v18fQSvUayQ+ARHF1dlu/oY=",
-   "module": "sha256-PxqK+qC2Yi3g2S/4zTFpBoB1CGXpSJSu7DCf7kmqDEs=",
-   "pom": "sha256-BSEm2SxKXGAHZjYcxATm4AR7V6VjfQKI0CTvb5IAPn8="
+  "org/springframework#spring-framework-bom/6.2.5": {
+   "module": "sha256-cGjuMW7K/Caddl57c+LX/cK2kvwtPMeB2uiPspDF2OY=",
+   "pom": "sha256-fyh8p+xN0cZuM13PyktIXJILcYVK2VTadN7UInPyW2s="
   },
-  "org/springframework#spring-jdbc/6.2.3": {
-   "jar": "sha256-cM1y3vgW8p0Qui6ICKVS9D4TIYUKLvV5O3mQHnStw8w=",
-   "module": "sha256-k+Y/mIrnZX1pO7X4ltvXnwa/JtvvzHzfGsAr2XLZPOw=",
-   "pom": "sha256-dQRppvGVOmPIhGHw2n//jhEgDoKsYy2H84srrSeNfTM="
+  "org/springframework#spring-jcl/6.2.5": {
+   "jar": "sha256-T5ORX6sQwU3zuQBUz9XRwBop3vWbbiXA8z2erE/+wHk=",
+   "module": "sha256-XmoAS9bTzk9i7in2ByXOmGmn9q3uqHiA6oGj/CPCPRI=",
+   "pom": "sha256-8t98qvowo7Ku34ViqGh0RsJUMviNNvGwt3+keA7nxr0="
   },
-  "org/springframework#spring-orm/6.2.3": {
-   "jar": "sha256-VvEQqzpSODIktEOqCZbfcSgh3cwFRFQGVuvaQLJyJSE=",
-   "module": "sha256-e33Zj/sPHn6k9lwXJ+101v4EP1HdFqwUq/hLNz4fuUQ=",
-   "pom": "sha256-rzzkiCAaTkm4YiCHkxB+rbKdrSTTthlb1Ps4OQi4fGM="
+  "org/springframework#spring-jdbc/6.2.5": {
+   "jar": "sha256-ImiwovsId/R2d/bqZ/KD2XK5WR9M0o1jcZo9+6vNCi0=",
+   "module": "sha256-K4G/JP/SmxlnnDJ8o+A5YpO6eHzYcmrDINxH/hkuqSY=",
+   "pom": "sha256-7sBqbI/Klbvud5iWqhquoDj5UbLHCBw3X2BiCh5YksM="
   },
-  "org/springframework#spring-test/6.2.3": {
-   "jar": "sha256-NJ6qfY1JajtoSQzMci8Ey9cRzkMIMAxZIqE7sgdGm8Y=",
-   "module": "sha256-GMxC2lXQt+498HpBmHjhPSIiT558nyrkqi+BSM3p7ZU=",
-   "pom": "sha256-vlg4/nRULaOZETV8Sfnx+TZ66weVDOeIeUP8ZoKG/4E="
+  "org/springframework#spring-orm/6.2.5": {
+   "jar": "sha256-CMVMIusCIhhOBvvq1qjCBwmpsflNYYJYJF/gHvtgJEs=",
+   "module": "sha256-brvzlRbCRfEqMBqxIdPYhbxwRsrhwqRGM2jdUclxeQI=",
+   "pom": "sha256-6u3ZSb3Fmcz0Pl51Ud4YQtL1zy4ioHKLmYpqkVf8f74="
   },
-  "org/springframework#spring-tx/6.2.3": {
-   "jar": "sha256-7ThK4V3aMGD/jf54jtPtrDVOOqVY7lr+drt5nrTBYNs=",
-   "module": "sha256-KNcWUlaIIUe/TIL0nRmDO2BtlqXk4hdS8tlFHgGpthc=",
-   "pom": "sha256-O4SjuqAyYKv0uA1ev/9q2mp8U/IBkEOsfmVy6bP7UHo="
+  "org/springframework#spring-test/6.2.5": {
+   "jar": "sha256-VYVYYpbPl3jY0CeXG1KXRlYeDZspU9AJVrJ6H1sfDX4=",
+   "module": "sha256-K0bkH/tj15DGnUfq/EX/SPa+nQIuyTHIHJJP18bB7uM=",
+   "pom": "sha256-8VFyp2/mWduThqY9IJaa/zeeYpjtx/IC/DaJ+Np8paU="
   },
-  "org/springframework#spring-web/6.2.3": {
-   "jar": "sha256-dz8cpN0moeu/zWog4+tSdF6q1wXisDF3NOoG2Jea/yA=",
-   "module": "sha256-0rxhKFwJudN4ET6LkFxJlMFDYOlWrIdTLdVuGSbGYYg=",
-   "pom": "sha256-jzK2ZmCmSCtaA4t1D5lnRk4Zu7+hZbOp5MKi5A80upQ="
+  "org/springframework#spring-tx/6.2.5": {
+   "jar": "sha256-oPxPJ14Ezxsx3ei1NI4Q7QM3LNc0xuPRTghjJjeUqeA=",
+   "module": "sha256-EgVuBdYr9YBe8u2K1iMDs+92xorwqGYpju0nvmZH7+A=",
+   "pom": "sha256-QIUxUoXgMOOw/bQaghZnhxxwyZiOaP1BrUre6nt16uA="
   },
-  "org/springframework#spring-webmvc/6.2.3": {
-   "jar": "sha256-ei5JzIkShsFNmVoMX/ocr7S1Xuv6HPo3M88SAU/dnwA=",
-   "module": "sha256-D4DegT3bAFeB4P4fIyC/2GwxEnk+GWFVLOgg9s+E9U4=",
-   "pom": "sha256-JRI2/pHBk9hEnmJMBz+mfuRtoru/rnXqx+NzEEp9AvM="
+  "org/springframework#spring-web/6.2.5": {
+   "jar": "sha256-hfDBrK8DOl96vcrzSPHdLOvh93aH7nfwXoy2a/vG/s8=",
+   "module": "sha256-yEX4BsUU3Z2Kjc1bq0+1fTi6IaAB7m1vfjDwsszJ7Zo=",
+   "pom": "sha256-QJ3SB/YroB93ofMB8PpbendWZU2lcrXpPXw4qoqDIik="
+  },
+  "org/springframework#spring-webmvc/6.2.5": {
+   "jar": "sha256-uNKBrt8enL9zuyxs9y0+r4Efkpiy3FAX6cQLPLkoS0Y=",
+   "module": "sha256-pvMa5KRyE+iNlZnYvLdMYL9oAvbXurMsbi74oXJmHCA=",
+   "pom": "sha256-32UTRYMZFI7c/ZkZiXoc0l7EUD/XcRTqe3ac3QEf0nU="
   },
   "org/springframework/amqp#spring-amqp-bom/3.0.6": {
    "pom": "sha256-sch8n8omH3LZPz+tDWBfn6FQECv1fU6eT9Ga0ltYvB4="
   },
-  "org/springframework/amqp#spring-amqp-bom/3.2.3": {
-   "module": "sha256-9eSGj7HQVpOpf4+6OVkrLfMKbLQysTCX8BCXf6ZBAdE=",
-   "pom": "sha256-tRG87VNspJqsdf6UkHNXCG83RhBNu/xBv5ZHWePLD9w="
+  "org/springframework/amqp#spring-amqp-bom/3.2.4": {
+   "module": "sha256-6GajudWTyzW9is6za3K6oNenSrtg/izG5fkN0nqmgGs=",
+   "pom": "sha256-16+mzir5n+3pJ+EyyGq3N9gTZKDwyzHF3sAFLx6UsKI="
   },
   "org/springframework/batch#spring-batch-bom/5.0.2": {
    "pom": "sha256-aDpeNRsQ0aR8gkN/CtTnhmTUICWhpXBtaPpDhCHt1uw="
   },
-  "org/springframework/batch#spring-batch-bom/5.2.1": {
-   "pom": "sha256-lQOF8+SgFyJyld6ACk14EiJtOhdEe8tCXSAUrcOTl/g="
+  "org/springframework/batch#spring-batch-bom/5.2.2": {
+   "pom": "sha256-SJs2UNjohLCPgk5pY7T9M/GIrgTewdAIIP4Ap939nsE="
   },
-  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.4.3": {
-   "jar": "sha256-779BRL0hktvf7XBEZfJ2aqoJcjGYiFkeuSsGZraHYlo=",
-   "module": "sha256-XfsMhg8KiWNguoBCoH479QA/mGBgK8vNSoZfcwAJ7zY=",
-   "pom": "sha256-WOOd7mQObDWgwSRp8fUXfLxf7d28MtemFuVEq2JUJ74="
+  "org/springframework/boot#spring-boot-actuator-autoconfigure/3.4.4": {
+   "jar": "sha256-vtL6GJeJuV1RHOGDjf+cBBo0yT2sb5A8OoaVnbAzt6w=",
+   "module": "sha256-/cS/xtYp8OhC0TTdpxBeo+A0pzCGtDMdbWTQl6DBJIY=",
+   "pom": "sha256-KWiDSGfOQEdgqdAFG2kdJhgr8qDzmntixSy5E1bQ15Y="
   },
-  "org/springframework/boot#spring-boot-actuator/3.4.3": {
-   "jar": "sha256-VJOhr9BtiVAB6d6ME6Ui33CSYUWkJHNOIKMEI6+/mXc=",
-   "module": "sha256-SpeVwjti57YszLEAM/pC2BWDnH+lyvffKtQ+EOBaZoM=",
-   "pom": "sha256-pSlmhtJ9MMRPGKmR8I35EdTaVVdfNGrVeSM3oFqcJX4="
+  "org/springframework/boot#spring-boot-actuator/3.4.4": {
+   "jar": "sha256-lMHGya+W1NLKSvVbgMd4uXUPzGOjeIk/WHMSKzucDfw=",
+   "module": "sha256-Zj8ORbOC7Bem+WXDUoaiwZ4DPhWrTXCqdyCtsrzpbV8=",
+   "pom": "sha256-mQ3SrTASowMCG0NkWxC+1yg/nSO8J8AsMgyopr+psaw="
   },
-  "org/springframework/boot#spring-boot-autoconfigure/3.4.3": {
-   "jar": "sha256-F/vUV0fyav9SO05IkZjOW8K0kN5Fm2YSUm+7y983N0c=",
-   "module": "sha256-YqvS8kI9ojpn90Qle/62as/0MsTfwZaM18u8rZc8MYs=",
-   "pom": "sha256-Aw+107YhiUomkNk0dLk1YM8ijLECjBxmfXA/f4MKhtE="
+  "org/springframework/boot#spring-boot-autoconfigure/3.4.4": {
+   "jar": "sha256-BKO098Tgqzn7i03XeiCS7VwDaWETPSeAYK8URV3FXTk=",
+   "module": "sha256-IcDgeQGfH0VlygVqmP8m+abKJ2BqHV1u6ky6IlU/d20=",
+   "pom": "sha256-AdJdJ6o3eAfpMWPgjZcIQKwN9gBDTUgwb78pbrVWLf4="
   },
   "org/springframework/boot#spring-boot-dependencies/3.1.2": {
    "pom": "sha256-DIaB6QfO2iWOWU6lt8/aByuKxHDamKrAGEqO62lQV9o="
   },
-  "org/springframework/boot#spring-boot-dependencies/3.4.3": {
-   "pom": "sha256-EwzZoLGErLnXfpcHo0AvVhwmhrd3olNcqIf+VrMAMqA="
+  "org/springframework/boot#spring-boot-dependencies/3.4.4": {
+   "pom": "sha256-6ptKw3zUDVMf33fO3yIIrSrmhN5FQ4kfDDJyCYFp4Bo="
   },
-  "org/springframework/boot#spring-boot-devtools/3.4.3": {
-   "jar": "sha256-uL1vjudEi2TM3P1N1JsJp3nEqdT9MjU3Zmwcos1X7As=",
-   "module": "sha256-fAijzkbz04ZpdS8uexmBLwW0ytVGdXmnuptPFHnqjzo=",
-   "pom": "sha256-jb3XksKStLGNT8IVjNJj/yTlFl1IDU+hL18bY9K18E0="
+  "org/springframework/boot#spring-boot-devtools/3.4.4": {
+   "jar": "sha256-o73D3co6U8KwF5c3bqvbcYrT+5qzAboEI9OG/5X8ARU=",
+   "module": "sha256-+w/feE+rwolwt/jHnNN66tVSqAbqzKps/cqcZZlL3ro=",
+   "pom": "sha256-Q+9kcSYqi1KE64ZYMAslgujy6bVO+J37LeIUdGmvWnQ="
   },
-  "org/springframework/boot#spring-boot-starter-actuator/3.4.3": {
-   "jar": "sha256-zIa5c9J9P3m4xR4wGvdb14uNDvqJz+K/TRqi+b4gQuk=",
-   "module": "sha256-wMSmwTKgvJPURscC9apTfnv1xG1E3FXOGXKfqo8nOzk=",
-   "pom": "sha256-t7zmB93aqDAwaDqQE6XItoxzcBQVFquw4wGUbSWakDg="
+  "org/springframework/boot#spring-boot-starter-actuator/3.4.4": {
+   "jar": "sha256-c4501nr76yKerWHT4jNHfum0XwB3iQeaWv1/g5ukF88=",
+   "module": "sha256-hCSxu+We4S+wKH8fohf4CYYXS8Fj84SzyCDMc/XwGq0=",
+   "pom": "sha256-myBG2TnIK/cH2rpzNkY1OW2mPnc5X4nlxEpzeWD+MsI="
   },
-  "org/springframework/boot#spring-boot-starter-data-jpa/3.4.3": {
-   "jar": "sha256-YEAipoj2eHrdrPQXgHT2fHDpX0FCrXdzT957QTjw+KM=",
-   "module": "sha256-JC+Q0SkCWjuhxswscQXe6m5oVgVSbR/1NpmvQHZnjPo=",
-   "pom": "sha256-sIcbkCFwi5EUkp7KnwpwObueboZ1OWmQQJuhu1y54Oo="
+  "org/springframework/boot#spring-boot-starter-data-jpa/3.4.4": {
+   "jar": "sha256-skBAVJ48JRWWGJTeUaL9Kqw//DGSmDDnDkNAvpv2Tbw=",
+   "module": "sha256-H/DOoNICiZXVNUcAjougxyTr/WUK1omOfFaoXnR5TyE=",
+   "pom": "sha256-OOG9qSGt+LtW8TVAknHeoaQQCG5izZx6QyFefAVKW/E="
   },
-  "org/springframework/boot#spring-boot-starter-jdbc/3.4.3": {
-   "jar": "sha256-pkioQnt5Zt/rGs2fEyqPuxLwT2vBGSm0/8fsOsfZVC8=",
-   "module": "sha256-Oyge+t4WZjdaJUdlldkYAyy1eN55rohSR9ddtaLTgu8=",
-   "pom": "sha256-9nhimCgGKw82aPSiQraB1Aee5vM4Mt8a3BBDA1MlxF8="
+  "org/springframework/boot#spring-boot-starter-jdbc/3.4.4": {
+   "jar": "sha256-Fwq7oCy0t9W72pZYctVNWH7B+nzQSUM3umopRAt0Tlg=",
+   "module": "sha256-KwQs8INnguLfp81ejxhYSN/4B6YlKpMn+Y3nDecfDi4=",
+   "pom": "sha256-NP45Tc7DfcNS22b/m9hu3n1zyyzKOprB7umwWJpKCJs="
   },
-  "org/springframework/boot#spring-boot-starter-jetty/3.4.3": {
-   "jar": "sha256-xfTwqqH9CBUc4lSHKc7jMYGI99Ku3mEao9yobYsG6GU=",
-   "module": "sha256-CptRu25KA+bkzpJjON1hHWL69spJ8X3eM1IoLYqxpP0=",
-   "pom": "sha256-M/lRilpLBQebjWuWYXSsH1OpfhcPGXadi9j24P59Xn8="
+  "org/springframework/boot#spring-boot-starter-jetty/3.4.4": {
+   "jar": "sha256-iZahtQOPlQUlFf4zDmdpwPS95N6LhNSzpAOXcv8TT6I=",
+   "module": "sha256-hIf1ZE7PjN+OuT6vsJ66eqy71qLZFpxb/VFK4GHRBrc=",
+   "pom": "sha256-XZqnFLOmdOrZ+a9Kyv12/soP0r3bjsEfyMswA3Cl/BM="
   },
-  "org/springframework/boot#spring-boot-starter-json/3.4.3": {
-   "jar": "sha256-A/uEve/+cIdbJnp/mYQL/VcjQRPvlqjbrM4pXCP5lO8=",
-   "module": "sha256-h3gZa3wmkiDcUKthq1xRyTK5vEnLVBXKP/+XglP82tE=",
-   "pom": "sha256-k0pjQWlNz9EntXsqQ1+CHFzhnm0jolvKucnOW+51Z/o="
+  "org/springframework/boot#spring-boot-starter-json/3.4.4": {
+   "jar": "sha256-yS3db30QmlFzkaWcDZ1PAlbVxbqNtdGvRxDgyhf98sI=",
+   "module": "sha256-Zuu/iZ4e4fy0k8FPBuUvlri8ukkyvegnCcXuSpupR/g=",
+   "pom": "sha256-FtGm0ENM4DCz0BmII1NlzhBrOTCgt6bOhckzZcL68Tk="
   },
-  "org/springframework/boot#spring-boot-starter-logging/3.4.3": {
-   "jar": "sha256-xl3ww6bdHMmS+b7SzPLgh7cr4KtQMdUIXkB51lPeTVI=",
-   "module": "sha256-9n2snuAUiNQceB9z3M2AF+57/EycZ3bq7z6raTebe20=",
-   "pom": "sha256-WTGytzxUdEMPEMi1woSbTXyMBbuXRSOft7ju3Y12Prc="
+  "org/springframework/boot#spring-boot-starter-logging/3.4.4": {
+   "jar": "sha256-H80SNqOLXuvDV1J8BYBwZpJyt7YMg5T4h9uIK0tHokA=",
+   "module": "sha256-nppuvQXs+pb6EM8UamLBDQxUP6mvwC3ii7VAwp6prj0=",
+   "pom": "sha256-4GxccC+sEHw2beJEAQEwyGogewHcLXnNi0b96ngYIok="
   },
-  "org/springframework/boot#spring-boot-starter-oauth2-client/3.4.3": {
-   "jar": "sha256-VfFS+hujHUuZdljexDMlJ26q12+s7o68Nljkrz45wq0=",
-   "module": "sha256-e2B8EnIDU2lilRC3wSs73V4Vq9TQisoHj57YPrDinrM=",
-   "pom": "sha256-+EDFSardW03f9CgxXMNI9RdFBMPUTtiqcQk8vXKvmAw="
+  "org/springframework/boot#spring-boot-starter-oauth2-client/3.4.4": {
+   "jar": "sha256-vCtxAsJkixgBiBPA/5p24DyIUTv+u/fgvQeHfgpn6Ik=",
+   "module": "sha256-BGYau4OFMgpJTF2H8vyw79qWCXfyAeYE3/KBKzu37mU=",
+   "pom": "sha256-0h5c9iowmm0mkIlbRTh8gEAxBOGaIXDRSWhMWQy4hPg="
   },
   "org/springframework/boot#spring-boot-starter-parent/3.1.2": {
    "pom": "sha256-TB9NCfr9cgJEhZCDvfx7VytHF22Bil965q1m0ZOODO4="
   },
-  "org/springframework/boot#spring-boot-starter-security/3.4.3": {
-   "jar": "sha256-jA4Rik0gVX02V6x4R2jwWRN07E2W9eIWCJQiS/4r2KY=",
-   "module": "sha256-y6iIFbbOCKQOn6T/+8vER/dRCYVKGjzMeiLOXHl4FlI=",
-   "pom": "sha256-nzJbiep1ND5afKIrjKr7Co8KUuwlKyrUbGmCux8nwpQ="
+  "org/springframework/boot#spring-boot-starter-security/3.4.4": {
+   "jar": "sha256-eWRSwgqaC0btch1vMv012vhAdOjjRc7IMYrRIX0I5/E=",
+   "module": "sha256-CC3hd2cjAqqwSgqbeIue3kmFYlETplmC7jJBaEtcVzk=",
+   "pom": "sha256-w9zMpiZeWDAbC07uiSG/IM49etts8svVlA8Zs4k02MQ="
   },
-  "org/springframework/boot#spring-boot-starter-test/3.4.3": {
-   "jar": "sha256-F3xoASxNaUbPg/6AeTR7r9VHGfsw5HzzwgFBXsIog3s=",
-   "module": "sha256-XBwaDTnUR5tWq2cFoBzDiQzaYnrKuHWiOu71tCggSGk=",
-   "pom": "sha256-oY8jYvnn6mCrrgQ0b4dU60ZaaVMg/Uf1GD0yaqcmwwU="
+  "org/springframework/boot#spring-boot-starter-test/3.4.4": {
+   "jar": "sha256-7z4g9cxwRspOefXHVv9qKz0QSs1D+s8+fP7+x6FejAg=",
+   "module": "sha256-WWkQeS6C2rHBnOT9iAzbIt74WZQGYSxNAYKHyMDf5sk=",
+   "pom": "sha256-Mh7cErHbGEV2excLV1Oj/iOl+Ld9HS89vagkAO4omis="
   },
-  "org/springframework/boot#spring-boot-starter-thymeleaf/3.4.3": {
-   "jar": "sha256-lMxGBKihVKZinwmmMHipWJh3oCusQrvhPznBgAIxdhw=",
-   "module": "sha256-qwzxFW5bIeZ0K1ebySgGOAydAegxpWXHxbb5WCIu69o=",
-   "pom": "sha256-sNb9RVc0CU07Rp5Xubi9MLB16s8PTGbX/dFcqhznSCw="
+  "org/springframework/boot#spring-boot-starter-thymeleaf/3.4.4": {
+   "jar": "sha256-y2zT/kOStQv1jsisILEDu/FaP8wf2kiR+ymOJpuowe4=",
+   "module": "sha256-MUOlQxu7uudG4qOEeB+gWO2/UJpEpwswkWB4ax719pk=",
+   "pom": "sha256-viYp+eY8MexI2bzbqgP/mDwKKejLk4U94jNgKjwKaik="
   },
-  "org/springframework/boot#spring-boot-starter-tomcat/3.4.3": {
-   "module": "sha256-aTHJpE4/Q9DwDTnZSmBfyrtWuxF5AgqiaAQT1Ni5M5U=",
-   "pom": "sha256-tvp16RbAM51BYqPExKYqB1HuvIz+YYF85Zm44AOpdRI="
+  "org/springframework/boot#spring-boot-starter-tomcat/3.4.4": {
+   "module": "sha256-MoqFXUkkPdJtdm8llVGWcs8tLm1AErxMqL4ztw2qYho=",
+   "pom": "sha256-i+/NL8lM5FoAgBio/O8HCaJ3IOQdQEnj2iv8cTM/iO4="
   },
-  "org/springframework/boot#spring-boot-starter-web/3.4.3": {
-   "jar": "sha256-raJMFSbJog2P26tdTzvE13lJWjF8/zp9eJ+ofjNihoU=",
-   "module": "sha256-rzMsCpbLc0WNInWghBJZDDz5j3XneNzWiNc11+fDP1o=",
-   "pom": "sha256-g8FkECxnf+APWFSflfMPE8oINVqQXHY77sPoJehfiIY="
+  "org/springframework/boot#spring-boot-starter-web/3.4.4": {
+   "jar": "sha256-xii40NfIMMfqO8EllQ4RMyt843eevW1lXxg+RW/+RIE=",
+   "module": "sha256-brhwwPlZ2AOxm09SSvEMqazIlKbl804kkVL52DGQI/M=",
+   "pom": "sha256-kNNNh039JtkHpq7L6ohn6aCmEaqXjTlaij9W1GKzVDg="
   },
-  "org/springframework/boot#spring-boot-starter/3.4.3": {
-   "jar": "sha256-c7SFJciK+2H2ZF143luwx7NmrCAWV9NvgUdYwVkbeT8=",
-   "module": "sha256-gfghsIQaMRdz574z7EtljzMLQSnBGIVi3LkPBUJmXzw=",
-   "pom": "sha256-Vbe/CCnxy1uCRgG1/s28NbXRoTg9b0PL9sOdfBg6mok="
+  "org/springframework/boot#spring-boot-starter/3.4.4": {
+   "jar": "sha256-L83AA3/RwKzrtLHvcAgYyX2EV/q8bVvrw4ePWEwccn8=",
+   "module": "sha256-6+eaKOIivSRmYBaa5xJmstSO3hYfdvpHKxvI+bjBey0=",
+   "pom": "sha256-MZ6iobSR8Tk8UQZVmfLjZ1HK+0+QD7MaveDHaLw7p4s="
   },
-  "org/springframework/boot#spring-boot-test-autoconfigure/3.4.3": {
-   "jar": "sha256-p3IWX/JGiqN73NimbnWwQQEVzC0NFC0FV5Nch4rL9rg=",
-   "module": "sha256-VycMQkAMiJ4z6m+TZYVqj3hNekCS5zMAswCqz5lTsY0=",
-   "pom": "sha256-+DhcWbROFGHtwvZkChXkxVYK/q/G8CtV0QzqxeBqqg4="
+  "org/springframework/boot#spring-boot-test-autoconfigure/3.4.4": {
+   "jar": "sha256-iWJsqo7ffUfeWotpiMILiav01zoEZA1A+6OtlEOZETo=",
+   "module": "sha256-TYIZZ+u5QVZO9cyXgnb/bGQIFi67EsENhGNx4ewFbBE=",
+   "pom": "sha256-G4xBG/jarW2I41axYCf9kx59t/PD8gmSwr/Z2IDjeSU="
   },
-  "org/springframework/boot#spring-boot-test/3.4.3": {
-   "jar": "sha256-c7lhTT8oKyxe7gVq/8rSQcmqYqLdeG+CR5cOhTKlrlA=",
-   "module": "sha256-Q26UnuWF/tHj+SsYF7l3GbJvtWQCamMOVlW8/lJAxtw=",
-   "pom": "sha256-kXNsfxk7e30iMnc4cMJC02xrAtw6YQSQe1cksVCxw3U="
+  "org/springframework/boot#spring-boot-test/3.4.4": {
+   "jar": "sha256-vGlYSIYAXFYH2JEg+6N1C8aJOWwSWGtrkX4hvVu5KxU=",
+   "module": "sha256-SZekaJmYRLS7D4twxt5Pqz/6fRznI8Jz26D94PDUiYY=",
+   "pom": "sha256-/ivGB4/3vjc3xCBFFl0i8bDZ8p8ksiA2df6aZyE64ds="
   },
-  "org/springframework/boot#spring-boot/3.4.3": {
-   "jar": "sha256-QYpq/Skgr+YvxcCcxGtIWnpv3QnhZ/Cu1aI0eAnrVgw=",
-   "module": "sha256-o67EOT2xuuPgcKoJU+zy4ImgDKq7XNvuwn/oGJ+WkOs=",
-   "pom": "sha256-LaJ6GNBSueVA4rwdA6oKU5xHT88M5mmjPPStM/IzMMI="
+  "org/springframework/boot#spring-boot/3.4.4": {
+   "jar": "sha256-8TTULRnB9wdAjizmrOjViHqefD5Qo1GnWtqAr7vW7K8=",
+   "module": "sha256-lGUna66QcisNzKFdPXIvC86w5UBRYMoTriVyjzoPX3s=",
+   "pom": "sha256-89A19FDWaGe58oqGQzMhiMzioFWXnb0ACASiQ3ySCfs="
   },
   "org/springframework/data#spring-data-bom/2023.0.2": {
    "pom": "sha256-r5JYFO1beGWJH9CGEGBVcLS7hFCi9Rv55bhjXNNoHgQ="
   },
-  "org/springframework/data#spring-data-bom/2024.1.3": {
-   "pom": "sha256-jVIbBkHCz1WpZKiCyUtmQpRxOOhldjBsBY+jije5Smo="
+  "org/springframework/data#spring-data-bom/2024.1.4": {
+   "pom": "sha256-sBmDPBXeOQFuZm5MHIyqQfHmbEAv2Op0k8e+e6PPuT8="
   },
-  "org/springframework/data#spring-data-commons/3.4.3": {
-   "jar": "sha256-bo3k4YhQPn1iR+EPsHeeIwYZMEqneqqHD6XtnJzeRgw=",
-   "pom": "sha256-zAZASufV1Depo4Glva0SnUKhFPOsvdxRoFLEQl50JeM="
+  "org/springframework/data#spring-data-commons/3.4.4": {
+   "jar": "sha256-Nreu2b8d4YCABFQyc69Zw1VtCxXDG8PJFPdq/8thSGY=",
+   "pom": "sha256-6u3bs8j7PFfLa29rvLNb3zFX3pQzGN/JaX1E1698XGM="
   },
-  "org/springframework/data#spring-data-jpa-parent/3.4.3": {
-   "pom": "sha256-RL6rGLGNlTUI39ExT1C+tAv44zQvcR+h4nMHv/objHc="
+  "org/springframework/data#spring-data-jpa-parent/3.4.4": {
+   "pom": "sha256-5ENpbkQx2iLDRLqqnOOQxmAwJWwFmNUDDGFYrFvxni4="
   },
-  "org/springframework/data#spring-data-jpa/3.4.3": {
-   "jar": "sha256-vMERcu3I8b81JuiENhIF64r0G701DoilcxRfUDb5MPk=",
-   "pom": "sha256-CdId6Nf+SaKm4O3pep7TAU2cLja1ukllGiA8uHApGKI="
+  "org/springframework/data#spring-data-jpa/3.4.4": {
+   "jar": "sha256-FOHxgWUopL6VWYGQKuWSPWK5dOnW81Tn4l7KP3dLA9g=",
+   "pom": "sha256-4WoQ3RojDP8LCtbwOSDLuUM8hVN7jCujJhnTJcoMmIA="
   },
-  "org/springframework/data/build#spring-data-build/3.4.3": {
-   "pom": "sha256-ojJb5SAowdM/DsJ5rKpbaxvKby7S5c+2GvLqGQVyEpM="
+  "org/springframework/data/build#spring-data-build/3.4.4": {
+   "pom": "sha256-FpQ4zLn6cUyRWbPcR0LZN4xNJ9r6HBO/mH0K9mFCHrw="
   },
-  "org/springframework/data/build#spring-data-parent/3.4.3": {
-   "pom": "sha256-Ulh3zIcXyWH04IAmytx0mg68jqXonHR59UYebnMLHjs="
+  "org/springframework/data/build#spring-data-parent/3.4.4": {
+   "pom": "sha256-xNKwHEdypqLrMSWbOcpccmVZgMUgv/3Wq6+W185MhfI="
   },
   "org/springframework/integration#spring-integration-bom/6.1.2": {
    "pom": "sha256-0mxOaZYUSD15O82BeZxUTtpYlXYrSzGXFX7tAo7GL+c="
   },
-  "org/springframework/integration#spring-integration-bom/6.4.2": {
-   "module": "sha256-9d6pRUNT+kUOFie5X/9BAbXUuD0uE5UjISLVQO+QRJ8=",
-   "pom": "sha256-LqskSezM/plnbIrxlmoD60DNGcYq79eX7oX40fOw7Ok="
+  "org/springframework/integration#spring-integration-bom/6.4.3": {
+   "module": "sha256-eKT7QrIcbMErc1cvlWR2qYvYJztf8WLl9vsxt6qUolk=",
+   "pom": "sha256-CAzdoKJKOILsGygPsvoGw7Ck8ibqJxMOsJih3jWnoJg="
   },
-  "org/springframework/pulsar#spring-pulsar-bom/1.2.3": {
-   "module": "sha256-kKJY0Et+aALU62ipbovDfNkgjj2fD36BllPk5RM8qDo=",
-   "pom": "sha256-XQHgYZtimzI6V89ByehHv/dxTxVCih54PdZhgQfU0a8="
+  "org/springframework/pulsar#spring-pulsar-bom/1.2.4": {
+   "module": "sha256-11oIRNX4om9A6ZagK+qeCifczpf5AovyGGK3+3UIWJU=",
+   "pom": "sha256-eANokQLSMKDWAyyRQn8t7BGfa3abYbIWLhG3XkwOV/Q="
   },
   "org/springframework/restdocs#spring-restdocs-bom/3.0.0": {
    "pom": "sha256-/8nEe+Wo60iO3pJozgiaeZyT6JT7G9P5QPYsRnpmEyM="
@@ -2337,49 +2390,49 @@
    "module": "sha256-HMJ40imEfP7hLpBd9w5W5W4eo2m+LKd3S/u60EtbMos=",
    "pom": "sha256-P0nGqe8bTNCnKRAzAyshnLkmzIPX3KlutclyzSQnI44="
   },
-  "org/springframework/security#spring-security-bom/6.4.3": {
-   "module": "sha256-TIpHk0q+SGYF9ZOhrFp1qylQ9kQMSvzffNBjzcyJzPI=",
-   "pom": "sha256-VvjOf8pjVlnMUHikZGh8zrwY5T/NX008rJldz+xEFII="
+  "org/springframework/security#spring-security-bom/6.4.4": {
+   "module": "sha256-qOtMz9NfTa56PwqReln3SCjniYenROdD0GnOVX3FTmQ=",
+   "pom": "sha256-gv5qePWLA683DDc2NN0a3USD7tw4ELhGpPlJaGl9X5o="
   },
-  "org/springframework/security#spring-security-config/6.4.3": {
-   "jar": "sha256-gH1jbFh3txFUtPvi3Wx8I4AcowO5yxjjST+fRocAZ7I=",
-   "module": "sha256-nrBNAW38U20n9yXUmT4y5znRKYdLvcBN2jKyWD0c+DI=",
-   "pom": "sha256-wT0Zv9/hLOUaqseVxcfQM0KfzgblI9Qtk4dur2MH6p0="
+  "org/springframework/security#spring-security-config/6.4.4": {
+   "jar": "sha256-8T8jZbSvQbM+QK9lcBTbdz3oWNhMdPNMmtpHHJb5wWk=",
+   "module": "sha256-A5Fel4GjWAuBxkuTNzI5Ba5HKmthZWWq6SEQd1Z25GM=",
+   "pom": "sha256-VaDxS3ukEE/lmVGCN9B+zVqxUHCFB1UYj57lX7OJ3WE="
   },
-  "org/springframework/security#spring-security-core/6.4.3": {
-   "jar": "sha256-X2GPUcX40ad0R/PLToyM9CABip/iVVrz8HC1hz87ELQ=",
-   "module": "sha256-kQdEWEeVZaRbGymMqQwVsZSjWmO6gq2jxfBkxct2rjQ=",
-   "pom": "sha256-XTxUZsTuHccAssoudONf1p3/j41GVTRRijKtrLfLu7U="
+  "org/springframework/security#spring-security-core/6.4.4": {
+   "jar": "sha256-2ffKVZ7K3AcAVV/BbL1Mi9+77dJHT1/R8MQpvtlGZY0=",
+   "module": "sha256-kD4+6mRHlchaZc3k/BPIuow2fqJCUsaKUvkt3Qp2HQc=",
+   "pom": "sha256-8gIi/vESbaPnKf3dIFU1WtlJhl3XAbHDPM7C/7eK57I="
   },
-  "org/springframework/security#spring-security-crypto/6.4.3": {
-   "jar": "sha256-PbETxWk6q8qHiV5VpDVaWRdJV1nHG1q7nT6FH3PJ1Bw=",
-   "module": "sha256-2zN0lhzqd0rU0usK+XWBpCNAzK20AGnhh91fuzTg+sg=",
-   "pom": "sha256-UtLMXNeYLmR4WW4FrPYGmcahli2Xyza3fr1i2WIvHNQ="
+  "org/springframework/security#spring-security-crypto/6.4.4": {
+   "jar": "sha256-YrNCS+Yg5FcUalGj2pqoeO6YdGZ80kmNcwhag5TTaUA=",
+   "module": "sha256-204pLvMQAIHc2TOLCcs+lKE71vqV3t/gIy9olsksvXg=",
+   "pom": "sha256-ebual+pdPEX9xHMepqxpssL//0wTwjQfWFA6S2ojsc4="
   },
-  "org/springframework/security#spring-security-oauth2-client/6.4.3": {
-   "jar": "sha256-72uf/dH5DBqmDEsIP1EGlGViMf3Ym8V/oROC0uE1+6Q=",
-   "module": "sha256-b0X3o554wIjoqEeUuGWocwPRABf75b2q6ZBqvA/JBQ8=",
-   "pom": "sha256-vtsMg8kHeKOZh2r+OTzkevDcCHKlDMHar4HiMxw35vU="
+  "org/springframework/security#spring-security-oauth2-client/6.4.4": {
+   "jar": "sha256-K71c0xh7cLOS2SgIwmbMJJDQb+mkyQodarNn+6zhELg=",
+   "module": "sha256-gwD0FCVeqGmZ5fIwxIzHG58bH4j77x1vb/zCe823YAs=",
+   "pom": "sha256-EM/PVBFACsmFaADcUIP4oaYTbOENCTZCCWzPb1vcatc="
   },
-  "org/springframework/security#spring-security-oauth2-core/6.4.3": {
-   "jar": "sha256-x1N19G+oZ5RLWslTV1z2p8rg9h7xvhWVguTvXlFy7DA=",
-   "module": "sha256-apDWFB54kVUpvzUUYvZuuB66Z5Mp91Lt9TRGeK2XYKU=",
-   "pom": "sha256-N6qX9P4FC36hrv42ooiBSY792PhETu4ZQ74cB17my2M="
+  "org/springframework/security#spring-security-oauth2-core/6.4.4": {
+   "jar": "sha256-cLfRUUKU8Ni16gZ4JTA7yZS/iw/DmiUEb6UWBYfoa3U=",
+   "module": "sha256-RlW0afpNdYzzIU2JUYxF5A8q9rHQTN6Eh558Xj4nzFY=",
+   "pom": "sha256-u3hbA6cUq7bMNlhcWoBdSx6xmDKIYMrECM+zcpWHreo="
   },
-  "org/springframework/security#spring-security-oauth2-jose/6.4.3": {
-   "jar": "sha256-WFOM7XQBe4A2WX+aNExdmcDBF7dXhbYI8/FUdl0dr4k=",
-   "module": "sha256-k+yyUDaTdOGlL09LORwBnRtLuFj5u0SZtioExMGMUJY=",
-   "pom": "sha256-Disd/Vcm2dz21vMzzydu4ue0qhy87thpw62T5Tb0R8o="
+  "org/springframework/security#spring-security-oauth2-jose/6.4.4": {
+   "jar": "sha256-vGXW6EYjUj7mtTNK6uuUBPm9aUuL5eSfkfgJN2Pa+jw=",
+   "module": "sha256-HRq3Bw2lHv4sPZVGoo9hibLGuYTdpA5aD1AtdbvcN8E=",
+   "pom": "sha256-3g7o1az46wXuqbD7IvcLgDrH0aVdGERx3lcgB3m3G0U="
   },
-  "org/springframework/security#spring-security-saml2-service-provider/6.4.3": {
-   "jar": "sha256-zNm5o8dcx93f4i0bgCEyd6sbMjEN7nMH7QDxBG43peQ=",
-   "module": "sha256-1YRoM+23Bzkqp3BppBgHdwedeZ3s3tjzEsq1dqFmsjI=",
-   "pom": "sha256-b3MqF4nav7mjRnu7S112vUPwHeZiX+fvw2mzca7cyXI="
+  "org/springframework/security#spring-security-saml2-service-provider/6.4.4": {
+   "jar": "sha256-s0NAkF+aWL1xqAWiyk9O0zHjzPbEFlaLSzzTI5Lk0bA=",
+   "module": "sha256-9/AoBxl7+u4OrrDk5VsmgaoPowXjFulAV+22NW8QOO4=",
+   "pom": "sha256-cfS6/m2dsuoxZGq3BuIQuu7cNElJWtanmQ5jOs9O9WI="
   },
-  "org/springframework/security#spring-security-web/6.4.3": {
-   "jar": "sha256-9q8n+yPpNosgSP7h+5ovnH7SWVzU1xnoQOnIV4dJx/c=",
-   "module": "sha256-vp8tr6DVp3FrseBf+PCYP4JiPpwlCaa4SxVpl85CWA4=",
-   "pom": "sha256-SjsmEhgVndo7snw2Fwatcmbg/yl8Qj6YCVJC1V46BII="
+  "org/springframework/security#spring-security-web/6.4.4": {
+   "jar": "sha256-dwXuw0yGYH0+LIGWXSBYT6RoGbrzEao+k4He677OuaQ=",
+   "module": "sha256-9WsRnHRd70ctreao+y/RVMd1X4Etk4CQ0j60f2eJdYc=",
+   "pom": "sha256-+uhgUYPsCNRbZj6xaILBLahuLROhNisEiKuX5ZU6Z3s="
   },
   "org/springframework/session#spring-session-bom/3.1.1": {
    "module": "sha256-1pUWyPsAHxEYTRTC/WPXiiXTt3H27w40+UMFo+/cYyc=",
@@ -2394,8 +2447,8 @@
    "module": "sha256-A02zA9rMLOu/2//SCtgR4CxzfElHx9A3Ja9HLPO/jkY=",
    "pom": "sha256-3kg0+gkVeP2a5IGlrK2oqirJc1a30A30y4txM22z+IA="
   },
-  "org/springframework/ws#spring-ws-bom/4.0.11": {
-   "pom": "sha256-ebcaocK/ikSdMKx+g6qJOo0Ah5L8KUvIYCYVUvoQ7fA="
+  "org/springframework/ws#spring-ws-bom/4.0.12": {
+   "pom": "sha256-z4sPmYxvuuDkUByT8WuEXLoTqsVZNA8RF7j5K8+G6RI="
   },
   "org/springframework/ws#spring-ws-bom/4.0.5": {
    "pom": "sha256-8OjPCyFD18APnTYVoZy7cPI+Qy+B8OcCi91a0/KBo/w="
@@ -2406,8 +2459,8 @@
   "org/testcontainers#testcontainers-bom/1.20.4": {
    "pom": "sha256-oVFHwtqO3sE0AdHT5qCgG2Gea2e2bBA1ks7zpwzB7Ik="
   },
-  "org/testcontainers#testcontainers-bom/1.20.5": {
-   "pom": "sha256-TeDLRzMSJ4A2o5d2MTacmtFylGTDIUfYfJ9cMvcmbfA="
+  "org/testcontainers#testcontainers-bom/1.20.6": {
+   "pom": "sha256-OKLdmRxz50sJmGQoOqiJ2MNk1pUcrgB4l6vLe+t0APE="
   },
   "org/thymeleaf#thymeleaf-lib/3.1.3.RELEASE": {
    "pom": "sha256-+UdIWb85tid8foaXGj9qfLtu8Jos9r6/D1XO8/GUgtw="

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stirling-pdf";
-  version = "0.43.1";
+  version = "0.45.0";
 
   src = fetchFromGitHub {
     owner = "Stirling-Tools";
     repo = "Stirling-PDF";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-32NGRNVlFH5bXXeS5vQqZjYlk+EqCYcQh3z0t68bkeA=";
+    hash = "sha256-F7iTdFIH1OilRj8ZETd0woxB+mqOJsMKvVwlUi3/XcE=";
   };
 
   patches = [

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stirling-pdf";
-  version = "0.45.0";
+  version = "0.46.2";
 
   src = fetchFromGitHub {
     owner = "Stirling-Tools";
     repo = "Stirling-PDF";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-F7iTdFIH1OilRj8ZETd0woxB+mqOJsMKvVwlUi3/XcE=";
+    hash = "sha256-TVKU3OR5MfyYUoGPuEiHmuENSFdxcnJKE5MdJz83zn8=";
   };
 
   patches = [

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stirling-pdf";
-  version = "0.33.1";
+  version = "0.43.1";
 
   src = fetchFromGitHub {
     owner = "Stirling-Tools";
     repo = "Stirling-PDF";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Cl2IbFfw6TH904Y63YQnXS/mDEuUB6AdCoRT4G+W0hU=";
+    hash = "sha256-32NGRNVlFH5bXXeS5vQqZjYlk+EqCYcQh3z0t68bkeA=";
   };
 
   patches = [

--- a/pkgs/by-name/st/stirling-pdf/remove-props-file-timestamp.patch
+++ b/pkgs/by-name/st/stirling-pdf/remove-props-file-timestamp.patch
@@ -2,11 +2,10 @@ diff --git a/build.gradle b/build.gradle
 index e12cbd3..094a219 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -173,6 +173,7 @@ task writeVersion {
-     def props = new Properties()
-     props.setProperty('version', version)
-     props.store(propsFile.newWriter(), null)
-+    propsFile.text = propsFile.readLines().tail().join('\n')
+@@ -570,6 +570,7 @@ task writeVersion {
+         def props = new Properties()
+         props.setProperty("version", version)
+         props.store(propsFile.newWriter(), null)
++        propsFile.text = propsFile.readLines().tail().join('\n')
+     }
  }
- 
- swaggerhubUpload {


### PR DESCRIPTION
This upgrades Stirling-PDF to 0.43.1.

## Things done
- Upgraded programs to 0.43.1
- Depends on a LibreOffice version that does not check dbus (required to run as a service without a logged-in user)
  - I tried to set the lingering option on the user, but I could not get the DBUS information properly passed so it still tried to create the dbus dir in the state directory unsuccessfully. It felt ok to take this path, esp considering NixOS does not expose a proper way to set the lingering options on users.
- Removed the Dynamic user from systemd unit;
- Create a stirling-pdf user
- Allowed the Stirling directory to be updated (Stirling-pdf can take files externally added in its customFiles directory to avoid users to always upload them. For instance signatures, stamps, etc.)

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



I'm successfully running this version of Stirling on a private Ampere VPS.
~~There are still issues with LibreOffice that I can't explain yet (segfault), and if I find them before this gets merged, I'll add the fixes. In any case, this is a step closer to have it properly working.~~
Please let me know how I can improve this contribution since it is my first :)

cc @TomaSajt since you're the maintainer :)
