### PR TITLE
olm: add patch removing const statement

### DIFF
--- a/pkgs/by-name/ol/olm/no-const.patch
+++ b/pkgs/by-name/ol/olm/no-const.patch
@@ -1,0 +1,25 @@
+diff --git a/include/olm/list.hh b/include/olm/list.hh
+index 6906c87..952dee3 100644
+--- a/include/olm/list.hh
++++ b/include/olm/list.hh
+@@ -99,7 +99,7 @@ public:
+             return *this;
+         }
+         T * this_pos = _data;
+-        T * const other_pos = other._data;
++        T * other_pos = other._data;
+         while (other_pos != other._end) {
+             *this_pos = *other;
+             ++this_pos;
+diff --git a/include/olm/olm_export.h b/include/olm/olm_export.h
+index e8f3596..ca55fe9 100644
+--- a/include/olm/olm_export.h
++++ b/include/olm/olm_export.h
+@@ -33,6 +33,7 @@
+ #  define OLM_DEPRECATED_NO_EXPORT OLM_NO_EXPORT OLM_DEPRECATED
+ #endif
+ 
++/* NOLINTNEXTLINE(readability-avoid-unconditional-preprocessor-if) */
+ #if 0 /* DEFINE_NO_DEPRECATED */
+ #  ifndef OLM_NO_DEPRECATED
+ #    define OLM_NO_DEPRECATED

--- a/pkgs/by-name/ol/olm/package.nix
+++ b/pkgs/by-name/ol/olm/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  patches = [ ./no-const.patch ];
+
   postPatch = ''
     substituteInPlace olm.pc.in \
       --replace '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \


### PR DESCRIPTION
## Things done

OLM is dead - long live OLM. I figured out the last OLM release no longer builds on macOS since clang complains about the old c++ code being unsafe with a `const` where there should be none. Whelp.

Additional edit: Code formatting.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
