### PR TITLE
opengist: 1.8.4 -> 1.9.1

### DIFF
--- a/pkgs/by-name/op/opengist/package.nix
+++ b/pkgs/by-name/op/opengist/package.nix
@@ -12,12 +12,12 @@
 let
   # finalAttrs when 🥺 (buildGoModule does not support them)
   # https://github.com/NixOS/nixpkgs/issues/273815
-  version = "1.8.4";
+  version = "1.9.1";
   src = fetchFromGitHub {
     owner = "thomiceli";
     repo = "opengist";
     tag = "v${version}";
-    hash = "sha256-vpl3ztLHeVZndAwDgobfiI+3Xu3CFU38qgXy83p06As=";
+    hash = "sha256-Zjn38OGnDtgD2OfIhgUxWo0Cx+ZmNv6UjJanASbjiYU=";
   };
 
   frontend = buildNpmPackage {
@@ -40,13 +40,13 @@ let
       cp -R public $out
     '';
 
-    npmDepsHash = "sha256-l09TPGBGhWcsl3x14ovilDd1zZWv4XzFCAmAfapKtAE=";
+    npmDepsHash = "sha256-Uh+oXd//G/lPAMXRxijjEOpQNmeXK/XCIU7DJN3ujaY=";
   };
 in
 buildGoModule {
   pname = "opengist";
   inherit version src;
-  vendorHash = "sha256-mLFjRL4spAWuPLVOtt88KH+p2g9lGCYzaHokVxdrLOw=";
+  vendorHash = "sha256-aqfr3yGyTXDtZDU8d1lbWWvFfY4fo6/PsSDwpiDtM90=";
   tags = [ "fs_embed" ];
   ldflags = [
     "-s"

--- a/pkgs/by-name/op/opengist/update.sh
+++ b/pkgs/by-name/op/opengist/update.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash curl coreutils jq git prefetch-npm-deps moreutils common-updater-scripts common-updater-scripts
+#!nix-shell -i bash -p bash curl coreutils jq git prefetch-npm-deps moreutils common-updater-scripts
 
 # shellcheck shell=bash
 
 set -eou pipefail
+set -x
 
-NIXPKGS_DIR="$PWD"
+NIXPKGS_DIR="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # Get latest release
@@ -27,7 +28,9 @@ fi
 
 echo "Updating opengist $oldVersion -> $latestVersion"
 
+pushd "$NIXPKGS_DIR" >/dev/null || exit 1
 update-source-version opengist "${latestVersion}"
+popd >/dev/null
 
 pushd "$SCRIPT_DIR" >/dev/null || exit 1
 
@@ -43,7 +46,7 @@ popd >/dev/null
 # nix-prefetch broken due to ninja finalAttrs.src.rev
 # nix-update with goModules broken for this package
 
-setKV () {
+setKV() {
     sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${SCRIPT_DIR}/package.nix"
 }
 


### PR DESCRIPTION
- fix update script

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
