### PR TITLE
bitwarden-desktop: 2025.1.1 -> 2025.2.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/dont-auto-setup-biometrics.patch
@@ -1,8 +1,8 @@
-diff --git a/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts b/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
-index 8962e7f3ec..a7291420f2 100644
---- a/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
-+++ b/apps/desktop/src/key-management/biometrics/biometric.unix.main.ts
-@@ -109,7 +109,7 @@ export default class BiometricUnixMain implements OsBiometricService {
+diff --git a/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts b/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
+index 791b4d6f88..dfee0bbf8d 100644
+--- a/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
++++ b/apps/desktop/src/key-management/biometrics/os-biometrics-linux.service.ts
+@@ -115,7 +115,7 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
      // The user needs to manually set up the polkit policy outside of the sandbox
      // since we allow access to polkit via dbus for the sandboxed clients, the authentication works from
      // the sandbox, once the policy is set up outside of the sandbox.

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -4,8 +4,6 @@
   cargo,
   copyDesktopItems,
   electron_34,
-  esbuild,
-  buildGoModule,
   fetchFromGitHub,
   gnome-keyring,
   jq,

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -3,7 +3,9 @@
   buildNpmPackage,
   cargo,
   copyDesktopItems,
-  electron_33,
+  electron_34,
+  esbuild,
+  buildGoModule,
   fetchFromGitHub,
   gnome-keyring,
   jq,
@@ -23,7 +25,7 @@
 let
   description = "Secure and free password manager for all of your devices";
   icon = "bitwarden";
-  electron = electron_33;
+  electron = electron_34;
 
   bitwardenDesktopNativeArch =
     {
@@ -36,13 +38,13 @@ let
 in
 buildNpmPackage rec {
   pname = "bitwarden-desktop";
-  version = "2025.1.1";
+  version = "2025.2.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-0NXrTBkCyo9Hw+fyFTfXfa1efBlaM6xWd9Uvsbathpw=";
+    hash = "sha256-+RMeo+Kyum1WNm7citUe9Uk5yOtfhMPPlQRtnYL3Pj8=";
   };
 
   patches = [
@@ -66,8 +68,13 @@ buildNpmPackage rec {
     "--engine-strict"
     "--legacy-peer-deps"
   ];
+
+  npmRebuildFlags = [
+    # FIXME one of the esbuild versions fails to download @esbuild/linux-x64
+    "--ignore-scripts"
+  ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-DDsPkvLGOhjmdYEOmhZfe4XHGFyowvWO24YcCA5griM=";
+  npmDepsHash = "sha256-fYZJA6qV3mqxO2g+yxD0MWWQc9QYmdWJ7O7Vf88Qpbs=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
@@ -79,7 +86,7 @@ buildNpmPackage rec {
     ) patches;
     patchFlags = [ "-p4" ];
     sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-IL8+n+rhRbvRO1jxJSy9PjUMb/tI4S/gzpUNOojBPWk=";
+    hash = "sha256-OldVFMI+rcGAbpDg7pHu/Lqbw5I6/+oXULteQ9mXiFc=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 
@@ -162,7 +169,7 @@ buildNpmPackage rec {
     # This may break in the future but its better than copy-pasting it manually.
     mkdir -p $out/share/polkit-1/actions/
     pushd apps/desktop/src/key-management/biometrics
-    awk '/const polkitPolicy = `/{gsub(/^.*`/, ""); print; str=1; next} str{if (/`;/) str=0; gsub(/`;/, ""); print}' biometric.unix.main.ts > $out/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
+    awk '/const polkitPolicy = `/{gsub(/^.*`/, ""); print; str=1; next} str{if (/`;/) str=0; gsub(/`;/, ""); print}' os-biometrics-linux.service.ts > $out/share/polkit-1/actions/com.bitwarden.Bitwarden.policy
     popd
 
     pushd apps/desktop/resources/icons


### PR DESCRIPTION
See releases 2025.1.2, 2025.1.3 and 2025.1.4:

https://github.com/bitwarden/clients/releases?q=desktop-&expanded=true

Basically bug fixes and dependency updates.

Amongst the dependency updates are vite and esbuild. Both vite and bitwarden-desktop depend on different versions of esbuild. esbuild tries to download its binaries, but fails. Alternatively `ESBUILD_BINARY_PATH` can be used to skip the download. Setting this to one version of esbuild will fail the vite esbuild, setting this to another will fail the bitwarden-desktop esbuild. There need to be 2 versions of esbuild being used during the `npm rebuild`.

I've split the `npm rebuild` step into two. One rebuilds the dependencies vite and electron and thus skipping a rebuild of `bitwarden-desktop`. This is done by specifying the dependencies to rebuild explicitly in `npmRebuildFlags`. In `preBuild`, `npm rebuild .` is used for `bitwarden-desktop` only. This way `ESBUILD_BINARY_PATH` can be specified separately with different versions.

I also needed to update the biometrics patching, as the biometrics file has been renamed (`biometric.unix.main.ts` -> `os-biometrics-linux.service.ts`).

I'm still hoping this can be resolved in a nicer way, but I haven't figured this out yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
