### PR TITLE
electrum: add patch for aiorpcx 0.24 compatibility

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -108,10 +108,8 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace $out/share/applications/electrum.desktop \
-      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum %u"' \
-                "Exec=$out/bin/electrum %u" \
-      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum --testnet %u"' \
-                "Exec=$out/bin/electrum --testnet %u"
+      --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u" \
+      --replace "Exec=electrum --testnet %u" "Exec=$out/bin/electrum --testnet %u"
   '';
 
   postFixup = lib.optionalString enableQt ''

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -85,6 +85,17 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch =
     ''
+      # fix compatibility with recent aiorpcx version
+      # (remove as soon as https://github.com/spesmilo/electrum/commit/171aa5ee5ad4e25b9da10f757d9d398e905b4945 is included in source tarball)
+      substituteInPlace ./contrib/requirements/requirements.txt \
+        --replace-fail "aiorpcx>=0.22.0,<0.24" "aiorpcx>=0.22.0,<0.25"
+      substituteInPlace ./run_electrum \
+        --replace-fail "if not ((0, 22, 0) <= aiorpcx._version < (0, 24)):" "if not ((0, 22, 0) <= aiorpcx._version < (0, 25)):" \
+        --replace-fail "aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.24" "aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.25"
+      substituteInPlace ./electrum/electrum \
+        --replace-fail "if not ((0, 22, 0) <= aiorpcx._version < (0, 24)):" "if not ((0, 22, 0) <= aiorpcx._version < (0, 25)):" \
+        --replace-fail "aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.24" "aiorpcX version {aiorpcx._version} does not match required: 0.22.0<=ver<0.25"
+
       # make compatible with protobuf4 by easing dependencies ...
       substituteInPlace ./contrib/requirements/requirements.txt \
         --replace-fail "protobuf>=3.20,<4" "protobuf>=3.20"

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -87,18 +87,18 @@ python3.pkgs.buildPythonApplication rec {
     ''
       # make compatible with protobuf4 by easing dependencies ...
       substituteInPlace ./contrib/requirements/requirements.txt \
-        --replace "protobuf>=3.20,<4" "protobuf>=3.20"
+        --replace-fail "protobuf>=3.20,<4" "protobuf>=3.20"
       # ... and regenerating the paymentrequest_pb2.py file
       protoc --python_out=. electrum/paymentrequest.proto
 
       substituteInPlace ./electrum/ecc_fast.py \
-        --replace ${libsecp256k1_name} ${secp256k1}/lib/libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}
+        --replace-fail ${libsecp256k1_name} ${secp256k1}/lib/libsecp256k1${stdenv.hostPlatform.extensions.sharedLibrary}
     ''
     + (
       if enableQt then
         ''
           substituteInPlace ./electrum/qrscanner.py \
-            --replace ${libzbar_name} ${zbar.lib}/lib/libzbar${stdenv.hostPlatform.extensions.sharedLibrary}
+            --replace-fail ${libzbar_name} ${zbar.lib}/lib/libzbar${stdenv.hostPlatform.extensions.sharedLibrary}
         ''
       else
         ''
@@ -108,8 +108,8 @@ python3.pkgs.buildPythonApplication rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace $out/share/applications/electrum.desktop \
-      --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u" \
-      --replace "Exec=electrum --testnet %u" "Exec=$out/bin/electrum --testnet %u"
+      --replace-fail "Exec=electrum %u" "Exec=$out/bin/electrum %u" \
+      --replace-fail "Exec=electrum --testnet %u" "Exec=$out/bin/electrum --testnet %u"
   '';
 
   postFixup = lib.optionalString enableQt ''


### PR DESCRIPTION
`electrum` build [broke](https://hydra.nixos.org/build/287723280) due to the `aiorpcx` update in https://github.com/NixOS/nixpkgs/commit/4bbf5300d44ee9420a59650ba668f70e3f101bde via https://github.com/NixOS/nixpkgs/pull/375144 .

Upstream already has [a patch](https://github.com/spesmilo/electrum/commit/171aa5ee5ad4e25b9da10f757d9d398e905b4945), however, it&#39;s not so easy to apply:

*   the patch patches the file `/run_electrum` in the source repo
*   in the source repo, there is a symlink `/electrum/electrum` pointing to `../run_electrum`, i.e., to the file that is patched
*   in the source distribution tarball used by nixpkgs, `/electrum/electrum` is a simple copy of `/run_electrum` (probably the result of whatever process generates the tarball)
*   the file `/electrum/electrum` is used as executable in the package output
*   besides, the patch also attempts to patch the file `requirements.txt`, but fails with conflicts

Hence, although the patch will likely fix the next electrum release, just applying it to our source does not fix the issue.  To work around that, this pull request ~~also adds a copy command to the `postFixup` section to copy the patched `/run_electrum` over the unpatched `/electrum/electrum`.  This is also explained in a comment near the `fetchpatch` line, so whoever removes the patch when it is no longer needed is also reminded of removing the copy command below.~~ applies the changes from the patch file "by hand", with `substituteInPlace`.  Additionally, it converts existing `substituteInPlace` invocations to `--replace-fail` and drop two unneeded replacements (see the commits for details).

Note: https://github.com/NixOS/nixpkgs/pull/309576 also adds a (also temporary) patch for `aiorpcx` compatibility and experienced the same problem described above, ~~and employed the same solution~~.

Notifying maintainers: @joachifm @np @prusnak @chewblacka

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More: Tested few `electrum` functionality

- [x] `electrum` starts
- [x] `electrum` lists known transaction
- [x] `electrum` lists known addresses
- [x] "Electrum" shows up in the Xfce start menu, which starts `electrum` as expected

`nixpkgs-review` tries to rebuild 2820 packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
