### PR TITLE
yew-fmt: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5107,6 +5107,12 @@
     githubId = 245394;
     name = "Hannu Hartikainen";
   };
+  dandedotdev = {
+    email = "contact@dande.dev";
+    github = "dandedotdev";
+    githubId = 106054083;
+    name = "Dandelion Huang";
+  };
   dandellion = {
     email = "daniel@dodsorf.as";
     matrix = "@dandellion:dodsorf.as";

--- a/pkgs/by-name/ye/yew-fmt/package.nix
+++ b/pkgs/by-name/ye/yew-fmt/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustfmt,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "yew-fmt";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "its-the-shrimp";
+    repo = "yew-fmt";
+    tag = "v${version}";
+    hash = "sha256-Ck6WA6ROm8APTsgoxbVGUqoblc5awW+hmmzcy4ZFoBM=";
+  };
+
+  cargoHash = "sha256-Fp8MT1LJ1EpqwEZ+SpOomqZ7we47w2S5ExkB966Z3r0=";
+  nativeCheckInputs = [ rustfmt ];
+  passthru.updateScript = nix-update-script { };
+  useFetchCargoVendor = true;
+
+  meta = {
+    description = "Code formatter for the Yew framework";
+    mainProgram = "yew-fmt";
+    homepage = "https://github.com/its-the-shrimp/yew-fmt";
+    changelog = "https://github.com/its-the-shrimp/yew-fmt/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dandedotdev ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding the [`yew-fmt`](https://github.com/its-the-shrimp/yew-fmt), which is a code formatter for the Yew framework. (At the moment, the latest version is `0.5.3`.)

In the fact that formatting tools save tons of time for programmers, I would like to add it to `nixpkgs` to simplify the installation, which is usually installed using `cargo install yew-fmt`.

This tool inherits all of the configuration options for `rustfmt`, and [runs a small test named `regen-tests` when building](https://github.com/its-the-shrimp/yew-fmt/blob/master/build.rs). However, I don't think we should run tests when we enter the Nix shell every time, so I set `doCheck` as `false`. 

## Call for help

This is my first contribution to the `nixpkgs`.

I started using `nix` daily recently, and it helped me a lot. That's the reason I would like to try to contribute to the `nix` ecosystem and try to help others.

In the fact that I'm very new to the `nix` ecosystem, I might made some mistakes. I hope I could be helped to improve this PR and make it up to the standards of this community.

Thank you very much for your time and attention!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
