### PR TITLE
python3Packages.aria2p: Change python3Packages.appdirs to python3Packages.platformdirs in dependencies

### DIFF
--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -4,8 +4,8 @@
   fetchFromGitHub,
   pythonOlder,
   pdm-backend,
-  appdirs,
   loguru,
+  platformdirs,
   requests,
   setuptools,
   toml,
@@ -37,8 +37,8 @@ buildPythonPackage rec {
   build-system = [ pdm-backend ];
 
   dependencies = [
-    appdirs
     loguru
+    platformdirs
     requests
     setuptools # for pkg_resources
     toml

--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -34,9 +34,9 @@ buildPythonPackage rec {
     hash = "sha256-JEXTCDfFjxI1hooiEQq0KIGGoS2F7fyzOM0GMl+Jr7w=";
   };
 
-  nativeBuildInputs = [ pdm-backend ];
+  build-system = [ pdm-backend ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     appdirs
     loguru
     requests


### PR DESCRIPTION
nixpkgs commit 5f91e2ea808e5fb2757d1ddb677a4c2c75d367a0 updated aria2p from 0.12.0 to 0.12.1, breaking the build. The changelog for 0.12.1 (https://github.com/pawamoy/aria2p/blob/0.12.1/CHANGELOG.md) shows upstream changed from the appdirs package to platformdirs, but this change wasn't made in the above nixpkgs commit.

@k0ral 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
