### PR TITLE
python312Packages.sparse: cleanup & mark as broken on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -1,15 +1,21 @@
 {
   lib,
   buildPythonPackage,
-  dask,
-  fetchPypi,
-  numba,
-  numpy,
-  pytest7CheckHook,
-  pythonOlder,
+  fetchFromGitHub,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  numba,
+  numpy,
   scipy,
+
+  # tests
+  dask,
+  pytest-cov-stub,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -17,17 +23,12 @@ buildPythonPackage rec {
   version = "0.15.5";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-THbODJb1zVwxt+eeZQ8AIkJMKxbwXxAEnpxjge5L4mY=";
+  src = fetchFromGitHub {
+    owner = "pydata";
+    repo = "sparse";
+    tag = version;
+    hash = "sha256-W4rcq7G/bQsT9oTLieOzWNst5LnIAelRMbm+uUPeQgs=";
   };
-
-  postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace-fail "--cov-report term-missing --cov-report html --cov-report=xml --cov-report=term --cov sparse --cov-config .coveragerc --junitxml=junit/test-results.xml" ""
-  '';
 
   build-system = [
     setuptools
@@ -42,23 +43,23 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     dask
-    pytest7CheckHook
+    pytest-cov-stub
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "sparse" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pytest.PytestRemovedIn8Warning"
-  ];
-
-  meta = with lib; {
+  meta = {
     description = "Sparse n-dimensional arrays computations";
     homepage = "https://sparse.pydata.org/";
     changelog = "https://sparse.pydata.org/en/stable/changelog.html";
     downloadPage = "https://github.com/pydata/sparse/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = [ ];
-    maintainers = with maintainers; [ GaetanLepage ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    badPlatforms = [
+      # Most tests fail with: Fatal Python error: Segmentation fault
+      # numba/typed/typedlist.py", line 344 in append
+      "aarch64-linux"
+    ];
   };
 }

--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -59,5 +59,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/pydata/sparse/releases/tag/${version}";
     license = licenses.bsd3;
     maintainers = [ ];
+    maintainers = with maintainers; [ GaetanLepage ];
   };
 }


### PR DESCRIPTION
## Things done

- **python312Packages.sparse: add GaetanLepage as maintainer**
- **python312Packages.sparse: cleanup & mark as broken on aarch64-linux**

Fails in tests:
```
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-7.4.4, pluggy-1.5.0
rootdir: /build/sparse-0.15.5
configfile: pytest.ini
testpaths: sparse
collected 5738 items

sparse/tests/test_array_function.py Fatal Python error: Segmentation fault

Current thread 0x0000fffff7ff5f20 (most recent call first):
  File "/build/sparse-0.15.5/sparse/_coo/indexing.py", line 171 in _mask
  File "/build/sparse-0.15.5/sparse/_coo/indexing.py", line 74 in getitem
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 416 in reduce
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 307 in _reduce
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 342 in __array_ufunc__
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 449 in sum
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 705 in mean
  File "/build/sparse-0.15.5/sparse/_common.py", line 2122 in mean
  File "/build/sparse-0.15.5/sparse/_sparse_array.py", line 283 in __array_function__
  File "/build/sparse-0.15.5/sparse/tests/test_array_function.py", line 29 in test_unary
```

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
