### PR TITLE
vimPlugins.sniprun: 1.3.16 -> 1.3.17

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/sniprun/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sniprun/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
   fetchFromGitHub,
-  nix-update-script,
+
+  # sniprun-bin
   rustPlatform,
-  vimUtils,
   makeWrapper,
   bashInteractive,
   coreutils,
@@ -11,21 +11,26 @@
   gnugrep,
   gnused,
   procps,
+
+  # sniprun
+  vimUtils,
+  substituteAll,
+  nix-update-script,
 }:
 let
-  version = "1.3.16";
+  version = "1.3.17";
   src = fetchFromGitHub {
     owner = "michaelb";
     repo = "sniprun";
     tag = "v${version}";
-    hash = "sha256-2rVeBUkdLXUiHkd8slyiLTYQBKwgMQvIi/uyCToVBYA=";
+    hash = "sha256-o8U3GXg61dfEzQxrs9zCgRDWonhr628aSPd/l+HxS70=";
   };
   sniprun-bin = rustPlatform.buildRustPackage {
     pname = "sniprun-bin";
     inherit version src;
 
     useFetchCargoVendor = true;
-    cargoHash = "sha256-j3i86I5Lmt0+fQONikHnxfeLEbiyFSairgjHXmjZfTk=";
+    cargoHash = "sha256-HLPTt0JCmCM4SRmP8o435ilM1yxoxpAnf8hg3+8C54I=";
 
     nativeBuildInputs = [ makeWrapper ];
 
@@ -44,17 +49,20 @@ let
     '';
 
     doCheck = false;
+
+    meta.mainProgram = "sniprun";
   };
 in
 vimUtils.buildVimPlugin {
   pname = "sniprun";
   inherit version src;
 
-  patches = [ ./fix-paths.patch ];
-
-  postPatch = ''
-    substituteInPlace lua/sniprun.lua --replace '@sniprun_bin@' ${sniprun-bin}
-  '';
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      sniprun = lib.getExe sniprun-bin;
+    })
+  ];
 
   propagatedBuildInputs = [ sniprun-bin ];
 
@@ -69,7 +77,7 @@ vimUtils.buildVimPlugin {
 
   meta = {
     homepage = "https://github.com/michaelb/sniprun/";
-    changelog = "https://github.com/michaelb/sniprun/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/michaelb/sniprun/blob/v${version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ GaetanLepage ];
     license = lib.licenses.mit;
   };

--- a/pkgs/applications/editors/vim/plugins/non-generated/sniprun/fix-paths.patch
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sniprun/fix-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/lua/sniprun.lua b/lua/sniprun.lua
-index 49be442..1834566 100644
+index 49be442..9342351 100644
 --- a/lua/sniprun.lua
 +++ b/lua/sniprun.lua
 @@ -3,9 +3,7 @@ M.ping_anwsered = 0
@@ -9,7 +9,7 @@ index 49be442..1834566 100644
 -local binary_path = vim.fn.fnamemodify(
 -        vim.api.nvim_get_runtime_file("lua/sniprun.lua", false)[1], ":h:h")
 -    .. "/target/release/sniprun"
-+local binary_path = "@sniprun_bin@/bin/sniprun"
++local binary_path = "@sniprun@"
  
  local sniprun_path = vim.fn.fnamemodify(vim.api.nvim_get_runtime_file("lua/sniprun.lua", false)[1], ":p:h") .. "/.."
  


### PR DESCRIPTION
## Things done

Changelog: https://github.com/michaelb/sniprun/blob/v1.3.17/CHANGELOG.md

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
