### PR TITLE
python312Packages.dalle-mini: fix build

### DIFF
--- a/pkgs/development/python-modules/dalle-mini/default.nix
+++ b/pkgs/development/python-modules/dalle-mini/default.nix
@@ -3,13 +3,17 @@
   buildPythonPackage,
   fetchPypi,
   fetchpatch,
+
+  # dependencies
   einops,
   emoji,
   flax,
   ftfy,
   jax,
   jaxlib,
+  orbax-checkpoint,
   pillow,
+  pydantic,
   transformers,
   unidecode,
   wandb,
@@ -18,7 +22,7 @@
 buildPythonPackage rec {
   pname = "dalle-mini";
   version = "0.1.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -34,14 +38,26 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "transformers"
+    "jax"
+    "flax"
+  ];
+
+  pythonRemoveDeps = [
+    "orbax"
+  ];
+
+  dependencies = [
     einops
     emoji
     flax
     ftfy
     jax
     jaxlib
+    orbax-checkpoint
     pillow
+    pydantic
     transformers
     unidecode
     wandb
@@ -51,10 +67,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "dalle_mini" ];
 
-  meta = with lib; {
+  meta = {
     description = "Generate images from a text prompt";
     homepage = "https://github.com/borisdayma/dalle-mini";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ r-burns ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ r-burns ];
   };
 }

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -1,32 +1,38 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
-  decorator,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  decorator,
   imageio,
   imageio-ffmpeg,
-  matplotlib,
   numpy,
   proglog,
   python-dotenv,
-  pytest-timeout,
-  pytestCheckHook,
-  pythonOlder,
   requests,
+  tqdm,
+
+  # optional-dependencies
+  matplotlib,
   scikit-image,
   scikit-learn,
   scipy,
-  setuptools,
-  tqdm,
   yt-dlp,
+
+  # tests
+  pytest-timeout,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "moviepy";
   version = "2.1.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Zulko";
@@ -69,20 +75,25 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "moviepy" ];
 
-  disabledTests = [
-    # stalls
-    "test_doc_examples"
-    # video orientation mismatch, 0 != 180
-    "test_PR_529"
-    # video orientation [1920, 1080] != [1080, 1920]
-    "test_ffmpeg_parse_video_rotation"
-    "test_correct_video_rotation"
-    # media duration mismatch: assert 230.0 == 30.02
-    "test_ffmpeg_parse_infos_decode_file"
-    # Failed: DID NOT RAISE <class 'OSError'>
-    "test_ffmpeg_resize"
-    "test_ffmpeg_stabilize_video"
-  ];
+  disabledTests =
+    [
+      # stalls
+      "test_doc_examples"
+      # video orientation mismatch, 0 != 180
+      "test_PR_529"
+      # video orientation [1920, 1080] != [1080, 1920]
+      "test_ffmpeg_parse_video_rotation"
+      "test_correct_video_rotation"
+      # media duration mismatch: assert 230.0 == 30.02
+      "test_ffmpeg_parse_infos_decode_file"
+      # Failed: DID NOT RAISE <class 'OSError'>
+      "test_ffmpeg_resize"
+      "test_ffmpeg_stabilize_video"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Failed: Timeout >30.0s
+      "test_issue_1682"
+    ];
 
   disabledTestPaths = [
     "tests/test_compositing.py"
@@ -93,11 +104,11 @@ buildPythonPackage rec {
     "tests/test_videotools.py"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Video editing with Python";
     homepage = "https://zulko.github.io/moviepy/";
-    changelog = "https://github.com/Zulko/moviepy/blob/${src.tag}/CHANGELOG.md";
-    license = licenses.mit;
+    changelog = "https://github.com/Zulko/moviepy/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Things done

Currently broken on `master` (fails at import check phase because somehow `wandb` requires `pydantic`).

cc @r-burns

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
