### PR TITLE
flexoptix-app: update hash for udev rules

### DIFF
--- a/pkgs/by-name/fl/flexoptix-app/package.nix
+++ b/pkgs/by-name/fl/flexoptix-app/package.nix
@@ -16,7 +16,7 @@ let
 
   udevRules = fetchurl {
     url = "https://www.flexoptix.net/static/frontend/Flexoptix/default/en_US/files/99-tprogrammer.rules";
-    hash = "sha256-OZe5dV50xq99olImbo7JQxPjRd7hGyBIVwFvtR9cIVc=";
+    hash = "sha256-faowRYdrk88WUpOpaEfedzybBgxVRZhvAaYP9HAuzAE=";
   };
 
   appimageContents = (appimageTools.extract { inherit pname version src; }).overrideAttrs (oA: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I assume new v5 hardware.


```
# Please copy this file into /etc/udev/rules.d/

#V2 Legacy
SUBSYSTEM=="usb",ATTR{idVendor}=="0483",ATTR{idProduct}=="5750",MODE="0666"
KERNEL=="hidraw*",ATTRS{idVendor}=="0483",ATTRS{idProduct}=="5750",MODE="0666"

#V2
SUBSYSTEM=="usb",ATTR{idVendor}=="0483",ATTR{idProduct}=="[aA]0[eE]7",MODE="0666"
KERNEL=="hidraw*",ATTRS{idVendor}=="0483",ATTRS{idProduct}=="[aA]0[eE]7",MODE="0666"

#V3
SUBSYSTEM=="usb",ATTR{idVendor}=="0483",ATTR{idProduct}=="[aA]0[eE]8",MODE="0666"
KERNEL=="hidraw*",ATTRS{idVendor}=="0483",ATTRS{idProduct}=="[aA]0[eE]8",MODE="0666"

#V4  16D0 0B1A
SUBSYSTEM=="usb",ATTR{idVendor}=="16[dD]0",ATTR{idProduct}=="0[bB]1[aA]",MODE="0666"
KERNEL=="hidraw*",ATTRS{idVendor}=="16[dD]0",ATTRS{idProduct}=="0[bB]1[aA]",MODE="0666"

#5  16D0 0B1C
SUBSYSTEM=="usb",ATTR{idVendor}=="16[dD]0",ATTR{idProduct}=="0[bB]1[cC]",MODE="0666"
KERNEL=="hidraw*",ATTRS{idVendor}=="16[dD]0",ATTRS{idProduct}=="0[bB]1[cC]",MODE="0666"
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
