### PR TITLE
openbsd.{reboot,shutdown,wall}: init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/reboot.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/reboot.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/reboot";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/shutdown.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/shutdown.nix
@@ -1,8 +1,17 @@
-{ mkDerivation }:
+{
+  mkDerivation,
+  reboot,
+  wall,
+}:
 mkDerivation {
   path = "sbin/shutdown";
 
-  preBuild = ''
-    sed -i 's/4550/0550/' Makefile
+  postPatch = ''
+    sed -i 's/4550/0550/' $BSDSRCDIR/sbin/shutdown/Makefile
+
+    substituteInPlace $BSDSRCDIR/sbin/shutdown/pathnames.h \
+      --replace-fail /sbin/halt ${reboot}/bin/halt \
+      --replace-fail /sbin/reboot ${reboot}/bin/reboot \
+      --replace-fail /usr/bin/wall ${wall}/bin/wall
   '';
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/wall.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/wall.nix
@@ -1,0 +1,9 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/wall";
+
+  postPatch = ''
+    sed -i /BINMODE/d $BSDSRCDIR/usr.bin/wall/Makefile
+    sed -i /BINGRP/d $BSDSRCDIR/usr.bin/wall/Makefile
+  '';
+}


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
