### PR TITLE
python312Packages.cramjam: 2.8.3 -> 2.9.1-unstable-2025-01-04

### DIFF
--- a/pkgs/development/python-modules/cramjam/default.nix
+++ b/pkgs/development/python-modules/cramjam/default.nix
@@ -3,8 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   rustPlatform,
-  stdenv,
-  libiconv,
+
+  # tests
   hypothesis,
   numpy,
   pytest-xdist,
@@ -13,29 +13,29 @@
 
 buildPythonPackage rec {
   pname = "cramjam";
-  version = "2.8.3";
+  # 2.9.1 ships with experimental decoders that were having issues.
+  # They were removed afterwards but the change has not been released yet:
+  # https://github.com/milesgranger/cramjam/pull/197
+  # TODO: update to the next stable release when available
+  version = "2.9.1-unstable-2025-01-04";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "milesgranger";
-    repo = "pyrus-cramjam";
-    tag = "v${version}";
-    hash = "sha256-1KD5/oZjfdXav1ZByQoyyiDSzbmY4VJsSJg/FtUFdDE=";
+    repo = "cramjam";
+    rev = "61564e7761e38e5ec55e7939ccd6a276c2c55d11";
+    hash = "sha256-KTYTelQdN5EIJFbyQgrYcayqkAQQSNF+SHqUFFHf1Z8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    hash = "sha256-Gpj/LUCx/ivYlmxNJnEZr8caEfV4OaQwEPNjz7vobsw=";
+    inherit pname src version;
+    hash = "sha256-Jw9zbgcrX3pofW7E8b4xzZYKj3h6ufCVLjv2xD/qONo=";
   };
-
-  buildAndTestSubdir = "cramjam-python";
 
   nativeBuildInputs = with rustPlatform; [
     cargoSetupHook
     maturinBuildHook
   ];
-
-  buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
   nativeCheckInputs = [
     hypothesis
@@ -44,22 +44,23 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "cramjam-python/tests" ];
+  env = {
+    # Makes tests less flaky by relaxing performance constraints
+    # https://github.com/HypothesisWorks/hypothesis/issues/3713
+    CI = true;
+  };
 
   disabledTestPaths = [
-    "cramjam-python/benchmarks/test_bench.py"
-    # test_variants.py appears to be flaky
-    #
-    # https://github.com/NixOS/nixpkgs/pull/311584#issuecomment-2117656380
-    "cramjam-python/tests/test_variants.py"
+    "benchmarks/test_bench.py"
   ];
 
   pythonImportsCheck = [ "cramjam" ];
 
-  meta = with lib; {
+  meta = {
     description = "Thin Python bindings to de/compression algorithms in Rust";
     homepage = "https://github.com/milesgranger/pyrus-cramjam";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ veprbl ];
+    changelog = "https://github.com/milesgranger/cramjam/releases/tag/v${version}";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ veprbl ];
   };
 }


### PR DESCRIPTION
## Things done

Fix and update `cramjam`.

Changelog: https://github.com/milesgranger/cramjam/releases/tag/v2.9.1

cc @veprbl

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
