### PR TITLE
nixos/gitea: add CAPTCHA support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -469,6 +469,8 @@
 
 - `services.kmonad` now creates a determinate symlink (in `/dev/input/by-id/`) to each of KMonad virtual devices.
 
+- `services.gitea` now supports CAPTCHA usage through the `services.gitea.captcha` variable.
+
 - `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
 - [`services.mongodb.enableAuth`](#opt-services.mongodb.enableAuth) now uses the newer [mongosh](https://github.com/mongodb-js/mongosh) shell instead of the legacy shell to configure the initial superuser. You can configure the mongosh package to use through the [`services.mongodb.mongoshPackage`](#opt-services.mongodb.mongoshPackage) option.

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -163,6 +163,58 @@ in
         };
       };
 
+      captcha = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enables Gitea to display a CAPTCHA challenge on registration.
+          '';
+        };
+
+        secretFile = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "/var/lib/secrets/gitea/captcha_secret";
+          description = "Path to a file containing the CAPTCHA secret key.";
+        };
+
+        siteKey = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "my_site_key";
+          description = "CAPTCHA site key to use for Gitea.";
+        };
+
+        url = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "https://google.com/recaptcha";
+          description = "CAPTCHA url to use for Gitea. Only relevant for `recaptcha` and `mcaptcha`.";
+        };
+
+        type = mkOption {
+          type = types.enum [ "image" "recaptcha" "hcaptcha" "mcaptcha" "cfturnstile" ];
+          default = "image";
+          example = "recaptcha";
+          description = "The type of CAPTCHA to use for Gitea.";
+        };
+
+        requireForLogin = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Displays a CAPTCHA challenge whenever a user logs in.";
+        };
+
+        requireForExternalRegistration = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = "Displays a CAPTCHA challenge for users that register externally.";
+        };
+      };
+
       dump = {
         enable = mkOption {
           type = types.bool;
@@ -404,9 +456,30 @@ in
           and `ensureDatabases` doesn't have any effect.
         '';
       }
+      {
+        assertion = cfg.captcha.enable -> cfg.captcha.type != "image" -> (cfg.captcha.secretFile != null && cfg.captcha.siteKey != null);
+        message = ''
+          Using a CAPTCHA service that is not `image` requires providing a CAPTCHA secret through
+          the `captcha.secretFile` option and a CAPTCHA site key through the `captcha.siteKey` option.
+        '';
+      }
+      {
+        assertion = cfg.captcha.url != null -> (builtins.elem cfg.captcha.type ["mcaptcha" "recaptcha"]);
+        message = ''
+          `captcha.url` is only relevant when `captcha.type` is `mcaptcha` or `recaptcha`.
+        '';
+      }
     ];
 
-    services.gitea.settings = {
+    services.gitea.settings = let
+      captchaPrefix = optionalString cfg.captcha.enable ({
+        image = "IMAGE";
+        recaptcha = "RECAPTCHA";
+        hcaptcha = "HCAPTCHA";
+        mcaptcha = "MCAPTCHA";
+        cfturnstile = "CF_TURNSTILE";
+      }."${cfg.captcha.type}");
+    in {
       "cron.update_checker".ENABLED = lib.mkDefault false;
 
       database = mkMerge [
@@ -449,6 +522,24 @@ in
         INTERNAL_TOKEN = "#internaltoken#";
         INSTALL_LOCK = true;
       };
+
+      service = mkIf cfg.captcha.enable (mkMerge [
+        {
+          ENABLE_CAPTCHA = true;
+          CAPTCHA_TYPE = cfg.captcha.type;
+          REQUIRE_CAPTCHA_FOR_LOGIN = cfg.captcha.requireForLogin;
+          REQUIRE_EXTERNAL_REGISTRATION_CAPTCHA = cfg.captcha.requireForExternalRegistration;
+        }
+        (mkIf (cfg.captcha.secretFile != null) {
+          "${captchaPrefix}_SECRET" = "#captchasecret#";
+        })
+        (mkIf (cfg.captcha.siteKey != null) {
+          "${captchaPrefix}_SITEKEY" = cfg.captcha.siteKey;
+        })
+        (mkIf (cfg.captcha.url != null) {
+          "${captchaPrefix}_URL" = cfg.captcha.url;
+        })
+      ]);
 
       mailer = mkIf (cfg.mailerPasswordFile != null) {
         PASSWD = "#mailerpass#";
@@ -591,6 +682,10 @@ in
 
             ${lib.optionalString (cfg.metricsTokenFile != null) ''
               ${replaceSecretBin} '#metricstoken#' '${cfg.metricsTokenFile}' '${runConfig}'
+            ''}
+
+            ${lib.optionalString (cfg.captcha.secretFile != null) ''
+              ${replaceSecretBin} '#captchasecret#' '${cfg.captcha.secretFile}' '${runConfig}'
             ''}
             chmod u-w '${runConfig}'
           }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the `gitea.captcha` category of options, which enable the usage of `ENABLE_CAPTCHA` and its respective config keys within the [Gitea configuration](https://docs.gitea.com/administration/config-cheat-sheet#service-service).

Total added options (with relevant Gitea config value)
- `captcha.enable` (`ENABLE_CAPTCHA`)
- `captcha.type` (`CAPTCHA_TYPE`)
- `captcha.secretFile` (`*CAPTCHA_SECRET`)
- `captcha.siteKey` (`*CAPTCHA_SITEKEY`)
- `captcha.url` (`*CAPTCHA_URL`)
- `captcha.requireForLogin` (`REQUIRE_CAPTCHA_FOR_LOGIN`)
- `captcha.requireForExternalRegistration` (`REQUIRE_EXTERNAL_REGISTRATION_CAPTCHA`)

The CAPTCHA secret is retrieved from the file path given in `captcha.secretFile` and inserted into the `app.ini` on startup, same as how the other Gitea secrets are handled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
