### PR TITLE
python312Packages.kserve: fix on darwin

### DIFF
--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -121,19 +122,44 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "kserve" ];
 
+  pytestFlagsArray =
+    [
+      # AssertionError
+      "--deselect=test/test_server.py::TestTFHttpServerLoadAndUnLoad::test_unload"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # RuntimeError: Failed to start GCS
+      "--deselect=test/test_dataplane.py::TestDataPlane::test_explain"
+      "--deselect=test/test_dataplane.py::TestDataPlane::test_infer"
+      "--deselect=test/test_dataplane.py::TestDataPlane::test_model_metadata"
+      "--deselect=test/test_dataplane.py::TestDataPlane::test_server_readiness"
+      "--deselect=test/test_server.py::TestRayServer::test_explain"
+      "--deselect=test/test_server.py::TestRayServer::test_health_handler"
+      "--deselect=test/test_server.py::TestRayServer::test_infer"
+      "--deselect=test/test_server.py::TestRayServer::test_list_handler"
+      "--deselect=test/test_server.py::TestRayServer::test_liveness_handler"
+      "--deselect=test/test_server.py::TestRayServer::test_predict"
+    ];
+
   disabledTestPaths = [
     # Looks for a config file at the root of the repository
     "test/test_inference_service_client.py"
   ];
 
-  disabledTests = [
-    # Require network access
-    "test_infer_graph_endpoint"
-    "test_infer_path_based_routing"
+  disabledTests =
+    [
+      # Require network access
+      "test_infer_graph_endpoint"
+      "test_infer_path_based_routing"
 
-    # Tries to access `/tmp` (hardcoded)
-    "test_local_path_with_out_dir_exist"
-  ];
+      # Tries to access `/tmp` (hardcoded)
+      "test_local_path_with_out_dir_exist"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "test_local_path_with_out_dir_not_exist"
+    ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Standardized Serverless ML Inference Platform on Kubernetes";

--- a/pkgs/development/python-modules/kserve/default.nix
+++ b/pkgs/development/python-modules/kserve/default.nix
@@ -44,6 +44,7 @@
   avro,
   grpcio-testing,
   pytest-asyncio,
+  pytest-xdist,
   pytestCheckHook,
   tomlkit,
 }:
@@ -116,6 +117,7 @@ buildPythonPackage rec {
     avro
     grpcio-testing
     pytest-asyncio
+    pytest-xdist
     pytestCheckHook
     tomlkit
   ] ++ lib.flatten (builtins.attrValues optional-dependencies);


### PR DESCRIPTION
## Things done

- **python312Packages.kserve: fix on darwin**
- **python312Packages.kserve: use pytest-xdist to speedup testing**

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
