### PR TITLE
nixos-rebuild-ng: fix non-flake remote build evaluation

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -389,8 +389,6 @@ def execute(argv: list[str]) -> None:
 
             dry_run = action == Action.DRY_BUILD
             no_link = action in (Action.SWITCH, Action.BOOT)
-            build_flags |= {"no_out_link": no_link, "dry_run": dry_run}
-            flake_build_flags |= {"no_link": no_link, "dry_run": dry_run}
             rollback = bool(args.rollback)
 
             def validate_image_variant(variants: ImageVariants) -> None:
@@ -444,29 +442,32 @@ def execute(argv: list[str]) -> None:
                         flake,
                         build_host,
                         eval_flags=flake_common_flags,
-                        flake_build_flags=flake_build_flags,
+                        flake_build_flags=flake_build_flags
+                        | {"no_link": no_link, "dry_run": dry_run},
                         copy_flags=copy_flags,
                     )
                 case (_, False, None, Flake(_)):
                     path_to_config = nix.build_flake(
                         attr,
                         flake,
-                        flake_build_flags=flake_build_flags,
+                        flake_build_flags=flake_build_flags
+                        | {"no_link": no_link, "dry_run": dry_run},
                     )
                 case (_, False, Remote(_), None):
                     path_to_config = nix.build_remote(
                         attr,
                         build_attr,
                         build_host,
-                        instantiate_flags=common_flags,
+                        realise_flags=common_flags,
+                        instantiate_flags=build_flags,
                         copy_flags=copy_flags,
-                        build_flags=build_flags,
                     )
                 case (_, False, None, None):
                     path_to_config = nix.build(
                         attr,
                         build_attr,
-                        build_flags=build_flags,
+                        build_flags=build_flags
+                        | {"no_out_link": no_link, "dry_run": dry_run},
                     )
                 case never:
                     # should never happen, but mypy is not smart enough to

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -8,7 +8,7 @@ from importlib.resources import files
 from pathlib import Path
 from string import Template
 from subprocess import PIPE, CalledProcessError
-from typing import Final
+from typing import Final, Literal
 from uuid import uuid4
 
 from . import tmpdir
@@ -554,7 +554,7 @@ def set_profile(
 
 def switch_to_configuration(
     path_to_config: Path,
-    action: Action,
+    action: Literal[Action.SWITCH, Action.BOOT, Action.TEST, Action.DRY_ACTIVATE],
     target_host: Remote | None,
     sudo: bool,
     install_bootloader: bool = False,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -77,7 +77,7 @@ def build_remote(
     attr: str,
     build_attr: BuildAttr,
     build_host: Remote | None,
-    build_flags: Args | None = None,
+    realise_flags: Args | None = None,
     instantiate_flags: Args | None = None,
     copy_flags: Args | None = None,
 ) -> Path:
@@ -112,7 +112,7 @@ def build_remote(
                 drv,
                 "--add-root",
                 remote_tmpdir / uuid4().hex,
-                *dict_to_flags(build_flags),
+                *dict_to_flags(realise_flags),
             ],
             remote=build_host,
             stdout=PIPE,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -4,7 +4,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 
@@ -127,7 +127,7 @@ def test_parse_args() -> None:
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
     config_path = tmp_path / "test"
@@ -147,62 +147,59 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
 
     nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--no-reexec"])
 
-    assert mock_run.call_count == 6
-    mock_run.assert_has_calls(
-        [
-            call(
-                ["nix-instantiate", "--find-file", "nixpkgs", "-vvv"],
-                stdout=PIPE,
-                check=False,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
-                check=False,
-                capture_output=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["git", "-C", nixpkgs_path, "diff", "--quiet"],
-                check=False,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-build",
-                    "<nixpkgs/nixos>",
-                    "--attr",
-                    "config.system.build.toplevel",
-                    "-vvv",
-                    "--no-out-link",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-env",
-                    "-p",
-                    Path("/nix/var/nix/profiles/system"),
-                    "--set",
-                    config_path,
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [config_path / "bin/switch-to-configuration", "boot"],
-                check=True,
-                **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "0"}}),
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            ["nix-instantiate", "--find-file", "nixpkgs", "-vvv"],
+            stdout=PIPE,
+            check=False,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
+            check=False,
+            capture_output=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["git", "-C", nixpkgs_path, "diff", "--quiet"],
+            check=False,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-build",
+                "<nixpkgs/nixos>",
+                "--attr",
+                "config.system.build.toplevel",
+                "-vvv",
+                "--no-out-link",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-env",
+                "-p",
+                Path("/nix/var/nix/profiles/system"),
+                "--set",
+                config_path,
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [config_path / "bin/switch-to-configuration", "boot"],
+            check=True,
+            **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "0"}}),
+        ),
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -227,31 +224,28 @@ def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_count == 1
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix-build",
-                    "<nixpkgs/nixos>",
-                    "--attr",
-                    "config.system.build.vm",
-                    "--include",
-                    "nixos-config=./configuration.nix",
-                    "--include",
-                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            )
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix-build",
+                "<nixpkgs/nixos>",
+                "--attr",
+                "config.system.build.vm",
+                "--include",
+                "nixos-config=./configuration.nix",
+                "--include",
+                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        )
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_image_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -285,42 +279,39 @@ def test_execute_nix_build_image_flake(mock_run: Any, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_count == 2
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "eval",
-                    "--json",
-                    "/path/to/config#nixosConfigurations.hostname.config.system.build.images",
-                    "--apply",
-                    "builtins.mapAttrs (n: v: v.passthru.filePath)",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "build",
-                    "--print-out-paths",
-                    "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "eval",
+                "--json",
+                "/path/to/config#nixosConfigurations.hostname.config.system.build.images",
+                "--apply",
+                "builtins.mapAttrs (n: v: v.passthru.filePath)",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "build",
+                "--print-out-paths",
+                "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -349,46 +340,43 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_count == 3
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "build",
-                    "--print-out-paths",
-                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
-                    "-v",
-                    "--option",
-                    "narinfo-cache-negative-ttl",
-                    "1200",
-                    "--no-link",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "sudo",
-                    "nix-env",
-                    "-p",
-                    Path("/nix/var/nix/profiles/system"),
-                    "--set",
-                    config_path,
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["sudo", config_path / "bin/switch-to-configuration", "switch"],
-                check=True,
-                **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "1"}}),
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "build",
+                "--print-out-paths",
+                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
+                "-v",
+                "--option",
+                "narinfo-cache-negative-ttl",
+                "1200",
+                "--no-link",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "sudo",
+                "nix-env",
+                "-p",
+                Path("/nix/var/nix/profiles/system"),
+                "--set",
+                config_path,
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["sudo", config_path / "bin/switch-to-configuration", "switch"],
+            check=True,
+            **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "1"}}),
+        ),
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
@@ -396,9 +384,9 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 @patch(get_qualified_name(nr.nix.uuid4, nr.nix), autospec=True)
 def test_execute_nix_switch_build_target_host(
-    mock_uuid4: Any,
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_uuid4: Mock,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -442,157 +430,154 @@ def test_execute_nix_switch_build_target_host(
         ]
     )
 
-    assert mock_run.call_count == 10
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix-instantiate",
-                    "--find-file",
-                    "nixpkgs",
-                    "--include",
-                    "nixos-config=./configuration.nix",
-                    "--include",
-                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-                ],
-                check=False,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-instantiate",
-                    "<nixpkgs/nixos>",
-                    "--attr",
-                    "config.system.build.toplevel",
-                    "--add-root",
-                    nr.tmpdir.TMPDIR_PATH / "00000000000000000000000000000000",
-                    "--include",
-                    "nixos-config=./configuration.nix",
-                    "--include",
-                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["nix-copy-closure", "--to", "user@build-host", config_path],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@build-host",
-                    "--",
-                    "mktemp",
-                    "-d",
-                    "-t",
-                    "nixos-rebuild.XXXXX",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@build-host",
-                    "--",
-                    "nix-store",
-                    "--realise",
-                    str(config_path),
-                    "--add-root",
-                    "/tmp/tmpdir/00000000000000000000000000000000",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@build-host",
-                    "--",
-                    "readlink",
-                    "-f",
-                    "/tmp/tmpdir/config",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@build-host",
-                    "--",
-                    "rm",
-                    "-rf",
-                    "/tmp/tmpdir",
-                ],
-                check=False,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix",
-                    "copy",
-                    "--from",
-                    "ssh://user@build-host",
-                    "--to",
-                    "ssh://user@target-host",
-                    config_path,
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@target-host",
-                    "--",
-                    "sudo",
-                    "nix-env",
-                    "-p",
-                    "/nix/var/nix/profiles/system",
-                    "--set",
-                    str(config_path),
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@target-host",
-                    "--",
-                    "sudo",
-                    "env",
-                    "NIXOS_INSTALL_BOOTLOADER=0",
-                    str(config_path / "bin/switch-to-configuration"),
-                    "switch",
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix-instantiate",
+                "--find-file",
+                "nixpkgs",
+                "--include",
+                "nixos-config=./configuration.nix",
+                "--include",
+                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+            ],
+            check=False,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-instantiate",
+                "<nixpkgs/nixos>",
+                "--attr",
+                "config.system.build.toplevel",
+                "--add-root",
+                nr.tmpdir.TMPDIR_PATH / "00000000000000000000000000000000",
+                "--include",
+                "nixos-config=./configuration.nix",
+                "--include",
+                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["nix-copy-closure", "--to", "user@build-host", config_path],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@build-host",
+                "--",
+                "mktemp",
+                "-d",
+                "-t",
+                "nixos-rebuild.XXXXX",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@build-host",
+                "--",
+                "nix-store",
+                "--realise",
+                str(config_path),
+                "--add-root",
+                "/tmp/tmpdir/00000000000000000000000000000000",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@build-host",
+                "--",
+                "readlink",
+                "-f",
+                "/tmp/tmpdir/config",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@build-host",
+                "--",
+                "rm",
+                "-rf",
+                "/tmp/tmpdir",
+            ],
+            check=False,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix",
+                "copy",
+                "--from",
+                "ssh://user@build-host",
+                "--to",
+                "ssh://user@target-host",
+                config_path,
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@target-host",
+                "--",
+                "sudo",
+                "nix-env",
+                "-p",
+                "/nix/var/nix/profiles/system",
+                "--set",
+                str(config_path),
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@target-host",
+                "--",
+                "sudo",
+                "env",
+                "NIXOS_INSTALL_BOOTLOADER=0",
+                str(config_path / "bin/switch-to-configuration"),
+                "switch",
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_target_host(
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -619,69 +604,66 @@ def test_execute_nix_switch_flake_target_host(
         ]
     )
 
-    assert mock_run.call_count == 4
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "build",
-                    "--print-out-paths",
-                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
-                    "--no-link",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["nix-copy-closure", "--to", "user@localhost", config_path],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@localhost",
-                    "--",
-                    "sudo",
-                    "nix-env",
-                    "-p",
-                    "/nix/var/nix/profiles/system",
-                    "--set",
-                    str(config_path),
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@localhost",
-                    "--",
-                    "sudo",
-                    "env",
-                    "NIXOS_INSTALL_BOOTLOADER=0",
-                    str(config_path / "bin/switch-to-configuration"),
-                    "switch",
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "build",
+                "--print-out-paths",
+                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
+                "--no-link",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["nix-copy-closure", "--to", "user@localhost", config_path],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@localhost",
+                "--",
+                "sudo",
+                "nix-env",
+                "-p",
+                "/nix/var/nix/profiles/system",
+                "--set",
+                str(config_path),
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@localhost",
+                "--",
+                "sudo",
+                "env",
+                "NIXOS_INSTALL_BOOTLOADER=0",
+                str(config_path / "bin/switch-to-configuration"),
+                "switch",
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_build_host(
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -709,77 +691,74 @@ def test_execute_nix_switch_flake_build_host(
         ]
     )
 
-    assert mock_run.call_count == 6
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "eval",
-                    "--raw",
-                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                ["nix-copy-closure", "--to", "user@localhost", config_path],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "ssh",
-                    *nr.process.SSH_DEFAULT_OPTS,
-                    "user@localhost",
-                    "--",
-                    "nix",
-                    "--extra-experimental-features",
-                    "'nix-command flakes'",
-                    "build",
-                    f"'{config_path}^*'",
-                    "--print-out-paths",
-                    "--no-link",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-copy-closure",
-                    "--from",
-                    "user@localhost",
-                    config_path,
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-env",
-                    "-p",
-                    Path("/nix/var/nix/profiles/system"),
-                    "--set",
-                    config_path,
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [config_path / "bin/switch-to-configuration", "switch"],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "eval",
+                "--raw",
+                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            ["nix-copy-closure", "--to", "user@localhost", config_path],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "ssh",
+                *nr.process.SSH_DEFAULT_OPTS,
+                "user@localhost",
+                "--",
+                "nix",
+                "--extra-experimental-features",
+                "'nix-command flakes'",
+                "build",
+                f"'{config_path}^*'",
+                "--print-out-paths",
+                "--no-link",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-copy-closure",
+                "--from",
+                "user@localhost",
+                config_path,
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-env",
+                "-p",
+                Path("/nix/var/nix/profiles/system"),
+                "--set",
+                config_path,
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [config_path / "bin/switch-to-configuration", "switch"],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.touch()
 
@@ -804,52 +783,49 @@ def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_count == 4
-    mock_run.assert_has_calls(
-        [
-            call(
-                ["nix-instantiate", "--find-file", "nixpkgs"],
-                check=False,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "git",
-                    "-C",
-                    nixpkgs_path,
-                    "rev-parse",
-                    "--short",
-                    "HEAD",
-                ],
-                check=False,
-                capture_output=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    "nix-env",
-                    "--rollback",
-                    "-p",
-                    Path("/nix/var/nix/profiles/system"),
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    Path("/nix/var/nix/profiles/system/bin/switch-to-configuration"),
-                    "switch",
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            ["nix-instantiate", "--find-file", "nixpkgs"],
+            check=False,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "git",
+                "-C",
+                nixpkgs_path,
+                "rev-parse",
+                "--short",
+                "HEAD",
+            ],
+            check=False,
+            capture_output=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                "nix-env",
+                "--rollback",
+                "-p",
+                Path("/nix/var/nix/profiles/system"),
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                Path("/nix/var/nix/profiles/system/bin/switch-to-configuration"),
+                "switch",
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
     mock_run.side_effect = [
@@ -859,26 +835,23 @@ def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
 
     nr.execute(["nixos-rebuild", "build", "--no-flake", "--no-reexec"])
 
-    assert mock_run.call_count == 1
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix-build",
-                    "<nixpkgs/nixos>",
-                    "--attr",
-                    "config.system.build.toplevel",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            )
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix-build",
+                "<nixpkgs/nixos>",
+                "--attr",
+                "config.system.build.toplevel",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        )
+    ]
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -894,38 +867,35 @@ def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
         ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--no-reexec"]
     )
 
-    assert mock_run.call_count == 2
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "build",
-                    "--print-out-paths",
-                    "github:user/repo#nixosConfigurations.hostname.config.system.build.toplevel",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [config_path / "bin/switch-to-configuration", "test"],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "build",
+                "--print-out-paths",
+                "github:user/repo#nixosConfigurations.hostname.config.system.build.toplevel",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [config_path / "bin/switch-to-configuration", "test"],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
 @patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
 def test_execute_test_rollback(
-    mock_path_mkdir: Any,
-    mock_path_exists: Any,
-    mock_run: Any,
+    mock_path_mkdir: Mock,
+    mock_path_exists: Mock,
+    mock_run: Mock,
 ) -> None:
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-env":
@@ -947,29 +917,26 @@ def test_execute_test_rollback(
         ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--no-reexec"]
     )
 
-    assert mock_run.call_count == 2
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix-env",
-                    "-p",
-                    Path("/nix/var/nix/profiles/system-profiles/foo"),
-                    "--list-generations",
-                ],
-                check=True,
-                stdout=PIPE,
-                **DEFAULT_RUN_KWARGS,
-            ),
-            call(
-                [
-                    Path(
-                        "/nix/var/nix/profiles/system-profiles/foo-2083-link/bin/switch-to-configuration"
-                    ),
-                    "test",
-                ],
-                check=True,
-                **DEFAULT_RUN_KWARGS,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix-env",
+                "-p",
+                Path("/nix/var/nix/profiles/system-profiles/foo"),
+                "--list-generations",
+            ],
+            check=True,
+            stdout=PIPE,
+            **DEFAULT_RUN_KWARGS,
+        ),
+        call(
+            [
+                Path(
+                    "/nix/var/nix/profiles/system-profiles/foo-2083-link/bin/switch-to-configuration"
+                ),
+                "test",
+            ],
+            check=True,
+            **DEFAULT_RUN_KWARGS,
+        ),
+    ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -1,8 +1,7 @@
 import platform
 import subprocess
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from pytest import MonkeyPatch
 
@@ -79,7 +78,9 @@ def test_flake_to_attr() -> None:
 
 
 @patch(get_qualified_name(platform.node), autospec=True)
-def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_flake_from_arg(
+    mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
+) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -161,11 +162,12 @@ def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) 
 
 
 @patch(get_qualified_name(m.Path.mkdir, m), autospec=True)
-def test_profile_from_arg(mock_mkdir: Any) -> None:
+def test_profile_from_arg(mock_mkdir: Mock) -> None:
     assert m.Profile.from_arg("system") == m.Profile(
         "system",
         Path("/nix/var/nix/profiles/system"),
     )
+    mock_mkdir.assert_not_called()
 
     assert m.Profile.from_arg("something") == m.Profile(
         "something",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -117,9 +117,14 @@ def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) 
             autospec=True,
             return_value=False,
         ),
+        patch(
+            get_qualified_name(m.discover_git, m),
+            autospec=True,
+            return_value="/etc/nixos",
+        ),
     ):
         assert m.Flake.from_arg(None, None) == m.Flake(
-            Path("/etc/nixos"), "nixosConfigurations.hostname"
+            "git+file:///etc/nixos", "nixosConfigurations.hostname"
         )
 
     with (

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -20,13 +20,13 @@ from .helpers import get_qualified_name
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build(mock_run: Any) -> None:
+def test_build(mock_run: Mock) -> None:
     assert n.build(
         "config.system.build.attr",
         m.BuildAttr("<nixpkgs/nixos>", None),
         {"nix_flag": "foo"},
     ) == Path("/path/to/file")
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix-build",
             "<nixpkgs/nixos>",
@@ -38,13 +38,17 @@ def test_build(mock_run: Any) -> None:
         stdout=PIPE,
     )
 
+    mock_run.reset_mock()
+
     assert n.build(
         "config.system.build.attr", m.BuildAttr(Path("file"), "preAttr")
     ) == Path("/path/to/file")
-    mock_run.assert_called_with(
-        ["nix-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
-        stdout=PIPE,
-    )
+    assert mock_run.call_args_list == [
+        call(
+            ["nix-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
+            stdout=PIPE,
+        )
+    ]
 
 
 @patch(
@@ -52,7 +56,7 @@ def test_build(mock_run: Any) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
 
@@ -61,7 +65,7 @@ def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> N
         flake,
         {"no_link": True, "nix_flag": "foo"},
     ) == Path("/path/to/file")
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix",
             "--extra-experimental-features",
@@ -79,7 +83,9 @@ def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> N
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 @patch(get_qualified_name(n.uuid4, n), autospec=True)
-def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) -> None:
+def test_build_remote(
+    mock_uuid4: Mock, mock_run: Mock, monkeypatch: MonkeyPatch
+) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -108,58 +114,53 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) 
         instantiate_flags={"inst": True},
         copy_flags={"copy": True},
     ) == Path("/path/to/config")
-
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix-instantiate",
-                    "<nixpkgs/nixos>",
-                    "--attr",
-                    "preAttr.config.system.build.toplevel",
-                    "--add-root",
-                    n.tmpdir.TMPDIR_PATH / "00000000000000000000000000000001",
-                    "--inst",
-                ],
-                stdout=PIPE,
-            ),
-            call(
-                [
-                    "nix-copy-closure",
-                    "--copy",
-                    "--to",
-                    "user@host",
-                    Path("/path/to/file"),
-                ],
-                extra_env={
-                    "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])
-                },
-            ),
-            call(
-                ["mktemp", "-d", "-t", "nixos-rebuild.XXXXX"],
-                remote=build_host,
-                stdout=PIPE,
-            ),
-            call(
-                [
-                    "nix-store",
-                    "--realise",
-                    Path("/path/to/file"),
-                    "--add-root",
-                    Path("/tmp/tmpdir/00000000000000000000000000000002"),
-                    "--realise",
-                ],
-                remote=build_host,
-                stdout=PIPE,
-            ),
-            call(
-                ["readlink", "-f", "/tmp/tmpdir/config"],
-                remote=build_host,
-                stdout=PIPE,
-            ),
-            call(["rm", "-rf", Path("/tmp/tmpdir")], remote=build_host, check=False),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix-instantiate",
+                "<nixpkgs/nixos>",
+                "--attr",
+                "preAttr.config.system.build.toplevel",
+                "--add-root",
+                n.tmpdir.TMPDIR_PATH / "00000000000000000000000000000001",
+                "--inst",
+            ],
+            stdout=PIPE,
+        ),
+        call(
+            [
+                "nix-copy-closure",
+                "--copy",
+                "--to",
+                "user@host",
+                Path("/path/to/file"),
+            ],
+            extra_env={"NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])},
+        ),
+        call(
+            ["mktemp", "-d", "-t", "nixos-rebuild.XXXXX"],
+            remote=build_host,
+            stdout=PIPE,
+        ),
+        call(
+            [
+                "nix-store",
+                "--realise",
+                Path("/path/to/file"),
+                "--add-root",
+                Path("/tmp/tmpdir/00000000000000000000000000000002"),
+                "--realise",
+            ],
+            remote=build_host,
+            stdout=PIPE,
+        ),
+        call(
+            ["readlink", "-f", "/tmp/tmpdir/config"],
+            remote=build_host,
+            stdout=PIPE,
+        ),
+        call(["rm", "-rf", Path("/tmp/tmpdir")], remote=build_host, check=False),
+    ]
 
 
 @patch(
@@ -168,7 +169,7 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) 
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
 def test_build_remote_flake(
-    mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path
+    mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
@@ -183,47 +184,43 @@ def test_build_remote_flake(
         copy_flags={"copy": True},
         flake_build_flags={"build": True},
     ) == Path("/path/to/file")
-    mock_run.assert_has_calls(
-        [
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "eval",
-                    "--raw",
-                    ".#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
-                    "--flake",
-                ],
-                stdout=PIPE,
-            ),
-            call(
-                [
-                    "nix-copy-closure",
-                    "--copy",
-                    "--to",
-                    "user@host",
-                    Path("/path/to/file"),
-                ],
-                extra_env={
-                    "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])
-                },
-            ),
-            call(
-                [
-                    "nix",
-                    "--extra-experimental-features",
-                    "nix-command flakes",
-                    "build",
-                    "/path/to/file^*",
-                    "--print-out-paths",
-                    "--build",
-                ],
-                remote=build_host,
-                stdout=PIPE,
-            ),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "eval",
+                "--raw",
+                ".#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
+                "--flake",
+            ],
+            stdout=PIPE,
+        ),
+        call(
+            [
+                "nix-copy-closure",
+                "--copy",
+                "--to",
+                "user@host",
+                Path("/path/to/file"),
+            ],
+            extra_env={"NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])},
+        ),
+        call(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "build",
+                "/path/to/file^*",
+                "--print-out-paths",
+                "--build",
+            ],
+            remote=build_host,
+            stdout=PIPE,
+        ),
+    ]
 
 
 def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
@@ -236,7 +233,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     build_host = m.Remote("user@build.host", [], None)
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host)
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             ["nix-copy-closure", "--to", "user@target.host", closure],
             extra_env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
         )
@@ -244,7 +241,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh build-opt")
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, None, build_host, {"copy_flag": True})
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             ["nix-copy-closure", "--copy-flag", "--from", "user@build.host", closure],
             extra_env={
                 "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh build-opt"])
@@ -258,7 +255,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     }
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host, build_host, {"copy_flag": True})
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             [
                 "nix",
                 "copy",
@@ -275,26 +272,24 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(n, "WITH_NIX_2_18", False)
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host, build_host)
-        mock_run.assert_has_calls(
-            [
-                call(
-                    ["nix-copy-closure", "--from", "user@build.host", closure],
-                    extra_env=extra_env,
-                ),
-                call(
-                    ["nix-copy-closure", "--to", "user@target.host", closure],
-                    extra_env=extra_env,
-                ),
-            ]
-        )
+        assert mock_run.call_args_list == [
+            call(
+                ["nix-copy-closure", "--from", "user@build.host", closure],
+                extra_env=extra_env,
+            ),
+            call(
+                ["nix-copy-closure", "--to", "user@target.host", closure],
+                extra_env=extra_env,
+            ),
+        ]
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
     flake = m.Flake.parse(f"{tmpdir}#attr")
     n.edit(flake, {"commit_lock_file": True})
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix",
             "--extra-experimental-features",
@@ -316,7 +311,7 @@ def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
         mp.setenv("EDITOR", "editor")
 
         n.edit(None)
-        mock_run.assert_called_with(["editor", default_nix], check=False)
+        assert mock_run.call_args == call(["editor", default_nix], check=False)
 
 
 @patch(
@@ -333,13 +328,13 @@ def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
+def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
     build_attr = m.BuildAttr("<nixpkgs/nixos>", None)
     assert n.get_build_image_variants(build_attr) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix-instantiate",
             "--eval",
@@ -357,12 +352,14 @@ def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
         stdout=PIPE,
     )
 
+    mock_run.reset_mock()
+
     build_attr = m.BuildAttr(Path(tmp_path), "preAttr")
     assert n.get_build_image_variants(build_attr, {"inst_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix-instantiate",
             "--eval",
@@ -396,13 +393,13 @@ def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants_flake(mock_run: Any) -> None:
+def test_get_build_image_variants_flake(mock_run: Mock) -> None:
     flake = m.Flake(Path("flake.nix"), "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "nix",
             "eval",
@@ -427,7 +424,7 @@ def test_get_nixpkgs_rev() -> None:
         side_effect=[CompletedProcess([], 0, "")],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) is None
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
             capture_output=True,
@@ -454,7 +451,7 @@ def test_get_nixpkgs_rev() -> None:
         ],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6"
-        mock_run.assert_has_calls(expected_calls)
+        assert mock_run.call_args_list == expected_calls
 
     with patch(
         get_qualified_name(n.run_wrapper, n),
@@ -465,7 +462,7 @@ def test_get_nixpkgs_rev() -> None:
         ],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6M"
-        mock_run.assert_has_calls(expected_calls)
+        assert mock_run.call_args_list == expected_calls
 
 
 def test_get_generations(tmp_path: Path) -> None:
@@ -506,7 +503,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
             m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
         ]
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             ["nix-env", "-p", path, "--list-generations"],
             stdout=PIPE,
             remote=None,
@@ -524,7 +521,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
             m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
         ]
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             ["nix-env", "-p", path, "--list-generations"],
             stdout=PIPE,
             remote=remote,
@@ -548,7 +545,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
         ),
     ],
 )
-def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
+def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
     # Probably better to test this function in a real system, this test is
     # mostly to make sure it doesn't break horribly
     assert n.list_generations(m.Profile("system", tmp_path)) == [
@@ -574,18 +571,20 @@ def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl(mock_run: Any) -> None:
+def test_repl(mock_run: Mock) -> None:
     n.repl("attr", m.BuildAttr("<nixpkgs/nixos>", None), {"nix_flag": True})
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["nix", "repl", "--file", "<nixpkgs/nixos>", "--nix-flag"]
     )
 
     n.repl("attr", m.BuildAttr(Path("file.nix"), "myAttr"))
-    mock_run.assert_called_with(["nix", "repl", "--file", Path("file.nix"), "myAttr"])
+    assert mock_run.call_args == call(
+        ["nix", "repl", "--file", Path("file.nix"), "myAttr"]
+    )
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl_flake(mock_run: Any) -> None:
+def test_repl_flake(mock_run: Mock) -> None:
     n.repl_flake("attr", m.Flake(Path("flake.nix"), "myAttr"), {"nix_flag": True})
     # See nixos-rebuild-ng.tests.repl for a better test,
     # this is mostly for sanity check
@@ -593,14 +592,14 @@ def test_repl_flake(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_rollback(mock_run: Any, tmp_path: Path) -> None:
+def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
     path = tmp_path / "test"
     path.touch()
 
     profile = m.Profile("system", path)
 
     assert n.rollback(profile, None, False) == profile.path
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["nix-env", "--rollback", "-p", path],
         remote=None,
         sudo=False,
@@ -608,7 +607,7 @@ def test_rollback(mock_run: Any, tmp_path: Path) -> None:
 
     target_host = m.Remote("user@localhost", [], None)
     assert n.rollback(profile, target_host, True) == profile.path
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["nix-env", "--rollback", "-p", path],
         remote=target_host,
         sudo=True,
@@ -620,8 +619,10 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
     path.touch()
     profile = m.Profile("system", path)
 
-    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        mock_run.return_value = CompletedProcess(
+    with patch(
+        get_qualified_name(n.run_wrapper, n),
+        autospec=True,
+        return_value=CompletedProcess(
             [],
             0,
             stdout=textwrap.dedent("""\
@@ -629,12 +630,13 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
                 2083   2024-11-07 22:59:41
                 2084   2024-11-07 23:54:17   (current)
                 """),
-        )
+        ),
+    ) as mock_run:
         assert (
             n.rollback_temporary_profile(m.Profile("system", path), None, False)
             == path.parent / "system-2083-link"
         )
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             [
                 "nix-env",
                 "-p",
@@ -651,7 +653,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             n.rollback_temporary_profile(m.Profile("foo", path), target_host, True)
             == path.parent / "foo-2083-link"
         )
-        mock_run.assert_called_with(
+        assert mock_run.call_args == call(
             [
                 "nix-env",
                 "-p",
@@ -663,13 +665,16 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             sudo=True,
         )
 
-    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        mock_run.return_value = CompletedProcess([], 0, stdout="")
+    with patch(
+        get_qualified_name(n.run_wrapper, n),
+        autospec=True,
+        return_value=CompletedProcess([], 0, stdout=""),
+    ) as mock_run:
         assert n.rollback_temporary_profile(profile, None, False) is None
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_set_profile(mock_run: Any) -> None:
+def test_set_profile(mock_run: Mock) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
     n.set_profile(
@@ -679,7 +684,7 @@ def test_set_profile(mock_run: Any) -> None:
         sudo=False,
     )
 
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["nix-env", "-p", profile_path, "--set", config_path],
         remote=None,
         sudo=False,
@@ -687,7 +692,7 @@ def test_set_profile(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> None:
+def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
 
@@ -702,7 +707,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> Non
             specialisation=None,
             install_bootloader=False,
         )
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [profile_path / "bin/switch-to-configuration", "switch"],
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "0"},
         sudo=False,
@@ -736,7 +741,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> Non
             install_bootloader=True,
             specialisation="special",
         )
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             config_path / "specialisation/special/bin/switch-to-configuration",
             "test",
@@ -757,17 +762,17 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> Non
     ],
 )
 @patch(get_qualified_name(n.Path.is_dir, n), autospec=True, return_value=True)
-def test_upgrade_channels(mock_is_dir: Any, mock_glob: Any) -> None:
+def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)
-    mock_run.assert_called_with(["nix-channel", "--update", "nixos"], check=False)
+    assert mock_run.call_args == call(["nix-channel", "--update", "nixos"], check=False)
+
+    mock_run.reset_mock()
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(True)
-    mock_run.assert_has_calls(
-        [
-            call(["nix-channel", "--update", "nixos"], check=False),
-            call(["nix-channel", "--update", "nixos-hardware"], check=False),
-            call(["nix-channel", "--update", "home-manager"], check=False),
-        ]
-    )
+    assert mock_run.call_args_list == [
+        call(["nix-channel", "--update", "nixos"], check=False),
+        call(["nix-channel", "--update", "nixos-hardware"], check=False),
+        call(["nix-channel", "--update", "home-manager"], check=False),
+    ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -104,7 +104,7 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) 
         "config.system.build.toplevel",
         m.BuildAttr("<nixpkgs/nixos>", "preAttr"),
         build_host,
-        build_flags={"build": True},
+        realise_flags={"realise": True},
         instantiate_flags={"inst": True},
         copy_flags={"copy": True},
     ) == Path("/path/to/config")
@@ -147,7 +147,7 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) 
                     Path("/path/to/file"),
                     "--add-root",
                     Path("/tmp/tmpdir/00000000000000000000000000000002"),
-                    "--build",
+                    "--realise",
                 ],
                 remote=build_host,
                 stdout=PIPE,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -1,5 +1,4 @@
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 from pytest import MonkeyPatch
 
@@ -10,9 +9,9 @@ from .helpers import get_qualified_name
 
 
 @patch(get_qualified_name(p.subprocess.run), autospec=True)
-def test_run(mock_run: Any) -> None:
+def test_run(mock_run: Mock) -> None:
     p.run_wrapper(["test", "--with", "flags"], check=True)
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["test", "--with", "flags"],
         check=True,
         text=True,
@@ -28,7 +27,7 @@ def test_run(mock_run: Any) -> None:
             sudo=True,
             extra_env={"FOO": "bar"},
         )
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         ["sudo", "test", "--with", "flags"],
         check=False,
         text=True,
@@ -45,7 +44,7 @@ def test_run(mock_run: Any) -> None:
         check=True,
         remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
     )
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "ssh",
             "--ssh",
@@ -71,7 +70,7 @@ def test_run(mock_run: Any) -> None:
         extra_env={"FOO": "bar"},
         remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
     )
-    mock_run.assert_called_with(
+    assert mock_run.call_args == call(
         [
             "ssh",
             "--ssh",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -105,7 +105,7 @@ def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
 
     # get_qualified_name doesn't work because getpass is aliased to another
     # function
-    with patch(f"{p.__name__}.getpass", return_value="password"):
+    with patch(f"{p.__name__}.getpass", autospec=True, return_value="password"):
         monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar -t")
         assert m.Remote.from_arg("user@localhost", True, True) == m.Remote(
             "user@localhost",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #381457.

Also lots of tests improvements, replacing `Any` type annotation from mocks to `Mock` and  `Mock.{assert_called_with,assert_has_calls}` with `Mock.{call_args,call_args_list}`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
