### PR TITLE
[staging-next] libseccomp: fix out-of-bounds read

### DIFF
--- a/pkgs/by-name/li/libseccomp/oob-read.patch
+++ b/pkgs/by-name/li/libseccomp/oob-read.patch
@@ -1,0 +1,37 @@
+From 904e9dee373eca499e976dce131f0baee06db2d6 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Thu, 13 Feb 2025 12:05:17 +0100
+Subject: [PATCH] api: fix seccomp_export_bpf_mem out-of-bounds read
+
+*len is the length of the destination buffer, but program->blks is
+probably not anywhere near that long.  It's already been checked above
+that BPF_PGM_SIZE(program) is less than or equal to *len, so that's
+the correct value to use here to avoid either reading or writing too
+much.
+
+I noticed this because tests/11-basic-basic_errors started failing on
+musl after e797591 ("all: add seccomp_precompute() functionality").
+
+Signed-off-by: Alyssa Ross <hi@alyssa.is>
+---
+Link: https://github.com/seccomp/libseccomp/pull/458
+
+ src/api.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/api.c b/src/api.c
+index adccef3..65a277a 100644
+--- a/src/api.c
++++ b/src/api.c
+@@ -786,7 +786,7 @@ API int seccomp_export_bpf_mem(const scmp_filter_ctx ctx, void *buf,
+ 		if (BPF_PGM_SIZE(program) > *len)
+ 			rc = _rc_filter(-ERANGE);
+ 		else
+-			memcpy(buf, program->blks, *len);
++			memcpy(buf, program->blks, BPF_PGM_SIZE(program));
+ 	}
+ 	*len = BPF_PGM_SIZE(program);
+ 
+-- 
+2.47.0
+

--- a/pkgs/by-name/li/libseccomp/package.nix
+++ b/pkgs/by-name/li/libseccomp/package.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-g7YIUjLRWIw3ncm5yuR7s3QHzyYubnSZPGG6ctKnhNw=";
   };
 
+  patches = [
+    ./oob-read.patch
+  ];
+
   outputs = [
     "out"
     "lib"
@@ -30,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gperf ];
   buildInputs = [ getopt ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
   '';
 


### PR DESCRIPTION
Fixes the tests with musl, but we probably want this fix everywhere.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
