### PR TITLE
nixos/networking: don't add hostname / FQDN entries to `/etc/hosts`

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -24,6 +24,7 @@ in
           "192.168.0.2" = [ "fileserver.local" "nameserver.local" ];
         };
       '';
+      default = {};
       description = ''
         Locally defined maps of hostnames to IP addresses.
       '';
@@ -154,16 +155,6 @@ in
         `networking.extraHosts` if you really want to add such a mapping.
       '';
     }];
-
-    # These entries are required for "hostname -f" and to resolve both the
-    # hostname and FQDN correctly:
-    networking.hosts = let
-      hostnames = # Note: The FQDN (canonical hostname) has to come first:
-        lib.optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
-        ++ lib.optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
-    in {
-      "127.0.0.2" = hostnames;
-    };
 
     networking.hostFiles = let
       # Note: localhostHosts has to appear first in /etc/hosts so that 127.0.0.1

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -56,13 +56,6 @@ let
         )
         assert "localhost" == machine.succeed("getent hosts ::1 | awk '{print $2}'").strip()
 
-        # 127.0.0.2 should resolve back to the FQDN and hostname:
-        fqdn_and_host_name = "${optionalString (domain != null) "${hostName}.${domain} "}${hostName}"
-        assert (
-            fqdn_and_host_name
-            == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2,$3}'").strip()
-        )
-
         assert "${fqdn}" == machine.succeed("getent hosts ${hostName} | awk '{print $2}'").strip()
       '';
     };

--- a/nixos/tests/systemd-resolved.nix
+++ b/nixos/tests/systemd-resolved.nix
@@ -5,12 +5,19 @@ import ./make-test-python.nix (
     meta.maintainers = [ lib.maintainers.elvishjerricco ];
 
     nodes.server =
-      { lib, config, ... }:
+      {
+        lib,
+        config,
+        nodes,
+        ...
+      }:
       let
         exampleZone = pkgs.writeTextDir "example.com.zone" ''
           @ SOA ns.example.com. noc.example.com. 2019031301 86400 7200 3600000 172800
           @       A       ${(lib.head config.networking.interfaces.eth1.ipv4.addresses).address}
           @       AAAA    ${(lib.head config.networking.interfaces.eth1.ipv6.addresses).address}
+          client  A       ${(lib.head nodes.client.networking.interfaces.eth1.ipv4.addresses).address}
+          client  AAAA    ${(lib.head nodes.client.networking.interfaces.eth1.ipv6.addresses).address}
         '';
       in
       {
@@ -38,11 +45,20 @@ import ./make-test-python.nix (
       };
 
     nodes.client =
-      { nodes, ... }:
+      { lib, nodes, ... }:
       let
         inherit (lib.head nodes.server.networking.interfaces.eth1.ipv4.addresses) address;
       in
       {
+        networking.hostName = "client";
+        networking.domain = "example.com";
+
+        # The NixOS testing framework automatically generates host entries for
+        # the `hostName` and FQDN settings pointing to the nodes' primary
+        # IP. Instead, we want to test how a real, unmodified NixOS system will
+        # behave. Override the `extraHosts` setting accordingly:
+        networking.extraHosts = lib.mkForce "";
+
         networking.nameservers = [ address ];
         networking.interfaces.eth1.ipv6.addresses = lib.mkForce [
           {
@@ -68,8 +84,10 @@ import ./make-test-python.nix (
     testScript =
       { nodes, ... }:
       let
-        address4 = (lib.head nodes.server.networking.interfaces.eth1.ipv4.addresses).address;
-        address6 = (lib.head nodes.server.networking.interfaces.eth1.ipv6.addresses).address;
+        serverAddress4 = (lib.head nodes.server.networking.interfaces.eth1.ipv4.addresses).address;
+        serverAddress6 = (lib.head nodes.server.networking.interfaces.eth1.ipv6.addresses).address;
+        clientAddress4 = (lib.head nodes.client.networking.interfaces.eth1.ipv4.addresses).address;
+        clientAddress6 = (lib.head nodes.client.networking.interfaces.eth1.ipv6.addresses).address;
       in
       ''
         start_all()
@@ -77,10 +95,18 @@ import ./make-test-python.nix (
 
         def test_client():
             query = client.succeed("resolvectl query example.com")
-            assert "${address4}" in query
-            assert "${address6}" in query
+            assert "${serverAddress4}" in query
+            assert "${serverAddress6}" in query
             client.succeed("ping -4 -c 1 example.com")
             client.succeed("ping -6 -c 1 example.com")
+
+            # Ensure that the client can resolve its own FQDN and retreive both
+            # A and AAAA records:
+            query = client.succeed("resolvectl query client.example.com")
+            assert "${clientAddress4}" in query
+            assert "${clientAddress6}" in query
+            client.succeed("ping -4 -c 1 client.example.com")
+            client.succeed("ping -6 -c 1 client.example.com")
 
         client.wait_for_unit("initrd.target")
         test_client()


### PR DESCRIPTION
PR #362132 [1] removed multiple `/etc/hosts` entires mapping to the same IPv6 loopback address (`::1`). However, a mapping from a machine's hostname and FQDN still exists for a second IPv4 loopback address (`127.0.0.2`).

This causes issues when using systemd's resolved: when any `/etc/hosts` entry exists for a domain name being queried, systemd-resolved only returns entires from the `/etc/hosts` database, and no other records that can be obtained from DNS. In practice, this means that a host trying to resolve its own FQDN (which is further configured in the system's NixOS configuration through the `networking.hostName` and `networking.domain` settings) will only return its IPv4 loopback IP (`127.0.0.2`), but _no_ IPv6 address, regardless of whether a AAAA-record exists.

    [root@myserver:~]# cat /etc/hosts
    127.0.0.1 localhost
    ::1 localhost
    127.0.0.2 myserver.example.org

    [root@myserver:~]# resolvectl query myserver.example.org
    myserver.example.org: 127.0.0.2

    -- Information acquired via protocol DNS in 6.1ms.
    -- Data is authenticated: yes; Data was acquired via local or encrypted transport: yes
    -- Data from: synthetic

This pull request removes such default hostname or FQDN hosts-entries entirely. This is similar to the default configurations on AlmaLinux or Fedora systems:

    root@myserver:~# cat /etc/hosts
    # Loopback entries; do not change.
    # For historical reasons, localhost precedes localhost.localdomain:
    127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
    ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
    # See hosts(5) for proper format and other examples:
    # 192.168.1.10 foo.example.org foo
    # 192.168.1.13 bar.example.org bar

It does not prevent users from defining any custom such entires for the machine's public IPs, similar to the comment in the file above. We don't have a good idea to determine what the proper public IPv4 and IPv6 addresses are for a machine's FQDN, and as such this decision and responsibility should be on the user.

In a separate commit, this PR adds a test that ensures that hosts can resolve their own v4 and v6 addresses as encoded in A and AAAA records of their upstream DNS server or resolver respectively.

This test fails prior to this PR with a regular NixOS install, which contains an `/etc/hosts` mapping for FQDN to 127.0.0.2, but no such mapping for an IPv6 loopback IP (as there are no multiple loopback v6 IPs, and each address must only be listed once [1]). While, for NixOS test configurations, this test passes, this is only because the test networking module adds additional entries to `networking.extraHosts` which are not present in a regular NixOS configuration.

[1]: https://github.com/NixOS/nixpkgs/pull/362132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Ping @alyssais @ElvishJerricco @primeos @blitz 