### PR TITLE
umu-launcher: use steam's FHS profile

### DIFF
--- a/pkgs/by-name/um/umu-launcher/package.nix
+++ b/pkgs/by-name/um/umu-launcher/package.nix
@@ -1,11 +1,20 @@
 {
   buildFHSEnv,
   lib,
+  steam,
   umu-launcher-unwrapped,
   extraPkgs ? pkgs: [ ],
   extraLibraries ? pkgs: [ ],
+  extraProfile ? "", # string to append to shell profile
+  extraEnv ? { }, # Environment variables to include in shell profile
   withMultiArch ? true, # Many Wine games need 32-bit libraries.
 }:
+let
+  # Steam is not a dependency, but we re-use some of its implementation
+  steam' = steam.override {
+    inherit extraEnv extraProfile;
+  };
+in
 buildFHSEnv {
   pname = "umu-launcher";
   inherit (umu-launcher-unwrapped) version meta;
@@ -27,4 +36,10 @@ buildFHSEnv {
     ln -s ${umu-launcher-unwrapped}/lib $out/lib
     ln -s ${umu-launcher-unwrapped}/share $out/share
   '';
+
+  # For umu & proton, we need roughly the same environment as Steam.
+  # For simplicity, we use Steam's `profile` implementation.
+  # See https://github.com/NixOS/nixpkgs/pull/381047
+  # And https://github.com/NixOS/nixpkgs/issues/297662#issuecomment-2647656699
+  inherit (steam'.args) profile;
 }


### PR DESCRIPTION
Some games require additional profile/environment, according to https://github.com/NixOS/nixpkgs/issues/297662#issuecomment-2647656699

While we could copy just the relevant sections from steam's `profile`, I think we'll benefit from almost all of it and the rest should do no harm. Therefore, I'd rather inherit the `profile` arg directly from steam to avoid re-implementing and making things harder to maintain going forward.

For reference, stream's implementation is here:
https://github.com/NixOS/nixpkgs/blob/3f5198c541172f46867427d4160cc9a2918414a0/pkgs/by-name/st/steam/package.nix#L70-L106

cc interested users @2goodAP @RC-14
cc maintainers @diniamo @LovingMelody

(Supersedes #381045 due to branch renames)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
