### PR TITLE
zashboard: init at 1.62.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3516,6 +3516,13 @@
     githubId = 2379774;
     name = "Sean Buckley";
   };
+  Buer-Nahida = {
+    email = "me@nahida.im";
+    github = "Buer-Nahida";
+    githubId = 139795416;
+    name = "纳西妲 · Nahida";
+    keys = [ { fingerprint = "58E6 9E46 96C3 046A DB4E  314C B7CF AB72 643B 5A6B"; } ];
+  };
   bugworm = {
     email = "bugworm@zoho.com";
     github = "bugworm";

--- a/nixos/modules/services/networking/mihomo.nix
+++ b/nixos/modules/services/networking/mihomo.nix
@@ -38,6 +38,8 @@ in
           - https://yacd.haishan.me
         - clash-dashboard:
           - https://clash.razord.top
+        - zashboard:
+          - https://board.zash.run.place
       '';
     };
 

--- a/pkgs/by-name/za/zashboard/package.nix
+++ b/pkgs/by-name/za/zashboard/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs,
+  pnpm_9,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zashboard";
+  version = "1.62.1";
+
+  src = fetchFromGitHub {
+    owner = "Zephyruso";
+    repo = "zashboard";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RwbfJ6sZgRD21nMRAX/eKIN7n8oqA8wRYQUq9kLZB+w=";
+  };
+
+  nativeBuildInputs = [
+    pnpm_9.configHook
+    nodejs
+  ];
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-cY0x2VxPozKNFaoteKjfrINStkev8IO0BC9y/EMRVa0=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r ./dist $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Dashboard Using Clash API";
+    homepage = "https://github.com/Zephyruso/zashboard";
+    changelog = "https://github.com/Zephyruso/zashboard/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ Buer-Nahida ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same as https://github.com/NixOS/nixpkgs/pull/380654

# Description of changes

Add `zashboard`, a webui of `mihomo`.

Update the description of `services.mihomo.webui`.

Repo: https://github.com/Zephyruso/zashboard

Using:

```nix
service.mihomo.webui = pkgs.zashboard
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
