### PR TITLE
stack-client: init at 5.3.1

### DIFF
--- a/pkgs/applications/networking/stack-client/default.nix
+++ b/pkgs/applications/networking/stack-client/default.nix
@@ -1,33 +1,51 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, pkg-config, extra-cmake-modules
-, qt6, zlib, sqlite, kdePackages, callPackage }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, cmake
+, pkg-config
+, extra-cmake-modules
+, qt6
+, zlib
+, sqlite
+, kdePackages
+, callPackage
+}:
 
 let
   kdsingleapplication = callPackage ./kdsingleapplication.nix { };
 
-  libre-graph-api = stdenv.mkDerivation rec {
-    pname = "libre-graph-api-cpp-qt-client";
-    version = "1.0.4";
+libre-graph-api = stdenv.mkDerivation rec {
+pname = "libre-graph-api-cpp-qt-client";
+version = "1.0.4";
 
-    src = fetchFromGitHub {
-      owner = "owncloud";
-      repo = "libre-graph-api-cpp-qt-client";
-      rev = "v${version}";
-      sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
-    };
+src = fetchFromGitHub {
+    owner = "owncloud";
+    repo = "libre-graph-api-cpp-qt-client";
+    rev = "v${version}";
+    sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
+};
 
-    preConfigure = "cd client";
+preConfigure = "cd client";
 
-    nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
+nativeBuildInputs = [ 
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+];
 
-    buildInputs = [ qt6.qtbase qt6.qttools ];
+buildInputs = [
+    qt6.qtbase
+    qt6.qttools
+];
 
-    meta = with lib; {
-      description = "C++ Qt client library for Libre Graph API";
-      homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
-      license = licenses.asl20;
-      platforms = platforms.linux;
-    };
-  };
+meta = with lib; {
+    description = "C++ Qt client library for Libre Graph API";
+    homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+};
+};
 in stdenv.mkDerivation rec {
   pname = "stack-client";
   version = "5.3.1";
@@ -38,11 +56,20 @@ in stdenv.mkDerivation rec {
     sha256 = "ac69699edb1618ef094e4b642fe72c87bf15e65026029486bef50826a746e19c";
   };
 
-  nativeBuildInputs =
-    [ cmake extra-cmake-modules qt6.qttools qt6.wrapQtAppsHook ];
+nativeBuildInputs = [
+cmake
+extra-cmake-modules
+qt6.qttools
+qt6.wrapQtAppsHook
+];
 
-  buildInputs =
-    [ qt6.qtbase kdePackages.qtkeychain zlib sqlite libre-graph-api ];
+buildInputs = [
+qt6.qtbase
+kdePackages.qtkeychain
+zlib
+sqlite
+libre-graph-api
+];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/applications/networking/stack-client/default.nix
+++ b/pkgs/applications/networking/stack-client/default.nix
@@ -1,0 +1,80 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, pkg-config, extra-cmake-modules
+, qt6, zlib, sqlite, kdePackages, callPackage }:
+
+let
+  kdsingleapplication = callPackage ./kdsingleapplication.nix { };
+
+  libre-graph-api = stdenv.mkDerivation rec {
+    pname = "libre-graph-api-cpp-qt-client";
+    version = "1.0.4";
+
+    src = fetchFromGitHub {
+      owner = "owncloud";
+      repo = "libre-graph-api-cpp-qt-client";
+      rev = "v${version}";
+      sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
+    };
+
+    preConfigure = "cd client";
+
+    nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
+
+    buildInputs = [ qt6.qtbase qt6.qttools ];
+
+    meta = with lib; {
+      description = "C++ Qt client library for Libre Graph API";
+      homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
+      license = licenses.asl20;
+      platforms = platforms.linux;
+    };
+  };
+in stdenv.mkDerivation rec {
+  pname = "stack-client";
+  version = "5.3.1";
+
+  src = fetchurl {
+    url =
+      "https://filehosting-client.transip.nl/packages/stack-source-5.3.1.tar.gz";
+    sha256 = "ac69699edb1618ef094e4b642fe72c87bf15e65026029486bef50826a746e19c";
+  };
+
+  nativeBuildInputs =
+    [ cmake extra-cmake-modules qt6.qttools qt6.wrapQtAppsHook ];
+
+  buildInputs =
+    [ qt6.qtbase kdePackages.qtkeychain zlib sqlite libre-graph-api ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_PREFIX_PATH=${kdsingleapplication}"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt6.qtbase}/${qt6.qtbase.qtPluginPrefix}"
+    "--prefix QML2_IMPORT_PATH : ${qt6.qtbase}/${qt6.qtbase.qtQmlPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "Stack Client Application - A secure cloud storage solution";
+    longDescription = ''
+      Stack Client is a desktop application that provides secure cloud storage and file 
+      synchronization services by TransIP. It offers a robust set of features for both 
+      personal and business users:
+
+      Features:
+      * Secure file synchronization across devices
+      * Seamless desktop integration
+      * File sharing capabilities with granular permissions
+      * Automatic background synchronization
+      * Version control and file history
+      * Built-in security features
+      * Cross-platform support
+    '';
+    homepage = "https://www.transip.nl/stack/";
+    changelog = "https://www.transip.nl/stack/changelog/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ timoteuszelle ];
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/applications/networking/stack-client/default.nix
+++ b/pkgs/applications/networking/stack-client/default.nix
@@ -1,51 +1,33 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchurl
-, cmake
-, pkg-config
-, extra-cmake-modules
-, qt6
-, zlib
-, sqlite
-, kdePackages
-, callPackage
-}:
+{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, pkg-config, extra-cmake-modules
+, qt6, zlib, sqlite, kdePackages, callPackage }:
 
 let
   kdsingleapplication = callPackage ./kdsingleapplication.nix { };
 
-libre-graph-api = stdenv.mkDerivation rec {
-pname = "libre-graph-api-cpp-qt-client";
-version = "1.0.4";
+  libre-graph-api = stdenv.mkDerivation rec {
+    pname = "libre-graph-api-cpp-qt-client";
+    version = "1.0.4";
 
-src = fetchFromGitHub {
-    owner = "owncloud";
-    repo = "libre-graph-api-cpp-qt-client";
-    rev = "v${version}";
-    sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
-};
+    src = fetchFromGitHub {
+      owner = "owncloud";
+      repo = "libre-graph-api-cpp-qt-client";
+      rev = "v${version}";
+      sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
+    };
 
-preConfigure = "cd client";
+    preConfigure = "cd client";
 
-nativeBuildInputs = [
-    cmake
-    pkg-config
-    qt6.wrapQtAppsHook
-];
+    nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
 
-buildInputs = [
-    qt6.qtbase
-    qt6.qttools
-];
+    buildInputs = [ qt6.qtbase qt6.qttools ];
 
-meta = with lib; {
-    description = "C++ Qt client library for Libre Graph API";
-    homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
-    license = licenses.asl20;
-    platforms = platforms.linux;
-};
-};
+    meta = with lib; {
+      description = "C++ Qt client library for Libre Graph API";
+      homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
+      license = licenses.asl20;
+      platforms = platforms.linux;
+    };
+  };
 in stdenv.mkDerivation rec {
   pname = "stack-client";
   version = "5.3.1";
@@ -56,20 +38,11 @@ in stdenv.mkDerivation rec {
     sha256 = "ac69699edb1618ef094e4b642fe72c87bf15e65026029486bef50826a746e19c";
   };
 
-nativeBuildInputs = [
-cmake
-extra-cmake-modules
-qt6.qttools
-qt6.wrapQtAppsHook
-];
+  nativeBuildInputs =
+    [ cmake extra-cmake-modules qt6.qttools qt6.wrapQtAppsHook ];
 
-buildInputs = [
-qt6.qtbase
-kdePackages.qtkeychain
-zlib
-sqlite
-libre-graph-api
-];
+  buildInputs =
+    [ qt6.qtbase kdePackages.qtkeychain zlib sqlite libre-graph-api ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/applications/networking/stack-client/default.nix
+++ b/pkgs/applications/networking/stack-client/default.nix
@@ -28,7 +28,7 @@ src = fetchFromGitHub {
 
 preConfigure = "cd client";
 
-nativeBuildInputs = [ 
+nativeBuildInputs = [
     cmake
     pkg-config
     qt6.wrapQtAppsHook

--- a/pkgs/applications/networking/stack-client/default.nix
+++ b/pkgs/applications/networking/stack-client/default.nix
@@ -57,8 +57,8 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Stack Client Application - A secure cloud storage solution";
     longDescription = ''
-      Stack Client is a desktop application that provides secure cloud storage and file 
-      synchronization services by TransIP. It offers a robust set of features for both 
+      Stack Client is a desktop application that provides secure cloud storage and file
+      synchronization services by TransIP. It offers a robust set of features for both
       personal and business users:
 
       Features:

--- a/pkgs/applications/networking/stack-client/kdsingleapplication.nix
+++ b/pkgs/applications/networking/stack-client/kdsingleapplication.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, qt6 }:
+
+stdenv.mkDerivation rec {
+  pname = "kdsingleapplication-qt6";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "KDAB";
+    repo = "KDSingleApplication";
+    rev = "v${version}";
+    sha256 = "sha256-Ymm+qOZMWULg7u5xEpGzcAfIrbWBQ3jsndnFSnh6/PA=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules qt6.wrapQtAppsHook ];
+  buildInputs = [ qt6.qtbase ];
+
+  cmakeFlags =
+    [ "-DKDSingleApplication_QT6=ON" "-DKDSingleApplication_EXAMPLES=OFF" ];
+
+  meta = with lib; {
+    description = "Single instance application library for Qt6";
+    homepage = "https://github.com/KDAB/KDSingleApplication";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/applications/networking/stack-client/kdsingleapplication.nix
+++ b/pkgs/applications/networking/stack-client/kdsingleapplication.nix
@@ -1,10 +1,4 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, extra-cmake-modules
-, qt6
-}:
+{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, qt6 }:
 
 stdenv.mkDerivation rec {
   pname = "kdsingleapplication-qt6";
@@ -17,20 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ymm+qOZMWULg7u5xEpGzcAfIrbWBQ3jsndnFSnh6/PA=";
   };
 
-nativeBuildInputs = [
-cmake
-extra-cmake-modules
-qt6.wrapQtAppsHook
-];
+  nativeBuildInputs = [ cmake extra-cmake-modules qt6.wrapQtAppsHook ];
 
-buildInputs = [
-qt6.qtbase
-];
+  buildInputs = [ qt6.qtbase ];
 
-cmakeFlags = [
-"-DKDSingleApplication_QT6=ON"
-"-DKDSingleApplication_EXAMPLES=OFF"
-];
+  cmakeFlags =
+    [ "-DKDSingleApplication_QT6=ON" "-DKDSingleApplication_EXAMPLES=OFF" ];
 
   meta = with lib; {
     description = "Single instance application library for Qt6";

--- a/pkgs/applications/networking/stack-client/kdsingleapplication.nix
+++ b/pkgs/applications/networking/stack-client/kdsingleapplication.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, qt6 }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, qt6
+}:
 
 stdenv.mkDerivation rec {
   pname = "kdsingleapplication-qt6";
@@ -11,11 +17,20 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ymm+qOZMWULg7u5xEpGzcAfIrbWBQ3jsndnFSnh6/PA=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules qt6.wrapQtAppsHook ];
-  buildInputs = [ qt6.qtbase ];
+nativeBuildInputs = [
+cmake
+extra-cmake-modules
+qt6.wrapQtAppsHook
+];
 
-  cmakeFlags =
-    [ "-DKDSingleApplication_QT6=ON" "-DKDSingleApplication_EXAMPLES=OFF" ];
+buildInputs = [
+qt6.qtbase
+];
+
+cmakeFlags = [
+"-DKDSingleApplication_QT6=ON"
+"-DKDSingleApplication_EXAMPLES=OFF"
+];
 
   meta = with lib; {
     description = "Single instance application library for Qt6";


### PR DESCRIPTION
Add Stack client, a WebDAV-based cloud storage client by TransIP. Homepage: https://www.transip.nl/stack/

This PR adds the Stack client, which is a desktop application that allows users to sync and manage their files with TransIP's Stack cloud storage service. The client uses WebDAV protocol for communication with the cloud storage.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Added a release notes entry (not needed for new packages)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)