### PR TITLE
noBrokenSymlinks: check for unreadable symlinks

### DIFF
--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -13,7 +13,8 @@ postFixupHooks+=(noBrokenSymlinksInAllOutputs)
 
 # A symlink is "dangling" if it points to a non-existent target.
 # A symlink is "reflexive" if it points to itself.
-# A symlink is considered "broken" if it is either dangling or reflexive.
+# A symlink is "unreadable" if the readlink command fails, e.g. because of permission errors.
+# A symlink is considered "broken" if it is either dangling, reflexive or unreadable.
 noBrokenSymlinks() {
   local -r output="${1:?}"
   local path
@@ -21,6 +22,7 @@ noBrokenSymlinks() {
   local symlinkTarget
   local -i numDanglingSymlinks=0
   local -i numReflexiveSymlinks=0
+  local -i numUnreadableSymlinks=0
 
   # NOTE(@connorbaker): This hook doesn't check for cycles in symlinks.
 
@@ -33,7 +35,11 @@ noBrokenSymlinks() {
   # NOTE: path is absolute because we're running `find` against an absolute path (`output`).
   while IFS= read -r -d $'\0' path; do
     pathParent="$(dirname "$path")"
-    symlinkTarget="$(readlink "$path")"
+    if ! symlinkTarget="$(readlink "$path")"; then
+      nixErrorLog "the symlink $path is unreadable"
+      numUnreadableSymlinks+=1
+      continue
+    fi
 
     # Canonicalize symlinkTarget to an absolute path.
     if [[ $symlinkTarget == /* ]]; then
@@ -61,8 +67,8 @@ noBrokenSymlinks() {
     fi
   done < <(find "$output" -type l -print0)
 
-  if ((numDanglingSymlinks > 0 || numReflexiveSymlinks > 0)); then
-    nixErrorLog "found $numDanglingSymlinks dangling symlinks and $numReflexiveSymlinks reflexive symlinks"
+  if ((numDanglingSymlinks > 0 || numReflexiveSymlinks > 0 || numUnreadableSymlinks > 0)); then
+    nixErrorLog "found $numDanglingSymlinks dangling symlinks, $numReflexiveSymlinks reflexive symlinks and $numUnreadableSymlinks unreadable symlinks"
     exit 1
   fi
   return 0

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -69,6 +69,7 @@ let
       defaultNativeBuildInputs =
         extraNativeBuildInputs
         ++ [
+          ../../build-support/setup-hooks/no-broken-symlinks.sh
           ../../build-support/setup-hooks/audit-tmpdir.sh
           ../../build-support/setup-hooks/compress-man-pages.sh
           ../../build-support/setup-hooks/make-symlinks-relative.sh
@@ -77,7 +78,6 @@ let
           ../../build-support/setup-hooks/move-sbin.sh
           ../../build-support/setup-hooks/move-systemd-user-units.sh
           ../../build-support/setup-hooks/multiple-outputs.sh
-          ../../build-support/setup-hooks/no-broken-symlinks.sh
           ../../build-support/setup-hooks/patch-shebangs.sh
           ../../build-support/setup-hooks/prune-libtool-files.sh
           ../../build-support/setup-hooks/reproducible-builds.sh

--- a/pkgs/test/stdenv/hooks.nix
+++ b/pkgs/test/stdenv/hooks.nix
@@ -7,6 +7,7 @@
 # ordering should match defaultNativeBuildInputs
 
 {
+  no-broken-symlinks = import ./no-broken-symlinks.nix { inherit stdenv lib pkgs; };
   # TODO: add audit-tmpdir
   compress-man-pages =
     let
@@ -97,7 +98,6 @@
       [[ -e $out/bin/foo ]]
     '';
   };
-  no-broken-symlinks = import ./no-broken-symlinks.nix { inherit stdenv lib pkgs; };
   # TODO: add multiple-outputs
   patch-shebangs = import ./patch-shebangs.nix { inherit stdenv lib pkgs; };
   prune-libtool-files =

--- a/pkgs/test/stdenv/hooks.nix
+++ b/pkgs/test/stdenv/hooks.nix
@@ -7,7 +7,9 @@
 # ordering should match defaultNativeBuildInputs
 
 {
-  no-broken-symlinks = import ./no-broken-symlinks.nix { inherit stdenv lib pkgs; };
+  no-broken-symlinks = lib.recurseIntoAttrs (
+    import ./no-broken-symlinks.nix { inherit stdenv lib pkgs; }
+  );
   # TODO: add audit-tmpdir
   compress-man-pages =
     let

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -29,7 +29,10 @@ let
     )
     if readlink "$out/unreadable-symlink" >/dev/null 2>&1; then
       nixErrorLog "symlink permissions not supported"
-      ${optionalString failIfUnsupported "exit 1"}
+      ${optionalString failIfUnsupported
+        # Postpone the failure until after no-broken-symlinks.sh has a chance to print its messages
+        "postFixupHooks+=('exit 1')"
+      }
     fi
   '';
 

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -23,8 +23,10 @@ let
   # 'pass', to make sure the tests work properly for both kinds of platform.
   mkUnreadableSymlink = absolute: failIfUnsupported: ''
     touch "$out/unreadable-symlink-target"
-    ln -s${optionalString (!absolute) "r"} "$out/unreadable-symlink-target" "$out/unreadable-symlink"
-    chmod -h ugo-rwx "$out/unreadable-symlink"
+    (
+      umask 777
+      ln -s${optionalString (!absolute) "r"} "$out/unreadable-symlink-target" "$out/unreadable-symlink"
+    )
     if readlink "$out/unreadable-symlink" >/dev/null 2>&1; then
       nixErrorLog "symlink permissions not supported"
       ${optionalString failIfUnsupported "exit 1"}

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -19,9 +19,8 @@ let
 
   # Some platforms implement permissions for symlinks, while others - including Linux - ignore them.
   # As a result, testing this hook's handling of unreadable symlinks requires careful attention to
-  # which kind of platform we're on. See the comments by `meta.badPlatforms` below for details.
-  platformsWithSymlinkPermissions = with lib.platforms; darwin ++ freebsd ++ netbsd ++ openbsd;
-  platformsWithoutSymlinkPermissions = lib.subtractLists platformsWithSymlinkPermissions lib.platforms.all;
+  # which kind of platform we're on. See the comments by `lib.optionalAttrs` below for details.
+  hasSymlinkPermissions = with stdenv.hostPlatform; isDarwin || isBSD;
   mkUnreadableSymlink = absolute: ''
     touch "$out/unreadable-symlink-target"
     (
@@ -44,11 +43,10 @@ let
       name,
       commands ? [ ],
       derivationArgs ? { },
-      meta ? { },
     }:
     stdenv.mkDerivation (
       {
-        inherit name meta;
+        inherit name;
         strictDeps = true;
         dontUnpack = true;
         dontPatch = true;
@@ -145,60 +143,6 @@ in
     derivationArgs.dontCheckForBrokenSymlinks = true;
   };
 
-  fail-unreadable-symlink-relative =
-    runCommand "fail-unreadable-symlink-relative"
-      {
-        failed = testBuildFailure (testBuilder {
-          name = "fail-unreadable-symlink-relative-inner";
-          commands = [ (mkUnreadableSymlink false) ];
-        });
-
-        # Skip test if symlink permissions are not supported, since the hook won't have anything to report.
-        meta.badPlatforms = platformsWithoutSymlinkPermissions;
-      }
-      ''
-        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
-        grep -F 'found 0 dangling symlinks, 0 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"
-        touch $out
-      '';
-
-  pass-unreadable-symlink-relative-allowed = testBuilder {
-    name = "pass-unreadable-symlink-relative-allowed";
-    commands = [ (mkUnreadableSymlink false) ];
-    derivationArgs.dontCheckForBrokenSymlinks = true;
-
-    # This test will break on platforms that use symlink permissions, because even though this hook will be okay, later ones will error out.
-    # It should be safe to run on other platforms, just to make sure the hook isn't completely broken. It won't have anything to report, though.
-    meta.badPlatforms = platformsWithSymlinkPermissions;
-  };
-
-  fail-unreadable-symlink-absolute =
-    runCommand "fail-unreadable-symlink-absolute"
-      {
-        failed = testBuildFailure (testBuilder {
-          name = "fail-unreadable-symlink-absolute-inner";
-          commands = [ (mkUnreadableSymlink true) ];
-        });
-
-        # Skip test if symlink permissions are not supported, since the hook won't have anything to report.
-        meta.badPlatforms = platformsWithoutSymlinkPermissions;
-      }
-      ''
-        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
-        grep -F 'found 0 dangling symlinks, 0 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"
-        touch $out
-      '';
-
-  pass-unreadable-symlink-absolute-allowed = testBuilder {
-    name = "pass-unreadable-symlink-absolute-allowed";
-    commands = [ (mkUnreadableSymlink true) ];
-    derivationArgs.dontCheckForBrokenSymlinks = true;
-
-    # This test will break on platforms that use symlink permissions, because even though this hook will be okay, later ones will error out.
-    # It should be safe to run on other platforms, just to make sure the hook isn't completely broken. It won't have anything to report, though.
-    meta.badPlatforms = platformsWithSymlinkPermissions;
-  };
-
   # Leave the unreadable symlink out of the combined 'broken' test since it doesn't work on all platforms.
   fail-broken-symlinks-relative =
     runCommand "fail-broken-symlinks-relative"
@@ -254,81 +198,7 @@ in
 
   # The `all-broken` tests include unreadable symlinks along with the other kinds of broken links.
   # They should be run/skipped on the same sets platforms as the corresponding `unreadable` tests.
-  fail-all-broken-symlinks-relative =
-    runCommand "fail-all-broken-symlinks-relative"
-      {
-        failed = testBuildFailure (testBuilder {
-          name = "fail-all-broken-symlinks-relative-inner";
-          commands = [
-            (mkDanglingSymlink false)
-            (mkReflexiveSymlink false)
-            (mkUnreadableSymlink false)
-          ];
-        });
-
-        # Skip test if symlink permissions are not supported, since the hook won't have anything to report.
-        meta.badPlatforms = platformsWithoutSymlinkPermissions;
-      }
-      ''
-        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
-        if ! grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"; then
-          grep -F 'symlink permissions not supported' "$failed/testBuildFailure.log"
-          grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 0 unreadable symlinks' "$failed/testBuildFailure.log"
-        fi
-        touch $out
-      '';
-
-  pass-all-broken-symlinks-relative-allowed = testBuilder {
-    name = "pass-all-broken-symlinks-relative-allowed";
-    commands = [
-      (mkDanglingSymlink false)
-      (mkReflexiveSymlink false)
-      (mkUnreadableSymlink false)
-    ];
-    derivationArgs.dontCheckForBrokenSymlinks = true;
-
-    # This test will break on platforms that use symlink permissions, because even though this hook will be okay, later ones will error out.
-    # It should be safe to run on other platforms, just to make sure the hook isn't completely broken. It won't have anything to report, though.
-    meta.badPlatforms = platformsWithSymlinkPermissions;
-  };
-
-  fail-all-broken-symlinks-absolute =
-    runCommand "fail-all-broken-symlinks-absolute"
-      {
-        failed = testBuildFailure (testBuilder {
-          name = "fail-all-broken-symlinks-absolute-inner";
-          commands = [
-            (mkDanglingSymlink true)
-            (mkReflexiveSymlink true)
-            (mkUnreadableSymlink true)
-          ];
-        });
-
-        # Skip test if symlink permissions are not supported, since the hook won't have anything to report.
-        meta.badPlatforms = platformsWithoutSymlinkPermissions;
-      }
-      ''
-        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
-        if ! grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"; then
-          grep -F 'symlink permissions not supported' "$failed/testBuildFailure.log"
-          grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 0 unreadable symlinks' "$failed/testBuildFailure.log"
-        fi
-        touch $out
-      '';
-
-  pass-all-broken-symlinks-absolute-allowed = testBuilder {
-    name = "pass-all-broken-symlinks-absolute-allowed";
-    commands = [
-      (mkDanglingSymlink true)
-      (mkReflexiveSymlink true)
-      (mkUnreadableSymlink true)
-    ];
-    derivationArgs.dontCheckForBrokenSymlinks = true;
-
-    # This test will break on platforms that use symlink permissions, because even though this hook will be okay, later ones will error out.
-    # It should be safe to run on other platforms, just to make sure the hook isn't completely broken. It won't have anything to report, though.
-    meta.badPlatforms = platformsWithSymlinkPermissions;
-  };
+  # See below.
 
   pass-valid-symlink-relative = testBuilder {
     name = "pass-valid-symlink-relative";
@@ -348,5 +218,113 @@ in
   pass-valid-symlink-outside-nix-store-absolute = testBuilder {
     name = "pass-valid-symlink-outside-nix-store-absolute";
     commands = [ (mkValidSymlinkOutsideNixStore true) ];
+  };
+}
+# Skip these tests if symlink permissions are not supported, since the hook won't have anything to report.
+// lib.optionalAttrs hasSymlinkPermissions {
+  fail-unreadable-symlink-relative =
+    runCommand "fail-unreadable-symlink-relative"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-unreadable-symlink-relative-inner";
+          commands = [ (mkUnreadableSymlink false) ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        grep -F 'found 0 dangling symlinks, 0 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"
+        touch $out
+      '';
+
+  fail-unreadable-symlink-absolute =
+    runCommand "fail-unreadable-symlink-absolute"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-unreadable-symlink-absolute-inner";
+          commands = [ (mkUnreadableSymlink true) ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        grep -F 'found 0 dangling symlinks, 0 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"
+        touch $out
+      '';
+
+  fail-all-broken-symlinks-relative =
+    runCommand "fail-all-broken-symlinks-relative"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-all-broken-symlinks-relative-inner";
+          commands = [
+            (mkDanglingSymlink false)
+            (mkReflexiveSymlink false)
+            (mkUnreadableSymlink false)
+          ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        if ! grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"; then
+          grep -F 'symlink permissions not supported' "$failed/testBuildFailure.log"
+          grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 0 unreadable symlinks' "$failed/testBuildFailure.log"
+        fi
+        touch $out
+      '';
+
+  fail-all-broken-symlinks-absolute =
+    runCommand "fail-all-broken-symlinks-absolute"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-all-broken-symlinks-absolute-inner";
+          commands = [
+            (mkDanglingSymlink true)
+            (mkReflexiveSymlink true)
+            (mkUnreadableSymlink true)
+          ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        if ! grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 1 unreadable symlinks' "$failed/testBuildFailure.log"; then
+          grep -F 'symlink permissions not supported' "$failed/testBuildFailure.log"
+          grep -F 'found 1 dangling symlinks, 1 reflexive symlinks and 0 unreadable symlinks' "$failed/testBuildFailure.log"
+        fi
+        touch $out
+      '';
+
+}
+# These tests will break on platforms that do use symlink permissions, because even though this hook will be okay, later ones will error out.
+# They should be safe to run on other platforms, just to make sure the hook isn't completely broken. It won't have anything to report, though.
+// lib.optionalAttrs (!hasSymlinkPermissions) {
+  pass-unreadable-symlink-relative-allowed = testBuilder {
+    name = "pass-unreadable-symlink-relative-allowed";
+    commands = [ (mkUnreadableSymlink false) ];
+    derivationArgs.dontCheckForBrokenSymlinks = true;
+  };
+
+  pass-unreadable-symlink-absolute-allowed = testBuilder {
+    name = "pass-unreadable-symlink-absolute-allowed";
+    commands = [ (mkUnreadableSymlink true) ];
+    derivationArgs.dontCheckForBrokenSymlinks = true;
+  };
+
+  pass-all-broken-symlinks-relative-allowed = testBuilder {
+    name = "pass-all-broken-symlinks-relative-allowed";
+    commands = [
+      (mkDanglingSymlink false)
+      (mkReflexiveSymlink false)
+      (mkUnreadableSymlink false)
+    ];
+    derivationArgs.dontCheckForBrokenSymlinks = true;
+  };
+
+  pass-all-broken-symlinks-absolute-allowed = testBuilder {
+    name = "pass-all-broken-symlinks-absolute-allowed";
+    commands = [
+      (mkDanglingSymlink true)
+      (mkReflexiveSymlink true)
+      (mkUnreadableSymlink true)
+    ];
+    derivationArgs.dontCheckForBrokenSymlinks = true;
   };
 }


### PR DESCRIPTION
Resolves #380681.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
