### PR TITLE
[Backport release-24.11] electron{-source,-bin,chromedriver}: init at 34.0.2, 33.3.2 -> 33.4.0, 34.0.2 -> 34.1.1

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -86,5 +86,16 @@
             "x86_64-linux": "13b99da4a78dae9bf0960309cd1e9476faf5f7260bbf930bd302189d490ff77c"
         },
         "version": "33.3.2"
+    },
+    "34": {
+        "hashes": {
+            "aarch64-darwin": "604e5f6c706383dd7a86c3b9a59f60525c687f65907b60ccdabf43358dbb8661",
+            "aarch64-linux": "98e711d7678670572b873aec1e4df3a2fa0002b88bc6283dbff8fc13ac401670",
+            "armv7l-linux": "cc3bb0110fafbf5a9ef6576470b82864dacb6380cc312650d6b0cdf404ac9d9f",
+            "headers": "1zcm8j3qqvy6y5jgdj9aypbqa1sq4wkk9ynj0382wnk994bzjs86",
+            "x86_64-darwin": "3b34acc7908a311e05509cab9e1926604113e1f650b4dbe1ecfde1dbf4397c37",
+            "x86_64-linux": "74e55edc5d7cf9e63ba61f1a670134779109fcf33990e568f1992c46c1d31b89"
+        },
+        "version": "34.0.2"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -78,14 +78,14 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "4c7ffa4927aec31912ae2047d8d6c33e801501e4b576c724947866da9346110c",
-            "aarch64-linux": "c55b6b66fe8018e0e05953cd794735782f05b7e3b2a117a86413eafcedfda7ef",
-            "armv7l-linux": "2e7f915c71b11e6cc1ec46aee8f87c28fdd029a0a90a9196117a8f0c7aa81aa8",
-            "headers": "07m9p2nz0rzl3asq466kqzdq1bdmlvxb5slrr24dj9awijlyrrb6",
-            "x86_64-darwin": "fa451db2991506cacebd2a836e84ca7eff73770ed987d5b958f9854637c12d3d",
-            "x86_64-linux": "13b99da4a78dae9bf0960309cd1e9476faf5f7260bbf930bd302189d490ff77c"
+            "aarch64-darwin": "90044a7aa13f18ca4077a33131190b55fdf3ca5cb0704c537ca630fd0e06369e",
+            "aarch64-linux": "6542b3152ea9d8dd005a1b8f55b6971dee0f954b3b4e0bab4d625d501a946093",
+            "armv7l-linux": "95d79d2d2a154783fa6435d937a3e98b4408f2ce75f6706e5781d0d7e2e49d44",
+            "headers": "00v71c9fy3na040bnp5llp6951fsqls6hnlvbds5gckw3wfdcymc",
+            "x86_64-darwin": "d66a1400fe3c446f93eabf51b9520a300cdd25805a03d96a4528bda089f4988e",
+            "x86_64-linux": "f854ceb7362f7eeafdcdfc4a8898493adb72e3433595c59f072427912115d41b"
         },
-        "version": "33.3.2"
+        "version": "33.4.0"
     },
     "34": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -89,13 +89,13 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "604e5f6c706383dd7a86c3b9a59f60525c687f65907b60ccdabf43358dbb8661",
-            "aarch64-linux": "98e711d7678670572b873aec1e4df3a2fa0002b88bc6283dbff8fc13ac401670",
-            "armv7l-linux": "cc3bb0110fafbf5a9ef6576470b82864dacb6380cc312650d6b0cdf404ac9d9f",
-            "headers": "1zcm8j3qqvy6y5jgdj9aypbqa1sq4wkk9ynj0382wnk994bzjs86",
-            "x86_64-darwin": "3b34acc7908a311e05509cab9e1926604113e1f650b4dbe1ecfde1dbf4397c37",
-            "x86_64-linux": "74e55edc5d7cf9e63ba61f1a670134779109fcf33990e568f1992c46c1d31b89"
+            "aarch64-darwin": "a38a624bee92ee601777c20e6bdbf040d1b2a5506ba1ccac8be1447b1c6b0bfd",
+            "aarch64-linux": "37d68cef35888c8ca8bbe2002be0a122e8e8ccaf762b60ade1af5e71918e080b",
+            "armv7l-linux": "741374570bd9e435037f41b42aea7ab640f7ef1e75afb4705cc12344f43ed04c",
+            "headers": "0b0djna1bprfff0y1pb2wdzsx82v1c1zk20gl2vivgjhslxf0igl",
+            "x86_64-darwin": "a2ba4f91882819801da2d499de3426dbb191a22f2fe4a6ec92b756f1a0dc2de8",
+            "x86_64-linux": "9fbca20baea84800f7f50a9b245302dddbfab3425dd762c482d79e867a5a6dbe"
         },
-        "version": "34.0.2"
+        "version": "34.1.1"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -53,5 +53,16 @@
             "x86_64-linux": "85e3d980a43f4792d1b6246a50dad745653c0e13b95dbc37adadc78078cfcc99"
         },
         "version": "33.3.2"
+    },
+    "34": {
+        "hashes": {
+            "aarch64-darwin": "ae2ccc17a7f391869cf6cfe41d4b7c25013ccbf36861b5007fcdf62ac4db9eb0",
+            "aarch64-linux": "904c101b206e9d4de088c06ac6886563493e5abaac537cb55f129a8cfd2620c0",
+            "armv7l-linux": "0a295dc16833384dc51ac6baa0d7025f9767b587c30ac857d1461b41bc3246af",
+            "headers": "1zcm8j3qqvy6y5jgdj9aypbqa1sq4wkk9ynj0382wnk994bzjs86",
+            "x86_64-darwin": "f6419dca74fcd4affeb9c4a061abc343e52031cdc36d4abb01ece2b9ee731d7c",
+            "x86_64-linux": "fba4a47b7762142f4ca01f405746b99ddb36e0860316952c2118b4b90840897d"
+        },
+        "version": "34.0.2"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "96648a7aa64bff1b6fdce75da395451cca23aafdd06437c31544125962e25323",
-            "aarch64-linux": "a5bce192adbc7dfcb6134296c15409b8299a64b3ecc9c61d7d150a644a8187e6",
-            "armv7l-linux": "a921c696a7371712b14ed64e408a57ad874340fd8d61a447cbc83fcf79e599a3",
-            "headers": "07m9p2nz0rzl3asq466kqzdq1bdmlvxb5slrr24dj9awijlyrrb6",
-            "x86_64-darwin": "06ae393d176e8fdd67b1fb6a2b3f0771e3971de112e338d7d30d2ea1ffd0fe8c",
-            "x86_64-linux": "85e3d980a43f4792d1b6246a50dad745653c0e13b95dbc37adadc78078cfcc99"
+            "aarch64-darwin": "0b87f00cf22d2c73a795af554cf9548e0204769d22ffdc7f28183572d4f7fef0",
+            "aarch64-linux": "5387c7a22c93dfcac348ea5ec604fb8350926e8e2681ca189e0500ff993d58d0",
+            "armv7l-linux": "53e1fa127812bcfb5a095f781368ee2d9cceb4a91d83dcb32a7ecf072cf39034",
+            "headers": "00v71c9fy3na040bnp5llp6951fsqls6hnlvbds5gckw3wfdcymc",
+            "x86_64-darwin": "9a8ec97a21d41b146b010dfe7e4df71907a23bdf0500619036de623b4ddb1ce1",
+            "x86_64-linux": "ea57c5bafecd8502fa95df73c977efb2a061068eac965d97f99b824479d55de2"
         },
-        "version": "33.3.2"
+        "version": "33.4.0"
     },
     "34": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "ae2ccc17a7f391869cf6cfe41d4b7c25013ccbf36861b5007fcdf62ac4db9eb0",
-            "aarch64-linux": "904c101b206e9d4de088c06ac6886563493e5abaac537cb55f129a8cfd2620c0",
-            "armv7l-linux": "0a295dc16833384dc51ac6baa0d7025f9767b587c30ac857d1461b41bc3246af",
-            "headers": "1zcm8j3qqvy6y5jgdj9aypbqa1sq4wkk9ynj0382wnk994bzjs86",
-            "x86_64-darwin": "f6419dca74fcd4affeb9c4a061abc343e52031cdc36d4abb01ece2b9ee731d7c",
-            "x86_64-linux": "fba4a47b7762142f4ca01f405746b99ddb36e0860316952c2118b4b90840897d"
+            "aarch64-darwin": "c2aa24978fbe0c3dfb8ae36816633a75f498b4af5052b059631a626925951e41",
+            "aarch64-linux": "df87d6f0b91a549996c764bb60eaf692c59e087496406562e3bcbb3f90a52d50",
+            "armv7l-linux": "74b53fff1d210066024476ebbfef7476b05c2c71cd141953b5b7e0a35d129a02",
+            "headers": "0b0djna1bprfff0y1pb2wdzsx82v1c1zk20gl2vivgjhslxf0igl",
+            "x86_64-darwin": "95239f35723eeca036ed1e29f7871a4de843c6eda16bccc04436402dddd938aa",
+            "x86_64-linux": "62734cb681a6da3c73b20504f49c7759c9dbb1c923e250d67c11888426e3cad0"
         },
-        "version": "34.0.2"
+        "version": "34.1.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -988,10 +988,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-20ggSgks8zVYsFeMRHzqpnQFE9UazwOY2BVQYhVo/Vk=",
+                "hash": "sha256-1Sl36LYp/tePk5ChWKv9ZCVcoEZECMEDKKiKvpO8ea8=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v33.3.2"
+                "rev": "v33.4.0"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1891,6 +1891,6 @@
         "electron_yarn_hash": "0bzsswcg62b39xinq5vikk7qz7d15276s2vc15v1gcb5wvh05ff8",
         "modules": "130",
         "node": "20.18.1",
-        "version": "33.3.2"
+        "version": "33.4.0"
     }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7884,6 +7884,7 @@ with pkgs;
     electron_31-bin
     electron_32-bin
     electron_33-bin
+    electron_34-bin
     ;
 
   inherit (callPackages ../development/tools/electron/chromedriver { })
@@ -7902,6 +7903,7 @@ with pkgs;
   electron_31 = electron_31-bin;
   electron_32 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_32 then electron-source.electron_32 else electron_32-bin;
   electron_33 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_33 then electron-source.electron_33 else electron_33-bin;
+  electron_34 = electron_34-bin;
   electron = electron_33;
   electron-bin = electron_33-bin;
   electron-chromedriver = electron-chromedriver_33;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7893,6 +7893,7 @@ with pkgs;
     electron-chromedriver_31
     electron-chromedriver_32
     electron-chromedriver_33
+    electron-chromedriver_34
     ;
 
   electron_24 = electron_24-bin;


### PR DESCRIPTION
Partial backport of #376770 without the breaking `electron: 33 -> 34` change and all of #380954.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
