### PR TITLE
treewide: remove AndersonTorres from maintainers

### DIFF
--- a/pkgs/applications/emulators/zsnes/2.x.nix
+++ b/pkgs/applications/emulators/zsnes/2.x.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/xyproto/zsnes";
     description = "Maintained fork of zsnes";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.intersectLists lib.platforms.linux lib.platforms.x86;
   };
 })

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -306,7 +306,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     mainProgram = "mpv";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       fpletz
       globin
       ma27

--- a/pkgs/by-name/_0/_0verkill/package.nix
+++ b/pkgs/by-name/_0/_0verkill/package.nix
@@ -41,7 +41,7 @@ gccStdenv.mkDerivation rec {
     homepage = "https://github.com/hackndev/0verkill";
     description = "ASCII-ART bloody 2D action deathmatch-like game";
     license = with licenses; gpl2Only;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/_0/_0x/package.nix
+++ b/pkgs/by-name/_0/_0x/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage {
     description = "Colorful, configurable xxd";
     mainProgram = "0x";
     license = licenses.asl20;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/_1/_1oom/package.nix
+++ b/pkgs/by-name/_1/_1oom/package.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     description = "Master of Orion (1993) game engine recreation; a more updated fork";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/_4/_4th/package.nix
+++ b/pkgs/by-name/_4/_4th/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Portable Forth compiler";
     license = lib.licenses.lgpl3Plus;
     mainProgram = "4th";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "https://4ti2.github.io/";
     description = "Software package for algebraic, geometric and combinatorial problems on linear spaces";
     license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/_9/_9menu/package.nix
+++ b/pkgs/by-name/_9/_9menu/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "Simple X11 menu program for running commands";
     mainProgram = "9menu";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = libX11.meta.platforms;
   };
 }

--- a/pkgs/by-name/aa/aaphoto/package.nix
+++ b/pkgs/by-name/aa/aaphoto/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       one-by-one.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "aaphoto";
   };

--- a/pkgs/by-name/ac/ace-of-penguins/package.nix
+++ b/pkgs/by-name/ac/ace-of-penguins/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
       Martin Thornquist).
     '';
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ac/acr/package.nix
+++ b/pkgs/by-name/ac/acr/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
       m4. This means that ACR is faster, smaller and easy to use.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/af/afterstep/package.nix
+++ b/pkgs/by-name/af/afterstep/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
       improving aestetics, and efficient use of system resources.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "afterstep";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "a68g";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/an/antiprism/package.nix
+++ b/pkgs/by-name/an/antiprism/package.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.antiprism.com";
     description = "Collection of programs for generating, manipulating, transforming and viewing polyhedra";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 })

--- a/pkgs/by-name/ar/aranym/package.nix
+++ b/pkgs/by-name/ar/aranym/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "aranym";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ar/arcan/package.nix
+++ b/pkgs/by-name/ar/arcan/package.nix
@@ -202,7 +202,7 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       lgpl2Plus
     ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ar/ares/package.nix
+++ b/pkgs/by-name/ar/ares/package.nix
@@ -101,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "ares";
     maintainers = with lib.maintainers; [
       Madouura
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/ar/argagg/package.nix
+++ b/pkgs/by-name/ar/argagg/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
       pointers into the original command line argument C-strings.
     '';
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
     badPlatforms = [ "aarch64-darwin" ];
   };

--- a/pkgs/by-name/ar/argbash/package.nix
+++ b/pkgs/by-name/ar/argbash/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://argbash.io/";
     description = "Bash argument parsing code generator";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/as/as31/package.nix
+++ b/pkgs/by-name/as/as31/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "8031/8051 assembler";
     mainProgram = "as31";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/as/asl/package.nix
+++ b/pkgs/by-name/as/asl/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
       are used in workstations and PCs.
     '';
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/at/atari800/package.nix
+++ b/pkgs/by-name/at/atari800/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       library.
     '';
     license = with lib.licenses; [ gpl2Plus ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/at/ataripp/package.nix
+++ b/pkgs/by-name/at/ataripp/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
       and the Atari 5200 game console. The emulator is auto-configurable and
       will compile on a variety of systems (Linux, Solaris, Irix).
     '';
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     license = with lib.licenses; [ gpl2Plus ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/at/atasm/package.nix
+++ b/pkgs/by-name/at/atasm/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     description = "Commandline 6502 assembler compatible with Mac/65";
     license = licenses.gpl2Plus;
     changelog = "https://github.com/CycoPH/atasm/releases/tag/V${version}";
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/ba/barrage/package.nix
+++ b/pkgs/by-name/ba/barrage/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Destructive action game";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "barrage";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ba/base16-shell-preview/package.nix
+++ b/pkgs/by-name/ba/base16-shell-preview/package.nix
@@ -26,6 +26,6 @@ python3Packages.buildPythonApplication {
     description = "Browse and preview Base16 Shell themes in your terminal";
     mainProgram = "base16-shell-preview";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ba/basu/package.nix
+++ b/pkgs/by-name/ba/basu/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Sd-bus library, extracted from systemd";
     mainProgram = "basuctl";
     license = lib.licenses.lgpl21Only;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/be/berry/package.nix
+++ b/pkgs/by-name/be/berry/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.mit;
     mainProgram = "berry";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/be/bevelbar/package.nix
+++ b/pkgs/by-name/be/bevelbar/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "X11 status bar with beveled borders";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      AndersonTorres
       neeasade
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/bi/biblesync/package.nix
+++ b/pkgs/by-name/bi/biblesync/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       navigation, and handling of incoming packets.
     '';
     license = licenses.publicDomain;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/bi/bibletime/package.nix
+++ b/pkgs/by-name/bi/bibletime/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Powerful cross platform Bible study tool";
     license = lib.licenses.gpl2Plus;
     mainProgram = "bibletime";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bl/blockattack/package.nix
+++ b/pkgs/by-name/bl/blockattack/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/blockattack/blockattack-game/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "blockattack";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL2.meta) platforms;
   };
 })

--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       Intel x86 CPU, common I/O devices, and a custom BIOS.
     '';
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/bq/bqn/package.nix
+++ b/pkgs/by-name/bq/bqn/package.nix
@@ -56,7 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/mlochbaum/BQN/";
     description = "Original BQN implementation in Javascript";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (nodejs.meta) platforms;
   };
 })

--- a/pkgs/by-name/br/brogue-ce/package.nix
+++ b/pkgs/by-name/br/brogue-ce/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/tmewett/BrogueCE";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [
-      AndersonTorres
       fgaz
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/br/brogue/package.nix
+++ b/pkgs/by-name/br/brogue/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sites.google.com/site/broguegame/";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [
-      AndersonTorres
       fgaz
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/bs/bsd-finger/package.nix
+++ b/pkgs/by-name/bs/bsd-finger/package.nix
@@ -203,7 +203,7 @@ stdenv.mkDerivation (finalAttrs: {
         "daemon" = "fingerd";
       }
       .${buildProduct};
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bs/bsnes-hd/package.nix
+++ b/pkgs/by-name/bs/bsnes-hd/package.nix
@@ -101,7 +101,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Only;
     mainProgram = "bsnes";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       stevebob
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/bt/btanks/package.nix
+++ b/pkgs/by-name/bt/btanks/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fast 2d tank arcade game with multiplayer and split-screen modes";
     license = lib.licenses.gpl2Plus;
     mainProgram = "btanks";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL.meta) platforms;
   };
 })

--- a/pkgs/by-name/by/byacc/package.nix
+++ b/pkgs/by-name/by/byacc/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://invisible-island.net/byacc/CHANGES.html";
     license = lib.licenses.publicDomain;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/by/byobu/package.nix
+++ b/pkgs/by-name/by/byobu/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "byobu";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ca/calcoo/package.nix
+++ b/pkgs/by-name/ca/calcoo/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://calcoo.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     mainProgram = "calcoo";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (jdk.meta) platforms;
   };
 })

--- a/pkgs/by-name/ca/cardboard/package.nix
+++ b/pkgs/by-name/ca/cardboard/package.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation {
     description = "Scrollable, tiling Wayland compositor inspired on PaperWM";
     license = lib.licenses.gpl3Only;
     mainProgram = "cardboard";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
   };
 }

--- a/pkgs/by-name/ca/cat9/package.nix
+++ b/pkgs/by-name/ca/cat9/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/letoram/cat9";
     description = "User shell for LASH";
     license = with lib.licenses; [ unlicense ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/cb/cbftp/package.nix
+++ b/pkgs/by-name/cb/cbftp/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       semi-graphical user interface through ncurses.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/cc/cc65/package.nix
+++ b/pkgs/by-name/cc/cc65/package.nix
@@ -56,7 +56,7 @@ gccStdenv.mkDerivation rec {
       shouldn't be too much work.
     '';
     license = licenses.zlib;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/cd/cdk/package.nix
+++ b/pkgs/by-name/cd/cdk/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       raskin
-      AndersonTorres
     ];
     inherit (ncurses.meta) platforms;
   };

--- a/pkgs/by-name/ce/celluloid/package.nix
+++ b/pkgs/by-name/ce/celluloid/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/celluloid-player/celluloid/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "celluloid";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -179,7 +179,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       zhaofengli
       baduhai
-      AndersonTorres
     ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/cg/cgreen/package.nix
+++ b/pkgs/by-name/cg/cgreen/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Modern Unit Test and Mocking Framework for C and C++";
     mainProgram = "cgreen-runner";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ch/chemacs2/package.nix
+++ b/pkgs/by-name/ch/chemacs2/package.nix
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       Think of it as a bootloader for Emacs.
     '';
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ch/chemtool/package.nix
+++ b/pkgs/by-name/ch/chemtool/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
       hexagonal backdrop grids for easier alignment.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ch/chezmoi/package.nix
+++ b/pkgs/by-name/ch/chezmoi/package.nix
@@ -46,7 +46,7 @@ let
       changelog = "https://github.com/twpayne/chezmoi/releases/tag/${argset.src.rev}";
       license = lib.licenses.mit;
       mainProgram = "chezmoi";
-      maintainers = with lib.maintainers; [ AndersonTorres ];
+      maintainers = with lib.maintainers; [ ];
     };
   };
 in

--- a/pkgs/by-name/ch/chromium-bsu/package.nix
+++ b/pkgs/by-name/ch/chromium-bsu/package.nix
@@ -62,8 +62,7 @@ stdenv.mkDerivation rec {
     description = "Fast paced, arcade-style, top-scrolling space shooter";
     mainProgram = "chromium-bsu";
     license = licenses.artistic1;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }
-# TODO [ AndersonTorres ]: joystick; gothic uralic font

--- a/pkgs/by-name/ci/ciano/package.nix
+++ b/pkgs/by-name/ci/ciano/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/robertsanseries/ciano";
     description = "Multimedia file converter focused on simplicity";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/cl/clevis/package.nix
+++ b/pkgs/by-name/cl/clevis/package.nix
@@ -125,6 +125,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/latchset/clevis/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 })

--- a/pkgs/by-name/cm/cmatrix/package.nix
+++ b/pkgs/by-name/cm/cmatrix/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/abishekvashok/cmatrix";
     platforms = ncurses.meta.platforms;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     mainProgram = "cmatrix";
   };
 }

--- a/pkgs/by-name/co/comic-neue/package.nix
+++ b/pkgs/by-name/co/comic-neue/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/connman/package.nix
+++ b/pkgs/by-name/co/connman/package.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://git.kernel.org/pub/scm/network/connman/connman.git/about/";
     license = lib.licenses.gpl2Only;
     mainProgram = "connmanctl";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/cr/cronie/package.nix
+++ b/pkgs/by-name/cr/cronie/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Plus
     ];
     mainProgram = "crond";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/cs/csvkit/package.nix
+++ b/pkgs/by-name/cs/csvkit/package.nix
@@ -44,6 +44,6 @@ pythonEnv.pkgs.buildPythonApplication {
     description = "Suite of command-line tools for converting to and working with CSV";
     changelog = "https://github.com/wireservice/csvkit/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ct/ctx/package.nix
+++ b/pkgs/by-name/ct/ctx/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
       a vector graphics protocol.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/cu/cue2pops/package.nix
+++ b/pkgs/by-name/cu/cue2pops/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
     # Upstream license is unclear.
     # <https://github.com/ErikAndren/cue2pops-mac/issues/2#issuecomment-673983298>
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
     mainProgram = "cue2pops";
   };

--- a/pkgs/by-name/cy/cyberpunk-neon/package.nix
+++ b/pkgs/by-name/cy/cyberpunk-neon/package.nix
@@ -55,7 +55,7 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/Roboron3042/Cyberpunk-Neon";
     description = "Neon themes for many programs";
     license = lib.licenses.cc-by-sa-40;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -106,7 +106,6 @@ let
       license = with lib.licenses; [ mit ];
       mainProgram = "czkawka_gui";
       maintainers = with lib.maintainers; [
-        AndersonTorres
         yanganto
         _0x4A6F
       ];

--- a/pkgs/by-name/da/dap/package.nix
+++ b/pkgs/by-name/da/dap/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       analyses).
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/db/dbqn/package.nix
+++ b/pkgs/by-name/db/dbqn/package.nix
@@ -77,12 +77,9 @@ stdenv.mkDerivation rec {
       "BQN implementation in Java" + lib.optionalString buildNativeImage ", compiled as a native image";
     license = licenses.mit;
     maintainers = with maintainers; [
-      AndersonTorres
       sternenseemann
     ];
     inherit (jdk.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dbqn-native.x86_64-darwin
   };
 }
-# TODO: Processing app
-# TODO: minimalistic JDK

--- a/pkgs/by-name/de/desmume/package.nix
+++ b/pkgs/by-name/de/desmume/package.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
       commercial nds rom titles which other DS Emulators aren't.
     '';
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C compiler, assembler and linker environment for the production of 8086 executables";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      AndersonTorres
       sigmasquadron
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dg/dgen-sdl/package.nix
+++ b/pkgs/by-name/dg/dgen-sdl/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
       - VGM dumping
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/di/dialog/package.nix
+++ b/pkgs/by-name/di/dialog/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21Plus;
     mainProgram = "dialog";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       spacefrogg
     ];
     inherit (ncurses.meta) platforms;

--- a/pkgs/by-name/di/dillo/package.nix
+++ b/pkgs/by-name/di/dillo/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Helps authors to comply with web standards by using the bug meter.
     '';
     mainProgram = "dillo";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/di/disk-filltest/package.nix
+++ b/pkgs/by-name/di/disk-filltest/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "disk-filltest";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/do/doomretro/package.nix
+++ b/pkgs/by-name/do/doomretro/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "doomretro";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -124,7 +124,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       joshuafern
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
     priority = 101;

--- a/pkgs/by-name/do/doublecmd/package.nix
+++ b/pkgs/by-name/do/doublecmd/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Two-panel graphical file manager written in Pascal";
     license = lib.licenses.gpl2Plus;
     mainProgram = "doublecmd";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -143,7 +143,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     mainProgram = "duckstation-qt";
     maintainers = with lib.maintainers; [
       guibou
-      AndersonTorres
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/du/durden/package.nix
+++ b/pkgs/by-name/du/durden/package.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       of the desktop environment spectrum.
     '';
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/dv/dvdstyler/package.nix
+++ b/pkgs/by-name/dv/dvdstyler/package.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
       - customize navigation using DVD scripting
     '';
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; linux;
     mainProgram = "dvdstyler";
   };

--- a/pkgs/by-name/dw/dwl/package.nix
+++ b/pkgs/by-name/dw/dwl/package.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
       - Tied to as few external dependencies as possible
     '';
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     inherit (wayland.meta) platforms;
     mainProgram = "dwl";
   };

--- a/pkgs/by-name/dx/dxa/package.nix
+++ b/pkgs/by-name/dx/dxa/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Andre Fachat's open-source 6502 disassembler";
     mainProgram = "dxa";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; unix;
   };
 })

--- a/pkgs/by-name/ec/ecmtools/package.nix
+++ b/pkgs/by-name/ec/ecmtools/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/alucryd/ecm-tools";
     license = lib.licenses.gpl3Plus;
     mainProgram = "bin2ecm";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ed/ed/package.nix
+++ b/pkgs/by-name/ed/ed/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "ed";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ed/edit/package.nix
+++ b/pkgs/by-name/ed/edit/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
     description = "Relaxing mix of Vi and ACME";
     homepage = "https://c9x.me/edit";
     license = lib.licenses.publicDomain;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     mainProgram = "edit";
   };

--- a/pkgs/by-name/ed/edlin/package.nix
+++ b/pkgs/by-name/ed/edlin/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sourceforge.net/projects/freedos-edlin/";
     description = "FreeDOS line editor";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
     mainProgram = "edlin";
   };

--- a/pkgs/by-name/el/elvis/package.nix
+++ b/pkgs/by-name/el/elvis/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Vi clone for Unix and other operating systems";
     license = lib.licenses.free;
     mainProgram = "elvis";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/em/em/package.nix
+++ b/pkgs/by-name/em/em/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       (such as the ITT's at QMC).
     '';
     license = licenses.publicDomain;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "em";
   };

--- a/pkgs/by-name/em/emacspeak/package.nix
+++ b/pkgs/by-name/em/emacspeak/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/tvraman/emacspeak/blob/${finalAttrs.src.rev}/etc/NEWS";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "emacspeak";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     # Emacspeak requires a minimal Emacs version; let's use the broken flag
     broken = lib.versionOlder (lib.getVersion emacs) "29.1";

--- a/pkgs/by-name/em/emu2/package.nix
+++ b/pkgs/by-name/em/emu2/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dmsc/emu2/";
     description = "Simple text-mode x86 + DOS emulator";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;
     mainProgram = "emu2";
   };

--- a/pkgs/by-name/eu/eudev/package.nix
+++ b/pkgs/by-name/eu/eudev/package.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       raskin
-      AndersonTorres
     ];
     pkgConfigModules = [
       "libudev"

--- a/pkgs/by-name/ew/eweb/package.nix
+++ b/pkgs/by-name/ew/eweb/package.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     mainProgram = "etangle.py";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fa/fastjar/package.nix
+++ b/pkgs/by-name/fa/fastjar/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "fastjar";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/fc/fceux/package.nix
+++ b/pkgs/by-name/fc/fceux/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "fceux";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       sbruder
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/fl/fluxbox/package.nix
+++ b/pkgs/by-name/fl/fluxbox/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://fluxbox.org/";
     license = licenses.mit;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/fr/free42/package.nix
+++ b/pkgs/by-name/fr/free42/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/thomasokken/free42";
     description = "Software clone of HP-42S Calculator";
     license = with lib.licenses; [ gpl2Only ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "free42dec";
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/by-name/fr/freecell-solver/package.nix
+++ b/pkgs/by-name/fr/freecell-solver/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.mit;
     mainProgram = "fc-solve";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/fs/fsuae-launcher/package.nix
+++ b/pkgs/by-name/fs/fsuae-launcher/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fs-uae-launcher";
     maintainers = with lib.maintainers; [
       sander
-      AndersonTorres
     ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86 patterns.isLinux;
   };

--- a/pkgs/by-name/fs/fsuae/package.nix
+++ b/pkgs/by-name/fs/fsuae/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "fs-uae";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.systems.inspect; patternLogicalAnd patterns.isx86 patterns.isLinux;
   };
 })

--- a/pkgs/by-name/ft/ftgl/package.nix
+++ b/pkgs/by-name/ft/ftgl/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
       rendering modes.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/fu/funnelweb/package.nix
+++ b/pkgs/by-name/fu/funnelweb/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.ross.net/funnelweb/";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
   };
 }
 #TODO: implement it for other platforms

--- a/pkgs/by-name/fv/fvwm3/package.nix
+++ b/pkgs/by-name/fv/fvwm3/package.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/fvwmorg/fvwm3/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ga/galaxis/package.nix
+++ b/pkgs/by-name/ga/galaxis/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://catb.org/~esr/galaxis/";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "galaxis";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ga/galculator/package.nix
+++ b/pkgs/by-name/ga/galculator/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "galculator";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (gtk3.meta) platforms;
   };
 })

--- a/pkgs/by-name/ga/gavin-bc/package.nix
+++ b/pkgs/by-name/ga/gavin-bc/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Gavin Howard's BC calculator implementation";
     changelog = "https://git.gavinhoward.com/gavin/bc/raw/tag/${finalAttrs.version}/NEWS.md";
     license = lib.licenses.bsd2;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "gdbmtool";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ge/germinal/package.nix
+++ b/pkgs/by-name/ge/germinal/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Keruspe/Germinal";
     license = lib.licenses.gpl3Plus;
     mainProgram = "germinal";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/gi/git-branchstack/package.nix
+++ b/pkgs/by-name/gi/git-branchstack/package.nix
@@ -23,7 +23,7 @@ let
       homepage = "https://github.com/krobelus/git-branchstack";
       description = "Efficiently manage Git branches without leaving your local branch";
       license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ AndersonTorres ];
+      maintainers = with lib.maintainers; [ ];
     };
   };
 in

--- a/pkgs/by-name/gl/glpng/package.nix
+++ b/pkgs/by-name/gl/glpng/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://repo.or.cz/glpng.git/blob_plain/HEAD:/glpng.htm";
     description = "PNG loader library for OpenGL";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (variants.${variant}) description;
     license = lib.licenses.gpl3Plus;
     mainProgram = "gmic_qt";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/gm/gmic/package.nix
+++ b/pkgs/by-name/gm/gmic/package.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "gmic";
     license = lib.licenses.cecill21;
     maintainers = [
-      lib.maintainers.AndersonTorres
+      lib.maintainers.
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gn/gnu-smalltalk/package.nix
+++ b/pkgs/by-name/gn/gnu-smalltalk/package.nix
@@ -90,6 +90,6 @@ stdenv.mkDerivation rec {
       lgpl2
     ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/go/gofish/package.nix
+++ b/pkgs/by-name/go/gofish/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "Lightweight Gopher server";
     homepage = "https://gofish.sourceforge.net/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/gr/grafx2/package.nix
+++ b/pkgs/by-name/gr/grafx2/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "grafx2-sdl";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/gr/graphicsmagick/package.nix
+++ b/pkgs/by-name/gr/graphicsmagick/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
       PNM, TIFF, and WebP.
     '';
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "gm";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/gx/gxemul/package.nix
+++ b/pkgs/by-name/gx/gxemul/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
       unmodified "guest" operating systems to run.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "gxemul";
   };

--- a/pkgs/by-name/ha/hachimarupop/package.nix
+++ b/pkgs/by-name/ha/hachimarupop/package.nix
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/noriokanisawa/HachiMaruPop";
     description = "Cute, Japanese font";
     license = lib.licenses.ofl;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ha/hackedbox/package.nix
+++ b/pkgs/by-name/ha/hackedbox/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Bastard hacked offspring of Blackbox";
     homepage = "https://github.com/museoa/hackedbox/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ha/haunt/package.nix
+++ b/pkgs/by-name/ha/haunt/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
       to do things that aren't provided out-of-the-box.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (guile.meta) platforms;
   };
 })

--- a/pkgs/by-name/ha/havoc/package.nix
+++ b/pkgs/by-name/ha/havoc/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
       publicDomain
     ];
     mainProgram = "havoc";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin; # fatal error: 'sys/epoll.h' file not found
   };

--- a/pkgs/by-name/hi/higan/package.nix
+++ b/pkgs/by-name/hi/higan/package.nix
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
       Challenge V2.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ht/httplib/package.nix
+++ b/pkgs/by-name/ht/httplib/package.nix
@@ -28,9 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ header-only HTTP/HTTPS server and client library";
     changelog = "https://github.com/yhirose/cpp-httplib/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      AndersonTorres
-    ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ic/icewm/package.nix
+++ b/pkgs/by-name/ic/icewm/package.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
       a simple session manager and a system tray.
     '';
     license = licenses.lgpl2Only;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/ii/iir1/package.nix
+++ b/pkgs/by-name/ii/iir1/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/berndporr/iir1";
     changelog = "https://github.com/berndporr/iir1/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/in/intercal/package.nix
+++ b/pkgs/by-name/in/intercal/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.catb.org/~esr/intercal/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/is/isc-cron/package.nix
+++ b/pkgs/by-name/is/isc-cron/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Daemon for running commands at specific times";
     license = lib.licenses.bsd0;
     mainProgram = "cron";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/iw/iw/package.nix
+++ b/pkgs/by-name/iw/iw/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.isc;
     mainProgram = "iw";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ja/jam/package.nix
+++ b/pkgs/by-name/ja/jam/package.nix
@@ -120,7 +120,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       impl
       orivej
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/jo/joe/package.nix
+++ b/pkgs/by-name/jo/joe/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://joe-editor.sourceforge.io";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/jo/jove/package.nix
+++ b/pkgs/by-name/jo/jove/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Jonathan's Own Version of Emacs";
     changelog = "https://github.com/jonmacs/jove/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     # never built on Hydra: https://hydra.nixos.org/job/nixpkgs/trunk/jove.x86_64-darwin
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/ju/jupp/package.nix
+++ b/pkgs/by-name/ju/jupp/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       because these behave better overall.
     '';
     license = lib.licenses.gpl1Only;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/jw/jwasm/package.nix
+++ b/pkgs/by-name/jw/jwasm/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/Baron-von-Riedesel/JWasm/releases/tag/${finalAttrs.src.rev}";
     mainProgram = "jwasm";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ka/katriawm/package.nix
+++ b/pkgs/by-name/ka/katriawm/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Non-reparenting, dynamic window manager with decorations";
     license = lib.licenses.mit;
     mainProgram = "katriawm";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ke/kermit-terminal/package.nix
+++ b/pkgs/by-name/ke/kermit-terminal/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/orhun/kermit/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     mainProgram = "kermit";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ki/kirc/package.nix
+++ b/pkgs/by-name/ki/kirc/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       - Easy customized color scheme definition.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/la/labwc-tweaks/package.nix
+++ b/pkgs/by-name/la/labwc-tweaks/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      AndersonTorres
       romildo
     ];
   };

--- a/pkgs/by-name/la/lavalauncher/package.nix
+++ b/pkgs/by-name/la/lavalauncher/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.sr.ht/~leon_plickat/lavalauncher/refs/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "lavalauncher";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
     # meson.build:52:23: ERROR: C shared or static library 'rt' not found
     # https://logs.ofborg.org/?key=nixos/nixpkgs.340239&attempt_id=1f05cada-67d2-4cfe-b6a8-4bf4571b9375

--- a/pkgs/by-name/lb/lbreakout2/package.nix
+++ b/pkgs/by-name/lb/lbreakout2/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "lbreakout2";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       ciil
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/lb/lbreakouthd/package.nix
+++ b/pkgs/by-name/lb/lbreakouthd/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Widescreen Breakout clone";
     license = lib.licenses.gpl2Plus;
     mainProgram = "lbreakouthd";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL2.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/le/lefthook/package.nix
+++ b/pkgs/by-name/le/lefthook/package.nix
@@ -43,6 +43,6 @@ buildGoModule {
     changelog = "https://github.com/evilmartians/lefthook/raw/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "lefthook";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/li/libburn/package.nix
+++ b/pkgs/by-name/li/libburn/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       abbradar
-      AndersonTorres
     ];
     mainProgram = "cdrskin";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/libbytesize/package.nix
+++ b/pkgs/by-name/li/libbytesize/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tiny library providing a C 'class' for working with arbitrary big sizes in bytes";
     license = lib.licenses.lgpl2Plus;
     mainProgram = "bscalc";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/li/libcaca/package.nix
+++ b/pkgs/by-name/li/libcaca/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
       Libcaca was written by Sam Hocevar and Jean-Yves Lamoureux.
     '';
     license = licenses.wtfpl;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libedit/package.nix
+++ b/pkgs/by-name/li/libedit/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       similar to those found in GNU Readline.
     '';
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libisoburn/package.nix
+++ b/pkgs/by-name/li/libisoburn/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://dev.lovelyhq.com/libburnia/libisoburn/src/tag/${finalAttrs.src.rev}/ChangeLog";
     license = lib.licenses.gpl2Plus;
     mainProgram = "osirrox";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libisofs.meta) platforms;
   };
 })

--- a/pkgs/by-name/li/libisofs/package.nix
+++ b/pkgs/by-name/li/libisofs/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       abbradar
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/li/libmpdclient/package.nix
+++ b/pkgs/by-name/li/libmpdclient/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.musicpd.org/libs/libmpdclient/";
     changelog = "https://raw.githubusercontent.com/MusicPlayerDaemon/libmpdclient/${finalAttrs.src.rev}/NEWS";
     license = with lib.licenses; [ bsd2 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libpkgconf/package.nix
+++ b/pkgs/by-name/li/libpkgconf/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "pkgconf";
     maintainers = with lib.maintainers; [
       zaninime
-      AndersonTorres
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/li/libremidi/package.nix
+++ b/pkgs/by-name/li/libremidi/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/jcelerier/libremidi";
     description = "Modern C++ MIDI real-time & file I/O library";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/librep/package.nix
+++ b/pkgs/by-name/li/librep/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
       language but is also suitable for standalone scripts.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libtap/package.nix
+++ b/pkgs/by-name/li/libtap/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.shlomifish.org/open-source/projects/libtap/";
     license = licenses.bsd3;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libtcod/package.nix
+++ b/pkgs/by-name/li/libtcod/package.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation {
     homepage = "http://roguecentral.org/doryen/libtcod/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/li/libverto/package.nix
+++ b/pkgs/by-name/li/libverto/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       offload the choice of the main loop to the application.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libz/package.nix
+++ b/pkgs/by-name/li/libz/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sortix.org/libz/";
     description = "Clean fork of zlib";
     license = [ lib.licenses.zlib ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/lightning/package.nix
+++ b/pkgs/by-name/li/lightning/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       it abstracts over the target CPU, as it exposes to the clients a
       standardized RISC instruction set inspired by the MIPS and SPARC chips.
     '';
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     license = with lib.licenses; [ lgpl3Plus ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # failing tests

--- a/pkgs/by-name/li/live555/package.nix
+++ b/pkgs/by-name/li/live555/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Set of C++ libraries for multimedia streaming, using open standard protocols (RTP/RTCP, RTSP, SIP)";
     changelog = "http://www.live555.com/liveMedia/public/changelog.txt";
     license = with lib.licenses; [ lgpl21Plus ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/lo/lolcode/package.nix
+++ b/pkgs/by-name/lo/lolcode/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       whose keywords are LOLspeak.
     '';
     license = licenses.gpl3;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     mainProgram = "lolcode-lci";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/lp/lpairs2/package.nix
+++ b/pkgs/by-name/lp/lpairs2/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Matching the pairs - a typical Memory Game";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "lpairs2";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/lt/ltris/package.nix
+++ b/pkgs/by-name/lt/ltris/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tetris clone from the LGames series";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "ltris";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/lu/luakit/package.nix
+++ b/pkgs/by-name/lu/luakit/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Only;
     mainProgram = "luakit";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/lu/luckybackup/package.nix
+++ b/pkgs/by-name/lu/luckybackup/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "luckybackup";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/lu/lukesmithxyz-st/package.nix
+++ b/pkgs/by-name/lu/lukesmithxyz-st/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/LukeSmithxyz/st";
     description = "Luke Smith's fork of st";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/lw/lwm/package.nix
+++ b/pkgs/by-name/lw/lwm/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.jfc.org.uk/software/lwm.html";
     license = licenses.gpl2;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "lwm";
   };

--- a/pkgs/by-name/lz/lzsa/package.nix
+++ b/pkgs/by-name/lz/lzsa/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Byte-aligned, efficient lossless packer that is optimized for fast decompression on 8-bit micros";
     mainProgram = "lzsa";
     license = with lib.licenses; [ cc0 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ma/marst/package.nix
+++ b/pkgs/by-name/ma/marst/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
         from some other representations to MARST representation.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/mc/mcpp/package.nix
+++ b/pkgs/by-name/mc/mcpp/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Matsui's C preprocessor";
     mainProgram = "mcpp";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/md/md-tangle/package.nix
+++ b/pkgs/by-name/md/md-tangle/package.nix
@@ -25,6 +25,6 @@ python3.pkgs.buildPythonPackage rec {
     description = "Generates (\"tangles\") source code from Markdown documents";
     mainProgram = "md-tangle";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/md/md4c/package.nix
+++ b/pkgs/by-name/md/md4c/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/mity/md4c/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "md2html";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/md/mdds/package.nix
+++ b/pkgs/by-name/md/mdds/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Collection of multi-dimensional data structure and indexing algorithms";
     changelog = "https://gitlab.com/mdds/mdds/-/blob/${finalAttrs.version}/CHANGELOG";
     license = licenses.mit;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/me/mednafen-server/package.nix
+++ b/pkgs/by-name/me/mednafen-server/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "mednafen-server";
     homepage = "https://mednafen.github.io/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/me/mednafen/package.nix
+++ b/pkgs/by-name/me/mednafen/package.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "mednafen";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/me/mednaffe/package.nix
+++ b/pkgs/by-name/me/mednaffe/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "mednaffe";
     homepage = "https://github.com/AmatCoder/mednaffe";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/me/melonDS/package.nix
+++ b/pkgs/by-name/me/melonDS/package.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "melonDS";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       artemist
       benley
       shamilton

--- a/pkgs/by-name/mg/mgba/package.nix
+++ b/pkgs/by-name/mg/mgba/package.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://raw.githubusercontent.com/mgba-emu/mgba/${finalAttrs.src.rev}/CHANGES";
     license = with lib.licenses; [ mpl20 ];
     mainProgram = "mgba";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     broken = enableDiscordRpc; # Some obscure `ld` error
   };

--- a/pkgs/by-name/mk/mksh/package.nix
+++ b/pkgs/by-name/mk/mksh/package.nix
@@ -61,11 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
       unicode-dfs-2016
     ];
     maintainers = with lib.maintainers; [
-      AndersonTorres
       joachifm
     ];
     platforms = lib.platforms.unix;
   };
 })
-# TODO [ AndersonTorres ]: lksh
-# TODO [ AndersonTorres ]: a more accurate licensing info

--- a/pkgs/by-name/mo/moe/package.nix
+++ b/pkgs/by-name/mo/moe/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
       delimiter matching, text conversion from/to UTF-8, romanization, etc.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     mainProgram = "moe";
   };

--- a/pkgs/by-name/mo/monaspace/package.nix
+++ b/pkgs/by-name/mo/monaspace/package.nix
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
     homepage = "https://monaspace.githubnext.com/";
     license = lib.licenses.ofl;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/mp/mpc/package.nix
+++ b/pkgs/by-name/mp/mpc/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://raw.githubusercontent.com/MusicPlayerDaemon/mpc/refs/heads/master/NEWS";
     license = lib.licenses.gpl2Plus;
     mainProgram = "mpc";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/mp/mpvc/package.nix
+++ b/pkgs/by-name/mp/mpvc/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Mpc-like control interface for mpv";
     license = lib.licenses.mit;
     mainProgram = "mpvc";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ms/msr/package.nix
+++ b/pkgs/by-name/ms/msr/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "Linux tool to display or modify x86 model-specific registers (MSRs)";
     mainProgram = "msr";
     license = licenses.bsd0;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/by-name/mu/multimarkdown/package.nix
+++ b/pkgs/by-name/mu/multimarkdown/package.nix
@@ -61,6 +61,6 @@ stdenv.mkDerivation rec {
     '';
     license = with licenses; [ mit ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://muon.build/";
     description = "Implementation of Meson build system in C99";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # typical `ar failure`
     mainProgram = "muon";

--- a/pkgs/by-name/na/nanoflann/package.nix
+++ b/pkgs/by-name/na/nanoflann/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/jlblancoc/nanoflann/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.bsd2;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/na/nawk/package.nix
+++ b/pkgs/by-name/na/nawk/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "nawk";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       konimex
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ne/nestopia-ue/package.nix
+++ b/pkgs/by-name/ne/nestopia-ue/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://raw.githubusercontent.com/0ldsk00l/nestopia/${finalAttrs.src.rev}/ChangeLog";
     license = lib.licenses.gpl2Plus;
     mainProgram = "nestopia";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/no/notcurses/package.nix
+++ b/pkgs/by-name/no/notcurses/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       replacement for NCURSES on existing systems.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     inherit (ncurses.meta) platforms;
   };
 }

--- a/pkgs/by-name/no/notejot/package.nix
+++ b/pkgs/by-name/no/notejot/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/lainsce/notejot";
     description = "Stupidly-simple notes app";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     mainProgram = "io.github.lainsce.Notejot";
   };

--- a/pkgs/by-name/nu/nuweb/package.nix
+++ b/pkgs/by-name/nu/nuweb/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     mainProgram = "nuweb";
     homepage = "https://nuweb.sourceforge.net";
     license = licenses.free;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/nx/nxengine-evo/assets.nix
+++ b/pkgs/by-name/nx/nxengine-evo/assets.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = with lib.licenses; [
       unfreeRedistributable
     ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/nx/nxengine-evo/package.nix
+++ b/pkgs/by-name/nx/nxengine-evo/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
       gpl3Plus
     ];
     mainProgram = "nx";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/of/office-code-pro/package.nix
+++ b/pkgs/by-name/of/office-code-pro/package.nix
@@ -34,6 +34,6 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://github.com/nathco/Office-Code-Pro";
     license = licenses.ofl;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/og/oguri/package.nix
+++ b/pkgs/by-name/og/oguri/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vilhalmer/oguri/";
     description = "Very nice animated wallpaper daemon for Wayland compositors";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     inherit (wayland.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin; # this should be enfoced by wayland platforms in the future
   };

--- a/pkgs/by-name/on/onedrive/package.nix
+++ b/pkgs/by-name/on/onedrive/package.nix
@@ -86,7 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "onedrive";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       peterhoeg
       bertof
     ];

--- a/pkgs/by-name/op/openh264/package.nix
+++ b/pkgs/by-name/op/openh264/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Codec library which supports H.264 encoding and decoding";
     changelog = "https://github.com/cisco/openh264/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [ bsd2 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     # See meson.build
     platforms =
       lib.platforms.windows

--- a/pkgs/by-name/op/openmsx/package.nix
+++ b/pkgs/by-name/op/openmsx/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
       boost
       gpl2Plus
     ];
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "openmsx";
   };

--- a/pkgs/by-name/pa/paperkey/package.nix
+++ b/pkgs/by-name/pa/paperkey/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [
-      AndersonTorres
       peterhoeg
     ];
   };

--- a/pkgs/by-name/pa/passwdqc/package.nix
+++ b/pkgs/by-name/pa/passwdqc/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.openwall.com/passwdqc/";
     description = "Passphrase strength checking and enforcement";
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "passwdqc";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -130,7 +130,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "pcsx2-qt";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       hrdinka
       govanify
       matteopacini

--- a/pkgs/by-name/pe/pekwm/package.nix
+++ b/pkgs/by-name/pe/pekwm/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://raw.githubusercontent.com/pekwm/pekwm/release-${finalAttrs.version}/NEWS.md";
     license = lib.licenses.gpl2Plus;
     mainProgram = "pekwm";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/pf/pforth/package.nix
+++ b/pkgs/by-name/pf/pforth/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/philburk/pforth/blob/v${finalAttrs.version}/RELEASES.md";
     license = lib.licenses.bsd0;
     maintainers = with lib.maintainers; [
-      AndersonTorres
       yrashk
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/pg/pgf-pie/package.nix
+++ b/pkgs/by-name/pg/pgf-pie/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/pgf-tikz/pgf-pie";
     description = "Some LaTeX macros for pie charts using the PGF/TikZ package";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pg/pgf-umlcd/package.nix
+++ b/pkgs/by-name/pg/pgf-umlcd/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/pgf-tikz/pgf-umlcd";
     description = "Some LaTeX macros for UML Class Diagrams";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pg/pgf-umlsd/package.nix
+++ b/pkgs/by-name/pg/pgf-umlsd/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/pgf-tikz/pgf-umlsd";
     description = "Some LaTeX macros for UML Sequence Diagrams";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/pg/pgf1/package.nix
+++ b/pkgs/by-name/pg/pgf1/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Portable Graphic Format for TeX - version ${finalAttrs.version}";
     branch = lib.versions.major version;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pg/pgf2/package.nix
+++ b/pkgs/by-name/pg/pgf2/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Portable Graphic Format for TeX";
     branch = lib.versions.major version;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pg/pgf3/package.nix
+++ b/pkgs/by-name/pg/pgf3/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Portable Graphic Format for TeX - version ${finalAttrs.version}";
     branch = lib.versions.major version;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pg/pgfplots/package.nix
+++ b/pkgs/by-name/pg/pgfplots/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://pgfplots.sourceforge.net";
     description = "TeX package to draw plots directly in TeX in two and three dimensions";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/pi/pipeworld/package.nix
+++ b/pkgs/by-name/pi/pipeworld/package.nix
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (finalPackages: {
       terminal emulator.
     '';
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/pp/ppsspp/package.nix
+++ b/pkgs/by-name/pp/ppsspp/package.nix
@@ -172,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
       not run those.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     mainProgram = "ppsspp";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pr/previewqt/package.nix
+++ b/pkgs/by-name/pr/previewqt/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/lspies/previewqt/-/blob/v${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.gpl2Plus;
     mainProgram = "previewqt";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/pr/prio/package.nix
+++ b/pkgs/by-name/pr/prio/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/letoram/prio";
     description = "Plan9- Rio like Window Manager for Arcan";
     license = with lib.licenses; [ bsd3 ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/pr/pru/package.nix
+++ b/pkgs/by-name/pr/pru/package.nix
@@ -18,7 +18,7 @@ bundlerApp {
       grep etc.).
     '';
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 
   passthru.updateScript = bundlerUpdateScript "pru";

--- a/pkgs/by-name/py/pyp/package.nix
+++ b/pkgs/by-name/py/pyp/package.nix
@@ -58,7 +58,6 @@ let
       mainProgram = "pyp";
       maintainers = with lib.maintainers; [
         rmcgibbo
-        AndersonTorres
       ];
     };
   };

--- a/pkgs/by-name/py/pyspread/package.nix
+++ b/pkgs/by-name/py/pyspread/package.nix
@@ -83,6 +83,6 @@ python3.pkgs.buildPythonApplication {
     '';
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "pyspread";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/qm/qmplay2/package.nix
+++ b/pkgs/by-name/qm/qmplay2/package.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl3Plus;
     mainProgram = "qmplay2";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       kashw2
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/qn/qnial/package.nix
+++ b/pkgs/by-name/qn/qnial/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://bitbucket.com/museoa/qnial";
     license = lib.licenses.artistic1;
     mainProgram = "nial";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/qr/qrcodegen/package.nix
+++ b/pkgs/by-name/qr/qrcodegen/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.nayuki.io/page/qr-code-generator-library";
     description = "High-quality QR Code generator library in many languages";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/qu/quickjs-ng/package.nix
+++ b/pkgs/by-name/qu/quickjs-ng/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Mighty JavaScript engine";
     license = lib.licenses.mit;
     mainProgram = "qjs";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/qu/quickjs/package.nix
+++ b/pkgs/by-name/qu/quickjs/package.nix
@@ -122,7 +122,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       stesie
-      AndersonTorres
     ];
     mainProgram = "qjs";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ra/ratpoison/package.nix
+++ b/pkgs/by-name/ra/ratpoison/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "ratpoison";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/rc/rcm/package.nix
+++ b/pkgs/by-name/rc/rcm/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [
       malyn
-      AndersonTorres
     ];
     platforms = with platforms; unix;
   };

--- a/pkgs/by-name/re/recutils/package.nix
+++ b/pkgs/by-name/re/recutils/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
       records, each record containing an arbitrary number of named fields.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.mit;
     mainProgram = "renderdoccmd";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.intersectLists lib.platforms.linux (lib.platforms.x86_64 ++ lib.platforms.i686);
   };
 })

--- a/pkgs/by-name/re/rep-gtk/package.nix
+++ b/pkgs/by-name/re/rep-gtk/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://sawfish.tuxfamily.org";
     description = "GTK bindings for librep";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ro/robotfindskitten/package.nix
+++ b/pkgs/by-name/ro/robotfindskitten/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://robotfindskitten.org/";
     license = lib.licenses.gpl2Plus;
     mainProgram = "robotfindskitten";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ro/rockbox-utility/package.nix
+++ b/pkgs/by-name/ro/rockbox-utility/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation  rec {
     homepage = "https://www.rockbox.org";
     description = "Open source firmware for digital music players";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     mainProgram = "RockboxUtility";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/ro/rootbar/package.nix
+++ b/pkgs/by-name/ro/rootbar/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       was designed to address the lack of good bars for wayland.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ro/roxterm/package.nix
+++ b/pkgs/by-name/ro/roxterm/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl3Plus
     ];
     mainProgram = "roxterm";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/rp/rpcemu/package.nix
+++ b/pkgs/by-name/rp/rpcemu/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     maintainers = builtins.attrValues {
-      inherit (lib.maintainers) AndersonTorres;
+      inherit (lib.maintainers) ;
     };
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/rs/rs/package.nix
+++ b/pkgs/by-name/rs/rs/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       the rows and columns.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/rs/rst2html5/package.nix
+++ b/pkgs/by-name/rs/rst2html5/package.nix
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonPackage rec {
     description = "Converts ReSTructuredText to (X)HTML5";
     homepage = "https://rst2html5.readthedocs.io/";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     mainProgram = "rst2html5";
   };
 }

--- a/pkgs/by-name/rx/rxvt/package.nix
+++ b/pkgs/by-name/rx/rxvt/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       omitting some of its little-used features, like Tektronix 4014
       emulation and toolkit-style configurability.
     '';
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2;
     platforms = platforms.linux;
     knownVulnerabilities = [

--- a/pkgs/by-name/sa/sawfish/package.nix
+++ b/pkgs/by-name/sa/sawfish/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
       extensibility or redefinition.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sc/scdoc/package.nix
+++ b/pkgs/by-name/sc/scdoc/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "scdoc";
     maintainers = with lib.maintainers; [
       primeos
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/sc/scimark/package.nix
+++ b/pkgs/by-name/sc/scimark/package.nix
@@ -34,8 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://math.nist.gov/scimark2/download_c.html";
     license = lib.licenses.publicDomain;
     mainProgram = "scimark4";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })
-# TODO [ AndersonTorres ]: Java version

--- a/pkgs/by-name/se/setconf/package.nix
+++ b/pkgs/by-name/se/setconf/package.nix
@@ -25,7 +25,7 @@ let
       description = "Small utility for changing settings in configuration textfiles";
       changelog = "https://github.com/xyproto/setconf/releases/tag/${self.src.rev}";
       mainProgram = "setconf";
-      maintainers = with lib.maintainers; [ AndersonTorres ];
+      maintainers = with lib.maintainers; [ ];
     };
   };
 in

--- a/pkgs/by-name/sh/shfm/package.nix
+++ b/pkgs/by-name/sh/shfm/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/dylanaraps/shfm";
     description = "POSIX-shell based file manager";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
     mainProgram = "shfm";
   };

--- a/pkgs/by-name/si/simh/package.nix
+++ b/pkgs/by-name/si/simh/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
       available copies of significant or representative software.
     '';
     license = with licenses; mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/si/simpleini/package.nix
+++ b/pkgs/by-name/si/simpleini/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       HeitorAugustoLN
-      AndersonTorres
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/sk/skribilo/package.nix
+++ b/pkgs/by-name/sk/skribilo/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
       conventions used in emails, Usenet and text.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sl/slang/package.nix
+++ b/pkgs/by-name/sl/slang/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.jedsoft.org/slang/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     mainProgram = "slsh";
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/sm/smallwm/package.nix
+++ b/pkgs/by-name/sm/smallwm/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/adamnew123456/SmallWM";
     license = lib.licenses.bsd2;
     mainProgram = "smallwm";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/sm/smplayer/package.nix
+++ b/pkgs/by-name/sm/smplayer/package.nix
@@ -53,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/smplayer-dev/smplayer/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })
-# TODO [ AndersonTorres ]: create a wrapper including mplayer/mpv
+# TODO [ ]: create a wrapper including mplayer/mpv

--- a/pkgs/by-name/sn/snes9x/package.nix
+++ b/pkgs/by-name/sn/snes9x/package.nix
@@ -135,7 +135,6 @@ stdenv.mkDerivation (finalAttrs: {
       };
       mainProgram = "snes9x";
       maintainers = with lib.maintainers; [
-        AndersonTorres
         qknight
         thiagokokada
         sugar700

--- a/pkgs/by-name/sn/sng/package.nix
+++ b/pkgs/by-name/sn/sng/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "sng";
     maintainers = with lib.maintainers; [
       dezgeg
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/so/sound-of-sorting/package.nix
+++ b/pkgs/by-name/so/sound-of-sorting/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://panthema.net/2013/sound-of-sorting/";
     license = lib.licenses.gpl3Plus;
     mainProgram = "sound-of-sorting";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL2.meta) platforms;
   };
 })

--- a/pkgs/by-name/sp/spigot/package.nix
+++ b/pkgs/by-name/sp/spigot/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Command-line exact real calculator";
     mainProgram = "spigot";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sr/src/package.nix
+++ b/pkgs/by-name/sr/src/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.com/esr/src/-/raw/${finalAttrs.version}/NEWS.adoc";
     license = licenses.bsd2;
     mainProgram = "src";
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     inherit (python3.meta) platforms;
   };
 })

--- a/pkgs/by-name/ss/ssh-askpass-fullscreen/package.nix
+++ b/pkgs/by-name/ss/ssh-askpass-fullscreen/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Small, fullscreen SSH askpass GUI using GTK+2";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "ssh-askpass-fullscreen";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/st/stacktile/package.nix
+++ b/pkgs/by-name/st/stacktile/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Layout generator for the river Wayland compositor";
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "stacktile";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/st/steghide/package.nix
+++ b/pkgs/by-name/st/steghide/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/museoa/steghide";
     description = "Open source steganography program";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
     mainProgram = "steghide";
   };

--- a/pkgs/by-name/st/stella/package.nix
+++ b/pkgs/by-name/st/stella/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/stella-emu/stella/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "stella";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ta/tap-plugins/package.nix
+++ b/pkgs/by-name/ta/tap-plugins/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
       TubeWarmth, TAP Vibrato.
     '';
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/te/teapot/package.nix
+++ b/pkgs/by-name/te/teapot/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
       systems.
     '';
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "teapot";
   };

--- a/pkgs/by-name/te/tecla/package.nix
+++ b/pkgs/by-name/te/tecla/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://sites.astro.caltech.edu/~mcs/tecla/release.html";
     license = with lib.licenses; [ mit ];
     mainProgram = "enhance";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/th/the-legend-of-edgar/package.nix
+++ b/pkgs/by-name/th/the-legend-of-edgar/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl1Plus;
     mainProgram = "edgar";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ti/tilda/package.nix
+++ b/pkgs/by-name/ti/tilda/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Gtk based drop down terminal for Linux and Unix";
     mainProgram = "tilda";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ti/tiny8086/package.nix
+++ b/pkgs/by-name/ti/tiny8086/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
       "unobfuscated" version :)
     '';
     license = licenses.mit;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "8086tiny";
   };

--- a/pkgs/by-name/ti/tinyemu/package.nix
+++ b/pkgs/by-name/ti/tinyemu/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
       mit
       bsd2
     ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ti/tinywm/package.nix
+++ b/pkgs/by-name/ti/tinywm/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.publicDomain;
     mainProgram = "tinywm";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ti/tinyxml-2/package.nix
+++ b/pkgs/by-name/ti/tinyxml-2/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/leethomason/tinyxml2";
     changelog = "https://github.com/leethomason/tinyxml2/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [ zlib ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/to/tomato-c/package.nix
+++ b/pkgs/by-name/to/tomato-c/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/gabrielzschmitz/Tomato.C";
     description = " A pomodoro timer written in pure C";
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "tomato";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/to/tomlcpp/package.nix
+++ b/pkgs/by-name/to/tomlcpp/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/cktan/tomlcpp";
     description = "No fanfare TOML C++ Library";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/tr/trealla/package.nix
+++ b/pkgs/by-name/tr/trealla/package.nix
@@ -96,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       siraben
-      AndersonTorres
     ];
     mainProgram = "tpl";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/tr/triehash/package.nix
+++ b/pkgs/by-name/tr/triehash/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/julian-klode/triehash";
     description = "Order-preserving minimal perfect hash function generator";
     license = with licenses; mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = perlPackages.perl.meta.platforms;
     mainProgram = "triehash";
   };

--- a/pkgs/by-name/tt/tty-solitaire/package.nix
+++ b/pkgs/by-name/tt/tty-solitaire/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://github.com/mpereira/tty-solitaire";
     platforms = ncurses.meta.platforms;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     mainProgram = "ttysolitaire";
   };
 }

--- a/pkgs/by-name/tw/twolame/package.nix
+++ b/pkgs/by-name/tw/twolame/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     homepage = "https://www.twolame.org/";
     license = with licenses; [ lgpl2Plus ];
     platforms = with platforms; unix;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/tx/txr/package.nix
+++ b/pkgs/by-name/tx/txr/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://www.kylheku.com/cgit/txr/tree/RELNOTES?h=txr-${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
-      AndersonTorres
       dtzWill
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/uc/ucg/package.nix
+++ b/pkgs/by-name/uc/ucg/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "ucg";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -148,7 +148,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [
       rasendubi
-      AndersonTorres
     ];
     platforms = lib.platforms.linux;
     badPlatforms = lib.platforms.aarch64;

--- a/pkgs/by-name/un/units/package.nix
+++ b/pkgs/by-name/un/units/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "units";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/un/universal-ctags/package.nix
+++ b/pkgs/by-name/un/universal-ctags/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
       editors and other tools to locate the indexed items.
     '';
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.all;
     mainProgram = "ctags";
     priority = 1; # over the emacs implementation

--- a/pkgs/by-name/un/unzoo/package.nix
+++ b/pkgs/by-name/un/unzoo/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/museoa/unzoo/";
     description = "Manipulate archives of files in Zoo compressed form";
     license = licenses.publicDomain;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
     mainProgram = "unzoo";
   };

--- a/pkgs/by-name/ur/urjtag/package.nix
+++ b/pkgs/by-name/ur/urjtag/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       gpl2Plus
       lgpl21Plus
     ];
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ux/uxn/package.nix
+++ b/pkgs/by-name/ux/uxn/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wiki.xxiivv.com/site/uxn.html";
     description = "Assembler and emulator for the Uxn stack machine";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "uxnemu";
     inherit (SDL2.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/ve/ventoy/package.nix
+++ b/pkgs/by-name/ve/ventoy/package.nix
@@ -211,7 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://www.ventoy.net/doc_news.html";
     license = lib.licenses.gpl3Plus;
     mainProgram = "ventoy";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/by-name/vi/viw/package.nix
+++ b/pkgs/by-name/vi/viw/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "VI Worsened, a fun and light clone of VI";
     homepage = "https://github.com/lpan/viw";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     mainProgram = "viw";
   };
 }

--- a/pkgs/by-name/vm/vms-empire/package.nix
+++ b/pkgs/by-name/vm/vms-empire/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Only;
     mainProgram = "vms-empire";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/vn/vnote/package.nix
+++ b/pkgs/by-name/vn/vnote/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "vnote";
     changelog = "https://github.com/vnotex/vnote/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/vp/vp/package.nix
+++ b/pkgs/by-name/vp/vp/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "SDL based picture viewer/slideshow";
     license = lib.licenses.gpl3Plus;
     mainProgram = "vp";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (SDL.meta) platforms;
     hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };

--- a/pkgs/by-name/vy/vym/package.nix
+++ b/pkgs/by-name/vy/vym/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "vym";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/wa/wallutils/package.nix
+++ b/pkgs/by-name/wa/wallutils/package.nix
@@ -70,7 +70,7 @@ buildGoModule rec {
     description = "Utilities for handling monitors, resolutions, and (timed) wallpapers";
     inherit (src.meta) homepage;
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     inherit (wayland.meta) platforms;
     badPlatforms = lib.platforms.darwin;
   };

--- a/pkgs/by-name/wa/waybox/package.nix
+++ b/pkgs/by-name/wa/waybox/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Openbox clone on Wayland";
     license = lib.licenses.mit;
     mainProgram = "waybox";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
   };
 })

--- a/pkgs/by-name/wi/wifish/package.nix
+++ b/pkgs/by-name/wi/wifish/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "Simple wifi shell script for linux";
     mainProgram = "wifish";
     license = licenses.wtfpl;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/by-name/wi/windowmaker/package.nix
+++ b/pkgs/by-name/wi/windowmaker/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://www.windowmaker.org/news/";
     license = lib.licenses.gpl2Plus;
     mainProgram = "wmaker";
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/wi/wio/package.nix
+++ b/pkgs/by-name/wi/wio/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ bsd3 ];
     mainProgram = "wio";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
   };
 })

--- a/pkgs/by-name/wi/with-shell/package.nix
+++ b/pkgs/by-name/wi/with-shell/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
       To exit use either :q or :exit.
     '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     mainProgram = "with";
   };

--- a/pkgs/by-name/wl/wlay/package.nix
+++ b/pkgs/by-name/wl/wlay/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/atx/wlay";
     description = "Graphical output management for Wayland";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
     mainProgram = "wlay";
   };

--- a/pkgs/by-name/wl/wlogout/package.nix
+++ b/pkgs/by-name/wl/wlogout/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/ArtsyMacaw/wlogout/releases/tag/${finalAttrs.src.rev}";
     license = with lib.licenses; [ mit ];
     mainProgram = "wlogout";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
   };
 })

--- a/pkgs/by-name/wo/worker/package.nix
+++ b/pkgs/by-name/wo/worker/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "worker";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/x1/x16/package.nix
+++ b/pkgs/by-name/x1/x16/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Official emulator of CommanderX16 8-bit computer";
     changelog = "https://github.com/X16Community/x16-emulator/blob/r${finalAttrs.version}/RELEASES.md";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "x16emu";
     inherit (SDL2.meta) platforms;
     broken = stdenv.hostPlatform.isAarch64; # ofborg fails to compile it

--- a/pkgs/by-name/x1/x16/rom.nix
+++ b/pkgs/by-name/x1/x16/rom.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/X16Community/x16-rom";
     description = "ROM file for CommanderX16 8-bit computer";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (cc65.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };

--- a/pkgs/by-name/x1/x16/run.nix
+++ b/pkgs/by-name/x1/x16/run.nix
@@ -32,9 +32,3 @@ symlinkJoin {
     runScript
   ];
 }
-# TODO [ AndersonTorres ]:
-
-# 1. Parse the command line in order to allow the user to set an optional
-# rom-file
-# 2. generate runScript based on symlinkJoin (maybe a postBuild?)
-# 3. a NixOS module to abstract the runner

--- a/pkgs/by-name/xa/xa/package.nix
+++ b/pkgs/by-name/xa/xa/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       - block structure for label scoping
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; unix;
   };
 })

--- a/pkgs/by-name/xa/xarcan/package.nix
+++ b/pkgs/by-name/xa/xarcan/package.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalPackages: {
       allows running an X session as a window under Arcan.
     '';
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/xe/xemu/package.nix
+++ b/pkgs/by-name/xe/xemu/package.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/xemu-project/xemu/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     mainProgram = "xemu";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xi/xine-lib/package.nix
+++ b/pkgs/by-name/xi/xine-lib/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl2Plus
     ];
     # No useful mainProgram
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xi/xine-ui/package.nix
+++ b/pkgs/by-name/xi/xine-ui/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Xlib-based frontend for Xine video player";
     license = lib.licenses.gpl2Plus;
     mainProgram = "xine";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xi/xiphos/package.nix
+++ b/pkgs/by-name/xi/xiphos/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.xiphos.org/";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/xo/xosview/package.nix
+++ b/pkgs/by-name/xo/xosview/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Classic system monitoring tool";
     license = lib.licenses.gpl2Plus;
     mainProgram = "xosview";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
   };
 })

--- a/pkgs/by-name/xo/xosview2/package.nix
+++ b/pkgs/by-name/xo/xosview2/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
       bsdOriginal
     ];
     mainProgram = "xosview2";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/xs/xscreensaver/package.nix
+++ b/pkgs/by-name/xs/xscreensaver/package.nix
@@ -136,7 +136,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       raskin
-      AndersonTorres
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/ya/yabasic/package.nix
+++ b/pkgs/by-name/ya/yabasic/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://2484.de/yabasic/whatsnew.html";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ya/yambar/package.nix
+++ b/pkgs/by-name/ya/yambar/package.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://codeberg.org/dnkl/yambar/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     mainProgram = "yambar";
   };

--- a/pkgs/by-name/ya/yapesdl/package.nix
+++ b/pkgs/by-name/ya/yapesdl/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/calmopyrin/yapesdl/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl2Plus;
     mainProgram = "yapesdl";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ye/yeahwm/package.nix
+++ b/pkgs/by-name/ye/yeahwm/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "http://phrat.de/README";
     license = lib.licenses.isc;
     mainProgram = "yeahwm";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     inherit (libX11.meta) platforms;
   };
 })

--- a/pkgs/by-name/ye/yex-lang/package.nix
+++ b/pkgs/by-name/ye/yex-lang/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nonamescm/yex-lang";
     description = "Functional scripting language written in rust";
     license = licenses.mit;
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     mainProgram = "yex";
     platforms = platforms.unix;
   };

--- a/pkgs/by-name/yt/ytree/package.nix
+++ b/pkgs/by-name/yt/ytree/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Curses-based file manager similar to DOS Xtree(TM)";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "ytree";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/zc/zchunk/package.nix
+++ b/pkgs/by-name/zc/zchunk/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.bsd2;
     mainProgram = "zck";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ze/zegrapher/package.nix
+++ b/pkgs/by-name/ze/zegrapher/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "ZeGrapher";
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ze/zesarux/package.nix
+++ b/pkgs/by-name/ze/zesarux/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "ZX Second-Emulator And Released for UniX";
     mainProgram = "zesarux";
     license = with lib.licenses; [ gpl3Plus ];
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/zo/zoekt/package.nix
+++ b/pkgs/by-name/zo/zoekt/package.nix
@@ -39,7 +39,7 @@ buildGoModule {
     description = "Fast trigram based code search";
     homepage = "https://github.com/sourcegraph/zoekt";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ AndersonTorres ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "zoekt";
   };
 }

--- a/pkgs/by-name/zy/zydis/package.nix
+++ b/pkgs/by-name/zy/zydis/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       jbcrail
-      AndersonTorres
       athre0z
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/zz/zziplib/package.nix
+++ b/pkgs/by-name/zz/zziplib/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
       lgpl2Plus
       mpl11
     ];
-    maintainers = with maintainers; [ AndersonTorres ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       peterhoeg
-      AndersonTorres
     ];
     mainProgram = "zeal";
     inherit (qtbase.meta) platforms;

--- a/pkgs/development/python-modules/py65/default.nix
+++ b/pkgs/development/python-modules/py65/default.nix
@@ -35,7 +35,6 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     mainProgram = "py65mon";
     maintainers = with lib.maintainers; [
-      AndersonTorres
       tomasajt
     ];
   };

--- a/pkgs/games/2048-cli/default.nix
+++ b/pkgs/games/2048-cli/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/tiehuis/2048-cli";
     description = "Game 2048 for your Linux terminal";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.AndersonTorres ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "2048";
   };


### PR DESCRIPTION
As I said before, I want to keep a narrow focus on Nixpkgs
Now that I am back at undergrad, this focus should be even narrower:
I will keep my eyes on Emacs, and nothing else.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
