### PR TITLE
arma3-unix-launcher: 413 -> 413-unstable-2025-02-10

### DIFF
--- a/pkgs/by-name/ar/arma3-unix-launcher/disable_steam_integration.patch
+++ b/pkgs/by-name/ar/arma3-unix-launcher/disable_steam_integration.patch
@@ -1,25 +1,18 @@
-diff --git a/src/arma3-unix-launcher/mainwindow.cpp b/src/arma3-unix-launcher/mainwindow.cpp
-index 66b73cc..f89f66b 100644
---- a/src/arma3-unix-launcher/mainwindow.cpp
-+++ b/src/arma3-unix-launcher/mainwindow.cpp
-@@ -56,6 +56,3 @@ MainWindow::MainWindow(std::unique_ptr<ARMA3::Client> arma3_client, std::filesys
- {
--    if (use_steam_integration)
--        steam_integration = std::make_unique<Steam::SteamIntegration>(ARMA3::Definitions::app_id);
--    else
--        steam_integration = std::make_unique<Steam::IntegrationStub>(ARMA3::Definitions::app_id);
-+    steam_integration = std::make_unique<Steam::IntegrationStub>(ARMA3::Definitions::app_id);
- 
-diff --git a/src/dayz-linux-launcher/mainwindow.cpp b/src/dayz-linux-launcher/mainwindow.cpp
-index d9223db..5773593 100644
---- a/src/dayz-linux-launcher/mainwindow.cpp
-+++ b/src/dayz-linux-launcher/mainwindow.cpp
-@@ -56,6 +56,3 @@ MainWindow::MainWindow(std::unique_ptr<DayZ::Client> arma3_client, std::filesyst
- {
--    if (use_steam_integration)
--        steam_integration = std::make_unique<Steam::SteamIntegration>(DayZ::Definitions::app_id);
--    else
--        steam_integration = std::make_unique<Steam::IntegrationStub>(DayZ::Definitions::app_id);
-+    steam_integration = std::make_unique<Steam::IntegrationStub>(DayZ::Definitions::app_id);
- 
+diff --git a/src/arma3-unix-launcher/main.cpp b/src/arma3-unix-launcher/main.cpp
+index 10f6ed9..c706734 100644
+--- a/src/arma3-unix-launcher/main.cpp
++++ b/src/arma3-unix-launcher/main.cpp
+@@ -216,3 +216,3 @@ int main(int argc, char *argv[])
 
+-        MainWindow w(std::move(client), config_file, parser.get<bool>("--disable-steam-integration"));
++        MainWindow w(std::move(client), config_file, !parser.get<bool>("--disable-steam-integration"));
+         w.show();
+diff --git a/src/dayz-linux-launcher/main.cpp b/src/dayz-linux-launcher/main.cpp
+index f30bf8a..e0cef66 100644
+--- a/src/dayz-linux-launcher/main.cpp
++++ b/src/dayz-linux-launcher/main.cpp
+@@ -216,3 +216,3 @@ int main(int argc, char *argv[])
+
+-        MainWindow w(std::move(client), config_file, parser.get<bool>("--disable-steam-integration"));
++        MainWindow w(std::move(client), config_file, !parser.get<bool>("--disable-steam-integration"));
+         w.show();

--- a/pkgs/by-name/ar/arma3-unix-launcher/package.nix
+++ b/pkgs/by-name/ar/arma3-unix-launcher/package.nix
@@ -16,13 +16,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "arma3-unix-launcher";
-  version = "413";
+  version = "413-unstable-2025-02-10";
 
   src = fetchFromGitHub {
     owner = "muttleyxd";
     repo = "arma3-unix-launcher";
-    rev = "2ea62d961522f1542d4c8e669ef5fe856916f9ec";
-    hash = "sha256-uym93mYmVj9UxT8RbwdRUyIPrQX7nZTNWUUVjxCQmVU=";
+    rev = "7d4bcb166da3bb64ef10af421619d0b00136ebd5";
+    hash = "sha256-so7fjxESUAkQfO4hO5aQTzU5lHpeJlOOfEGp0Pb89sQ=";
   };
 
   patches = [


### PR DESCRIPTION
Adds support for the new Expeditionary Forces DLC

Also changed `disable_steam_integration.patch` to invert the `--disable-steam-integration` command line option instead of disabling steam integration entirely in the event someone wants to re-enable it. (It's currently bugged, the game fails to launch with it enabled; see muttleyxd/arma3-unix-launcher#284)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
