### PR TITLE
apple-sdk_15: 15.0 -> 15.2; darwin.*: source release updates

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
@@ -711,14 +711,14 @@
       "version": "10063.101.15"
     }
   },
-  "15.0": {
+  "15.2": {
     "CarbonHeaders": {
       "hash": "sha256-nIPXnLr21yVnpBhx9K5q3l/nPARA6JL/dED08MeyhP8=",
       "version": "18.1"
     },
     "CommonCrypto": {
-      "hash": "sha256-qwQEFoycAw+YLwqpZgJB1Ppg8mrWFnRPDj4I5f2Ggns=",
-      "version": "600032"
+      "hash": "sha256-+qAwL6+s7di9cX/qXtapLkjCFoDuZaSYltRJEG4qekM=",
+      "version": "600033.60.1"
     },
     "IOAudioFamily": {
       "hash": "sha256-VSk3jvsITJugtL67Qt0m4qJ879i7Fj6B/NGBFVCwpiU=",
@@ -761,12 +761,12 @@
       "version": "598"
     },
     "IOHIDFamily": {
-      "hash": "sha256-4hIztdbKpoC0VrRVwZkoCZuByyTGw02lrrcFDBAXyko=",
-      "version": "2102.0.6"
+      "hash": "sha256-utWAwmn9jss/6fc4flDHXeJR5ZBymO0ZFbDFIFVBnt4=",
+      "version": "2104.61.1"
     },
     "IOKitUser": {
-      "hash": "sha256-ytMma1ft1fKjCvP0SKdwnVonPEixzthoCR7ML94/pLE=",
-      "version": "100140.0.6"
+      "hash": "sha256-vfz/kLZlVyoHKOlrNdNrf2HcUOB6bY+mpbCvEEg2sus=",
+      "version": "100140.60.14"
     },
     "IONetworkingFamily": {
       "hash": "sha256-gZ7Dkk4Iu7AV9K2ioqSeJ1W7bTNxv77bmT18iv3ljLg=",
@@ -777,16 +777,16 @@
       "version": "93"
     },
     "IOStorageFamily": {
-      "hash": "sha256-W9H3jzaXLvAb0cziHBpNo5Iom7c7H5bg4MxQIhIsefc=",
-      "version": "317"
+      "hash": "sha256-tjzvlJYVjSTG7oF3AhHgCASKax1fYjOBAxcsrKh/urY=",
+      "version": "317.40.2"
     },
     "IOUSBFamily": {
       "hash": "sha256-Z0E3TfKP49toYo1Fo9kElRap8CZ+mVDHy5RIexgJTpA=",
       "version": "630.4.5"
     },
     "Libc": {
-      "hash": "sha256-1t+e8DQUmsrmr1f6QUU4uUm/el3G7EOL+vUO28srPAM=",
-      "version": "1669.0.4"
+      "hash": "sha256-/J1Oawa+cMbcAlMlpr6ce32KQQp2lMGnfbRi/2Oc1cY=",
+      "version": "1669.60.4"
     },
     "Libinfo": {
       "hash": "sha256-D7JMCakQVCQ9j2zUHQSGB8zZcHD6azwYY3bsJU0JfEE=",
@@ -797,8 +797,8 @@
       "version": "2026"
     },
     "Libnotify": {
-      "hash": "sha256-qYox9iQUnU0AGVfPK2p61/2zlNAJmixCE5K7WojMQ3I=",
-      "version": "327.0.5"
+      "hash": "sha256-XwVB4sYXPLAHDuLv8mxAWlC1ia17V4cf73DEJDDm4ck=",
+      "version": "327.60.1"
     },
     "Librpcsvc": {
       "hash": "sha256-UWYdCQ9QsBqwM01bWr+igINAHSdSluB/FrOclC5AjTI=",
@@ -813,68 +813,68 @@
       "version": "146"
     },
     "Security": {
-      "hash": "sha256-ptS/IESkJmbcO3H+v6mmN2jvH2mfLXi+fMQfGCLSt7M=",
-      "version": "61439.1.1"
+      "hash": "sha256-sRpFQyMk3x4kRthXpqeAnfQ9dE5RMxiSFUiUKRCneck=",
+      "version": "61439.60.117"
     },
     "architecture": {
       "hash": "sha256-PRNUrhzSOrwmxSPkKmV0LV7yEIik65sdkfKdBqcwFhU=",
       "version": "282"
     },
     "configd": {
-      "hash": "sha256-Wks7d0Kere6YYPJar593ZSC5bbkyKcaTxrHK6Ah6u0c=",
-      "version": "1345"
+      "hash": "sha256-xRaEzq/OOMBi7lvi2bV2/ObN5JJJ5vcFy8DGHLItUWM=",
+      "version": "1351"
     },
     "copyfile": {
-      "hash": "sha256-lIhl5sr1gewIHkh10hD+H/I7MVPzlHlONGRMOO7OZuA=",
-      "version": "213"
+      "hash": "sha256-Vz1fo4p2b6S8xfyDPu1FNgMkH1aX0tkpXCZkdzkRdq0=",
+      "version": "213.40.2"
     },
     "dtrace": {
-      "hash": "sha256-S0gI+9eTcuZkh0FWmTmZ+AhZ4qoSdnUb5GTp1melk9A=",
-      "version": "409"
+      "hash": "sha256-iNEZyxK3DmEwO3gzrfvCaVZSEuuOMQm5IG/6FodPNdI=",
+      "version": "411"
     },
     "dyld": {
-      "hash": "sha256-q0GN5+4mW8Yxer0XxhlLK7JRM4JDoxeSFDRzbZ738lw=",
-      "version": "1231.3"
+      "hash": "sha256-DDhV7X81nhd3oeJuICEvF8FU43yE/afQ/LYgDNtXswA=",
+      "version": "1241.17"
     },
     "eap8021x": {
       "hash": "sha256-2FdEb76KBbCAl2iwly4c1Xstar53O8qgGdN/3WXO23U=",
       "version": "364"
     },
     "hfs": {
-      "hash": "sha256-utmIFAW7Gdbbj71oZnHSaTUse9cIN3ZSfXyFTmuxnc4=",
-      "version": "672"
+      "hash": "sha256-isTLSBDxh12W10I5KY6O6SsygqnOvqJ0TfdWIKSK3pM=",
+      "version": "677.60.1"
     },
     "launchd": {
       "hash": "sha256-8mW9bnuHmRXCx9py8Wy28C5b2QPICW0rlAps5njYa00=",
       "version": "842.1.4"
     },
     "libclosure": {
-      "hash": "sha256-21OuQearKTN75OgHN+RPLR1VGdf3ZffPYpV51Kj6LYE=",
-      "version": "94"
+      "hash": "sha256-I0PKQFnoJVRMA7H3yT+inHS0454/FXHhQB6nwmHFvFs=",
+      "version": "95"
     },
     "libdispatch": {
-      "hash": "sha256-q2oyaEdt8clVLjLwBjAAvLKodpuYThscK3VcQotCmIM=",
-      "version": "1502.0.1"
+      "hash": "sha256-f2ex/53OFeSR5A0nMapxC6AocqBSweecNtEhp4bWjhE=",
+      "version": "1504.60.7"
     },
     "libmalloc": {
-      "hash": "sha256-tFaYSvebk4uIIPu/46eMp6QnwiO/SmShjUoFnJjnmsc=",
-      "version": "646.0.13"
+      "hash": "sha256-Rw/9s7yY3qPtKfDhP+p+0z+aaCsxgwvdUyRG2V1N6D8=",
+      "version": "657.60.21"
     },
     "libplatform": {
-      "hash": "sha256-U3TRUGBxuspEPfzdsd+53Kh8E9GmceMhsxxXuQbcdcc=",
-      "version": "340"
+      "hash": "sha256-o/W1pQ9yGTE8HQlGcggM+XiJbEyqgc/s0uiY3+yBtnA=",
+      "version": "340.60.2"
     },
     "libpthread": {
       "hash": "sha256-eYHDAt2wNk7hJZJxsC7Y9w4ASKdexidu613kPo7TAKs=",
       "version": "535"
     },
     "mDNSResponder": {
-      "hash": "sha256-w+Pw/VsHl8hkDiS7EEEYKp9P2NVwu8NSVPSn2U15vHM=",
-      "version": "2559.1.1"
+      "hash": "sha256-mDyY/2S4EHbGh02J6VWZVxhNXXZmWGX+NjUjPfMZgZA=",
+      "version": "2559.60.39.0.1"
     },
     "objc4": {
-      "hash": "sha256-Z9UAm/hjjO2K0c7ag/ws4e/Y2nKOWnObPgp4HUZe+W4=",
-      "version": "928.2"
+      "hash": "sha256-uBFS5extMQkXAXJfPtPlBYAQpz+zsRHQnEaLpDOcYGM=",
+      "version": "928.3"
     },
     "ppp": {
       "hash": "sha256-8+QUA79sHf85yvGSPE9qCmGsrZDT3NZnbgZVroJw/Hg=",
@@ -885,8 +885,8 @@
       "version": "75"
     },
     "xnu": {
-      "hash": "sha256-9cFPrWtTpCb02YrvKX1KWoExoH2VjPdOBU4dscmKL4A=",
-      "version": "11215.1.10"
+      "hash": "sha256-o8CxHvM2OXiAWJmnFe5ERQYnrNyJ+Bpdb9H0sjd6L10=",
+      "version": "11215.61.5"
     }
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -20,8 +20,8 @@
     "hash": "sha256-QozDiwY0Czc0g45vPD7G4v4Ra+3DujCJbSads3fJjjM="
   },
   "15": {
-    "url": "https://swcdn.apple.com/content/downloads/33/46/042-32691-A_3MH7S3118O/3dblccqo9ws17dc5lk3hojfbt3s74q0ql6/CLTools_macOSNMOS_SDK.pkg",
-    "version": "15.0",
-    "hash": "sha256-JhaAPyfX46D+9sematdAYAORw40JP3xvleWRz7Hj/1s="
+    "url": "https://web.archive.org/web/20250210234739/https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg",
+    "version": "15.2",
+    "hash": "sha256-OP5Ah/JnSZ6sD42BD5vGDmikgFzjsfFBmz1hvQD1dOI="
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -1,21 +1,21 @@
 {
   "11": {
-    "url": "https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg",
+    "url": "https://web.archive.org/web/20250210235110/https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg",
     "version": "11.3",
     "hash": "sha256-/go8utcx3jprf6c8V/DUbXwsmNYSFchOAai1OaJs3Bg="
   },
   "12": {
-    "url": "https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg",
+    "url": "https://web.archive.org/web/20250210235341/https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg",
     "version": "12.3",
     "hash": "sha256-qG21ssNUmkqxPLTXALGP2N/RBHu8NMlI1dWvGlV+Wm8="
   },
   "13": {
-    "url": "https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg",
+    "url": "https://web.archive.org/web/20250210235949/https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg",
     "version": "13.3",
     "hash": "sha256-zZ4pbgoXunLGwdYDemxOfyH4CE5WGfMy2s5jN+0q4B4="
   },
   "14": {
-    "url": "https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
+    "url": "https://web.archive.org/web/20250211001355/https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
     "version": "14.4",
     "hash": "sha256-QozDiwY0Czc0g45vPD7G4v4Ra+3DujCJbSads3fJjjM="
   },

--- a/pkgs/os-specific/darwin/apple-source-releases/PowerManagement/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/PowerManagement/package.nix
@@ -20,7 +20,7 @@ in
 mkAppleDerivation {
   releaseName = "PowerManagement";
 
-  xcodeHash = "sha256-yonvCPa4lJZ9VOO5BIcd0fLsnr0n2v/SHrLTlAJq+q0=";
+  xcodeHash = "sha256-l6lm8aaiJg4H2BQVCjlFldpfhnmPAlsiMK7Cghzuh1E=";
 
   env.NIX_CFLAGS_COMPILE = "-I${privateHeaders}/include";
 

--- a/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/meson.build.in
+++ b/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/meson.build.in
@@ -78,3 +78,15 @@ executable(
     sources : [ 'unifdef/unifdef.c' ],
 )
 install_man('unifdef/unifdef.1')
+
+install_data(
+    'unifdef/unifdefall.sh',
+    install_dir : get_option('bindir'),
+    install_mode : 'r-xr-xr-x',
+    rename : 'unifdefall',
+)
+install_symlink(
+    'unifdefall.1',
+    install_dir : get_option('mandir') / 'man1',
+    pointing_to : 'unifdef.1',
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/developer_cmds/package.nix
@@ -14,7 +14,7 @@ mkAppleDerivation {
     "man"
   ];
 
-  xcodeHash = "sha256-oE1GJF/M4vXLTM7BBjezKqrMu9iTUlEKDBKgwyFqu3k=";
+  xcodeHash = "sha256-NurkF9AnPuaQ7Ev36PCknuTNV6z622yFi2bXZsow+xA=";
 
   postPatch = ''
     substituteInPlace rpcgen/rpc_main.c \

--- a/pkgs/os-specific/darwin/apple-source-releases/libpcap/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libpcap/package.nix
@@ -26,26 +26,7 @@ let
       unifdef -x 1 -DPRIVATE -o "$out/include/net/droptap.h" '${xnu}/bsd/net/droptap.h'
       unifdef -x 1 -DPRIVATE -o "$out/include/net/iptap.h" '${xnu}/bsd/net/iptap.h'
       unifdef -x 1 -DPRIVATE -o "$out/include/net/pktap.h" '${xnu}/bsd/net/pktap.h'
-
-      cat <<EOF > "$out/include/net/bpf.h"
-      #pragma once
-      #include_next <net/bpf.h>
-      $(sed -n \
-        -e '/^struct bpf_comp_stats\s*{/,/};/p' \
-        -e '/^struct bpf_hdr_ext\s*{/,/};/p' \
-        -e '/^#define BIOCGBATCHWRITE\s/p' \
-        -e '/^#define BIOCGHDRCOMPSTATS\s/p' \
-        -e '/^#define BIOCGIFATTACHCOUNT\s/p' \
-        -e '/^#define BIOCGWRITEMAX\s/p' \
-        -e '/^#define BIOCSBATCHWRITE\s/p' \
-        -e '/^#define BIOCSEXTHDR\s/p' \
-        -e '/^#define BIOCSHEADDROP\s/p' \
-        -e '/^#define BIOCSPKTHDRV2\s/p' \
-        -e '/^#define BIOCSTRUNCATE\s/p' \
-        -e '/^#define BIOCSWANTPKTAP\s/p' \
-        -e '/^#define BIOCSWRITEMAX\s/p' \
-        '${xnu}/bsd/net/bpf.h')
-      EOF
+      unifdef -x 1 -DPRIVATE -o "$out/include/net/bpf.h" '${xnu}/bsd/net/bpf.h'
 
       cat <<EOF > "$out/include/net/if.h"
       #pragma once

--- a/pkgs/os-specific/darwin/apple-source-releases/network_cmds/meson.build.in
+++ b/pkgs/os-specific/darwin/apple-source-releases/network_cmds/meson.build.in
@@ -19,21 +19,6 @@ add_global_arguments(
 )
 
 
-# Generators
-rpcgen_bin = find_program('rpcgen')
-rpcgen = generator(
-    rpcgen_bin,
-    arguments : [ '-c', '-o', '@OUTPUT@', '@INPUT@' ],
-    output : '@BASENAME@_xdr.c',
-)
-
-rpcgen_header = generator(
-    rpcgen_bin,
-    arguments : [ '-h', '-o', '@OUTPUT@', '@INPUT@' ],
-    output : '@BASENAME@.h',
-)
-
-
 # Dependencies
 cc = meson.get_compiler('c')
 
@@ -340,8 +325,7 @@ executable(
     install : true,
     sources : [
         'spray.tproj/spray.c',
-        rpcgen_header.process('spray.tproj/spray.x'),
-        rpcgen.process('spray.tproj/spray.x'),
+        'spray.tproj/spray_xdr.c',
     ],
 )
 install_man('spray.tproj/spray.8')

--- a/pkgs/os-specific/darwin/apple-source-releases/network_cmds/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/network_cmds/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   apple-sdk,
-  developer_cmds,
   fetchurl,
   libpcap,
   libresolv,
@@ -405,7 +404,7 @@ mkAppleDerivation {
     "man"
   ];
 
-  xcodeHash = "sha256-L5upfoE6uHsdFOzylTTH+UPftA96qdpnvgFcK5dmhgY=";
+  xcodeHash = "sha256-HkcIvKB4ektuk+3J/Sque8Pr5dMeNFZRlENuiu3KdsA=";
 
   patches = [
     # Some private headers depend on corecrypto, which we can’t use.
@@ -444,7 +443,6 @@ mkAppleDerivation {
   env.NIX_CFLAGS_COMPILE = "-I${privateHeaders}/include";
 
   nativeBuildInputs = [
-    developer_cmds
     pkg-config
   ];
 

--- a/pkgs/os-specific/darwin/apple-source-releases/system_cmds/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/system_cmds/package.nix
@@ -62,7 +62,11 @@ let
 
       install -D -t "$out/include/os" \
         '${Libc}/os/assumes.h' \
+        '${Libc}/os/variant_private.h' \
         '${xnu}/libkern/os/base_private.h'
+      substituteInPlace "$out/include/os/variant_private.h" \
+        --replace-fail ', bridgeos(4.0)' "" \
+        --replace-fail ', bridgeos' ""
       touch "$out/include/os/feature_private.h"
 
       install -D -t "$out/include/sys" \

--- a/pkgs/os-specific/darwin/apple-source-releases/top/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/top/package.nix
@@ -13,7 +13,7 @@ in
 mkAppleDerivation {
   releaseName = "top";
 
-  xcodeHash = "sha256-b7Qv9ks9JmilY9GaEU3/iXoHBNyHRYr4IB0jVf0fYdo=";
+  xcodeHash = "sha256-YeBhEstvPh8IX8ArVc7U8IRU6vqPoOE6kBTqcqZonGc=";
 
   patches = [
     # Upstream removed aarch64 support from the 137 source release, but the removal can be reverted.

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -40,8 +40,8 @@
     "version": "83"
   },
   "diskdev_cmds": {
-    "hash": "sha256-TebggzBS/HwEP3W2w2p+XvPDxsQtdTbtKEn9wik653Q=",
-    "version": "735"
+    "hash": "sha256-v3TFHLUlumt/sHxkOTyxDA4iG8ci5ZmMn7HCb4+9Uo0=",
+    "version": "737.60.1"
   },
   "doc_cmds": {
     "hash": "sha256-/Mf+RhaTU9O5i95gddZ2h9eDjLezwj3nP6FvryMF54E=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -32,8 +32,8 @@
     "version": "136"
   },
   "copyfile": {
-    "hash": "sha256-lIhl5sr1gewIHkh10hD+H/I7MVPzlHlONGRMOO7OZuA=",
-    "version": "213"
+    "hash": "sha256-Vz1fo4p2b6S8xfyDPu1FNgMkH1aX0tkpXCZkdzkRdq0=",
+    "version": "213.40.2"
   },
   "developer_cmds": {
     "hash": "sha256-rgmmPHxlKPb84BHVs8oY99E8iGWbqEjS4B8H7+JK7NY=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -36,8 +36,8 @@
     "version": "213.40.2"
   },
   "developer_cmds": {
-    "hash": "sha256-rgmmPHxlKPb84BHVs8oY99E8iGWbqEjS4B8H7+JK7NY=",
-    "version": "79"
+    "hash": "sha256-jgQUjN9zmqi0/7XpqzbRsJjZIYeMrxXT1Zf3qi7+o+8=",
+    "version": "83"
   },
   "diskdev_cmds": {
     "hash": "sha256-TebggzBS/HwEP3W2w2p+XvPDxsQtdTbtKEn9wik653Q=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -108,7 +108,7 @@
     "version": "190.0.1"
   },
   "top": {
-    "hash": "sha256-jz7udjXO5INtMHTDDdTUYAc4Tpy8v9nW0401LAHiPpA=",
-    "version": "139"
+    "hash": "sha256-e+k/jE49BMZZ24ge9JCa2ct5f1og6ewWb6U5ZMWdIEc=",
+    "version": "139.40.2"
   }
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -8,8 +8,8 @@
     "version": "88"
   },
   "ICU": {
-    "hash": "sha256-CvpMLFNCEQ05t3nkzDyA9nsm3cmRgXG/QxbyiLpSpIs=",
-    "version": "74221"
+    "hash": "sha256-7ImBX4SlrFaLnHdQ4bm4F8q9IpHhQMaeVOO6pnnhyzQ=",
+    "version": "74222.203"
   },
   "IOKitTools": {
     "hash": "sha256-Oknsvzn4nv77WU7f0WPS446iwR2BM2q4iw46r/qctAE=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -52,8 +52,8 @@
     "version": "448.0.3"
   },
   "libffi": {
-    "hash": "sha256-tQJdKCz2OIwVtorHQapq9Xs2e1Ac96lGEzIWUXmsasY=",
-    "version": "35"
+    "hash": "sha256-YjRMS3H3hIEfQm5MVSxGNTBtFc/9al7iQGDeZy6m/0U=",
+    "version": "39"
   },
   "libiconv": {
     "hash": "sha256-4I70hci8SUQ5QERbImP3htjYCGXdZZ0a6RM7ggUnVa4=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -1,7 +1,7 @@
 {
   "AvailabilityVersions": {
-    "hash": "sha256-CmFrmbk3XJXhGStc+prNoFTDJiFu4n2wVP3OvMfQwOU=",
-    "version": "143.3"
+    "hash": "sha256-PT54BPSRkQiIHrpxZCdjo6XvNuWxESabLndCBYjulfs=",
+    "version": "143.6"
   },
   "Csu": {
     "hash": "sha256-l8RI8aiin7ovZuoDh54thDmd/b502w+dtjN5ZoISZBg=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -16,8 +16,8 @@
     "version": "125"
   },
   "PowerManagement": {
-    "hash": "sha256-BBEh2+ldmT+8tFvKcTp+4A253hxbUrmY3j7omBXRYf0=",
-    "version": "1740.0.7"
+    "hash": "sha256-APkvbp0FhNrypQcDUuREUYOnNLOZGOKhsj5JLcDgvAU=",
+    "version": "1740.60.27"
   },
   "adv_cmds": {
     "hash": "sha256-alJOcKeHmIh67ZmN7/YdIouCP/qzakkhimsuZaOkr+c=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -100,8 +100,8 @@
     "version": "319.0.1"
   },
   "system_cmds": {
-    "hash": "sha256-SZfgMX0znyESzRNNzqyq/FAa9NQeI+5yiBS2xIvsP5g=",
-    "version": "1012"
+    "hash": "sha256-9nNJeVJo4XwGSHh+SJydhVt+I8+Rb5hCsPiFYKQ8/28=",
+    "version": "1012.60.2"
   },
   "text_cmds": {
     "hash": "sha256-76dagwRcAf5fpoyH5FDR5kdCldv6Mgre6aFBzxaCRkg=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -80,8 +80,8 @@
     "version": "44"
   },
   "network_cmds": {
-    "hash": "sha256-8aW3dAA/dfZTayGLHqzRqnVLmwJzRpvVmXL4eJGz5OQ=",
-    "version": "696"
+    "hash": "sha256-aGBsxdYW21QjTILxcR8tHufQKvkvmai9MKOCxBNZvmI=",
+    "version": "698.60.4"
   },
   "patch_cmds": {
     "hash": "sha256-foIoIMe+zgPISFmE10q4cwEUBhiah4nbD7UtjBumZYU=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -56,8 +56,8 @@
     "version": "39"
   },
   "libiconv": {
-    "hash": "sha256-4I70hci8SUQ5QERbImP3htjYCGXdZZ0a6RM7ggUnVa4=",
-    "version": "107"
+    "hash": "sha256-eaUp0z7HqX0AW2C90gDVFeiJnmGRxPDuzyb1Jlm1pNc=",
+    "version": "109"
   },
   "libpcap": {
     "hash": "sha256-x5mKK6LXGS3LBRUVNZwxA750a0NoRScTpoDUsumlg+s=",

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -60,8 +60,8 @@
     "version": "109"
   },
   "libpcap": {
-    "hash": "sha256-x5mKK6LXGS3LBRUVNZwxA750a0NoRScTpoDUsumlg+s=",
-    "version": "135"
+    "hash": "sha256-RViIXv5zP2Bcive5qrcfb9vNWwhSe6fGCaToSgDYNxU=",
+    "version": "137"
   },
   "libresolv": {
     "hash": "sha256-ndGcicbHizPazTCB0P3aioDOv7IJPmTOgLnioFHH2+o=",


### PR DESCRIPTION
Thankfully it is possible to save pages to the Wayback Machine again, and it works fine to archive the SDKs, so we shouldn’t run into any more bitrotting mishaps like https://github.com/NixOS/nixpkgs/pull/359460.

A few non‐trivial commits here that could use review; see the commit messages for details.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin `{apple-sdk_{11,12,13,14,15},darwin.{AvailabilityVersions,ICU,PowerManagement,copyfile,developer_cmds,diskdev_cmds,libffi,libiconv,libpcap,network_cmds,system_cmds,top}}`
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
