### PR TITLE
python3Packages.jira: fix build

### DIFF
--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -36,12 +36,12 @@ buildPythonPackage rec {
     hash = "sha256-P3dbrBKpHvLNIA+JBeSXEQl4QVZ0FdKkNIU8oPHWw6k=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-scm
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     defusedxml
     packaging
     requests

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pycontribs";
-    repo = pname;
+    repo = "jira";
     tag = version;
     hash = "sha256-P3dbrBKpHvLNIA+JBeSXEQl4QVZ0FdKkNIU8oPHWw6k=";
   };

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -10,6 +10,7 @@
   pillow,
   pyjwt,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
   requests,
   requests-futures,
@@ -67,13 +68,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     flaky
     pytestCheckHook
+    pytest-cov-stub
     requests-mock
   ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov-report=xml --cov jira" ""
-  '';
 
   pythonImportsCheck = [ "jira" ];
 


### PR DESCRIPTION
7e7963d8736b (python3Packages.jira: 3.8.0 -> 3.9.4, 2025-01-19) update python3Packages.jira to 3.9.4.  After that commit, python3.12-jira fails to build:

    $ nix build -L --impure --expr '(import ./. {}).python3.withPackages(ps: [ ps.jira ])'
    [...]
    error: builder for '/nix/store/bfr24lmgw4izl9ixh2sdm794a9kky7w6-python3.12-jira-3.9.4.drv' failed with exit code 1;
           last 19 log lines:
           > Sourcing python-remove-tests-dir-hook
           > Sourcing python-catch-conflicts-hook.sh
           > Sourcing python-remove-bin-bytecode-hook.sh
           > Sourcing pypa-build-hook
           > Using pypaBuildPhase
           > Sourcing python-runtime-deps-check-hook
           > Using pythonRuntimeDepsCheckHook
           > Sourcing pypa-install-hook
           > Using pypaInstallPhase
           > Sourcing python-imports-check-hook.sh
           > Using pythonImportsCheckPhase
           > Sourcing python-namespaces-hook
           > Sourcing python-catch-conflicts-hook.sh
           > Running phase: unpackPhase
           > unpacking source archive /nix/store/ck51dycsghmkf7449p615crsqdn2xsni-source
           > source root is source
           > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tox.ini"
           > Running phase: patchPhase
           > substitute(): ERROR: file 'setup.cfg' does not exist
           For full logs, run 'nix log /nix/store/bfr24lmgw4izl9ixh2sdm794a9kky7w6-python3.12-jira-3.9.4.drv'.
    error: 1 dependencies of derivation '/nix/store/i5xib9msa42grs3cwa1ibw0cfdi799f9-python3-3.12.8-env.drv' failed to build

The functionality in setup.cfg was moved to pyproject.toml in pycontribs/jira@668562a3f8c7 (migrate `setup.cfg` to `pyproject.toml` (pycontribs/jira#1776), 2024-03-25).

Patch pyproject.toml so that python3Packages.jira builds again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - ~~[ ] (Package updates) Added a release notes entry if the change is major or breaking~~
    - Not needed
  - ~~[ ] (Module updates) Added a release notes entry if the change is significant~~
    - Not needed
  - ~~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~~
    - Not needed
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
