### PR TITLE
oscmix: init at 0-unstable-2025-06-01

### DIFF
--- a/pkgs/by-name/os/oscmix/package.nix
+++ b/pkgs/by-name/os/oscmix/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+
+  pkgsCross,
+  pkg-config,
+  glib,
+  wrapGAppsHook3,
+
+  alsa-lib,
+  gtk3,
+  librsvg,
+  hicolor-icon-theme,
+
+  oscmix,
+  unstableGitUpdater,
+
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  gtkSupport ? false,
+  enableWebui ? false,
+}:
+
+stdenv.mkDerivation {
+  pname = "oscmix";
+  version = "0-unstable-2025-06-01";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "michaelforney";
+    repo = "oscmix";
+    rev = "2411b12d8a13b82829caf3b0b628078980c3d3a4";
+    hash = "sha256-b/FzAyTnQJ2t9TdcfEuOhsMixSa1TeYjKXCtyfkG7zs=";
+  };
+
+  nativeBuildInputs =
+    lib.optionals (alsaSupport || gtkSupport) [ pkg-config ]
+    ++ lib.optionals (gtkSupport) [
+      glib
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals (enableWebui) [ pkgsCross.wasi32.stdenv.cc.bintools ];
+
+  buildInputs =
+    lib.optionals alsaSupport [ alsa-lib ]
+    ++ lib.optionals gtkSupport [
+      gtk3
+      librsvg
+      hicolor-icon-theme
+    ];
+
+  makeFlags =
+    let
+      option = bool: if bool then "y" else "n";
+    in
+    [
+      "ALSA=${option alsaSupport}"
+      "GTK=${option gtkSupport}"
+      "WEB=${option enableWebui}"
+    ]
+    ++ lib.optionals (enableWebui) [
+      "WASM_CC=${lib.getExe pkgsCross.wasi32.stdenv.cc}"
+    ];
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "MANDIR=$(man)/share/man"
+  ];
+
+  postInstall = lib.optionalString gtkSupport ''
+    pushd gtk
+
+    schemadir="${glib.makeSchemaPath "$out" "$name"}"
+
+    mkdir -p "$schemadir"
+    cp gschemas.compiled "$schemadir"
+    cp *.{ui,css,svg} "$schemadir"
+
+    cp oscmix-gtk "$out/bin/"
+
+    popd
+  '';
+
+  dontWrapGApps = true;
+
+  fixupPhase = lib.optionalString gtkSupport ''
+    runHook preFixup
+
+    wrapGApp "$out/bin/oscmix-gtk"
+
+    runHook postFixup
+  '';
+
+  passthru = {
+    tests = {
+      oscmix-gtk = oscmix.override { gtkSupport = true; };
+      oscmix-web = oscmix.override { enableWebui = true; };
+    };
+
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "Open Sound Control API for RME Fireface UCX II";
+    homepage = "https://github.com/michaelforney/oscmix";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mvs ];
+    platforms = if alsaSupport then lib.platforms.linux else lib.platforms.all;
+  };
+}


### PR DESCRIPTION
[oscmix](https://github.com/michaelforney/oscmix) is an [Open Sound Control](https://opensoundcontrol.stanford.edu/) (OSC) API implementation for the [RME Fireface UCX II](https://rme-audio.de/fireface-ucx-ii.html) USB audio interface.

While the base functionality of the device is available through a standard USB Audio 2.0 (UAC2) interface, oscmix enables access to more advanced hardware functions through USB MIDI.

The packages provides the following configuration options:

- `alsaSupport`: Enables wrappers to connect `oscmix` through ALSA on Linux (where it is enabled by default).
- `gtkSupport`: Enables a [graphical user interface](https://github.com/michaelforney/oscmix?tab=readme-ov-file#gtk-ui) based on GTK 3.
- `enableWebui`: Enables a [web user interface](https://github.com/michaelforney/oscmix?tab=readme-ov-file#web-ui).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - ~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
  - ~and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)~
  - ~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~
  - ~made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages~
- [ ] ~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
