### PR TITLE
termusic: fix build

### DIFF
--- a/pkgs/by-name/te/termusic/package.nix
+++ b/pkgs/by-name/te/termusic/package.nix
@@ -41,9 +41,9 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postPatch = ''
-    pushd $cargoDepsCopy/stream-download
+    pushd $cargoDepsCopy/stream-download-0.6.0
     oldHash=$(sha256sum src/lib.rs | cut -d " " -f 1)
-    substituteInPlace $cargoDepsCopy/stream-download/src/lib.rs \
+    substituteInPlace $cargoDepsCopy/stream-download-0.6.0/src/lib.rs \
       --replace-warn '#![doc = include_str!("../README.md")]' ""
     substituteInPlace .cargo-checksum.json \
       --replace-warn $oldHash $(sha256sum src/lib.rs | cut -d " " -f 1)


### PR DESCRIPTION
Build was resulting in:

```
nix/store/dh9szsq14j2w2dx7pn219n27gwq7w3dn-stdenv-linux/setup: line 269: pushd: /build/termusic-0.9.1-vendor/stream-download: No such file or directory
```

Items in `$cargoDepsCopy/stream-download` now all include a version number, I assume something that changed with a Rust/Cargo upgrade.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc