### PR TITLE
opentofu-ls: init at 0-unstable-2025-01-01

### DIFF
--- a/pkgs/by-name/op/opentofu-ls/package.nix
+++ b/pkgs/by-name/op/opentofu-ls/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  unstableGitUpdater,
+}:
+
+buildGoModule {
+  pname = "opentofu-ls";
+  version = "0-unstable-2025-01-01";
+
+  src = fetchFromGitHub {
+    owner = "opentofu";
+    repo = "opentofu-ls";
+    rev = "e6fe83c83107728dd39bb9324b8e1ecc31ad44d3";
+    hash = "sha256-3d/vlW+U1YrGR34edyaMZmV6HaMra0yDCgnQwkQGzuY=";
+  };
+
+  vendorHash = "sha256-CrbLqcwPXHB80m4VhqrC8j5VhU2BUeuNy87+bc+Bq6I=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Require network access
+        "TestCompletion_moduleWithValidData"
+        "TestCompletion_multipleModulesWithValidData"
+        "TestCompletion_multipleModulesWithValidData"
+        "TestExec_cancel"
+        "TestLangServer_DidChangeWatchedFiles_moduleInstalled"
+        "TestLangServer_workspace_symbol_basic"
+        "TestLangServer_workspace_symbol_missing"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "OpenTofu Language Server";
+    homepage = "https://github.com/opentofu/opentofu-ls";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "opentofu-ls";
+  };
+}


### PR DESCRIPTION
## Things done

[opentofu-ls](https://github.com/opentofu/opentofu-ls) is the official [OpenTofu](https://opentofu.org/) language server.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
