### PR TITLE
silence the noBrokenSymlinks during lldb build

### DIFF
--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -149,6 +149,11 @@ stdenv.mkDerivation (rec {
     ln -s $out/bin/*${if lib.versionAtLeast release_version "18" then vscodeExt.name else "-vscode"} $out/share/vscode/extensions/llvm-org.${vscodeExt.name}-${vscodeExt.version}/bin
   '';
 
+  fixupPhase = ''
+    # fix noBrokenSymlinks ERROR
+    rm -v -f $out/lib/python3.12/site-packages/lldb/lldb-argdumper
+  '';
+
   passthru.vscodeExtName = vscodeExt.name;
   passthru.vscodeExtPublisher = "llvm";
   passthru.vscodeExtUniqueId = "llvm-org.${vscodeExt.name}-${vscodeExt.version}";


### PR DESCRIPTION
This is a small change to the `lldb` build that adds `fixupPhase` which is complaint with the `noBrokenSymlinks` check.

Before this change the behaviour was:
```
$ nix build 'nixpkgs#lldb'
...
error: builder for '/nix/store/f5jskhf9m14bgwwpdzfy4h2v9jklazs8-lldb-19.1.7.drv' failed with exit code 1;
       last 10 log lines:
       > patching script interpreter paths in /nix/store/n7qjwgnyvkyjg93fq5rvyk5n74rl9g2s-lldb-19.1.7-dev
       > shrinking RPATHs of ELF executables and libraries in /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib
       > shrinking /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib/lib/liblldbIntelFeatures.so.19.1
       > shrinking /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib/lib/liblldb.so.19.1.7
       > checking for references to /tmp/nix-build-lldb-19.1.7.drv-0/ in /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib...
       > patching script interpreter paths in /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib
       > stripping (with command strip and flags -S -p) in  /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib/lib
       > rewriting symlink /nix/store/m2a55zmrdafavxcwqn1grbmivsbs9ag0-lldb-19.1.7/share/vscode/extensions/llvm-org.lldb-dap-0.2.0/bin/lldb-dap to be relative to /nix/store/m2a55zmrdafavxcwqn1grbmivsbs9ag0-lldb-19.1.7
       > ERROR: noBrokenSymlinks: the symlink /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib/lib/python3.12/site-packages/lldb/lldb-argdumper points to a missing target /nix/store/bh01jmr7dlbbclykswsamdhisixq6q3x-lldb-19.1.7-lib/bin/lldb-argdumper
       > ERROR: noBrokenSymlinks: found 1 dangling symlinks and 0 reflexive symlinks
       For full logs, run 'nix log /nix/store/f5jskhf9m14bgwwpdzfy4h2v9jklazs8-lldb-19.1.7.drv'.
```

as mentioned here: https://github.com/NixOS/nixpkgs/issues/380196#issuecomment-2645944815



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
