### PR TITLE
openbsd.{fdisk,umount,newfs,newfs_msdos,disklabel,mount_msdosfs,mknod}: init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/disklabel/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/disklabel/package.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  mkDerivation,
+  mandoc,
+}:
+mkDerivation {
+  path = "sbin/disklabel";
+  extraNativeBuildInputs = [
+    mandoc
+  ];
+  meta.platforms = lib.platforms.openbsd;
+  meta.mainProgram = "disklabel";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fdisk.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fdisk.nix
@@ -1,0 +1,11 @@
+{
+  lib,
+  mkDerivation,
+  mandoc,
+}:
+mkDerivation {
+  path = "sbin/fdisk";
+  extraNativeBuildInputs = [ mandoc ];
+  meta.mainProgram = "fdisk";
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mknod.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mknod.nix
@@ -1,0 +1,9 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/mknod";
+  meta.mainProgram = "mknod";
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount_msdos/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount_msdos/package.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/mount_msdos";
+  extraPaths = [
+    "sbin/mount"
+  ];
+  meta.mainProgram = "mount_msdos";
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/newfs/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/newfs/package.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/newfs";
+  extraPaths = [
+    "sbin/mount"
+    "sbin/disklabel"
+  ];
+  meta.mainProgram = "newfs";
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/newfs_msdos.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/newfs_msdos.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/newfs_msdos";
+  meta.mainProgram = "newfs_msdos";
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/umount/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/umount/package.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/umount";
+  meta.mainProgram = "ummount";
+  meta.platforms = lib.platforms.openbsd;
+}


### PR DESCRIPTION
Not much to say here. Just a bunch of filesystem utilities!

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
