### PR TITLE
nixos/services.mysql: fix wait for galera cluster sync to be done

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -469,7 +469,7 @@ in
                     ( echo 'CREATE DATABASE IF NOT EXISTS `${database.name}`;'
 
                       ${lib.optionalString (database.schema != null) ''
-                        echo 'use `${database.name}`;'
+                        echo 'USE `${database.name}`;'
 
                         # TODO: this silently falls through if database.schema does not exist,
                         # we should catch this somehow and exit, but can't do it here because we're in a subshell.
@@ -488,7 +488,7 @@ in
               ${lib.optionalString (cfg.replication.role == "master") ''
                 # Set up the replication master
 
-                ( echo "use mysql;"
+                ( echo "USE mysql;"
                   echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
                   echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
                   echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
@@ -498,9 +498,9 @@ in
               ${lib.optionalString (cfg.replication.role == "slave") ''
                 # Set up the replication slave
 
-                ( echo "stop slave;"
-                  echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
-                  echo "start slave;"
+                ( echo "STOP SLAVE;"
+                  echo "CHANGE MASTER TO MASTER_HOST='${cfg.replication.masterHost}', MASTER_USER='${cfg.replication.masterUser}', MASTER_PASSWORD='${cfg.replication.masterPassword}';"
+                  echo "START SLAVE;"
                 ) | ${cfg.package}/bin/mysql -u ${superUser} -N
               ''}
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -466,7 +466,7 @@ in
                 # Create initial databases
                 if ! test -e "${cfg.dataDir}/${database.name}"; then
                     echo "Creating initial database: ${database.name}"
-                    ( echo 'create database `${database.name}`;'
+                    ( echo 'CREATE DATABASE IF NOT EXISTS `${database.name}`;'
 
                       ${lib.optionalString (database.schema != null) ''
                         echo 'use `${database.name}`;'


### PR DESCRIPTION
When you init a new galera cluster node, it still goes through the init process of the mariadb. but then it syncs while the systemd postStart script wants to do the last "first time inits".

this had trubled me **a lot** till i figured it out.

~~the workaround is to let it fail the first time then manually delete the `/var/lib/mysql/mysql_init` file.~~
nop that may only work if you delete all data and force a new initial sync from another cluster node ... **that is not good if you just want to restart the service!!!**

the error you get other wise on startup is:
```
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 2 [Note] WSREP: ================================================
Feb 10 12:00:54 DB_1 mysql-start[19234]: View:
Feb 10 12:00:54 DB_1 mysql-start[19234]:   id: ab262b68-e4b4-11ef-b301-2fd85ce810cd:470347
Feb 10 12:00:54 DB_1 mysql-start[19234]:   status: primary
Feb 10 12:00:54 DB_1 mysql-start[19234]:   protocol_version: 4
Feb 10 12:00:54 DB_1 mysql-start[19234]:   capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO
Feb 10 12:00:54 DB_1 mysql-start[19234]:   final: no
Feb 10 12:00:54 DB_1 mysql-start[19234]:   own_index: -1
Feb 10 12:00:54 DB_1 mysql-start[19234]:   members(2):
Feb 10 12:00:54 DB_1 mysql-start[19234]:         0: 619b4ff6-e8d6-11ef-925d-36d7fe26bb65, DB_2
Feb 10 12:00:54 DB_1 mysql-start[19234]:         1: ee2b4268-e8d2-11ef-a96d-fb7373fb82b6, DB_3
Feb 10 12:00:54 DB_1 mysql-start[19234]: =================================================
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 2 [Note] WSREP: wsrep_notify_cmd is not defined, skipping notification.
Feb 10 12:00:54 DB_1 systemd-timesyncd[1067]: Network configuration changed, trying to establish connection.
Feb 10 12:00:54 DB_1 systemd-timesyncd[1067]: Network configuration changed, trying to establish connection.
Feb 10 12:00:54 DB_1 systemd-timesyncd[1067]: Contacted time server 193.203.3.170:123 (3.nixos.pool.ntp.org).
Feb 10 12:00:54 DB_1 mysql-post-start[19416]: /nix/store/s4i8abwx7ra38jwqwirxw7m2j6aw1jlk-mariadb-server-11.4.4/bin/mysql: Deprecated program name. It will be removed in a future release, use '/nix/store/s4i8abwx7ra38jwqwirxw7m2j6aw1jlk-mariadb-server-11.4.4/bin/mariadb' instead
Feb 10 12:00:54 DB_1 mysql-post-start[19416]: --------------
Feb 10 12:00:54 DB_1 mysql-post-start[19416]: CREATE USER IF NOT EXISTS 'mysql'@'localhost' IDENTIFIED WITH unix_socket
Feb 10 12:00:54 DB_1 mysql-post-start[19416]: --------------
Feb 10 12:00:54 DB_1 mysql-post-start[19416]: ERROR 1047 (08S01) at line 1: WSREP has not yet prepared node for application use
Feb 10 12:00:54 DB_1 systemd[1]: mysql.service: Control process exited, code=exited, status=1/FAILURE
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] /nix/store/s4i8abwx7ra38jwqwirxw7m2j6aw1jlk-mariadb-server-11.4.4/bin/mysqld (initiated by: unknown): Normal shutdown
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: Shutdown replication
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: Server status change initialized -> disconnecting
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: Closing send monitor...
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: Closed send monitor.
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: gcomm: terminating thread
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: gcomm: joining thread
Feb 10 12:00:54 DB_1 mysql-start[19234]: 2025-02-12  2:00:54 0 [Note] WSREP: gcomm: closing backend

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
