### PR TITLE
sasquatch: 4.5.1-4 -> 4.5.1-5

### DIFF
--- a/pkgs/by-name/sa/sasquatch/package.nix
+++ b/pkgs/by-name/sa/sasquatch/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gitUpdater,
   lz4,
   lzo,
   which,
@@ -59,6 +60,10 @@ let
     postInstall = lib.optionalString bigEndian ''
       mv $out/bin/sasquatch{,-v4be}
     '';
+
+    passthru = {
+      updateScript = gitUpdater { rev-prefix = "sasquatch-v"; };
+    };
 
     meta = {
       homepage = "https://github.com/onekey-sec/sasquatch";

--- a/pkgs/by-name/sa/sasquatch/package.nix
+++ b/pkgs/by-name/sa/sasquatch/package.nix
@@ -15,13 +15,13 @@
 let
   drv = stdenv.mkDerivation (finalAttrs: {
     pname = "sasquatch";
-    version = "4.5.1-4";
+    version = "4.5.1-5";
 
     src = fetchFromGitHub {
       owner = "onekey-sec";
       repo = "sasquatch";
       rev = "sasquatch-v${finalAttrs.version}";
-      hash = "sha256-0itva+j5WMKvueiUaO253UQ1S6W29xgtFvV4i3yvMtU=";
+      hash = "sha256-4Mltt0yFt4oh9hsrHL8/ch5n7nZYiXIJ1UgLktPvlKQ=";
     };
 
     patches = lib.optional stdenv.hostPlatform.isDarwin ./darwin.patch;


### PR DESCRIPTION
Release notes: https://github.com/onekey-sec/sasquatch/releases/tag/sasquatch-v4.5.1-5
Main change is [a bugfix](https://github.com/plougher/squashfs-tools/issues/214) ported from upstream squashfs-tools

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
