### PR TITLE
texpresso: fix `nextonic` symlink

### DIFF
--- a/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
+++ b/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
@@ -18,6 +18,14 @@ tectonic-unwrapped.override (old: {
           cargoHash = "sha256-mqhbIv5r/5EDRDfP2BymXv9se2NCKxzRGqNqwqbD9A0=";
           # binary has a different name, bundled tests won't work
           doCheck = false;
+          postInstall = ''
+            ${args.postInstall or ""}
+
+            # Remove the broken `nextonic` symlink
+            # It points to `tectonic`, which doesn't exist because the exe is
+            # renamed to texpresso-tonic
+            rm $out/bin/nextonic
+          '';
           meta.mainProgram = "texpresso-tonic";
         }
       );


### PR DESCRIPTION
Remove the broken `nextonic` symlink in the `texpresso-tonic` package. Fixes build failure, due to new symlink checking added in https://github.com/NixOS/nixpkgs/pull/370750.

We could create a fixed symlink, but TBH I don't think there's any value in the `nextonic` alias, especially given the `texpresso-tonic` package can't be directly installed... AFAICT it is only ever available within texpresso's private PATH?

If we _did_ want to keep the alias, we'd just add this to `postInstall`:
```sh
ln -s $out/bin/texpresso-tonic $out/bin/nextonic
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - `nix-build -A texpresso`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
