### PR TITLE
Fail GHA eval on non-empty stderr

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -113,6 +113,9 @@ let
           echo "Evaluation failed with exit code $exitCode"
           # This immediately halts all xargs processes
           kill $PPID
+        elif [[ -s "$outputDir/stderr/$myChunk" ]]; then
+          echo "Nixpkgs on $system evaluated with warnings, aborting"
+          kill $PPID
         fi
       '';
     in


### PR DESCRIPTION
Makes the GHA eval fail when stderr isn't empty, closing https://github.com/NixOS/nixpkgs/issues/371223.

## Things done

- [x] Manually tested locally that warnings fail the eval.

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
