### PR TITLE
prusa-slicer: fix gcode viewer association with *.bgcode

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -91,13 +91,16 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  # required for GCC 14
+  # Patch required for GCC 14.
   # (not applicable to super-slicer fork)
+  # Make Gcode viewer open newer bgcode files.
   postPatch = lib.optionalString (finalAttrs.pname == "prusa-slicer") ''
     substituteInPlace src/slic3r-arrange/include/arrange/DataStoreTraits.hpp \
       --replace-fail \
       "WritableDataStoreTraits<ArrItem>::template set" \
       "WritableDataStoreTraits<ArrItem>::set"
+    substituteInPlace src/platform/unix/PrusaGcodeviewer.desktop \
+      --replace-fail 'MimeType=text/x.gcode;' 'MimeType=application/x-bgcode;text/x.gcode;'
   '';
 
   nativeBuildInputs = [
@@ -202,6 +205,17 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/share/pixmaps/"
     ln -s "$out/share/PrusaSlicer/icons/PrusaSlicer.png" "$out/share/pixmaps/PrusaSlicer.png"
     ln -s "$out/share/PrusaSlicer/icons/PrusaSlicer-gcodeviewer_192px.png" "$out/share/pixmaps/PrusaSlicer-gcodeviewer.png"
+
+    mkdir -p "$out"/share/mime/packages
+    cat << EOF > "$out"/share/mime/packages/prusa-gcode-viewer.xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+      <mime-type type="application/x-bgcode">
+        <comment xml:lang="en">Binary G-code file</comment>
+        <glob pattern="*.bgcode"/>
+      </mime-type>
+    </mime-info>
+    EOF
   '';
 
   preFixup = ''
@@ -231,6 +245,7 @@ stdenv.mkDerivation (finalAttrs: {
       maintainers = with maintainers; [
         tweber
         tmarkus
+        fliegendewurst
       ];
       platforms = platforms.unix;
     }


### PR DESCRIPTION
At the moment .bgcode files are not recognized or associated with the gcode viewer.
Fix by adding a new mime type and patch the desktop file to use it.

https://github.com/prusa3d/PrusaSlicer/issues/14122

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested: KDE recognizes the new file type and opens the gcode viewer without further configuration
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).