### PR TITLE
zoxide: add nushell-integration test

### DIFF
--- a/pkgs/by-name/zo/zoxide/package.nix
+++ b/pkgs/by-name/zo/zoxide/package.nix
@@ -3,10 +3,14 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
+  runCommandLocal,
   withFzf ? true,
   fzf,
   installShellFiles,
   libiconv,
+  testers,
+  nushell,
+  zoxide,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +34,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   cargoHash = "sha256-4BXZ5NnwY2izzJFkPkECKvpuyFWfZ2CguybDDk0GDU0=";
+
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = zoxide;
+      };
+      nushell-integration =
+        runCommandLocal "test-${zoxide.name}-nushell-integration"
+          {
+            nativeBuildInputs = [
+              nushell
+              zoxide
+            ];
+            meta.platforms = nushell.meta.platforms;
+          }
+          ''
+            mkdir $out
+            nu -c "zoxide init nushell | save zoxide.nu"
+            nu -c "source zoxide.nu"
+          '';
+    };
+  };
 
   postInstall = ''
     installManPage man/man*/*


### PR DESCRIPTION
Problem: As nushell releases breaking changes frequently, my config breaks quite often.
When this happens, I have to roll back and wait for other package updates. A recent example is the zoxide integration.

Proposed solution: I think it makes sense to ensure some stability in nixpkgs by adding tests for various nushell integrations.

This PR proposes such a test for zoxide.
The idea is to hold off on merging nushell updates until all integrations have been fixed upstream and the tests pass.

If the nushell maintainers are on board with this, I'd be happy to add myself as a maintainer and add some more tests for other integrations.

cc @Br1ght0ne @JohnTitor @JoaquinTrinanes 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
