### PR TITLE
haskellPackages: clean up overrides (part 2)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1551,9 +1551,6 @@ self: super: {
     })
   ] super.jsaddle-hello;
 
-  # Too strict upper bounds on text
-  lsql-csv = doJailbreak super.lsql-csv;
-
   # Tests disabled and broken override needed because of missing lib chrome-test-utils: https://github.com/reflex-frp/reflex-dom/issues/392
   reflex-dom-core = lib.pipe super.reflex-dom-core [
     doDistribute

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2048,6 +2048,9 @@ self: super: {
     revision = null;
   } super.llvm-hs-pure);
 
+  # 2025-02-11: Too strict bounds on tasty-quickcheck < 0.11
+  exact-pi = doJailbreak super.exact-pi;
+
   # Too strict bounds on dimensional
   # https://github.com/enomsg/science-constants-dimensional/pull/1
   science-constants-dimensional = doJailbreak super.science-constants-dimensional;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1992,10 +1992,6 @@ self: super: {
   # https://github.com/obsidiansystems/database-id/issues/1
   database-id-class = doJailbreak super.database-id-class;
 
-  # https://github.com/softwarefactory-project/matrix-client-haskell/issues/36
-  # Restrictive bounds on aeson
-  matrix-client = doJailbreak super.matrix-client;
-
   cabal2nix-unstable = overrideCabal {
     passthru = {
       updateScript = ../../../maintainers/scripts/haskell/update-cabal2nix-unstable.sh;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2714,9 +2714,7 @@ self: super: {
   unleash-client-haskell = doJailbreak super.unleash-client-haskell;
 
   # Tests rely on (missing) submodule
-  # Too strict bounds on aeson, text and text-show
-  # https://github.com/finn-no/unleash-client-haskell-core/issues/24
-  unleash-client-haskell-core = doJailbreak (dontCheck super.unleash-client-haskell-core);
+  unleash-client-haskell-core = dontCheck super.unleash-client-haskell-core;
 
   # Workaround for Cabal failing to find nonexistent SDL2 library?!
   # https://github.com/NixOS/nixpkgs/issues/260863

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2621,7 +2621,6 @@ self: super: {
   webauthn = dontCheck super.webauthn;
 
   # multiple bounds too strict
-  co-log-polysemy = doJailbreak super.co-log-polysemy;
   co-log-polysemy-formatting = doJailbreak super.co-log-polysemy-formatting;
 
   # calls ghc in tests

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1937,7 +1937,6 @@ self: super: {
 
   cli-git = addBuildTool pkgs.git super.cli-git;
 
-  # Need https://github.com/obsidiansystems/cli-nix/pull/5 and more
   cli-nix = addBuildTools [
     pkgs.nix
     pkgs.nix-prefetch-git

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1637,10 +1637,6 @@ self: super: {
   # $PWD/dist/build/haskeline-examples-Test to $PATH.
   haskeline_0_8_3_0 = doDistribute (dontCheck super.haskeline_0_8_3_0);
 
-  # Too strict upper bound on HTF
-  # https://github.com/nikita-volkov/stm-containers/issues/29
-  stm-containers = doJailbreak super.stm-containers;
-
   # Test suite fails to compile https://github.com/agrafix/Spock/issues/177
   Spock = dontCheck super.Spock;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1254,8 +1254,6 @@ self: super: {
 
   # dontCheck: https://github.com/haskell-servant/servant-auth/issues/113
   servant-auth-client = dontCheck super.servant-auth-client;
-  # Allow hspec >= 2.10 https://github.com/haskell-servant/servant/issues/1704
-  servant-foreign = doJailbreak super.servant-foreign;
 
   # Generate cli completions for dhall.
   dhall = self.generateOptparseApplicativeCompletions [ "dhall" ] super.dhall;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1245,9 +1245,6 @@ self: super: {
     preCheck = ''export PATH="$PWD/dist/build/alex:$PATH"'';
   }) super.alex;
 
-  # 2023-07-14: Restrictive upper bounds: https://github.com/luke-clifton/shh/issues/76
-  shh = doJailbreak super.shh;
-
   # Compiles some C or C++ source which requires these headers
   VulkanMemoryAllocator = addExtraLibrary pkgs.vulkan-headers super.VulkanMemoryAllocator;
   # dontCheck can be removed on the next package set bump

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1949,9 +1949,8 @@ self: super: {
   # https://github.com/mpickering/hs-speedscope/issues/16
   hs-speedscope = doJailbreak super.hs-speedscope;
 
-  # Test suite doesn't support base16-bytestring >= 1.0
-  # https://github.com/centromere/blake2/issues/6
-  blake2 = dontCheck super.blake2;
+  # 2025-02-11: Too strict bounds on base < 4.19, bytestring < 0.12, tasty < 1.5, tasty-quickcheck < 0.11
+  blake2 = doJailbreak super.blake2;
 
   # Test suite doesn't support base16-bytestring >= 1.0
   # https://github.com/serokell/haskell-crypto/issues/25

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1461,8 +1461,6 @@ self: super: {
 
   # Chart-tests needs and compiles some modules from Chart itself
   Chart-tests = overrideCabal (old: {
-    # https://github.com/timbod7/haskell-chart/issues/233
-    jailbreak = true;
     preCheck = old.preCheck or "" + ''
       tar --one-top-level=../chart --strip-components=1 -xf ${self.Chart.src}
     '';

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2328,15 +2328,6 @@ self: super: {
   # 2022-03-16: Upstream stopped updating bounds https://github.com/haskell-hvr/base-noprelude/pull/15
   base-noprelude = doJailbreak super.base-noprelude;
 
-  # 2024-01-14: Support hedgehog 1.5 https://github.com/kowainik/relude/pull/463/
-  relude = appendPatch (fetchpatch {
-    url = "https://github.com/kowainik/relude/commit/b6bf99ee83e929d11bd4088d6a1d928c3ce0070b.patch";
-    sha256 = "sha256-YhGZ0l7FuTyLee1b2yGcvxdvwgnOhZBy7qTg7aymmDc=";
-  }) (overrideCabal (drv: {
-    revision = null;
-    editedCabalFile = null;
-  }) super.relude);
-
   # 2025-01-07: unreleased upstream supports hedgehog 1.5 but drifted quite a bit from hackage revisions so hard to patch
   hw-hspec-hedgehog = doJailbreak super.hw-hspec-hedgehog;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2668,7 +2668,6 @@ self: super: {
 
   # Too strict bounds on hspec < 2.11
   fuzzyset_0_2_4 = doJailbreak super.fuzzyset_0_2_4;
-  swagger2 = doJailbreak super.swagger2;
 
   html-charset = dontCheck super.html-charset;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1262,6 +1262,7 @@ self: super: {
   # 2023-12-19: jailbreaks due to hnix-0.17 https://github.com/dhall-lang/dhall-haskell/pull/2559
   # until dhall-nix 1.1.26+, dhall-nixpkgs 1.0.10+
   dhall-nix = self.generateOptparseApplicativeCompletions [ "dhall-to-nix" ] (doJailbreak super.dhall-nix);
+  # 2025-02-10: jailbreak due to aeson < 2.2, hnix < 0.17, transformers < 0.6, turtle < 1.6
   dhall-nixpkgs = self.generateOptparseApplicativeCompletions [ "dhall-to-nixpkgs" ] (doJailbreak super.dhall-nixpkgs);
   dhall-yaml = self.generateOptparseApplicativeCompletions ["dhall-to-yaml-ng" "yaml-to-dhall"] super.dhall-yaml;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2114,8 +2114,7 @@ self: super: {
     testFlags = [ "-j1" ];
   } super.libarchive;
 
-  # Too strict bounds on QuickCheck
-  # https://github.com/muesli4/table-layout/issues/16
+  # 2025-02-11: Too strict bounds on doclayout < 0.5
   table-layout = doJailbreak super.table-layout;
 
   # https://github.com/plow-technologies/hspec-golden-aeson/issues/17

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1312,6 +1312,9 @@ self: super: {
   # dontCheck: The test suite tries to mess with ALSA, which doesn't work in the build sandbox.
   xmobar = dontCheck super.xmobar;
 
+  # 2025-02-10: Too strict bounds on aeson < 1.5
+  json-alt = doJailbreak super.json-alt;
+
   # https://github.com/mgajda/json-autotype/issues/25
   json-autotype = dontCheck super.json-autotype;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1945,8 +1945,6 @@ self: super: {
   # list `modbus` in librarySystemDepends, correct to `libmodbus`
   libmodbus = doJailbreak (addExtraLibrary pkgs.libmodbus super.libmodbus);
 
-  ginger = doJailbreak super.ginger;
-
   # Too strict version bounds on ghc-events
   # https://github.com/mpickering/hs-speedscope/issues/16
   hs-speedscope = doJailbreak super.hs-speedscope;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2576,9 +2576,6 @@ self: super: {
   # unix-compat <0.5
   hxt-cache = doJailbreak super.hxt-cache;
 
-  # base <4.16
-  fast-builder = doJailbreak super.fast-builder;
-
   # QuickCheck <2.14
   term-rewriting = doJailbreak super.term-rewriting;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1502,10 +1502,6 @@ self: super: {
       # https://github.com/NixOS/nixpkgs/issues/198495
       (dontCheckIf (!pkgs.postgresql.doCheck) super.persistent-postgresql);
 
-  # Test suite requires a later version of persistent-test which depends on persistent 2.14
-  # https://github.com/commercialhaskell/stackage/issues/6884
-  persistent-sqlite = dontCheck super.persistent-sqlite;
-
   # Needs matching lsp-types
   lsp_2_4_0_0 = super.lsp_2_4_0_0.override {
     lsp-types = self.lsp-types_2_1_1_0;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1814,9 +1814,6 @@ self: super: {
   };
   hspec-core_2_7_10 = doJailbreak (dontCheck super.hspec-core_2_7_10);
 
-  # waiting for aeson bump
-  servant-swagger-ui-core = doJailbreak super.servant-swagger-ui-core;
-
   hercules-ci-agent = self.generateOptparseApplicativeCompletions [ "hercules-ci-agent" ] super.hercules-ci-agent;
 
   hercules-ci-cli = lib.pipe super.hercules-ci-cli [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2277,8 +2277,6 @@ self: super: {
 
   # 2025-02-11: Too strict bounds on hedgehog < 1.5, hspec-hedgehog < 0.2
   validation-selective = doJailbreak super.validation-selective;
-  # https://github.com/system-f/validation/issues/57
-  validation = doJailbreak super.validation;
 
   # 2022-03-16: strict upper bounds https://github.com/monadfix/shower/issues/18
   shower = doJailbreak super.shower;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1490,11 +1490,6 @@ self: super: {
           sed -i test/PgInit.hs \
             -e s^'host=" <> host <> "'^^
         '';
-        # https://github.com/commercialhaskell/stackage/issues/6884
-        # persistent-postgresql-2.13.5.1 needs persistent-test >= 2.13.1.3 which
-        # is incompatible with the stackage version of persistent, so the tests
-        # are disabled temporarily.
-        doCheck = false;
         preCheck = drv.preCheck or "" + ''
           PGDATABASE=test
           PGUSER=test

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2132,6 +2132,8 @@ self: super: {
 
   # 2021-08-18: streamly-posix was released with hspec 2.8.2, but it works with older versions too.
   streamly-posix = doJailbreak super.streamly-posix;
+  # 2025-02-11: Too strict bounds on bytestring
+  streamly-bytestring = doJailbreak super.streamly-bytestring;
 
   # Stackage LTS 19 still has 10.*
   hadolint = super.hadolint.override {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2298,7 +2298,7 @@ self: super: {
     Cabal-syntax = self.Cabal-syntax_3_10_3_0;
   });
 
-  # 2023-07-18: https://github.com/srid/ema/issues/156
+  # 2025-02-11: Too strict bounds on base < 4.17
   ema = doJailbreak super.ema;
 
   # Too strict bounds on text and tls

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1880,9 +1880,8 @@ self: super: {
   # Missing test files in 1.8.1.0, fixed in 1.8.1.1
   sequence-formats = dontCheck super.sequence-formats;
 
-  # Test suite has overly strict bounds on tasty, jailbreaking fails.
-  # https://github.com/input-output-hk/nothunks/issues/9
-  nothunks = dontCheck super.nothunks;
+  # 2025-02-11: Too strict bounds on hedgehog < 1.5
+  nothunks = doJailbreak super.nothunks;
 
   # Allow building with older versions of http-client.
   http-client-restricted = doJailbreak super.http-client-restricted;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2620,9 +2620,6 @@ self: super: {
   # https://github.com/tweag/webauthn/issues/166
   webauthn = dontCheck super.webauthn;
 
-  # doctest <0.19
-  polysemy = doJailbreak super.polysemy;
-
   # multiple bounds too strict
   co-log-polysemy = doJailbreak super.co-log-polysemy;
   co-log-polysemy-formatting = doJailbreak super.co-log-polysemy-formatting;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1259,9 +1259,7 @@ self: super: {
   dhall = self.generateOptparseApplicativeCompletions [ "dhall" ] super.dhall;
   # 2025-01-27: allow aeson >= 2.2, 9.8 versions of text and bytestring
   dhall-json = self.generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"] (doJailbreak super.dhall-json);
-  # 2023-12-19: jailbreaks due to hnix-0.17 https://github.com/dhall-lang/dhall-haskell/pull/2559
-  # until dhall-nix 1.1.26+, dhall-nixpkgs 1.0.10+
-  dhall-nix = self.generateOptparseApplicativeCompletions [ "dhall-to-nix" ] (doJailbreak super.dhall-nix);
+  dhall-nix = self.generateOptparseApplicativeCompletions [ "dhall-to-nix" ] super.dhall-nix;
   # 2025-02-10: jailbreak due to aeson < 2.2, hnix < 0.17, transformers < 0.6, turtle < 1.6
   dhall-nixpkgs = self.generateOptparseApplicativeCompletions [ "dhall-to-nixpkgs" ] (doJailbreak super.dhall-nixpkgs);
   dhall-yaml = self.generateOptparseApplicativeCompletions ["dhall-to-yaml-ng" "yaml-to-dhall"] super.dhall-yaml;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1280,10 +1280,6 @@ self: super: {
   # https://github.com/hslua/hslua/issues/106
   hslua-core = if pkgs.stdenv.hostPlatform.isMusl then dontCheck super.hslua-core else super.hslua-core;
 
-  # Missing files required by the test suite.
-  # https://github.com/deemp/flakes/issues/4
-  lima = dontCheck super.lima;
-
   # The test suite runs for 20+ minutes on a very fast machine, which feels kinda disproportionate.
   prettyprinter = dontCheck super.prettyprinter;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2513,9 +2513,6 @@ self: super: {
   # transformers <0.3
   monads-fd = doJailbreak super.monads-fd;
 
-  # HTF <0.15
-  cases = doJailbreak super.cases;
-
   # exceptions <0.9
   eprocess = doJailbreak super.eprocess;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2331,9 +2331,8 @@ self: super: {
   # 2025-01-07: unreleased upstream supports hedgehog 1.5 but drifted quite a bit from hackage revisions so hard to patch
   hw-hspec-hedgehog = doJailbreak super.hw-hspec-hedgehog;
 
-  # doJailbreak: too strict bounds on chell: https://github.com/fpco/haskell-filesystem/issues/24
   # dontCheck:   tests don't typecheck after ghc 8.4 (possibly introduced by api change of unix library)
-  system-fileio = doJailbreak (dontCheck super.system-fileio);
+  system-fileio = dontCheck super.system-fileio;
 
   # Bounds too strict on base and ghc-prim: https://github.com/tibbe/ekg-core/pull/43 (merged); waiting on hackage release
   hasura-ekg-core = doJailbreak super.hasura-ekg-core;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2772,8 +2772,6 @@ self: super: {
   # https://github.com/isovector/type-errors/issues/9
   type-errors = dontCheck super.type-errors;
 
-  lzma = doJailbreak super.lzma;
-
   # Too strict bounds on text. Can be removed after https://github.com/alx741/currencies/pull/3 is merged
   currencies = doJailbreak super.currencies;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2594,7 +2594,6 @@ self: super: {
   heist-extra = doJailbreak super.heist-extra;  # base <4.18.0.0.0
   unionmount = doJailbreak super.unionmount;  # base <4.18
   tailwind = doJailbreak super.tailwind;  # base <=4.17.0.0
-  tagtree = doJailbreak super.tagtree;  # base <=4.17  https://github.com/srid/tagtree/issues/1
   commonmark-wikilink = doJailbreak super.commonmark-wikilink; # base <4.18.0.0.0
 
   # 2024-03-02: Apply unreleased changes necessary for compatibility

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1880,9 +1880,6 @@ self: super: {
   # Missing test files in 1.8.1.0, fixed in 1.8.1.1
   sequence-formats = dontCheck super.sequence-formats;
 
-  # Break out of overspecified constraint on QuickCheck.
-  haddock-library = doJailbreak super.haddock-library;
-
   # Test suite has overly strict bounds on tasty, jailbreaking fails.
   # https://github.com/input-output-hk/nothunks/issues/9
   nothunks = dontCheck super.nothunks;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2385,17 +2385,6 @@ self: super: {
   doctest-parallel = dontCheck super.doctest-parallel;
   clash-prelude = dontCheck super.clash-prelude;
 
-  # Ships a broken Setup.hs
-  # https://github.com/lehins/conduit-aeson/issues/1
-  conduit-aeson = overrideCabal (drv: {
-    postPatch = ''
-      ${drv.postPatch or ""}
-      rm Setup.hs
-    '';
-    # doctest suite uses doctest-parallel which still doesn't work in nixpkgs
-    testTargets = [ "tests" ];
-  }) super.conduit-aeson;
-
   hermes-json = overrideCabal (drv: {
     # Upper bounds are too strict:
     # https://github.com/velveteer/hermes/pull/22

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1247,8 +1247,7 @@ self: super: {
 
   # Compiles some C or C++ source which requires these headers
   VulkanMemoryAllocator = addExtraLibrary pkgs.vulkan-headers super.VulkanMemoryAllocator;
-  # dontCheck can be removed on the next package set bump
-  vulkan-utils = dontCheck (addExtraLibrary pkgs.vulkan-headers super.vulkan-utils);
+  vulkan-utils = addExtraLibrary pkgs.vulkan-headers super.vulkan-utils;
 
   # Work around overspecified constraint on github ==0.18.
   github-backup = doJailbreak super.github-backup;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1474,11 +1474,9 @@ self: super: {
 
   # The test suite depends on an impure cabal-install installation in
   # $HOME, which we don't have in our build sandbox.
-  # 2022-08-31: Jailbreak is done to allow aeson 2.0.*:
-  # https://github.com/haskell-CI/haskell-ci/commit/6ad0d5d701cbe101013335d597acaf5feadd3ab9#r82681900
-  cabal-install-parsers = doJailbreak (dontCheck (super.cabal-install-parsers.override {
+  cabal-install-parsers = dontCheck (super.cabal-install-parsers.override {
     Cabal-syntax = self.Cabal-syntax_3_10_3_0;
-  }));
+  });
 
   # Test suite requires database
   persistent-mysql = dontCheck super.persistent-mysql;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1883,9 +1883,6 @@ self: super: {
   # 2025-02-11: Too strict bounds on hedgehog < 1.5
   nothunks = doJailbreak super.nothunks;
 
-  # Allow building with older versions of http-client.
-  http-client-restricted = doJailbreak super.http-client-restricted;
-
   # Test suite fails, upstream not reachable for simple fix (not responsive on github)
   vivid-osc = dontCheck super.vivid-osc;
   vivid-supercollider = dontCheck super.vivid-supercollider;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1884,7 +1884,6 @@ self: super: {
   nothunks = doJailbreak super.nothunks;
 
   # Test suite fails, upstream not reachable for simple fix (not responsive on github)
-  vivid-osc = dontCheck super.vivid-osc;
   vivid-supercollider = dontCheck super.vivid-supercollider;
 
   # Test suite does not compile.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2865,8 +2865,8 @@ self: super: {
       sha256 = "1q0n7338rjz7zl6xpw51lljp7xw1gl128s1d5877kfil3fc23npp";
     }) super.http2-client;
 
-    # 2025-01-23: jailbreak to allow base >= 4.17
-    warp-systemd = doJailbreak super.warp-systemd;
+  # 2025-01-23: jailbreak to allow base >= 4.17
+  warp-systemd = doJailbreak super.warp-systemd;
 
   yesod-core = appendPatch
     (fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2186,17 +2186,15 @@ self: super: {
   }) super.json-to-haskell;
   # https://github.com/fieldstrength/aeson-deriving/issues/5
   aeson-deriving = dontCheck super.aeson-deriving;
-  # https://github.com/morpheusgraphql/morpheus-graphql/issues/660
-  morpheus-graphql-core = overrideCabal (drv: {
-    testFlags = [
-      "-p" "!/field.unexpected-value/&&!/field.missing-field/&&!/argument.unexpected-value/&&!/argument.missing-field/"
-    ] ++ drv.testFlags or [];
-  }) super.morpheus-graphql-core;
-  morpheus-graphql = overrideCabal (drv: {
-    testFlags = [
-      "-p" "!/Test Rendering/"
-    ] ++ drv.testFlags or [];
-  }) super.morpheus-graphql;
+
+  # 2025-02-11: Too strict bounds on tasty < 1.5, all of the below.
+  morpheus-graphql-app = doJailbreak super.morpheus-graphql-app;
+  morpheus-graphql-client = doJailbreak super.morpheus-graphql-client;
+  morpheus-graphql-core = doJailbreak super.morpheus-graphql-core;
+  morpheus-graphql-server = doJailbreak super.morpheus-graphql-server;
+  morpheus-graphql-tests = doJailbreak super.morpheus-graphql-tests;
+  morpheus-graphql = doJailbreak super.morpheus-graphql;
+
   drunken-bishop = doJailbreak super.drunken-bishop;
   # https://github.com/SupercedeTech/dropbox-client/issues/1
   dropbox = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2386,8 +2386,7 @@ self: super: {
   clash-prelude = dontCheck super.clash-prelude;
 
   hermes-json = overrideCabal (drv: {
-    # Upper bounds are too strict:
-    # https://github.com/velveteer/hermes/pull/22
+    # 2025-02-11: Upper bounds on hedgehog < 1.5 too strict.
     jailbreak = true;
 
     # vendored simdjson breaks with clang-19. apply patches that work with

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -711,7 +711,8 @@ self: super: {
   hquery = dontCheck super.hquery;
   hs2048 = dontCheck super.hs2048;
   hsbencher = dontCheck super.hsbencher;
-  hsexif = dontCheck super.hsexif;
+  # 2025-02-11: Too strict bounds on bytestring
+  hsexif = doJailbreak (dontCheck super.hsexif);
   hspec-server = dontCheck super.hspec-server;
   HTF = overrideCabal (orig: {
     # The scripts in scripts/ are needed to build the test suite.

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1254,8 +1254,6 @@ self: super: {
 
   # dontCheck: https://github.com/haskell-servant/servant-auth/issues/113
   servant-auth-client = dontCheck super.servant-auth-client;
-  # Allow lens-aeson >= 1.2 https://github.com/haskell-servant/servant/issues/1703
-  servant-auth-server = doJailbreak super.servant-auth-server;
   # Allow hspec >= 2.10 https://github.com/haskell-servant/servant/issues/1704
   servant-foreign = doJailbreak super.servant-foreign;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2672,9 +2672,6 @@ self: super: {
 
   html-charset = dontCheck super.html-charset;
 
-  # 2024-08-15: primitive >=0.9 && <0.10
-  posix-api = doJailbreak super.posix-api;
-
   # bytestring <0.11.0, optparse-applicative <0.13.0
   # https://github.com/kseo/sfnt2woff/issues/1
   sfnt2woff = doJailbreak super.sfnt2woff;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2504,10 +2504,6 @@ self: super: {
   # We provide newer dependencies than upstream expects.
   swarm = doJailbreak super.swarm;
 
-  # Too strict upper bound on bytestring
-  # https://github.com/TravisWhitaker/rdf/issues/8
-  rdf = doJailbreak super.rdf;
-
   # random <1.2
   unfoldable = doJailbreak super.unfoldable;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2567,9 +2567,6 @@ self: super: {
   # Test suite doesn't compile anymore
   twitter-types = dontCheck super.twitter-types;
 
-  # base <4.14
-  numbered-semigroups = doJailbreak super.numbered-semigroups;
-
   # Tests open file "data/test_vectors_aserti3-2d_run01.txt" but it doesn't exist
   haskoin-core = dontCheck super.haskoin-core;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2278,7 +2278,7 @@ self: super: {
   # 2025-02-11: Too strict bounds on hedgehog < 1.5, hspec-hedgehog < 0.2
   validation-selective = doJailbreak super.validation-selective;
 
-  # 2022-03-16: strict upper bounds https://github.com/monadfix/shower/issues/18
+  # 2025-02-11: strict upper bounds on base < 4.18
   shower = doJailbreak super.shower;
 
   # Test suite isn't supposed to succeed yet, apparently…

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2275,7 +2275,7 @@ self: super: {
     editedCabalFile = null;
   } super.regex-compat-tdfa);
 
-  # https://github.com/kowainik/validation-selective/issues/64
+  # 2025-02-11: Too strict bounds on hedgehog < 1.5, hspec-hedgehog < 0.2
   validation-selective = doJailbreak super.validation-selective;
   # https://github.com/system-f/validation/issues/57
   validation = doJailbreak super.validation;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3954,7 +3954,6 @@ broken-packages:
   - morfette # failure in job https://hydra.nixos.org/build/233249575 at 2023-09-02
   - morfeusz # failure in job https://hydra.nixos.org/build/233232351 at 2023-09-02
   - morpheus-graphql-cli # failure in job https://hydra.nixos.org/build/233249063 at 2023-09-02
-  - morpheus-graphql-code-gen # failure in job https://hydra.nixos.org/build/252733361 at 2024-03-16
   - morphisms-functors # failure in job https://hydra.nixos.org/build/233255311 at 2023-09-02
   - morphisms-objects # failure in job https://hydra.nixos.org/build/233216076 at 2023-09-02
   - morte # failure in job https://hydra.nixos.org/build/233212193 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -3256,7 +3256,6 @@ broken-packages:
   - jpeg # failure in job https://hydra.nixos.org/build/233204056 at 2023-09-02
   - js-good-parts # failure in job https://hydra.nixos.org/build/233198958 at 2023-09-02
   - json2 # failure in job https://hydra.nixos.org/build/233242447 at 2023-09-02
-  - json-alt # failure in job https://hydra.nixos.org/build/233242230 at 2023-09-02
   - json-api # failure in job https://hydra.nixos.org/build/233198171 at 2023-09-02
   - json-api-lib # failure in job https://hydra.nixos.org/build/233210901 at 2023-09-02
   - json-assertions # failure in job https://hydra.nixos.org/build/233196774 at 2023-09-02


### PR DESCRIPTION
Follow up to #381006. Made it all the way through `configuration-common.nix`.

## Things done

I only tested on `haskellPackages`, default compiler.

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
