### PR TITLE
python312package.metaflow: init at 2.13.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12545,6 +12545,12 @@
     githubId = 787421;
     name = "Kevin Quick";
   };
+  kr7x = {
+    name = "Carlos Reyes";
+    email = "carlosreyesml18@gmail.com";
+    github = "K4rlosReyes";
+    githubId = 108368394;
+  };
   kraanzu = {
     name = "Murli Tawari";
     email = "kraanzu@gmail.com";

--- a/pkgs/development/python-modules/metaflow/default.nix
+++ b/pkgs/development/python-modules/metaflow/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  boto3,
+  requests,
+  setuptools,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "metaflow";
+  version = "2.13.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Netflix";
+    repo = "metaflow";
+    tag = version;
+    hash = "sha256-f/cWZl59i1PRqNqLV5LtcZoDKdovdCKoQJNxzXKczgs=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    boto3
+    requests
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    export HOME="$TMPDIR"
+    export USER="metaflow-test-user"
+
+    pushd test/core
+    ${python.interpreter} run_tests.py --num-parallel $NIX_BUILD_CORES \
+      --tests FlowOptionsTest,BasicLogTest
+    popd
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "metaflow" ];
+
+  meta = {
+    description = "Open Source AI/ML Platform";
+    homepage = "https://metaflow.org/";
+    changelog = "https://github.com/Netflix/metaflow/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kr7x ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8199,6 +8199,8 @@ self: super: with self; {
 
   messagebird = callPackage ../development/python-modules/messagebird { };
 
+  metaflow = callPackage ../development/python-modules/metaflow { };
+
   metakernel = callPackage ../development/python-modules/metakernel { };
 
   metar = callPackage ../development/python-modules/metar { };


### PR DESCRIPTION
# Add metaflow Python package

Added metaflow, a Python library developed by Netflix that helps data scientists build and manage real-life data science projects. Metaflow provides a unified API to manage various infrastructure stacks, and helps data scientists focus on data science instead of engineering.

Added my information to the maintainers list.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Verified metaflow CLI tool works with `metaflow --help`
  - Tested Python import functionality using `pythonImportsCheck`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

Package builds successfully and passes basic functionality tests. The package includes:
- Core metaflow library
- Command-line interface
- Basic dependencies (boto3, requests)