### PR TITLE
[staging-next] Get util-linux building on Darwin again

### DIFF
--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -75,6 +75,8 @@ stdenv.mkDerivation rec {
       "--with-systemdtmpfilesdir=${placeholder "out"}/lib/tmpfiles.d"
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
       "--with-pager=less"
+    ]
+    ++ lib.optionals util-linuxMinimal.hasCol [
       "--with-col=${util-linuxMinimal}/bin/col"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -168,6 +168,10 @@ stdenv.mkDerivation rec {
       rev-prefix = "v";
       ignoredVersions = "(-rc).*";
     };
+
+    # encode upstream assumption to be used in man-db
+    # https://github.com/util-linux/util-linux/commit/8886d84e25a457702b45194d69a47313f76dc6bc
+    hasCol = stdenv.hostPlatform.libc == "glibc";
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -101,6 +101,10 @@ stdenv.mkDerivation rec {
       "--disable-nls"
       "--disable-ipcrm"
       "--disable-ipcs"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Doesn't build on Darwin, also doesn't really make sense on Darwin
+      "--disable-liblastlog2"
     ];
 
   makeFlags = [

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -23,7 +23,12 @@ preConfigure() {
     local flagsArray=()
     concatTo flagsArray makeMakerFlags
 
-    perl Makefile.PL AR=$AR FULL_AR=$AR CC=$CC LD=$CC CPPRUN="$CC -E" \
+    # Perl expect these to be exported
+    export CPPRUN="$CC -E"
+    export FULL_AR=$AR
+    # Requires to be $CC since it tries adding "-Wl"
+    export LD=$CC
+    perl Makefile.PL AR="$AR" FULL_AR="$AR" CC="$CC" LD="$CC" CPPRUN="$CPPRUN" \
         PREFIX=$out INSTALLDIRS=site "${flagsArray[@]}" \
         PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
 }


### PR DESCRIPTION
Oof.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
