### PR TITLE
aflplusplus: 4.21c -> 4.31c

### DIFF
--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -37,13 +37,13 @@ let
   libtokencap = callPackage ./libtokencap.nix { inherit aflplusplus; };
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "4.21c";
+    version = "4.31c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
       repo = "AFLplusplus";
       tag = "v${version}";
-      hash = "sha256-DKwPRxSO+JEJYWLldnfrAYqzwqukNzrbo4R5FzJqzzg=";
+      hash = "sha256-O3NPtQaxcRRFE6H7O6JTsmQsO+iEl8eQxHGKtc+1g8w=";
     };
 
     enableParallelBuilding = true;

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -209,6 +209,7 @@ let
       maintainers = with lib.maintainers; [
         ris
         mindavi
+        msanft
       ];
     };
   };

--- a/pkgs/tools/security/aflplusplus/libdislocator.nix
+++ b/pkgs/tools/security/aflplusplus/libdislocator.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation {
       several ways
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ris ];
+    maintainers = with lib.maintainers; [
+      ris
+      msanft
+    ];
   };
 }

--- a/pkgs/tools/security/aflplusplus/libtokencap.nix
+++ b/pkgs/tools/security/aflplusplus/libtokencap.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/AFLplusplus/AFLplusplus";
     description = "strcmp & memcmp token capture library";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ris ];
+    maintainers = with lib.maintainers; [
+      ris
+      msanft
+    ];
   };
 }

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -140,7 +140,10 @@ stdenv.mkDerivation {
     homepage = "https://github.com/AFLplusplus/qemuafl";
     description = "Fork of QEMU with AFL++ instrumentation support";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ ris ];
+    maintainers = with lib.maintainers; [
+      ris
+      msanft
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -25,9 +25,10 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AFLplusplus";
     repo = "qemuafl";
-    # rev origin: https://github.com/AFLplusplus/AFLplusplus/blob/v4.21c/qemu_mode/QEMUAFL_VERSION
-    rev = "a6f0632a65e101e680dd72643a6128dd180dff72";
-    sha256 = "sha256-4kaQA5KDUqkK+fbjHg47lxZHRN8JrfSC2zdjrbMbDPo=";
+    # Use a fixed qemuafl version instead of the one in https://github.com/AFLplusplus/AFLplusplus/blob/v4.31c/qemu_mode/QEMUAFL_VERSION.
+    # See: https://github.com/AFLplusplus/AFLplusplus/issues/2296.
+    rev = "ef1cd9a8cb1522c918faab42805216f9a4054dda";
+    hash = "sha256-tbKDnDoBtFhvtE9nbi9XuHPuFuGezUFngnw4pJyKFgY=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog for 4.30c](https://github.com/AFLplusplus/AFLplusplus/releases/tag/v4.30c)
[Changelog for 4.31c](https://github.com/AFLplusplus/AFLplusplus/releases/tag/v4.31c)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
