### PR TITLE
nixos/opendkim: Add selector in multi domain

### DIFF
--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -9,16 +9,25 @@ let
   cfg = config.services.opendkim;
 
   defaultSock = "local:/run/opendkim/opendkim.sock";
+  trustedHostsFile = pkgs.writeText "TrustedHosts" (lib.concatStringsSep "\n" cfg.trustedHosts);
 
   mergedSettings =
     if cfg.domainConfigs != { } then
-      cfg.settings
+      (lib.optionalAttrs (cfg.trustedHosts != [ ]) {
+        InternalHosts = "refile:/etc/opendkim/TrustedHosts";
+        ExternalIgnoreList = "refile:/etc/opendkim/TrustedHosts";
+      })
+      // cfg.settings
       // {
         KeyTable = "refile:${cfg.keyPath}/KeyTable";
         SigningTable = "refile:${cfg.keyPath}/SigningTable";
       }
     else
-      cfg.settings;
+      (lib.optionalAttrs (cfg.trustedHosts != [ ]) {
+        InternalHosts = "refile:/etc/opendkim/TrustedHosts";
+        ExternalIgnoreList = "refile:/etc/opendkim/TrustedHosts";
+      })
+      // cfg.settings;
 
   configFile = pkgs.writeText "opendkim.conf" (
     lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") mergedSettings)
@@ -134,6 +143,22 @@ in
         default = { };
         description = "Optional per-domain configurations for selectors";
       };
+
+      trustedHosts = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        example = [
+          "127.0.0.1"
+          "::1"
+          "localhost"
+          "192.168.1.0/24"
+          "*.example.com"
+        ];
+        description = ''
+          List of hosts that are considered trusted and allowed to send emails.
+          These hosts will be added to TrustedHosts file used by InternalHosts and ExternalIgnoreList.
+        '';
+      };
     };
   };
 
@@ -150,9 +175,14 @@ in
     };
 
     environment = {
-      etc = lib.mkIf (mergedSettings != { }) {
-        "opendkim/opendkim.conf".source = configFile;
-      };
+      etc = lib.mkMerge [
+        (lib.mkIf (mergedSettings != { }) {
+          "opendkim/opendkim.conf".source = configFile;
+        })
+        (lib.mkIf (cfg.trustedHosts != [ ]) {
+          "opendkim/TrustedHosts".source = trustedHostsFile;
+        })
+      ];
       systemPackages = [ pkgs.opendkim ];
     };
 

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -278,7 +278,8 @@ in
         RemoveIPC = true;
         RestrictAddressFamilies = [
           "AF_INET"
-          "AF_INET6 AF_UNIX"
+          "AF_INET6"
+          "AF_UNIX"
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -10,25 +10,45 @@ let
 
   defaultSock = "local:/run/opendkim/opendkim.sock";
 
+  mergedSettings =
+    if cfg.domainConfigs != { } then
+      cfg.settings
+      // {
+        KeyTable = "refile:${cfg.keyPath}/KeyTable";
+        SigningTable = "refile:${cfg.keyPath}/SigningTable";
+      }
+    else
+      cfg.settings;
+
+  configFile = pkgs.writeText "opendkim.conf" (
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") mergedSettings)
+  );
+
   args = [
     "-f"
     "-l"
     "-p"
     cfg.socket
-    "-d"
-    cfg.domains
-    "-k"
-    "${cfg.keyPath}/${cfg.selector}.private"
-    "-s"
-    cfg.selector
   ]
-  ++ lib.optionals (cfg.configFile != null) [
-    "-x"
-    cfg.configFile
-  ];
-
-  configFile = pkgs.writeText "opendkim.conf" (
-    lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") cfg.settings)
+  ++ (
+    if cfg.domainConfigs != { } then
+      [
+        "-x"
+        configFile
+      ]
+    else
+      [
+        "-d"
+        cfg.domains
+        "-k"
+        "${cfg.keyPath}/${cfg.selector}.private"
+        "-s"
+        cfg.selector
+      ]
+      ++ lib.optionals (cfg.configFile != null) [
+        "-x"
+        cfg.configFile
+      ]
   );
 in
 {
@@ -99,6 +119,21 @@ in
         default = { };
         description = "Additional opendkim configuration";
       };
+
+      domainConfigs = lib.mkOption {
+        type =
+          with lib.types;
+          attrsOf (submodule {
+            options = {
+              selector = lib.mkOption {
+                type = lib.types.str;
+                description = "Selector to use for this domain";
+              };
+            };
+          });
+        default = { };
+        description = "Optional per-domain configurations for selectors";
+      };
     };
   };
 
@@ -115,7 +150,7 @@ in
     };
 
     environment = {
-      etc = lib.mkIf (cfg.settings != { }) {
+      etc = lib.mkIf (mergedSettings != { }) {
         "opendkim/opendkim.conf".source = configFile;
       };
       systemPackages = [ pkgs.opendkim ];
@@ -132,16 +167,51 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = ''
-        cd "${cfg.keyPath}"
-        if ! test -f ${cfg.selector}.private; then
-          ${pkgs.opendkim}/bin/opendkim-genkey -s ${cfg.selector} -d all-domains-generic-key
-          echo "Generated OpenDKIM key! Please update your DNS settings:\n"
-          echo "-------------------------------------------------------------"
-          cat ${cfg.selector}.txt
-          echo "-------------------------------------------------------------"
-        fi
-      '';
+      preStart =
+        if cfg.domainConfigs != { } then
+          ''
+            cd "${cfg.keyPath}"
+            ${lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (domain: conf: ''
+                mkdir -p "${cfg.keyPath}/${domain}"
+                if ! test -f ${domain}/${conf.selector}.private; then
+                  ${pkgs.opendkim}/bin/opendkim-genkey -s ${conf.selector} -d ${domain} -D "${cfg.keyPath}/${domain}"
+                  echo "Generated OpenDKIM key for ${domain}! Please update your DNS settings:\n"
+                  echo "-------------------------------------------------------------"
+                  cat ${domain}/${conf.selector}.txt
+                  echo "-------------------------------------------------------------"
+                fi
+              '') cfg.domainConfigs
+            )}
+
+            cat > ${cfg.keyPath}/KeyTable <<EOF
+            ${lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (
+                domain: conf:
+                "${conf.selector}._domainkey.${domain} ${domain}:${conf.selector}:${cfg.keyPath}/${domain}/${conf.selector}.private"
+              ) cfg.domainConfigs
+            )}
+            EOF
+
+            cat > ${cfg.keyPath}/SigningTable <<EOF
+            ${lib.concatStringsSep "\n" (
+              lib.mapAttrsToList (
+                domain: conf: "*@${domain} ${conf.selector}._domainkey.${domain}"
+              ) cfg.domainConfigs
+            )}
+            EOF
+          ''
+        else
+          ''
+            cd "${cfg.keyPath}"
+            if ! test -f ${cfg.selector}.private; then
+              ${pkgs.opendkim}/bin/opendkim-genkey -s ${cfg.selector} -d all-domains-generic-key
+              echo "Generated OpenDKIM key! Please update your DNS settings:\n"
+              echo "-------------------------------------------------------------"
+              cat ${cfg.selector}.txt
+              echo "-------------------------------------------------------------"
+            fi
+          '';
 
       serviceConfig = {
         ExecStart = "${pkgs.opendkim}/bin/opendkim ${lib.escapeShellArgs args}";

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -165,6 +165,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.domainConfigs != { } && cfg.configFile != null);
+        message = "services.opendkim: Cannot use both 'domainConfigs' and 'configFile' options simultaneously. Please use either one or the other.";
+      }
+    ];
+
     users.users = lib.optionalAttrs (cfg.user == "opendkim") {
       opendkim = {
         group = cfg.group;

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -12,22 +12,15 @@ let
   trustedHostsFile = pkgs.writeText "TrustedHosts" (lib.concatStringsSep "\n" cfg.trustedHosts);
 
   mergedSettings =
-    if cfg.domainConfigs != { } then
-      (lib.optionalAttrs (cfg.trustedHosts != [ ]) {
-        InternalHosts = "refile:/etc/opendkim/TrustedHosts";
-        ExternalIgnoreList = "refile:/etc/opendkim/TrustedHosts";
-      })
-      // cfg.settings
-      // {
-        KeyTable = "refile:${cfg.keyPath}/KeyTable";
-        SigningTable = "refile:${cfg.keyPath}/SigningTable";
-      }
-    else
-      (lib.optionalAttrs (cfg.trustedHosts != [ ]) {
-        InternalHosts = "refile:/etc/opendkim/TrustedHosts";
-        ExternalIgnoreList = "refile:/etc/opendkim/TrustedHosts";
-      })
-      // cfg.settings;
+    (lib.optionalAttrs (cfg.trustedHosts != [ ]) {
+      InternalHosts = "refile:/etc/opendkim/TrustedHosts";
+      ExternalIgnoreList = "refile:/etc/opendkim/TrustedHosts";
+    })
+    // cfg.settings
+    // lib.optionalAttrs (cfg.domainConfigs != { }) {
+      KeyTable = "refile:${cfg.keyPath}/KeyTable";
+      SigningTable = "refile:${cfg.keyPath}/SigningTable";
+    };
 
   configFile = pkgs.writeText "opendkim.conf" (
     lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") mergedSettings)
@@ -159,6 +152,15 @@ in
           These hosts will be added to TrustedHosts file used by InternalHosts and ExternalIgnoreList.
         '';
       };
+
+      keySize = lib.mkOption {
+        type = lib.types.int;
+        default = 2048;
+        description = ''
+          Key size in bits for RSA key generation.
+          Common values are 1024, 2048, or 4096.
+        '';
+      };
     };
   };
 
@@ -205,11 +207,9 @@ in
               lib.mapAttrsToList (domain: conf: ''
                 mkdir -p "${cfg.keyPath}/${domain}"
                 if ! test -f ${domain}/${conf.selector}.private; then
-                  ${pkgs.opendkim}/bin/opendkim-genkey -s ${conf.selector} -d ${domain} -D "${cfg.keyPath}/${domain}"
+                  ${pkgs.opendkim}/bin/opendkim-genkey -b ${toString cfg.keySize} -s ${conf.selector} -d ${domain} -D "${cfg.keyPath}/${domain}"
                   echo "Generated OpenDKIM key for ${domain}! Please update your DNS settings:\n"
-                  echo "-------------------------------------------------------------"
                   cat ${domain}/${conf.selector}.txt
-                  echo "-------------------------------------------------------------"
                 fi
               '') cfg.domainConfigs
             )}
@@ -235,11 +235,9 @@ in
           ''
             cd "${cfg.keyPath}"
             if ! test -f ${cfg.selector}.private; then
-              ${pkgs.opendkim}/bin/opendkim-genkey -s ${cfg.selector} -d all-domains-generic-key
+              ${pkgs.opendkim}/bin/opendkim-genkey -b ${toString cfg.keySize} -s ${cfg.selector} -d all-domains-generic-key
               echo "Generated OpenDKIM key! Please update your DNS settings:\n"
-              echo "-------------------------------------------------------------"
               cat ${cfg.selector}.txt
-              echo "-------------------------------------------------------------"
             fi
           '';
 

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -62,6 +62,8 @@ in
     services.opendkim = {
       enable = lib.mkEnableOption "OpenDKIM sender authentication system";
 
+      package = lib.mkPackageOption pkgs "opendkim" { };
+
       socket = lib.mkOption {
         type = lib.types.str;
         default = defaultSock;
@@ -192,10 +194,12 @@ in
           "opendkim/TrustedHosts".source = trustedHostsFile;
         })
       ];
-      systemPackages = [ pkgs.opendkim ];
+      systemPackages = [ cfg.package ];
     };
 
-    services.opendkim.configFile = lib.mkIf (cfg.settings != { }) configFile;
+    services.opendkim.configFile = lib.mkIf (
+      cfg.settings != { } && cfg.domainConfigs == { }
+    ) configFile;
 
     systemd.tmpfiles.rules = [
       "d '${cfg.keyPath}' - ${cfg.user} ${cfg.group} - -"
@@ -214,7 +218,7 @@ in
               lib.mapAttrsToList (domain: conf: ''
                 mkdir -p "${cfg.keyPath}/${domain}"
                 if ! test -f ${domain}/${conf.selector}.private; then
-                  ${pkgs.opendkim}/bin/opendkim-genkey -b ${toString cfg.keySize} -s ${conf.selector} -d ${domain} -D "${cfg.keyPath}/${domain}"
+                  ${lib.getExe' cfg.package "opendkim-genkey"} -b ${toString cfg.keySize} -s ${conf.selector} -d ${domain} -D "${cfg.keyPath}/${domain}"
                   echo "Generated OpenDKIM key for ${domain}! Please update your DNS settings:\n"
                   cat ${domain}/${conf.selector}.txt
                 fi
@@ -242,14 +246,14 @@ in
           ''
             cd "${cfg.keyPath}"
             if ! test -f ${cfg.selector}.private; then
-              ${pkgs.opendkim}/bin/opendkim-genkey -b ${toString cfg.keySize} -s ${cfg.selector} -d all-domains-generic-key
+              ${lib.getExe' cfg.package "opendkim-genkey"} -b ${toString cfg.keySize} -s ${cfg.selector} -d all-domains-generic-key
               echo "Generated OpenDKIM key! Please update your DNS settings:\n"
               cat ${cfg.selector}.txt
             fi
           '';
 
       serviceConfig = {
-        ExecStart = "${pkgs.opendkim}/bin/opendkim ${lib.escapeShellArgs args}";
+        ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs args}";
         User = cfg.user;
         Group = cfg.group;
         RuntimeDirectory = lib.optional (cfg.socket == defaultSock) "opendkim";


### PR DESCRIPTION
- Add ability to set selector in specific domain.
- Add TrustedHosts Support.
- Add KeySize Support
- Add Package Support
- Remove duplication from Args (Thank @drupol for the improvement)
- Set explicit usage with assertions

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
