### PR TITLE
workflows/eval-lib-tests: Run on maintainer changes

### DIFF
--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     paths:
       - 'lib/**'
+      - 'maintainers/**'
 
 permissions: {}
 


### PR DESCRIPTION
The lib tests also check maintainers, not doing so can cause problems: https://github.com/NixOS/nixpkgs/pull/379894

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
