### PR TITLE
plex-desktop: fix hardware acceleration, 1.101.0 -> 1.108.1

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -2,35 +2,24 @@
   alsa-lib,
   autoPatchelfHook,
   buildFHSEnv,
-  dbus,
   elfutils,
-  expat,
   extraEnv ? { },
-  fetchFromGitLab,
   fetchurl,
-  glib,
-  glibc,
+  ffmpeg_6-headless,
   lib,
-  libGL,
-  libapparmor,
-  libbsd,
   libdrm,
   libedit,
-  libffi_3_3,
-  libgcrypt,
-  libglvnd,
+  libpulseaudio,
+  libva,
+  libxkbcommon,
   makeShellWrapper,
-  sqlite,
+  minizip,
+  nss,
   squashfsTools,
   stdenv,
-  tcp_wrappers,
-  udev,
-  waylandpp,
   writeShellScript,
   xkeyboard_config,
   xorg,
-  xz,
-  zstd,
 }:
 let
   pname = "plex-desktop";
@@ -50,17 +39,6 @@ let
     platforms = [ "x86_64-linux" ];
     mainProgram = "plex-desktop";
   };
-
-  # The latest unstable version isn't compatible with libraries that ship in the snap.
-  libglvnd-1_4_0 = libglvnd.overrideAttrs {
-    src = fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "glvnd";
-      repo = "libglvnd";
-      rev = "v1.4.0";
-      sha256 = "sha256-Y6JHRygXcZtnrdnqi1Lzyvh/635gwZWnMeW9aRCpxxs";
-    };
-  };
   plex-desktop = stdenv.mkDerivation {
     inherit pname version meta;
 
@@ -76,25 +54,26 @@ let
     ];
 
     buildInputs = [
-      alsa-lib
-      dbus
       elfutils
-      expat
-      glib
-      libGL
-      libapparmor
-      libbsd
-      libedit
-      libffi_3_3
-      libgcrypt
-      sqlite
+      ffmpeg_6-headless
+      libpulseaudio
+      libva
+      libxkbcommon
+      minizip
+      nss
       stdenv.cc.cc
-      tcp_wrappers
-      udev
-      waylandpp
+      xorg.libXcomposite
+      xorg.libXdamage
       xorg.libXinerama
-      xz
-      zstd
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libxshmfence
+      xorg.xcbutilimage
+      xorg.xcbutilkeysyms
+      xorg.xcbutilrenderutil
+      xorg.xcbutilwm
+      xorg.xrandr
     ];
 
     strictDeps = true;
@@ -112,17 +91,32 @@ let
       runHook preInstall
 
       cp -r . $out
+      rm -r $out/etc
+      rm -r $out/usr
+
+      # flatpak removes these during installation.
+      rm -r $out/lib/dri
+      rm $out/lib/libpciaccess.so*
+      rm $out/lib/libswresample.so*
+      rm $out/lib/libva-*.so*
+      rm $out/lib/libva.so*
+      rm $out/lib/libEGL.so*
+      rm $out/lib/libdrm.so*
+      rm $out/lib/libdrm*
 
       ln -s ${libedit}/lib/libedit.so.0 $out/lib/libedit.so.2
-      rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2
-      ln -s ${alsa-lib}/lib/libasound.so.2 $out/usr/lib/x86_64-linux-gnu/libasound.so.2
-      rm $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
-      ln -s ${alsa-lib}/lib/libasound.so.2.0.0 $out/usr/lib/x86_64-linux-gnu/libasound.so.2.0.0
 
-      ln -snf ${glib.dev}/bin/gio-querymodules $out/usr/bin/gio-querymodules
-      ln -snf ${glib.dev}/bin/glib-compile-schemas $out/usr/bin/glib-compile-schemas
-      rm $out/usr/share/doc/libglib2.0-bin/changelog.Debian.gz
-      rm $out/usr/share/doc/libxml2/NEWS.gz
+      # Keep dependencies where the version from nixpkgs is higher.
+      cp usr/lib/x86_64-linux-gnu/libasound.so.2 $out/lib/libasound.so.2
+      cp usr/lib/x86_64-linux-gnu/libjbig.so.0 $out/lib/libjbig.so.0
+      cp usr/lib/x86_64-linux-gnu/libjpeg.so.8 $out/lib/libjpeg.so.8
+      cp usr/lib/x86_64-linux-gnu/liblcms2.so.2 $out/lib/liblcms2.so.2
+      cp usr/lib/x86_64-linux-gnu/libpci.so.3.6.4 $out/lib/libpci.so.3
+      cp usr/lib/x86_64-linux-gnu/libsnappy.so.1.1.8 $out/lib/libsnappy.so.1
+      cp usr/lib/x86_64-linux-gnu/libtiff.so.5 $out/lib/libtiff.so.5
+      cp usr/lib/x86_64-linux-gnu/libwebp.so.6 $out/lib/libwebp.so.6
+      cp usr/lib/x86_64-linux-gnu/libxkbfile.so.1.0.2 $out/lib/libxkbfile.so.1
+      cp usr/lib/x86_64-linux-gnu/libxslt.so.1.1.34 $out/lib/libxslt.so.1
 
       runHook postInstall
     '';
@@ -131,6 +125,7 @@ in
 buildFHSEnv {
   inherit pname version meta;
   targetPkgs = pkgs: [
+    alsa-lib
     libdrm
     xkeyboard_config
   ];
@@ -158,16 +153,7 @@ buildFHSEnv {
     # db files should have write access.
     chmod --recursive 750 "$PLEX_DB"
 
-    PLEX_USR_PATH=${lib.makeSearchPath "usr/lib/x86_64-linux-gnu" [ plex-desktop ]}
-
     set -o allexport
-    LD_LIBRARY_PATH=${
-      lib.makeLibraryPath [
-        plex-desktop
-        libglvnd-1_4_0
-      ]
-    }:$PLEX_USR_PATH
-    LIBGL_DRIVERS_PATH=$PLEX_USR_PATH/dri
     ${lib.toShellVars extraEnv}
     exec ${plex-desktop}/Plex.sh
   '';

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -23,8 +23,8 @@
 }:
 let
   pname = "plex-desktop";
-  version = "1.101.0";
-  rev = "75";
+  version = "1.108.1";
+  rev = "84";
   meta = {
     homepage = "https://plex.tv/";
     description = "Streaming media player for Plex";
@@ -44,7 +44,7 @@ let
 
     src = fetchurl {
       url = "https://api.snapcraft.io/api/v1/snaps/download/qc6MFRM433ZhI1XjVzErdHivhSOhlpf0_${rev}.snap";
-      hash = "sha512-3ofO4a8HDWeUfjsv+4A5bC0jlQwxIew1CnL39Oa0bjnqShwRQjMW1vSHOjsJ1AHMkbp3h5W/2tFRxPL2C/Heqg==";
+      hash = "sha512-ZcP84maap5Dskf9yECd76gn5x+tWxyVcIo+c0P2VJiQ4VwN2KCgWmwH2JkHzafFCcCFm9EqFBrFlNXWEvnUieQ==";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pl/plex-desktop/update.sh
+++ b/pkgs/by-name/pl/plex-desktop/update.sh
@@ -69,16 +69,3 @@ sed --regexp-extended \
   -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
   -i "$plex_nix"
 
-#
-# try to build the updated version
-#
-
-export NIXPKGS_ALLOW_UNFREE=1
-if ! nix-build -A plex-desktop "$nixpkgs"; then
-  echo "The updated plex-desktop failed to build."
-  exit 1
-fi
-
-# Commit changes
-git add "$plex_nix"
-git commit -m "plex-desktop: ${current_version} -> ${upstream_version}"


### PR DESCRIPTION
The flatpak for Plex ships with several dependencies that are causing problems with things like compatibility and hardware acceleration. This PR removes the libraries that seem to be causing the most issues.

Fixes https://github.com/NixOS/nixpkgs/issues/379807.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
