### PR TITLE
[staging-next] libical: 3.0.18 -> 3.0.19

### DIFF
--- a/pkgs/by-name/li/libical/fix-cmake.patch
+++ b/pkgs/by-name/li/libical/fix-cmake.patch
@@ -1,0 +1,30 @@
+diff --git a/src/test/libical-glib/CMakeLists.txt b/src/test/libical-glib/CMakeLists.txt
+index 01a0894a1..d7d2af5bb 100644
+--- a/src/test/libical-glib/CMakeLists.txt
++++ b/src/test/libical-glib/CMakeLists.txt
+@@ -36,19 +36,19 @@ list(
+ 
+ if(PYTHON3)
+   set(GI_TYPELIB_PATH_STR "${PROJECT_BINARY_DIR}/src/libical-glib")
+-  if(DEFINED GI_TYPELIB_PATH)
+-    if($ENV{GI_TYPELIB_PATH})
++  if(DEFINED ENV{GI_TYPELIB_PATH})
++    if(NOT ENV{GI_TYPELIB_PATH} STREQUAL "")
+       set(GI_TYPELIB_PATH_STR "${GI_TYPELIB_PATH_STR}:$ENV{GI_TYPELIB_PATH}")
+     endif()
+   endif()
+   set(LIBRARY_PATH_STR "${LIBRARY_OUTPUT_PATH}")
+-  if(DEFINED LD_LIBRARY_PATH)
+-    if($ENV{LD_LIBRARY_PATH})
++  if(DEFINED ENV{LD_LIBRARY_PATH})
++    if(NOT ENV{LD_LIBRARY_PATH} STREQUAL "")
+       set(LIBRARY_PATH_STR "${LIBRARY_PATH_STR}:$ENV{LD_LIBRARY_PATH}")
+     endif()
+   endif()
+-  if(DEFINED DYLD_LIBRARY_PATH)
+-    if($ENV{DYLD_LIBRARY_PATH})
++  if(DEFINED ENV{DYLD_LIBRARY_PATH})
++    if(NOT ENV{DYLD_LIBRARY_PATH} STREQUAL "")
+       set(LIBRARY_PATH_STR "${LIBRARY_PATH_STR}:$ENV{DYLD_LIBRARY_PATH}")
+     endif()
+   endif()

--- a/pkgs/by-name/li/libical/package.nix
+++ b/pkgs/by-name/li/libical/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libical";
-  version = "3.0.18";
+  version = "3.0.19";
 
   outputs = [
     "out"
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     owner = "libical";
     repo = "libical";
     rev = "v${version}";
-    sha256 = "sha256-32FNnCybXO67Vtg1LM6miJUaK+r0mlfjxgLQg1LD8Es=";
+    sha256 = "sha256-ZJXxi1LOZyEpgdcmoK0pe5IA3+l9WY0zLu6Ttzy1QSc=";
   };
 
   strictDeps = true;
@@ -91,18 +91,14 @@ stdenv.mkDerivation rec {
     # Will appear in 3.1.0
     # https://github.com/libical/libical/issues/350
     ./respect-env-tzdir.patch
+
+    # CMake setup fix for tests
+    # Submitted upstream: https://github.com/libical/libical/pull/885
+    # FIXME: remove when merged
+    ./fix-cmake.patch
   ];
 
-  postPatch = ''
-    # Fix typo in test env setup
-    # https://github.com/libical/libical/commit/03c02ced21494413920744a400c638b0cb5d493f
-    substituteInPlace src/test/libical-glib/CMakeLists.txt \
-      --replace-fail "''${CMAKE_BINARY_DIR}/src/libical-glib;\$ENV{GI_TYPELIB_PATH}" "''${CMAKE_BINARY_DIR}/src/libical-glib:\$ENV{GI_TYPELIB_PATH}" \
-      --replace-fail "''${LIBRARY_OUTPUT_PATH};\$ENV{LD_LIBRARY_PATH}" "''${LIBRARY_OUTPUT_PATH}:\$ENV{LD_LIBRARY_PATH}"
-  '';
-
-  # Using install check so we do not have to manually set
-  # LD_LIBRARY_PATH and GI_TYPELIB_PATH variables
+  # Using install check so we do not have to manually set GI_TYPELIB_PATH
   # Musl does not support TZDIR.
   doInstallCheck = !stdenv.hostPlatform.isMusl;
   enableParallelChecking = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
