### PR TITLE
zoom-us: fix memory usage bug, add test, update

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -40,6 +40,7 @@
   pulseaudioSupport ? true,
   libpulseaudio,
   pulseaudio,
+  callPackage,
 }:
 
 let
@@ -220,6 +221,7 @@ stdenv.mkDerivation {
   dontPatchELF = true;
 
   passthru.updateScript = ./update.sh;
+  passthru.tests.startwindow = callPackage ./test.nix { };
 
   meta = with lib; {
     homepage = "https://zoom.us/";

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -123,6 +123,7 @@ let
       coreutils
       glib.dev
       pciutils
+      pipewire
       procps
       util-linux
     ]

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -51,23 +51,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.3.1.45300";
-  versions.x86_64-darwin = "6.3.1.45300";
-  versions.x86_64-linux = "6.2.11.5069";
+  versions.aarch64-darwin = "6.3.6.47101";
+  versions.x86_64-darwin = "6.3.6.47101";
+  versions.x86_64-linux = "6.3.6.6315";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-WPhqYof/XR6TDkuA4NK2a30ksdhN7NBfs4KCQwqKJ0g=";
+      hash = "sha256-tqDf3Z5RRf4aRvtINWdM3oppZXbDdtihhPBHu4QxzDM=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-BywBvJCcNXARHTkO/UJbOFRjuiXRkmFWmSuZsW9t1pk=";
+      hash = "sha256-BZkBx5eZ3c3p9JIz+ChyJrGM12HwyNToSuS86f9QnF0=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-k8T/lmfgAFxW1nwEyh61lagrlHP5geT2tA7e5j61+qw=";
+      hash = "sha256-QJR8SsMtyYBvd5G+mEjEEISkJJukCYeHErKrgs1uDQc=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/test.nix
+++ b/pkgs/by-name/zo/zoom-us/test.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  xvfb-run,
+  zoom-us,
+  runCommand,
+  writeShellApplication,
+  xorg,
+}:
+
+let
+  testScript = writeShellApplication {
+    name = "zoom-us-test-script";
+    runtimeInputs = [
+      xorg.xwininfo
+      zoom-us
+    ];
+    text = ''
+      function is_zoom_window_present {
+        echo
+        xwininfo -root -tree  \
+            | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'  \
+            | tee window-names
+        grep -q "Zoom Workplace" window-names
+      }
+      # don't let zoom eat all RAM, like it did
+      # https://github.com/NixOS/nixpkgs/issues/371488
+      prlimit --{as,data}=$((4*2**30)):$((4*2**30)) zoom-us &
+      for _ in {0..900} ; do
+        if is_zoom_window_present ; then
+          break
+        fi
+        sleep 1
+      done
+      # if libraries are missing, the window still appears,
+      # but disappears again immediatelly; check for that too:
+      sleep 20
+      is_zoom_window_present
+    '';
+  };
+in
+runCommand "zoom-us-test" { buildInputs = [ xvfb-run ]; } ''
+  HOME=$PWD xvfb-run ${lib.getExe testScript}
+  touch ${placeholder "out"}
+''


### PR DESCRIPTION
*   Fix https://github.com/NixOS/nixpkgs/issues/371488 .
*   Update zoom (supersede https://github.com/NixOS/nixpkgs/pull/369514 ).
*   Add simple test for `zoom-us`.
*   Fix an error message about missing `pipewire`.

This is done with four commits (see their messages for more information):

*   Add a simple test derivation that starts zoom and checks for the zoom window to appear.  This should help catching bad updates.
*   Change the build recipe such that it is compatible with newer zoom versions: `zoom` eats all RAM as soon as it is touched by `patchelf`.  I haven't been able to uncover the reason for this.  However, by poking zoom inside a flatpak container and inside a `buildFHSEnv` container, it turned out it works well if called indirectly by calling the elf interpreter `ld-linux-x86-64.so.2` with the `zoom` binary as argument.  However, this generates a half-working zoom only -- e.g. it fails to play its usual notification sounds.  `strace` shows that it is looking for its files in the directory of the elf interpreter, because it assumes its own data files are stored where `/proc/self/exe` points to.  So we need to copy the elf interpreter in zooms data directory to make zoom find its files again.  Note that a symlink doesn't work -- apparently zoom follows that one.  Also settings argv0 doesn't help as this does not alter `/proc/self/exe`.
*   Update to newest zoom version: This simply cherry-picks the commit from https://github.com/NixOS/nixpkgs/pull/369514 .
*   `pipewire` is added to `PATH` to silence an error message.

Manipulating all those dynamic linking mechanisms felt awkward.  I guess this pull requests need thorough testing.

<details>
  <summary>If you want to test it inside a NixOS installation, you can use this overlay</summary>

```nix
config.nixpkgs.overlays = [( finalPkgs: prevPkgs: {
  zoom-us = prevPkgs.zoom-us.overrideAttrs (finalAttrs: prevAttrs: {
    version = "6.3.6.6315";
    src = finalPkgs.fetchurl {
      url = "https://zoom.us/client/${finalAttrs.version}/zoom_x86_64.pkg.tar.xz";
      hash = "sha256-QJR8SsMtyYBvd5G+mEjEEISkJJukCYeHErKrgs1uDQc=";
    };
    postFixup = finalPkgs.lib.replaceStrings
      [
        ''zopen zoom ZoomLauncher''
        ''makeWrapper $out/opt/zoom/.zoom $out/opt/zoom/zoom''
        '' PATH : ''
      ]
      [
        ''zopen ZoomLauncher''
        ''cp "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zoom/ld.so ; makeWrapper $out/opt/zoom/{ld.so,zoom} --add-flags $out/opt/zoom/.zoom''
        '' PATH : ${finalPkgs.lib.makeBinPath [ finalPkgs.pipewire ]}:''
      ]
      prevAttrs.postFixup
    ;
  });
})];
```

</details>

Notifying maintainers: @danbst @tadfisher


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More (tested with the overlay stated above, on NixOS 24.11, X11, Plasma5, PulseAudio):

- [x] sending camera picture in video conference works
- [x] receiving camera picture in video conference works
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude
- [x] audio is produced: Test speaker generates audible ting-a-ling
- [x] audio is received in video conference
- [x] video is received in video conference
- [x] screen sharing sends screen to other participants
- [x] screen sharing of other participants is shown (tested without `pkgs.pipewire` in `PATH`)
- [x] reading team chat messages works as expected
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual

`nixpkgs-review` tries to rebuild 6269 packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc