### PR TITLE
djbdns: Fix compile warnings and errors

### DIFF
--- a/pkgs/by-name/dj/djbdns/fix-warnings.patch
+++ b/pkgs/by-name/dj/djbdns/fix-warnings.patch
@@ -1,0 +1,127 @@
+diff --git a/chkshsgr.c b/chkshsgr.c
+index b6eb8a1..caa1b2b 100644
+--- a/chkshsgr.c
++++ b/chkshsgr.c
+@@ -1,9 +1,11 @@
++#include <unistd.h>
++#include <grp.h>
+ #include "exit.h"
+ 
+ int main()
+ {
+   return 0;
+-  short x[4];
++  unsigned int x[4];
+ 
+   x[0] = x[1] = 0;
+   if (getgroups(1,x) == 0) if (setgroups(1,x) == -1) _exit(1);
+diff --git a/dnsq.c b/dnsq.c
+index 533e6af..23b08e7 100644
+--- a/dnsq.c
++++ b/dnsq.c
+@@ -1,3 +1,4 @@
++#include <unistd.h>
+ #include "uint16.h"
+ #include "strerr.h"
+ #include "buffer.h"
+diff --git a/dnsqr.c b/dnsqr.c
+index ff8ea6e..d3879ea 100644
+--- a/dnsqr.c
++++ b/dnsqr.c
+@@ -1,3 +1,4 @@
++#include <unistd.h>
+ #include "uint16.h"
+ #include "strerr.h"
+ #include "buffer.h"
+diff --git a/hier.c b/hier.c
+index a598e61..6eddb21 100644
+--- a/hier.c
++++ b/hier.c
+@@ -1,4 +1,5 @@
+ #include "auto_home.h"
++#include "instcheck.h"
+ 
+ void hier()
+ {
+diff --git a/instcheck.h b/instcheck.h
+new file mode 100644
+index 0000000..056b74c
+--- /dev/null
++++ b/instcheck.h
+@@ -0,0 +1,9 @@
++void h(const char *home, int uid, int gid, int mode);
++
++void d(const char *home, char *subdir, int uid, int gid, int mode);
++
++void p(char *home, char *fifo, int uid, int gid, int mode);
++
++void c(const char *home, char *subdir, char *file, int uid, int gid, int mode);
++
++void z(char *home, char *file, int len, int uid, int gid, int mode);
+diff --git a/prot.c b/prot.c
+index 0a8a373..1c56e9c 100644
+--- a/prot.c
++++ b/prot.c
+@@ -1,3 +1,5 @@
++#include <grp.h>
++#include <unistd.h>
+ #include "hasshsgr.h"
+ #include "prot.h"
+ 
+diff --git a/seek_set.c b/seek_set.c
+index d08d4f3..47c61e4 100644
+--- a/seek_set.c
++++ b/seek_set.c
+@@ -1,4 +1,5 @@
+ #include <sys/types.h>
++#include <unistd.h>
+ #include "seek.h"
+ 
+ #define SET 0 /* sigh */
+diff --git a/tinydns-data.c b/tinydns-data.c
+index ba82f84..c70382e 100644
+--- a/tinydns-data.c
++++ b/tinydns-data.c
+@@ -251,19 +251,19 @@ int main()
+ 	if (!dns_domain_fromdot(&d1,f[0].s,f[0].len)) nomem();
+ 
+ 	if (!stralloc_0(&f[3])) nomem();
+-	if (!scan_ulong(f[3].s,&u)) uint32_unpack_big(defaultsoa,&u);
++	if (!scan_ulong(f[3].s,&u)) uint32_unpack_big(defaultsoa,(unsigned int *)&u);
+ 	uint32_pack_big(soa,u);
+ 	if (!stralloc_0(&f[4])) nomem();
+-	if (!scan_ulong(f[4].s,&u)) uint32_unpack_big(defaultsoa + 4,&u);
++	if (!scan_ulong(f[4].s,&u)) uint32_unpack_big(defaultsoa + 4,(unsigned int *)&u);
+ 	uint32_pack_big(soa + 4,u);
+ 	if (!stralloc_0(&f[5])) nomem();
+-	if (!scan_ulong(f[5].s,&u)) uint32_unpack_big(defaultsoa + 8,&u);
++	if (!scan_ulong(f[5].s,&u)) uint32_unpack_big(defaultsoa + 8,(unsigned int *)&u);
+ 	uint32_pack_big(soa + 8,u);
+ 	if (!stralloc_0(&f[6])) nomem();
+-	if (!scan_ulong(f[6].s,&u)) uint32_unpack_big(defaultsoa + 12,&u);
++	if (!scan_ulong(f[6].s,&u)) uint32_unpack_big(defaultsoa + 12,(unsigned int *)&u);
+ 	uint32_pack_big(soa + 12,u);
+ 	if (!stralloc_0(&f[7])) nomem();
+-	if (!scan_ulong(f[7].s,&u)) uint32_unpack_big(defaultsoa + 16,&u);
++	if (!scan_ulong(f[7].s,&u)) uint32_unpack_big(defaultsoa + 16,(unsigned int *)&u);
+ 	uint32_pack_big(soa + 16,u);
+ 
+ 	if (!stralloc_0(&f[8])) nomem();
+diff --git a/utime.c b/utime.c
+index 4b7984f..6a64060 100644
+--- a/utime.c
++++ b/utime.c
+@@ -1,3 +1,4 @@
++#include <utime.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include "scan.h"
+@@ -19,6 +20,7 @@ int main(int argc,char **argv)
+   scan_ulong(ustr,&u);
+ 
+   ut[0] = ut[1] = u;
+-  if (utime(fn,ut) == -1) _exit(111);
++  struct utimbuf new_time = { .actime = u, .modtime = u };
++  if (utime(fn,&new_time) == -1) _exit(111);
+   _exit(0);
+ }

--- a/pkgs/by-name/dj/djbdns/package.nix
+++ b/pkgs/by-name/dj/djbdns/package.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation {
     # To fix https://github.com/NixOS/nixpkgs/issues/119066.
     # Note that the NixOS test <nixpkgs/nixos/tests/tinydns.nix> tests for this.
     ./softlimit.patch
+
+    # Fix warnings introduced due to implicit type conversions and implicit function declarations
+    ./fix-warnings.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
This adds a new patch to the package definition that fixes compiler warnings and errors by including the correct files, or by adding the required forward declarations.

At one point the other used implicit pointer conversion, this has been done explicitly now. As such, it should retain its behaviour, for good or worse.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
