### PR TITLE
libguestfs-appliance-debian: init at 1.54.1

### DIFF
--- a/pkgs/build-support/vm/deb/deb-closure.pl
+++ b/pkgs/build-support/vm/deb/deb-closure.pl
@@ -132,7 +132,7 @@ foreach my $pkgName (@toplevelPkgs) {
 print "# This is a generated file.  Do not modify!\n";
 print "# Following are the Debian packages constituting the closure of: @toplevelPkgs\n\n";
 print "{fetchurl}:\n\n";
-print "[\n\n";
+print "[\n";
 
 # Output the packages in strongly connected components.
 my %done;
@@ -148,7 +148,7 @@ foreach my $pkgName (@order) {
     }
     delete $forward{$pkgName};
 
-    print "  [\n\n" if $newComponent;
+    print "  [\n" if $newComponent;
     $newComponent = 0;
 
     my $origName = basename $cdata->{Filename};
@@ -160,10 +160,9 @@ foreach my $pkgName (@order) {
     print "      sha256 = \"$cdata->{SHA256}\";\n";
     print "      name = \"$cleanedName\";\n" if $cleanedName ne $origName;
     print "    })\n";
-    print "\n";
 
     if (keys %forward == 0) {
-        print "  ]\n\n";
+        print "  ]\n";
         $newComponent = 1;
     }
 }

--- a/pkgs/by-name/li/libguestfs-appliance-debian/deb-closure-amd64.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-debian/deb-closure-amd64.nix
@@ -1,0 +1,1885 @@
+# This is a generated file.  Do not modify!
+# Following are the Debian packages constituting the closure of: base-passwd dpkg libc6-dev perl bash dash gzip bzip2 tar grep mawk sed findutils g++ make curl patch locales coreutils util-linux file dpkg-dev pkg-config login passwd sysvinit diff libguestfs-tools linux-image-amd64 qemu-utils
+
+{ fetchurl }:
+
+[
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-17_amd64.deb";
+      sha256 = "b8d322fb3099b4e78909bda633ece6cb68d08b52bfabd73b4d89d4ea0af61d58";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-17_amd64.deb";
+      sha256 = "ff4f57b0ce6a82daf6194bf6d9fc6f069858eb4d5e995b0191d7f2d4e45e7344";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc6_2.40-7_amd64.deb";
+      sha256 = "5072445cef9e11283bd5aa9ceb3debdc737baf0c93ae77949096ae6fc47a2c96";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cdebconf/libdebconfclient0_0.277_amd64.deb";
+      sha256 = "1514f1938db009125c15f343c40d5ea8bd8406837b69bcb7a1785751dbd1762b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pcre2/libpcre2-8-0_10.45-1_amd64.deb";
+      sha256 = "f2bd0bcb2a93c27bbac1453c223932ccebfc37b69b899b38dc389b064e4e2257";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libselinux/libselinux1_3.8-4_amd64.deb";
+      sha256 = "f2eac6c18f9b2634ec553485bb0bd36e86b14c9ea29cb287cae0bdbd4b95dc77";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/base-passwd/base-passwd_3.6.6_amd64.deb";
+      sha256 = "c250bac054d3e5141e06b0dc05370486e775766c829b2a8708d05185bc2641d7";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/acl/libacl1_2.3.2-2+b1_amd64.deb";
+      sha256 = "08074f01e384bc07c0c2d79a58cf4a6523f71cf75d1808101c79617656c9a39d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/t/tar/tar_1.35+dfsg-3.1_amd64.deb";
+      sha256 = "214c02e1aa291076a3147b8a4c4cae02fadf4c67df629186e3e313726faef1de";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-6_amd64.deb";
+      sha256 = "cba4cda04244b5e481bb15524bc3c983a7d1b6f330013b9b381706a2fcb65310";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xz-utils/liblzma5_5.6.4-1_amd64.deb";
+      sha256 = "55b43990974f36c7bc551839e5f8570bce626e80a78f26f1d45209dc7f9654ae";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libm/libmd/libmd0_1.1.0-2+b1_amd64.deb";
+      sha256 = "7244ec3839b61fac0c1884fe08aaa040f26e8f1f35f1f5d3482eacefd30d1b44";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-2_amd64.deb";
+      sha256 = "0f34d795fb815c118fea6f88e0c75b8c3ea4e6721982decfab677e726af98844";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb";
+      sha256 = "015be740d6236ad114582dea500c1d907f29e16d6db00566ca32fb68d71ac90d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/dpkg_1.22.15_amd64.deb";
+      sha256 = "ba0592e8e1e9e278b3e39a04f9b94edd38193953af9955ae89a553535b854810";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-dev-bin_2.40-7_amd64.deb";
+      sha256 = "33d5598b607638799efe66ba0042c2814ef272874bdae090443474f631485bb3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux/linux-libc-dev_6.12.12-1_all.deb";
+      sha256 = "4df2b95ca251c87d736a485c6d27ae1a73c7a4888ae7f7abc9d587b4daf3e485";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb";
+      sha256 = "0ebc144d662e3197982d1bf3a7b8b35ca845e54c68811de0328b1f0d7c67585c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_amd64.deb";
+      sha256 = "98e2333aea8d64ca68f9b75c16256d3a05492fd8f9e6dba96adbc6f19e4f5a09";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1_amd64.deb";
+      sha256 = "32ac0692694f8a34cc90c895f4fc739680fb2ef0e2d4870a68833682bf1c81a3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc6-dev_2.40-7_amd64.deb";
+      sha256 = "90849c9241eae7e687bb615941302485d103e66b61a558cc54b0c7ac50d29f2c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl-base_5.40.1-2_amd64.deb";
+      sha256 = "ef4ca7f03c856a7a7a2c0e532ed7a55e57178eee0240210a8a927095497e54e5";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl-modules-5.40_5.40.1-2_all.deb";
+      sha256 = "9cf0ce4ae1fed57dab7d4e7bb2e3e728d634dc50b2924a1b1274ba2b8ce4f893";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-9_amd64.deb";
+      sha256 = "18d02510ee78b67e4504ba050176797a200ff24214a7cd318082ab60ad7bf3fc";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdbm/libgdbm6t64_1.24-2_amd64.deb";
+      sha256 = "e7b42c68c391e278733adb3c1efdacd24d660862bd7bac0efbc10a91e5696dfc";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_amd64.deb";
+      sha256 = "2cbd43cf2dfbf57ff48188b5d79d29cf7ea8f0dedaa61ab0bcc02eceff50ea01";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/libperl5.40_5.40.1-2_amd64.deb";
+      sha256 = "db3085eb8acd8e516b2a9bcfde8d3ca2d31b8b5829d784c4b771e1a77045ba28";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl_5.40.1-2_amd64.deb";
+      sha256 = "507219bcb24aadef67b08e0868216cdc768299bbcf275bf8ee127a44e561f771";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/original-awk/original-awk_2025-01-16-1_amd64.deb";
+      sha256 = "220e09441ee61bd73cf34502de7505f924b4dc459f4b11ba3c1af8734a5e9254";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/base-files/base-files_13.6_amd64.deb";
+      sha256 = "a2fd18c986ea826ddd469565433a314f75334c8cd7907e8620b60e463bea1026";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debianutils/debianutils_5.21_amd64.deb";
+      sha256 = "4224c12ebcd2d8eedbd7981c9f12a3ab35163a039a5c5b667ad465da2d191542";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ncurses/libtinfo6_6.5+20250216-1_amd64.deb";
+      sha256 = "41599d794693baaa9ad0197743af422c39a96070214be1214951371220122345";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bash/bash_5.2.37-1.1_amd64.deb";
+      sha256 = "03ae6956930e3724b67965e30a62d6f78cb9e3dc8d06a3d4e8aa70f8d704405e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dash/dash_0.5.12-12_amd64.deb";
+      sha256 = "a8902cb6d8650134764a25fb80aec8589d858ef71ece1680a62e84816c37bb04";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gzip/gzip_1.13-1_amd64.deb";
+      sha256 = "c98b1130f08ef6ac3932972c56be84cfc308ce1afa37105cb06aaf47ced2d078";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb";
+      sha256 = "6b5fbe71f0fc41e85919bc4b3c514e6c47577c5005dbf1f5af6e4a49cc221aab";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grep/grep_3.11-4_amd64.deb";
+      sha256 = "2d78ed07d86a530ebf538f05cb2415f37c8daf908596bc32fc2563cc7e88c55a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mawk/mawk_1.3.4.20250131-1_amd64.deb";
+      sha256 = "ade14470c4dff8921bca6ca8b1ea20eadc0f2178b48caff3c74534b17a633292";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sed/sed_4.9-2_amd64.deb";
+      sha256 = "50d175d968ee626b1210ef6e8c43c597b912ca30f249f686c0c219532d2a5354";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/findutils/findutils_4.10.0-3_amd64.deb";
+      sha256 = "3edf02b016456b6a98cefdbab99c5ce6f829b786f63affe970badea221aecfc7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-3_amd64.deb";
+      sha256 = "d0d0265eb01770f17afd0f7c8c0622f80479dcfbbe13653a0debeec61464e622";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/isl/libisl23_0.27-1_amd64.deb";
+      sha256 = "ac8518042e81c00de1effb72bba7e88ac4ecd488f7ea8b9e3ebc63159cb53b35";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mpfr4/libmpfr6_4.2.1-1+b2_amd64.deb";
+      sha256 = "cddb6a0c62c9e17507c0435ca8fa90d2f82fb252144fe38a9ff5a738948d0252";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mpclib3/libmpc3_1.3.1-1+b3_amd64.deb";
+      sha256 = "2af0a5c128e03694a41c0b011bd8a958b7297436cdb3a15ddad7866dae8c300b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/cpp-14-x86-64-linux-gnu_14.2.0-17_amd64.deb";
+      sha256 = "0cea6826616fa5a6ca6c5d7207e3935881b9959133876af1c86c82c0d7fac31f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/cpp-14_14.2.0-17_amd64.deb";
+      sha256 = "c38e01cf093a073ac3cb639cfc7ef212eba5cb9e5a54ce5ec1f66f382ee9d9b9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_14.2.0-1_amd64.deb";
+      sha256 = "d902f484e38bce59e82efc0df2fe20139a0932ca759ecafdfe6e5b6c72238eb8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/cpp_14.2.0-1_amd64.deb";
+      sha256 = "a6ba40550aadec80437813e0fce5516574945ff40e72306a5b378c03af3a6544";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libstdc++6_14.2.0-17_amd64.deb";
+      sha256 = "93be9f44d060a421d3434fd6d529b3bcb0e672de405062e96f91f92258b0a137";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libcc1-0_14.2.0-17_amd64.deb";
+      sha256 = "f948c5f9964f404f19fe7c1cb467d5cfcb7a6e82aacb2f07879bf6304e3986f1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils-common_2.44-2_amd64.deb";
+      sha256 = "dee96c9914fe01404d86d8135e7c8f1e44571986bccf8fb2b3f08d0edce08a1b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libsframe1_2.44-2_amd64.deb";
+      sha256 = "cf26982a1ef964a6c676981803fe27ac3dc031f13a9a13665fe0a65c6ff223a7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libbinutils_2.44-2_amd64.deb";
+      sha256 = "4197f162d7e24e1637faa30eb5ea2b720519b1185afad77768653d383d6e49d7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libctf-nobfd0_2.44-2_amd64.deb";
+      sha256 = "d829e9b7a3b3373f5365dc91409e922a4a37ecda2c2ad46e493e640621cb87f6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libctf0_2.44-2_amd64.deb";
+      sha256 = "98904992203a68da1935f29a976db5e41adf3b1e51c988c0b4c139a63af408f0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/jansson/libjansson4_2.14-2+b3_amd64.deb";
+      sha256 = "60707a62fe6c1228c3389b12a13ca4efd76defc5532473e547a29e99cf7d2a6e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.44-2_amd64.deb";
+      sha256 = "fb96edfc9ab8bd6ab930bd5282191c6fdcafad4eac5cdc7c00abf95aebf2e510";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgomp1_14.2.0-17_amd64.deb";
+      sha256 = "9808aebc52e162fd4c294c6495ef57627c2a4544a1608ba4ffac6a4435a38451";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libitm1_14.2.0-17_amd64.deb";
+      sha256 = "369579a13af8ea2838549da696ef5411b08c4aa915f28f7596cacb323d31387f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libatomic1_14.2.0-17_amd64.deb";
+      sha256 = "3966d347e811300d8ff42aa5b209605ad7870fad74b569ee16a819c1a121aa04";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libasan8_14.2.0-17_amd64.deb";
+      sha256 = "7c93c7164ccbd9a776d8f0bba164f28da0e9b90988f2dc56d811d43c045c1da6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/liblsan0_14.2.0-17_amd64.deb";
+      sha256 = "27715c4ef3de154900307721020e6c969701f3733e2353d9499bdc4726a6193a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libtsan2_14.2.0-17_amd64.deb";
+      sha256 = "44d8aedf33f2b2af98546f6ee616d733202c4b7496da2c2cfa220d4d533cb998";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libubsan1_14.2.0-17_amd64.deb";
+      sha256 = "3ffbcae4d1338d7c29513313897b79a9c3bb4691cf7c16dc252e914eeeae033d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libhwasan0_14.2.0-17_amd64.deb";
+      sha256 = "35fb531746a7ec93261e37b072f0f0f18943b84ae5ef8e5d9ef875f514d9f4a0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libquadmath0_14.2.0-17_amd64.deb";
+      sha256 = "a368e1ddb39220a97de2cafca1511549c8a2430a26ece2bb7c37a2fca9c8d16e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-17_amd64.deb";
+      sha256 = "98cc4bae5c9c8b56f92c87cde42af2405ea00fae2617a00ecf64f13507320c16";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-17_amd64.deb";
+      sha256 = "a8651cb69bac83682a40a29585f6edf40641d4e818318291b5335b4fb9201b8d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libgprofng0_2.44-2_amd64.deb";
+      sha256 = "5c9e293430abe7a1fa7941090c13b645e7d02811b1d04712034fe9b7b00a9ecf";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils_2.44-2_amd64.deb";
+      sha256 = "9c27921cc8bcd5309f0ff35959e311420a7a8918c09cc0faace57bb2d923bd10";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14_14.2.0-17_amd64.deb";
+      sha256 = "b816dc3b2880d8dbf3d18f5d17bcccf38b067e2ef660bb831824bcb484c645b4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1_amd64.deb";
+      sha256 = "04c28c2760b0094b3d7758154ac095303dd00599b63ebad4086a325b607308b7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/gcc_14.2.0-1_amd64.deb";
+      sha256 = "eee65c41a441c57c05f754ced1b9d093956966a1c7da9938c3ec00d3dc2f905d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libstdc++-14-dev_14.2.0-17_amd64.deb";
+      sha256 = "2766c7ff14e5e2fff144e86e00a35e4d9240ff57462db6a32b52ba0cf3c96a5d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/g++-14-x86-64-linux-gnu_14.2.0-17_amd64.deb";
+      sha256 = "ed02574f34f5b38f8acae602260be252405e29a3d019c241e88e6a96a282c532";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/g++-14_14.2.0-17_amd64.deb";
+      sha256 = "b15af4b597899da94f600b2ae479d4e02188f45e769f681341ef5027d65e32e7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/g++-x86-64-linux-gnu_14.2.0-1_amd64.deb";
+      sha256 = "15e10fc3948ec76be8d51b23e75ad9df9c39588c94f1f47059cee02c117c7583";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/g++_14.2.0-1_amd64.deb";
+      sha256 = "f86661c021ab2acb39ceb87315e7c2d4d420fdadc19945d5d589f3953410445c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb";
+      sha256 = "4c6db0e3d5f3e990fc0123fe0bc08b4cdaba36f20d01d2fdcea119fb89d59496";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/brotli/libbrotli1_1.1.0-2+b7_amd64.deb";
+      sha256 = "0fb79f88db210afbd69282ab9649e525f393ec6950ca34da1a6b359250b8d7db";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nettle/libnettle8t64_3.10.1-1_amd64.deb";
+      sha256 = "1b03d4a9cd9c8143ba50fe6396f36937e901a317d492d179f4596862c1731cfe";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nettle/libhogweed6t64_3.10.1-1_amd64.deb";
+      sha256 = "b059ed155115ac09da295322de48ee1ed58ef5fa45edcc9e12ff0e94636ef25f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/libunistring/libunistring5_1.3-1_amd64.deb";
+      sha256 = "db82293b67b63c809bc3cf5ef1b6f1a4bcabd0dde1fdc83c43e47d7f8ca0a267";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2+b1_amd64.deb";
+      sha256 = "17fc01829a4951856a2484a7a1fb469baa35337c66dd8095212613e60c357fc8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libffi/libffi8_3.4.7-1_amd64.deb";
+      sha256 = "99e28ddc9f6f02a147be07440f0c781bddffe1d59fdb444b242b79f128db3df3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/p11-kit/libp11-kit0_0.25.5-3_amd64.deb";
+      sha256 = "784bf2063e166c8bc851a32623b74ebd85c499043a9d57c5bbd64fa63447f45a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtasn1-6/libtasn1-6_4.20.0-2_amd64.deb";
+      sha256 = "296509910b09cfa62608818bd55423bbd27c0542d8176d612afe03521882e830";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gnutls28/libgnutls30t64_3.8.9-2_amd64.deb";
+      sha256 = "9fbd2ae6bdadfd96a93eaa192687651e0a545e146e5837c8f082fc7c6f88420b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libkrb5support0_1.21.3-4_amd64.deb";
+      sha256 = "f82c6d5826c570ef905f5d47dc2e2d6692c6202eee1f4c06392d086461b32cae";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libcom-err2_1.47.2-1_amd64.deb";
+      sha256 = "cc24a08f423d038099b4fa30062643cf719addfb1213110d928064ed9599a7e5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libk5crypto3_1.21.3-4_amd64.deb";
+      sha256 = "1fcd3b4bd58b9230d0f3c844d6328348410efa64861ba550a5bc0a9b035c246f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/keyutils/libkeyutils1_1.6.3-4_amd64.deb";
+      sha256 = "b06a91f5395cc80354df4100b4ce2e3cbe3efb845858c6a063415c7335cfcee2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/openssl-provider-legacy_3.4.1-1_amd64.deb";
+      sha256 = "21645ffde6aadcd6192662455f154f6a789bacfedebfb728e28cc563e958a687";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/libssl3t64_3.4.1-1_amd64.deb";
+      sha256 = "95ec621ad83819cae4b2c04fe2b0cfc5bdd90f8e60e687d5803f2956d177fb7e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libkrb5-3_1.21.3-4_amd64.deb";
+      sha256 = "ff55609ee29d5edc3fa7a0068459cafdaca468f8c783523e4ceb78b88715c06b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libgssapi-krb5-2_1.21.3-4_amd64.deb";
+      sha256 = "fa81f3a5d93c6ce50855a2f78b022441514cc38b1b78a40a2b97f92036e8c2d7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-9_amd64.deb";
+      sha256 = "a5c38659fbd62c33c6d9bfa2be43e75a572d1818531aad32dd74d0a58cc4bd19";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-9_amd64.deb";
+      sha256 = "66e49d7ae026811b49a0050f18b0325960a2625ffd1ff60d91b7844a815fa9d2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openldap/libldap2_2.6.9+dfsg-1_amd64.deb";
+      sha256 = "68c58f4823f7552681822a2de7d5f2059286aac9f59627568e4b6b3d0d0fd05a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nghttp2/libnghttp2-14_1.64.0-1_amd64.deb";
+      sha256 = "15bde7d0f62a8f7d819ff32a981dca817f786f71ca922a033775e46ce89c3f67";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nghttp3/libnghttp3-9_1.6.0-2_amd64.deb";
+      sha256 = "7100e92e39ddc12a357f22dd81ce9d2e7701ef8559d670c65fca9502f95701e6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ngtcp2/libngtcp2-16_1.9.1-1_amd64.deb";
+      sha256 = "146ae8d56997c454a22d3da0b46097279e204b4172688d96ee8306b43240f16f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.9.1-1_amd64.deb";
+      sha256 = "698f6d71821c0000c1cabb3cf019f8e9ae0873e3de0a3d87a04037fbc0f35171";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1+b1_amd64.deb";
+      sha256 = "59d42bb1f9ebc0d1776fe616efb08a7a8568b05982e00f70b03c63863db768ab";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b5_amd64.deb";
+      sha256 = "93baa2004cbe6c8721b9e81beed078612540aef120970b4751305c51c6697368";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libssh2/libssh2-1t64_1.11.1-1_amd64.deb";
+      sha256 = "7cd32dd28148c672f156d1d4ae56d6129bf776980bc6abb4f27c5714c190b958";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/libcurl3t64-gnutls_8.12.1-3_amd64.deb";
+      sha256 = "71b3c55ddc7b04a59e899533005e2b31c774825739857b42275baa2aa70b22d3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/curl_8.12.1-3_amd64.deb";
+      sha256 = "f3b49b24f56a1a5177b5844d6aa954899a24c8a3ad77c161537adca3e8380918";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/patch/patch_2.7.6-7_amd64.deb";
+      sha256 = "8c6d49b771530dbe26d7bd060582dc7d2b4eeb603a20789debc1ef4bbbc4ef67";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-bin_2.40-7_amd64.deb";
+      sha256 = "931733c24eee2b5380388f130629d413e353fcdfb3ba146d3a8c2091878fa38e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-l10n_2.40-7_all.deb";
+      sha256 = "fd0f6e1d75c5c2f71bdbc94fc73382f3cdd673addaf885476a0757b95a13b0c9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debconf/debconf_1.5.89_all.deb";
+      sha256 = "3b7529580fae9a804999861ceb802c17a65cb734de2558e8423f9a449ac22e2c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/locales_2.40-7_all.deb";
+      sha256 = "753f1fbc436fa2d03aec87f76a8ebbd3ac55ee94de892c9b6f0b191b44aeb541";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/attr/libattr1_2.5.2-3_amd64.deb";
+      sha256 = "606b5ee12ea2786be607a17f40c1fb5e65c76ceaff66665bdf8f8c6c1b71d1fb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/coreutils/coreutils_9.5-1+b1_amd64.deb";
+      sha256 = "feead508ba503cf90b5fc1fa8e1269cb59325afa53f44185e1d4bb2d9c889b93";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/audit/libaudit-common_4.0.2-2_all.deb";
+      sha256 = "b6edcd7aa36a2a5a1abd2c52966d69a99eebdb69c8f5cb33cbf415b0875775e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap-ng/libcap-ng0_0.8.5-4+b1_amd64.deb";
+      sha256 = "20a9e4b0619a3eb2566338223bed135dde5a601eaa2f8fdd5f20b94506addcac";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/audit/libaudit1_4.0.2-2+b2_amd64.deb";
+      sha256 = "e5c200c6f9db0d0e5766c5cad66a686f46c7649868435fba966cdb0be59b42f2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam0g_1.7.0-3_amd64.deb";
+      sha256 = "91c8ddb989d1e9bd9f72213c48d5e06b5ac7a730138615326a3587c0449b4143";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap2/libcap2_2.66-5+b1_amd64.deb";
+      sha256 = "2d03c230350e5d19990f604d843a0afc95fd9e554e31a6606bd02c042aaa8a5a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libsystemd0_257.3-1_amd64.deb";
+      sha256 = "cba9428ddffae7d0e5b05f86b8e832af6dfbf3f9326d9742ca8a584a8dfaf478";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-modules-bin_1.7.0-3_amd64.deb";
+      sha256 = "b42582a890670b2cfbc8968f9f56513f80941cf16c227cfedb99e0d43d8c0711";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-modules_1.7.0-3_amd64.deb";
+      sha256 = "21a718466d15892ec079f816553ad7e95102e2354dfc5756646b0dc1dd4906a7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-runtime_1.7.0-3_all.deb";
+      sha256 = "0f19f338c735e2ba51d9448e2dcba195d9698c5829dc864aec9b3b8913bb6f69";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libblkid1_2.40.4-5_amd64.deb";
+      sha256 = "3f2601dc1b0e45f2b5ba2b378974571825cdc671de87ce26ecf5d04f45f45913";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libmount1_2.40.4-5_amd64.deb";
+      sha256 = "053a3712ea7a195e07e2fc7b92437890da626b7cfa35cba5d73fb212897cbc3d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libsmartcols1_2.40.4-5_amd64.deb";
+      sha256 = "bf4cb1af52a9529fd38207f98eb5f50cb9dca5b0b68fc51680cd13932492a5ce";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libudev1_257.3-1_amd64.deb";
+      sha256 = "7fc5163d13ef61b05d7531393d4383c7e8c88834e1d3639adb7b428215281623";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libuuid1_2.40.4-5_amd64.deb";
+      sha256 = "b3a1471bf400a28dac5c598600b08e817eed80f6daa027688dad30e1c9f52ddb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/util-linux_2.40.4-5_amd64.deb";
+      sha256 = "521ca8021437df8556b5aeb23db7f62fe9a8f73afcb088983ab43c2e74955e08";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/libmagic-mgc_5.45-3+b1_amd64.deb";
+      sha256 = "a047c138b3d682df665c7dba105d8e0dd416d4a6d76b9bd6cdcd088ca3bac44b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/libmagic1t64_5.45-3+b1_amd64.deb";
+      sha256 = "aa391a4a96e87e0ce8a4431863bcc7ea4ac21dce141b9fae06b7b362c551198a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/file_5.45-3+b1_amd64.deb";
+      sha256 = "ece3eae2a764271287990a2f1a08ae073814b303297dfa89bb487c5354248bea";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/libdpkg-perl_1.22.15_all.deb";
+      sha256 = "b77d5fdc901d9057cd558d1b9c34ba4d47a444193ebf7f85957e3dc18cbea9fe";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xz-utils/xz-utils_5.6.4-1_amd64.deb";
+      sha256 = "c91874c4dd1b3a7781fa4e06588c275970772461b71404e28f5ca3df8fcc8d39";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/dpkg-dev_1.22.15_all.deb";
+      sha256 = "9ed603f1c79c284b9abc86a6f615f86d1a41ee6d1670ab7311d08df92dcd205e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb";
+      sha256 = "85087cd04e57fd4ab7d6e816d348c335047823ab60c78878336b74f07b352ca1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb";
+      sha256 = "54efef2aef4db5fcb5e0f5b7746465000c6a779b06f3686d0ec3d2a901b20aeb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb";
+      sha256 = "f1fcad470ca3ac80b4a0f4af6f03cd215089473996b07e508b3ee342bbb11af7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb";
+      sha256 = "385209ba52e5c97808bbdc2fc4da22aea9020f96fbab6fbfb144921c4a31d400";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/shadow/login.defs_4.17.3-1_all.deb";
+      sha256 = "1eba8412effd0c0f2d290b0d00b0dfb73263d6424ae19f904240eb8937b5a76f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/login_4.16.0-2+really2.40.4-5_amd64.deb";
+      sha256 = "56ebcb47c3182192bda8c298f023626f2f4d329c8e121d9a7bcc73def5c1548c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbsd/libbsd0_0.12.2-2_amd64.deb";
+      sha256 = "e5a85986fa6bec3307ab1bc860736b478b331882bc45e17675a7bdf88eecb43a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsemanage/libsemanage-common_3.8-1_all.deb";
+      sha256 = "28fba03d5c00dd41a57964f265104cce2d820a1f28f2e83e5ac66e529655e602";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsepol/libsepol2_3.8-1_amd64.deb";
+      sha256 = "bb951f643c6a9784cc2c8c35ee0e5310ce58bac517a6d2a96797fc7ffa69382f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsemanage/libsemanage2_3.8-1+b1_amd64.deb";
+      sha256 = "db4dfd67efe8c9a30724a1b5adf3637db6eee01ed1618e562de948687fc37659";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/shadow/passwd_4.17.3-1_amd64.deb";
+      sha256 = "f202db9840986609a265fcde9f0b8356418ca80e0284e3b92ab070e861afff66";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysvinit-utils_3.14-3_amd64.deb";
+      sha256 = "e038a82199b1f377ccabe416342b92ac3894f9b292f6324c3602c83991b35cd1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/insserv/insserv_1.26.0-1_amd64.deb";
+      sha256 = "c1e71f879de0226d6da7c8bd1deb10bd79e0667f14c3956f9c1275cb3a329d43";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/startpar/startpar_0.66-1_amd64.deb";
+      sha256 = "2e7fe320ed88b1d59484f7beb76331589664eed012d9458aa223e09a4a9d6dd8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysv-rc_3.14-3_all.deb";
+      sha256 = "4db19a15402a913ae0cbf5827116c27685ea377119d037a83056b71ae8cfbbb4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/initscripts_3.14-3_all.deb";
+      sha256 = "349a2c9108258b3beab3cc37eb7ec60a7053b0784531ad4078be794ed993f19d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/mount_2.40.4-5_amd64.deb";
+      sha256 = "42f0df2bee57b6c8f939f1d6221c92a14763e01d519e59b06d835ab6583be65a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysvinit-core_3.14-3_amd64.deb";
+      sha256 = "f2d2c49cc1977ea8c2e19b0020c65aa19e50c4f13501ec723b0990844dac337a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/diffutils/diffutils_3.10-2_amd64.deb";
+      sha256 = "8cb3ed1d4c473cc11ffad83d7ae6d9b232e257accd3173e030c32856c20985f7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/icu/libicu72_72.1-6_amd64.deb";
+      sha256 = "bbe2b275aaad89b1a6ee959e31d7b7f3f0af3ac1f97140a7efd2b7b802a11871";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml2/libxml2_2.12.7+dfsg+really2.9.14-0.2+b2_amd64.deb";
+      sha256 = "f1f3e845044f52712ff0d7e6409f5f715167f950750c33e5966b2be1f531382f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/augeas/augeas-lenses_1.14.1-1_all.deb";
+      sha256 = "489ab4b8d58fc93937294a54d4c0eb8776c253a9a53500997eca0d9a7f15fce7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/augeas/libaugeas0_1.14.1-1+b3_amd64.deb";
+      sha256 = "4ab96ac3bca4a82a2990fdcbee9fb8a0cfeed107776923ac5f9645544b2956df";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse/libfuse2t64_2.9.9-9_amd64.deb";
+      sha256 = "e60474070e983693ac461af291b876c2304340f75a6b8379a3ba017e4848341e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/h/hivex/libhivex0_1.3.24-1+b9_amd64.deb";
+      sha256 = "1d2c6217b261e8fdc19faddca93cbfe2c3efe60bbee54451026bfbe31d0e3f18";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lua5.3/liblua5.3-0_5.3.6-2+b4_amd64.deb";
+      sha256 = "35af63e29e035d7f1ce3586922c51868df86c7fd9a4d28777d80384ad809df61";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/popt/libpopt0_1.19+dfsg-2_amd64.deb";
+      sha256 = "07f649b706852af937654295697dcfc7858f3295718ec18681dce1704663e4f2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libgpg-error/libgpg-error0_1.51-3_amd64.deb";
+      sha256 = "01bf2a3cf366f53f4daeab267fc948cefbba0243064ac619c2de21e2fe7a941c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libgcrypt20/libgcrypt20_1.11.0-7_amd64.deb";
+      sha256 = "2e228206277d1262e76d5a78098f205edd80ee2c3ee1822ef42cdfdbb98620f9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpm/librpmio10_4.20.1+dfsg-1_amd64.deb";
+      sha256 = "8b5dab731c2b06bb61e9e32453c04dab3b9117d8a3cd591163aaa01648563df8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb";
+      sha256 = "dbc22a2c055d1700d2a3e2a196ca7610678f8152891ca6caa21e7b629bdf3da5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpm/librpm10_4.20.1+dfsg-1_amd64.deb";
+      sha256 = "9daa1b447990a527e0ab4b2c6a19d54024555ddcd9ab303605b9e7617361f4c8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtirpc/libtirpc-common_1.3.4+ds-1.3_all.deb";
+      sha256 = "d31cc2c412789fdd234d6d84b148a5b355d64a2fa3fc21db397a7ccaa64fa7a7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtirpc/libtirpc3t64_1.3.4+ds-1.3+b1_amd64.deb";
+      sha256 = "84a08219066de3a97bc961d5c35964a3bf1758bfa548e8a98032fcfa413c236f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/libcurl4t64_8.12.1-3_amd64.deb";
+      sha256 = "dc70e4aaf4a21376a8f5e46eb0fd178b2e9507c73e3652cd68e3ff1b6db1aa83";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/expat/libexpat1_2.6.4-1_amd64.deb";
+      sha256 = "8a6088dbcf12540c982ea39e72d5e76aca7e530646feb011fd945a8738c10a87";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/afflib/libafflib0t64_3.7.20-2+b1_amd64.deb";
+      sha256 = "2bcca7ddcd61d028e00ab627c5516fb7b839a09922bff367ebe0fad31772456f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libewf/libewf2_20140816-1+b1_amd64.deb";
+      sha256 = "e7c64171e71cf1226b7918cfcb84eb3c64819e5833af1770c6510799e90320da";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvhdi/libvhdi1_20240509-2+b1_amd64.deb";
+      sha256 = "e98ad0aa3f084d525b4c1059660e79d47d8ea88e705bfed0e92f6d3a6f955a0a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvmdk/libvmdk1_20240510-1+b1_amd64.deb";
+      sha256 = "59de59843ef26310a3c9b2bde1c409d4d07dbd89841f42d36ba7fb8b6890c6e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sleuthkit/libtsk19t64_4.12.1+dfsg-3_amd64.deb";
+      sha256 = "b3a5446755ba62f6a54b67946c8653b0ddde070bc53608df8c0b974b26de3be9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvirt/libvirt-common_11.0.0-2_amd64.deb";
+      sha256 = "5b20584f1da8ef74303af39c5ac0eeef8eb20fc21819ed1b02a20cab8000555a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apparmor/libapparmor1_3.1.7-4_amd64.deb";
+      sha256 = "711af3f44325355b9f8e777001faf05e98bc5263fc77f329d46d0abdfe2ed930";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib2.0/libglib2.0-0t64_2.83.4-1_amd64.deb";
+      sha256 = "870dc900b0592e6699b5ab27f4f65aac01698f8d148721131ea7e9076c9670b1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-c/libjson-c5_0.18+ds-1_amd64.deb";
+      sha256 = "4fbd5fb4d54c626f05d68abf38a31533fbf1bf4a87068696abe041ee9c974fe0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnl3/libnl-3-200_3.7.0-0.3+b1_amd64.deb";
+      sha256 = "4489648deb251bbee4b07001a897ec22b8dacf9e87c4c9e667ee5264f9303d0d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/numactl/libnuma1_2.0.18-1+b1_amd64.deb";
+      sha256 = "665f5b01324b94aaa453a0db3f73453e7af812275162e30e7777f21d3470045e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libssh/libssh-4_0.11.1-1_amd64.deb";
+      sha256 = "ac16b59e52827962c709b8f1b95521f3a4eb00b0c4723a9bdef50b9daa9b3410";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvirt/libvirt0_11.0.0-2_amd64.deb";
+      sha256 = "59c16e89accaebe3268aae06f9fc3f4be2dd643d81b268cbde4374687881aedc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/y/yara/libyara10_4.5.2-1_amd64.deb";
+      sha256 = "fcb41d8e1aaf6fffece2f40f71aff95f1892e26aeb6c40a6e7b07cc760c80e3c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libext2fs2t64_1.47.2-1_amd64.deb";
+      sha256 = "0f30bc8d520cc0c1597f4e7e7888383a3612915d7f94ea2f5b7431bb2d87c644";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rust-sequoia-sqv/sqv_1.2.1-6+b1_amd64.deb";
+      sha256 = "27a7ccd53e924214985c57aeb67420334dcba80db951aeace8299787e099550a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xxhash/libxxhash0_0.8.3-2_amd64.deb";
+      sha256 = "81da7064d56fc044f5db4bb3c1e80ff50a4986dcbbf80d958eeca565b44c157f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lz4/liblz4-1_1.10.0-3_amd64.deb";
+      sha256 = "c3572abc2c9fcfe535087ea8df6f69beea7540a52c696dfdafa3e395e3768bdb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apt/libapt-pkg7.0_2.9.30_amd64.deb";
+      sha256 = "7e486334a18d6d9af06a822e93cdbed7ce9452f0af75db638f61c775e5ff3a78";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2023.4_all.deb";
+      sha256 = "6e93a87b9e50bd81518880ec07a62f95d7d8452f4aa703f5b0a3076439f1022c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-2+b1_amd64.deb";
+      sha256 = "02349908f4e6accc61d86002a88d5beb7f0cb73da7f2dbc10e352bf94cd51f93";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apt/apt_2.9.30_amd64.deb";
+      sha256 = "208733509db3b29696e797fc2a30c3eafc074859e20c55eb7c97aa033596d824";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cpio/cpio_2.15+dfsg-2_amd64.deb";
+      sha256 = "d8faece250bcf72e91ac15a5fef198be173af18c9f48bae257e7ee937fbc6cdc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/logsave_1.47.2-1_amd64.deb";
+      sha256 = "f4ab0cace0979bdfad14c8a62164ad37f638960e01997616f17b5798a9f0b5e1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libss2_1.47.2-1_amd64.deb";
+      sha256 = "e8461b2ffe672783d39b1d11b0752944d6f6f58cc5129df22a65ea4c2d82634b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.2-1_amd64.deb";
+      sha256 = "563b0b745a9c2788de1b3362c0de3aa08bc055d8fd72271488f678d76483306c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/supermin/supermin_5.2.2-6_amd64.deb";
+      sha256 = "6152d3e9d17088ed8356b5c0ea45fca8a407ee0343f9fa8af9735c6f56a85949";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/liba/libaio/libaio1t64_0.3.113-8+b1_amd64.deb";
+      sha256 = "490c8a2d116001a5f3b0a6d7a7aabf6a7b629366590dc5c3f75b078e931dd129";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/elfutils/libelf1t64_0.192-4_amd64.deb";
+      sha256 = "94497b7e17b6f574a0605b380d454e20d3f01a9c63b70c2a2263f679d30053e1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbpf/libbpf1_1.5.0-2_amd64.deb";
+      sha256 = "dcd780edd2dbdae624c396143c2615e2a77b195ebd394de67771c15d0aed5079";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/capstone/libcapstone5_5.0.5-1+b1_amd64.deb";
+      sha256 = "837be9f77123893a2c90f0a912377500e03f3fc715d0f29633b07b7f4960822c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/device-tree-compiler/libfdt1_1.7.2-2+b1_amd64.deb";
+      sha256 = "8e37034d7864807ae2063efcc82fc79aad59069546212e6e0908ed67f9f7e107";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse3/libfuse3-3_3.14.0-10_amd64.deb";
+      sha256 = "1f9513724c18f0587e8ebab2119845d703a312042b679f9cdeeb1ec70c6d089c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/adduser/adduser_3.137_all.deb";
+      sha256 = "40b77d8b5b482baee2d0c95bbb4a4b9bcf7271b79dec039ef45e541142edfc12";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnl3/libnl-route-3-200_3.7.0-0.3+b1_amd64.deb";
+      sha256 = "5c87344caa2f72c08d5f9590284b7e9302129968fc255c1451e26bebb4a7e3ca";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rdma-core/libibverbs1_55.0-1_amd64.deb";
+      sha256 = "e0af02ee1ee71a709dbc9031eb4f0e4c85654f614c3d79ba9fb25717d885ba45";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-3.1_amd64.deb";
+      sha256 = "75ce948401245779e0d0f09b558f2bae2daa7c971bdcfa300494fa4b34f26d5b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pixman/libpixman-1-0_0.44.0-3_amd64.deb";
+      sha256 = "3862c87596f6b4b60fc916395fd69aa10af28a875a8e5c081a8cf30ddd120bd6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/kmod/libkmod2_33+20240816-2_amd64.deb";
+      sha256 = "babb24689d31648baa07d45da56ef249f3a6e7225c4bf61a1e77eba66fdbc6c8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ndctl/libdaxctl1_77-2.2+b2_amd64.deb";
+      sha256 = "5f0008db43c846244911168357618ae6f9f6cff00a3f23252f34e299592f3b25";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ndctl/libndctl6_77-2.2+b2_amd64.deb";
+      sha256 = "ba955cd5bfbc98c2bbfcf07811b2547bc7f66a38d8d61c0905afaf9eb968150c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pmdk/libpmem1_1.13.1-1.1+b1_amd64.deb";
+      sha256 = "7d972d6958e915ce602e4b90debc6b4b91a01dfea1fe003d0b013756e7d9d863";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libpng1.6/libpng16-16t64_1.6.47-1_amd64.deb";
+      sha256 = "ba6447e088c324cd3a43c88d7e0a1266cf4aa54602324a65ef39361de2a67062";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rdma-core/librdmacm1t64_55.0-1_amd64.deb";
+      sha256 = "656eb08bb3908b098fe61a6d7c326fd604bd204dd7ea9521e3ff3f1ecadd5187";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libslirp/libslirp0_4.8.0-1+b1_amd64.deb";
+      sha256 = "bf69b5be5afac788edc8248ed952c4ad7a279331ba653ef3536d47ef68bd8dd3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/liburing/liburing2_2.9-1_amd64.deb";
+      sha256 = "4b589c00c7a51172aace2cb2fb3d3ff32daf86c644023126dcfcaa840cc941ea";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libexecs/libexecs1_1.4-2+b2_amd64.deb";
+      sha256 = "05b578fead365a81141fe834c3b3b6df89d17a050784a237f736489fbd426105";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/v/vdeplug4/libvdeplug2t64_4.0.1-5.1+b1_amd64.deb";
+      sha256 = "01291e2c8e28e91eac6b59c983a3a44e29ad0ddb8622699fbb84cbd5f26334a4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/alsa-lib/libasound2-data_1.2.13-1_all.deb";
+      sha256 = "bac4c89919fcf9f2fad94049312d9368ad0852bffdda1c1be5f353a34916b35f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/alsa-lib/libasound2t64_1.2.13-1+b1_amd64.deb";
+      sha256 = "8658243e884021593bdb4458f5240876923949c450f07d8b836c23b395393659";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/brltty/libbrlapi0.8_6.7-1+b2_amd64.deb";
+      sha256 = "ccadf991587934b9dd92ec9946fbb32913853dbd96ba85a03b586499bc92d993";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nspr/libnspr4_4.36-1_amd64.deb";
+      sha256 = "87fc2039ee89cff2b8010fa9535706b1def40031acfc52bf12197dcb3cb7b064";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nss/libnss3_3.108-1_amd64.deb";
+      sha256 = "921256a4e9d83f40ac0c8a2c083eb1a5f6fae8d7572bd3c233213809a92e9eab";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pcsc-lite/libpcsclite1_2.3.1-1_amd64.deb";
+      sha256 = "23f0f5fa1c8887b9a1a5a76c8d33cd189a477ee91f8d86b3ab75d3a7a4bc7c13";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcacard/libcacard0_2.8.0-3+b2_amd64.deb";
+      sha256 = "1d6a8d17b893e54dfea8fe78df16c9a8ab4a6e626f9312881784592d480d9317";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ncurses/libncursesw6_6.5+20250216-1_amd64.deb";
+      sha256 = "10e49521a83afc11fc5c0ed87133922ee7b490661d08ede4ef1b96bf3ec4c3a4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.27-2_amd64.deb";
+      sha256 = "95a0c46bf9ca2a3cf31dbdba77afef56b62f7d511b55dc302c122b9b60b9d1e7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/usbredir/libusbredirparser1t64_0.15.0-1_amd64.deb";
+      sha256 = "4b039802dac140bae5a6f3fb6341eeeb9ea8c3e4d7b95ad36a07a8c28572f177";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-common_9.2.1+ds-1_amd64.deb";
+      sha256 = "9730a24c9f4b1703477715c465ce2a335632747cc00146b5279bafddb71deab0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-data_9.2.1+ds-1_all.deb";
+      sha256 = "7e5a9506737386a4f3bb7d865253837d8945f6c35a4ed38014c3054aac80a847";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/seabios/seabios_1.16.3-2_all.deb";
+      sha256 = "2b590534250b940f43222eeab9a8f57f337a9d9a73fc412a43ab8cd07a7e56f6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/ipxe/ipxe-qemu_1.21.1+git20250224.12ea8c40+dfsg-2_all.deb";
+      sha256 = "aa389ab1fe17bbb2bcc998414fe9b2908ab7b2db03fefd94c82faa0079c5c20f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-x86_9.2.1+ds-1_amd64.deb";
+      sha256 = "0a945fc03b2c03610682f736af222b7008f151ce9b9dfaa74324838bbf0acdb9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-utils_9.2.1+ds-1_amd64.deb";
+      sha256 = "135d1bf8756b05102b371f3d0a0f523924513ce132958ee5f61a04622ae74154";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db5.3/db5.3-util_5.3.28+dfsg2-9_amd64.deb";
+      sha256 = "151e292f711229b0d29b359eaa0253958997377569d37e5a8105543346d153e5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db-defaults/db-util_5.3.4_all.deb";
+      sha256 = "1c1bf1d3905c975b55339d3b268ec879658848aee568d5d1ec62635bc1bf23b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/openssl_3.4.1-1_amd64.deb";
+      sha256 = "f940e452145f0e5bca187d33de9636a163fd9c41aadb6d0ce9dbbf0b7d42d7e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/ca-certificates/ca-certificates_20241223_all.deb";
+      sha256 = "bb96f2467c71323e738349080520689e4697df88c7ee90a83e9bcff1d29f3f5d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libencode-locale-perl/libencode-locale-perl_1.05-3_all.deb";
+      sha256 = "071bff2a1d193ec1b0d71e1a1ba7e718909866874e600f19d99a6f8c5ae30bcd";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtimedate-perl/libtimedate-perl_2.3300-2_all.deb";
+      sha256 = "8e36723da883c2975d83199e7f4b5331e291881372fde944b0d56660965f38bb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-date-perl/libhttp-date-perl_6.06-1_all.deb";
+      sha256 = "b46bf28a321e344be21b3161969c613abeddc63b1ff627ee94487a0ee4b53eda";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libfile-listing-perl/libfile-listing-perl_6.16-1_all.deb";
+      sha256 = "171410be7be03a39e6ad531b19d3b95049d43dae9f19076fe250b3b7bcc30574";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-tagset-perl/libhtml-tagset-perl_3.24-1_all.deb";
+      sha256 = "5efdaf433e10ce127257176d8093e41eabc642839e71f1961bc17f2e4f6169b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libencode-perl/libencode-perl_3.21-1+b2_amd64.deb";
+      sha256 = "ea20d3d506fc201fec6476e429bb9de8980a734a184ef2c9304950cec8b3c09b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libscalar-list-utils-perl/libscalar-list-utils-perl_1.63-1+b4_amd64.deb";
+      sha256 = "93b7ed975d41e50ba78b2c23799baa11242fc5c50d465c6fab2585184aff3e6f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/liburi-perl/liburi-perl_5.30-1_all.deb";
+      sha256 = "33957bd8218ddd3a86cc19fdf3bf7832b0640337a4be6cf23b2714b73d220220";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-parser-perl/libhtml-parser-perl_3.83-1+b2_amd64.deb";
+      sha256 = "a8948f22f77f6f29e5103798de18c740cf1579814dd41a69c30022b3c87bcccc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-tree-perl/libhtml-tree-perl_5.07-3_all.deb";
+      sha256 = "00f857bb27388432df3e4d6510334a560c2de19feb4b31897cb5d83251bb54ac";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libclone-perl/libclone-perl_0.47-1+b1_amd64.deb";
+      sha256 = "c1ca65f05a5fb68b04b4fb0c9f1bd1210c80041c98b0ea7848d80be8bc7a72a5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcompress-raw-bzip2-perl/libcompress-raw-bzip2-perl_2.213-1+b1_amd64.deb";
+      sha256 = "8c028b8eb8916707d7d4f47cf695c7088c99c54424b422e811227b7d2b8097f4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcompress-raw-zlib-perl/libcompress-raw-zlib-perl_2.213-1+b1_amd64.deb";
+      sha256 = "761bb8266f128b8e4b413ae4a76dcb01a226a09a8709c1dc676d1783af0e6499";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-html-perl/libio-html-perl_1.004-3_all.deb";
+      sha256 = "66c87e3e92460b9dcf56257fd6a48cc7fd1283790acb365a111ecb9d74e9ea43";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/liblwp-mediatypes-perl/liblwp-mediatypes-perl_6.04-2_all.deb";
+      sha256 = "c3ae8bca625ab6e16d6257698de402090135b5eca511df2c8086b0c23eefbaff";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-message-perl/libhttp-message-perl_7.00-2_all.deb";
+      sha256 = "e55e830b16af9c2b5269000c4dd9b93fd24b304a0675aeb0ab83438c566d2ca7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-cookies-perl/libhttp-cookies-perl_6.11-1_all.deb";
+      sha256 = "f3a57264a6704bd22397c644b1b91ed6055bdb190bd4d5d995cdf92840d049ed";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-negotiate-perl/libhttp-negotiate-perl_6.01-2_all.deb";
+      sha256 = "b2770aaf4d638283d9b4f713005702fbab42304be169cb4d6761e8537f724261";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl-openssl-defaults/perl-openssl-defaults_7+b2_amd64.deb";
+      sha256 = "e1d601fe96d5465a90042b49921b2086347a2e2111705972ba415ce9f9f3a871";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnet-ssleay-perl/libnet-ssleay-perl_1.94-3_amd64.deb";
+      sha256 = "fc67b418ec1ed7277902702791c91b3023eb488d7c01029f0cc2acfdfdebd13a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netbase/netbase_6.4_all.deb";
+      sha256 = "29b23c48c0fe6f878e56c5ddc9f65d1c05d729360f3690a593a8c795031cd867";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-socket-ssl-perl/libio-socket-ssl-perl_2.089-1_all.deb";
+      sha256 = "9fe58e2dd2847896e380f9fb26b5344d62cab21d8390598912e485ceedb30f00";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-socket-ip-perl/libio-socket-ip-perl_0.43-1_all.deb";
+      sha256 = "f9c5929f513c20b0500db78cc4a4a75d5d74d95a67bbfc10e1776363ab81b5f3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnet-http-perl/libnet-http-perl_6.23-1_all.deb";
+      sha256 = "ef8220824939149b88ff230081e4bd686d1d92f0a233c4f80d1e14115ab1b510";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/liblwp-protocol-https-perl/liblwp-protocol-https-perl_6.14-1_all.deb";
+      sha256 = "9201070118916bfbf3111008cac59769fb240376bb04e981132805a915f57223";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtry-tiny-perl/libtry-tiny-perl_0.32-1_all.deb";
+      sha256 = "f160af736fa67df5a5f6ec222d28e6c188b5b87965bd649956a6bea8795c1d3a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwww-robotrules-perl/libwww-robotrules-perl_6.02-1_all.deb";
+      sha256 = "be69cda8c2a860e64c43396bf2ff1c7145259cb85753ded14e0434f15ed647a0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwww-perl/libwww-perl_6.78-1_all.deb";
+      sha256 = "ddcecf6d01b33f14faf6ebd511deb114fcb0c043bb4291e4b45c82cbe7b4ec88";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/icoutils/icoutils_0.32.3-6_amd64.deb";
+      sha256 = "16a1b2b359ef3d90e9b83b8cf44ce58b11f097c023d02f3bf77745362a6f7247";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netpbm-free/libnetpbm11t64_11.09.02-2_amd64.deb";
+      sha256 = "59c877ae2af31ad8ce159d16cc016f12a719031b8fbffd4240f76e6baa88d353";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libd/libdeflate/libdeflate0_1.23-1+b1_amd64.deb";
+      sha256 = "872ca1f7a916c0dc726249e5028c601b045a997cc76a3f251203a0b871eaf141";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/jbigkit/libjbig0_2.1-6.1+b2_amd64.deb";
+      sha256 = "95cbc44561651e1b3385454df08e8f2efe84498f6963a85259be2cc2fe798709";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lerc/liblerc4_4.0.0+ds-5_amd64.deb";
+      sha256 = "2e0c13c0ddbde12968c2c713c2e0474a5b78e90d5216031256a725e8c76aa31c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwebp/libsharpyuv0_1.5.0-0.1_amd64.deb";
+      sha256 = "51934833d909588f7761fd84362114e90d8d2d38af57edf5df5c4a705e037547";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwebp/libwebp7_1.5.0-0.1_amd64.deb";
+      sha256 = "c749744b04abdd1426b0c7718e516362c03a557c5151662092d6d4f2cef6e7c1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_amd64.deb";
+      sha256 = "2773400039a7c4274ce49a4e3d65f3fedee48bea1562d7014a1f02d32f04345c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxau/libxau6_1.0.11-1_amd64.deb";
+      sha256 = "689a9f0e0ba3e2c65431f864871e303ee904de69dd28abfc462663fae030227f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.5-1_amd64.deb";
+      sha256 = "0740dc760916b2008b45417a42a8fd7dd5de370fb57d31373f15034cda8acf0b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcb/libxcb1_1.17.0-2+b1_amd64.deb";
+      sha256 = "5c222a72d11b866447da31693254f738430726e3e065a384e82687b2fd2f978b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libx11/libx11-data_1.8.10-2_all.deb";
+      sha256 = "fe7976c52351e7c403e6beb75a943111bbcd673a13540b85541ca71d1285dde0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libx11/libx11-6_1.8.10-2_amd64.deb";
+      sha256 = "c6299f67cab258bb0c251194f97f0b2301901fb0c53eabbc35bc54f9f5b9c842";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netpbm-free/netpbm_11.09.02-2_amd64.deb";
+      sha256 = "7a856bde1777acd8d26ebcf334423b8fa842a59df8074885ffffdd0c2468ff69";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/osinfo-db/osinfo-db_0.20250124-1_all.deb";
+      sha256 = "0c3d3688f5308311adf7d9ab45663eb7cf30d96e49585fcc8cac3bb9d8057658";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/acl/acl_2.3.2-2+b1_amd64.deb";
+      sha256 = "fa89b05576c590211c8e8965761fc76b830e3eeb3dd100ac59c8440f11ea18fd";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/attr/attr_2.5.2-3_amd64.deb";
+      sha256 = "f2eac7412d2df3e36ccea2db110e2fc529a473ce3e348a35ca9c9a521a6bdfb8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/bsdextrautils_2.40.4-5_amd64.deb";
+      sha256 = "ca32c48b47944b1f3079d90dd62b9801a112d904444990f226185b15aff81d60";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lzo2/liblzo2-2_2.10-3+b1_amd64.deb";
+      sha256 = "f3032201fe2928a87e13f05ce256ff3ac2a7860c7e594dc51ae6d7348a4466ce";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/reiserfsprogs/libreiserfscore0t64_3.6.27-9_amd64.deb";
+      sha256 = "138245c2abc72dc0428328da0a5991cae176d51b20552a313f566ccbca7f8a98";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/btrfs-progs/btrfs-progs_6.12-1+b1_amd64.deb";
+      sha256 = "fc13dc8e210a4b7dd484930770330cdcee6cd9fd58b597cbe5f4f308aa28f624";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/dmsetup_1.02.201-1_amd64.deb";
+      sha256 = "f813153c4b6bfa5c6f75aa6c87aba92c40bf7d9c5feaa4c1f944f34b3c0fbfb9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_amd64.deb";
+      sha256 = "29a68d5d539af88c3c67d45e07a869c94f0cee344d69e994fc3fcac558444542";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1_amd64.deb";
+      sha256 = "92d44ec6d04febd96497d5814a8ac765afcd0bdef5878a304d3d644b69884045";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1_amd64.deb";
+      sha256 = "b0cd69d8ce90150fa7acaa1d225a6d2f802098bdfbb3af6dba82f31e0ad7c528";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dosfstools/dosfstools_4.2-1.1_amd64.deb";
+      sha256 = "937f57ad1efee1d6b284a4378d7705fdf390fee6e3542ee206a89a4d8b93ef60";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/exfatprogs/exfatprogs_1.2.7-3_amd64.deb";
+      sha256 = "0b9d0f5cc6f5e6156168a875156508b0c59ab8e382aa002b18057d7496235d49";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/syslinux/extlinux_6.04~git20190206.bf6db5b4+dfsg1-3+b1_amd64.deb";
+      sha256 = "43d2cc3947ddc842e535240c4c1f713df407863ab39e430211e3385a7cf0e315";
+      name = "extlinux_6.04git20190206.bf6db5b4+dfsg1-3+b1_amd64.deb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/f2fs-tools/f2fs-tools_1.16.0-1.1+b1_amd64.deb";
+      sha256 = "2470227305f92e0399147bd5f74a4b1c423d081a61ce705c0e689f2b408ead9e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libfdisk1_2.40.4-5_amd64.deb";
+      sha256 = "93ac9a44159ae66ac245d1932470ccac0b0e9fae2b34f7738903d064590b8df5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/readline/readline-common_8.2-6_all.deb";
+      sha256 = "f77e8aa0bf0de618f11cb0b21658a4ed60f177d63b3cf26d7fc3706b6d0eaaa9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/readline/libreadline8t64_8.2-6_amd64.deb";
+      sha256 = "eeadf2b5e755c9f183883feea2d9b5b28560284275d5f54d3e55d0923b1d0967";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/fdisk_2.40.4-5_amd64.deb";
+      sha256 = "5c59817dfdaa03ba5f29229d97dd20a39b5c39371d2f14caf6aafcfcbffe03c8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsigsegv/libsigsegv2_2.14-1+b2_amd64.deb";
+      sha256 = "bac603b965f303ea88dc39cd723b3d88cd86e3be9c948783f0d5e0d00e971302";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gawk/gawk_5.2.1-2+b1_amd64.deb";
+      sha256 = "0e3b376e74cadfa5049bc8248c563efe89fd45e31466f8891c094c65c0879f5c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdisk/gdisk_1.0.10-2_amd64.deb";
+      sha256 = "a64944b38e8477bf23b9a0ffb6fc653c8847facb1f851864b1a5c40a931456d2";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/efivar/libefivar1t64_38-3.1+b1_amd64.deb";
+      sha256 = "34bfb96ca9422af293aeac800438682112b4019adc5ed25728bc35dff4ad4ca4";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/efivar/libefiboot1t64_38-3.1+b1_amd64.deb";
+      sha256 = "932d5799069e2af3f044cfd615518f0c1539400f1e8e1cdd9eeb407ca213926e";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/freetype/libfreetype6_2.13.3+dfsg-1_amd64.deb";
+      sha256 = "1fcf0600356ff0d9b387ad908a897e1e5418705ffb8d7cb66d6dcb25af55b76f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gettext/gettext-base_0.23.1-1_amd64.deb";
+      sha256 = "e6ea4542a54c0a0f7508be4c5830c4a86ff403e336868b4f9531375b4e2c692b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grub2/grub-common_2.12-5_amd64.deb";
+      sha256 = "5ead5a3142700efbf6a8e2dcbd4f283f6e8c61f7b5c815e273f9e26369437a11";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grub2/grub2-common_2.12-5_amd64.deb";
+      sha256 = "4e23feb4c516ce8685e2b60d8940977f9511c1c42496957840f930b2fb6ab4f5";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libm/libmnl/libmnl0_1.0.5-3_amd64.deb";
+      sha256 = "4ec9c1096e0b954e3bdb03a62314ee7f49999045d3d55be3e4ded520ffc9baf5";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/iptables/libxtables12_1.8.11-2_amd64.deb";
+      sha256 = "4de5aa59faef5e98d6ba9f5f521a915be5641f224f597862f8d29e8319e8db16";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap2/libcap2-bin_2.66-5+b1_amd64.deb";
+      sha256 = "d26a126b4b5f919d24c4f2c2ccb879f40de330149f69b6b39ecd51b45db068d1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/iproute2/iproute2_6.13.0-1_amd64.deb";
+      sha256 = "9e75975b198f53947a98624895fb00113278e215457a57f583ebf046ee0cf946";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dhcpcd/dhcpcd-base_10.1.0-7_amd64.deb";
+      sha256 = "227ab976f938119c0df15131414b98b4972b1b653ac34161a72faef78f7713fa";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/kmod/kmod_33+20240816-2_amd64.deb";
+      sha256 = "1e32699d89a605794962384637412f4409cd5ec8a48735eda216c1e9ed7dcb48";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-glib/libjson-glib-1.0-common_1.10.6+ds-1_all.deb";
+      sha256 = "70cf0f4d8e71f0404c989df7502fb5d8832439354c1a3e809c86f1b0df6b5e9a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-glib/libjson-glib-1.0-0_1.10.6+ds-1_amd64.deb";
+      sha256 = "a358ed1c227c35b93073ebae26c71596a725aa3b826e82164bf3ebc0c3cec8ad";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/libldm/libldm-1.0-0t64_0.2.5-1.1+b2_amd64.deb";
+      sha256 = "2774116e8d441b3c29ad390b969e37b882a40d3d8c1628c4529aaf479155bb35";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/libldm/ldmtool_0.2.5-1.1+b2_amd64.deb";
+      sha256 = "3862aea5faa6b818fc1f0dc9e133a7aa57ace78a0ab962d27ef2c187b6a6d320";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/less/less_643-1_amd64.deb";
+      sha256 = "f9e16accd8a8915abb2a667c5414c6eb99480470ebcc7ff7bf73bdf2b5d34c59";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lsscsi/lsscsi_0.32-2_amd64.deb";
+      sha256 = "21cbbe49fa99acdcc910b9e1e9d526b4c1ebc05b9c3767ff67b44395266e540f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/libdevmapper-event1.02.1_1.02.201-1_amd64.deb";
+      sha256 = "53082d383ebb7fa4c8822d5ce5ca7c8e6abef7ff6c765a5d918fdf607e15a450";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libedit/libedit2_3.1-20250104-1_amd64.deb";
+      sha256 = "b002ea172b9c1e34a67bc497c523c67bb74c3f0a4e98113cb083990a1f1d3bfe";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/liblvm2cmd2.03_2.03.27-1_amd64.deb";
+      sha256 = "13b5e378a130ce5b8a25dc81a31f192fb4684dd7fee40bfaece5c0ff54525145";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/dmeventd_1.02.201-1_amd64.deb";
+      sha256 = "c20707b92c5cfd758ec99286ae6fd3131cc10fc2e1ffdd4b6705cb25432b9ef6";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/lvm2_2.03.27-1_amd64.deb";
+      sha256 = "6735528f862ea38f9c205fde37f8ece6b40bbb0ca3de865020cc308974cb2b12";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lzop/lzop_1.04-2_amd64.deb";
+      sha256 = "84c1650e9cbbe08da100606159d84babcb1da590d244cefb2f0aa66db1a24275";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libsystemd-shared_257.3-1_amd64.deb";
+      sha256 = "ee3052ef71a8e4a7fc2d138bf6197dfc23e97fcb2a3efd7cf2a78dd4d2a820a3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/systemd_257.3-1_amd64.deb";
+      sha256 = "0ec7eb4a5d463d1efab4484f2a9efd1f2c62409c46724116867b53443116830c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/udev_257.3-1_amd64.deb";
+      sha256 = "2de9e505475364486658b2bc05dc2ae38aecb238a9072e189eda18a827b67401";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mdadm/mdadm_4.4-5_amd64.deb";
+      sha256 = "7210ac80510ed5683a818c2a2631efabd3c6bb7b20205fbbb1d94c8aa953c8b0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mtools/mtools_4.0.48-1_amd64.deb";
+      sha256 = "e7069109ce49f5a450caeca681e454f24dc412f9fdb289cde54e115162203760";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ntfs-3g/libntfs-3g89t64_2022.10.3-5_amd64.deb";
+      sha256 = "e9d61d7b05b794280ff20c25bbd579f5213df44bf1e1a69c77eb9a27adb1a3fe";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse3/fuse3_3.14.0-10_amd64.deb";
+      sha256 = "922299d9bb8bd464275ff6a4afa30417174f154312c47f08ecb9c4629d028382";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ntfs-3g/ntfs-3g_2022.10.3-5_amd64.deb";
+      sha256 = "50d9a768a471da7b221765f8d0795457f1da5dcb984f729bfcc5f78eba33db23";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcbor/libcbor0.10_0.10.2-2_amd64.deb";
+      sha256 = "2457686e375dcb7567ba01da6638a0711e2a55725d084d65de44dd11bb1f52e2";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libfido2/libfido2-1_1.15.0-1+b1_amd64.deb";
+      sha256 = "094fc0fe20c652be848ab2a8b3793eb03bc4327140ebd232145356352004e6c0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssh/openssh-client_9.9p2-1_amd64.deb";
+      sha256 = "e010d4b64889bb54f601dd297997a816b5e807268e5d1e09a8474e839d918733";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dmidecode/dmidecode_3.6-2_amd64.deb";
+      sha256 = "6ad5a5483752ea05e425e77adc9ccf58ce9da22cca28d8932ea316d641f199d3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/parted/libparted2t64_3.6-5_amd64.deb";
+      sha256 = "65bc42f046f51f01152da1c6b48f7b65d2e84bc0b04c0da29c33bded87217a36";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/parted/parted_3.6-5_amd64.deb";
+      sha256 = "fbb8429783a8dd065bf9c37e249acaa56cb7bb8a3ff5bb531ef0aac3e8945f2d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pci.ids/pci.ids_0.0~2025.02.12-1_all.deb";
+      sha256 = "483aad3ad6cb3d0003499139107b24254d0deebfbb7e690dabf44e8a1d80627e";
+      name = "pci.ids_0.02025.02.12-1_all.deb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pciutils/libpci3_3.13.0-2_amd64.deb";
+      sha256 = "f8f01883368fe86417b3845aa08ea3508ca59f5e1bb0983673629e227f5ac868";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pciutils/pciutils_3.13.0-2_amd64.deb";
+      sha256 = "bd0e35ccc3378825b7b5f967e1eae687850025a91a49b055e433f1522bfa80f6";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/procps/libproc2-0_4.0.4-7_amd64.deb";
+      sha256 = "1c19babbc9cf029e8a1faf259a9f0d7b69b16a940f31e43cd6c175b6eb167e2e";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/init-system-helpers/init-system-helpers_1.68_all.deb";
+      sha256 = "119713cf7ab3535ac141eea4a11d76ceb117b3326f237c87dc2d4ab9ecbd5620";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/procps/procps_4.0.4-7_amd64.deb";
+      sha256 = "730a3f345977c90756fed89e39bff832316da7d637f40ba2e42516c480279f20";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/psmisc/psmisc_23.7-2_amd64.deb";
+      sha256 = "19e772bca5ad0b28620229fe4f91383044c5c6322c7c50ae46da1c60d73d9960";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/scrub/scrub_2.6.1+git20240819.9b4267e-1_amd64.deb";
+      sha256 = "95de3e58c844027cec4b8c05c1b0ea6ee99b9ece094cdae99300d3774b2b92c3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libd/libdate-manip-perl/libdate-manip-perl_6.96-1_all.deb";
+      sha256 = "be8f09cbd685a30db35f0c63407df6d45e4b600108e283a5b4bfa25cc4af49f9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbfio/libbfio1_20170123-6+b2_amd64.deb";
+      sha256 = "c64c853f42df88409c54d08b8b43d631fbb25264eee17dc92042538ca73b0715";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sleuthkit/sleuthkit_4.12.1+dfsg-3_amd64.deb";
+      sha256 = "47df7313141f5dd244ed8777cbf9985925c6b161e38293868deb60ca0f324423";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/squashfs-tools/squashfs-tools_4.6.1-1_amd64.deb";
+      sha256 = "0e185122f5858132bbc709e26228ba28cf7f0c41f6ed26e3f55f518f2a53b59d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/syslinux/syslinux_6.04~git20190206.bf6db5b4+dfsg1-3+b1_amd64.deb";
+      sha256 = "07a34a8b09e19ef44285d45c24aefd1119cf3c1580223cbca0dc58f8dd33ee33";
+      name = "syslinux_6.04git20190206.bf6db5b4+dfsg1-3+b1_amd64.deb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/systemd-sysv_257.3-1_amd64.deb";
+      sha256 = "3210e945a631381edefb61dc5ba29b3d900cbb0b5fbea9ab4f295b9c68cc3134";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/util-linux-extra_2.40.4-5_amd64.deb";
+      sha256 = "a731cd11bb4c12357d244732be0450c98aa0441566773aa2c66f082833752647";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/uuid-runtime_2.40.4-5_amd64.deb";
+      sha256 = "227f1d81091e8f2e6bc35972d42d47c4b5902fcdda50ba2ad239274f0afaa6c0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/z/zerofree/zerofree_1.1.1-1+b1_amd64.deb";
+      sha256 = "68775644c1351319a236528299e8ea5fa20984139fa769c977b0b6716d687943";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libz/libzstd/zstd_1.5.6+dfsg-2_amd64.deb";
+      sha256 = "57bba0e724ee6e9849d2ca53f5252b4f0d4a3fb7162b41e7783303efa548b0b3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs0t64_1.54.1-1+b1_amd64.deb";
+      sha256 = "cc3d055f7a6ffe4be9fe04300758ae26683615a2b9c684f4d22902db40c1adea";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/duktape/libduktape207_2.7.0-2+b2_amd64.deb";
+      sha256 = "2d92606f49cf79e23fb4ea67ab7702d52e016a671d32edc51482c4f1e3bade7c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb";
+      sha256 = "794a8526989464cb17f1dec9dab921f0e5afb82bcc665e938fac925be47698eb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking-common_2.80.1-1_all.deb";
+      sha256 = "aa697ddbd07ba9e16391bd81f73661b2583859c8671d1ce92f28e6a870d37059";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking-services_2.80.1-1_amd64.deb";
+      sha256 = "545f6d24809a79f3b527ec37c30dee0b2c3b18c1466e7983d8e7b0a2cc3a4431";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/libdbus-1-3_1.16.2-1_amd64.deb";
+      sha256 = "82d86bf84d14d2707fabfb07cc0e4140e7f07cf59471a7cc17545db77f04fcd1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-bin_1.16.2-1_amd64.deb";
+      sha256 = "b295c0ff60db1ab0698b617530bcc70147dcbdb6fa72bf7ce23b7b85b347c1e1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-session-bus-common_1.16.2-1_all.deb";
+      sha256 = "3e02d0c4c3bdfc77972aa404a51f04f76b7a2353641c395091793bea4d7d46d9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-daemon_1.16.2-1_amd64.deb";
+      sha256 = "d29227c2021778182eccf423624af1aa8888847ac9ab9aafc1e1ea4f7ac4eb2c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-system-bus-common_1.16.2-1_all.deb";
+      sha256 = "e28a4a0e057fe4da53b60898f52670214a56f9b820d1431c55721a5f56656b97";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus_1.16.2-1_amd64.deb";
+      sha256 = "49bbb4a13667b53fd180b4f596774b4d52fc2b0ea28f30c2fb6c8c8ab58d85ae";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libpam-systemd_257.3-1_amd64.deb";
+      sha256 = "b0fadeb1050028676def4a20669d56d783d057c109122661db66038497ed0a9b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-user-session_1.16.2-1_amd64.deb";
+      sha256 = "b804e07c8c0809f58722c7d8b03fcc561a495bdb40d57b6bd74e1757874d9d33";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/libdconf1_0.40.0-5_amd64.deb";
+      sha256 = "6e7f670e1cf493ae8f60dea52f5a4aef56605d5b06d921113d7c2a2800ff5af1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/dconf-service_0.40.0-5_amd64.deb";
+      sha256 = "4a1feeda4605be8561ec32fb4d0655fbe2313e62e457107168f528d959b530b8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/dconf-gsettings-backend_0.40.0-5_amd64.deb";
+      sha256 = "393e8deffcc78d4396e860f10cb5e7d0aab448d6e0965add62941fcd27be00fb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_48~beta-1_all.deb";
+      sha256 = "e58a08f7841150134ae76f14c3dfab03520069dc56d3fe8a27c1a8de11189b64";
+      name = "gsettings-desktop-schemas_48beta-1_all.deb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking_2.80.1-1_amd64.deb";
+      sha256 = "183829044aa67f7e8c41a407dcee71d446da0ed3c87113689603a27007099137";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsoup3/libsoup-3.0-common_3.6.4-2_all.deb";
+      sha256 = "eac04de1dcaee4899dd93dde51beac8f14b26fcac2e382a247130e92d2e9fff1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsoup3/libsoup-3.0-0_3.6.4-2_amd64.deb";
+      sha256 = "5bf081b9ef44a51aab23e253f4542f2e330439d8f3cc1c6aea16f410d57a1893";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxslt/libxslt1.1_1.1.35-1.1+b1_amd64.deb";
+      sha256 = "1e5a8045452db38ab50d86c6acd047004aee704e38937a8474251d58b81c8669";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb";
+      sha256 = "07d11308eb6021b984ae6e15afd0c1b4e6ded6463d05e3930db6d252c2e3287f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libo/libosinfo/libosinfo-l10n_1.12.0-2_all.deb";
+      sha256 = "3d8c424973c15f69c7c52916e6e27ebd522decdf004abd7ff88ff2380ca21808";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libo/libosinfo/libosinfo-1.0-0_1.12.0-2_amd64.deb";
+      sha256 = "cd3a482babcabba0817c66d7f004d6379d5072ce14efe827572678e410025ae5";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml-parser-perl/libxml-parser-perl_2.47-1+b3_amd64.deb";
+      sha256 = "030a808e359a851c6c712044158c261d44f52c3d3bdeefaedaef96f9da0dd94d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml-xpath-perl/libxml-xpath-perl_1.48-1_all.deb";
+      sha256 = "af896c45e1dae5c0a4b9dec19404f41b688fac0e444f8744522fa3d04ccd9b9a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/h/hivex/libwin-hivex-perl_1.3.24-1+b9_amd64.deb";
+      sha256 = "66ce82efa04011c71460f204353e29d946112e49d936e1f32f4e8db0e96d01c4";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsys-virt-perl/libsys-virt-perl_11.0.0-1_amd64.deb";
+      sha256 = "1ca45ee9c72f04e2b651b496c4abf99cf25beba2b38c32db7790377ebc0d122d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs-perl_1.54.1-1+b1_amd64.deb";
+      sha256 = "2e6c3669b995eccf7b471167bb311635681ea96a8be002b1758f85f0aebad894";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libintl-perl/libintl-perl_1.35-1_all.deb";
+      sha256 = "056ebe90f7ca7046f7f64e5eea8ed57d2da19a9531646bcf1f7856a5da07fb27";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libstring-shellquote-perl/libstring-shellquote-perl_1.04-3_all.deb";
+      sha256 = "5860ee3928d3031a5a43ecfd8b3c093c58885cafb865473a612b9571d48e6d6a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/guestfs-tools/guestfs-tools_1.52.2-4_amd64.deb";
+      sha256 = "4897c4137f0070adbb84fd0f9e726e36ff2204af9b886f1a032316cba16057ec";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libconfig/libconfig11_1.7.3-2_amd64.deb";
+      sha256 = "0609351b0069ef47f9ade42625a760f8889aeb55bd7107339f61a4abf9a4068e";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/guestmount_1.54.1-1+b1_amd64.deb";
+      sha256 = "3d559b24e38deb89de800fea6c3a9246d5a79706fc64243c7a67a26de1729410";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/guestfish_1.54.1-1+b1_amd64.deb";
+      sha256 = "5f15f7ba3526a3d74fd21e0967c04cb61ce65f68ace6ac3cd0f3a52e3dc63d78";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs-tools_1.54.1-1+b1_amd64.deb";
+      sha256 = "947d26d11215f87a0798005894f692c91b1e8e8bc3a2b97e58dc3c0542e33945";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-base/linux-base_4.11_all.deb";
+      sha256 = "b74452838f8460f2c8812430208eeb40788eb782e0c87cf8bb91f3367625bcce";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dracut/dracut-install_106-5_amd64.deb";
+      sha256 = "a7fff057e89a64acf829977f484aef7276ea7b3443d7b2c141991ff5aae3c096";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/klibc/libklibc_2.0.13-4_amd64.deb";
+      sha256 = "39733ce0d80c5042ce3569a3d0594f585f0a60889e4e9eb2cccc486182c18b74";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/klibc/klibc-utils_2.0.13-4_amd64.deb";
+      sha256 = "d087c9c1ff0115c103203c1d04b2ef609c70dfe9fbc6441569b7133c4ff0fdd0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/initramfs-tools/initramfs-tools-core_0.145_all.deb";
+      sha256 = "19f6789f200a9b1ccae87c54a0c74f3a53faedee5030030c9d5e434b40998eac";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/initramfs-tools/initramfs-tools_0.145_all.deb";
+      sha256 = "d63e61ea1119a9a539021ec4e2f63bdfc5b6446104e8de7e5d92528dae08920b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-signed-amd64/linux-image-6.12.12-amd64_6.12.12-1_amd64.deb";
+      sha256 = "00822f6af7202dbb7b45c02e36db3dbd23bd98f0f97e72483749fb595dae220e";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-signed-amd64/linux-image-amd64_6.12.12-1_amd64.deb";
+      sha256 = "da0ae1dba152e6cb9082f066a51a3df768d82b31d146b8dda224ed467012a633";
+    })
+  ]
+]

--- a/pkgs/by-name/li/libguestfs-appliance-debian/deb-closure-arm64.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-debian/deb-closure-arm64.nix
@@ -1,0 +1,1855 @@
+# This is a generated file.  Do not modify!
+# Following are the Debian packages constituting the closure of: base-passwd dpkg libc6-dev perl bash dash gzip bzip2 tar grep mawk sed findutils g++ make curl patch locales coreutils util-linux file dpkg-dev pkg-config login passwd sysvinit diff libguestfs-tools linux-image-arm64 qemu-utils
+
+{ fetchurl }:
+
+[
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-17_arm64.deb";
+      sha256 = "e0edb75399c798b8bafa6843a7448b36be2b17bc7035db1c0044a8b0a3b05029";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-17_arm64.deb";
+      sha256 = "e08c185dc7415d4d45090982fad5bb58577d4db7ef685d332fc03f9b1a986773";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc6_2.40-7_arm64.deb";
+      sha256 = "339dc8a20e37e527448c76ea119d7fd921e0908851ca80322d30a1d7a2127390";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cdebconf/libdebconfclient0_0.277_arm64.deb";
+      sha256 = "a1f119c4d0ad50946e7da7e35c1f03c3002db1dbb04982ca263de53ba96a9e49";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pcre2/libpcre2-8-0_10.45-1_arm64.deb";
+      sha256 = "1427e605a281d966c55934363362f3aa2ce458ed38a65db3b908b7d1122aa479";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libselinux/libselinux1_3.8-4_arm64.deb";
+      sha256 = "9eca3e6d53307052ccb8a28b3a5848c596ce29a56c9d0e4d70cae2493104c821";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/base-passwd/base-passwd_3.6.6_arm64.deb";
+      sha256 = "f43fcbf04bf117e50e13e387bd65d72abc6c6c0c93e8d2a7544b41da6e2e9b27";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/acl/libacl1_2.3.2-2+b1_arm64.deb";
+      sha256 = "10b2399169e42e6d8db55944116cb2ed61caab997cf700acb83de0b0668e5721";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/t/tar/tar_1.35+dfsg-3.1_arm64.deb";
+      sha256 = "c460a8294202ca3802b7c703b0bd70dd8bda1f2fc8785839595cf9d5e060d71b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-6_arm64.deb";
+      sha256 = "3537fe4fc577a60c8a9568873cd577db7ebc135eb8bb1825f18caf8972d9d2f2";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xz-utils/liblzma5_5.6.4-1_arm64.deb";
+      sha256 = "e096978fbafa216f4972a4a1ec3867d2735d8f9fca99d84406acd426eeac5043";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libm/libmd/libmd0_1.1.0-2+b1_arm64.deb";
+      sha256 = "772e86842fd3fa1816a0cfee4833a73996aaa550461491543b886b9c8f999052";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-2_arm64.deb";
+      sha256 = "dcb29cb750248f27c8249b8efdceb8fd3827e1b52302d417f5f9bca2ebfcc195";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb";
+      sha256 = "209aa5cf671e97b9eb0410844fa6df4cae2e75b0c72e7802ab6c8ece13e6ddef";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/dpkg_1.22.15_arm64.deb";
+      sha256 = "01b6de79276db932966590175f0bf36a63e026d6bb51f7556e11ad0ccb48e0d7";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-dev-bin_2.40-7_arm64.deb";
+      sha256 = "cd61a4f194acccace51b4caa9145524e665311ab6c0202d2aabec4f696a73c6a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux/linux-libc-dev_6.12.12-1_all.deb";
+      sha256 = "4df2b95ca251c87d736a485c6d27ae1a73c7a4888ae7f7abc9d587b4daf3e485";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb";
+      sha256 = "b9aaa808aa3812b3de3e54eb5dfb16762c1779db032604abef2354c02fdc29b8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_arm64.deb";
+      sha256 = "eec6d4658495cdb8ce505cad91e0918edb8086677f280f3851c07ccd70543054";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1+b1_arm64.deb";
+      sha256 = "6ae3c216e6c7d8e042ad3f122b8aa89aff56b2b5174b1c5780a7841b3becd61c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc6-dev_2.40-7_arm64.deb";
+      sha256 = "9bef03a0c5df75496368af85edda51e3129f363030fc01b8c38418002dad8319";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl-base_5.40.1-2_arm64.deb";
+      sha256 = "4311b71d07b3ca713d70fa4f5ef7902bc33b7659b09b7425d040c93ffb6e8094";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl-modules-5.40_5.40.1-2_all.deb";
+      sha256 = "9cf0ce4ae1fed57dab7d4e7bb2e3e728d634dc50b2924a1b1274ba2b8ce4f893";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-9_arm64.deb";
+      sha256 = "bfef56508d69fd3f940668f6abd0a466a362cabf63c4cc1c787cc58d28f6e92f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdbm/libgdbm6t64_1.24-2_arm64.deb";
+      sha256 = "329efe726e24a413b9933e298ce24d255973ec111eea0ca721157968fd24156a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_arm64.deb";
+      sha256 = "266b9a9e8d1ecc4393ebd29bec7e7c0fe1505b1d8755033af9e15df161316627";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/libperl5.40_5.40.1-2_arm64.deb";
+      sha256 = "acc72d4415abc02bf3ceb68dee1f967d837976e8158eebe4827f47ee40957c27";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl/perl_5.40.1-2_arm64.deb";
+      sha256 = "3ada04a565f1e5fecd04ea6c8e7bacba9c13aa7042388288674843d0092687c8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/original-awk/original-awk_2025-01-16-1_arm64.deb";
+      sha256 = "6dac386d90a2c91d026e11011ee0344a7da9132a72512e000ab3e676e8e8361a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/base-files/base-files_13.6_arm64.deb";
+      sha256 = "3c8054ecd64258f6affbe06ba60b648a90b67303f7208fc4225aa618e137d3ce";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debianutils/debianutils_5.21_arm64.deb";
+      sha256 = "7a607fcc1702b4264dcdb8682fb9aaf6cf47af0743b13fd161488cfb195d55e1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ncurses/libtinfo6_6.5+20250216-1_arm64.deb";
+      sha256 = "0b8e0ab244962d28a06fa406e657fd3cb19c2fd43ff99a6c801b6b66b0c65bdc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bash/bash_5.2.37-1.1_arm64.deb";
+      sha256 = "f290d2b7a860155fce899cb6fc2e2b2429125647577e5fb2d7d9a5e875a186b2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dash/dash_0.5.12-12_arm64.deb";
+      sha256 = "ce4c8688a1a3ea510186ba95aba74d4c49863094e47e1effc0b602839e840c04";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gzip/gzip_1.13-1_arm64.deb";
+      sha256 = "cd46c9482fd3b96d4ecf282b01185ef9341b0ffcd40816372141f73037ce2c36";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/bzip2/bzip2_1.0.8-6_arm64.deb";
+      sha256 = "9fa8514c3fb3f363e7fa8bc85f699aaf15e747afaf220c57b978e9b74fd568bc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grep/grep_3.11-4+b1_arm64.deb";
+      sha256 = "6f7257fbec0197bd54b2347861ff01e2c4e8411790b0df20242483615324fe66";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mawk/mawk_1.3.4.20250131-1_arm64.deb";
+      sha256 = "0ab946ff4b8a34d93f81727957612f290c86cd0db39e849dc0ae5e3f3a9563d6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sed/sed_4.9-2+b1_arm64.deb";
+      sha256 = "338be72b4203acd9ee69d10377b800ae131db7b8ef44a4471ef1890d2c99e07c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/findutils/findutils_4.10.0-3_arm64.deb";
+      sha256 = "c8b505ce907c293031095b3a237cb231967963b1d5aa8b1699aff45ccec3158a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-3_arm64.deb";
+      sha256 = "a27bbc27f119161ea9702c8dd66f54131cdf0d2ca73000f50ea91ef2fdfef0fb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/isl/libisl23_0.27-1_arm64.deb";
+      sha256 = "21c490db3fa5f0a517c55090a199334da6164589772ebd922dff1e569c78515d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mpfr4/libmpfr6_4.2.1-1+b2_arm64.deb";
+      sha256 = "69dac0d1f7e4e0b27b8682f7ddf2ca7ae6c83138d9b25c9d9216479d2143705b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mpclib3/libmpc3_1.3.1-1+b3_arm64.deb";
+      sha256 = "d4cfe026a624e51641c80ef2af77387185714f62f3b5c87035e62d9ed8d9eec1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/cpp-14-aarch64-linux-gnu_14.2.0-17_arm64.deb";
+      sha256 = "ccc64b5625662fbb0edfd57a3c3985eeab9112f98cc5437bfa1a2d3b99724698";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/cpp-14_14.2.0-17_arm64.deb";
+      sha256 = "d8b2e4ef41736c797d2ef906fae6b9c9dc8a5f6bb4ccf98614c8d9dca55e4d6b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/cpp-aarch64-linux-gnu_14.2.0-1_arm64.deb";
+      sha256 = "bd9c9f4536a0aea285c4735d2dfedff624f8457b8f1bb3d15ab924e029cd7aff";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/cpp_14.2.0-1_arm64.deb";
+      sha256 = "88b702b0fa5942a4ee52c27f1ccf6316b831357e86693b709d216ba43348172e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libstdc++6_14.2.0-17_arm64.deb";
+      sha256 = "10560f08b8390d8e9ede9ba008d5f97b44ee8e52df1865147c0476d4e331b472";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libcc1-0_14.2.0-17_arm64.deb";
+      sha256 = "542ccd38255ab8e55b6b180fd9303adc8cd4d9fa2fcf7419a9726146dbc3c2c5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils-common_2.44-2_arm64.deb";
+      sha256 = "debb3628dbd9bb658ebab1f45425a889db028be916b132f9b40dba3856b44676";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libsframe1_2.44-2_arm64.deb";
+      sha256 = "b31f658e11000c6a9af35c38024f356e6892c7657aa98cdbb1145e180a676ae2";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libbinutils_2.44-2_arm64.deb";
+      sha256 = "f248ea0b127db1ec6aaedc411148065f7fad90e273cc4fedd78abe4506469b9a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libctf-nobfd0_2.44-2_arm64.deb";
+      sha256 = "c665cb8388b0b7a34ef07896536b6697ffb6f53383b496cced4baa2ae3e009e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libctf0_2.44-2_arm64.deb";
+      sha256 = "5442cff2f4381a5769b41615f7b608336ad991e15cb54d53597dced3dd7030b8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/jansson/libjansson4_2.14-2+b3_arm64.deb";
+      sha256 = "7938472b1ddfa8b0c8f58d5f44406ae7a77a342dbb502a02f6bf292b4f853ab0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.44-2_arm64.deb";
+      sha256 = "60a59917489cc92046b818e464bb260938632b062b1ec6c79e1ee848295af8b1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgomp1_14.2.0-17_arm64.deb";
+      sha256 = "81b585763d2fe9cdb774fbe6db4f03b3bac4bee43a2f8d45b2c6b789abf0b2ce";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libitm1_14.2.0-17_arm64.deb";
+      sha256 = "3170b74396d3677b84e636f4eef3bdaf1d7f869f707173237aa09869a6af27c4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libatomic1_14.2.0-17_arm64.deb";
+      sha256 = "d3d0c055765e8dd56003904710e1b9c5e666a19e025e95e081738b8663f4dcc4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libasan8_14.2.0-17_arm64.deb";
+      sha256 = "e90cd476c6b2c814701718fe60585c16ec693c86a1139e030478fa7993e26585";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/liblsan0_14.2.0-17_arm64.deb";
+      sha256 = "819c5a6b61aab8bf689ecc2c6dfafa5ece76dd274d7ee19bbd0436cd7cbfd0cb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libtsan2_14.2.0-17_arm64.deb";
+      sha256 = "52686475bd26a629428645762cd45b572bdcc1edf121c156ab15ffd0d4b34c54";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libubsan1_14.2.0-17_arm64.deb";
+      sha256 = "f8ce7ed92471af6419f4406bbb0225b7e0a45f94f9e81cae6131b5c219a261a7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libhwasan0_14.2.0-17_arm64.deb";
+      sha256 = "ec2be3c30ab71cca4d8d0d49ef3f6e8516939313d073a5f589e025c98b6a0e64";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-17_arm64.deb";
+      sha256 = "35a9284197d500941b08a68f435b5cfac7975e486b702806e98b7698449eb77b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14-aarch64-linux-gnu_14.2.0-17_arm64.deb";
+      sha256 = "5b0f74afbc9dd943e84e5a88d13fc3684f4d6cff21980010de38b42e2d9ce202";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/libgprofng0_2.44-2_arm64.deb";
+      sha256 = "f45790b43a411cd9794247feebe4358cdc179fe19712f239e4d24f2dd3df847b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/binutils/binutils_2.44-2_arm64.deb";
+      sha256 = "ec4d9560351c61dbfd05569cc30247bd5b6805014f5752f05e31c6e86445119f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/gcc-14_14.2.0-17_arm64.deb";
+      sha256 = "19d60111d4cb72f0b7af52738ed78552c871dc24871adbb62559a57f2aebcc5d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/gcc-aarch64-linux-gnu_14.2.0-1_arm64.deb";
+      sha256 = "c8390408ed90cc96d4fead68e313ed5ce147f1654807c23235818d535d2d7d7e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/gcc_14.2.0-1_arm64.deb";
+      sha256 = "f543b52e29a6780a78c73cf08e551e8e524d623c1092c477cfd8beb5285a86f5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/libstdc++-14-dev_14.2.0-17_arm64.deb";
+      sha256 = "766510f2a9c4980fb1c7952230bc6d6e221344fd7a93dbc57b4969d96d38b1c4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/g++-14-aarch64-linux-gnu_14.2.0-17_arm64.deb";
+      sha256 = "f937e73dffc912335958b56349880f55bce6f3823f67ad72d7d5375b8b2c44ea";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-14/g++-14_14.2.0-17_arm64.deb";
+      sha256 = "91fae2a24ee96db428bfd77ab308a1c45b9de7205f2d3459c382b759e1aae759";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/g++-aarch64-linux-gnu_14.2.0-1_arm64.deb";
+      sha256 = "655d9a7cb70b0342f5f1bf4f2a7b0241df15d49ab9a2567445c785b7592122f9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gcc-defaults/g++_14.2.0-1_arm64.deb";
+      sha256 = "e4b8f8fae7c838c40b9db29251b152c9af03a4d4463388d69efdda66c4e97e79";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb";
+      sha256 = "e3c149f3c9699497d81ad637b0c8a794d833439d40fec7a6ca4b0d0dd71683fb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/brotli/libbrotli1_1.1.0-2+b7_arm64.deb";
+      sha256 = "10270398c4842e71c72b4081fa1761728b3225d6c8dce7c58d5baafe58a5e18f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nettle/libnettle8t64_3.10.1-1_arm64.deb";
+      sha256 = "16107ce5a7b522da021fa8aba42d42af9c5e90ddabfcda3710aff6ea95808ee0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nettle/libhogweed6t64_3.10.1-1_arm64.deb";
+      sha256 = "cb92d5a51c4fd6c7b7cbb62aaa60c7af830d0bea5b410fb1f47ee685e26944d1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/libunistring/libunistring5_1.3-1_arm64.deb";
+      sha256 = "63756a9d18cbe33212831cfbe92e9fcb2394138850e8e3627ef601675bc6b3d6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2+b1_arm64.deb";
+      sha256 = "b6ba47e886f6ca2c4b86626393d72f4e296a4573f8321694412f8ca8bc784488";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libffi/libffi8_3.4.7-1_arm64.deb";
+      sha256 = "928b165e952e3e6da226ce4db4a0169a017edb38405049e4c19f2ba02f5d1481";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/p11-kit/libp11-kit0_0.25.5-3_arm64.deb";
+      sha256 = "78bfc746e68a5217e845f488f69100ed89d10c8886fbd3ffce937acb6a7d88fb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtasn1-6/libtasn1-6_4.20.0-2_arm64.deb";
+      sha256 = "94fdbc4861998837a1e7fd9e40b1883c3647705566126e89c51304c1f9e3ec69";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gnutls28/libgnutls30t64_3.8.9-2_arm64.deb";
+      sha256 = "e6b2b2f56bae22b6d6b8d35cb7359122901f0bb232cbbe15f59e765a3d7a45f1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libkrb5support0_1.21.3-4_arm64.deb";
+      sha256 = "e7e63559701e4b8d5e2bafa5122d0687741d58e1974c7281273f28ff5986065b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libcom-err2_1.47.2-1_arm64.deb";
+      sha256 = "77f72a4aa97374667c5181a2f31216df822d2bc159adc57ee04a42ca402055cd";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libk5crypto3_1.21.3-4_arm64.deb";
+      sha256 = "c236c66d10f223cb6c137f207f426c0c0665dd5055df0151f5a181ef5bab5981";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/keyutils/libkeyutils1_1.6.3-4_arm64.deb";
+      sha256 = "147e7da822c5f313bc22dbd5484036491ea6f77ef8dd40d3f66af09873ae3729";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/openssl-provider-legacy_3.4.1-1_arm64.deb";
+      sha256 = "9e7e3d095c28d082658ba3bff15696b72fca119f3ec6dde0f9fbbe3475bc16e0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/libssl3t64_3.4.1-1_arm64.deb";
+      sha256 = "a34dbe7dc52eb0372f2079f3daafdfa53c4e2cf54583bcae0f229ef8970a697f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libkrb5-3_1.21.3-4_arm64.deb";
+      sha256 = "8a0a680d2912650d0f526a298a8ed9b4d3df04edfe2a8d923cd522da4e296f6c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/krb5/libgssapi-krb5-2_1.21.3-4_arm64.deb";
+      sha256 = "049a80866f055394812a863bf9ae19081e75a4dfe2144f80127b56c8d1ee5b4c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-9_arm64.deb";
+      sha256 = "ed6eb05f8ded71ab16a0369845805b373fc8a71c0e7d33f73fa2fb11e83a1977";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-9_arm64.deb";
+      sha256 = "6431628c62524c8397255c1c4a7c7ef63661b801f3be9a59ad41e7a2e46e6210";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openldap/libldap2_2.6.9+dfsg-1_arm64.deb";
+      sha256 = "caf800e8eb36c32a1fe2e774a4ab5dd4c44d3766b64fc59f3e1cbcc5d57bbdc7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nghttp2/libnghttp2-14_1.64.0-1_arm64.deb";
+      sha256 = "fede311b0cbdf4c674f81e52b17f7eb5b9ff2ecda365de175882febd80535b8f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nghttp3/libnghttp3-9_1.6.0-2_arm64.deb";
+      sha256 = "14861f00c2987418c39547c6e522f1847a4a041f39c6e9618ebed9a34a96bf9a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ngtcp2/libngtcp2-16_1.9.1-1_arm64.deb";
+      sha256 = "60651a257c852a59f3b86086b02fae07d888a52579e5033ed4fa0f9a82d4cef0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.9.1-1_arm64.deb";
+      sha256 = "6a3edfb474e8a35b55e04aeff712c0db9b2b4b74bc556cb5fd970fb6022e51e7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1+b1_arm64.deb";
+      sha256 = "7ea03d8a7d16edce7b1b1e94980c058c0f1fb3c595eb9154b0e8590d0e7f75af";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b5_arm64.deb";
+      sha256 = "20d52d20c4834158e956ae8e1d42a61d22330062052116d5422daa2d3b1d433b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libssh2/libssh2-1t64_1.11.1-1_arm64.deb";
+      sha256 = "c4eefd2ef53766d4cebbdae42cba1cc46e4e4f1b818b45877c832633f3235062";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/libcurl3t64-gnutls_8.12.1-3_arm64.deb";
+      sha256 = "f6f0520e49ab99df102ad53501e354522a1ade31f0cefcac7589e3a026efa4f0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/curl_8.12.1-3_arm64.deb";
+      sha256 = "d2a7dab6463759f982a3b495d44809256759d385faab0c1bb391f8caf494d8b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/patch/patch_2.7.6-7+b1_arm64.deb";
+      sha256 = "7d53a81cbd4d1862bd7ccac7c8d65dcd46a4b3d8b2d528619846f6245e652749";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-bin_2.40-7_arm64.deb";
+      sha256 = "04bf5b013aa72406a318751d6c00d99836f56edf936b29f57d7e36b1c6fe0e01";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/libc-l10n_2.40-7_all.deb";
+      sha256 = "fd0f6e1d75c5c2f71bdbc94fc73382f3cdd673addaf885476a0757b95a13b0c9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debconf/debconf_1.5.89_all.deb";
+      sha256 = "3b7529580fae9a804999861ceb802c17a65cb734de2558e8423f9a449ac22e2c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glibc/locales_2.40-7_all.deb";
+      sha256 = "753f1fbc436fa2d03aec87f76a8ebbd3ac55ee94de892c9b6f0b191b44aeb541";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/attr/libattr1_2.5.2-3_arm64.deb";
+      sha256 = "25057d7bfba969a76cdf18ae88ce7ff6e664520726ddf02cdde97c03d5e9a43c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/coreutils/coreutils_9.5-1+b1_arm64.deb";
+      sha256 = "b7fcf35a87b68577f2902e527d93a1b17e21a6f0dcc16f12e6adba73f0d1fc77";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/audit/libaudit-common_4.0.2-2_all.deb";
+      sha256 = "b6edcd7aa36a2a5a1abd2c52966d69a99eebdb69c8f5cb33cbf415b0875775e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap-ng/libcap-ng0_0.8.5-4+b1_arm64.deb";
+      sha256 = "eb6da83296e4710a8600c1426692ed9b9eadcab7ebd36dbabc2a562b5c1ab691";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/audit/libaudit1_4.0.2-2+b2_arm64.deb";
+      sha256 = "a1124818a702c584ee139948c20596f6bb464d8110a14bc2dc748646ae461cab";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam0g_1.7.0-3_arm64.deb";
+      sha256 = "0a6cb41c7c6e6357df28716d8160239d44524e3893b4407cb6ca4060f648de6d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap2/libcap2_2.66-5+b1_arm64.deb";
+      sha256 = "71c4343142a26e7fffd49a9fe8f405f3ac60679f431789bb321ba0239b7b1db6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libsystemd0_257.3-1_arm64.deb";
+      sha256 = "20e3df16a006d55d88d2620459275040759d6d9545699a3d51ac8071f1e63568";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-modules-bin_1.7.0-3_arm64.deb";
+      sha256 = "37595f59046790bba47e007c78876efe3366404c80b6a61aec03fe924d1f5d64";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-modules_1.7.0-3_arm64.deb";
+      sha256 = "1f6c3366f3b8a31d708e258275d75367ac65b6747e13533920ada7e2eed53415";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pam/libpam-runtime_1.7.0-3_all.deb";
+      sha256 = "0f19f338c735e2ba51d9448e2dcba195d9698c5829dc864aec9b3b8913bb6f69";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libblkid1_2.40.4-5_arm64.deb";
+      sha256 = "5aa5cf3b396910a3fd1936ee45652ec7aac612601a88276f279ee210d7934257";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libmount1_2.40.4-5_arm64.deb";
+      sha256 = "cdfe4b68a14a5a6c615df8513c9eab4fa758c80b44b7ce93a7c7130c643fcc79";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libsmartcols1_2.40.4-5_arm64.deb";
+      sha256 = "54c3be481b631a83de81f694aeb01698339962aad8be2186c63e71919269cdee";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libudev1_257.3-1_arm64.deb";
+      sha256 = "946fad8705479e0c2b2aed450fb21dcd31b0d8ab48ef5a49b981325acd7a9326";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libuuid1_2.40.4-5_arm64.deb";
+      sha256 = "a96f7ce91c66ccd474871eea85bc401d92e2ace94c1a633bb54ebf96402c2463";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/util-linux_2.40.4-5_arm64.deb";
+      sha256 = "a65334a124058844b491241454cfa7df21dd397b21ef0f722fea2eff9f8ddfdd";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/libmagic-mgc_5.45-3+b1_arm64.deb";
+      sha256 = "3994076e338cb368881037fc5d4f0f98d7b5334393e5c2f510de9a400ff28ccf";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/libmagic1t64_5.45-3+b1_arm64.deb";
+      sha256 = "5627348e412c0e448a2aebbd2dd328b8a37f83e3106684a08977db93d53fc97a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/file/file_5.45-3+b1_arm64.deb";
+      sha256 = "7e786866e014a9b173d532863449024094ab925126c3dcb0369c1f5db6cdff77";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/libdpkg-perl_1.22.15_all.deb";
+      sha256 = "b77d5fdc901d9057cd558d1b9c34ba4d47a444193ebf7f85957e3dc18cbea9fe";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xz-utils/xz-utils_5.6.4-1_arm64.deb";
+      sha256 = "97ff5f2535b930e99aa3022e4805ee172ee052894750a50d99100814bfabb47a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dpkg/dpkg-dev_1.22.15_all.deb";
+      sha256 = "9ed603f1c79c284b9abc86a6f615f86d1a41ee6d1670ab7311d08df92dcd205e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb";
+      sha256 = "8a9477ed7af47d7ddefa1fe02bf9f87d6778e8cc59062064f1b076880a7a14a5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb";
+      sha256 = "bce0638102650b61224901da320c2f867a91cfc133532a5fb526d2ce05465fe6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb";
+      sha256 = "aaf89947e9a5a6d980d14f43dfde8d0ad4e869b5cd33567321ca8baeb7ee7740";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb";
+      sha256 = "fef9662964fa4ff2ebbeefe076adffad79374f744274085c8ce931d5feb462a1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/shadow/login.defs_4.17.3-1_all.deb";
+      sha256 = "1eba8412effd0c0f2d290b0d00b0dfb73263d6424ae19f904240eb8937b5a76f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/login_4.16.0-2+really2.40.4-5_arm64.deb";
+      sha256 = "da033de1e36335668c37361fda5a5aeeda4cd32718b55c60306ddb1117de5aee";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbsd/libbsd0_0.12.2-2_arm64.deb";
+      sha256 = "6827c1b3ad8dcbf3478803f9150359433e3376a3bde01c4503888a22eb3924e3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsemanage/libsemanage-common_3.8-1_all.deb";
+      sha256 = "28fba03d5c00dd41a57964f265104cce2d820a1f28f2e83e5ac66e529655e602";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsepol/libsepol2_3.8-1_arm64.deb";
+      sha256 = "a730c88ba7b9b6888cf046dee83db90a26a62f0798e84fb4e06bda5849aba81b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsemanage/libsemanage2_3.8-1+b1_arm64.deb";
+      sha256 = "3798affa11a64a5d481257fd9518c133a5c4fe6bdbbc0d1dbf6d8242964fa95f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/shadow/passwd_4.17.3-1_arm64.deb";
+      sha256 = "71fe6235d8639665678a553385846b6b071ca9e32c8698f9dfba539b39b17f4d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysvinit-utils_3.14-3_arm64.deb";
+      sha256 = "aa5f53e812fe12bf7b49672886c22bfdc76e4d00d6480ba5afbb226a3c525498";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/insserv/insserv_1.26.0-1_arm64.deb";
+      sha256 = "8bbc013d4859104350f11c7ba1fa6fe43115545f4795c13035cb98f189bd86fe";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/startpar/startpar_0.66-1_arm64.deb";
+      sha256 = "b43d365340ec3079c92a1ef2d222f2bd5d6e34769808360d82eb26bd33a2c25e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysv-rc_3.14-3_all.deb";
+      sha256 = "4db19a15402a913ae0cbf5827116c27685ea377119d037a83056b71ae8cfbbb4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/initscripts_3.14-3_all.deb";
+      sha256 = "349a2c9108258b3beab3cc37eb7ec60a7053b0784531ad4078be794ed993f19d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/mount_2.40.4-5_arm64.deb";
+      sha256 = "3ace11d8e5307e6ba5274dd528960f64e9141be5344a991d011442d051116463";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sysvinit/sysvinit-core_3.14-3_arm64.deb";
+      sha256 = "db9e0271a74ab539f20f2232204aa07faeb1e60431db0aa1cd0975a3c56dc2c0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/diffutils/diffutils_3.10-2_arm64.deb";
+      sha256 = "566ee11b4ba0c8912f879067d73257358638439bd4bfc7518abb60d0f375dc00";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/icu/libicu72_72.1-6_arm64.deb";
+      sha256 = "27a3f4be8f93a5daac4ea4f39b51fa6f3dc9b90deb5ccd0a026efd610a3030ff";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml2/libxml2_2.12.7+dfsg+really2.9.14-0.2+b2_arm64.deb";
+      sha256 = "975650b62ddaea79fe4e7b92e63287105b07da8701580e222e32637612a46cd0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/augeas/augeas-lenses_1.14.1-1_all.deb";
+      sha256 = "489ab4b8d58fc93937294a54d4c0eb8776c253a9a53500997eca0d9a7f15fce7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/augeas/libaugeas0_1.14.1-1+b3_arm64.deb";
+      sha256 = "4f6347c9a925530f48a5eff719c1eb9dccccffe37c0b8142e282247bca229acc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse/libfuse2t64_2.9.9-9_arm64.deb";
+      sha256 = "c92aa3f45505aa5fbc4495e621e76edbfbfdd5ea33e90fd9c977b8b3b8df6543";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/h/hivex/libhivex0_1.3.24-1+b9_arm64.deb";
+      sha256 = "1937f7501612b8c989ba419c062a5da913e8db0412eb9536f77c63fd1dc4c1c5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lua5.3/liblua5.3-0_5.3.6-2+b4_arm64.deb";
+      sha256 = "42bb0ab1e6648650114ad28aa839600c6e242482826797e271dce685316365b4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/popt/libpopt0_1.19+dfsg-2_arm64.deb";
+      sha256 = "b58ba178effc24280c4c6be3cf2c93a34607e18ad76b2f74b2de818136699076";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libgpg-error/libgpg-error0_1.51-3_arm64.deb";
+      sha256 = "48fd5d6d74731bd4c278796d78eaadaeec4938614f90ac0c9444ed7622d78b0d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libgcrypt20/libgcrypt20_1.11.0-7_arm64.deb";
+      sha256 = "6bbe0489bdad5d02b66dbaecb08d9975636bbf95e894195915240bca6cd7bdba";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpm/librpmio10_4.20.1+dfsg-1_arm64.deb";
+      sha256 = "26fc320660187b23056fc2456e002cacc4955df4e1927927a63c5b8b7f0508ee";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb";
+      sha256 = "ae7effea7177d15156783d23421790dc585e2587add4d071b3b2812ce8d99232";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rpm/librpm10_4.20.1+dfsg-1_arm64.deb";
+      sha256 = "49cb4f6a940974579932777975dd5fea1b712cd7d744405735b27d2780dd5a4d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtirpc/libtirpc-common_1.3.4+ds-1.3_all.deb";
+      sha256 = "d31cc2c412789fdd234d6d84b148a5b355d64a2fa3fc21db397a7ccaa64fa7a7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtirpc/libtirpc3t64_1.3.4+ds-1.3+b1_arm64.deb";
+      sha256 = "f3de5e60eb87243789ca27262e08499162cec6d8b32d0c2a0628d59b7220737b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/curl/libcurl4t64_8.12.1-3_arm64.deb";
+      sha256 = "74e28eb71c21149821d8f43ac920fb8309d483c279234ef774149436d718ee80";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/expat/libexpat1_2.6.4-1_arm64.deb";
+      sha256 = "dbb8a8c020295f4c19fdccc6b0da2c87a4657be0ffa07ec422aee4fa4538ac61";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/afflib/libafflib0t64_3.7.20-2+b1_arm64.deb";
+      sha256 = "5504b6b111746b41b6b626fbef20a5db48af6c6048a2d72cdb55f60bd16a4369";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libewf/libewf2_20140816-1+b1_arm64.deb";
+      sha256 = "e9b6ee4a7c45bb69ca9c4f8231a2d465771e3af6c71dfe1db6c76d3956b31ea4";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvhdi/libvhdi1_20240509-2+b1_arm64.deb";
+      sha256 = "dc73240d3f2d929a9e96c9c493db3444199ad276fdfdd0927712c012814dcbd8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvmdk/libvmdk1_20240510-1+b1_arm64.deb";
+      sha256 = "09610ff49c672f52c0052af945421d6387c39148be048afa4e80655cbcb8d010";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sleuthkit/libtsk19t64_4.12.1+dfsg-3_arm64.deb";
+      sha256 = "a1f115b6cd55dc5e968052ee9b37688788e412c51ef1fec19b24ddf15c93c474";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvirt/libvirt-common_11.0.0-2_arm64.deb";
+      sha256 = "f9ce1308eb7df77c8e5c36ccef288e27e97dfc3ca34eb4fe90637e750682fe74";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apparmor/libapparmor1_3.1.7-4_arm64.deb";
+      sha256 = "0832e403a18d65a262d7a0716316e82be98b2dacc1fec1a1f89a69bfd6f15dce";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib2.0/libglib2.0-0t64_2.83.4-1_arm64.deb";
+      sha256 = "f52317d4901125a1f2bad9dbc04b0b9b3f8eaae5bb1db97a394497d811504c31";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-c/libjson-c5_0.18+ds-1_arm64.deb";
+      sha256 = "f631829107005b15c2ca5c48ac74bc2df437c7eb608756eb865b147985f7bb45";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnl3/libnl-3-200_3.7.0-0.3+b1_arm64.deb";
+      sha256 = "34e5b0b20a1c6056a79b7e19d9b8f8336c6166e67b19d6fc7ed99e4b4a6e9dad";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/numactl/libnuma1_2.0.18-1+b1_arm64.deb";
+      sha256 = "0fdb47ac21333472212a668485e1b030ae69fd4e743754f7b974a2ee09eabfa8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libssh/libssh-4_0.11.1-1_arm64.deb";
+      sha256 = "8371e0369ecc8a964796d2bc4b4a1b3e6c62c47977832d111c1ed54e765b884d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libv/libvirt/libvirt0_11.0.0-2_arm64.deb";
+      sha256 = "4e0c15a85e7763ea2a75b532c45949b848c535a30d1a8072a86c7559448ca76d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/y/yara/libyara10_4.5.2-1_arm64.deb";
+      sha256 = "7053ef0159f21c7f2ac024fbf19b2af1f8c510a8480c78d057828ec125830144";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libext2fs2t64_1.47.2-1_arm64.deb";
+      sha256 = "f6e370e9895b10791c29ad8950c256f7eb12d9d4decd59a1a22b81de65d7e3f3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rust-sequoia-sqv/sqv_1.2.1-6+b1_arm64.deb";
+      sha256 = "3f1de7c95bd4f16f1c4c35d3edc6655d41036d389375c72f28967abce9a57166";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/x/xxhash/libxxhash0_0.8.3-2_arm64.deb";
+      sha256 = "66665776740ced6c5ddcb48a89a92b056d0dcb13851e1ff573d2b99b766e5c6c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lz4/liblz4-1_1.10.0-3_arm64.deb";
+      sha256 = "bd6e1771d1a3716b30f259a0892476e9d22e270870697d6b09851e79a3a13746";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apt/libapt-pkg7.0_2.9.30_arm64.deb";
+      sha256 = "13251d609530ac1b8998cc2cca1c9ee3795ddc9278da82332a8044680012a4c5";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2023.4_all.deb";
+      sha256 = "6e93a87b9e50bd81518880ec07a62f95d7d8452f4aa703f5b0a3076439f1022c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-2+b1_arm64.deb";
+      sha256 = "2121c9be647bda75a7c0f25cbeefec9de5e4aaad1025915f0f96c07c906d8c4d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/apt/apt_2.9.30_arm64.deb";
+      sha256 = "35fe58dbb4869e02cc8a4b8b6a9cc5b818633bf3c811722c929b69141e2ab64d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cpio/cpio_2.15+dfsg-2_arm64.deb";
+      sha256 = "cbb9ecfc347a854e78d56b7ebeb1b58cdc4316de816132588c457a76ee823d96";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/logsave_1.47.2-1_arm64.deb";
+      sha256 = "dcc7ddb3ba63506b08e8d4c5f7608478ef4fb88c81721903ecf17b90d9cf0c3a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/libss2_1.47.2-1_arm64.deb";
+      sha256 = "164ed70a3cdb77d941b1f0575f7553df00dc278963e866514d9f38b241b86216";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/e2fsprogs/e2fsprogs_1.47.2-1_arm64.deb";
+      sha256 = "f697a0f239c64b9ea534d0538eb4e6a230124a0f7b6e6123afc0a9b923c86682";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/supermin/supermin_5.2.2-6_arm64.deb";
+      sha256 = "a2b0ad9c51b7fb361ef6f23461fec9f4287610f5af7997a98d66c64161b345c6";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/liba/libaio/libaio1t64_0.3.113-8+b1_arm64.deb";
+      sha256 = "733b961bd2b6f1b644f14681ee57ce353e2854e21e49e445e3ae250e585c7301";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/elfutils/libelf1t64_0.192-4_arm64.deb";
+      sha256 = "815b4265c7d6c89c5bbad456bdeed7af893da6912c9d16cf4c581001927c0e37";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbpf/libbpf1_1.5.0-2_arm64.deb";
+      sha256 = "3f9521835db6f8f9dea7659320a3f1398092db2c8955f9f1550b94bf98dca79e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/capstone/libcapstone5_5.0.5-1+b1_arm64.deb";
+      sha256 = "5f8f0731b815dd8589f8a3293640d58ab738bf103d783d8c56275af98ee2160a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/device-tree-compiler/libfdt1_1.7.2-2+b1_arm64.deb";
+      sha256 = "43b3435ff8d67a3cbd91f88bdeffcb147f7f5da61fba50cf004505f03025ae1e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse3/libfuse3-3_3.14.0-10_arm64.deb";
+      sha256 = "f24d97ec99594f56dacb500c84ab44071b9c0c7e53ba785f0750f27acd6caf1b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/adduser/adduser_3.137_all.deb";
+      sha256 = "40b77d8b5b482baee2d0c95bbb4a4b9bcf7271b79dec039ef45e541142edfc12";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnl3/libnl-route-3-200_3.7.0-0.3+b1_arm64.deb";
+      sha256 = "51597e3bf3559cb03c33dc675fd668be2961c61f987e8f2a353a20a8876b1316";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rdma-core/libibverbs1_55.0-1_arm64.deb";
+      sha256 = "bc0819ae1f0e7084155594fdab6b5b31a1b225ed869e7cb7c7160358d7a625d9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-3.1_arm64.deb";
+      sha256 = "10826a6910a0af0d8ae96e903e12f669bf87bd945bf1f2a342a85b5911d27c95";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pixman/libpixman-1-0_0.44.0-3_arm64.deb";
+      sha256 = "b502cd8b1ece222f42b44c42c33a300d84152c20089660167b9422ad2ebb6132";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/kmod/libkmod2_33+20240816-2_arm64.deb";
+      sha256 = "4e33a4ccd7a45ea9ab937b82a780cf857b4bcce61eeb1341f8a9857a13a24f04";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ndctl/libdaxctl1_77-2.2+b2_arm64.deb";
+      sha256 = "72989645d5ced8af6b7afa3f3441ed8d7813abadaa8d0b1e53195d9dd564b09b";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ndctl/libndctl6_77-2.2+b2_arm64.deb";
+      sha256 = "92ef010734bd16725e7f0377aebd6a22a59c695bfd6d1f033367803769e0113e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pmdk/libpmem1_1.13.1-1.1+b1_arm64.deb";
+      sha256 = "6fb4d7569f301d279211f0bc53cda7c21324aec7f2b7e4c8ed30928bbeb88384";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libpng1.6/libpng16-16t64_1.6.47-1_arm64.deb";
+      sha256 = "523ff56c2ee2e8945e400cb636f3f2b055a9d943949bd931765e8cc834c1d355";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/rdma-core/librdmacm1t64_55.0-1_arm64.deb";
+      sha256 = "58c73feef4c1d0af65abe1465090f070e7f37a8049a23a20a3c0cf15bbab8a13";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libslirp/libslirp0_4.8.0-1+b1_arm64.deb";
+      sha256 = "adc6ccaa69b8305269da98b293d3da28f69dfd664e9a1037b7326a47006d8bd7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/liburing/liburing2_2.9-1_arm64.deb";
+      sha256 = "523dfbe829acf3aeae6df81528426a75995944923fd6bd35f6ccd0332034c713";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libexecs/libexecs1_1.4-2+b2_arm64.deb";
+      sha256 = "749229c6aa58a6595db3352c4d3ac3bfbba6991e94a6196bec7d21624d33d88d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/v/vdeplug4/libvdeplug2t64_4.0.1-5.1+b1_arm64.deb";
+      sha256 = "6651077e2156305d3151d57756b6072086a8ee3dbce405b11063ea9f78cf8768";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/alsa-lib/libasound2-data_1.2.13-1_all.deb";
+      sha256 = "bac4c89919fcf9f2fad94049312d9368ad0852bffdda1c1be5f353a34916b35f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/alsa-lib/libasound2t64_1.2.13-1+b1_arm64.deb";
+      sha256 = "72d85facc6f8b0adccb2b2c1a01c3e160a89e32cb4ff9ea2b4edda19babf741e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/brltty/libbrlapi0.8_6.7-1+b2_arm64.deb";
+      sha256 = "50ebf6b786a2d0febab26cae86313c6473383aea7f77fe3fddd8b3a28da7a47d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nspr/libnspr4_4.36-1_arm64.deb";
+      sha256 = "b8cd0221e4c35a77ec6e3b89959ca96deb75919a3c55b6735ca0288a1b61bdbb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/nss/libnss3_3.108-1_arm64.deb";
+      sha256 = "c0a7bf34d82d46860757797aaaa5d2b9526fa775935cae0be97f2709d6ac90ab";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pcsc-lite/libpcsclite1_2.3.1-1_arm64.deb";
+      sha256 = "f9811f4a8b1cc3f11bbdd46c2b4b8e01fb1c3e37763488ee52842f91c3a41b73";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcacard/libcacard0_2.8.0-3+b2_arm64.deb";
+      sha256 = "54f87ddff1f4ea2dd0b9d14faf7283ce9af1ae02e3a7567af17842251c5266b8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ncurses/libncursesw6_6.5+20250216-1_arm64.deb";
+      sha256 = "d9b604e7641f3381cf3fe9ad19f8af5a90143372d5a5df6a783528d05af79f7c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.27-2_arm64.deb";
+      sha256 = "5864658ab21e3b9e8322bf35209be964434260e4c9a34c1fd4ad4b61f991d5b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/usbredir/libusbredirparser1t64_0.15.0-1_arm64.deb";
+      sha256 = "72a2674abb3dcf56519e93a8fa1e7f6907114ce772a7876ed67e5878dad12d7a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-common_9.2.1+ds-1_arm64.deb";
+      sha256 = "e57e9c84c14f8511c74540fd1636257851f445f8e1c09e47b4ade93d3e708076";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-data_9.2.1+ds-1_all.deb";
+      sha256 = "7e5a9506737386a4f3bb7d865253837d8945f6c35a4ed38014c3054aac80a847";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-system-arm_9.2.1+ds-1_arm64.deb";
+      sha256 = "e0e1ca21c2d0ed764bad40e2f9e31c53ffa7e43741dd1237d281125cb7cdc21d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/q/qemu/qemu-utils_9.2.1+ds-1_arm64.deb";
+      sha256 = "3ba1fda96256e65f3f98cd0763c66c9a54371342c47dc81ea3634dd3b2f51607";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db5.3/db5.3-util_5.3.28+dfsg2-9_arm64.deb";
+      sha256 = "dc9d8b9282e44ebc176fd322df641f3ab4eb9062af5ece161b5e110473a61a31";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/db-defaults/db-util_5.3.4_all.deb";
+      sha256 = "1c1bf1d3905c975b55339d3b268ec879658848aee568d5d1ec62635bc1bf23b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssl/openssl_3.4.1-1_arm64.deb";
+      sha256 = "6acc9a1f51b976a7c439d70f7780a314608e246f32447c5d9b2caf3859afa356";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/ca-certificates/ca-certificates_20241223_all.deb";
+      sha256 = "bb96f2467c71323e738349080520689e4697df88c7ee90a83e9bcff1d29f3f5d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libencode-locale-perl/libencode-locale-perl_1.05-3_all.deb";
+      sha256 = "071bff2a1d193ec1b0d71e1a1ba7e718909866874e600f19d99a6f8c5ae30bcd";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtimedate-perl/libtimedate-perl_2.3300-2_all.deb";
+      sha256 = "8e36723da883c2975d83199e7f4b5331e291881372fde944b0d56660965f38bb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-date-perl/libhttp-date-perl_6.06-1_all.deb";
+      sha256 = "b46bf28a321e344be21b3161969c613abeddc63b1ff627ee94487a0ee4b53eda";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libfile-listing-perl/libfile-listing-perl_6.16-1_all.deb";
+      sha256 = "171410be7be03a39e6ad531b19d3b95049d43dae9f19076fe250b3b7bcc30574";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-tagset-perl/libhtml-tagset-perl_3.24-1_all.deb";
+      sha256 = "5efdaf433e10ce127257176d8093e41eabc642839e71f1961bc17f2e4f6169b0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libencode-perl/libencode-perl_3.21-1+b2_arm64.deb";
+      sha256 = "e49158dfe936aa72b4ac199132e44d4f1277028bcf08cf6294e6c9f38f2b294c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libscalar-list-utils-perl/libscalar-list-utils-perl_1.63-1+b4_arm64.deb";
+      sha256 = "76177ee7a2a67b9d1c0c1c3f0df4b4996b6beb60d627c767b55a781819f48635";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libu/liburi-perl/liburi-perl_5.30-1_all.deb";
+      sha256 = "33957bd8218ddd3a86cc19fdf3bf7832b0640337a4be6cf23b2714b73d220220";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-parser-perl/libhtml-parser-perl_3.83-1+b2_arm64.deb";
+      sha256 = "0ce717bb16456ff28219ffc27faedacc38a0c521c2659bb0c39dd90dda1725a3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhtml-tree-perl/libhtml-tree-perl_5.07-3_all.deb";
+      sha256 = "00f857bb27388432df3e4d6510334a560c2de19feb4b31897cb5d83251bb54ac";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libclone-perl/libclone-perl_0.47-1+b1_arm64.deb";
+      sha256 = "48e3a080da34e615d64d495a8c9d0c745115a479d1f1120f2fb44b706d596e4d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcompress-raw-bzip2-perl/libcompress-raw-bzip2-perl_2.213-1+b1_arm64.deb";
+      sha256 = "3ef7c86048a15eb7af640b4580be6da1500a17ee3e827566eb947c3d48c61d24";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcompress-raw-zlib-perl/libcompress-raw-zlib-perl_2.213-1+b1_arm64.deb";
+      sha256 = "d723a20baa3ba32f052e73a50b5440f4e885d4d25bae52abc8e9e20336bb8b22";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-html-perl/libio-html-perl_1.004-3_all.deb";
+      sha256 = "66c87e3e92460b9dcf56257fd6a48cc7fd1283790acb365a111ecb9d74e9ea43";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/liblwp-mediatypes-perl/liblwp-mediatypes-perl_6.04-2_all.deb";
+      sha256 = "c3ae8bca625ab6e16d6257698de402090135b5eca511df2c8086b0c23eefbaff";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-message-perl/libhttp-message-perl_7.00-2_all.deb";
+      sha256 = "e55e830b16af9c2b5269000c4dd9b93fd24b304a0675aeb0ab83438c566d2ca7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-cookies-perl/libhttp-cookies-perl_6.11-1_all.deb";
+      sha256 = "f3a57264a6704bd22397c644b1b91ed6055bdb190bd4d5d995cdf92840d049ed";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libh/libhttp-negotiate-perl/libhttp-negotiate-perl_6.01-2_all.deb";
+      sha256 = "b2770aaf4d638283d9b4f713005702fbab42304be169cb4d6761e8537f724261";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/perl-openssl-defaults/perl-openssl-defaults_7+b2_arm64.deb";
+      sha256 = "1fa2d99f1f7d32147cd5935eb2700ac49b366c086fea21c963c73e6dc62d62b1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnet-ssleay-perl/libnet-ssleay-perl_1.94-3_arm64.deb";
+      sha256 = "50622582eec91dac26bf34e19a255b4e1bfaaf9cf44431fb437f3ade9bcbb7bc";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netbase/netbase_6.4_all.deb";
+      sha256 = "29b23c48c0fe6f878e56c5ddc9f65d1c05d729360f3690a593a8c795031cd867";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-socket-ssl-perl/libio-socket-ssl-perl_2.089-1_all.deb";
+      sha256 = "9fe58e2dd2847896e380f9fb26b5344d62cab21d8390598912e485ceedb30f00";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libio-socket-ip-perl/libio-socket-ip-perl_0.43-1_all.deb";
+      sha256 = "f9c5929f513c20b0500db78cc4a4a75d5d74d95a67bbfc10e1776363ab81b5f3";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libn/libnet-http-perl/libnet-http-perl_6.23-1_all.deb";
+      sha256 = "ef8220824939149b88ff230081e4bd686d1d92f0a233c4f80d1e14115ab1b510";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/liblwp-protocol-https-perl/liblwp-protocol-https-perl_6.14-1_all.deb";
+      sha256 = "9201070118916bfbf3111008cac59769fb240376bb04e981132805a915f57223";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libt/libtry-tiny-perl/libtry-tiny-perl_0.32-1_all.deb";
+      sha256 = "f160af736fa67df5a5f6ec222d28e6c188b5b87965bd649956a6bea8795c1d3a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwww-robotrules-perl/libwww-robotrules-perl_6.02-1_all.deb";
+      sha256 = "be69cda8c2a860e64c43396bf2ff1c7145259cb85753ded14e0434f15ed647a0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwww-perl/libwww-perl_6.78-1_all.deb";
+      sha256 = "ddcecf6d01b33f14faf6ebd511deb114fcb0c043bb4291e4b45c82cbe7b4ec88";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/icoutils/icoutils_0.32.3-6_arm64.deb";
+      sha256 = "51d975bc7c9407def9f5199d505cec40a10096a2490281cc12dd54d08115e221";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netpbm-free/libnetpbm11t64_11.09.02-2_arm64.deb";
+      sha256 = "0998cb82683f21db7581e1af22e2251d7697ae9546f5b9de3c5d2c25293e861c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libd/libdeflate/libdeflate0_1.23-1+b1_arm64.deb";
+      sha256 = "644c852d3ca33a221c833d32b9000dd8108ac6afd4e83c836542c59c2a629941";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/jbigkit/libjbig0_2.1-6.1+b2_arm64.deb";
+      sha256 = "dbecef09dbafd82ff6444aa1cb45053b6331985b20ab2590eff052d7d6b1bb18";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lerc/liblerc4_4.0.0+ds-5_arm64.deb";
+      sha256 = "db015dc1888371e490594f8aaaaa55356313478d744fa69e242e034e4c2a0019";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwebp/libsharpyuv0_1.5.0-0.1_arm64.deb";
+      sha256 = "5a37f40f806df4b67a2bdaa750add7a9ff29abd3119a8ceac773b886cbf3d9f9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libw/libwebp/libwebp7_1.5.0-0.1_arm64.deb";
+      sha256 = "d5ebdb920770ee135c4e319babb2bcef61e9f37283a37a8cb4e673769dd0d676";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_arm64.deb";
+      sha256 = "454975d025d0159adea62dd752a8ae4ae6dffecf1273ff14f009f7fb3cafec4e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxau/libxau6_1.0.11-1_arm64.deb";
+      sha256 = "ac1061728670f4626adaa1288953a0e6fb801c9cae72ee1c3231e63e2609d23a";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.5-1_arm64.deb";
+      sha256 = "e10bbb0802181992ecf091e9425171850eee16068729c109214ba4924f81fb52";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxcb/libxcb1_1.17.0-2+b1_arm64.deb";
+      sha256 = "d0178198e80ed4cacdececabe2c112ec88c7a9258cc11a55b8e267ab14a90d82";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libx11/libx11-data_1.8.10-2_all.deb";
+      sha256 = "fe7976c52351e7c403e6beb75a943111bbcd673a13540b85541ca71d1285dde0";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libx11/libx11-6_1.8.10-2_arm64.deb";
+      sha256 = "5c5fca8a2423d431151153712456ce3a41311da5456432beb35ea20a7ec67e1f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/netpbm-free/netpbm_11.09.02-2_arm64.deb";
+      sha256 = "76c25b02fe6942ceeddcbd2664d21870045be115285cb1ce19af68bbf1c20af8";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/osinfo-db/osinfo-db_0.20250124-1_all.deb";
+      sha256 = "0c3d3688f5308311adf7d9ab45663eb7cf30d96e49585fcc8cac3bb9d8057658";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/acl/acl_2.3.2-2+b1_arm64.deb";
+      sha256 = "099b5f8bfa3ffea30a10308a89a5467d3fa7d8d16b94df931f0299344c2a4291";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/a/attr/attr_2.5.2-3_arm64.deb";
+      sha256 = "0aa332f846145248135aa782cfeea722ff6a4b9386a08455b84dceecdb301ec1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/bsdextrautils_2.40.4-5_arm64.deb";
+      sha256 = "8ab302d8d1676b45d7c777a4ebe9830544a9c09b84003919e1baa9f69851495c";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lzo2/liblzo2-2_2.10-3+b1_arm64.deb";
+      sha256 = "ee0f990bef6693c8249d7a3de4b17f65d549beae84b6d1413421618ac6427914";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/reiserfsprogs/libreiserfscore0t64_3.6.27-9_arm64.deb";
+      sha256 = "d6b935a8b795ae0e4a3e0445b287ec0140e78f4180f360cff37e6cbed0878f8e";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/b/btrfs-progs/btrfs-progs_6.12-1+b1_arm64.deb";
+      sha256 = "d74f8cbf66917f9330d306bf83185d718d9814bf92a9e953bdb89fc40114c41f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/dmsetup_1.02.201-1_arm64.deb";
+      sha256 = "275a9e9d37d86d32513b2c5643066a137826b65b922c0a4b91e3abc4baffb84d";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_arm64.deb";
+      sha256 = "33b5e4b37419c9bc90e7871e116b22a37e6e95d62c253550a844dd2bbc196825";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1_arm64.deb";
+      sha256 = "5c89a3d284ff54eee4adc60dab622498e932d066ad6efcf87c3513d631f50f3f";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1_arm64.deb";
+      sha256 = "71bf8b15653e9351b3c4191ab053d07c19b80e89267415e68b8be9f3a682d2db";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dosfstools/dosfstools_4.2-1.1+b1_arm64.deb";
+      sha256 = "7c9dbc889c2f143caa91c69b4750dc1d2afc4da168da9b6e7ab896e441bac8eb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/exfatprogs/exfatprogs_1.2.7-3_arm64.deb";
+      sha256 = "d1777899b24ebc1b33bf02187ebf0f08cd4646b82aadd23bc199587229e14abe";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/f2fs-tools/f2fs-tools_1.16.0-1.1+b1_arm64.deb";
+      sha256 = "6c0b6c6b79d2c8d8ced7f2ba9a5eb813ba6108b7a3fd3213d0afb509944b07ec";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/libfdisk1_2.40.4-5_arm64.deb";
+      sha256 = "bd5e8f1607bd19ac079a8b8e2ef7df1f450ca005f3bf5de3fc7920e04def56f1";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/readline/readline-common_8.2-6_all.deb";
+      sha256 = "f77e8aa0bf0de618f11cb0b21658a4ed60f177d63b3cf26d7fc3706b6d0eaaa9";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/r/readline/libreadline8t64_8.2-6_arm64.deb";
+      sha256 = "f78ff432b2a627bc04f7eef0e6e2696501c9e06feca748a5b741d5e594429033";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/fdisk_2.40.4-5_arm64.deb";
+      sha256 = "856aaa0997424069f522027cc006851d163d31571c88458ae046963b7adcaeb7";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsigsegv/libsigsegv2_2.14-1+b2_arm64.deb";
+      sha256 = "4fd72af654e2a72c84093cc2a38c856fba9492ecd828721117867e99c2c9cd92";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gawk/gawk_5.2.1-2+b2_arm64.deb";
+      sha256 = "0c040f686b0dd34387c0aa69848dd9f29741043821a843b480c38a1cf5956142";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gdisk/gdisk_1.0.10-2+b1_arm64.deb";
+      sha256 = "b6b48390e63bff9d18b32be3270910fab83f8c14117d49ada13cba8a2a75c7e9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/efivar/libefivar1t64_38-3.1+b1_arm64.deb";
+      sha256 = "16f70b215c390790294ddf454e0c244bc8f64104b361d8ef5790a17f06c7bc16";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/e/efivar/libefiboot1t64_38-3.1+b1_arm64.deb";
+      sha256 = "a19f6a081314f9ddc246d1e8a0141ac866fd0b34bcbfbabb47349f10f3a1fa24";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/freetype/libfreetype6_2.13.3+dfsg-1_arm64.deb";
+      sha256 = "dcb545c78601b14049e85901f8f83ddb5d05b7792ae6188b21d0edf7dc449ac0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gettext/gettext-base_0.23.1-1_arm64.deb";
+      sha256 = "5dca3bd324a7eab3d6a33125ed4ca2f186e88f9b8eb233fa471a86731a24892f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grub2/grub-common_2.12-5_arm64.deb";
+      sha256 = "634c56700704064cdbf3465d720611e22b737c1c86e332c6acfd3f86d555c867";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/grub2/grub2-common_2.12-5_arm64.deb";
+      sha256 = "7e2da95b620d06d1b25fb25a42f0d8f6cdde4352f9b84264762e017f78d6ea20";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libm/libmnl/libmnl0_1.0.5-3_arm64.deb";
+      sha256 = "f21bb29056e9ede0031cc411ffa3b1272858fa4b950e1cd9e50756c5c2ece97f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/iptables/libxtables12_1.8.11-2_arm64.deb";
+      sha256 = "b200a559a4ae1b4ebcee4fb0fcaef6a16ef01abbe3da8887de15e800b1a6440d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcap2/libcap2-bin_2.66-5+b1_arm64.deb";
+      sha256 = "f0b41aaf2a4afe1a5845cac679224cf9ae6a3632ad9666e9ced4248b227304ee";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/iproute2/iproute2_6.13.0-1_arm64.deb";
+      sha256 = "459265e763fa0900c373b514fce07790ad03b4c7bd04c2b1c8d1d12051765776";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dhcpcd/dhcpcd-base_10.1.0-7_arm64.deb";
+      sha256 = "827487f65a40b167f9bf0adbb467f034e17b2e7b65636d3ac133115aacb3611d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/kmod/kmod_33+20240816-2_arm64.deb";
+      sha256 = "972b43517f34d660ef91bfe68e2d7bf09e713a29e53745a7c301ae1d2034668d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-glib/libjson-glib-1.0-common_1.10.6+ds-1_all.deb";
+      sha256 = "70cf0f4d8e71f0404c989df7502fb5d8832439354c1a3e809c86f1b0df6b5e9a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/j/json-glib/libjson-glib-1.0-0_1.10.6+ds-1_arm64.deb";
+      sha256 = "e87aeea6d81c35ad0089a03743bd33f548b949bb4115d6c5626be4be7cc6784c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/libldm/libldm-1.0-0t64_0.2.5-1.1+b2_arm64.deb";
+      sha256 = "337a0beb5aadaa46fa4e53a903871cf49f978dd1519cb258f098d0fe77af2b68";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libl/libldm/ldmtool_0.2.5-1.1+b2_arm64.deb";
+      sha256 = "f9730dd69845213cbc3eb171c84f75b98738553023398ea8633f11b09772eae6";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/less/less_643-1+b1_arm64.deb";
+      sha256 = "08be695e5e339005a3bd2cf02110f3d6829469c6c2bd3303583dfb67628f8f46";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lsscsi/lsscsi_0.32-2_arm64.deb";
+      sha256 = "ea4da5290d51465f3748f098cdb39772789a9aa3c6581df4fbf4dd42aa8c0436";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/libdevmapper-event1.02.1_1.02.201-1_arm64.deb";
+      sha256 = "858622d066d0a46d658c827ec60f4b481995c14fd6ce778b3332bc20e6d32e2d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libe/libedit/libedit2_3.1-20250104-1_arm64.deb";
+      sha256 = "496c31df89fac9cb7e98102fcc21daf887376dcd9914f6322c86dd5bd4360ff1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/liblvm2cmd2.03_2.03.27-1_arm64.deb";
+      sha256 = "b60607a4a6fb2034e2f0cacfd2c974d5ca92737f5d2db8dfebf43448bbbf14bb";
+    })
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/dmeventd_1.02.201-1_arm64.deb";
+      sha256 = "eb0c6898892ed86fdeac38ae680dd9a1a898c4ba39c8412dfdacfe26d29e0f4f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lvm2/lvm2_2.03.27-1_arm64.deb";
+      sha256 = "ee9f76f638f0ebd64f7797a40ae0517f959bc34db2692cd3ca663dc4132d501b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/lzop/lzop_1.04-2+b1_arm64.deb";
+      sha256 = "20a7171efc5600198bf33e510b3c48012a2b5af6cfda22e14bf634979c21a548";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libsystemd-shared_257.3-1_arm64.deb";
+      sha256 = "fcad5d3e9d6e13d6438368578d2c2d403476d9dd0714270ecd224e2fde8b4b19";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/systemd_257.3-1_arm64.deb";
+      sha256 = "59af85188381345e710de7b0cd815994d59c5f0f95de86e0d47df2e9659d992d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/udev_257.3-1_arm64.deb";
+      sha256 = "fb74c523e1c772e58878f853937fbeac015ccc251376cd54bf76c1ee813ef3f0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mdadm/mdadm_4.4-5_arm64.deb";
+      sha256 = "d856ddd1a4d3082ee7a3bdff9936c1a5359f2853a8590f17dcf571308c3c2b23";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/m/mtools/mtools_4.0.48-1_arm64.deb";
+      sha256 = "296cf0a6b06433520effc30542a695307f4abf0d377f94d8a22dc8bd1dd4785f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ntfs-3g/libntfs-3g89t64_2022.10.3-5_arm64.deb";
+      sha256 = "045db448e206c139a4738a4ae995a7f50d55e10ff34ec19a62701b6ac57e10fe";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/f/fuse3/fuse3_3.14.0-10_arm64.deb";
+      sha256 = "44c8d62edab776f227975a5db53a41cfb5c2abc6b0d270608e0359cf1c05febb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/n/ntfs-3g/ntfs-3g_2022.10.3-5_arm64.deb";
+      sha256 = "3e45bce3d720317d740a57a8192e51250b049a543645f4e317d2e946d93df67a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libcbor/libcbor0.10_0.10.2-2_arm64.deb";
+      sha256 = "5e129095192ff766884e5ed13260644e510d20ed6b4facc47809bf2cb630117d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libf/libfido2/libfido2-1_1.15.0-1+b1_arm64.deb";
+      sha256 = "510f81957f2905c57d3d8681c3ed9bf68a17bfb254d721a578c88edd8158477c";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/o/openssh/openssh-client_9.9p2-1_arm64.deb";
+      sha256 = "cfb7f244d1984b1d29c125274412177000690716388af898ff45c4f01193d41d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/parted/libparted2t64_3.6-5_arm64.deb";
+      sha256 = "cc441a27a61a0d7320cc991f147049b12444c6e290277f1a0a5a3fc5942ded63";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/parted/parted_3.6-5_arm64.deb";
+      sha256 = "62006921ec2a8b10ad3e52d0bbaf41b31f6806ea5d3ee15c8544b379c6e712ab";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pci.ids/pci.ids_0.0~2025.02.12-1_all.deb";
+      sha256 = "483aad3ad6cb3d0003499139107b24254d0deebfbb7e690dabf44e8a1d80627e";
+      name = "pci.ids_0.02025.02.12-1_all.deb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pciutils/libpci3_3.13.0-2_arm64.deb";
+      sha256 = "fde73536f93fcd930362531506f8431b2e959bfbdeb41e772100c1cfc1f83953";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/pciutils/pciutils_3.13.0-2_arm64.deb";
+      sha256 = "e60b3a48ce93ed5634713226b6ca623a7e7a77007ac0de0a38698c84f36e1867";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/procps/libproc2-0_4.0.4-7_arm64.deb";
+      sha256 = "dcf2f6288634548ad2d76220195410bbcca66f97922a548dfa69afdc9ee15aa4";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/init-system-helpers/init-system-helpers_1.68_all.deb";
+      sha256 = "119713cf7ab3535ac141eea4a11d76ceb117b3326f237c87dc2d4ab9ecbd5620";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/procps/procps_4.0.4-7_arm64.deb";
+      sha256 = "6f76018ece35808db1841cc3d004ec008386a89f5a1b40980e28d5a1991e8547";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/p/psmisc/psmisc_23.7-2_arm64.deb";
+      sha256 = "9ebae564434a8fb5f23b770b5810e9e9c887cde32c23498f340db353a629c993";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/scrub/scrub_2.6.1+git20240819.9b4267e-1_arm64.deb";
+      sha256 = "e0df9cdf3b98ad76a43bbbda51efeb6331d6d032ef47bde9f48dede089529ffa";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libd/libdate-manip-perl/libdate-manip-perl_6.96-1_all.deb";
+      sha256 = "be8f09cbd685a30db35f0c63407df6d45e4b600108e283a5b4bfa25cc4af49f9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libb/libbfio/libbfio1_20170123-6+b2_arm64.deb";
+      sha256 = "476005fd9b111e0fa36cdfa18bf6e7a7b383c43a3779f8c798e137911df6ba3b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/sleuthkit/sleuthkit_4.12.1+dfsg-3_arm64.deb";
+      sha256 = "2396c1365534d29c77b351cdab56da5544e21b43b70c678f392eb897d40d7cf2";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/squashfs-tools/squashfs-tools_4.6.1-1+b1_arm64.deb";
+      sha256 = "c074f409b735b80ca5dbbf415436aef49a162e2daf148de007ffceabf0332304";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/systemd-sysv_257.3-1_arm64.deb";
+      sha256 = "b4ee2cdca3fad9734470740efe15fc9a53b710c15f369c4e20d3b7910bc23c3f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/util-linux-extra_2.40.4-5_arm64.deb";
+      sha256 = "a4bce4aa7b4f28a81c9e692953f258115dd663c9f070c3dd6e7554639449a846";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/util-linux/uuid-runtime_2.40.4-5_arm64.deb";
+      sha256 = "48b74f778d54cd16ba2642bdbab1027234ad6278a9a56362bda5ba46c8e1b108";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/z/zerofree/zerofree_1.1.1-1+b2_arm64.deb";
+      sha256 = "1b96d1b2b3ff430dc0804634397d166fed6fdcd3e7af9bb8bb5cedc330492e12";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libz/libzstd/zstd_1.5.6+dfsg-2_arm64.deb";
+      sha256 = "e521ebd98c5308f36b55e14c0e7ac2fcc1a9794685f36d11c1d33bcdf5091a63";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs0t64_1.54.1-1+b1_arm64.deb";
+      sha256 = "7f9d6732fb55a9f4aaaf982799e79cdb6817d9e598ebf16a341e8bac93a6ccb0";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/duktape/libduktape207_2.7.0-2+b2_arm64.deb";
+      sha256 = "9dcf4d316a8ece7277d21bbdd26b75a5d7d829faf3c7cfd861e30ba89d385516";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb";
+      sha256 = "7758242ac0263b1fcefc01622160c6a965a25d7f284ee6a62a46a8784cfedd6e";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking-common_2.80.1-1_all.deb";
+      sha256 = "aa697ddbd07ba9e16391bd81f73661b2583859c8671d1ce92f28e6a870d37059";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking-services_2.80.1-1_arm64.deb";
+      sha256 = "231f911c07eb9cb4a68b6709e0963aaeddeda523f21d24f10a593d4c2963f982";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/libdbus-1-3_1.16.2-1_arm64.deb";
+      sha256 = "8470c9358b31151d9cbbc94e8f76d6e1b4553c2bde34fd72a148edb8df5ce7b8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-bin_1.16.2-1_arm64.deb";
+      sha256 = "8813f401a4d43819f9ca4a97334200e716b52e4121b19b377812ef4ee9cd1d24";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-session-bus-common_1.16.2-1_all.deb";
+      sha256 = "3e02d0c4c3bdfc77972aa404a51f04f76b7a2353641c395091793bea4d7d46d9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-daemon_1.16.2-1_arm64.deb";
+      sha256 = "f8a56cc2a4928497eb0cb3ba1ff0aa2f704ae82c2809cc1e32e84334ec39d108";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-system-bus-common_1.16.2-1_all.deb";
+      sha256 = "e28a4a0e057fe4da53b60898f52670214a56f9b820d1431c55721a5f56656b97";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus_1.16.2-1_arm64.deb";
+      sha256 = "d802b34a3888ae9135e9acfae1baf4b0a11532168186190a2afe409e0b4db911";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/s/systemd/libpam-systemd_257.3-1_arm64.deb";
+      sha256 = "1f35562195fc038eb8a68f5f12bb49a6ea096516060c5f9779cedf086a696df3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dbus/dbus-user-session_1.16.2-1_arm64.deb";
+      sha256 = "b3e01b4ce6363cd13cc21f3da9fcba10ddddcb10fd40b03574586d632704caf8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/libdconf1_0.40.0-5_arm64.deb";
+      sha256 = "ff0a3e38b2fb4b96f209a3ae75714cb14e0df14a26a1aded11f5afb87d0eaef9";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/dconf-service_0.40.0-5_arm64.deb";
+      sha256 = "da9d81b0cd090e3933367a9be7562f13edebc9fd06f6f631c9e41fbc0a082fc3";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dconf/dconf-gsettings-backend_0.40.0-5_arm64.deb";
+      sha256 = "6ba9fcaa892934c9cfc601aeca15cfbac9751cb1377c541b1b0e098ab587a31d";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_48~beta-1_all.deb";
+      sha256 = "e58a08f7841150134ae76f14c3dfab03520069dc56d3fe8a27c1a8de11189b64";
+      name = "gsettings-desktop-schemas_48beta-1_all.deb";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/glib-networking/glib-networking_2.80.1-1_arm64.deb";
+      sha256 = "06815a6cfd3ad5386eba73db253ea1a25ede4a01b3b92d1dbc5315d001915e21";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsoup3/libsoup-3.0-common_3.6.4-2_all.deb";
+      sha256 = "eac04de1dcaee4899dd93dde51beac8f14b26fcac2e382a247130e92d2e9fff1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsoup3/libsoup-3.0-0_3.6.4-2_arm64.deb";
+      sha256 = "f924d7d54172bc82ed5b11f8a6656193f050339f4e993c92f8d293b9a6fb60bc";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxslt/libxslt1.1_1.1.35-1.1+b1_arm64.deb";
+      sha256 = "764fe34d60341143c9aa43ee8006591f1685b0769413e7df473e367b80f81e51";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb";
+      sha256 = "07d11308eb6021b984ae6e15afd0c1b4e6ded6463d05e3930db6d252c2e3287f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libo/libosinfo/libosinfo-l10n_1.12.0-2_all.deb";
+      sha256 = "3d8c424973c15f69c7c52916e6e27ebd522decdf004abd7ff88ff2380ca21808";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libo/libosinfo/libosinfo-1.0-0_1.12.0-2_arm64.deb";
+      sha256 = "c572276f24b6485f7c0065c7aa60a37d6b5c33207bc48305def249fff0ef2410";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml-parser-perl/libxml-parser-perl_2.47-1+b3_arm64.deb";
+      sha256 = "130645a2cd46e8133cdaae96f0bfe4b99ba43bd08d60457fc3189a5da8669429";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libx/libxml-xpath-perl/libxml-xpath-perl_1.48-1_all.deb";
+      sha256 = "af896c45e1dae5c0a4b9dec19404f41b688fac0e444f8744522fa3d04ccd9b9a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/h/hivex/libwin-hivex-perl_1.3.24-1+b9_arm64.deb";
+      sha256 = "526e362fc704a0597a00e00242c238e80d38c67e8d965f4e5ab2ba05924d6d48";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libsys-virt-perl/libsys-virt-perl_11.0.0-1_arm64.deb";
+      sha256 = "df77ce5525c3a7472cb8f4ccbe5c902fb46c6d22f795215faecc9cbff40666a1";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs-perl_1.54.1-1+b1_arm64.deb";
+      sha256 = "0dfc8918597fd76d8cd290d1285b5d160b63cfa68aa5167a8226c2eb8d9bbfc8";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libi/libintl-perl/libintl-perl_1.35-1_all.deb";
+      sha256 = "056ebe90f7ca7046f7f64e5eea8ed57d2da19a9531646bcf1f7856a5da07fb27";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libs/libstring-shellquote-perl/libstring-shellquote-perl_1.04-3_all.deb";
+      sha256 = "5860ee3928d3031a5a43ecfd8b3c093c58885cafb865473a612b9571d48e6d6a";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/g/guestfs-tools/guestfs-tools_1.52.2-4_arm64.deb";
+      sha256 = "da8560b4b684ce0379de89f59e9d8c10c8463191600b20b87282186d953ada8f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libc/libconfig/libconfig11_1.7.3-2_arm64.deb";
+      sha256 = "d1c7cf833b21df577682865a8867b8124263ed8ef418550d413bc75ed40830ed";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/guestmount_1.54.1-1+b1_arm64.deb";
+      sha256 = "5b48b6e55e7974a555d48cfb19a56c36fdb7a000a2aac39b42ece8b1bfbe8193";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/guestfish_1.54.1-1+b1_arm64.deb";
+      sha256 = "3250e4847a28a659ba268deca0b1be49bda9fb46715cb7424c7015b3ca112b6f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/libg/libguestfs/libguestfs-tools_1.54.1-1+b1_arm64.deb";
+      sha256 = "8b86d8c4b9fb296e6b39f49c39a21c610fbce5e2403cfd1bde214b78b925a659";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-base/linux-base_4.11_all.deb";
+      sha256 = "b74452838f8460f2c8812430208eeb40788eb782e0c87cf8bb91f3367625bcce";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/d/dracut/dracut-install_106-5_arm64.deb";
+      sha256 = "c30e9da5b9c12d3669b9bccbae524f484f2c33a7370ab3bcb26fd50b342f527b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/klibc/libklibc_2.0.13-4_arm64.deb";
+      sha256 = "12e4a5651288ec90f144577f564529e1cd8bb9e401c615d86c1abf9924b8994b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/k/klibc/klibc-utils_2.0.13-4_arm64.deb";
+      sha256 = "0711743f9b69fd2e421cf04b785b532360d336c4ee3bcdaeb3a500d6fdd2837f";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/initramfs-tools/initramfs-tools-core_0.145_all.deb";
+      sha256 = "19f6789f200a9b1ccae87c54a0c74f3a53faedee5030030c9d5e434b40998eac";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/i/initramfs-tools/initramfs-tools_0.145_all.deb";
+      sha256 = "d63e61ea1119a9a539021ec4e2f63bdfc5b6446104e8de7e5d92528dae08920b";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-signed-arm64/linux-image-6.12.12-arm64_6.12.12-1_arm64.deb";
+      sha256 = "2066e659ed5a81f40e2fa1d3dbadfc203d926c9161f0452ce869659c168e2c11";
+    })
+  ]
+  [
+    (fetchurl {
+      url = "https://snapshot.debian.org/archive/debian/20250305T144614Z/pool/main/l/linux-signed-arm64/linux-image-arm64_6.12.12-1_arm64.deb";
+      sha256 = "4191a64efad5edb9331e2520fc02c6a52e1fea58b1bd7d900f887bd7e19f01fb";
+    })
+  ]
+]

--- a/pkgs/by-name/li/libguestfs-appliance-debian/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-debian/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenvNoCC,
+  vmTools,
+  fetchurl,
+  runCommand,
+}:
+let
+  debianSnapshot = "20250305T144614Z";
+
+  debianArch =
+    {
+      "x86_64-linux" = "amd64";
+      "aarch64-linux" = "arm64";
+    }
+    .${stdenvNoCC.hostPlatform.system};
+
+  debClosureForArch =
+    arch:
+    vmTools.debClosureGenerator rec {
+      name = "libguestfs-appliance-deb-closure-${arch}";
+      packages = vmTools.commonDebianPackages ++ [
+        "libguestfs-tools"
+        "linux-image-${arch}" # required by supermin
+        "qemu-utils"
+      ];
+      packagesLists = [
+        (fetchurl {
+          url = "${urlPrefix}/dists/testing/main/binary-${arch}/Packages.xz";
+          hash =
+            {
+              "amd64" = "sha256-drhdsPvZhHpOwWh1G3NfhED3a8rBATI76ypEc4ZgJeM=";
+              "arm64" = "sha256-jDC8SY8P7tnrwutaORdQ7DwfYSuhhhLD5fvH/TInKHk=";
+            }
+            .${arch};
+        })
+      ];
+      urlPrefix = "https://snapshot.debian.org/archive/debian/${debianSnapshot}";
+    };
+
+  debClosures = runCommand "libguestfs-deb-closures" { } (
+    lib.concatMapStringsSep "\n"
+      (arch: "install -Dm444 ${debClosureForArch arch} $out/deb-closure-${arch}.nix")
+      [
+        "amd64"
+        "arm64"
+      ]
+  );
+
+  diskImage = vmTools.fillDiskWithDebs {
+    name = "debian-testing-${debianArch}";
+    fullName = "Debian testing (${debianArch})";
+    debs =
+      {
+        amd64 = import ./deb-closure-amd64.nix { inherit fetchurl; };
+        arm64 = import ./deb-closure-arm64.nix { inherit fetchurl; };
+      }
+      .${debianArch};
+  };
+in
+vmTools.runInLinuxImage (
+  stdenvNoCC.mkDerivation {
+    pname = "libguestfs-appliance";
+    # Since the appliance is built in a Debian guest, its version will be
+    # the version of the libguestfs package in the Debian snapshot we're using.
+    # When a new version of libguestfs lands in Debian testing, this package
+    # can be updated as follows:
+    # 1. Change the snapshot at the top of this file.
+    # 2. Run `nix build .#libguestfs-appliance-debian.debClosures` and adjust
+    #    the hashes accordingly.
+    # 3. Copy the resulting .nix files to ./deb-closure-{amd64,arm64}.nix.
+    # 4. Update the version number below to reflect the version number of
+    #    libguestfs in the new Debian snapshot.
+    version = "1.54.1";
+
+    inherit diskImage;
+    diskImageFormat = "qcow2";
+    memSize = "2048"; # we need to be generous here
+
+    dontUnpack = true;
+
+    # libguestfs-make-fixed-appliance tests appliance it has built using QEMU,
+    # which fails when using KVM due to a lack of support for nested KVM
+    # virtualization. Therefore we have to force software virtualization.
+    LIBGUESTFS_BACKEND_SETTINGS = "force_tcg";
+
+    buildPhase = ''
+      runHook preBuild
+
+      libguestfs-make-fixed-appliance $out
+      qemu-img convert -f raw -O qcow2 $out/root $out/root.qcow2
+      mv $out/root.qcow2 $out/root
+
+      runHook postBuild
+    '';
+
+    passthru = { inherit debClosures; };
+
+    meta = {
+      description = "Debian-based VM appliance disk image used in libguestfs package";
+      homepage = "https://libguestfs.org";
+      license = with lib.licenses; [
+        gpl2Plus
+        lgpl2Plus
+      ];
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      maintainers = with lib.maintainers; [ malte-v ];
+    };
+  }
+)

--- a/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-fedora/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenvNoCC.mkDerivation rec {
-  pname = "libguestfs-appliance";
+  pname = "libguestfs-appliance-fedora";
   version = "1.54.0";
 
   src = fetchurl {
@@ -22,18 +22,19 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "VM appliance disk image used in libguestfs package";
+  meta = {
+    description = "Fedora-based upstream VM appliance disk image used in libguestfs package";
     homepage = "https://libguestfs.org";
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl2Plus
       lgpl2Plus
     ];
-    maintainers = with maintainers; [ lukts30 ];
+    maintainers = with lib.maintainers; [ lukts30 ];
     platforms = [
       "i686-linux"
       "x86_64-linux"
     ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     hydraPlatforms = [ ]; # Hydra fails with "Output limit exceeded"
   };
 }

--- a/pkgs/by-name/li/libguestfs-with-appliance/package.nix
+++ b/pkgs/by-name/li/libguestfs-with-appliance/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   libguestfs,
-  libguestfs-appliance,
+  libguestfs-appliance-debian,
 }:
 
 let
-  appliance = libguestfs-appliance;
+  appliance = libguestfs-appliance-debian;
   # check explicit forward compatibility declaration:
   # then do not warn if older appliance if known to work fine with newer libguestfs
   libguestfsCompatible =

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -118,6 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--enable-daemon"
     "--enable-install-daemon"
+    "--enable-appliance-format-auto"
     "--disable-appliance"
     "--with-distro=NixOS"
     "--with-readline"

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -47,6 +47,11 @@ assert appliance == null || lib.isDerivation appliance;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libguestfs";
+
+  # It is advisable to keep the `libguestfs` and `libguestfs-appliance-debian`
+  # packages in sync to prevent issues like https://github.com/NixOS/nixpkgs/issues/280881.
+  # In particular, this package should be updated only after the update in
+  # question lands in Debian testing (see `libguestfs-appliance-debian` package).
   version = "1.54.1";
 
   src = fetchurl {
@@ -195,7 +200,5 @@ stdenv.mkDerivation (finalAttrs: {
       lukts30
     ];
     platforms = lib.platforms.linux;
-    # this is to avoid "output size exceeded"
-    hydraPlatforms = if appliance != null then appliance.meta.hydraPlatforms else lib.platforms.linux;
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -954,6 +954,7 @@ mapAliases {
   libgnome-keyring3 = libgnome-keyring; # Added 2024-06-22
   libgpgerror = throw "'libgpgerror' has been renamed to/replaced by 'libgpg-error'"; # Converted to throw 2024-10-17
   libgrss = throw "'libgrss' has been removed as it was archived upstream and had no users in nixpkgs"; # Added 2025-04-17
+  libguestfs-appliance = lib.warnOnInstantiate "'libguestfs-appliance' has been renamed to 'libguestfs-appliance-fedora'; also consider using 'libguestfs-appliance-debian' instead" libguestfs-appliance-fedora; # Added 2025-04-28
   libheimdal = heimdal; # Added 2022-11-18
   libhttpseverywhere = throw "'libhttpseverywhere' has been removed due to lack of upstream maintenance. It was no longer used in nixpkgs."; # Added 2025-04-17
   libiconv-darwin = darwin.libiconv;


### PR DESCRIPTION
Instead of downloading the binary appliance from upstream, build it locally inside a debian guest. This adds aarch64 support as upstream does not provide prebuilt aarch64 appliances.

This currently leads to an evaluation warning because the `libguestfs-appliance` package has a lower version than the `libguestfs` package. It's probably no big deal™ and can be solved once the debian maintainers update their libguestfs package to 1.54.0.

Needs testing on x86_64.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
