### PR TITLE
gopher64: init at 1.0.16

### DIFF
--- a/pkgs/by-name/go/gopher64/package.nix
+++ b/pkgs/by-name/go/gopher64/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+
+  bzip2,
+  libGL,
+  libX11,
+  libXcursor,
+  libxkbcommon,
+  libXi,
+  moltenvk,
+  sdl3,
+  wayland,
+  zstd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gopher64";
+  version = "1.0.16";
+
+  src = fetchFromGitHub {
+    owner = "gopher64";
+    repo = "gopher64";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TduOmKK4OAmhP2VUT0eeoKHQHmsM8kptrxfgCdDFTRU=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/GIT_REV
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  cargoPatches = [
+    # upstream rebuilds SDL3 from source
+    # this patch makes it use the SDL3 library provided by nixpkgs
+    ./use-sdl3-via-pkg-config.patch
+
+    # make the build script use the @GIT_REV@ string that will be substituted in the logic below
+    ./set-git-rev.patch
+  ];
+
+  postPatch = ''
+    # use the file generated in the fetcher to supply the git revision
+    substituteInPlace build.rs \
+      --replace-fail "@GIT_REV@" $(cat GIT_REV)
+  '';
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9fZ7zFTqt1VNnmCqFzWrZFD1PQZ7paz7r2Mb+9+C9Rs=";
+
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs =
+    [
+      bzip2
+      sdl3
+      zstd
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      moltenvk
+    ];
+
+  # these are dlopen-ed during runtime
+  runtimeDependencies = lib.optionalString stdenv.hostPlatform.isLinux [
+    libGL
+    libxkbcommon
+
+    # for X11
+    libX11
+    libXcursor
+    libXi
+
+    # for wayland
+    wayland
+  ];
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/bin/gopher64 --add-rpath ${lib.makeLibraryPath finalAttrs.runtimeDependencies}
+  '';
+
+  meta = {
+    changelog = "https://github.com/gopher64/gopher64/releases/tag/${finalAttrs.src.tag}";
+    description = "N64 emulator written in Rust";
+    homepage = "https://github.com/gopher64/gopher64";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gopher64";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+})

--- a/pkgs/by-name/go/gopher64/set-git-rev.patch
+++ b/pkgs/by-name/go/gopher64/set-git-rev.patch
@@ -1,0 +1,19 @@
+diff --git a/build.rs b/build.rs
+index 0b20db2..d904e63 100644
+--- a/build.rs
++++ b/build.rs
+@@ -163,13 +163,7 @@ fn main() {
+         simd_build.compile("simd");
+     }
+ 
+-    let git_output = std::process::Command::new("git")
+-        .args(["rev-parse", "HEAD"])
+-        .output()
+-        .unwrap();
+-
+-    let git_hash = String::from_utf8(git_output.stdout).unwrap();
+-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
++    println!("cargo:rustc-env=GIT_HASH={}", "@GIT_REV@");
+ 
+     println!("cargo:rustc-env=N64_STACK_SIZE={}", 8 * 1024 * 1024);
+ }

--- a/pkgs/by-name/go/gopher64/use-sdl3-via-pkg-config.patch
+++ b/pkgs/by-name/go/gopher64/use-sdl3-via-pkg-config.patch
@@ -1,0 +1,85 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 89bc1d0..72b65cd 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -626,15 +626,6 @@ dependencies = [
+  "error-code",
+ ]
+ 
+-[[package]]
+-name = "cmake"
+-version = "0.1.54"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+-dependencies = [
+- "cc",
+-]
+-
+ [[package]]
+ name = "cobs"
+ version = "0.2.3"
+@@ -3245,12 +3236,6 @@ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
+-[[package]]
+-name = "rpkg-config"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5a2d2f3481209a6b42eec2fbb49063fb4e8d35b57023401495d4fe0f85c817f0"
+-
+ [[package]]
+ name = "rustc-demangle"
+ version = "0.1.24"
+@@ -3380,21 +3365,13 @@ version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+ 
+-[[package]]
+-name = "sdl3-src"
+-version = "3.2.10"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e677fa126db179fb8f03c982163321496ddf57a6d8a1e41eeef4600f956038b1"
+-
+ [[package]]
+ name = "sdl3-sys"
+ version = "0.4.7+SDL3-3.2.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f0d16a8a3623a4cb39a3661c81d9d4c5fd77ada27fc056e320b3651bf7bde1b1"
+ dependencies = [
+- "cmake",
+- "rpkg-config",
+- "sdl3-src",
++ "pkg-config",
+ ]
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index 1f41e04..9d9ea33 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -18,7 +18,7 @@ serde-big-array = "0.5"
+ eframe = { version = "0.31", default-features = false, features = ["wayland", "x11", "glow"] }
+ sha2 = "0.10"
+ ab_glyph = "0.2"
+-sdl3-sys = { version = "0.4", features = ["build-from-source-static"] }
++sdl3-sys = { version = "0.4", features = ["use-pkg-config"] }
+ rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
+ tokio = {version = "1.43", features = ["rt-multi-thread", "macros"] }
+ spin_sleep = "1.3"
+diff --git a/build.rs b/build.rs
+index 67a6e8d..6c9f63b 100644
+--- a/build.rs
++++ b/build.rs
+@@ -52,10 +52,7 @@ fn main() {
+         .include("parallel-rdp/parallel-rdp-standalone/vulkan")
+         .include("parallel-rdp/parallel-rdp-standalone/vulkan-headers/include")
+         .include("parallel-rdp/parallel-rdp-standalone/util")
+-        .include(
+-            std::path::PathBuf::from(std::env::var("DEP_SDL3_OUT_DIR").to_owned().unwrap())
+-                .join("include"),
+-        );
++        ;
+ 
+     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();


### PR DESCRIPTION
Homepage: https://github.com/gopher64/gopher64
Description: N64 emulator written in Rust

Made by the creator of `simple64`, who has recently announced that they will be focusing on this project instead.

Note: this package uses xdg-desktop-portal for file dialogs, so if you don't have it configured, the "Load ROM" button will not do anything.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
