### PR TITLE
wesnoth: fix darwin and LLVM 19 compatibility

### DIFF
--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -26,14 +26,14 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wesnoth";
   version = "1.18.4";
 
   src = fetchFromGitHub {
-    rev = version;
     owner = "wesnoth";
     repo = "wesnoth";
+    tag = finalAttrs.version;
     hash = "sha256-c3BoTFnSUqtp71QeSCsC2teVuzsQwV8hOJtIcZdP+1E=";
   };
 
@@ -131,7 +131,7 @@ stdenv.mkDerivation rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Battle for Wesnoth, a free, turn-based strategy game with a fantasy theme";
     longDescription = ''
       The Battle for Wesnoth is a Free, turn-based tactical strategy
@@ -142,9 +142,9 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://www.wesnoth.org/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ abbradar ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ abbradar ];
+    platforms = lib.platforms.unix;
     mainProgram = "wesnoth";
   };
-}
+})

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -21,6 +21,7 @@
   icu,
   lua,
   curl,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,6 +34,33 @@ stdenv.mkDerivation rec {
     repo = "wesnoth";
     hash = "sha256-c3BoTFnSUqtp71QeSCsC2teVuzsQwV8hOJtIcZdP+1E=";
   };
+
+  # LLVM 19 removed support for types not officially supported by `std::char_traits`:
+  # https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals
+  # Wesnoth <1.19 relies on this previously supported non-standard behavior for
+  # some types that should either have been a vector or span:
+  # https://github.com/wesnoth/wesnoth/issues/9546
+  # Wesnoth moved to a `std::span` wrapper for byte views in the 1.19 branch, which we apply as
+  # patches until 1.20 is released.
+  patches = lib.optionals (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "19") [
+    # The next two patches are cherry-picked from https://github.com/wesnoth/wesnoth/pull/10102,
+    # which is already included in the 1.19 branch.
+    # Introduces the `std::span` wrapper based on `boost::span`.
+    (fetchpatch {
+      url = "https://github.com/wesnoth/wesnoth/commit/63266cc2c88fefa7e0792ac59d14c14e3711440c.patch";
+      hash = "sha256-3Zi/njG7Kovmyd7yiKUoeu4u0QPQxxw+uLz+k9isOLU=";
+    })
+    # Replace all string views with spans.
+    (fetchpatch {
+      url = "https://github.com/wesnoth/wesnoth/commit/d3daa161eb2c02670b5ffbcf86cd0ec787f6b9ee.patch";
+      hash = "sha256-9DCeZQZKE6fN91T5DCpNJsKGXbv5ihZC8UpuNkiA9zc=";
+    })
+    # Wesnoth <1.19 uses `std::basic_string` for lightmap computations, which is not standard compliant
+    # and incompatible to LLVM 19.
+    # While this was fixed in https://github.com/wesnoth/wesnoth/pull/10128, the fix is not
+    # trivially backportable to 1.18 so we apply a simpler fix instead.
+    ./llvm19-lightmap.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -23,6 +23,7 @@
   lua,
   curl,
   fetchpatch,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -120,6 +121,15 @@ stdenv.mkDerivation rec {
     EOF
     chmod +x "$out/bin/wesnoth"
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      # the minor release number also denotes if this is a beta release:
+      # even is stable, odd is beta
+      "^(\\d+\\.\\d*[02468]\\.\\d+)$"
+    ];
+  };
 
   meta = with lib; {
     description = "Battle for Wesnoth, a free, turn-based strategy game with a fantasy theme";

--- a/pkgs/games/wesnoth/default.nix
+++ b/pkgs/games/wesnoth/default.nix
@@ -143,7 +143,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "https://www.wesnoth.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ abbradar ];
+    maintainers = with lib.maintainers; [
+      abbradar
+      niklaskorz
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "wesnoth";
   };

--- a/pkgs/games/wesnoth/llvm19-lightmap.patch
+++ b/pkgs/games/wesnoth/llvm19-lightmap.patch
@@ -1,0 +1,59 @@
+diff --git a/src/display.cpp b/src/display.cpp
+index 0f6552222b7..9d50046de2f 100644
+--- a/src/display.cpp
++++ b/src/display.cpp
+@@ -1082,7 +1082,8 @@ void display::get_terrain_images(const map_location& loc, const std::string& tim
+
+ 		// add the directional transitions
+ 		tod_color acol = atod1.color + color_adjust_;
+-		lt += image::get_light_string(d + 1, acol.r, acol.g, acol.b);
++		auto new_lt = image::get_light_string(d + 1, acol.r, acol.g, acol.b);
++		lt.insert(lt.end(), new_lt.begin(), new_lt.end());
+ 	}
+
+ 	for(int d = 0; d < 6; ++d) {
+@@ -1114,7 +1115,8 @@ void display::get_terrain_images(const map_location& loc, const std::string& tim
+
+ 		// add the directional transitions
+ 		tod_color acol = atod1.color + color_adjust_;
+-		lt += image::get_light_string(d + 7, acol.r, acol.g, acol.b);
++		auto new_lt = image::get_light_string(d + 7, acol.r, acol.g, acol.b);
++		lt.insert(lt.end(), new_lt.begin(), new_lt.end());
+ 	}
+
+ 	for(int d = 0; d < 6; ++d) {
+@@ -1146,7 +1148,8 @@ void display::get_terrain_images(const map_location& loc, const std::string& tim
+
+ 		// add the directional transitions
+ 		tod_color acol = atod2.color + color_adjust_;
+-		lt += image::get_light_string(d + 13, acol.r, acol.g, acol.b);
++		auto new_lt = image::get_light_string(d + 13, acol.r, acol.g, acol.b);
++		lt.insert(lt.end(), new_lt.begin(), new_lt.end());
+ 	}
+
+ 	if(lt.empty()){
+diff --git a/src/picture.cpp b/src/picture.cpp
+index e7aeddaa821..5ad1ebcbcbc 100644
+--- a/src/picture.cpp
++++ b/src/picture.cpp
+@@ -526,7 +526,9 @@ static surface apply_light(surface surf, const light_string& ls)
+
+ 		// decompose into atomic lightmap operations (4 chars)
+ 		for(std::size_t c = 0; c + 3 < ls.size(); c += 4) {
+-			light_string sls = ls.substr(c, 4);
++			auto start = ls.begin() + c;
++			auto end = start + 4;
++			light_string sls(start, end);
+
+ 			// get the corresponding image and apply the lightmap operation to it
+ 			// This allows to also cache lightmap parts.
+diff --git a/src/picture.hpp b/src/picture.hpp
+index 85a3b3a15a1..a26e1e27bc7 100644
+--- a/src/picture.hpp
++++ b/src/picture.hpp
+@@ -120,7 +120,7 @@ std::ostream& operator<<(std::ostream&, const locator&);
+  *  7-12: convex half-corners 1
+  * 13-19: convex half-corners 2
+  */
+-typedef std::basic_string<signed char> light_string;
++typedef std::vector<signed char> light_string;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

LLVM 19 removed support for types not officially supported by `std::char_traits`: <https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals>
Wesnoth relies on this previously supported non-standard behavior for some types that should either have been a vector or span: <https://github.com/wesnoth/wesnoth/issues/9546>
~~Unfortunately we can't just use `std::span` as that requires C++20, and making Wesnoth C++20 compatible is a non-trivial problem.
As a workaround, we make use of gsl-lite, which includes a lightweight implementation of span.~~
I've applied the relevant commits from 1.19 that wrap `boost::span`, and kept my own patch for fixing the lightmap (see comment above the patch).

Furthermore, while this package built on darwin before Clang 19 landed, it didn't run, as Wesnoth requires the binary to be contained in a macOS app bundle to function. This is also fixed in this PR by manually creating the app bundle using the upstream resources and `Info.plist`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
