### PR TITLE
owntone: init at 28.11

### DIFF
--- a/pkgs/by-name/ow/owntone/package.nix
+++ b/pkgs/by-name/ow/owntone/package.nix
@@ -1,0 +1,101 @@
+{
+  config,
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  autoreconfHook,
+  fetchFromGitHub,
+  nix-update-script,
+
+  chromecastSupport ? config.chromecast or stdenv.hostPlatform.isLinux,
+  pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+
+  avahi,
+  curl,
+  bison,
+  ffmpeg,
+  flex,
+  gettext,
+  gnutls,
+  gperf,
+  json_c,
+  libconfuse,
+  libevent,
+  libgcrypt,
+  libgpg-error,
+  libplist,
+  libpulseaudio,
+  libsodium,
+  libtool,
+  libunistring,
+  libwebsockets,
+  libxml2,
+  pkg-config,
+  protobufc,
+  sqlite,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "28.11";
+  pname = "owntone";
+
+  src = fetchFromGitHub {
+    owner = "owntone";
+    repo = "owntone-server";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-lUelBZy7kAJ9tkvVbmxfXHiANJvhrnQydZkWiuoYTNU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    autoreconfHook
+    bison
+    flex
+    libtool
+    gperf
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      avahi
+      curl
+      ffmpeg
+      gettext
+      json_c
+      libconfuse
+      libevent
+      libgcrypt
+      libgpg-error
+      libplist
+      libsodium
+      libunistring
+      libwebsockets
+      libxml2
+      protobufc
+      sqlite
+      zlib
+    ]
+    ++ lib.optionals chromecastSupport [ gnutls ]
+    ++ lib.optionals pulseSupport [ libpulseaudio ];
+
+  configureFlags =
+    lib.optionals chromecastSupport [ "--enable-chromecast" ]
+    ++ lib.optionals pulseSupport [ "--with-pulseaudio" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Media server to stream audio to AirPlay and Chromecast receivers";
+    homepage = "https://github.com/owntone/owntone-server";
+    downloadPage = "https://github.com/owntone/owntone-server/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/owntone/owntone-server/releases/tag/${finalAttrs.version}";
+    mainProgram = "owntone";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      hensoko
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add Owntone Server to the package index.

https://github.com/owntone/owntone-server

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
