### PR TITLE
{nix, boehmgc}: fix build on OpenBSD

### DIFF
--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -54,6 +54,13 @@ stdenv.mkDerivation (finalAttrs: {
     "CFLAGS_EXTRA=-DNO_SOFT_VDB"
   ];
 
+  # OpenBSD patches lld (!!!!) to inject this symbol into every linker invocation.
+  # We are obviously not doing that.
+  postConfigure = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
+    echo >$TMP/openbsd.ldscript "__data_start = ADDR(.data);"
+    export NIX_LDFLAGS="$NIX_LDFLAGS -T $TMP/openbsd.ldscript"
+  '';
+
   # `gctest` fails under x86_64 emulation on aarch64-darwin
   # and also on aarch64-linux (qemu-user)
   doCheck =

--- a/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
+++ b/pkgs/tools/package-management/nix/patches/boehmgc-coroutine-sp-fallback.patch
@@ -2,7 +2,7 @@ diff --git a/pthread_stop_world.c b/pthread_stop_world.c
 index 2b45489..0e6d8ef 100644
 --- a/pthread_stop_world.c
 +++ b/pthread_stop_world.c
-@@ -776,6 +776,8 @@ STATIC void GC_restart_handler(int sig)
+@@ -776,6 +776,8 @@
  /* world is stopped.  Should not fail if it isn't.                      */
  GC_INNER void GC_push_all_stacks(void)
  {
@@ -11,21 +11,26 @@ index 2b45489..0e6d8ef 100644
      GC_bool found_me = FALSE;
      size_t nthreads = 0;
      int i;
-@@ -868,6 +870,40 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -868,6 +870,45 @@
              hi = p->altstack + p->altstack_size;
  #         endif
            /* FIXME: Need to scan the normal stack too, but how ? */
 +        } else {
-+          #ifdef HAVE_PTHREAD_ATTR_GET_NP
++          #if defined(HAVE_PTHREAD_ATTR_GET_NP)
 +          if (pthread_attr_init(&pattr) != 0) {
 +            ABORT("GC_push_all_stacks: pthread_attr_init failed!");
 +          }
 +          if (pthread_attr_get_np(p->id, &pattr) != 0) {
 +            ABORT("GC_push_all_stacks: pthread_attr_get_np failed!");
 +          }
-+          #else
++          #elif defined(HAVE_PTHREAD_GETATTR_NP)
 +          if (pthread_getattr_np(p->id, &pattr)) {
 +            ABORT("GC_push_all_stacks: pthread_getattr_np failed!");
++          }
++          #else
++          /* assume default */
++          if (pthread_attr_init(&pattr) != 0) {
++            ABORT("GC_push_all_stacks: pthread_attr_init failed!");
 +          }
 +          #endif
 +          if (pthread_attr_getstacksize(&pattr, &stack_limit)) {


### PR DESCRIPTION
Two pieces here.

1) nix. The bundled patch for boehmgc requires various flavors of nonstandard pthread extensions, of which OpenBSD implements none of them. This adds a final fallback case.
2) boehmgc. See the diff, but the gist is that OpenBSD's vendored `lld` includes patches to inject extra symbols. Work around this with a linker script.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
