### PR TITLE
bruno-cli: fix build with noBrokenSymlinks

### DIFF
--- a/pkgs/by-name/br/bruno-cli/package.nix
+++ b/pkgs/by-name/br/bruno-cli/package.nix
@@ -51,12 +51,21 @@ buildNpmPackage {
 
     echo "Removing unnecessary files"
     pushd $out/lib/node_modules/usebruno
-    rm -rfv packages/bruno-{app,electron,tests,toml,schema,docs}
-    rm -rfv packages/*/node_modules/typescript
-    rm -rfv node_modules/{next,@next,@tabler,pdfjs-dist,*redux*,*babel*,prettier,@types*,*react*,*graphiql*}
+
+    # packages used by the GUI app, unused by CLI
+    rm -r packages/bruno-{app,electron,tests,toml,schema,docs}
+    rm node_modules/bruno
+    rm node_modules/@usebruno/{app,tests,toml,schema}
+
+    # heavy dependencies that seem to be unused
+    rm -rf node_modules/{@tabler,pdfjs-dist,*redux*,*babel*,prettier,@types*,*react*,*graphiql*}
+    rm -r node_modules/.bin
+
+    # unused file types
     for pattern in '*.map' '*.map.js' '*.ts'; do
-      find . -type f -name "$pattern" -exec rm -v {} +
+      find . -type f -name "$pattern" -exec rm {} +
     done
+
     popd
     echo "Removed unnecessary files"
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes https://hydra.nixos.org/build/288080325

The reason for removing all those files in the first place to reduce the size of the built package (from 372M to 133M).  The automatic `npm prune` alone does help (1.1G -> 372M), but multiple packages marking dev deps as normal deps, or a package not using another package's dep can increase the size by a lot. It's a hacky solution and I'm open to suggestions if it can be solved in a simpler way.

cc @wolfgangwalther for being involved in [similar](https://github.com/NixOS/nixpkgs/pull/380354) PRs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
