### PR TITLE
ufbt: init at 0.2.5, flipperzero-toolchain: init at 39

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4599,6 +4599,11 @@
     email = "jupiter@m.rdis.dev";
     name = "Scott Little";
   };
+  CodeRadu = {
+    github = "CodeRadu";
+    githubId = 47945947;
+    name = "Radu";
+  };
   coderofsalvation = {
     github = "coderofsalvation";
     githubId = 180068;

--- a/pkgs/by-name/fl/flipperzero-toolchain/package.nix
+++ b/pkgs/by-name/fl/flipperzero-toolchain/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  libgcc,
+  libnsl,
+  libxcrypt,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flipperzero-toolchain";
+  version = "39";
+
+  src = fetchurl {
+    url = "https://update.flipperzero.one/builds/toolchain/gcc-arm-none-eabi-12.3-x86_64-linux-flipper-${version}.tar.gz";
+    hash = "sha256-wETFkjP2b278+FSv/i1eCdutBNaHCdUTvHYLHZiJWFM=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    libgcc
+    stdenv.cc.cc.lib # for libstdc++.so.6
+    libnsl
+    libxcrypt
+  ];
+
+  sourceRoot = ".";
+
+  shellHook = ''
+    export FBT_TOOLCHAIN_PATH=$out/opt/flipperzero-toolchain
+  '';
+
+  installPhase = ''
+    mkdir -p $out/opt/flipperzero-toolchain/toolchain/x86_64-linux
+    cp -r gcc-arm-none-eabi-12.3-x86_64-linux-flipper/* $out/opt/flipperzero-toolchain/toolchain/x86_64-linux
+    ln -sf ${libnsl}/lib/libnsl.so.3 $out/opt/flipperzero-toolchain/toolchain/x86_64-linux/lib/libnsl.so.2
+    ln -sf ${libxcrypt}/lib/libcrypt.so.2 $out/opt/flipperzero-toolchain/toolchain/x86_64-linux/lib/libcrypt.so.1
+    ln -sf $out/opt/flipperzero-toolchain/toolchain/x86_64-linux $out/opt/flipperzero-toolchain/toolchain/current
+  '';
+
+  meta = {
+    description = "Toolchain for the flipperzero";
+    homepage = "https://github.com/flipperdevices/flipperzero-toolchain";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ CodeRadu ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/uf/ufbt/package.nix
+++ b/pkgs/by-name/uf/ufbt/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  setuptools-git-versioning,
+  flipperzero-toolchain,
+}:
+
+buildPythonPackage rec {
+  pname = "ufbt";
+  version = "0.2.5";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pQI8pSn5X6ISJ2rlEIfe6je4g7PY8HhKITl1GemMvf8=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    setuptools-git-versioning
+  ];
+
+  makeWrapperArgs = [
+    "--set-default FBT_TOOLCHAIN_PATH ${flipperzero-toolchain}/opt/flipperzero-toolchain"
+  ];
+
+  meta = {
+    description = "Cross-platform tool for building applications for Flipper Zero";
+    mainProgram = "ufbt";
+    homepage = "https://github.com/flipperdevices/flipperzero-ufbt";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ CodeRadu ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7420,6 +7420,10 @@ with pkgs;
     };
   }));
 
+  ufbt = callPackage ../by-name/uf/ufbt/package.nix {
+    inherit (python3Packages) buildPythonPackage setuptools setuptools-git-versioning;
+  };
+
   ansible-builder = with python3Packages; toPythonApplication ansible-builder;
 
   ansible-doctor = callPackage ../tools/admin/ansible/doctor.nix { };


### PR DESCRIPTION
Added the `ufbt` package at version `0.2.5` and it's dependency `flipperzero-toolchain` at version `39`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
