### PR TITLE
rustPlatform.defaultCrateOverrides: adding native support for PyO3 and mlua-sys

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -30,6 +30,12 @@
 , libtool
 , linux-pam
 , llvmPackages
+, luajit
+, luau
+, lua5_1
+, lua5_2
+, lua5_3
+, lua5_4
 , nettle
 , openssl
 , pango
@@ -229,6 +235,32 @@ in
     buildInputs = [ webkitgtk_4_1 ];
   };
 
+  mlua-sys = attrs:
+    let hasLuajit = builtins.elem "luajit" attrs.features;
+        hasLuau = builtins.elem "luau" attrs.features;
+        hasLua51 = builtins.elem "lua51" attrs.features;
+        hasLua52 = builtins.elem "lua52" attrs.features;
+        hasLua53 = builtins.elem "lua53" attrs.features;
+        hasLua54 = builtins.elem "lua54" attrs.features;
+    in
+      {
+        # `crate2nix` may enable the "vendored" feature if not run
+        # with the proper Lua packages in the path. This is especially
+        # likely to happen on the first run, when we haven't generated
+        # the Cargo.nix to import these in the scope. Therefore, we
+        # choose to disable the feature by default, as it can still be
+        # overriden by consumers of these overrides.
+        features = lib.lists.filter (k: k != "vendored") attrs.features;
+        nativeBuildInputs = [ pkg-config ];
+        buildInputs =
+          lib.optional hasLuajit luajit ++
+          lib.optional hasLuau luau ++
+          lib.optional hasLua51 lua5_1 ++
+          lib.optional hasLua52 lua5_2 ++
+          lib.optional hasLua53 lua5_3 ++
+          lib.optional hasLua54 lua5_4;
+      };
+
   nettle-sys = attrs: {
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ nettle clang ];
@@ -268,6 +300,11 @@ in
 
   prost-wkt-types = attr: {
     nativeBuildInputs = [ protobuf ];
+  };
+
+  pyo3 = attrs: {
+    nativeBuildInputs = [ pkg-config ];
+    extraLinkFlags = [ "-L${python3}/lib" "-l${python3.libPrefix}" ];
   };
 
   rdkafka-sys = attr: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
