### PR TITLE
Bwa-mem2: fix compilation issue

### DIFF
--- a/pkgs/by-name/bw/bwa-mem2/no-submodule.patch
+++ b/pkgs/by-name/bw/bwa-mem2/no-submodule.patch
@@ -1,0 +1,42 @@
+diff --git a/Makefile b/Makefile
+index 359585f..13ec279 100644
+--- a/Makefile
++++ b/Makefile
+@@ -49,7 +49,6 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/memcpy_bwamem.o src/kthread.
+ 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/kswv.o src/bwa.o \
+ 			src/bwamem_extra.o src/kopen.o
+ BWA_LIB=    libbwa.a
+-SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
+ 
+ ifeq ($(arch),sse41)
+ 	ifeq ($(CXX), icpc)
+@@ -101,16 +100,6 @@ CXXFLAGS+=	-g -O3 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
+ all:$(EXE)
+ 
+ multi:
+-	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+-	$(MAKE) arch=sse41    EXE=bwa-mem2.sse41    CXX=$(CXX) all
+-	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+-	$(MAKE) arch=sse42    EXE=bwa-mem2.sse42    CXX=$(CXX) all
+-	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+-	$(MAKE) arch=avx    EXE=bwa-mem2.avx    CXX=$(CXX) all
+-	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+-	$(MAKE) arch=avx2   EXE=bwa-mem2.avx2     CXX=$(CXX) all
+-	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+-	$(MAKE) arch=avx512 EXE=bwa-mem2.avx512bw CXX=$(CXX) all
+ 	$(CXX) -Wall -O3 src/runsimd.cpp -Iext/safestringlib/include -Lext/safestringlib/ -lsafestring $(STATIC_GCC) -o bwa-mem2
+ 
+ 
+@@ -120,12 +109,8 @@ $(EXE):$(BWA_LIB) $(SAFE_STR_LIB) src/main.o
+ $(BWA_LIB):$(OBJS)
+ 	ar rcs $(BWA_LIB) $(OBJS)
+ 
+-$(SAFE_STR_LIB):
+-	cd ext/safestringlib/ && $(MAKE) clean && $(MAKE) CC=$(CC) directories libsafestring.a
+-
+ clean:
+ 	rm -fr src/*.o $(BWA_LIB) $(EXE) bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw
+-	cd ext/safestringlib/ && $(MAKE) clean
+ 
+ depend:
+ 	(LC_ALL=C; export LC_ALL; makedepend -Y -- $(CXXFLAGS) $(CPPFLAGS) -I. -- src/*.cpp)

--- a/pkgs/by-name/bw/bwa-mem2/package.nix
+++ b/pkgs/by-name/bw/bwa-mem2/package.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/bwa-mem2/bwa-mem2/";
     changelog = "https://github.com/bwa-mem2/bwa-mem2/blob/${finalAttrs.src.rev}/NEWS.md";
     platforms = platforms.x86_64;
-    maintainers = with maintainers; [ alxsimon ];
+    maintainers = with maintainers; [ apraga ];
   };
 })

--- a/pkgs/by-name/bw/bwa-mem2/package.nix
+++ b/pkgs/by-name/bw/bwa-mem2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  safestringlib,
   zlib,
 }:
 
@@ -13,20 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "bwa-mem2";
     repo = "bwa-mem2";
     rev = "cf4306a47dac35e7e79a9e75398a35f33900cfd0";
-    fetchSubmodules = true;
-    hash = "sha256-1AYSn7nBrDwbX7oSrdEoa1d3t6xzwKnA0S87Y/XeXJg=";
+    hash = "sha256-hY8nLRFWt0GAElhDIcYdUX6cJrzOE3NlYRQr0tC3on4=";
   };
 
   buildInputs = [ zlib ];
-
-  # see https://github.com/bwa-mem2/bwa-mem2/issues/93
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    sed -i 's/memset_s/memset8_s/g' ext/safestringlib/include/safe_mem_lib.h
-    sed -i 's/memset_s/memset8_s/g' ext/safestringlib/safeclib/memset16_s.c
-    sed -i 's/memset_s/memset8_s/g' ext/safestringlib/safeclib/memset32_s.c
-    sed -i 's/memset_s/memset8_s/g' ext/safestringlib/safeclib/memset_s.c
-    sed -i 's/memset_s/memset8_s/g' ext/safestringlib/safeclib/wmemset_s.c
-  '';
 
   buildFlags = [
     (
@@ -43,14 +34,45 @@ stdenv.mkDerivation (finalAttrs: {
     )
   ];
 
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_CFLAGS_COMPILE = toString [
+  patches = [
+    ./no-submodule.patch
+  ];
+
+  # Also, patch the tests
+  postPatch =
+    # Force path to static link, otherwise, it fails at runtime to
+    # find the shared library
+    ''
+      substituteInPlace Makefile \
+        --replace-fail "-Iext/safestringlib/include" "-I${safestringlib}/include" \
+        --replace-fail "-Lext/safestringlib" "-L${safestringlib}/lib"
+    ''
+    # Make test compile by changing the compiler and path to library
+    # Remove xeonbsw test that fails to compile due to missing _rdsc
+    # also, not portable
+    + ''
+      substituteInPlace test/Makefile \
+        --replace-fail "icpc" "g++" \
+        --replace-fail "../ext/safestringlib/libsafestring.a"  \
+                       "${safestringlib}/lib/libsafestring.a" \
+        --replace-fail \
+          "fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw" \
+          "fmi_test smem2_test bwt_seed_strategy_test sa2ref_test"
+    '';
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.hostPlatform.isDarwin [
       "-Wno-error=register"
       "-Wno-error=implicit-function-declaration"
-    ];
-  };
+    ]
+  );
+
+  nativeBuildInputs = [
+    safestringlib
+  ];
 
   enableParallelBuilding = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/sa/safestringlib/package.nix
+++ b/pkgs/by-name/sa/safestringlib/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  fetchpatch,
+}:
+
+stdenv.mkDerivation {
+  pname = "safestringlib";
+  # Latest release is 1.2.0 and has compilation issues
+  version = "1.2.0-unstable-2024-10-21";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "safestringlib";
+    rev = "e99c03cfafdce5311c4dbf1fd3f916ccc6e300be";
+    hash = "sha256-d+6YDtMtdaS2eW0eIfuwzdQRiExsoexL3fKj7C2zENM=";
+  };
+
+  outputs = [
+    "out"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_UNITTESTS" true)
+  ];
+
+  patches = [
+    # https://github.com/intel/safestringlib/issues/74
+    (fetchpatch {
+      name = "darwin-fix";
+      url = "https://github.com/intel/safestringlib/pull/75/commits/3ff9c6234be7dd4ee1dd5cdc2ccbb2c7541adfec.patch";
+      hash = "sha256-4HS7XyKPQSmKczaMCi1s6NxgTNzRZXTds2CXBTbpuAM=";
+    })
+  ];
+
+  # see https://github.com/bwa-mem2/bwa-mem2/issues/93
+  # Skip wmemset too
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    sed -i 's/memset_s/memset8_s/g' include/safe_mem_lib.h
+    sed -i 's/memset_s/memset8_s/g' safeclib/memset16_s.c
+    sed -i 's/memset_s/memset8_s/g' safeclib/memset32_s.c
+    sed -i 's/memset_s/memset8_s/g' safeclib/memset_s.c
+    sed -i 's/memset_s/memset8_s/g' safeclib/wmemset_s.c
+    sed -i 's/ memset_s/ memset8_s/g' unittests/*.c
+    sed -i 's/ wmemset_s/ wmemset8_s/g' unittests/*.c
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    cd unittests
+    ./safestring_test
+    runHook postCheck
+  '';
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp ../libsafestring_static.a $out/lib/libsafestring.a
+    mkdir -p $out/
+    cp -r ../../include  $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/intel/safestringlib";
+    description = "Safer replacements for C library functions that prevent serious security vulnerabilities";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ apraga ];
+  };
+}


### PR DESCRIPTION
 On latest unstable, there are several implicit function declarations in safestrlib, which are new errors instead of warnings.
safestrlib was not a seperate package but simply a submodule in this nix packages.

I have separated it into a library and updated it to latest unstable, which essentially fixes the issue.

Also, there are no tests upstream (the `test` folder is for benchmarking).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
