### PR TITLE
canon-cups-ufr2: Rework build script with RPM spec

### DIFF
--- a/pkgs/by-name/ca/canon-cups-ufr2/package.nix
+++ b/pkgs/by-name/ca/canon-cups-ufr2/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
   stdenv,
+  writeTextFile,
+  writeScript,
   fetchurl,
   unzip,
   autoconf,
@@ -61,6 +63,43 @@ let
     cairo
     atk
   ];
+
+  convertSpec = writeTextFile {
+    name = "convert-spec.awk";
+    checkPhase = "awk -f $target < /dev/null";
+    text = ''
+      $1 == "%" phase { inPhase = 1; next }
+      inPhase && /^%/ { exit }
+
+      inPhase {
+        gsub("[$]{RPM_BUILD_DIR}", "$sourceRoot");
+        gsub("[$]{RPM_BUILD_ROOT}", "");
+        gsub("%{nobuild}", "0");
+        gsub("%{_builddir}", "$sourceRoot");
+        gsub("%{_prefix}", "$out");
+        gsub("%{_libsarch}", "libs64/${system}");
+        gsub("%{_libdir}", "$out/lib");
+        gsub("%{locallibs}", "$out/lib");
+        gsub("%{_bindir}", "$out/bin");
+        gsub("%{_includedir}", "$out/include");
+        gsub("%{_cflags}", "");
+        gsub("%{_machine_type}", "MACHINETYPE=${stdenv.hostPlatform.parsed.cpu.name}");
+        gsub("%{common_dir}", "cnrdrvcups-common-${version}");
+        gsub("%{driver_dir}", "cnrdrvcups-lb-${version}");
+        gsub("%{utility_dir}", "cnrdrvcups-utility-${version}");
+        gsub("%{b_lib_dir}", "$sourceRoot/lib");
+        gsub("%{b_include_dir}", "$sourceRoot/include");
+        gsub("-m 4755", "-m 755"); # no setuid
+
+        if (/%/) {
+          print "error: variable not replaced:", $0 > "/dev/stderr"
+          print "exit 1"
+          exit 1
+        }
+        print
+      }
+    '';
+  };
 in
 stdenv.mkDerivation rec {
   pname = "canon-cups-ufr2";
@@ -71,26 +110,30 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   postUnpack = ''
+    export sourceRoot=$PWD/$sourceRoot
     (
       cd $sourceRoot
       tar -xf Sources/cnrdrvcups-lb-${version}-1.${suffix2}.tar.xz
-      sed -i -e "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-common-${version}/allgen.sh
-      sed -i -e "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-common-${version}/allgen.sh
-      sed -i -e "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-common-${version}/allgen.sh
-      sed -i -e "s@/usr@$out@" cnrdrvcups-common-${version}/{{backend,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h}
-      sed -i -e "s@etc/cngplp@$out/etc/cngplp@" cnrdrvcups-common-${version}/cngplp/Makefile.am
-      sed -i -e "s@usr/share/cngplp@$out/usr/share/cngplp@" cnrdrvcups-common-${version}/cngplp/src/Makefile.am
-      patchShebangs cnrdrvcups-common-${version}
-
-      sed -i -e "s@_prefix=/usr@_prefix=$out@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -i -e "s@_libdir=/usr/lib@_libdir=$out/lib@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -i -e "s@_bindir=/usr/bin@_bindir=$out/bin@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -i -e '/^cd \.\.\/cngplp/,/^cd files/{/^cd files/!{d}}' cnrdrvcups-lb-${version}/allgen.sh
-      sed -i -e "s@cd \.\./pdftocpca@cd pdftocpca@" cnrdrvcups-lb-${version}/allgen.sh
-      sed -i -e "s@/usr@$out@" cnrdrvcups-lb-${version}/pdftocpca/Makefile.am
-      sed -i "/CNGPLPDIR/d" cnrdrvcups-lb-${version}/Makefile
-      patchShebangs cnrdrvcups-lb-${version}
     )
+  '';
+
+  patches = [
+    ./replace_incorrect_int_with_char.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace $(find cnrdrvcups-lb-${version}/cngplp -name Makefile.am) \
+      --replace-quiet /usr/include/libxml2/ ${libxml2.dev}/include/libxml2/
+
+    substituteInPlace \
+      cnrdrvcups-common-${version}/{{backend,cngplp/src,rasterfilter}/Makefile.am,rasterfilter/cnrasterproc.h} \
+      cnrdrvcups-lb-${version}/{cngplp/files,pdftocpca}/Makefile.am \
+      --replace-fail /usr "$out"
+
+    substituteInPlace cnrdrvcups-common-${version}/cngplp/Makefile.am \
+      --replace-fail etc/cngplp "$out/etc/cngplp"
+
+    patchShebangs cnrdrvcups-common-${version} cnrdrvcups-lb-${version}
   '';
 
   nativeBuildInputs = [
@@ -104,77 +147,38 @@ stdenv.mkDerivation rec {
 
   inherit buildInputs;
 
+  configureScript = writeScript "canon-cups-ufr2-configure" ''
+    set -eu
+    # Update old automake files
+    for dir in \
+      cnrdrvcups-common-${version}/{backend,buftool,cngplp,cnjbig,rasterfilter} \
+      cnrdrvcups-lb-${version}/{cngplp/files,cngplp,cpca,pdftocpca}
+    do
+      echo autoreconf $dir
+      pushd "$dir"
+      # For some reason, autoreconf fails to create ltmain.sh on first run.
+      autoreconf --force --install --warnings=none || autoreconf --force --install --warnings=none
+      popd
+    done
+
+    awk -f ${convertSpec} -v phase=setup cnrdrvcups-lb.spec | bash -eux
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    awk -f ${convertSpec} -v phase=build cnrdrvcups-lb.spec | bash -eux
+
+    runHook postBuild
+  '';
+
   installPhase = ''
     runHook preInstall
 
-    (
-      cd cnrdrvcups-common-${version}
-      ./allgen.sh
-      make install
-    )
-    (
-      cd cnrdrvcups-common-${version}/Rule
-      mkdir -p $out/share/cups/usb
-      install -m 644 *.usb-quirks $out/share/cups/usb
-    )
-    (
-      cd cnrdrvcups-lb-${version}
-      ./allgen.sh
-      make install
-
-      mkdir -p $out/share/cups/model
-      install -m 644 ppd/*.ppd $out/share/cups/model/
-    )
-
-    (
-      cd lib
-      mkdir -p $out/lib
-      install -m 755 libs64/${system}/libColorGearCufr2.so.2.0.0 $out/lib
-      install -m 755 libs64/${system}/libcaepcmufr2.so.1.0 $out/lib
-      install -m 755 libs64/${system}/libcaiocnpkbidir.so.1.0.0 $out/lib
-      install -m 755 libs64/${system}/libcaiousb.so.1.0.0 $out/lib
-      install -m 755 libs64/${system}/libcaiowrapufr2.so.1.0.0 $out/lib
-      install -m 755 libs64/${system}/libcanon_slimufr2.so.1.0.0 $out/lib
-      install -m 755 libs64/${system}/libcanonufr2r.so.1.0.0 $out/lib
-      install -m 755 libs64/${system}/libcnaccm.so.1.0 $out/lib
-      install -m 755 libs64/${system}/libcnlbcmr.so.1.0 $out/lib
-      install -m 755 libs64/${system}/libcnncapcmr.so.1.0 $out/lib
-      install -m 755 libs64/${system}/libufr2filterr.so.1.0.0 $out/lib
-
-      install -m 755 libs64/${system}/cnpdfdrv $out/bin
-      install -m 755 libs64/${system}/cnpkbidir $out/bin
-      install -m 755 libs64/${system}/cnpkmoduleufr2r $out/bin
-      install -m 755 libs64/${system}/cnrsdrvufr2 $out/bin
-      install -m 755 libs64/${system}/cnsetuputil2 $out/bin/cnsetuputil2
-
-      mkdir -p $out/share/cnpkbidir
-      install -m 644 libs64/${system}/cnpkbidir_info* $out/share/cnpkbidir
-
-      mkdir -p $out/share/ufr2filter
-      install -m 644 libs64/${system}/ThLB* $out/share/ufr2filter
-    )
+    awk -f ${convertSpec} -v phase=install cnrdrvcups-lb.spec | bash -eux
 
     (
       cd $out/lib
-
-      ln -sf libColorGearCufr2.so.2.0.0 libColorGearCufr2.so
-      ln -sf libColorGearCufr2.so.2.0.0 libColorGearCufr2.so.2
-      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so
-      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so.1
-      ln -sf libcaiocnpkbidir.so.1.0.0 libcaiocnpkbidir.so
-      ln -sf libcaiocnpkbidir.so.1.0.0 libcaiocnpkbidir.so.1
-      ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so
-      ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so.1
-      ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so
-      ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so.1
-      ln -sf libcanonufr2r.so.1.0.0 libcanonufr2r.so
-      ln -sf libcanonufr2r.so.1.0.0 libcanonufr2r.so.1
-      ln -sf libcnlbcmr.so.1.0 libcnlbcmr.so
-      ln -sf libcnlbcmr.so.1.0 libcnlbcmr.so.1
-      ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so
-      ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so.1
-      ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so
-      ln -sf libuictlufr2r.so.1.0.0 libuictlufr2r.so.1
 
       patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64:$out/lib" libcanonufr2r.so.1.0.0
       patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${lib.getLib stdenv.cc.cc}/lib64:${stdenv.cc.libc}/lib64" libcaepcmufr2.so.1.0
@@ -194,21 +198,6 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/cnsetuputil2 \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
         --set NIX_REDIRECTS /usr/share/cnsetuputil2=$out/usr/share/cnsetuputil2
-    )
-
-    (
-      cd lib/data/ufr2
-      mkdir -p $out/share/caepcm
-      install -m 644 *.ICC $out/share/caepcm
-      install -m 644 *.icc $out/share/caepcm
-      install -m 644 *.PRF $out/share/caepcm
-      install -m 644 CnLB* $out/share/caepcm
-    )
-
-    (
-      cd cnrdrvcups-utility-${version}/data
-      mkdir -p $out/usr/share/cnsetuputil2
-      install -m 644 cnsetuputil* $out/usr/share/cnsetuputil2
     )
 
     makeWrapper "${ghostscript}/bin/gs" "$out/bin/gs" \

--- a/pkgs/by-name/ca/canon-cups-ufr2/replace_incorrect_int_with_char.patch
+++ b/pkgs/by-name/ca/canon-cups-ufr2/replace_incorrect_int_with_char.patch
@@ -1,0 +1,11 @@
+--- ./cnrdrvcups-lb-6.00/cngplp/cngplpmod/execjob.c	2024-01-08 04:18:42.000000000 +0100
++++ ./cnrdrvcups-lb-6.00/cngplp/cngplpmod/execjob.c	2024-08-06 17:13:52.234522912 +0200
+@@ -1161,7 +1161,7 @@
+ 			ptr_param += num;
+ 			list_num += num;
+ 			if (strlen(ppd_opt->job_result_notice_address) > 0){
+-				num = add_param_int(ptr_param, kPPD_Items_CNJobResultNoticeAddress, ppd_opt->job_result_notice_address);
++				num = add_param_char(ptr_param, kPPD_Items_CNJobResultNoticeAddress, ppd_opt->job_result_notice_address);
+ 				ptr_param += num;
+ 				list_num += num;
+ 			}


### PR DESCRIPTION
Strongly inspired by the AUR package [1], this commit removes most manual build and install commands in favor of reusing the RPM spec file.

With the rework and a small patch, cngplp now builds and is installed correctly. Previously, we would skip building cngplp, resulting in broken symlinks in the output folder.

[1]: https://aur.archlinux.org/packages/cnrdrvcups-lb

Fixes #380572


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
