### PR TITLE
truecrack: fix build on gcc-14

### DIFF
--- a/pkgs/by-name/tr/truecrack/fix-empty-return.patch
+++ b/pkgs/by-name/tr/truecrack/fix-empty-return.patch
@@ -1,0 +1,11 @@
+--- a/src/Common/CpuCore.c
++++ b/src/Common/CpuCore.c
+@@ -96,7 +96,7 @@
+ 		derive_key_whirlpool (  word, wordlength+1, salt, PKCS5_SALT_SIZE, 1000, headerKey, cpu_GetMaxPkcs5OutSize ());
+ 	else{
+ 		perror("Key derivation function not supported");
+-		return;
++		return 0;
+ 	}
+ 
+ 	value=cpu_Xts(encryptionAlgorithm,encryptedHeader,headerKey,cpu_GetMaxPkcs5OutSize(), masterKey, &length);

--- a/pkgs/by-name/tr/truecrack/package.nix
+++ b/pkgs/by-name/tr/truecrack/package.nix
@@ -6,6 +6,7 @@
   config,
   cudaSupport ? config.cudaSupport,
   pkg-config,
+  versionCheckHook,
 }:
 
 gccStdenv.mkDerivation rec {
@@ -15,9 +16,13 @@ gccStdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "kalilinux";
     repo = "packages/truecrack";
-    rev = "debian/${version}+git20150326-0kali1";
-    sha256 = "+Rw9SfaQtO1AJO6UVVDMCo8DT0dYEbv7zX8SI+pHCRQ=";
+    tag = "kali/${version}+git20150326-0kali4";
+    hash = "sha256-d6ld6KHSqYM4RymHf5qcm2AWK6FHWC0rFaLRfIQ2m5Q=";
   };
+
+  patches = [
+    ./fix-empty-return.patch
+  ];
 
   configureFlags = (
     if cudaSupport then
@@ -38,24 +43,54 @@ gccStdenv.mkDerivation rec {
     cudatoolkit
   ];
 
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: CpuAes.o:/build/source/src/Crypto/CpuAes.h:1233: multiple definition of
-  #     `t_rc'; CpuCore.o:/build/source/src/Crypto/CpuAes.h:1237: first defined here
-  # TODO: remove on upstream fixes it:
-  #   https://gitlab.com/kalilinux/packages/truecrack/-/issues/1
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env.NIX_CFLAGS_COMPILE = toString ([
+    # Workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: CpuAes.o:/build/source/src/Crypto/CpuAes.h:1233: multiple definition of
+    #     `t_rc'; CpuCore.o:/build/source/src/Crypto/CpuAes.h:1237: first defined here
+    # TODO: remove on upstream fixes it:
+    #   https://gitlab.com/kalilinux/packages/truecrack/-/issues/1
+    "-fcommon"
+    # Function are declared after they are used in the file, this is error since gcc-14.
+    #   Common/Crypto.c:42:13: error: implicit declaration of function 'cpu_CipherInit'; did you mean 'CipherInit'? []
+    # https://gitlab.com/kalilinux/packages/truecrack/-/commit/5b0e3a96b747013bded7b33f65bb42be2dbafc86
+    "-Wno-error=implicit-function-declaration"
+  ]);
 
-  installFlags = [ "prefix=$(out)" ];
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  installFlags = [ "prefix=$(out)" ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    echo "Cracking test volumes"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_aes.test.tc -c test/tes -m 4 | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/whirlpool_aes.test.tc -w test/passwords.txt -k whirlpool | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/sha512_aes.test.tc -w test/passwords.txt -k sha512 | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_aes.test.tc -w test/passwords.txt | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_serpent.test.tc -w test/passwords.txt -e serpent | grep -aF "Found password"
+    $out/bin/${meta.mainProgram} -t test/ripemd160_twofish.test.tc -w test/passwords.txt -e twofish | grep -aF "Found password"
+    echo "Finished cracking test volumes"
+
+    runHook postInstallCheck
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  meta = {
     description = "Brute-force password cracker for TrueCrypt volumes, optimized for Nvidia Cuda technology";
     mainProgram = "truecrack";
     homepage = "https://gitlab.com/kalilinux/packages/truecrack";
     broken = cudaSupport;
-    license = licenses.gpl3Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ethancedwards8 ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
   };
 }


### PR DESCRIPTION
Truecrack is unmaintained upstream, but [Kali Linux](https://gitlab.com/kalilinux/packages/truecrack/) publishes patches to keep it building.

In this PR:

- Update Kali patches to `0kali4`
- Fix build error reporting `return;` where `int` is expected
- Add version check
- Add install check using the test files which are present in the upstream repo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
