### PR TITLE
pkgsCross.loongarch64-linux.libgcc: update for `gcc-14`

### DIFF
--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -105,6 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
       arm-isa.h \
       arm-cpu.h \
     ''
+    + lib.optionalString stdenv.targetPlatform.isLoongArch64 ''
+      loongarch-multilib.h \
+    ''
     + ''
           insn-modes.h
       )


### PR DESCRIPTION
Without the change the `pkgsCross.loongarch64-linux.stdenv` fails as:

    In file included from /build/source/libgcc/../gcc/config/loongarch/loongarch.h:53,
                     from ../../.././gcc/tm.h:53,
                     from /build/source/libgcc/fixed-bit.c:48:
    /build/source/libgcc/../gcc/config/loongarch/loongarch-driver.h:82:10: fatal error: loongarch-multilib.h: No such file or directory
       82 | #include "loongarch-multilib.h"
          |          ^~~~~~~~~~~~~~~~~~~~~~

This started happening in `nixpkgs` after `gcc` was update from `gcc-13` to `gcc-14`. `gcc-14` added new auto-generated `loongarch-multilib.h` in

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=227b18f5d7616d6d34ac44836a8679de9b43c857

That broke fragile `libgcc` derivation in `nixpkgs`: the derivation sidesteps normal `gcc` build flow and relies on build details quite heavily by explicitly listing `gcc/` dependencies of `libgcc/` sources.

This change forces `loongarch-multilib.h` build which is a new dependency of `libgcc` on `loongarch64`.

Closes: https://github.com/NixOS/nixpkgs/issues/380901


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
