### PR TITLE
tsm-client: fix symlink fixup

### DIFF
--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -131,22 +131,11 @@ let
       runHook postInstall
     '';
 
-    # fix relative symlinks after `/usr` was moved up one level,
-    # fix absolute symlinks pointing to `/opt`
+    # fix symlinks pointing to `..../opt/....`
     preFixup = ''
-      for link in $out/lib{,64}/* $out/bin/*
+      for link in $(find $out -type l -lname '*../opt*')
       do
-        target=$(readlink "$link")
-        if [ "$(cut -b -6 <<< "$target")" != "../../" ]
-        then
-          echo "cannot fix this symlink: $link -> $target"
-          exit 1
-        fi
-        ln --symbolic --force --no-target-directory "$out/$(cut -b 7- <<< "$target")" "$link"
-      done
-      for link in $(find $out -type l -lname '/opt/*')
-      do
-        ln --symbolic --force --no-target-directory "$out$(readlink "$link")" "$link"
+        ln --symbolic --force --no-target-directory "$(readlink "$link" | sed 's|../opt|opt|')" "$link"
       done
     '';
   });


### PR DESCRIPTION
The new setup hook [`no-broken-symlinks`](https://github.com/NixOS/nixpkgs/pull/370750) uncovered some dangling symlinks in `tsm-client`.  The pull request at hand updates the symlink fixup code: It removes the fixup code for absolute `/usr/....` symlinks (such symlinks apparently vanished from `tsm-client` long ago) and fixes the fixup code for relative `..../opt/....` symlinks so it correctly changes all such symlinks.

Comparing the old package with the new one shows that dangling symlinks got fixed while no other symlinks are affected by this pull request.  The new setup hook is also satisfied with the result.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] Both test derivations (cli and gui) build/pass.
- [x] Successfully tested with a real tsm server: uploaded some files for backup without errors/problems.

`nixpkgs-review` tries to rebuild 2820 packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
