### PR TITLE
git-buildpackage: init at 0.9.37

### DIFF
--- a/pkgs/by-name/gi/git-buildpackage/package.nix
+++ b/pkgs/by-name/gi/git-buildpackage/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+
+  coreutils,
+  fetchFromGitHub,
+  python3Packages,
+  stdenv,
+
+  # nativeCheckInputs
+  debian-devscripts,
+  dpkg,
+  gitMinimal,
+  gitSetupHook,
+  man,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "git-buildpackage";
+  version = "0.9.37";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "agx";
+    repo = "git-buildpackage";
+    tag = "debian/${version}";
+    hash = "sha256-0gfryd1GrVfL11u/IrtLSJAABRsTpFfPOGxWfVdYtgE=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace gbp/command_wrappers.py \
+    --replace-fail "/bin/true" "${lib.getExe' coreutils "true"}" \
+    --replace-fail "/bin/false" "${lib.getExe' coreutils "false"}"
+  '';
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    python-dateutil
+  ];
+
+  pythonImportsCheck = [
+    "gbp"
+  ];
+
+  nativeCheckInputs =
+    [
+      debian-devscripts
+      dpkg
+      gitMinimal
+      gitSetupHook
+      man
+    ]
+    ++ (with python3Packages; [
+      coverage
+      pytest-cov
+      pytestCheckHook
+      pyyaml
+      rpm
+    ]);
+
+  disabledTests =
+    [
+      # gbp.command_wrappers.CommandExecFailed:
+      # Couldn't commit to 'pristine-tar' with upstream 'upstream':
+      # execution failed: [Errno 2] No such file or directory: 'pristine-tar'
+      "tests.doctests.test_PristineTar.test_pristine_tar"
+
+      # When gitMinimal is used instead of git:
+      # UNEXPECTED EXCEPTION: GitRepositoryError("Invalid git command 'branch': No manual entry for git-branch")
+      "tests.doctests.test_GitRepository.test_repo"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # gbp.git.repository.GitRepositoryError:
+      # Cannot create Git repository at '/does/not/exist':
+      # [Errno 30] Read-only file system: '/does'
+      "tests.doctests.test_GitRepository.test_create_noperm"
+    ];
+
+  meta = {
+    description = "Suite to help with maintaining Debian packages in Git repositories";
+    homepage = "https://honk.sigxcpu.org/piki/projects/git-buildpackage/";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "git-buildpackage";
+  };
+}


### PR DESCRIPTION
Hi,

This add git-buildpackage (`gbp` for short), a tool to maintain a package from a git repository, used by Debian and ROS.

https://wiki.debian.org/PackagingWithGit
https://honk.sigxcpu.org/piki/projects/git-buildpackage/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
