### PR TITLE
crates-lsp: init at version 0.4.3

### DIFF
--- a/pkgs/by-name/cr/crates-lsp/package.nix
+++ b/pkgs/by-name/cr/crates-lsp/package.nix
@@ -7,16 +7,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "crates-lsp";
-  version = "0.4.1";
+  version = "0.4.3";
 
   src = fetchFromGitHub {
     owner = "MathiasPius";
     repo = "crates-lsp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9+0qgdUn5l9oQQavbnR6rHe5zp5WHhGuRyOXt2Dv8Tw=";
+    hash = "sha256-HzoOsizeV2LOXXc8BKA7u5mwBJbWNaBZvPepAaVeTCQ=";
   };
 
-  cargoHash = "sha256-oS6xi8BH5vCVOimYWsDoW0Na7eUXzeHKKSOwpK9wbu8=";
+  cargoHash = "sha256-tQBNCTqvVNYqT5ArQE7ji0MeDWxi7Bcd9AxPP3sHvX4=";
+
+  checkFlags = [
+    # These tests fail on system `x86_64-darwin` with error:
+    # failed to create crates-lsp .gitignore file.: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
+    "--skip=crates::api::tests::get_common_crates"
+    "--skip=crates::sparse::tests::get_common_crates"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/cr/crates-lsp/package.nix
+++ b/pkgs/by-name/cr/crates-lsp/package.nix
@@ -1,0 +1,32 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "crates-lsp";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "MathiasPius";
+    repo = "crates-lsp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9+0qgdUn5l9oQQavbnR6rHe5zp5WHhGuRyOXt2Dv8Tw=";
+  };
+
+  cargoHash = "sha256-oS6xi8BH5vCVOimYWsDoW0Na7eUXzeHKKSOwpK9wbu8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language Server implementation for Cargo.toml";
+    homepage = "https://github.com/MathiasPius/crates-lsp";
+    changelog = "https://github.com/MathiasPius/crates-lsp/blob/v${finalAttrs.version}/CHANGELOG.md";
+    mainProgram = "crates-lsp";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.kpbaks ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a new package called [crates-lsp](https://github.com/MathiasPius/crates-lsp). It is a language server for the Rust language's `Cargo.toml` project manifest that will use inlay-hints and diagnostics in your editor to notify you about whether there are updates to your listed dependencies.

For reviewers. I have another [PR](https://github.com/NixOS/nixpkgs/pull/378338) under review that I am waiting to be accepted and merged. That PR also adds me `kpbaks` as a maintainer to the maintainers list. Therefore this PR will refer to a maintainers entry that does not exist on this branch. What is the best way to handle this? Is it to have this PR be put on hold until the other one is resolved?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
