### PR TITLE
ubi_reader: 0.8.9 -> 0.8.10

### DIFF
--- a/pkgs/by-name/ub/ubi_reader/package.nix
+++ b/pkgs/by-name/ub/ubi_reader/package.nix
@@ -7,14 +7,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ubi_reader";
-  version = "0.8.9";
+  version = "0.8.10";
   pyproject = true;
+  disabled = python3.pkgs.pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "onekey-sec";
     repo = "ubi_reader";
     rev = "v${version}";
-    hash = "sha256-04HwzkonPzzWfX8VE//fMoVv5ggAS+61zx2W8VEUIy4=";
+    hash = "sha256-fXJiQZ1QWUmkRM+WI8DSIsay9s1w3hKloRuCcUNwZjM=";
   };
 
   build-system = [ python3.pkgs.poetry-core ];

--- a/pkgs/by-name/ub/ubi_reader/package.nix
+++ b/pkgs/by-name/ub/ubi_reader/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  gitUpdater,
   lib,
   python3,
 }:
@@ -22,6 +23,13 @@ python3.pkgs.buildPythonApplication rec {
 
   # There are no tests in the source
   doCheck = false;
+
+  passthru = {
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+      ignoredVersions = "_[a-z]+$";
+    };
+  };
 
   meta = {
     description = "Python scripts capable of extracting and analyzing the contents of UBI and UBIFS images";

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -104,12 +104,18 @@ python3.pkgs.buildPythonApplication rec {
 
   versionCheckProgramArg = "--version";
 
-  pytestFlagsArray = [
-    "--no-cov"
-    # `disabledTests` swallows the parameters between square brackets
-    # https://github.com/tytso/e2fsprogs/issues/152
-    "-k 'not test_all_handlers[filesystem.extfs]'"
-  ];
+  pytestFlagsArray =
+    let
+      # `disabledTests` swallows the parameters between square brackets
+      disabled = [
+        # https://github.com/tytso/e2fsprogs/issues/152
+        "test_all_handlers[filesystem.extfs]"
+      ];
+    in
+    [
+      "--no-cov"
+      "-k 'not ${lib.concatStringsSep " and not " disabled}'"
+    ];
 
   passthru = {
     updateScript = gitUpdater { };

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -110,6 +110,13 @@ python3.pkgs.buildPythonApplication rec {
       disabled = [
         # https://github.com/tytso/e2fsprogs/issues/152
         "test_all_handlers[filesystem.extfs]"
+
+        # Should be dropped after upgrading to next version
+        # Needs https://github.com/onekey-sec/unblob/pull/1128/commits/c6af67f0c6f32fa01d7abbf495eb0293e9184438
+        # Unfortunately patches touching LFS stored assets cannot be applied
+        "test_all_handlers[filesystem.ubi.ubi]"
+        "test_all_handlers[archive.dlink.encrpted_img]"
+        "test_all_handlers[archive.dlink.shrs]"
       ];
     in
     [


### PR DESCRIPTION
Changelog: https://github.com/onekey-sec/ubi_reader/releases/tag/v0.8.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
