### PR TITLE
ocamlPackages.dream: init at 1.0.0-alpha8

### DIFF
--- a/pkgs/development/ocaml-modules/dream/default.nix
+++ b/pkgs/development/ocaml-modules/dream/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildDunePackage,
+  dream-pure,
+  lwt_ppx,
+  camlp-streams,
+  caqti-lwt,
+  cstruct,
+  digestif,
+  dream-httpaf,
+  graphql-lwt,
+  h2-lwt-unix,
+  httpun-lwt-unix,
+  httpun-ws,
+  lambdasoup,
+  lwt_ssl,
+  magic-mime,
+  markup,
+  mirage-clock,
+  mirage-crypto-rng,
+  mirage-crypto-rng-lwt,
+  multipart_form-lwt,
+  ssl,
+  unstrctrd,
+  uri,
+  yojson,
+}:
+
+buildDunePackage {
+  pname = "dream";
+
+  inherit (dream-pure) version src;
+
+  # Compatibility with httpun 0.2.0 and h2 0.13
+  patches = [ ./httpun.patch ];
+
+  buildInputs = [ lwt_ppx ];
+
+  propagatedBuildInputs = [
+    camlp-streams
+    caqti-lwt
+    cstruct
+    digestif
+    dream-httpaf
+    dream-pure
+    graphql-lwt
+    h2-lwt-unix
+    httpun-lwt-unix
+    httpun-ws
+    lambdasoup
+    lwt_ssl
+    magic-mime
+    markup
+    mirage-clock
+    mirage-crypto-rng
+    mirage-crypto-rng-lwt
+    multipart_form-lwt
+    ssl
+    unstrctrd
+    uri
+    yojson
+  ];
+
+  meta = dream-pure.meta // {
+    description = "Tidy, feature-complete Web framework";
+  };
+}

--- a/pkgs/development/ocaml-modules/dream/httpaf.nix
+++ b/pkgs/development/ocaml-modules/dream/httpaf.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  buildDunePackage,
+  dream-pure,
+  lwt_ppx,
+  httpun-ws,
+}:
+
+buildDunePackage {
+  pname = "dream-httpaf";
+
+  inherit (dream-pure) version src;
+
+  buildInputs = [ lwt_ppx ];
+  propagatedBuildInputs = [
+    dream-pure
+    httpun-ws
+  ];
+
+  meta = dream-pure.meta // {
+    description = "Shared http/af stack for Dream (server) and Hyper (client)";
+  };
+}

--- a/pkgs/development/ocaml-modules/dream/httpun.patch
+++ b/pkgs/development/ocaml-modules/dream/httpun.patch
@@ -1,0 +1,20 @@
+diff --git a/src/http/adapt.ml b/src/http/adapt.ml
+index c6bd416..5b01e17 100644
+--- a/src/http/adapt.ml
++++ b/src/http/adapt.ml
+@@ -74,7 +74,7 @@ let forward_body
+     response
+     (Httpun.Body.Writer.write_string body)
+     (Httpun.Body.Writer.write_bigstring body)
+-    (Httpun.Body.Writer.flush body)
++    (fun f -> Httpun.Body.Writer.flush body (fun _ -> f ()))
+     (fun _code -> Httpun.Body.Writer.close body)
+ 
+ let forward_body_h2
+@@ -85,5 +85,5 @@ let forward_body_h2
+     response
+     (H2.Body.Writer.write_string body)
+     (H2.Body.Writer.write_bigstring body)
+-    (H2.Body.Writer.flush body)
++    (fun f -> H2.Body.Writer.flush body (fun _ -> f ()))
+     (fun _code -> H2.Body.Writer.close body)

--- a/pkgs/development/ocaml-modules/dream/pure.nix
+++ b/pkgs/development/ocaml-modules/dream/pure.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  lwt_ppx,
+  base64,
+  hmap,
+  lwt,
+  ptime,
+  uri,
+}:
+
+buildDunePackage rec {
+  pname = "dream-pure";
+  version = "1.0.0-alpha8";
+
+  src = fetchurl {
+    url = "https://github.com/aantron/dream/releases/download/${version}/dream-${version}.tar.gz";
+    hash = "sha256-I+2BKJDAP+XJl0pJYano5iEmvte8fX0UQLhGUslc8pY=";
+  };
+
+  buildInputs = [ lwt_ppx ];
+
+  propagatedBuildInputs = [
+    base64
+    hmap
+    lwt
+    ptime
+    uri
+  ];
+
+  meta = {
+    description = "Shared HTTP types for Dream (server) and Hyper (client)";
+    homepage = "https://aantron.github.io/dream/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -383,6 +383,8 @@ let
 
     dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
 
+    dream-httpaf = callPackage ../development/ocaml-modules/dream/httpaf.nix { };
+
     dream-pure = callPackage ../development/ocaml-modules/dream/pure.nix { };
 
     dscheck = callPackage ../development/ocaml-modules/dscheck { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -383,6 +383,8 @@ let
 
     dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
 
+    dream-pure = callPackage ../development/ocaml-modules/dream/pure.nix { };
+
     dscheck = callPackage ../development/ocaml-modules/dscheck { };
 
     dssi = callPackage ../development/ocaml-modules/dssi { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -383,6 +383,8 @@ let
 
     dot-merlin-reader = callPackage ../development/tools/ocaml/merlin/dot-merlin-reader.nix { };
 
+    dream = callPackage ../development/ocaml-modules/dream { };
+
     dream-httpaf = callPackage ../development/ocaml-modules/dream/httpaf.nix { };
 
     dream-pure = callPackage ../development/ocaml-modules/dream/pure.nix { };


### PR DESCRIPTION
Dependencies of `lambdapi`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
