### PR TITLE
nixos/caddy: validate config on build by default

### DIFF
--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -60,6 +60,8 @@ let
               cp --no-preserve=mode ${Caddyfile}/Caddyfile $out/Caddyfile
               caddy fmt --overwrite $out/Caddyfile
               ${lib.optionalString cfg.validateConfigFile ''
+                # 'validate' cannot be used for validation, due to log location access
+                # See https://github.com/caddyserver/caddy/issues/6788
                 caddy adapt --adapter caddyfile --config $out/Caddyfile
               ''}
             '';

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -89,6 +89,16 @@ import ./make-test-python.nix (
               '';
             };
           };
+          specialisation.invalid-config-fail.configuration = {
+            services.caddy = {
+              validateConfigFile = false;
+              extraConfig = ''
+                not-a-real-directive {
+                  this-should-fail
+                }
+              '';
+            };
+          };
         };
     };
 
@@ -101,6 +111,7 @@ import ./make-test-python.nix (
         multipleHostnames = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-hostnames";
         rfc42Config = "${nodes.webserver.system.build.toplevel}/specialisation/rfc42";
         withPluginsConfig = "${nodes.webserver.system.build.toplevel}/specialisation/with-plugins";
+        invalidConfigFail = "${nodes.webserver.system.build.toplevel}/specialisation/invalid-config-fail";
       in
       ''
         url = "http://localhost/example.html"
@@ -150,6 +161,11 @@ import ./make-test-python.nix (
             )
             webserver.wait_for_open_port(80)
             webserver.succeed("curl http://localhost | grep caddy")
+
+        with subtest("invalid config fails to switch to, as validation was not enforced"):
+            webserver.fail(
+                "${invalidConfigFail}/bin/switch-to-configuration test >&2"
+            )
       '';
   }
 )


### PR DESCRIPTION
Adds `enforceConfigValidation` option (default: true) to validate Caddy 
configurations during system build. This catches configuration errors early 
in the deployment pipeline, improving reliability and security of Caddy 
deployments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

![image](https://github.com/user-attachments/assets/b7b473ec-f23e-4f37-a502-35fdf705440a)


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
