### PR TITLE
Snort: init at 3.6.3.0

### DIFF
--- a/pkgs/by-name/li/libdaq/package.nix
+++ b/pkgs/by-name/li/libdaq/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libpcap,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdaq";
+  version = "3.0.18";
+
+  src = fetchFromGitHub {
+    owner = "snort3";
+    repo = "libdaq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PMb8q8QcfUXxEf0s2UdaZogmxzqUCw0wRdzfT1xio/E=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libpcap
+    stdenv.cc.cc # libstdc++
+  ];
+
+  outputs = [
+    "lib"
+    "dev"
+    "out"
+  ];
+
+  autoreconfPhase = ''
+    ./bootstrap
+  '';
+
+  postInstall = ''
+    # remove build directory (/build/**, or /tmp/nix-build-**) from RPATHs
+    for f in "$out"/bin/*; do
+      local nrp="$(patchelf --print-rpath "$f" | sed -E 's@(:|^)'$NIX_BUILD_TOP'[^:]*:@\1@g')"
+      patchelf --set-rpath "$nrp" "$f"
+    done
+  '';
+
+  meta = {
+    description = "Data AcQuisition library (libDAQ), for snort packet I/O";
+    homepage = "https://www.snort.org";
+    maintainers = with lib.maintainers; [
+      aycanirican
+      brianmcgillion
+    ];
+    license = lib.licenses.gpl2;
+    outputsToInstall = [
+      "lib"
+      "dev"
+    ];
+    platforms = with lib.platforms; linux;
+  };
+})

--- a/pkgs/by-name/sn/snort/0001-cmake-fix-pkg-config-path-for-libdir.patch
+++ b/pkgs/by-name/sn/snort/0001-cmake-fix-pkg-config-path-for-libdir.patch
@@ -1,0 +1,47 @@
+From a4dd3bf78fc8d4c22b40ddb4e91f525012703a5a Mon Sep 17 00:00:00 2001
+From: Brian McGillion <bmg.avoin@gmail.com>
+Date: Mon, 10 Feb 2025 23:31:47 +0400
+Subject: [PATCH] cmake: fix pkg-config path for libdir
+
+on systems that prefer absolute paths there is a mixing and matching of
+the relative and absolute paths that can result in the below creation of
+libdir having the prefix and the full path appended to it.
+
+** added to highlight
+
+``prefix=/nix/store/3npvhj5wfwhc0q42qwiinj64bzfb1vvz-snort-3.6.3.0
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+**libdir=${prefix}//nix/store/3npvhj5wfwhc0q42qwiinj64bzfb1vvz-snort-3.6.3.0/lib**
+includedir=${prefix}/include
+datarootdir=${prefix}/share
+datadir=${datarootdir}
+mandir=${datarootdir}/man
+infodir=${datarootdir}/info
+``
+
+In order to preserve backwards compatibility we will use the cmake
+fullpath option ${CMAKE_INSTALL_FULL_LIBDIR} in place of
+${prefix}/${CMAKE_INSTALL_LIBDIR} which will support both contexts.
+
+Signed-off-by: Brian McGillion <bmg.avoin@gmail.com>
+---
+ cmake/create_pkg_config.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/create_pkg_config.cmake b/cmake/create_pkg_config.cmake
+index 300350cbd..4ce8b16e6 100644
+--- a/cmake/create_pkg_config.cmake
++++ b/cmake/create_pkg_config.cmake
+@@ -5,7 +5,7 @@
+ set(prefix "${CMAKE_INSTALL_PREFIX}")
+ set(exec_prefix "\${prefix}")
+ set(bindir "\${exec_prefix}/bin")
+-set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
++set(libdir "\${CMAKE_INSTALL_FULL_LIBDIR}")
+ set(includedir "\${prefix}/include")
+ set(datarootdir "\${prefix}/share")
+ set(datadir "\${datarootdir}")
+-- 
+2.47.2
+

--- a/pkgs/by-name/sn/snort/package.nix
+++ b/pkgs/by-name/sn/snort/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libdaq,
+  libdnet,
+  flex,
+  hwloc,
+  luajit,
+  openssl,
+  libpcap,
+  pcre2,
+  pkg-config,
+  zlib,
+  xz,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "snort";
+  version = "3.6.3.0";
+
+  src = fetchFromGitHub {
+    owner = "snort3";
+    repo = "snort3";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-loMmmpoaEncW31FUIE9Zf9w635Prvke6vCY+mIt6oGI=";
+  };
+
+  nativeBuildInputs = [
+    libdaq
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    libdaq
+    libpcap
+    stdenv.cc.cc # libstdc++
+    libdnet
+    flex
+    hwloc
+    luajit
+    openssl
+    libpcap
+    pcre2
+    zlib
+    xz
+  ];
+
+  # Patch that is tracking upstream PR https://github.com/snort3/snort3/pull/399
+  patches = [ ./0001-cmake-fix-pkg-config-path-for-libdir.patch ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Network intrusion prevention and detection system (IDS/IPS)";
+    homepage = "https://www.snort.org";
+    maintainers = with lib.maintainers; [
+      aycanirican
+      brianmcgillion
+    ];
+    license = lib.licenses.gpl2;
+    platforms = with lib.platforms; linux;
+  };
+})

--- a/pkgs/by-name/sn/snort2/package.nix
+++ b/pkgs/by-name/sn/snort2/package.nix
@@ -16,13 +16,15 @@
   libtirpc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "2.9.20";
-  pname = "snort";
+  pname = "snort2";
 
-  src = fetchurl {
-    name = "${pname}-${version}.tar.gz";
-    url = "https://snort.org/downloads/archive/snort/${pname}-${version}.tar.gz";
+  # TODO: remove this package after 25.05 release
+  # https://github.com/NixOS/nixpkgs/pull/381363#issuecomment-2653483597
+  src = fetchurl rec {
+    name = "snort-${finalAttrs.version}.tar.gz";
+    url = "https://snort.org/downloads/snort/${name}";
     sha256 = "sha256-KUAOE/U7GDHguLEOwSJKHLqm3BUzpTIqIN2Au4S0mBw=";
   };
 
@@ -65,4 +67,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = with lib.platforms; linux;
   };
-}
+})


### PR DESCRIPTION
Snort 3 aka snort++ is the next generation Snort IPS (Intrusion
Prevention System).

[snort3](https://github.com/snort3/snort3) is actively maintained and developed unlike the snort2 baseline
so this will replace the old snort2 as the default version.

snort2 is not yet removed from the pkgs to allow folks to utilize that
if required.

In addition to the primary binary `snort` there is `snort2lua` a tool to
convert Snort 2.X conf and rules to the new form.

This PR also includes the new [libdaq]( https://github.com/snort3/libdaq) data acquisition library that is required by snort.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
