### PR TITLE
openbsd.stand: add patch to support 3x longer config lines

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/cmd-buff-size.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cmd-buff-size.patch
@@ -1,0 +1,17 @@
+OpenBSD's bootloader supports input configuration lines from both the console
+and configuration files of only up to 133 characters. This is easy to break
+with nix store paths. Triple it to 399.
+
+diff --git a/sys/stand/boot/cmd.h b/sys/stand/boot/cmd.h
+index 5045f052b8b..9fc5ce9e50a 100644
+--- a/sys/stand/boot/cmd.h
++++ b/sys/stand/boot/cmd.h
+@@ -27,7 +27,7 @@
+  *
+  */
+ 
+-#define CMD_BUFF_SIZE		133
++#define CMD_BUFF_SIZE		399
+ #define BOOTDEVLEN		1024
+ 
+ struct cmd_table {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
@@ -8,7 +8,10 @@ mkDerivation {
   path = "sys/arch/amd64/stand";
   extraPaths = [ "sys" ];
 
-  patches = [ ../sys/initpath.patch ];
+  patches = [
+    ../sys/initpath.patch
+    ./cmd-buff-size.patch
+  ];
 
   # gcc compat
   postPatch = ''


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
