### PR TITLE
vimPlugins.{cmp-async-path, nvim-julia-autotest, vim-stationeers-ic10-syntax}: fix update script

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/cmp-async-path/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/cmp-async-path/default.nix
@@ -7,7 +7,7 @@
 }:
 vimUtils.buildVimPlugin {
   pname = "cmp-async-path";
-  version = "unstable-2024-10-21";
+  version = "0-unstable-2024-10-21";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
@@ -19,7 +19,9 @@ vimUtils.buildVimPlugin {
 
   checkInputs = [ vimPlugins.nvim-cmp ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Nvim-cmp source for filesystem paths with async processing";

--- a/pkgs/applications/editors/vim/plugins/non-generated/nvim-julia-autotest/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/nvim-julia-autotest/default.nix
@@ -6,7 +6,7 @@
 }:
 vimUtils.buildVimPlugin {
   pname = "nvim-julia-autotest";
-  version = "unstable-2022-10-31";
+  version = "0-unstable-2022-10-31";
 
   src = fetchFromGitLab {
     owner = "usmcamp0811";
@@ -15,7 +15,9 @@ vimUtils.buildVimPlugin {
     hash = "sha256-IaNsbBe5q7PB9Q/N/Z9nEnP6jlkQ6+xlkC0TCFnJpkk=";
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Automatically run Julia tests when you save runtest.jl file";

--- a/pkgs/applications/editors/vim/plugins/non-generated/vim-stationeers-ic10-syntax/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/vim-stationeers-ic10-syntax/default.nix
@@ -6,7 +6,7 @@
 }:
 vimUtils.buildVimPlugin {
   pname = "vim-ic10";
-  version = "unstable-2025-01-08";
+  version = "0-unstable-2025-01-08";
 
   src = fetchFromGitLab {
     owner = "LittleMorph";
@@ -15,7 +15,9 @@ vimUtils.buildVimPlugin {
     hash = "sha256-4Q1JiDA7PBUWNBNfCIZC6nImhe2FJzOqrslHazAOs18=";
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Stationeers IC10 syntax highlighting for Vim";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
These don't have releases/tags. Updating to use branch updating. 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
