### PR TITLE
nixos/k3s: use dynamic networking in multi node test

### DIFF
--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -60,7 +60,7 @@ import ../make-test-python.nix (
 
     nodes = {
       server =
-        { pkgs, ... }:
+        { nodes, pkgs, ... }:
         {
           environment.systemPackages = with pkgs; [
             gzip
@@ -83,8 +83,12 @@ import ../make-test-python.nix (
               "--disable metrics-server"
               "--disable servicelb"
               "--disable traefik"
-              "--node-ip 192.168.1.1"
               "--pause-image test.local/pause:local"
+              "--node-ip ${nodes.server.networking.primaryIPAddress}"
+              # The interface selection logic of flannel would normally use eth0, as the nixos
+              # testing driver sets a default route via dev eth0. However, in test setups we
+              # have to use eth1 for inter-node communication.
+              "--flannel-iface eth1"
             ];
           };
           networking.firewall.allowedTCPPorts = [
@@ -93,19 +97,10 @@ import ../make-test-python.nix (
             6443
           ];
           networking.firewall.allowedUDPPorts = [ 8472 ];
-          networking.firewall.trustedInterfaces = [ "flannel.1" ];
-          networking.useDHCP = false;
-          networking.defaultGateway = "192.168.1.1";
-          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-            {
-              address = "192.168.1.1";
-              prefixLength = 24;
-            }
-          ];
         };
 
       server2 =
-        { pkgs, ... }:
+        { nodes, pkgs, ... }:
         {
           environment.systemPackages = with pkgs; [
             gzip
@@ -119,7 +114,7 @@ import ../make-test-python.nix (
             enable = true;
             package = k3s;
             images = [ pauseImage ];
-            serverAddr = "https://192.168.1.1:6443";
+            serverAddr = "https://${nodes.server.networking.primaryIPAddress}:6443";
             clusterInit = false;
             extraFlags = [
               "--disable coredns"
@@ -127,8 +122,9 @@ import ../make-test-python.nix (
               "--disable metrics-server"
               "--disable servicelb"
               "--disable traefik"
-              "--node-ip 192.168.1.3"
               "--pause-image test.local/pause:local"
+              "--node-ip ${nodes.server2.networking.primaryIPAddress}"
+              "--flannel-iface eth1"
             ];
           };
           networking.firewall.allowedTCPPorts = [
@@ -137,19 +133,10 @@ import ../make-test-python.nix (
             6443
           ];
           networking.firewall.allowedUDPPorts = [ 8472 ];
-          networking.firewall.trustedInterfaces = [ "flannel.1" ];
-          networking.useDHCP = false;
-          networking.defaultGateway = "192.168.1.3";
-          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-            {
-              address = "192.168.1.3";
-              prefixLength = 24;
-            }
-          ];
         };
 
       agent =
-        { pkgs, ... }:
+        { nodes, pkgs, ... }:
         {
           virtualisation.memorySize = 1024;
           virtualisation.diskSize = 2048;
@@ -159,23 +146,15 @@ import ../make-test-python.nix (
             role = "agent";
             package = k3s;
             images = [ pauseImage ];
-            serverAddr = "https://192.168.1.3:6443";
+            serverAddr = "https://${nodes.server2.networking.primaryIPAddress}:6443";
             extraFlags = [
               "--pause-image test.local/pause:local"
-              "--node-ip 192.168.1.2"
+              "--node-ip ${nodes.agent.networking.primaryIPAddress}"
+              "--flannel-iface eth1"
             ];
           };
           networking.firewall.allowedTCPPorts = [ 6443 ];
           networking.firewall.allowedUDPPorts = [ 8472 ];
-          networking.firewall.trustedInterfaces = [ "flannel.1" ];
-          networking.useDHCP = false;
-          networking.defaultGateway = "192.168.1.2";
-          networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-            {
-              address = "192.168.1.2";
-              prefixLength = 24;
-            }
-          ];
         };
     };
 


### PR DESCRIPTION
The dynamic setup requires less network configuration and allows to use features of the nixos testing driver, e.g. port forwarding and SSH access to nodes in interactive mode.

@NixOS/k3s 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
