### PR TITLE
nixos/nginx: remove recommendedZstdSettings, add experimental option

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -171,6 +171,14 @@ let
           quic_bpf on;
         ''}
 
+        ${optionalString cfg.experimentalZstdSettings ''
+          zstd on;
+          zstd_comp_level 9;
+          zstd_min_length 256;
+          zstd_static on;
+          zstd_types ${lib.concatStringsSep " " compressMimeTypes};
+        ''}
+
         ${cfg.config}
 
         ${optionalString (cfg.eventsConfig != "" || cfg.config == "") ''
@@ -630,11 +638,11 @@ in
         '';
       };
 
-      recommendedZstdSettings = mkOption {
+      experimentalZstdSettings = mkOption {
         default = false;
         type = types.bool;
         description = ''
-          Enable recommended zstd settings.
+          Enable alpha quality zstd module with recommended settings.
           Learn more about compression in Zstd format [here](https://github.com/tokers/zstd-nginx-module).
 
           This adds `pkgs.nginxModules.zstd` to `services.nginx.additionalModules`.
@@ -1305,6 +1313,12 @@ in
       [ "services" "nginx" "proxyCache" "enable" ]
       [ "services" "nginx" "proxyCachePath" "" "enable" ]
     )
+    (mkRemovedOptionModule [ "services" "nginx" "recommendedZstdSettings" ] ''
+      The zstd module for Nginx has known bugs and is not maintained well. It is thus not
+      generally recommend to use it. You may enable anyway by setting
+      `services.nginx.experimentalZstdSettings` which adds the same configuration as the
+      removed option.
+    '')
   ];
 
   config = mkIf cfg.enable {
@@ -1453,7 +1467,7 @@ in
 
     services.nginx.additionalModules =
       optional cfg.recommendedBrotliSettings pkgs.nginxModules.brotli
-      ++ lib.optional cfg.recommendedZstdSettings pkgs.nginxModules.zstd;
+      ++ lib.optional cfg.experimentalZstdSettings pkgs.nginxModules.zstd;
 
     services.nginx.virtualHosts.localhost = mkIf cfg.statusPage {
       serverAliases = [ "127.0.0.1" ] ++ lib.optional config.networking.enableIPv6 "[::1]";


### PR DESCRIPTION
The zstd nginx module has known bugs and upstream is currently not maintained. We should not recommend a buggy module and configuration to our users since we are not maintaining the module either.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
