### PR TITLE
sqlite: backport patch to resolve regression in 3.48.0

### DIFF
--- a/pkgs/development/libraries/sqlite/3.48.0-fk-conflict-handling.patch
+++ b/pkgs/development/libraries/sqlite/3.48.0-fk-conflict-handling.patch
@@ -1,0 +1,16 @@
+diff --git a/sqlite3.c b/sqlite3.c
+index 80433f6..7c234f6 100644
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -231721,6 +231721,11 @@ static int sessionChangesetApply(
+     }
+   }
+ 
++  {
++    int rc2 = sqlite3_exec(db, "PRAGMA defer_foreign_keys = 0", 0, 0, 0);
++    if( rc==SQLITE_OK ) rc = rc2;
++  }
++
+   if( (flags & SQLITE_CHANGESETAPPLY_NOSAVEPOINT)==0 ){
+     if( rc==SQLITE_OK ){
+       rc = sqlite3_exec(db, "RELEASE changeset_apply", 0, 0, 0);

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -34,6 +34,11 @@ stdenv.mkDerivation rec {
     # Can be removed with the next release.
     # Test: pkgsStatic.gnupg
     ./Libs.private.patch
+
+    # https://sqlite.org/forum/forumpost/00f3aab3d3be9690
+    # https://sqlite.org/src/info/d7c07581
+    # TODO: Remove in 3.49.0
+    ./3.48.0-fk-conflict-handling.patch
   ];
 
   outputs = [ "bin" "dev" "man" "doc" "out" ];


### PR DESCRIPTION
Unblocks the test suite of nodejs and probably other packages.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (up to nodejs)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
