### PR TITLE
openbsd.libc: add libkvm

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/dmesg.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dmesg.nix
@@ -1,8 +1,6 @@
-{ mkDerivation, libkvm }:
+{ mkDerivation }:
 mkDerivation {
   path = "sbin/dmesg";
-
-  buildInputs = [ libkvm ];
 
   postPatch = ''
     sed -i /DPADD/d $BSDSRCDIR/sbin/dmesg/Makefile

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
@@ -8,6 +8,7 @@
   librpcsvc,
   libutil,
   libexecinfo,
+  libkvm,
   rtld,
   version,
 }:
@@ -38,6 +39,7 @@ symlinkJoin rec {
           librpcsvc
           libutil
           libexecinfo
+          libkvm
         ]
         ++ (lib.optional (!stdenvNoLibc.hostPlatform.isStatic) rtld)
       );

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libkvm.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libkvm.nix
@@ -3,4 +3,6 @@
 }:
 mkDerivation {
   path = "lib/libkvm";
+
+  libcMinimal = true;
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pkill.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pkill.nix
@@ -1,13 +1,8 @@
 {
   mkDerivation,
-  libkvm,
 }:
 mkDerivation {
   path = "usr.bin/pkill";
-
-  buildInputs = [
-    libkvm
-  ];
 
   postPatch = ''
     sed -i /DPADD/d $BSDSRCDIR/usr.bin/pkill/Makefile

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ps.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ps.nix
@@ -1,8 +1,7 @@
-{ mkDerivation, libkvm }:
+{ mkDerivation }:
 mkDerivation {
   path = "bin/ps";
 
-  buildInputs = [ libkvm ];
   postPatch = ''
     sed -i /DPADD/d $BSDSRCDIR/bin/ps/Makefile
   '';

--- a/pkgs/os-specific/bsd/openbsd/pkgs/vmstat.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/vmstat.nix
@@ -1,8 +1,7 @@
-{ mkDerivation, libkvm }:
+{ mkDerivation }:
 mkDerivation {
   path = "usr.bin/vmstat";
 
-  buildInputs = [ libkvm ];
   postPatch = ''
     sed -i /DPADD/d $BSDSRCDIR/usr.bin/vmstat/Makefile
   '';


### PR DESCRIPTION
This package is also included in libc on FreeBSD.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
