### PR TITLE
ofono: 2.3 -> 2.14, fix some CVEs

### DIFF
--- a/pkgs/by-name/of/ofono/package.nix
+++ b/pkgs/by-name/of/ofono/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchzip,
+  fetchpatch,
+  testers,
   autoreconfHook,
   pkg-config,
   glib,
@@ -10,11 +12,12 @@
   systemd,
   bluez,
   mobile-broadband-provider-info,
+  python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ofono";
-  version = "2.3";
+  version = "2.14";
 
   outputs = [
     "out"
@@ -22,17 +25,42 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchzip {
-    url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/snapshot/ofono-${version}.tar.gz";
-    sha256 = "sha256-rX3ngXoW7YISyytpRPLX/lGmQa5LPtFxeA2XdtU1gV0=";
+    url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/snapshot/ofono-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-7hYGSU8mEu9MfKAA0vR1tm/l46hHQmpZSYfMNkces5c=";
   };
 
   patches = [
+    (fetchpatch {
+      name = "0001-ofono-CVE-2024-7539.patch";
+      url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/patch/?id=389e2344f86319265fb72ae590b470716e038fdc";
+      hash = "sha256-jaZswtkWa8A9WlmjUxcwWtU2uUX5+g8m2Y/60Lb9C5Q=";
+    })
+
+    (fetchpatch {
+      name = "0002-ofono-CVE-2024-7540-through-7542.patch";
+      url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/patch/?id=29ff6334b492504ace101be748b256e6953d2c2f";
+      hash = "sha256-3iKG+5AQUVO4alZd3stTpyanwI2IfKbVTzatflMsurY=";
+    })
+
+    (fetchpatch {
+      name = "0003-ofono-Ensure-decode_hex_own_buf-valid-buffer.patch";
+      url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/patch/?id=1e2a768445aecfa0a0e9c788651a9205cfd3744f";
+      hash = "sha256-MD+LMnVK1JcVU47jQ+X0AHe8c/WqjsFycDroONE9ZLM=";
+    })
+
     ./0001-Search-connectors-in-OFONO_PLUGIN_PATH.patch
   ];
+
+  postPatch = ''
+    patchShebangs tools/provisiontool
+  '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    python3
   ];
 
   buildInputs = [
@@ -45,9 +73,9 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--with-dbusconfdir=${placeholder "out"}/share"
-    "--with-systemdunitdir=${placeholder "out"}/lib/systemd/system"
-    "--enable-external-ell"
+    (lib.strings.withFeatureAs true "dbusconfdir" "${placeholder "out"}/share")
+    (lib.strings.withFeatureAs true "systemdunitdir" "${placeholder "out"}/lib/systemd/system")
+    (lib.strings.enableFeature true "external-ell")
     "--sysconfdir=/etc"
   ];
 
@@ -58,15 +86,20 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   enableParallelChecking = false;
 
-  doCheck = true;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
-  meta = with lib; {
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
     description = "Infrastructure for building mobile telephony (GSM/UMTS) applications";
     homepage = "https://git.kernel.org/pub/scm/network/ofono/ofono.git";
-    changelog = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/plain/ChangeLog?h=${version}";
-    license = licenses.gpl2Only;
+    changelog = "https://git.kernel.org/pub/scm/network/ofono/ofono.git/plain/ChangeLog?h=${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "ofonod";
+    pkgConfigModules = [
+      "ofono"
+    ];
   };
-}
+})


### PR DESCRIPTION
[2.3 is more than>1y old](https://git.kernel.org/pub/scm/network/ofono/ofono.git/tag/?h=2.3), r-ryantm failed due to a Python script being required to build.

There were [abunch of CVEs released on this in August](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078555). 2.14 fixes afew of them, and we can fetch some patches to resolve afew more. According to Debian, we're then left with [CVE-2024-7537](https://security-tracker.debian.org/tracker/CVE-2024-7537) and [CVE-2024-7538](https://security-tracker.debian.org/tracker/CVE-2024-7538) still being exploitable. Not great, but bumping the state of this up by >1y should still be an improvement over the current situation.

Should prolly be backported to stable?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
