### PR TITLE
kora-icon-theme: 1.6.2 -> 1.6.3

### DIFF
--- a/pkgs/data/icons/kora-icon-theme/default.nix
+++ b/pkgs/data/icons/kora-icon-theme/default.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation rec  {
   pname = "kora-icon-theme";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchFromGitHub  {
     owner = "bikass";
     repo = "kora";
     rev = "v${version}";
-    sha256 = "sha256-FBUOmiw3Ak1QVUrpj0+pfFqG/oKNnEXMRNlVKVNzK2I=";
+    sha256 = "sha256-miVtdEmlW4BTQ4wNASISQcn+XqHF40nLXLwkxS2TYbE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1.6.2 has a build failure since there was broken symlink, but that was fixed in 1.6.3.
<details>
<summary> 1.6.2 Log </summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/mngdfq4xbyx82ffmj4s5jll7fjvsmckw-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
no Makefile or custom buildPhase, doing nothing
Running phase: glibPreInstallPhase
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
gtk-update-icon-cache: Cache file created successfully.
gtk-update-icon-cache: Cache file created successfully.
gtk-update-icon-cache: Cache file created successfully.
gtk-update-icon-cache: Cache file created successfully.
Running phase: dropIconThemeCache
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
Symlinking parent icon themes...
  theme: kora-light-panel
    parent: kora	-> /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora
    parent: breeze	-> /nix/store/70xnzn80hxl8b2hggg4ls5zhh754dc60-breeze-icons-5.116.0/share/icons/breeze
    parent: hicolor	-> /nix/store/yp2hvdjkz9xky0nf9lq4dydsfcavas9i-hicolor-icon-theme-0.18/share/icons/hicolor
  theme: kora-light
    parent: kora	-> /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora
    parent: breeze	-> /nix/store/70xnzn80hxl8b2hggg4ls5zhh754dc60-breeze-icons-5.116.0/share/icons/breeze
    parent: hicolor	-> /nix/store/yp2hvdjkz9xky0nf9lq4dydsfcavas9i-hicolor-icon-theme-0.18/share/icons/hicolor
  theme: kora-pgrey
    parent: kora	-> /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora
    parent: breeze	-> /nix/store/70xnzn80hxl8b2hggg4ls5zhh754dc60-breeze-icons-5.116.0/share/icons/breeze
    parent: hicolor	-> /nix/store/yp2hvdjkz9xky0nf9lq4dydsfcavas9i-hicolor-icon-theme-0.18/share/icons/hicolor
  theme: kora
    parent: breeze	-> /nix/store/70xnzn80hxl8b2hggg4ls5zhh754dc60-breeze-icons-5.116.0/share/icons/breeze
    parent: hicolor	-> /nix/store/yp2hvdjkz9xky0nf9lq4dydsfcavas9i-hicolor-icon-theme-0.18/share/icons/hicolor
shrinking RPATHs of ELF executables and libraries in /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2
checking for references to /build/ in /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2...
patching script interpreter paths in /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/gtk-home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/gtg-home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/stock_home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/akonadi-phone-home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home-large.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/kfm_home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/gohome.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: the symlink /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/redhat-home.svg points to a missing target /nix/store/8s3lm47x56imj08cxw7ng7nxblb2k3a6-kora-icon-theme-1.6.2/share/icons/kora/actions/16/go-home.svg
ERROR: noBrokenSymlinks: found 8 dangling symlinks and 0 reflexive symlinks

```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
