### PR TITLE
stack-client: init at 5.3.1

### DIFF
--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -42,12 +42,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "rabbitmq-server";
-  version = "4.0.5";
+  version = "4.0.6";
 
   # when updating, consider bumping elixir version in all-packages.nix
   src = fetchurl {
     url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${version}/${pname}-${version}.tar.xz";
-    hash = "sha256-Jn6DvSvegezhq+zjZbUdHR/b6Kgg+QqZwDDrxu21+0g=";
+    hash = "sha256-JkXBZtOUJXfccYZyryO/fZUKL3jyKLGq2vhpRENeDo4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/st/default.nix
+++ b/pkgs/st/default.nix
@@ -1,0 +1,3 @@
+{ callPackage }: {
+  stack-client = callPackage ./stack-client {};
+}

--- a/pkgs/st/default.nix
+++ b/pkgs/st/default.nix
@@ -1,3 +1,4 @@
-{ callPackage }: {
-  stack-client = callPackage ./stack-client {};
+{ callPackage }:
+{
+  stack-client = callPackage ./stack-client { };
 }

--- a/pkgs/st/stack-client/default.nix
+++ b/pkgs/st/stack-client/default.nix
@@ -1,0 +1,80 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, pkg-config, extra-cmake-modules
+, qt6, zlib, sqlite, kdePackages, callPackage }:
+
+let
+  kdsingleapplication = callPackage ./kdsingleapplication.nix { };
+
+  libre-graph-api = stdenv.mkDerivation rec {
+    pname = "libre-graph-api-cpp-qt-client";
+    version = "1.0.4";
+
+    src = fetchFromGitHub {
+      owner = "owncloud";
+      repo = "libre-graph-api-cpp-qt-client";
+      rev = "v${version}";
+      sha256 = "wbdamPi2XSLWeprrYZtBUDH1A2gdp6/5geFZv+ZqSWk=";
+    };
+
+    preConfigure = "cd client";
+
+    nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
+
+    buildInputs = [ qt6.qtbase qt6.qttools ];
+
+    meta = with lib; {
+      description = "C++ Qt client library for Libre Graph API";
+      homepage = "https://github.com/owncloud/libre-graph-api-cpp-qt-client";
+      license = licenses.asl20;
+      platforms = platforms.linux;
+    };
+  };
+in stdenv.mkDerivation rec {
+  pname = "stack-client";
+  version = "latest";
+
+  src = fetchurl {
+    url =
+      "https://filehosting-client.transip.nl/packages/stack-source-latest.tar.gz";
+    sha256 = "ac69699edb1618ef094e4b642fe72c87bf15e65026029486bef50826a746e19c";
+  };
+
+  nativeBuildInputs =
+    [ cmake extra-cmake-modules qt6.qttools qt6.wrapQtAppsHook ];
+
+  buildInputs =
+    [ qt6.qtbase kdePackages.qtkeychain zlib sqlite libre-graph-api ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_PREFIX_PATH=${kdsingleapplication}"
+  ];
+
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt6.qtbase}/${qt6.qtbase.qtPluginPrefix}"
+    "--prefix QML2_IMPORT_PATH : ${qt6.qtbase}/${qt6.qtbase.qtQmlPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "Stack Client Application - A secure cloud storage solution";
+    longDescription = ''
+      Stack Client is a desktop application that provides secure cloud storage and file 
+      synchronization services by TransIP. It offers a robust set of features for both 
+      personal and business users:
+
+      Features:
+      * Secure file synchronization across devices
+      * Seamless desktop integration
+      * File sharing capabilities with granular permissions
+      * Automatic background synchronization
+      * Version control and file history
+      * Built-in security features
+      * Cross-platform support
+    '';
+    homepage = "https://www.transip.nl/stack/";
+    changelog = "https://www.transip.nl/stack/changelog/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ timoteuszelle ];
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/st/stack-client/default.nix
+++ b/pkgs/st/stack-client/default.nix
@@ -1,5 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, cmake, pkg-config, extra-cmake-modules
-, qt6, zlib, sqlite, kdePackages, callPackage }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  pkg-config,
+  extra-cmake-modules,
+  qt6,
+  zlib,
+  sqlite,
+  kdePackages,
+  callPackage,
+}:
 
 let
   kdsingleapplication = callPackage ./kdsingleapplication.nix { };
@@ -17,9 +29,16 @@ let
 
     preConfigure = "cd client";
 
-    nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
+    nativeBuildInputs = [
+      cmake
+      pkg-config
+      qt6.wrapQtAppsHook
+    ];
 
-    buildInputs = [ qt6.qtbase qt6.qttools ];
+    buildInputs = [
+      qt6.qtbase
+      qt6.qttools
+    ];
 
     meta = with lib; {
       description = "C++ Qt client library for Libre Graph API";
@@ -28,21 +47,30 @@ let
       platforms = platforms.linux;
     };
   };
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "stack-client";
   version = "latest";
 
   src = fetchurl {
-    url =
-      "https://filehosting-client.transip.nl/packages/stack-source-latest.tar.gz";
+    url = "https://filehosting-client.transip.nl/packages/stack-source-latest.tar.gz";
     sha256 = "ac69699edb1618ef094e4b642fe72c87bf15e65026029486bef50826a746e19c";
   };
 
-  nativeBuildInputs =
-    [ cmake extra-cmake-modules qt6.qttools qt6.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    qt6.qttools
+    qt6.wrapQtAppsHook
+  ];
 
-  buildInputs =
-    [ qt6.qtbase kdePackages.qtkeychain zlib sqlite libre-graph-api ];
+  buildInputs = [
+    qt6.qtbase
+    kdePackages.qtkeychain
+    zlib
+    sqlite
+    libre-graph-api
+  ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"

--- a/pkgs/st/stack-client/kdsingleapplication.nix
+++ b/pkgs/st/stack-client/kdsingleapplication.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, qt6 }:
+
+stdenv.mkDerivation rec {
+  pname = "kdsingleapplication-qt6";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "KDAB";
+    repo = "KDSingleApplication";
+    rev = "v${version}";
+    sha256 = "sha256-Ymm+qOZMWULg7u5xEpGzcAfIrbWBQ3jsndnFSnh6/PA=";
+  };
+
+  nativeBuildInputs = [ cmake extra-cmake-modules qt6.wrapQtAppsHook ];
+  buildInputs = [ qt6.qtbase ];
+
+  cmakeFlags =
+    [ "-DKDSingleApplication_QT6=ON" "-DKDSingleApplication_EXAMPLES=OFF" ];
+
+  meta = with lib; {
+    description = "Single instance application library for Qt6";
+    homepage = "https://github.com/KDAB/KDSingleApplication";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/st/stack-client/kdsingleapplication.nix
+++ b/pkgs/st/stack-client/kdsingleapplication.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, cmake, extra-cmake-modules, qt6 }:
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  extra-cmake-modules,
+  qt6,
+}:
 
 stdenv.mkDerivation rec {
   pname = "kdsingleapplication-qt6";
@@ -11,11 +18,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ymm+qOZMWULg7u5xEpGzcAfIrbWBQ3jsndnFSnh6/PA=";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules qt6.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    qt6.wrapQtAppsHook
+  ];
   buildInputs = [ qt6.qtbase ];
 
-  cmakeFlags =
-    [ "-DKDSingleApplication_QT6=ON" "-DKDSingleApplication_EXAMPLES=OFF" ];
+  cmakeFlags = [
+    "-DKDSingleApplication_QT6=ON"
+    "-DKDSingleApplication_EXAMPLES=OFF"
+  ];
 
   meta = with lib; {
     description = "Single instance application library for Qt6";
@@ -24,4 +37,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
Adds the Stack client, a command-line tool for TransIP's Stack cloud storage service.

Stack is a cloud storage service provided by TransIP (https://www.transip.nl/stack/), 
offering secure file storage and synchronization capabilities.

This PR adds the command-line client that allows users to interact with Stack from their terminal.

- [x] Tested build on x86_64-linux
- [x] Package is fetchable and builds successfully
- [x] Added relevant meta attributes (description, homepage, license)