### PR TITLE
element-{web,desktop}: 1.11.91 -> 1.11.95

### DIFF
--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.11.91";
+  "version" = "1.11.95";
   "hashes" = {
-    "desktopSrcHash" = "sha256-nHA/j9V+vZUgY+eCCp/iO458GrXSkla+ruJbJjh9NJw=";
-    "desktopYarnHash" = "09k4kislf1zimbyn6m68bh2s3kpn2cs9h04wqli3j3qgkplcvxdv";
+    "desktopSrcHash" = "sha256-0OCL1m+/FOdmp7npavnAygpuEryBypie+yR1eQK1eLM=";
+    "desktopYarnHash" = "sha256-h5ZjpInF/qh/Cm46uzi1tTEUIbmHC/muV6X/FxGyFms=";
   };
 }

--- a/pkgs/by-name/el/element-desktop/keytar/default.nix
+++ b/pkgs/by-name/el/element-desktop/keytar/default.nix
@@ -24,11 +24,11 @@ let
 
 in
 stdenv.mkDerivation rec {
-  pname = "keytar";
+  pname = "keytar-forked";
   inherit (pinData) version;
 
   src = fetchFromGitHub {
-    owner = "atom";
+    owner = "shiftkey";
     repo = "node-keytar";
     rev = "v${version}";
     hash = pinData.srcHash;

--- a/pkgs/by-name/el/element-desktop/keytar/pin.json
+++ b/pkgs/by-name/el/element-desktop/keytar/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.9.0",
-  "srcHash": "sha256-Mnl0Im2hZJXJEtyXb5rgMntekkUAnOG2MN1bwfgh0eg=",
-  "npmHash": "sha256-ldfRWV+HXBdBYO2ZiGbVFSHV4/bMG43U7w+sJ4kpVUY="
+  "version": "7.10.0",
+  "srcHash": "sha256-G0IYBVB37ANnI/XEyzahs9DbTQLgUKmkDoGryRkra08=",
+  "npmHash": "sha256-bd4YK3AuD0N5Q9ijx1jqBRBL0WADhw1ZlaxspEctse4="
 }

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -67,8 +67,8 @@ stdenv.mkDerivation (
       yarn --offline run i18n
       yarn --offline run build:res
 
-      rm -rf node_modules/matrix-seshat node_modules/keytar
-      ${lib.optionalString useKeytar "ln -s ${keytar} node_modules/keytar"}
+      rm -rf node_modules/matrix-seshat node_modules/keytar-forked
+      ${lib.optionalString useKeytar "ln -s ${keytar} node_modules/keytar-forked"}
       ln -s $seshat node_modules/matrix-seshat
 
       runHook postBuild

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -8,7 +8,7 @@
   nodejs,
   fetchYarnDeps,
   jq,
-  electron_33,
+  electron_34,
   element-web,
   sqlcipher,
   callPackage,
@@ -22,7 +22,7 @@ let
   pinData = import ./element-desktop-pin.nix;
   inherit (pinData.hashes) desktopSrcHash desktopYarnHash;
   executableName = "element-desktop";
-  electron = electron_33;
+  electron = electron_34;
   keytar = callPackage ./keytar {
     inherit electron;
   };

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.11.91";
+  "version" = "1.11.95";
   "hashes" = {
-    "webSrcHash" = "sha256-kdjkmVkoJuV3SBFkVQr4IAi69mAs8V5i3qFOd66BP2s=";
-    "webYarnHash" = "sha256-in7qiGIXP+Ki820RB/uB2st2FIwrxjqYpdOmmLI6RSM=";
+    "webSrcHash" = "sha256-JS+lwPRj4Fb+UZNATS7IFMfytqRou+aIpjDVjI+iqao=";
+    "webYarnHash" = "sha256-Aw0wDGE0WbI975y+J2FVxlDrHcPeBDkHiD/7W8eTf1E=";
   };
 }


### PR DESCRIPTION
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
