### PR TITLE
change kube-scheduler and kube-controller-manager default port to 10259 and 10257

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -76,8 +76,8 @@ in
 
     securePort = lib.mkOption {
       description = "Kubernetes controller manager secure listening port.";
-      default = 10252;
-      type = int;
+      default = 10257;
+      type = port;
     };
 
     serviceAccountKeyFile = lib.mkOption {

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -43,9 +43,9 @@ in
       default = true;
     };
 
-    port = lib.mkOption {
-      description = "Kubernetes scheduler listening port.";
-      default = 10251;
+    securePort = lib.mkOption {
+      description = "Kubernetes scheduler secure listening port.";
+      default = 10259;
       type = port;
     };
 
@@ -81,7 +81,7 @@ in
                     } \
                     --kubeconfig=${top.lib.mkKubeConfig "kube-scheduler" cfg.kubeconfig} \
                     --leader-elect=${lib.boolToString cfg.leaderElect} \
-                    --secure-port=${toString cfg.port} \
+                    --secure-port=${toString cfg.securePort} \
                     ${lib.optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
                     ${cfg.extraOpts}
         '';


### PR DESCRIPTION
## Things done

Change the default port of kube-scheduler and kube-controller-manager to `10259` and `10257`, as `kubernetes >= 1.22` uses these two ports by default. If not changing them, the default option will make the health probe fail.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)

  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
