### PR TITLE
umu-launcher: set FHS profile, matching Steam's

### DIFF
--- a/pkgs/by-name/um/umu-launcher/package.nix
+++ b/pkgs/by-name/um/umu-launcher/package.nix
@@ -4,6 +4,8 @@
   umu-launcher-unwrapped,
   extraPkgs ? pkgs: [ ],
   extraLibraries ? pkgs: [ ],
+  extraProfile ? "", # string to append to profile
+  extraEnv ? { }, # Environment variables to pass to Steam
   withMultiArch ? true, # Many Wine games need 32-bit libraries.
 }:
 buildFHSEnv {
@@ -26,5 +28,38 @@ buildFHSEnv {
   extraInstallCommands = ''
     ln -s ${umu-launcher-unwrapped}/lib $out/lib
     ln -s ${umu-launcher-unwrapped}/share $out/share
+  '';
+
+  # For umu & proton, we need roughly the same environment as steam.
+  # See https://github.com/NixOS/nixpkgs/issues/297662#issuecomment-2647656699
+  #
+  # TODO: if it was exposed as a drv attr, it might be nice to re-use steam's implementation.
+  profile = ''
+    # prevents log spam from SteamRT GTK trying to load host GIO modules
+    unset GIO_EXTRA_MODULES
+
+    # udev event notifications don't work reliably inside containers.
+    # SDL2 already tries to automatically detect flatpak and pressure-vessel
+    # and falls back to inotify-based discovery [1]. We make SDL2 do the
+    # same by telling it explicitly.
+    #
+    # [1] <https://github.com/libsdl-org/SDL/commit/8e2746cfb6e1f1a1da5088241a1440fd2535e321>
+    export SDL_JOYSTICK_DISABLE_UDEV=1
+
+    # This is needed for IME (e.g. iBus, fcitx5) to function correctly on non-CJK locales
+    # https://github.com/ValveSoftware/steam-for-linux/issues/781#issuecomment-2004757379
+    export GTK_IM_MODULE='xim'
+
+    # See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/distro-assumptions.md#graphics-driver
+    export LIBGL_DRIVERS_PATH=/run/opengl-driver/lib/dri:/run/opengl-driver-32/lib/dri
+    export __EGL_VENDOR_LIBRARY_DIRS=/run/opengl-driver/share/glvnd/egl_vendor.d:/run/opengl-driver-32/share/glvnd/egl_vendor.d
+    export LIBVA_DRIVERS_PATH=/run/opengl-driver/lib/dri:/run/opengl-driver-32/lib/dri
+    export VDPAU_DRIVER_PATH=/run/opengl-driver/lib/vdpau:/run/opengl-driver-32/lib/vdpau
+
+    set -a
+    ${lib.toShellVars extraEnv}
+    set +a
+
+    ${extraProfile}
   '';
 }


### PR DESCRIPTION
Some games require additional profile/environment, according to https://github.com/NixOS/nixpkgs/issues/297662#issuecomment-2647656699

Copy the relevant sections of `profile` from steam's FHS env.

I'm not too keen on just having copied 90% of steam's profile, as this feels like it could be hard to keep in sync if fixes/changes are added over time. If it was exposed as a drv attr, it might be nice to re-use steam's implementation. But currently, steam's `profile` argument is not preserved in the package's final attrs.

For reference, stream's implementation is here:
https://github.com/NixOS/nixpkgs/blob/3f5198c541172f46867427d4160cc9a2918414a0/pkgs/by-name/st/steam/package.nix#L70-L106


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
