### PR TITLE
ceph: 19.2.0 -> 19.2.1

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -27,7 +27,16 @@
   # Runtime dependencies
   arrow-cpp,
   babeltrace,
-  boost186,
+  # Note when trying to upgrade boost:
+  # * When upgrading Ceph, it's recommended to check which boost version Ceph uses on Fedora,
+  #   and default to that.
+  # * The version that Ceph downloads if `-DWITH_SYSTEM_BOOST:BOOL=ON` is not given
+  #   is declared in `cmake/modules/BuildBoost.cmake` line `set(boost_version ...)`.
+  #
+  # If you want to upgrade to boost >= 1.86, you need a Ceph version that
+  # has this PR in:
+  #     https://github.com/ceph/ceph/pull/61312
+  boost183,
   bzip2,
   cryptsetup,
   cunit,
@@ -293,7 +302,7 @@ let
       };
   };
 
-  boost' = boost186.override {
+  boost' = boost183.override {
     enablePython = true;
     inherit python;
   };
@@ -343,10 +352,10 @@ let
   );
   inherit (ceph-python-env.python) sitePackages;
 
-  version = "19.2.0";
+  version = "19.2.1";
   src = fetchurl {
     url = "https://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    hash = "sha256-30vkW1j49hFIxyxzkssSKVSq0VqiwLfDtOb62xfxadM=";
+    hash = "sha256-QEX3LHxySVgLBg21iQga1DnyQsXFi6593e+WSjgT/h8=";
   };
 in
 rec {
@@ -361,12 +370,6 @@ rec {
         hash = "sha256-21fi5tMIs/JmuhwPYMWtampv/aqAe+EoPAXZLJlOvgo=";
         stripLen = 1;
         extraPrefix = "src/s3select/";
-      })
-
-      (fetchpatch2 {
-        name = "ceph-gcc-14.patch";
-        url = "https://github.com/ceph/ceph/commit/0eace4ea9ea42412d4d6a16d24a8660642e41173.patch?full_index=1";
-        hash = "sha256-v+AExf/npe4NgmVl2j6o8860nwF9YuzC/vR0TWxTrIE=";
       })
 
       ./boost-1.85.patch
@@ -473,9 +476,20 @@ rec {
       "${placeholder "out"}/${ceph-python-env.sitePackages}"
     ];
 
-    # replace /sbin and /bin based paths with direct nix store paths
-    # increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
+    # * `unset AS` because otherwise the Ceph CMake build errors with
+    #       configure: error: No modern nasm or yasm found as required. Nasm should be v2.11.01 or later (v2.13 for AVX512) and yasm should be 1.2.0 or later.
+    #   because the code at
+    #       https://github.com/intel/isa-l/blob/633add1b569fe927bace3960d7c84ed9c1b38bb9/configure.ac#L99-L191
+    #   doesn't even consider using `nasm` or `yasm` but instead uses `$AS`
+    #   from `gcc-wrapper`.
+    #   (Ceph's error message is extra confusing, because it says
+    #   `No modern nasm or yasm found` when in fact it found e.g. `nasm`
+    #   but then uses `$AS` instead.
+    # * replace /sbin and /bin based paths with direct nix store paths
+    # * increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
     preConfigure = ''
+      unset AS
+
       substituteInPlace src/common/module.c \
         --replace "char command[128];" "char command[256];" \
         --replace "/sbin/modinfo"  "${kmod}/bin/modinfo" \


### PR DESCRIPTION
Had to downgrade the used boost186 -> boost183, see added comment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


CC for testing from the [last version upgrade](https://github.com/NixOS/nixpkgs/pull/344993):

@benaryorg 

and other `maintainers` @adev @ak @johanot @krav
