### PR TITLE
llvmPackages_17.{clang,tblgen}: fix builds on aarch64

### DIFF
--- a/pkgs/development/compilers/llvm/17/clang/aarch64-tblgen.patch
+++ b/pkgs/development/compilers/llvm/17/clang/aarch64-tblgen.patch
@@ -1,0 +1,39 @@
+diff --git a/include/clang/Basic/TokenKinds.def b/include/clang/Basic/TokenKinds.def
+index ef0dad0f2..afd101b00 100644
+--- a/include/clang/Basic/TokenKinds.def
++++ b/include/clang/Basic/TokenKinds.def
+@@ -753,7 +753,7 @@ KEYWORD(__builtin_sycl_unique_stable_name, KEYSYCL)
+
+ // Keywords defined by Attr.td.
+ #ifndef KEYWORD_ATTRIBUTE
+-#define KEYWORD_ATTRIBUTE(X) KEYWORD(X, KEYALL)
++#define KEYWORD_ATTRIBUTE(X, EMPTY) KEYWORD(EMPTY ## X, KEYALL)
+ #endif
+ #include "clang/Basic/AttrTokenKinds.inc"
+
+diff --git a/include/clang/Basic/TokenKinds.h b/include/clang/Basic/TokenKinds.h
+index e4857405b..ff117bd5a 100644
+--- a/include/clang/Basic/TokenKinds.h
++++ b/include/clang/Basic/TokenKinds.h
+@@ -109,7 +109,7 @@ bool isPragmaAnnotation(TokenKind K);
+
+ inline constexpr bool isRegularKeywordAttribute(TokenKind K) {
+   return (false
+-#define KEYWORD_ATTRIBUTE(X) || (K == tok::kw_##X)
++#define KEYWORD_ATTRIBUTE(X, ...) || (K == tok::kw_##X)
+ #include "clang/Basic/AttrTokenKinds.inc"
+   );
+ }
+diff --git a/utils/TableGen/ClangAttrEmitter.cpp b/utils/TableGen/ClangAttrEmitter.cpp
+index b5813c6ab..79db17501 100644
+--- a/utils/TableGen/ClangAttrEmitter.cpp
++++ b/utils/TableGen/ClangAttrEmitter.cpp
+@@ -3430,7 +3430,7 @@ void EmitClangAttrTokenKinds(RecordKeeper &Records, raw_ostream &OS) {
+                      "RegularKeyword attributes with arguments are not "
+                      "yet supported");
+         OS << "KEYWORD_ATTRIBUTE("
+-           << S.getSpellingRecord().getValueAsString("Name") << ")\n";
++           << S.getSpellingRecord().getValueAsString("Name") << ", )\n";
+       }
+   OS << "#undef KEYWORD_ATTRIBUTE\n";
+ }

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -117,7 +117,11 @@ let
           ];
           stripLen = 1;
           hash = "sha256-1NKej08R9SPlbDY/5b0OKUsHjX07i9brR84yXiPwi7E=";
-        });
+        })
+        ++ lib.optional (stdenv.isAarch64 && lib.versions.major release_version == "17")
+          # Fixes llvm17 tblgen builds on aarch64.
+          # https://github.com/llvm/llvm-project/issues/106521#issuecomment-2337175680
+          (getVersionFile "clang/aarch64-tblgen.patch");
 
     nativeBuildInputs = [ cmake ]
       ++ (lib.optional (lib.versionAtLeast release_version "15") ninja)

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -106,6 +106,13 @@ let
                   path = ../12;
                 }
               ];
+              "clang/aarch64-tblgen.patch" = [
+                {
+                  after = "17";
+                  before = "18";
+                  path = ../17;
+                }
+              ];
               "lld/add-table-base.patch" = [
                 {
                   after = "16";
@@ -373,12 +380,17 @@ let
             # Crude method to drop polly patches if present, they're not needed for tblgen.
             (p: (!lib.hasInfix "-polly" p))
             tools.libllvm.patches;
-        clangPatches = [
-          # Would take tools.libclang.patches, but this introduces a cycle due
-          # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
-          # So take the only patch known to be necessary.
-          (metadata.getVersionFile "clang/gnu-install-dirs.patch")
-        ];
+        clangPatches =
+          [
+            # Would take tools.libclang.patches, but this introduces a cycle due
+            # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
+            # So take the only patch known to be necessary.
+            (metadata.getVersionFile "clang/gnu-install-dirs.patch")
+          ]
+          ++ lib.optional (stdenv.isAarch64 && lib.versions.major metadata.release_version == "17")
+            # Fixes llvm17 tblgen builds on aarch64.
+            # https://github.com/llvm/llvm-project/issues/106521#issuecomment-2337175680
+            (metadata.getVersionFile "clang/aarch64-tblgen.patch");
       };
 
       libclang = callPackage ./clang {


### PR DESCRIPTION
Fixes #371077
Fixes https://github.com/NixOS/nixpkgs/pull/381163

Applies the patch proposed in the [llvm issue](https://github.com/llvm/llvm-project/issues/106521#issuecomment-2337175680). The fix will not make it to the llvm itself as they don't accept fixes for old release branches due to the complexity of the process.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
