### PR TITLE
spine-pro: init at 4.2.39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11680,6 +11680,12 @@
     githubId = 2396926;
     name = "Justin Woo";
   };
+  justryanw = {
+    email = "nixpkgs@ryanjw.net";
+    github = "justryanw";
+    githubId = 34030157;
+    name = "Ryan Walker";
+  };
   jvanbruegge = {
     email = "supermanitu@gmail.com";
     github = "jvanbruegge";

--- a/pkgs/by-name/sp/spine-pro/package.nix
+++ b/pkgs/by-name/sp/spine-pro/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  requireFile,
+  runCommand,
+  writeShellScript,
+  buildFHSEnv,
+  makeDesktopItem,
+  fetchurl,
+}:
+
+let
+  pname = "spine-pro";
+
+  spineTarball = requireFile rec {
+    name = pname;
+    url = "https://eu.esotericsoftware.com/";
+    message = ''
+      Unfortunately, we cannot download file ${name} automatically.
+      Please run the following command replacing LICENSE_KEY with your Spine license key to download it manually.
+        nix-prefetch-url --name spine-pro --type sha256 https://eu.esotericsoftware.com/launcher/linux/LICENSE_KEY
+    '';
+    sha256 = "0ayja2p6p4wkgiqw2f5xvbifh55gicvhxbwm5yh9b9hwwhxx28z5";
+  };
+
+  unpackedSpine = runCommand "spine-pro-unpacked" { } ''
+    mkdir -p $out
+    tar -xzf ${spineTarball} -C $out --strip-components=1
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = pname;
+    desktopName = "Spine";
+    type = "Application";
+    icon = fetchurl {
+      url = "http://esotericsoftware.com/files/branding/spine_badge.png";
+      sha256 = "sha256-1vZg+ViV+Q9nmijGlYNu5E8MF5nRGXrvT4iAdFdlQ2A=";
+    };
+  };
+
+in
+buildFHSEnv {
+  inherit pname;
+  version = "4.2.39";
+
+  runScript = writeShellScript "spine-launcher" ''
+    ${unpackedSpine}/launcher/2/bin/java \
+      -Xms512m -Xmx4096m \
+      com.esotericsoftware.spine.launcher.Launcher
+  '';
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      zlib
+      freetype
+      fontconfig
+
+      libGL
+      libglvnd
+      mesa.drivers
+      xorg.libX11
+      xorg.libXext
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXcursor
+      xorg.libXxf86vm
+
+      alsa-lib
+      libpulseaudio
+      udev
+    ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications/
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
+  '';
+
+  meta = {
+    description = "2D skeletal animation for games";
+    homepage = "https://esotericsoftware.com/";
+    changelog = "https://en.esotericsoftware.com/spine-changelog";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ justryanw ];
+    mainProgram = "spine-pro";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds [spine-pro](https://esotericsoftware.com/) and also adds myself to the nixpkgs maintainer list.
requireFile is used here as a license key is required to reach the download page for each paid version.
This is specifically the professional version as that is the only version I have a key for so I am unable to get the sha256 for the other versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
