### PR TITLE
haskellPackages.miso-examples: build with js backend

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -24,6 +24,10 @@ with haskellLib;
   ghcjs-dom-javascript = addBuildDepend self.ghcjs-base super.ghcjs-dom-javascript;
   jsaddle = addBuildDepend self.ghcjs-base super.jsaddle;
   jsaddle-dom = addBuildDepend self.ghcjs-base super.jsaddle-dom;
+  jsaddle-warp = overrideCabal (drv: {
+    libraryHaskellDepends = [ ];
+    testHaskellDepends = [ ];
+  }) super.jsaddle-warp;
 
   entropy = addBuildDepend self.ghcjs-dom super.entropy;
 

--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -41,4 +41,17 @@ with haskellLib;
       (drv: {
         jsaddle-webkit2gtk = null;
       });
+
+  miso-examples = pkgs.lib.pipe super.miso-examples [
+    (addBuildDepends (
+      with self;
+      [
+        aeson
+        ghcjs-base
+        jsaddle-warp
+        miso
+        servant
+      ]
+    ))
+  ];
 })

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3661,8 +3661,6 @@ broken-packages:
   - MIP # failure in job https://hydra.nixos.org/build/233199688 at 2023-09-02
   - mirror-tweet # failure in job https://hydra.nixos.org/build/233216951 at 2023-09-02
   - mismi-p # failure in job https://hydra.nixos.org/build/233257227 at 2023-09-02
-  - miso-action-logger # failure in job https://hydra.nixos.org/build/233229061 at 2023-09-02
-  - miso-examples # failure in job https://hydra.nixos.org/build/233237380 at 2023-09-02
   - mit-3qvpPyAi6mH # failure in job https://hydra.nixos.org/build/233229967 at 2023-09-02
   - mix-arrows # failure in job https://hydra.nixos.org/build/233257720 at 2023-09-02
   - mixpanel-client # failure in job https://hydra.nixos.org/build/233220132 at 2023-09-02


### PR DESCRIPTION
```
$ nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.miso-action-logger
/nix/store/q085a26dp38kzjy0q2pyghgzfblnv1rc-miso-action-logger-0.1.0.1
$ nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.miso-examples
/nix/store/2r9dqw1phig9m8ldk1rvfk21wi6a05nf-miso-examples-1.8.7.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
