### PR TITLE
glibc_multi: add output "static"

### DIFF
--- a/pkgs/development/libraries/glibc/multi.nix
+++ b/pkgs/development/libraries/glibc/multi.nix
@@ -16,7 +16,8 @@ runCommand "${nameVersion.name}-multi-${nameVersion.version}"
       "out"
       "bin"
       "dev"
-    ]; # TODO: no static version here (yet)
+      "static"
+    ];
     passthru = {
       libgcc = lib.lists.filter (x: x != null) [
         (glibc64.libgcc or null)
@@ -42,4 +43,13 @@ runCommand "${nameVersion.name}-multi-${nameVersion.version}"
     cp -rs '${glibc32.dev}'/include "$dev/"
     chmod +w -R "$dev"
     cp -rsf '${glibc64.dev}'/include "$dev/"
+
+    mkdir -p "$static/lib" "$static/lib64"
+    # create symlinks for files used for dynamic linking
+    # -> removing this will cause dynamically linked programs to segfault
+    cp -rs '${glibc32.out}'/lib/* "$static/lib"
+    cp -rs '${glibc64.out}'/lib/* "$static/lib64"
+    # create symlinks for files used for static linking
+    cp -rs '${glibc32.static}'/lib/* "$static/lib"
+    cp -rs '${glibc64.static}'/lib/* "$static/lib64"
   ''


### PR DESCRIPTION
This change enables static compilation with glibc in a multilib setup. For building a nix shell the output can now be referenced as follows:
```
devShells.default = pkgs.mkShell {
    packages = [
        pkgs.glibc_multi.static
    ];
};
```

In the implementation I was forced to make two design decisions:
1. The directory `$static/lib64` has to be a "real" directory and not a symlink. Otherwise, the path to this directory is not added to $NIX_LDFLAGS, which in turn causes the files to not be visible to gcc and ld during the build process (for details see `pkgs/build-support/bintools-wrapper/setup-hook.sh` line 16).
2. The directories `$static/lib` and `$static/lib64` have to contain symlinks to both the files used for static and for dynamic linking (i.e. the outputs of `static` and `out` of the 32 and 64 bit variant of glibc). Without this, dynamic linking still works, however the resulting binaries will segfault.

(not part of the commit message)

I'm unsure why I've had to add the files for dynamic linking into the output for static linking to prevent the resulting binaries to segfault. However, since this solution works and does not modify/impact any other modules/packages, I'm satisfied with it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Open issues related to this pull request

This is my second attempt at this pr. I've deleted my first attempt, because the test `tests.cc-multilib-clang` failed while running `nixpkgs-review`. However, I'm now confident, that this test does not fail due to any of the changes in this pr and have reported this as a separate issue in https://github.com/NixOS/nixpkgs/issues/380752.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

# Snippets for manual testing

I tested the changes manually using the following setup:

hello-world.c
```.c
#include <stdio.h>

int main() {
    printf("Hello World!\n");
    return 0;
}
```

flake.nix
```.nix
{
  description = "Flake for testing";
  inputs = {
    nixpkgs.url = "github:Tim-Wsm/nixpkgs/glibc-multilib-static";
    flake-utils.url = "github:numtide/flake-utils";
  };
  outputs = {
    nixpkgs,
    flake-utils,
    ...
  }:
    flake-utils.lib.eachDefaultSystem
    (
      system: let
        pkgs = nixpkgs.legacyPackages.${system};
      in {
        devShells.default = pkgs.mkShell {
          packages = [
            pkgs.gcc_multi
            pkgs.clang_multi
            pkgs.glibc_multi
            pkgs.glibc_multi.static
          ];
        };
      }
    );
}
```

Then I've used the following commands for testing.

```.bash
# enter the development shell
$ nix develop .
# compile all variants of hello world
$ gcc hello-world.c -o hello-world-64bit-dynamic-gcc
$ gcc -static hello-world.c -o hello-world-64bit-static-gcc
$ gcc -m32 hello-world.c -o hello-world-32bit-dynamic-gcc
$ gcc -static -m32 hello-world.c -o hello-world-32bit-static-gcc
$ clang hello-world.c -o hello-world-64bit-dynamic-clang
$ clang -static hello-world.c -o hello-world-64bit-static-clang
$ clang -m32 hello-world.c -o hello-world-32bit-dynamic-clang
$ clang -static -m32 hello-world.c -o hello-world-32bit-static-clang
# run all binaries
$ ./hello-world-64bit-dynamic-gcc; ./hello-world-64bit-static-gcc; ./hello-world-32bit-dynamic-gcc; ./hello-world-32bit-static-gcc; ./hello-world-64bit-dynamic-clang ; ./hello-world-64bit-static-clang; ./hello-world-32bit-dynamic-clang; ./hello-world-32bit-static-clang
```


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
