### PR TITLE
peertube: remove broken symlinks

### DIFF
--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -77,9 +77,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-x5qFCprn8q0xC88HudLV7W53X1Nkbz3F52RMp2PxIu8=";
   };
 
-  # There are broken symlinks in the node_modules
-  dontCheckForBrokenSymlinks = true;
-
   outputs = [
     "out"
     "cli"
@@ -170,6 +167,14 @@ stdenv.mkDerivation rec {
     mv ~/packages/transcription/{dist,package.json} $out/packages/transcription
     mv ~/packages/typescript-utils/{dist,package.json} $out/packages/typescript-utils
     mv ~/{config,support,CREDITS.md,FAQ.md,LICENSE,README.md,package.json,yarn.lock} $out
+
+    # Remove broken symlinks in node_modules from workspace packages that aren't needed
+    # by the built artifact. If any new packages break the check for broken symlinks,
+    # they should be checked before adding them here to make sure they aren't likely to
+    # be needed, either now or in the future. If they might be, then we probably want
+    # to move the package to $out above instead of removing the broken symlink.
+    rm $out/node_modules/@peertube/{peertube-server,peertube-transcription-devtools,peertube-types-generator,tests}
+    rm $out/client/node_modules/@peertube/{peertube-transcription-devtools,peertube-types-generator,tests}
 
     mkdir -p $cli/bin
     mv ~/apps/peertube-cli/{dist,node_modules,package.json,yarn.lock} $cli


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to #380275 that removes the broken symlinks instead of disabling the check. I've taken a closer look at the symlinks in question to make sure it makes sense to remove them.

All of them exist because of Peertube's use of Yarn workspaces. They are declared under "workspaces" in `package.json` or `client/package.json`, so Yarn makes symlinks to them under `node_modules`/`client/node_modules`.

The workspace packages that Peertube actually needs after the build get moved to be under `$out` in `installPhase` so the symlinks resolve. The ones that were triggering the check are others that are either:

- tests
- the server code (which is only imported by tests)
- dev tools (the types generator and transcription devtools)

All of these seem pretty safe to me to just remove. I left a pretty big comment suggesting that if the broken symlinks check ever breaks in the future (due to a new workspace package being added), we should be hesistant to just blindly remove more things unless we've checked that it makes sense to not need it in the artifact.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
