### PR TITLE
mastodon: remove workspace package with broken symlinks

### DIFF
--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -74,6 +74,10 @@ stdenv.mkDerivation rec {
       yarn cache clean --all
       rm -rf ~/node_modules/.cache
 
+      # Remove workspace "package" as it contains broken symlinks
+      # See https://github.com/NixOS/nixpkgs/issues/380366
+      rm -rf ~/node_modules/@mastodon
+
       # Remove execute permissions
       find ~/public/assets -type f ! -perm 0555 \
         -exec chmod 0444 {} ';'


### PR DESCRIPTION
Fixes #380366 (build failure) caused by broken symlinks now being checked (#370750)

The fix was investigated and proposed by @networkException in https://github.com/NixOS/nixpkgs/issues/380366#issuecomment-2646169311. I'm just upstreaming that solution.

I believe the nixpkgs-review failures are unrelated, `nix-build -A mastodon.mastodonModules` builds without issue.

cc maintainers: @happy-river @erictapen @Izorkin @ghuntley

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---

### `x86_64-linux`

<details><summary>:x: 33 packages failed to build:</summary>
    <ul>
    <li>python312Packages.batchspawner</li>
    <li>python312Packages.batchspawner.dist</li>
    <li>python312Packages.great-tables</li>
    <li>python312Packages.great-tables.dist</li>
    <li>python312Packages.reflex</li>
    <li>python312Packages.reflex.dist</li>
    <li>python312Packages.shiny</li>
    <li>python312Packages.shiny.dist</li>
    <li>python313Packages.batchspawner</li>
    <li>python313Packages.batchspawner.dist</li>
    <li>python313Packages.django-filingcabinet</li>
    <li>python313Packages.django-filingcabinet.dist</li>
    <li>python313Packages.dockerspawner</li>
    <li>python313Packages.dockerspawner.dist</li>
    <li>python313Packages.great-tables</li>
    <li>python313Packages.great-tables.dist</li>
    <li>python313Packages.jupyterhub</li>
    <li>python313Packages.jupyterhub-ldapauthenticator</li>
    <li>python313Packages.jupyterhub-ldapauthenticator.dist</li>
    <li>python313Packages.jupyterhub-systemdspawner</li>
    <li>python313Packages.jupyterhub-systemdspawner.dist</li>
    <li>python313Packages.jupyterhub-tmpauthenticator</li>
    <li>python313Packages.jupyterhub-tmpauthenticator.dist</li>
    <li>python313Packages.jupyterhub.dist</li>
    <li>python313Packages.oauthenticator</li>
    <li>python313Packages.oauthenticator.dist</li>
    <li>python313Packages.reflex</li>
    <li>python313Packages.reflex.dist</li>
    <li>python313Packages.shiny</li>
    <li>python313Packages.shiny.dist</li>
    <li>theharvester</li>
    <li>theharvester.dist</li>
    <li>wivrn</li>
  </ul>
</details>

<details><summary>:white_check_mark: 56 packages built:</summary>
    <ul>
    <li>changedetection-io</li>
    <li>changedetection-io.dist</li>
    <li>dnsproxy</li>
    <li>envision</li>
    <li>harper</li>
    <li>lacus</li>
    <li>lacus.dist</li>
    <li>mastodon</li>
    <li>pentestgpt</li>
    <li>pentestgpt.dist</li>
    <li>pinnwand</li>
    <li>pinnwand.dist</li>
    <li>playwright-test</li>
    <li>python312Packages.django-filingcabinet</li>
    <li>python312Packages.django-filingcabinet.dist</li>
    <li>python312Packages.dockerspawner</li>
    <li>python312Packages.dockerspawner.dist</li>
    <li>python312Packages.jupyterhub</li>
    <li>python312Packages.jupyterhub-ldapauthenticator</li>
    <li>python312Packages.jupyterhub-ldapauthenticator.dist</li>
    <li>python312Packages.jupyterhub-systemdspawner</li>
    <li>python312Packages.jupyterhub-systemdspawner.dist</li>
    <li>python312Packages.jupyterhub-tmpauthenticator</li>
    <li>python312Packages.jupyterhub-tmpauthenticator.dist</li>
    <li>python312Packages.jupyterhub.dist</li>
    <li>python312Packages.lacuscore</li>
    <li>python312Packages.lacuscore.dist</li>
    <li>python312Packages.oauthenticator</li>
    <li>python312Packages.oauthenticator.dist</li>
    <li>python312Packages.playwright</li>
    <li>python312Packages.playwright-stealth</li>
    <li>python312Packages.playwright-stealth.dist</li>
    <li>python312Packages.playwright.dist</li>
    <li>python312Packages.playwrightcapture</li>
    <li>python312Packages.playwrightcapture.dist</li>
    <li>python312Packages.pycookiecheat</li>
    <li>python312Packages.pycookiecheat.dist</li>
    <li>python312Packages.pytest-playwright</li>
    <li>python312Packages.pytest-playwright.dist</li>
    <li>python313Packages.lacuscore</li>
    <li>python313Packages.lacuscore.dist</li>
    <li>python313Packages.playwright</li>
    <li>python313Packages.playwright-stealth</li>
    <li>python313Packages.playwright-stealth.dist</li>
    <li>python313Packages.playwright.dist</li>
    <li>python313Packages.playwrightcapture</li>
    <li>python313Packages.playwrightcapture.dist</li>
    <li>python313Packages.pycookiecheat</li>
    <li>python313Packages.pycookiecheat.dist</li>
    <li>python313Packages.pytest-playwright</li>
    <li>python313Packages.pytest-playwright.dist</li>
    <li>shot-scraper</li>
    <li>shot-scraper.dist</li>
    <li>teamspeak6-client</li>
    <li>urlwatch</li>
    <li>urlwatch.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
