### PR TITLE
linux-manual: clean up and improve

### DIFF
--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     mandir=$out/share/man/man9
     mkdir -p $mandir
 
-    KBUILD_BUILD_TIMESTAMP=$(stat -c %Y Makefile) \
+    KBUILD_BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH")" \
     grep -F -l -Z \
       --exclude-dir Documentation \
       --exclude-dir tools \

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -1,8 +1,9 @@
 {
   lib,
   stdenv,
-  perl,
   linuxPackages_latest,
+  perl,
+  man,
 }:
 
 stdenv.mkDerivation {
@@ -10,9 +11,11 @@ stdenv.mkDerivation {
   inherit (linuxPackages_latest.kernel) version src;
 
   nativeBuildInputs = [ perl ];
+  nativeInstallCheckInputs = [ man ];
 
   dontConfigure = true;
   dontBuild = true;
+  doInstallCheck = true;
 
   postPatch = ''
     patchShebangs --build \
@@ -35,9 +38,16 @@ stdenv.mkDerivation {
         "$SHELL" -c '{ scripts/kernel-doc -man "$@" || :; } \
           | scripts/split-man.pl "$mandir"' kernel-doc
 
-    test -f "$mandir/kmalloc.9"
-
     runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Check for well‐known man page
+    man -M "$out/share/man" -P cat 9 kmalloc >/dev/null
+
+    runHook postInstallCheck
   '';
 
   meta = {

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     export mandir="$out/share/man/man9"
     mkdir -p "$mandir"
 
@@ -34,6 +36,8 @@ stdenv.mkDerivation {
           | scripts/split-man.pl "$mandir"' kernel-doc
 
     test -f "$mandir/kmalloc.9"
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -5,7 +5,7 @@
   linuxPackages_latest,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "linux-manual";
   inherit (linuxPackages_latest.kernel) version src;
 

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -21,19 +21,19 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mandir=$out/share/man/man9
-    mkdir -p $mandir
+    export mandir="$out/share/man/man9"
+    mkdir -p "$mandir"
 
     KBUILD_BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH")" \
     grep -F -l -Z \
       --exclude-dir Documentation \
       --exclude-dir tools \
       -R '/**' \
-      | xargs -0 -n 256 -P $NIX_BUILD_CORES \
-        $SHELL -c '{ scripts/kernel-doc -man "$@" || :; } \
-          | scripts/split-man.pl '$mandir kernel-doc
+      | xargs -0 -n 256 -P "$NIX_BUILD_CORES" \
+        "$SHELL" -c '{ scripts/kernel-doc -man "$@" || :; } \
+          | scripts/split-man.pl "$mandir"' kernel-doc
 
-    test -f $mandir/kmalloc.9
+    test -f "$mandir/kmalloc.9"
   '';
 
   meta = {

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation {
     test -f $mandir/kmalloc.9
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://kernel.org/";
     description = "Linux kernel API manual pages";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ mvs ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ mvs ];
   };
 }

--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -41,5 +41,6 @@ stdenv.mkDerivation {
     description = "Linux kernel API manual pages";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ mvs ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
- Rely on `SOURCE_DATE_EPOCH` environment variable instead of calling `stat`,
- remove use of `with lib;`,
- remove use of `rec`,
- quote all shell expansions to ensure proper tokenisation,
- provide a simple installation check,
- call pre / post hooks, and
- define `meta.platforms`.

I looked into validation of the generated man pages, but that might require some upstream fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
