### PR TITLE
e-imzo: init at 4.64

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17469,6 +17469,13 @@
     githubId = 7820716;
     name = "orthros";
   };
+  orzklv = {
+    email = "sakhib@orzklv.uz";
+    github = "orzklv";
+    githubId = 54666588;
+    name = "Sokhibjon Orzikulov";
+    keys = [ { fingerprint = "00D2 7BC6 8707 0683 FBB9  137C 3C35 D3AF 0DA1 D6A8"; } ];
+  };
   osbm = {
     email = "osmanfbayram@gmail.com";
     github = "osbm";

--- a/pkgs/by-name/e-/e-imzo/package.nix
+++ b/pkgs/by-name/e-/e-imzo/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  jre8,
+  curl,
+  ccid,
+  pcsclite,
+  pcsc-tools,
+  writeShellScript,
+}:
+let
+  exec = writeShellScript "e-imzo" ''
+    cd "$(dirname "$0")/../lib/e-imzo"
+
+    ${jre8}/bin/java -Dsun.security.smartcardio.library=${pcsclite.lib}/lib/libpcsclite.${stdenvNoCC.hostPlatform.extensions.sharedLibrary} -jar E-IMZO.jar
+
+    exit 0
+  '';
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "e-imzo";
+  version = "4.64";
+
+  src = fetchurl {
+    url = "https://dls.yt.uz/E-IMZO-v${finalAttrs.version}.tar.gz";
+    hash = "sha256-ej99PJrO9ufJ8+VlC/HpfvS/bGBtKqUWcsRyiZRlU4c=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/e-imzo
+    install -m 755 -d $out/lib/e-imzo
+    install -m 644 ./E-IMZO.jar $out/lib/e-imzo/
+    install -m 644 ./E-IMZO.pem $out/lib/e-imzo/
+    install -m 644 ./truststore.jks $out/lib/e-imzo/
+    cp -r ./lib $out/lib/e-imzo/
+
+    install -m 755 "${exec}" $out/bin/e-imzo
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "For uzbek state web identity proving & key signing";
+    mainProgram = "e-imzo";
+    platforms = with lib.platforms; linux ++ darwin;
+    homepage = "https://e-imzo.soliq.uz";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    maintainers = with lib.maintainers; [ orzklv ];
+  };
+})


### PR DESCRIPTION
[E-IMZO](https://e-imzo.uz), a local app from Uzbekistan used by citizens to prove their identity in uzbek local & gov  websites. It's typically a java web app that hosts websocket and reads keys at specific locations to confirm identity requests coming from websites in browser.

Ported from flake: https://github.com/xinux-org/e-imzo

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
