### PR TITLE
python313Packages.paho-mqtt: 1.6.1 -> 2.1.0

### DIFF
--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -26,7 +26,6 @@ let
   python = python312.override {
     self = python;
     packageOverrides = self: super: {
-      paho-mqtt = super.paho-mqtt_2;
     };
   };
 

--- a/pkgs/by-name/ha/ha-mqtt-discoverable-cli/package.nix
+++ b/pkgs/by-name/ha/ha-mqtt-discoverable-cli/package.nix
@@ -4,7 +4,16 @@
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  python = python3.override {
+    self = python;
+    packageOverrides = self: super: {
+      # https://github.com/unixorn/ha-mqtt-discoverable/pull/310
+      paho-mqtt = self.paho-mqtt_1;
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
   pname = "ha-mqtt-discoverable-cli";
   version = "0.16.4.1";
   pyproject = true;
@@ -18,9 +27,9 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [ "ha-mqtt-discoverable" ];
 
-  build-system = with python3.pkgs; [ poetry-core ];
+  build-system = with python.pkgs; [ poetry-core ];
 
-  dependencies = with python3.pkgs; [ ha-mqtt-discoverable ];
+  dependencies = with python.pkgs; [ ha-mqtt-discoverable ];
 
   # Project has no real tests
   doCheck = false;

--- a/pkgs/by-name/mq/mqtt-exporter/package.nix
+++ b/pkgs/by-name/mq/mqtt-exporter/package.nix
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
   build-system = with python3.pkgs; [ setuptools ];
 
   dependencies = with python3.pkgs; [
-    paho-mqtt_2
+    paho-mqtt
     prometheus-client
   ];
 

--- a/pkgs/development/python-modules/amshan/default.nix
+++ b/pkgs/development/python-modules/amshan/default.nix
@@ -37,6 +37,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "han" ];
 
+  # 2021.12.1 is an older version
+  passthru.skipBulkUpdate = true;
+
   meta = {
     description = "Decode smart power meter data stream of Cosem HDLC frames used by MBUS";
     longDescription = ''

--- a/pkgs/development/python-modules/amshan/default.nix
+++ b/pkgs/development/python-modules/amshan/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "amshan";
-  version = "2021.12.1";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "toreamun";
     repo = "amshan";
-    tag = version;
-    hash = "sha256-eL8YzQB6Vj4l3cYFgWve88vLojvcxMtr2xvTUKT+Ekk=";
+    rev = version;
+    hash = "sha256-aw0wTqb2s84STVUN55h6L926pXwaMSppBCfXZVb87w0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/azure-iot-device/default.nix
+++ b/pkgs/development/python-modules/azure-iot-device/default.nix
@@ -50,6 +50,8 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    # https://github.com/Azure/azure-iot-sdk-python/issues/1196
+    broken = lib.versionAtLeast paho-mqtt.version "2";
     description = "Microsoft Azure IoT Device Library for Python";
     homepage = "https://github.com/Azure/azure-iot-sdk-python";
     license = licenses.mit;

--- a/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
+++ b/pkgs/development/python-modules/ha-mqtt-discoverable/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ha_mqtt_discoverable" ];
 
   meta = with lib; {
+    # https://github.com/unixorn/ha-mqtt-discoverable/pull/310
+    broken = lib.versionAtLeast paho-mqtt.version "2";
     description = "Python module to create MQTT entities that are automatically discovered by Home Assistant";
     homepage = "https://github.com/unixorn/ha-mqtt-discoverable";
     changelog = "https://github.com/unixorn/ha-mqtt-discoverable/releases/tag/v${version}";

--- a/pkgs/development/python-modules/meross-iot/default.nix
+++ b/pkgs/development/python-modules/meross-iot/default.nix
@@ -41,6 +41,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "meross_iot" ];
 
   meta = with lib; {
+    # https://github.com/albertogeniola/MerossIot/pull/413
+    broken = lib.versionAtLeast paho-mqtt.version "2";
     description = "Python library to interact with Meross devices";
     homepage = "https://github.com/albertogeniola/MerossIot";
     changelog = "https://github.com/albertogeniola/MerossIot/releases/tag/${version}";

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  paho-mqtt_2,
+  paho-mqtt,
   pytest-cov-stub,
   pytestCheckHook,
   python-dateutil,
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    paho-mqtt_2
+    paho-mqtt
     python-dateutil
     weconnect
   ] ++ weconnect.optional-dependencies.Images;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10040,7 +10040,7 @@ self: super: with self; {
 
   paho-mqtt_1 = callPackage ../development/python-modules/paho-mqtt/1.nix { };
   paho-mqtt_2 = callPackage ../development/python-modules/paho-mqtt/default.nix { };
-  paho-mqtt = paho-mqtt_1;
+  paho-mqtt = paho-mqtt_2;
 
   paintcompiler = callPackage ../development/python-modules/paintcompiler { };
 


### PR DESCRIPTION
We're following Home Assistant's example: https://github.com/home-assistant/core/pull/136130
This breaks the following top-level attributes.

- [ ] `azure-cli-extensions.azure-iot` https://github.com/Azure/azure-iot-sdk-python/issues/1196 @Mikutut
      (I think azure-cli-extensions should reuse the Python override from azure-cli.)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
