### PR TITLE
write-good: remove `node_modules/.bin`

### DIFF
--- a/pkgs/by-name/wr/write-good/package.nix
+++ b/pkgs/by-name/wr/write-good/package.nix
@@ -19,6 +19,11 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
+  postInstall = ''
+    # Remove the .bin directory as it contains broken symlinks
+    rm -rf $out/lib/node_modules/write-good/node_modules/.bin
+  '';
+
   meta = {
     description = "Naive linter for English prose";
     homepage = "https://github.com/btford/write-good";


### PR DESCRIPTION
Fixes the build failure caused by symlinks now being checked: https://github.com/NixOS/nixpkgs/pull/370750.

I don't think `lib/node_modules/write-good/node_modules/.bin` is used by anything? If it was, there would've already been issues due to the broken symlinks. But maybe there's some better solution or underlying issue I'm missing.

Reported by @pinarruiz downstream in https://github.com/nix-community/nixvim/issues/3003

(No maintainers to ping for this package)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
