### PR TITLE
ci/eval/compare: Ignore null packages

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -24,8 +24,11 @@ let
     pkg:
     if (lib.attrsets.hasAttrByPath pkg.path pkgs) then
       (
-        if (builtins.tryEval (lib.attrsets.attrByPath pkg.path null pkgs)).success then
-          true
+        let
+          value = lib.attrsets.attrByPath pkg.path null pkgs;
+        in
+        if (builtins.tryEval value).success then
+          if value != null then true else builtins.trace "${pkg.name} exists but is null" false
         else
           builtins.trace "Failed to access ${pkg.name} even though it exists" false
       )


### PR DESCRIPTION
CI can fail to evaluate if a package is null:
https://github.com/NixOS/nixpkgs/actions/runs/13209876145/job/36881335314?pr=380228

Should fix pings for xanmod, ping @eljamm, thanks for the report in https://github.com/NixOS/nixpkgs/issues/378595#issuecomment-2644989939 :)

## Things done
- [x] Manually tested by locally running the same as CI

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
