### PR TITLE
yed: use archive.org link to reproduce even when pruned

### DIFF
--- a/pkgs/by-name/ye/yed/package.nix
+++ b/pkgs/by-name/ye/yed/package.nix
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
   version = "3.25";
 
   src = fetchzip {
-    url = "https://www.yworks.com/resources/yed/demo/${pname}-${version}.zip";
+    # to update: archive https://www.yworks.com/resources/yed/demo/yEd-${version}.zip
+    url = "https://web.archive.org/web/20250212125159/https://www.yworks.com/resources/yed/demo/yEd-${version}.zip";
     sha256 = "sha256-6Z24XmFPK+aomO7hImN4AdN08kjOsyn9PvHToyQj8sk=";
   };
 


### PR DESCRIPTION
 ## Things done
 
 Use archive.org link to reproduce even when pruned
 
 cc @abbradar
 
* Built on platform(s)
    * [x] x86_64-linux
    * [ ]  aarch64-linux
    * [ ]  x86_64-darwin
    * [ ]  aarch64-darwin
* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/anual/nix/stable/command-ref/conf-file.html))
      * [ ]  `sandbox = relaxed`
      * [ ]  `sandbox = true`
* [ ]  Tested, as applicable:
      * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
      * and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
      * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
      * made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
    * [ ]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
    * [ ]  Tested basic functionality of all binary files (usually in `./result/bin/`)
    * [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
      * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
      * [ ]  (Module updates) Added a release notes entry if the change is significant
      * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
    * [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
