### PR TITLE
treewide: remove "v" prefix in version

### DIFF
--- a/pkgs/by-name/cr/criterion/tests/001-version.nix
+++ b/pkgs/by-name/cr/criterion/tests/001-version.nix
@@ -5,7 +5,7 @@
 }:
 stdenv.mkDerivation rec {
   name = "version-tester";
-  version = "v${criterion.version}";
+  inherit (criterion) version;
   src = ./test_dummy.c;
 
   dontUnpack = true;

--- a/pkgs/by-name/do/docker-init/package.nix
+++ b/pkgs/by-name/do/docker-init/package.nix
@@ -6,7 +6,8 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "docker-init";
-  version = "v1.4.0";
+  version = "1.4.0";
+
   tag = "175267";
 
   src = fetchurl {

--- a/pkgs/by-name/gi/git-together/package.nix
+++ b/pkgs/by-name/gi/git-together/package.nix
@@ -10,12 +10,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "git-together";
-  version = "v0.1.0-alpha.26";
+  version = "0.1.0-alpha.26";
 
   src = fetchFromGitHub {
     owner = "kejadlen";
     repo = "git-together";
-    rev = version;
+    tag = "v${version}";
     hash = "sha256-2HgOaqlX0mmmvRlALHm90NAdIhby/jWUJO63bQFqc+4=";
   };
 
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-5LKKjHzIlXw0bUmF7GDCVW0cptCxohq6CNPIrMZKorM=";
 
   meta = with lib; {
-    changelog = "https://github.com/kejadlen/git-together/releases/tag/${src.rev}";
+    changelog = "https://github.com/kejadlen/git-together/releases/tag/v${version}";
     description = "Better commit attribution while pairing without messing with your git workflow";
     homepage = "https://github.com/kejadlen/git-together";
     license = licenses.mit;

--- a/pkgs/by-name/hu/hullcaster/package.nix
+++ b/pkgs/by-name/hu/hullcaster/package.nix
@@ -6,12 +6,12 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hullcaster";
-  version = "v0.1.2";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "gilcu3";
     repo = "hullcaster";
-    rev = version;
+    tag = "v${version}";
     hash = "sha256-TaELX/xMxm7OTmVnvkgEmdhnVrIlxSNqlE73+I5qxCc=";
   };
 

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -7,12 +7,12 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "lora";
-  version = "v3.005";
+  version = "3.005";
 
   src = fetchFromGitHub {
     owner = "cyrealtype";
     repo = "lora";
-    rev = version;
+    rev = "v${version}";
     hash = "sha256-EHa8DUPFRvdYBdCY41gfjKGtTHwGIXCwD9Qc+Npmt1s=";
   };
 

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -30,11 +30,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Lora is a well-balanced contemporary serif with roots in calligraphy";
     homepage = "https://github.com/cyrealtype/lora";
-    license = licenses.ofl;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ ofalvai ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ofalvai ];
   };
 })

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -5,14 +5,14 @@
   nix-update-script,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "lora";
   version = "3.005";
 
   src = fetchFromGitHub {
     owner = "cyrealtype";
     repo = "lora";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-EHa8DUPFRvdYBdCY41gfjKGtTHwGIXCwD9Qc+Npmt1s=";
   };
 
@@ -37,4 +37,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ ofalvai ];
   };
-}
+})

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cyrealtype";
     repo = "lora";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-EHa8DUPFRvdYBdCY41gfjKGtTHwGIXCwD9Qc+Npmt1s=";
   };
 

--- a/pkgs/by-name/ms/msgraph-cli/package.nix
+++ b/pkgs/by-name/ms/msgraph-cli/package.nix
@@ -7,12 +7,12 @@
 }:
 buildDotnetModule rec {
   pname = "msgraph-cli";
-  version = "v1.9.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "microsoftgraph";
     repo = "msgraph-cli";
-    rev = version;
+    tag = "v${version}";
     hash = "sha256-bpdxzVlQWQLNYTZHN25S6qa3NKHhDc+xV6NvzSNMVnQ=";
   };
 

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -8,17 +8,17 @@
 let
   finalAttrs = {
     pname = "ncps";
-    version = "v0.1.1";
+    version = "0.1.1";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
-      rev = finalAttrs.version;
+      tag = "v${finalAttrs.version}";
       hash = "sha256-Vr/thppCABdZDl1LEc7l7c7Ih55U/EFwJInWSUWoLJA";
     };
 
     ldflags = [
-      "-X github.com/kalbasit/ncps/cmd.Version=${finalAttrs.version}"
+      "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
 
     subPackages = [ "." ];

--- a/pkgs/by-name/vm/vmctl/package.nix
+++ b/pkgs/by-name/vm/vmctl/package.nix
@@ -16,7 +16,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "vmctl";
-  version = "v0.99-unstable-2024-05-14";
+  version = "0.99-unstable-2024-05-14";
 
   src = fetchFromGitHub {
     owner = "SamsungDS";

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -144,9 +144,9 @@ super: lib.trivial.pipe super [
   }))
 
   (patchExtension "pano@elhan.io" (final: prev: {
-    version = "v23-alpha3";
+    version = "23-alpha3";
     src = fetchzip {
-      url = "https://github.com/oae/gnome-shell-pano/releases/download/${final.version}/pano@elhan.io.zip";
+      url = "https://github.com/oae/gnome-shell-pano/releases/download/v${final.version}/pano@elhan.io.zip";
       hash = "sha256-LYpxsl/PC8hwz0ZdH5cDdSZPRmkniBPUCqHQxB4KNhc=";
       stripRoot = false;
     };

--- a/pkgs/development/php-packages/uuid/default.nix
+++ b/pkgs/development/php-packages/uuid/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "v1.2.1";
+  version = "1.2.1";
 in
 buildPecl {
   inherit version;
@@ -15,7 +15,7 @@ buildPecl {
   src = fetchFromGitHub {
     owner = "php";
     repo = "pecl-networking-uuid";
-    tag = version;
+    tag = "v${version}";
     hash = "sha256-C4SoSKkCTQOLKM1h47vbBgiHTG+ChocDB9tzhWfKUsw=";
   };
 
@@ -26,7 +26,7 @@ buildPecl {
   env.PHP_UUID_DIR = libuuid;
 
   meta = {
-    changelog = "https://github.com/php/pecl-networking-uuid/releases/tag/${version}";
+    changelog = "https://github.com/php/pecl-networking-uuid/releases/tag/v${version}";
     description = "A wrapper around Universally Unique IDentifier library (libuuid).";
     license = lib.licenses.php301;
     homepage = "https://github.com/php/pecl-networking-uuid";

--- a/pkgs/development/python-modules/falconpy/default.nix
+++ b/pkgs/development/python-modules/falconpy/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "falconpy";
-  version = "v1.4.6";
+  version = "1.4.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CrowdStrike";
     repo = "falconpy";
-    tag = version;
+    tag = "v${version}";
     hash = "sha256-boebQI//NenEqctQbEdxiXKU3/07C6jVzWVHecmJjPk=";
   };
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   meta = {
     description = "The CrowdStrike Falcon SDK for Python";
     homepage = "https://github.com/CrowdStrike/falconpy";
-    changelog = "https://github.com/CrowdStrike/falconpy/releases/tag/${version}";
+    changelog = "https://github.com/CrowdStrike/falconpy/releases/tag/v${version}";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ levigross ];
   };

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -13,12 +13,12 @@
 
 mkDerivation rec {
   pname = "gede";
-  version = "v2.22.1";
+  version = "2.22.1";
 
   src = fetchFromGitHub {
     owner = "jhn98032";
     repo = "gede";
-    rev = version;
+    tag = "v${version}";
     hash = "sha256-6YSrqLDuV4G/uvtYy4vzbwqrMFftMvZdp3kr3R436rs=";
   };
 

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -16,11 +16,11 @@ let
   # This is copied from influxdb2 with the required flux version
   flux = rustPlatform.buildRustPackage rec {
     pname = "libflux";
-    version = "v${libflux_version}";
+    version = libflux_version;
     src = fetchFromGitHub {
       owner = "influxdata";
       repo = "flux";
-      rev = "v${libflux_version}";
+      tag = "v${libflux_version}";
       hash = "sha256-XHT/+JMu5q1cPjZT2x/OKEPgxFJcnjrQKqn8w9/Mb3s=";
     };
     patches = [

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -32,7 +32,7 @@ let
 
   flux = rustPlatform.buildRustPackage {
     pname = "libflux";
-    version = "v${libflux_version}";
+    version = libflux_version;
     src = fetchFromGitHub {
       owner = "influxdata";
       repo = "flux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Remove `v` prefix from `version` from all packages that have it to comply with:

https://github.com/NixOS/nixpkgs/blob/38e15cc875f4f7292d1732f77d7f882073a34865/pkgs/README.md?plain=1#L383-L385

Might do a follow up for migrating `unstable` to `0-unstable`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
