### PR TITLE
selenium-manager: disable telemetry

### DIFF
--- a/pkgs/by-name/se/selenium-manager/disable-telemetry.patch
+++ b/pkgs/by-name/se/selenium-manager/disable-telemetry.patch
@@ -1,0 +1,13 @@
+diff --git a/rust/src/config.rs b/rust/src/config.rs
+index f7cd4f32ec..ec454127be 100644
+--- a/rust/src/config.rs
++++ b/rust/src/config.rs
+@@ -120,7 +120,7 @@ impl ManagerConfig {
+             avoid_browser_download: BooleanKey("avoid-browser-download", false).get_value(),
+             language_binding: StringKey(vec!["language-binding"], "").get_value(),
+             selenium_version: StringKey(vec!["selenium-version"], "").get_value(),
+-            avoid_stats: BooleanKey("avoid-stats", false).get_value(),
++            avoid_stats: BooleanKey("avoid-stats", true).get_value(),
+             skip_driver_in_path: BooleanKey("skip-driver-in-path", false).get_value(),
+             skip_browser_in_path: BooleanKey("skip-browser-in-path", false).get_value(),
+         }

--- a/pkgs/by-name/se/selenium-manager/package.nix
+++ b/pkgs/by-name/se/selenium-manager/package.nix
@@ -16,7 +16,13 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-b5xwuZ4lcwLbGhJuEmHYrFXoaTW/M0ABdK3dvbpj8oM=";
   };
 
-  sourceRoot = "${src.name}/rust";
+  patches = [
+    ./disable-telemetry.patch
+  ];
+
+  postPatch = ''
+    cd rust
+  '';
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-hXtF3qFzzM2TqpEP9JWdi7uU5TgFHF9lZO5bmZcEuDk=";


### PR DESCRIPTION
Gentoo does the same: https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-util/selenium-manager/selenium-manager-4.28.0.ebuild#n63
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
