### PR TITLE
ocamlPackages.js_of_ocaml: 5.9.1 → 6.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes_stubs_js/default.nix
@@ -14,7 +14,6 @@ buildDunePackage rec {
   pname = "ctypes_stubs_js";
   version = "0.1";
 
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   src = fetchFromGitLab {
@@ -27,7 +26,12 @@ buildDunePackage rec {
   propagatedBuildInputs = [ integers_stubs_js ];
   nativeCheckInputs = [
     nodejs
-    js_of_ocaml-compiler
+    (
+      if lib.versionAtLeast js_of_ocaml-compiler.version "6.0" then
+        js_of_ocaml-compiler.override { version = "5.9.1"; }
+      else
+        js_of_ocaml-compiler
+    )
   ];
   checkInputs = [
     ctypes

--- a/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
@@ -8,7 +8,6 @@ buildDunePackage rec {
   pname = "ojs";
 
   inherit (gen_js_api) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [ js_of_ocaml-compiler ];
 

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -9,6 +9,16 @@
   zstd,
 }:
 
+let
+  js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
+  js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
+  gen_js_api = self.gen_js_api.override {
+    inherit js_of_ocaml-compiler;
+    ojs = self.ojs.override { inherit js_of_ocaml-compiler; };
+  };
+  js_of_ocaml-ppx = self.js_of_ocaml-ppx.override { inherit js_of_ocaml; };
+in
+
 with self;
 
 {

--- a/pkgs/development/ocaml-modules/janestreet/0.16.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.16.nix
@@ -9,6 +9,16 @@
   krb5,
 }:
 
+let
+  js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
+  js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
+  gen_js_api = self.gen_js_api.override {
+    inherit js_of_ocaml-compiler;
+    ojs = self.ojs.override { inherit js_of_ocaml-compiler; };
+  };
+  js_of_ocaml-ppx = self.js_of_ocaml-ppx.override { inherit js_of_ocaml; };
+in
+
 with self;
 
 {

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -8,6 +8,16 @@
   zstd,
 }:
 
+let
+  js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
+  js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
+  gen_js_api = self.gen_js_api.override {
+    inherit js_of_ocaml-compiler;
+    ojs = self.ojs.override { inherit js_of_ocaml-compiler; };
+  };
+  js_of_ocaml-ppx = self.js_of_ocaml-ppx.override { inherit js_of_ocaml; };
+in
+
 with self;
 
 {

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -10,7 +10,7 @@
   menhir,
   menhirLib,
   sedlex,
-  version ? if lib.versionAtLeast ocaml.version "4.11" then "5.9.1" else "5.8.2",
+  version ? if lib.versionAtLeast ocaml.version "4.11" then "6.0.1" else "5.8.2",
 }:
 
 buildDunePackage {
@@ -22,6 +22,7 @@ buildDunePackage {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
     hash =
       {
+        "6.0.1" = "sha256-gT2+4rYuFUEEnqI6IOQFzyROJ+v6mFl4XPpT4obSxhQ=";
         "5.9.1" = "sha256-aMlcYIcdjpyaVMgvNeLtUEE7y0QPIg0LNRayoe4ccwc=";
         "5.8.2" = "sha256-ciAZS9L5sU2VgVOlogZ1A1nXtJ3hL+iNdFDThc7L8Eo=";
       }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,6 +1,5 @@
 {
   buildDunePackage,
-  js_of_ocaml-compiler,
   js_of_ocaml-ppx,
   js_of_ocaml,
   lwt,
@@ -10,7 +9,7 @@
 buildDunePackage {
   pname = "js_of_ocaml-lwt";
 
-  inherit (js_of_ocaml-compiler) version src;
+  inherit (js_of_ocaml) version src meta;
 
   buildInputs = [ js_of_ocaml-ppx ];
 
@@ -19,6 +18,4 @@ buildDunePackage {
     lwt
     lwt_log
   ];
-
-  meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx.nix
@@ -1,17 +1,14 @@
 {
   buildDunePackage,
-  js_of_ocaml-compiler,
-  ppxlib,
   js_of_ocaml,
+  ppxlib,
 }:
 
 buildDunePackage {
   pname = "js_of_ocaml-ppx";
 
-  inherit (js_of_ocaml-compiler) version src;
+  inherit (js_of_ocaml) version src meta;
 
   buildInputs = [ js_of_ocaml ];
   propagatedBuildInputs = [ ppxlib ];
-
-  meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -1,6 +1,5 @@
 {
   buildDunePackage,
-  js_of_ocaml-compiler,
   js_of_ocaml,
   ppxlib,
 }:
@@ -8,12 +7,10 @@
 buildDunePackage {
   pname = "js_of_ocaml-ppx_deriving_json";
 
-  inherit (js_of_ocaml-compiler) version src;
+  inherit (js_of_ocaml) version src meta;
 
   propagatedBuildInputs = [
     js_of_ocaml
     ppxlib
   ];
-
-  meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/tyxml.nix
@@ -1,6 +1,5 @@
 {
   buildDunePackage,
-  js_of_ocaml-compiler,
   js_of_ocaml-ppx,
   js_of_ocaml,
   reactivedata,
@@ -10,7 +9,7 @@
 buildDunePackage {
   pname = "js_of_ocaml-tyxml";
 
-  inherit (js_of_ocaml-compiler) version src;
+  inherit (js_of_ocaml) version src meta;
 
   buildInputs = [ js_of_ocaml-ppx ];
 
@@ -19,6 +18,4 @@ buildDunePackage {
     reactivedata
     tyxml
   ];
-
-  meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -458,7 +458,15 @@ let
       stdenv = pkgs.gcc13Stdenv;
     };
 
-    eliom = callPackage ../development/ocaml-modules/eliom { };
+    eliom = let
+      js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
+      js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
+    in callPackage ../development/ocaml-modules/eliom rec {
+      js_of_ocaml-ppx = self.js_of_ocaml-ppx.override { inherit js_of_ocaml; };
+      js_of_ocaml-ppx_deriving_json = self.js_of_ocaml-ppx_deriving_json.override { inherit js_of_ocaml; };
+      js_of_ocaml-lwt = self.js_of_ocaml-lwt.override { inherit js_of_ocaml js_of_ocaml-ppx; };
+      js_of_ocaml-tyxml = self.js_of_ocaml-tyxml.override { inherit js_of_ocaml js_of_ocaml-ppx; };
+    };
 
     elpi = callPackage ../development/ocaml-modules/elpi (
       let ppxlib_0_15 = if lib.versionAtLeast ppxlib.version "0.15"
@@ -1413,7 +1421,12 @@ let
 
     ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };
 
-    ocsigen-toolkit = callPackage ../development/ocaml-modules/ocsigen-toolkit { };
+    ocsigen-toolkit = let
+      js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
+      js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
+    in callPackage ../development/ocaml-modules/ocsigen-toolkit {
+      js_of_ocaml-ppx_deriving_json = self.js_of_ocaml-ppx_deriving_json.override { inherit js_of_ocaml; };
+    };
 
     ocsipersist = callPackage ../development/ocaml-modules/ocsipersist {};
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
