### PR TITLE
copilot-language-server: init at 1.273.0

### DIFF
--- a/pkgs/by-name/co/copilot-language-server/package-lock.json
+++ b/pkgs/by-name/co/copilot-language-server/package-lock.json
@@ -1,0 +1,44 @@
+{
+    "name": "@github/copilot-language-server",
+    "version": "1.273.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@github/copilot-language-server",
+            "version": "1.273.0",
+            "license": "https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features",
+            "dependencies": {
+                "vscode-languageserver-protocol": "^3.17.5"
+            },
+            "bin": {
+                "copilot-language-server": "dist/language-server.js"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "license": "MIT"
+        }
+    }
+}

--- a/pkgs/by-name/co/copilot-language-server/package.nix
+++ b/pkgs/by-name/co/copilot-language-server/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchurl,
+}:
+
+buildNpmPackage rec {
+  pname = "copilot-language-server";
+  version = "1.273.0";
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@github/copilot-language-server/-/copilot-language-server-${version}.tgz";
+    hash = "sha256-S3LhyNg8sSJPl+vnMir4AbyerORz0b1S7JyjCeoXW2E=";
+  };
+
+  npmDepsHash = "sha256-ikITGNY6a6SKOSTBU9q4sQMX51mOxMix+a1Bt+h9wGw=";
+
+  postPatch = ''
+    ln -s ${./package-lock.json} package-lock.json
+  '';
+
+  postInstall = ''
+    ln -s $out/lib/node_modules/@github/copilot-language-server/dist $out/lib/node_modules/@github/dist
+  '';
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Use GitHub Copilot with any editor or IDE via the Language Server Protocol";
+    homepage = "https://github.com/features/copilot";
+    license = {
+      deprecated = false;
+      free = false;
+      fullName = "GitHub Copilot Product Specific Terms";
+      redistributable = false;
+      shortName = "GitHub Copilot License";
+      url = "https://github.com/customer-terms/github-copilot-product-specific-terms";
+    };
+    mainProgram = "copilot-language-server";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ arunoruto ];
+  };
+}

--- a/pkgs/by-name/co/copilot-language-server/update.sh
+++ b/pkgs/by-name/co/copilot-language-server/update.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p gnused nix nodejs prefetch-npm-deps wget
+
+set -euo pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+
+version=$(npm view @github/copilot-language-server version)
+tarball="copilot-language-server-$version.tgz"
+url="https://registry.npmjs.org/@github/copilot-language-server/-/$tarball"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+    echo "Already up to date!"
+    exit 0
+fi
+
+sed -i 's#version = "[^"]*"#version = "'"$version"'"#' package.nix
+
+sha256=$(nix-prefetch-url "$url")
+src_hash=$(nix-hash --to-sri --type sha256 "$sha256")
+sed -i 's#hash = "[^"]*"#hash = "'"$src_hash"'"#' package.nix
+
+rm -f package-lock.json package.json *.tgz
+wget "$url"
+tar xf "$tarball" --strip-components=1 package/package.json
+npm i --package-lock-only --ignore-scripts
+npm_hash=$(prefetch-npm-deps package-lock.json)
+sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' package.nix
+rm -f package.json *.tgz
+
+popd


### PR DESCRIPTION
This is the first time I am adding an npm package to nixpkgs. Feel free to correct me, if I did something wrong!

I am aware that lock files are not desired in nixpkgs (#327064), but the copilot ls is still in a private repo by GitHub, so there is not way to contact them to provide a lockfile themselves. If they ever decide to provide a lock file in their tarball, I would delete the one from nixpkgs and use theirs!

npmjs: https://www.npmjs.com/package/@github/copilot-language-server

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
