### PR TITLE
pysaml2: 7.5.0 -> 7.5.2

### DIFF
--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -4,6 +4,7 @@
   cryptography,
   defusedxml,
   fetchFromGitHub,
+  fetchpatch,
   paste,
   poetry-core,
   pyasn1,
@@ -25,21 +26,24 @@
 
 buildPythonPackage rec {
   pname = "pysaml2";
-  version = "7.5.0";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.9";
+  version = "7.5.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "IdentityPython";
     repo = "pysaml2";
     tag = "v${version}";
-    hash = "sha256-M/tdKGu6K38TeBZc8/dt376bHhPB0svHB3iis/se0DY=";
+    hash = "sha256-2mvAXTruZqoSBUgfT2VEAnWQXVdviG0e49y7LPK5x00=";
   };
 
   patches = [
     (replaceVars ./hardcode-xmlsec1-path.patch {
       inherit xmlsec;
+    })
+    # Replaces usages of deprecated/removed pyopenssl APIs
+    (fetchpatch {
+      url = "https://github.com/IdentityPython/pysaml2/pull/977/commits/930a652a240c8cd1489429a7d70cf5fa7ef1606a.patch";
+      hash = "sha256-kBNvGk5pwVmpW1wsIWVH9wapu6kjFavaTt4e3Llaw2c=";
     })
   ];
 
@@ -86,6 +90,9 @@ buildPythonPackage rec {
     "test_load_remote_encoding"
     "test_load_external"
     "test_conf_syslog"
+
+    # Broken XML schema check in 7.5.2
+    "test_namespace_processing"
   ];
 
   pythonImportsCheck = [ "saml2" ];
@@ -96,8 +103,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/IdentityPython/pysaml2/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = [ ];
-    # Does not support pyopenssl above 24.3.0 due to use of a deprecated API,
-    # see https://github.com/IdentityPython/pysaml2/issues/975
-    broken = true;
   };
 }


### PR DESCRIPTION
This update adds a limit on the allowed version of `pyopenssl`, so an override for the correct version of the package was added (`pyopenssl_24_2_1`).

There is one new failing test:
```
FAILED tests/test_schema_validator.py::test_namespace_processing - saml2.xml.schema.XMLSchemaError: {'doc': '<saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n            <saml2:Attribute Name="urn:mace:dir:attribute-def:uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">\n                <saml2:AttributeValue xsi:type="xs:string" xmlns:xs="http://www.w3.org/2001/XMLSchema">alum11</saml2:AttributeValue></saml2:Attribute><saml2:Attribute Name="urn:mace:terena.org:attribute-def:schacHomeOrganization" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">\n                <saml2:AttributeValue xsi:nil="true" xsi:type="xs:string" /></saml2:Attribute></saml2:AttributeStatement>', 'error': '"global xs:simpleType/xs:complexType \'xs:string\' not found"'}
```

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
