### PR TITLE
ocamlPackages.atd: 2.15.0 → 2.16.0

### DIFF
--- a/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
@@ -6,11 +6,11 @@
 
 buildDunePackage rec {
   pname = "atdgen-codec-runtime";
-  version = "2.15.0";
+  version = "2.16.0";
 
   src = fetchurl {
     url = "https://github.com/ahrefs/atd/releases/download/${version}/atd-${version}.tbz";
-    hash = "sha256-ukJ5vtVNE9zz9nA6SzF0TbgV3yLAUC2ZZdbGdM4IOTM=";
+    hash = "sha256-Wea0RWICQcvWkBqEKzNmg6+w6xJbOtv+4ovZTNVODe8=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -4,6 +4,7 @@
   atd,
   atdgen-codec-runtime,
   atdgen-runtime,
+  biniou,
   re,
   python3,
 }:
@@ -11,8 +12,6 @@
 buildDunePackage {
   pname = "atdgen";
   inherit (atdgen-codec-runtime) version src;
-
-  duneVersion = "3";
 
   buildInputs = [
     atd
@@ -24,6 +23,7 @@ buildDunePackage {
   doCheck = true;
   nativeCheckInputs = [
     atd
+    biniou
     (python3.withPackages (ps: [ ps.jsonschema ]))
   ];
   checkInputs = [

--- a/pkgs/development/ocaml-modules/atdgen/runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/runtime.nix
@@ -10,7 +10,6 @@ buildDunePackage rec {
   inherit (atdgen-codec-runtime) version src;
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     biniou

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -3,6 +3,7 @@
 , ocaml
 , menhir, menhirLib
 , atdgen
+, atdgen-runtime
 , stdlib-shims
 , re, perl, ncurses
 , ppxlib, ppx_deriving
@@ -47,12 +48,11 @@ in buildDunePackage {
 
   minimalOCamlVersion = "4.07";
 
-  # atdgen is both a library and executable
   nativeBuildInputs = [ perl ]
   ++ [ (if lib.versionAtLeast version "1.15" || version == "dev" then menhir else camlp5) ]
   ++ lib.optional (lib.versionAtLeast version "1.16" || version == "dev") atdgen;
   buildInputs = [ ncurses ]
-  ++ lib.optional (lib.versionAtLeast version "1.16" || version == "dev") atdgen;
+  ++ lib.optional (lib.versionAtLeast version "1.16" || version == "dev") atdgen-runtime;
 
   propagatedBuildInputs = [ re stdlib-shims ]
   ++ (if lib.versionAtLeast version "1.15" || version == "dev"
@@ -73,5 +73,7 @@ in buildDunePackage {
 
   postPatch = ''
     substituteInPlace elpi_REPL.ml --replace-warn "tput cols" "${ncurses}/bin/tput cols"
+  '' + lib.optionalString (lib.versionAtLeast version "1.16" || version == "dev") ''
+    substituteInPlace src/dune --replace-warn ' atdgen re' ' atdgen-runtime re'
   '';
 }

--- a/pkgs/development/ocaml-modules/github/data.nix
+++ b/pkgs/development/ocaml-modules/github/data.nix
@@ -3,13 +3,16 @@
   github,
   yojson,
   atdgen,
+  atdgen-runtime,
 }:
 
 buildDunePackage {
   pname = "github-data";
   inherit (github) version src;
 
-  duneVersion = "3";
+  postPatch = ''
+    substituteInPlace lib_data/dune --replace-warn 'atdgen)' 'atdgen-runtime)'
+  '';
 
   nativeBuildInputs = [
     atdgen
@@ -17,7 +20,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     yojson
-    atdgen
+    atdgen-runtime
   ];
 
   meta = github.meta // {

--- a/pkgs/development/ocaml-modules/gitlab/default.nix
+++ b/pkgs/development/ocaml-modules/gitlab/default.nix
@@ -5,6 +5,7 @@
   uri,
   cohttp-lwt,
   atdgen,
+  atdgen-runtime,
   yojson,
   iso8601,
   stringext,
@@ -21,6 +22,10 @@ buildDunePackage rec {
     hash = "sha256-7pUpH1SoP4eW8ild5j+Tcy+aTXq0+eSkhKUOXJ6Z30k=";
   };
 
+  postPatch = ''
+    substituteInPlace lib/dune --replace-warn 'atdgen str' 'atdgen-runtime str'
+  '';
+
   minimalOCamlVersion = "4.08";
 
   buildInputs = [ stringext ];
@@ -30,7 +35,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     uri
     cohttp-lwt
-    atdgen
+    atdgen-runtime
     yojson
     iso8601
   ];

--- a/pkgs/development/ocaml-modules/reason-native/refmterr.nix
+++ b/pkgs/development/ocaml-modules/reason-native/refmterr.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   atdgen,
+  atdgen-runtime,
   re,
   reason,
   pastel,
@@ -14,13 +15,17 @@ buildDunePackage {
   pname = "refmterr";
   version = "3.3.0-unstable-2024-05-07";
 
+  postPatch = ''
+    substituteInPlace src/refmterr/lib/dune --replace-warn 'atdgen re' 'atdgen-runtime re'
+  '';
+
   nativeBuildInputs = [
     atdgen
     reason
   ];
 
   propagatedBuildInputs = [
-    atdgen
+    atdgen-runtime
     re
     pastel
   ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
