### PR TITLE
Revert "python312Packages.catboost: mark as broken"

### DIFF
--- a/pkgs/development/python-modules/catboost/default.nix
+++ b/pkgs/development/python-modules/catboost/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
     pname
     version
     src
+    meta
     ;
-
   pyproject = true;
 
   sourceRoot = "${src.name}/catboost/python-package";
@@ -55,10 +55,4 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "catboost" ];
-
-  meta = catboost.meta // {
-    # Incompatible with numpy >= 2.0
-    # https://github.com/catboost/catboost/issues/2671
-    broken = true;
-  };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#381085 because it's a duplicate of https://github.com/NixOS/nixpkgs/pull/381056