### PR TITLE
nemo-seahorse: init at 6.4.0

### DIFF
--- a/pkgs/by-name/ne/nemo-seahorse/fix-schemas.patch
+++ b/pkgs/by-name/ne/nemo-seahorse/fix-schemas.patch
@@ -1,0 +1,16 @@
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -1,10 +1,13 @@
+ dataconf = configuration_data()
+ dataconf.set('VERSION', meson.project_version())
+
++schemadir = get_option('prefix') / get_option('datadir') / 'glib-2.0' / 'schemas'
++
+ install_data(
+     'org.nemo.plugins.seahorse.gschema.xml',
+     'org.nemo.plugins.seahorse.window.gschema.xml',
+     install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
+ )
+
++meson.add_install_script('glib-compile-schemas', schemadir)
+ install_man('nemo-seahorse-tool.1')

--- a/pkgs/by-name/ne/nemo-seahorse/package.nix
+++ b/pkgs/by-name/ne/nemo-seahorse/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  pkg-config,
+  ninja,
+  glib,
+  gtk3,
+  nemo,
+  cmake,
+  dbus-glib,
+  libcryptui,
+  gcr,
+  libnotify,
+  gnupg,
+  gpgme,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nemo-seahorse";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    tag = version;
+    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+  };
+
+  sourceRoot = "${src.name}/nemo-seahorse";
+
+  patches = [ ./fix-schemas.patch ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    cmake
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    nemo
+    gpgme
+    dbus-glib
+    libcryptui
+    gcr
+    libnotify
+    gnupg
+  ];
+
+  PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-seahorse";
+    changelog = "https://github.com/linuxmint/nemo-extensions/blob/master/nemo-seahorse/ChangeLog";
+    description = "Nemo seahorse extension";
+    longDescription = ''
+      You can add the extension to nemo using the following configuration:
+      ```nix
+      {
+        environment.systemPackages = with pkgs; [
+          (nemo-with-extensions.override {
+            extensions = [ nemo-seahorse ];
+          })
+        ];
+
+        services.dbus.packages = with pkgs; [
+          libcryptui
+        ];
+
+        services.xserver.desktopManager.gnome.extraGSettingsOverridePackages = with pkgs; [
+          nemo
+          gcr
+          libcryptui
+          nemo-seahorse
+        ];
+      }
+      ```
+    '';
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.cinnamon.members;
+  };
+}


### PR DESCRIPTION
https://github.com/linuxmint/nemo-extensions/tree/master/nemo-seahorse
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I tried to implement it using:
```nix
{ pkgs, ... }:
let
  nemo-seahorse = (pkgs.callPackage ./nemo-seahorse.nix { });
in
{
  environment.systemPackages = [
    (pkgs.nemo-with-extensions.override {
      extensions = [ nemo-seahorse ];
    })
  ];
  programs.seahorse.enable = true;
  services.xserver = {
    # https://github.com/NixOS/nixpkgs/issues/33277
    desktopManager.gnome.extraGSettingsOverridePackages = [
      pkgs.nemo
      nemo-seahorse
    ];
  };
}
```
But when trying to use the extension (open nemo in terminal to see logs) the following error appears:
```
EXEC: nemo-seahorse-tool --sign 'file:///home/user/test'
(nemo-seahorse-tool:56518): GLib-GIO-ERROR **: 10:29:23.841: Settings schema 'org.nemo.plugins.seahorse' is not installed
```
After a reboot I get:
```
EXEC: nemo-seahorse-tool --sign 'file:///home/nicof2000/TODO'

** (nemo-seahorse-tool:4362): WARNING **: 19:53:03.281: dbus call to list keys failed: The name org.gnome.seahorse was not provided by any .service files

** (nemo-seahorse-tool:4362): WARNING **: 19:53:03.284: dbus call to list keys failed: The name org.gnome.seahorse was not provided by any .service files

(nemo-seahorse-tool:4362): GLib-GIO-ERROR **: 19:53:03.284: Settings schema 'org.gnome.seahorse.recipients' is not installed
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

closes https://github.com/NixOS/nixpkgs/issues/385631