### PR TITLE
vinegar: 1.7.8 -> 1.8.1

### DIFF
--- a/pkgs/by-name/vi/vinegar/package.nix
+++ b/pkgs/by-name/vi/vinegar/package.nix
@@ -7,20 +7,20 @@
   glib,
   makeBinaryWrapper,
   pkg-config,
+  cairo,
+  gdk-pixbuf,
+  graphene,
   gtk4,
   libadwaita,
   libGL,
   libxkbcommon,
+  pango,
   vulkan-headers,
   vulkan-loader,
   wayland,
   winetricks,
   xorg,
   symlinkJoin,
-  cairo,
-  gdk-pixbuf,
-  graphene,
-  pango,
   nix-update-script,
 }:
 let
@@ -33,7 +33,7 @@ let
       waylandSupport = true;
     }).overrideAttrs
       (oldAttrs: {
-        # https://github.com/flathub/org.vinegarhq.Vinegar/blob/1a42384ff0c5670504415190301c20e89601bbad/wine.yml#L31
+        # https://github.com/flathub/org.vinegarhq.Vinegar/blob/a3c2f1249dec9548bd870027f55edcc58343b685/wine.yml#L31-L38
         # --with-wayland is added by waylandSupport = true;
         configureFlags = oldAttrs.configureFlags or [ ] ++ [
           "--disable-tests"
@@ -55,16 +55,16 @@ let
 in
 buildGoModule rec {
   pname = "vinegar";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "vinegarhq";
     repo = "vinegar";
     tag = "v${version}";
-    hash = "sha256-eAQ5qlBY1PmpijEu7mPmCBFbAIA30ABcbirdBljAmTQ=";
+    hash = "sha256-7rc6LKZx0OOZDedtTpHIQT4grx1FejRiVnJnVDUddy4=";
   };
 
-  vendorHash = "sha256-NLNAUf99psBq8PayorBH1DT6o9wZyKwx9ab+TtpKU50=";
+  vendorHash = "sha256-TZhdwHom4DTgLs4z/eADeoKakMtyFrvVljDg4JJp7dc=";
 
   nativeBuildInputs = [
     glib
@@ -73,10 +73,15 @@ buildGoModule rec {
   ];
 
   buildInputs = [
+    cairo
+    gdk-pixbuf
+    glib.out
+    graphene
     gtk4
     libadwaita
     libGL
     libxkbcommon
+    pango.out
     vulkan-headers
     vulkan-loader
     wayland
@@ -86,6 +91,10 @@ buildGoModule rec {
     xorg.libXcursor
     xorg.libXfixes
   ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail 'gtk-update-icon-cache' '${lib.getExe' gtk4 "gtk4-update-icon-cache"}'
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -106,10 +115,6 @@ buildGoModule rec {
         find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
       fi
     }
-  '';
-
-  preInstall = ''
-    substituteInPlace Makefile --replace-fail 'gtk-update-icon-cache' '${lib.getExe' gtk4 "gtk4-update-icon-cache"}'
   '';
 
   installPhase = ''
@@ -136,9 +141,9 @@ buildGoModule rec {
       name = "vinegar-puregotk-lib-folder";
       paths = [
         cairo
+        gdk-pixbuf
         glib.out
         graphene
-        gdk-pixbuf
         gtk4
         libadwaita
         pango.out

--- a/pkgs/by-name/vi/vinegar/package.nix
+++ b/pkgs/by-name/vi/vinegar/package.nix
@@ -1,81 +1,162 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitHub,
-  fetchurl,
-  pkg-config,
-  xorg,
-  wayland,
-  vulkan-headers,
   wine64Packages,
+  fetchpatch,
+  fetchFromGitHub,
+  glib,
+  makeBinaryWrapper,
+  pkg-config,
+  gtk4,
+  libadwaita,
   libGL,
   libxkbcommon,
-  makeBinaryWrapper,
+  vulkan-headers,
+  vulkan-loader,
+  wayland,
+  winetricks,
+  xorg,
+  symlinkJoin,
+  cairo,
+  gdk-pixbuf,
+  graphene,
+  pango,
   nix-update-script,
 }:
 let
-  wine = (wine64Packages.staging.override { embedInstallers = true; }).overrideAttrs (oldAttrs: {
-    patches = oldAttrs.patches or [ ] ++ [
-      (fetchurl {
-        name = "loader-prefer-winedllpath.patch";
-        url = "https://raw.githubusercontent.com/flathub/org.vinegarhq.Vinegar/3e07606350d803fa386eb4c358836a230819380d/patches/wine/loader-prefer-winedllpath.patch";
-        hash = "sha256-89wnr2rIbyw490hHwckB9g1GKCXm6BERnplfwEUlNOg=";
-      })
-    ];
-  });
+  wine =
+    (wine64Packages.staging.override {
+      dbusSupport = true;
+      embedInstallers = true;
+      pulseaudioSupport = true;
+      x11Support = true;
+      waylandSupport = true;
+    }).overrideAttrs
+      (oldAttrs: {
+        # https://github.com/flathub/org.vinegarhq.Vinegar/blob/1a42384ff0c5670504415190301c20e89601bbad/wine.yml#L31
+        # --with-wayland is added by waylandSupport = true;
+        configureFlags = oldAttrs.configureFlags or [ ] ++ [
+          "--disable-tests"
+          "--disable-win16"
+          "--with-dbus"
+          "--with-pulse"
+          "--with-x"
+          "--without-oss"
+        ];
+
+        patches = oldAttrs.patches or [ ] ++ [
+          (fetchpatch {
+            name = "loader-prefer-winedllpath.patch";
+            url = "https://raw.githubusercontent.com/flathub/org.vinegarhq.Vinegar/3e07606350d803fa386eb4c358836a230819380d/patches/wine/loader-prefer-winedllpath.patch";
+            hash = "sha256-89wnr2rIbyw490hHwckB9g1GKCXm6BERnplfwEUlNOg=";
+          })
+        ];
+      });
 in
 buildGoModule rec {
   pname = "vinegar";
-  version = "1.7.8";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "vinegarhq";
     repo = "vinegar";
-    rev = "v${version}";
-    hash = "sha256-qyBYPBXQgjnGA2LnghPFOd0AO6+sQcZPzPI0rlJvGHE=";
+    tag = "v${version}";
+    hash = "sha256-eAQ5qlBY1PmpijEu7mPmCBFbAIA30ABcbirdBljAmTQ=";
   };
 
-  vendorHash = "sha256-SDJIoZf/Doa/NrEBRL1WXvz+fyTDGRyG0bvQ0S8A+KA=";
+  vendorHash = "sha256-NLNAUf99psBq8PayorBH1DT6o9wZyKwx9ab+TtpKU50=";
 
   nativeBuildInputs = [
-    pkg-config
+    glib
     makeBinaryWrapper
+    pkg-config
   ];
 
   buildInputs = [
+    gtk4
+    libadwaita
+    libGL
+    libxkbcommon
+    vulkan-headers
+    vulkan-loader
+    wayland
+    wine
+    winetricks
     xorg.libX11
     xorg.libXcursor
     xorg.libXfixes
-    wayland
-    vulkan-headers
-    wine
-    libGL
-    libxkbcommon
   ];
 
-  ldflags = [
-    "-s"
-    "-w"
-  ];
+  buildPhase = ''
+    runHook preBuild
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-  ];
+    make PREFIX=$out
+
+    runHook postBuild
+  '';
+
+  # Add getGoDirs to checkPhase since it is not being provided by the buildPhase
+  preCheck = ''
+    getGoDirs() {
+      local type;
+      type="$1"
+      if [ -n "$subPackages" ]; then
+        echo "$subPackages" | sed "s,\(^\| \),\1./,g"
+      else
+        find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
+      fi
+    }
+  '';
+
+  preInstall = ''
+    substituteInPlace Makefile --replace-fail 'gtk-update-icon-cache' '${lib.getExe' gtk4 "gtk4-update-icon-cache"}'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make PREFIX=$out install
+
+    runHook postInstall
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/vinegar \
-      --prefix PATH : ${lib.makeBinPath [ wine ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          wine
+          winetricks
+        ]
+      } \
+      --prefix PUREGOTK_LIB_FOLDER : ${passthru.libraryPath}/lib
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    libraryPath = symlinkJoin {
+      name = "vinegar-puregotk-lib-folder";
+      paths = [
+        cairo
+        glib.out
+        graphene
+        gdk-pixbuf
+        gtk4
+        libadwaita
+        pango.out
+        vulkan-loader
+      ];
+    };
+
+    updateScript = nix-update-script { };
+  };
 
   meta = {
-    description = "Open-source, minimal, configurable, fast bootstrapper for running Roblox on Linux";
-    homepage = "https://github.com/vinegarhq/vinegar";
     changelog = "https://github.com/vinegarhq/vinegar/releases/tag/v${version}";
+    description = "Open-source, minimal, configurable, fast bootstrapper for running Roblox Studio on Linux";
+    homepage = "https://github.com/vinegarhq/vinegar";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ HeitorAugustoLN ];
     mainProgram = "vinegar";
+    maintainers = with lib.maintainers; [ HeitorAugustoLN ];
     platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Drafting until vinegarhq/vinegar#506 is fixed/resolved

- Updates `vinegar` from `1.7.8` to `1.8.0`
- Changelog: https://github.com/vinegarhq/vinegar/releases/tag/v1.8.0
- Updates `vinegar` from `1.8.0` to `1.8.1`
- Changelog: https://github.com/vinegarhq/vinegar/releases/tag/v1.8.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
