### PR TITLE
anarch: init at 1.0-unstable-2023-09-08

### DIFF
--- a/pkgs/by-name/an/anarch/package.nix
+++ b/pkgs/by-name/an/anarch/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  SDL2,
+  xorg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "anarch";
+  version = "1.0-unstable-2023-09-08";
+
+  src = fetchFromGitLab {
+    owner = "drummyfish";
+    repo = "anarch";
+    rev = "6f90562161200682459e772f1dacb747f23c5f95";
+    hash = "sha256-KmuJruzQRFunhwUGz3bHhXgtD2m4+5Vk0n7xhzVBMWs=";
+  };
+
+  buildInputs = [
+    SDL2
+    xorg.libXcursor
+    xorg.libXrandr
+    xorg.libXfixes
+    xorg.libXext
+    xorg.libXi
+    xorg.libXScrnSaver
+  ];
+
+  # upstream is an error-prone make/build script
+  buildPhase = ''
+    runHook preBuild
+
+    $CC -O3 -o anarch main_sdl.c $(sdl2-config --cflags --libs)
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 anarch $out/bin/anarch
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://drummyfish.gitlab.io/anarch/";
+    description = "Suckless FPS game";
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    license = lib.licenses.cc0;
+    platforms = lib.platforms.unix;
+    mainProgram = "anarch";
+  };
+})


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/380688

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
