### PR TITLE
cargo-spellcheck: 0.15.1 -> 0.15.2

### DIFF
--- a/pkgs/by-name/ca/cargo-spellcheck/package.nix
+++ b/pkgs/by-name/ca/cargo-spellcheck/package.nix
@@ -2,32 +2,21 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  fetchpatch2,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-spellcheck";
-  version = "0.15.1";
+  version = "0.15.2";
 
   src = fetchFromGitHub {
     owner = "drahnr";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-o4gvTF9Zb6bZ9443zos4bz37w3bXKumW2x425MM5/FY=";
+    hash = "sha256-KiulbQhSg5CCZlts8FLsfOrN7nz16u3gRnQrWTFAzdc=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-wEcHMzeSj/JO/ZBPmQAiHaixtOTCT2+rTd1LDCY9wqc=";
-
-  patches = [
-    # fixes compilation of tests
-    # https://github.com/drahnr/cargo-spellcheck/pull/342
-    (fetchpatch2 {
-      name = "fix-test-compilation.patch";
-      url = "https://github.com/drahnr/cargo-spellcheck/pull/342/commits/aed8f3ca7a50fae38a5c6e0b974ed9773cd6c659.patch";
-      hash = "sha256-840t8uPg0EiiVppmMT38C1P16vps7F+g0o313tzghjE=";
-    })
-  ];
+  cargoHash = "sha256-iDulfKsw3Ui5b1v7QakIcf7HXNEBlMbhbzqLekuSsUU=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
@@ -35,6 +24,8 @@ rustPlatform.buildRustPackage rec {
 
   checkFlags = [
     "--skip=checker::hunspell::tests::hunspell_binding_is_sane"
+    # requires dictionaries
+    "--skip=tests::e2e::issue_226"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Removes the need for a patch: https://github.com/drahnr/cargo-spellcheck/compare/v0.15.1...v0.15.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
