### PR TITLE
spdlog: 1.15.0 -> 1.15.1

### DIFF
--- a/pkgs/by-name/sp/spdlog/package.nix
+++ b/pkgs/by-name/sp/spdlog/package.nix
@@ -1,14 +1,15 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, fmt
-, catch2_3
-, staticBuild ? stdenv.hostPlatform.isStatic
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  fmt,
+  catch2_3,
+  staticBuild ? stdenv.hostPlatform.isStatic,
 
-# tests
-, bear
-, tiledb
+  # tests
+  bear,
+  tiledb,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,9 +18,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "gabime";
-    repo  = "spdlog";
-    rev   = "v${version}";
-    hash  = "sha256-4QZVCounDbtkP+58fejHGWjquWT3b03b9TNGs45dN7c=";
+    repo = "spdlog";
+    rev = "v${version}";
+    hash = "sha256-HCpnN28qWreg0NvL6Q9pfSSxOTHgV6glHt6P0FbH/Cw=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,7 +37,11 @@ stdenv.mkDerivation rec {
     "-DSPDLOG_FMT_EXTERNAL=ON"
   ];
 
-  outputs = [ "out" "doc" "dev" ] ;
+  outputs = [
+    "out"
+    "doc"
+    "dev"
+  ];
 
   postInstall = ''
     mkdir -p $out/share/doc/spdlog
@@ -55,10 +60,10 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description    = "Very fast, header only, C++ logging library";
-    homepage       = "https://github.com/gabime/spdlog";
-    license        = licenses.mit;
-    maintainers    = with maintainers; [ obadz ];
-    platforms      = platforms.all;
+    description = "Very fast, header only, C++ logging library";
+    homepage = "https://github.com/gabime/spdlog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ obadz ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
## Things done

- **spdlog: format**
- **spdlog: 1.15.0 -> 1.15.1**

Changelog: https://github.com/gabime/spdlog/releases/tag/v1.15.1

cc @obadz

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
