### PR TITLE
nixos-rebuild-ng: improve tests

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -89,6 +89,7 @@ python3Packages.buildPythonApplication rec {
         ps: with ps; [
           mypy
           pytest
+          pytest-mock
           ruff
         ]
       );

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -89,6 +89,8 @@ python3Packages.buildPythonApplication rec {
         ps: with ps; [
           mypy
           pytest
+          # this is to help development (e.g.: better diffs) inside devShell
+          # only, do not use its helpers like `mocker`
           pytest-mock
           ruff
         ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -4,7 +4,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -218,7 +218,7 @@ def test_reexec_flake(
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
     config_path = tmp_path / "test"
@@ -238,59 +238,62 @@ def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
 
     nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--no-reexec"])
 
-    assert mock_run.call_args_list == [
-        call(
-            ["nix-instantiate", "--find-file", "nixpkgs", "-vvv"],
-            stdout=PIPE,
-            check=False,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
-            check=False,
-            capture_output=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["git", "-C", nixpkgs_path, "diff", "--quiet"],
-            check=False,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-build",
-                "<nixpkgs/nixos>",
-                "--attr",
-                "config.system.build.toplevel",
-                "-vvv",
-                "--no-out-link",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-env",
-                "-p",
-                Path("/nix/var/nix/profiles/system"),
-                "--set",
-                config_path,
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [config_path / "bin/switch-to-configuration", "boot"],
-            check=True,
-            **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "0"}}),
-        ),
-    ]
+    assert mock_run.call_count == 6
+    mock_run.assert_has_calls(
+        [
+            call(
+                ["nix-instantiate", "--find-file", "nixpkgs", "-vvv"],
+                stdout=PIPE,
+                check=False,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["git", "-C", nixpkgs_path, "rev-parse", "--short", "HEAD"],
+                check=False,
+                capture_output=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["git", "-C", nixpkgs_path, "diff", "--quiet"],
+                check=False,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-build",
+                    "<nixpkgs/nixos>",
+                    "--attr",
+                    "config.system.build.toplevel",
+                    "-vvv",
+                    "--no-out-link",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-env",
+                    "-p",
+                    Path("/nix/var/nix/profiles/system"),
+                    "--set",
+                    config_path,
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [config_path / "bin/switch-to-configuration", "boot"],
+                check=True,
+                **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "0"}}),
+            ),
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -315,28 +318,31 @@ def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix-build",
-                "<nixpkgs/nixos>",
-                "--attr",
-                "config.system.build.vm",
-                "--include",
-                "nixos-config=./configuration.nix",
-                "--include",
-                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        )
-    ]
+    assert mock_run.call_count == 1
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix-build",
+                    "<nixpkgs/nixos>",
+                    "--attr",
+                    "config.system.build.vm",
+                    "--include",
+                    "nixos-config=./configuration.nix",
+                    "--include",
+                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            )
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_nix_build_image_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -370,39 +376,42 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "eval",
-                "--json",
-                "/path/to/config#nixosConfigurations.hostname.config.system.build.images",
-                "--apply",
-                "builtins.mapAttrs (n: v: v.passthru.filePath)",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "build",
-                "--print-out-paths",
-                "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 2
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "eval",
+                    "--json",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.images",
+                    "--apply",
+                    "builtins.mapAttrs (n: v: v.passthru.filePath)",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "--print-out-paths",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -431,43 +440,46 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "build",
-                "--print-out-paths",
-                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
-                "-v",
-                "--option",
-                "narinfo-cache-negative-ttl",
-                "1200",
-                "--no-link",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "sudo",
-                "nix-env",
-                "-p",
-                Path("/nix/var/nix/profiles/system"),
-                "--set",
-                config_path,
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["sudo", config_path / "bin/switch-to-configuration", "switch"],
-            check=True,
-            **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "1"}}),
-        ),
-    ]
+    assert mock_run.call_count == 3
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "--print-out-paths",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
+                    "-v",
+                    "--option",
+                    "narinfo-cache-negative-ttl",
+                    "1200",
+                    "--no-link",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "sudo",
+                    "nix-env",
+                    "-p",
+                    Path("/nix/var/nix/profiles/system"),
+                    "--set",
+                    config_path,
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["sudo", config_path / "bin/switch-to-configuration", "switch"],
+                check=True,
+                **(DEFAULT_RUN_KWARGS | {"env": {"NIXOS_INSTALL_BOOTLOADER": "1"}}),
+            ),
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
@@ -475,9 +487,9 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 @patch(get_qualified_name(nr.nix.uuid4, nr.nix), autospec=True)
 def test_execute_nix_switch_build_target_host(
-    mock_uuid4: Mock,
-    mock_cleanup_ssh: Mock,
-    mock_run: Mock,
+    mock_uuid4: Any,
+    mock_cleanup_ssh: Any,
+    mock_run: Any,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -521,154 +533,157 @@ def test_execute_nix_switch_build_target_host(
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix-instantiate",
-                "--find-file",
-                "nixpkgs",
-                "--include",
-                "nixos-config=./configuration.nix",
-                "--include",
-                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-            ],
-            check=False,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-instantiate",
-                "<nixpkgs/nixos>",
-                "--attr",
-                "config.system.build.toplevel",
-                "--add-root",
-                nr.tmpdir.TMPDIR_PATH / "00000000000000000000000000000000",
-                "--include",
-                "nixos-config=./configuration.nix",
-                "--include",
-                "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["nix-copy-closure", "--to", "user@build-host", config_path],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@build-host",
-                "--",
-                "mktemp",
-                "-d",
-                "-t",
-                "nixos-rebuild.XXXXX",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@build-host",
-                "--",
-                "nix-store",
-                "--realise",
-                str(config_path),
-                "--add-root",
-                "/tmp/tmpdir/00000000000000000000000000000000",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@build-host",
-                "--",
-                "readlink",
-                "-f",
-                "/tmp/tmpdir/config",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@build-host",
-                "--",
-                "rm",
-                "-rf",
-                "/tmp/tmpdir",
-            ],
-            check=False,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix",
-                "copy",
-                "--from",
-                "ssh://user@build-host",
-                "--to",
-                "ssh://user@target-host",
-                config_path,
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@target-host",
-                "--",
-                "sudo",
-                "nix-env",
-                "-p",
-                "/nix/var/nix/profiles/system",
-                "--set",
-                str(config_path),
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@target-host",
-                "--",
-                "sudo",
-                "env",
-                "NIXOS_INSTALL_BOOTLOADER=0",
-                str(config_path / "bin/switch-to-configuration"),
-                "switch",
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 10
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix-instantiate",
+                    "--find-file",
+                    "nixpkgs",
+                    "--include",
+                    "nixos-config=./configuration.nix",
+                    "--include",
+                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+                ],
+                check=False,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-instantiate",
+                    "<nixpkgs/nixos>",
+                    "--attr",
+                    "config.system.build.toplevel",
+                    "--add-root",
+                    nr.tmpdir.TMPDIR_PATH / "00000000000000000000000000000000",
+                    "--include",
+                    "nixos-config=./configuration.nix",
+                    "--include",
+                    "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["nix-copy-closure", "--to", "user@build-host", config_path],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@build-host",
+                    "--",
+                    "mktemp",
+                    "-d",
+                    "-t",
+                    "nixos-rebuild.XXXXX",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@build-host",
+                    "--",
+                    "nix-store",
+                    "--realise",
+                    str(config_path),
+                    "--add-root",
+                    "/tmp/tmpdir/00000000000000000000000000000000",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@build-host",
+                    "--",
+                    "readlink",
+                    "-f",
+                    "/tmp/tmpdir/config",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@build-host",
+                    "--",
+                    "rm",
+                    "-rf",
+                    "/tmp/tmpdir",
+                ],
+                check=False,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix",
+                    "copy",
+                    "--from",
+                    "ssh://user@build-host",
+                    "--to",
+                    "ssh://user@target-host",
+                    config_path,
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@target-host",
+                    "--",
+                    "sudo",
+                    "nix-env",
+                    "-p",
+                    "/nix/var/nix/profiles/system",
+                    "--set",
+                    str(config_path),
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@target-host",
+                    "--",
+                    "sudo",
+                    "env",
+                    "NIXOS_INSTALL_BOOTLOADER=0",
+                    str(config_path / "bin/switch-to-configuration"),
+                    "switch",
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_target_host(
-    mock_cleanup_ssh: Mock,
-    mock_run: Mock,
+    mock_cleanup_ssh: Any,
+    mock_run: Any,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -695,66 +710,69 @@ def test_execute_nix_switch_flake_target_host(
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "build",
-                "--print-out-paths",
-                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
-                "--no-link",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["nix-copy-closure", "--to", "user@localhost", config_path],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@localhost",
-                "--",
-                "sudo",
-                "nix-env",
-                "-p",
-                "/nix/var/nix/profiles/system",
-                "--set",
-                str(config_path),
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@localhost",
-                "--",
-                "sudo",
-                "env",
-                "NIXOS_INSTALL_BOOTLOADER=0",
-                str(config_path / "bin/switch-to-configuration"),
-                "switch",
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 4
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "--print-out-paths",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
+                    "--no-link",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["nix-copy-closure", "--to", "user@localhost", config_path],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@localhost",
+                    "--",
+                    "sudo",
+                    "nix-env",
+                    "-p",
+                    "/nix/var/nix/profiles/system",
+                    "--set",
+                    str(config_path),
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@localhost",
+                    "--",
+                    "sudo",
+                    "env",
+                    "NIXOS_INSTALL_BOOTLOADER=0",
+                    str(config_path / "bin/switch-to-configuration"),
+                    "switch",
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_build_host(
-    mock_cleanup_ssh: Mock,
-    mock_run: Mock,
+    mock_cleanup_ssh: Any,
+    mock_run: Any,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -782,74 +800,77 @@ def test_execute_nix_switch_flake_build_host(
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "eval",
-                "--raw",
-                "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            ["nix-copy-closure", "--to", "user@localhost", config_path],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "ssh",
-                *nr.process.SSH_DEFAULT_OPTS,
-                "user@localhost",
-                "--",
-                "nix",
-                "--extra-experimental-features",
-                "'nix-command flakes'",
-                "build",
-                f"'{config_path}^*'",
-                "--print-out-paths",
-                "--no-link",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-copy-closure",
-                "--from",
-                "user@localhost",
-                config_path,
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-env",
-                "-p",
-                Path("/nix/var/nix/profiles/system"),
-                "--set",
-                config_path,
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [config_path / "bin/switch-to-configuration", "switch"],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 6
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "eval",
+                    "--raw",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                ["nix-copy-closure", "--to", "user@localhost", config_path],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "ssh",
+                    *nr.process.SSH_DEFAULT_OPTS,
+                    "user@localhost",
+                    "--",
+                    "nix",
+                    "--extra-experimental-features",
+                    "'nix-command flakes'",
+                    "build",
+                    f"'{config_path}^*'",
+                    "--print-out-paths",
+                    "--no-link",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-copy-closure",
+                    "--from",
+                    "user@localhost",
+                    config_path,
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-env",
+                    "-p",
+                    Path("/nix/var/nix/profiles/system"),
+                    "--set",
+                    config_path,
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [config_path / "bin/switch-to-configuration", "switch"],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.touch()
 
@@ -874,49 +895,52 @@ def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            ["nix-instantiate", "--find-file", "nixpkgs"],
-            check=False,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "git",
-                "-C",
-                nixpkgs_path,
-                "rev-parse",
-                "--short",
-                "HEAD",
-            ],
-            check=False,
-            capture_output=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                "nix-env",
-                "--rollback",
-                "-p",
-                Path("/nix/var/nix/profiles/system"),
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                Path("/nix/var/nix/profiles/system/bin/switch-to-configuration"),
-                "switch",
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 4
+    mock_run.assert_has_calls(
+        [
+            call(
+                ["nix-instantiate", "--find-file", "nixpkgs"],
+                check=False,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "git",
+                    "-C",
+                    nixpkgs_path,
+                    "rev-parse",
+                    "--short",
+                    "HEAD",
+                ],
+                check=False,
+                capture_output=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix-env",
+                    "--rollback",
+                    "-p",
+                    Path("/nix/var/nix/profiles/system"),
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    Path("/nix/var/nix/profiles/system/bin/switch-to-configuration"),
+                    "switch",
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
     mock_run.side_effect = [
@@ -926,23 +950,26 @@ def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
 
     nr.execute(["nixos-rebuild", "build", "--no-flake", "--no-reexec"])
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix-build",
-                "<nixpkgs/nixos>",
-                "--attr",
-                "config.system.build.toplevel",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        )
-    ]
+    assert mock_run.call_count == 1
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix-build",
+                    "<nixpkgs/nixos>",
+                    "--attr",
+                    "config.system.build.toplevel",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            )
+        ]
+    )
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
+def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -958,35 +985,38 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
         ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--no-reexec"]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "build",
-                "--print-out-paths",
-                "github:user/repo#nixosConfigurations.hostname.config.system.build.toplevel",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [config_path / "bin/switch-to-configuration", "test"],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 2
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "--print-out-paths",
+                    "github:user/repo#nixosConfigurations.hostname.config.system.build.toplevel",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [config_path / "bin/switch-to-configuration", "test"],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
 @patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
 def test_execute_test_rollback(
-    mock_path_mkdir: Mock,
-    mock_path_exists: Mock,
-    mock_run: Mock,
+    mock_path_mkdir: Any,
+    mock_path_exists: Any,
+    mock_run: Any,
 ) -> None:
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-env":
@@ -1008,26 +1038,29 @@ def test_execute_test_rollback(
         ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--no-reexec"]
     )
 
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix-env",
-                "-p",
-                Path("/nix/var/nix/profiles/system-profiles/foo"),
-                "--list-generations",
-            ],
-            check=True,
-            stdout=PIPE,
-            **DEFAULT_RUN_KWARGS,
-        ),
-        call(
-            [
-                Path(
-                    "/nix/var/nix/profiles/system-profiles/foo-2083-link/bin/switch-to-configuration"
-                ),
-                "test",
-            ],
-            check=True,
-            **DEFAULT_RUN_KWARGS,
-        ),
-    ]
+    assert mock_run.call_count == 2
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix-env",
+                    "-p",
+                    Path("/nix/var/nix/profiles/system-profiles/foo"),
+                    "--list-generations",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    Path(
+                        "/nix/var/nix/profiles/system-profiles/foo-2083-link/bin/switch-to-configuration"
+                    ),
+                    "test",
+                ],
+                check=True,
+                **DEFAULT_RUN_KWARGS,
+            ),
+        ]
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -4,7 +4,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -218,7 +218,7 @@ def test_reexec_flake(
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
     config_path = tmp_path / "test"
@@ -293,7 +293,7 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -342,7 +342,7 @@ def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_build_image_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -411,7 +411,7 @@ def test_execute_nix_build_image_flake(mock_run: Any, tmp_path: Path) -> None:
 
 @patch.dict(nr.process.os.environ, {}, clear=True)
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -487,9 +487,9 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 @patch(get_qualified_name(nr.nix.uuid4, nr.nix), autospec=True)
 def test_execute_nix_switch_build_target_host(
-    mock_uuid4: Any,
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_uuid4: Mock,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -682,8 +682,8 @@ def test_execute_nix_switch_build_target_host(
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_target_host(
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -771,8 +771,8 @@ def test_execute_nix_switch_flake_target_host(
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
 def test_execute_nix_switch_flake_build_host(
-    mock_cleanup_ssh: Any,
-    mock_run: Any,
+    mock_cleanup_ssh: Mock,
+    mock_run: Mock,
     tmp_path: Path,
 ) -> None:
     config_path = tmp_path / "test"
@@ -870,7 +870,7 @@ def test_execute_nix_switch_flake_build_host(
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.touch()
 
@@ -940,7 +940,7 @@ def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
     mock_run.side_effect = [
@@ -969,7 +969,7 @@ def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
+def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
 
@@ -1014,9 +1014,9 @@ def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
 @patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
 @patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
 def test_execute_test_rollback(
-    mock_path_mkdir: Any,
-    mock_path_exists: Any,
-    mock_run: Any,
+    mock_path_mkdir: Mock,
+    mock_path_exists: Mock,
+    mock_run: Mock,
 ) -> None:
     def run_side_effect(args: list[str], **kwargs: Any) -> CompletedProcess[str]:
         if args[0] == "nix-env":

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -167,6 +167,7 @@ def test_profile_from_arg(mock_mkdir: Mock) -> None:
         "system",
         Path("/nix/var/nix/profiles/system"),
     )
+    mock_mkdir.assert_not_called()
 
     assert m.Profile.from_arg("something") == m.Profile(
         "something",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -1,7 +1,8 @@
 import platform
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch
+from typing import Any
+from unittest.mock import patch
 
 from pytest import MonkeyPatch
 
@@ -78,9 +79,7 @@ def test_flake_to_attr() -> None:
 
 
 @patch(get_qualified_name(platform.node), autospec=True)
-def test_flake_from_arg(
-    mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
-) -> None:
+def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -162,12 +161,11 @@ def test_flake_from_arg(
 
 
 @patch(get_qualified_name(m.Path.mkdir, m), autospec=True)
-def test_profile_from_arg(mock_mkdir: Mock) -> None:
+def test_profile_from_arg(mock_mkdir: Any) -> None:
     assert m.Profile.from_arg("system") == m.Profile(
         "system",
         Path("/nix/var/nix/profiles/system"),
     )
-    mock_mkdir.assert_not_called()
 
     assert m.Profile.from_arg("something") == m.Profile(
         "something",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -1,8 +1,7 @@
 import platform
 import subprocess
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from pytest import MonkeyPatch
 
@@ -79,7 +78,9 @@ def test_flake_to_attr() -> None:
 
 
 @patch(get_qualified_name(platform.node), autospec=True)
-def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_flake_from_arg(
+    mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
+) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -161,7 +162,7 @@ def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) 
 
 
 @patch(get_qualified_name(m.Path.mkdir, m), autospec=True)
-def test_profile_from_arg(mock_mkdir: Any) -> None:
+def test_profile_from_arg(mock_mkdir: Mock) -> None:
     assert m.Profile.from_arg("system") == m.Profile(
         "system",
         Path("/nix/var/nix/profiles/system"),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, call, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -20,13 +20,13 @@ from .helpers import get_qualified_name
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build(mock_run: Mock) -> None:
+def test_build(mock_run: Any) -> None:
     assert n.build(
         "config.system.build.attr",
         m.BuildAttr("<nixpkgs/nixos>", None),
         {"nix_flag": "foo"},
     ) == Path("/path/to/file")
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix-build",
             "<nixpkgs/nixos>",
@@ -38,17 +38,13 @@ def test_build(mock_run: Mock) -> None:
         stdout=PIPE,
     )
 
-    mock_run.reset_mock()
-
     assert n.build(
         "config.system.build.attr", m.BuildAttr(Path("file"), "preAttr")
     ) == Path("/path/to/file")
-    assert mock_run.call_args_list == [
-        call(
-            ["nix-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
-            stdout=PIPE,
-        )
-    ]
+    mock_run.assert_called_with(
+        ["nix-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
+        stdout=PIPE,
+    )
 
 
 @patch(
@@ -56,7 +52,7 @@ def test_build(mock_run: Mock) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
 
@@ -65,7 +61,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
         flake,
         {"no_link": True, "nix_flag": "foo"},
     ) == Path("/path/to/file")
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix",
             "--extra-experimental-features",
@@ -83,9 +79,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 @patch(get_qualified_name(n.uuid4, n), autospec=True)
-def test_build_remote(
-    mock_uuid4: Mock, mock_run: Mock, monkeypatch: MonkeyPatch
-) -> None:
+def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -114,53 +108,58 @@ def test_build_remote(
         instantiate_flags={"inst": True},
         copy_flags={"copy": True},
     ) == Path("/path/to/config")
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix-instantiate",
-                "<nixpkgs/nixos>",
-                "--attr",
-                "preAttr.config.system.build.toplevel",
-                "--add-root",
-                n.tmpdir.TMPDIR_PATH / "00000000000000000000000000000001",
-                "--inst",
-            ],
-            stdout=PIPE,
-        ),
-        call(
-            [
-                "nix-copy-closure",
-                "--copy",
-                "--to",
-                "user@host",
-                Path("/path/to/file"),
-            ],
-            extra_env={"NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])},
-        ),
-        call(
-            ["mktemp", "-d", "-t", "nixos-rebuild.XXXXX"],
-            remote=build_host,
-            stdout=PIPE,
-        ),
-        call(
-            [
-                "nix-store",
-                "--realise",
-                Path("/path/to/file"),
-                "--add-root",
-                Path("/tmp/tmpdir/00000000000000000000000000000002"),
-                "--realise",
-            ],
-            remote=build_host,
-            stdout=PIPE,
-        ),
-        call(
-            ["readlink", "-f", "/tmp/tmpdir/config"],
-            remote=build_host,
-            stdout=PIPE,
-        ),
-        call(["rm", "-rf", Path("/tmp/tmpdir")], remote=build_host, check=False),
-    ]
+
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix-instantiate",
+                    "<nixpkgs/nixos>",
+                    "--attr",
+                    "preAttr.config.system.build.toplevel",
+                    "--add-root",
+                    n.tmpdir.TMPDIR_PATH / "00000000000000000000000000000001",
+                    "--inst",
+                ],
+                stdout=PIPE,
+            ),
+            call(
+                [
+                    "nix-copy-closure",
+                    "--copy",
+                    "--to",
+                    "user@host",
+                    Path("/path/to/file"),
+                ],
+                extra_env={
+                    "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])
+                },
+            ),
+            call(
+                ["mktemp", "-d", "-t", "nixos-rebuild.XXXXX"],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+            call(
+                [
+                    "nix-store",
+                    "--realise",
+                    Path("/path/to/file"),
+                    "--add-root",
+                    Path("/tmp/tmpdir/00000000000000000000000000000002"),
+                    "--realise",
+                ],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+            call(
+                ["readlink", "-f", "/tmp/tmpdir/config"],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+            call(["rm", "-rf", Path("/tmp/tmpdir")], remote=build_host, check=False),
+        ]
+    )
 
 
 @patch(
@@ -169,7 +168,7 @@ def test_build_remote(
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
 def test_build_remote_flake(
-    mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
+    mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
@@ -184,43 +183,47 @@ def test_build_remote_flake(
         copy_flags={"copy": True},
         flake_build_flags={"build": True},
     ) == Path("/path/to/file")
-    assert mock_run.call_args_list == [
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "eval",
-                "--raw",
-                ".#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
-                "--flake",
-            ],
-            stdout=PIPE,
-        ),
-        call(
-            [
-                "nix-copy-closure",
-                "--copy",
-                "--to",
-                "user@host",
-                Path("/path/to/file"),
-            ],
-            extra_env={"NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])},
-        ),
-        call(
-            [
-                "nix",
-                "--extra-experimental-features",
-                "nix-command flakes",
-                "build",
-                "/path/to/file^*",
-                "--print-out-paths",
-                "--build",
-            ],
-            remote=build_host,
-            stdout=PIPE,
-        ),
-    ]
+    mock_run.assert_has_calls(
+        [
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "eval",
+                    "--raw",
+                    ".#nixosConfigurations.hostname.config.system.build.toplevel.drvPath",
+                    "--flake",
+                ],
+                stdout=PIPE,
+            ),
+            call(
+                [
+                    "nix-copy-closure",
+                    "--copy",
+                    "--to",
+                    "user@host",
+                    Path("/path/to/file"),
+                ],
+                extra_env={
+                    "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh opts"])
+                },
+            ),
+            call(
+                [
+                    "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
+                    "build",
+                    "/path/to/file^*",
+                    "--print-out-paths",
+                    "--build",
+                ],
+                remote=build_host,
+                stdout=PIPE,
+            ),
+        ]
+    )
 
 
 def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
@@ -233,7 +236,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     build_host = m.Remote("user@build.host", [], None)
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host)
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             ["nix-copy-closure", "--to", "user@target.host", closure],
             extra_env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
         )
@@ -241,7 +244,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh build-opt")
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, None, build_host, {"copy_flag": True})
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             ["nix-copy-closure", "--copy-flag", "--from", "user@build.host", closure],
             extra_env={
                 "NIX_SSHOPTS": " ".join([*p.SSH_DEFAULT_OPTS, "--ssh build-opt"])
@@ -255,7 +258,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     }
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host, build_host, {"copy_flag": True})
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             [
                 "nix",
                 "copy",
@@ -272,24 +275,26 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(n, "WITH_NIX_2_18", False)
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host, build_host)
-        assert mock_run.call_args_list == [
-            call(
-                ["nix-copy-closure", "--from", "user@build.host", closure],
-                extra_env=extra_env,
-            ),
-            call(
-                ["nix-copy-closure", "--to", "user@target.host", closure],
-                extra_env=extra_env,
-            ),
-        ]
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["nix-copy-closure", "--from", "user@build.host", closure],
+                    extra_env=extra_env,
+                ),
+                call(
+                    ["nix-copy-closure", "--to", "user@target.host", closure],
+                    extra_env=extra_env,
+                ),
+            ]
+        )
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
     flake = m.Flake.parse(f"{tmpdir}#attr")
     n.edit(flake, {"commit_lock_file": True})
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix",
             "--extra-experimental-features",
@@ -311,7 +316,7 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
         mp.setenv("EDITOR", "editor")
 
         n.edit(None)
-        assert mock_run.call_args == call(["editor", default_nix], check=False)
+        mock_run.assert_called_with(["editor", default_nix], check=False)
 
 
 @patch(
@@ -328,13 +333,13 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
+def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
     build_attr = m.BuildAttr("<nixpkgs/nixos>", None)
     assert n.get_build_image_variants(build_attr) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix-instantiate",
             "--eval",
@@ -352,14 +357,12 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
         stdout=PIPE,
     )
 
-    mock_run.reset_mock()
-
     build_attr = m.BuildAttr(Path(tmp_path), "preAttr")
     assert n.get_build_image_variants(build_attr, {"inst_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix-instantiate",
             "--eval",
@@ -393,13 +396,13 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants_flake(mock_run: Mock) -> None:
+def test_get_build_image_variants_flake(mock_run: Any) -> None:
     flake = m.Flake(Path("flake.nix"), "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
     }
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "nix",
             "eval",
@@ -424,7 +427,7 @@ def test_get_nixpkgs_rev() -> None:
         side_effect=[CompletedProcess([], 0, "")],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) is None
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             ["git", "-C", path, "rev-parse", "--short", "HEAD"],
             check=False,
             capture_output=True,
@@ -451,7 +454,7 @@ def test_get_nixpkgs_rev() -> None:
         ],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6"
-        assert mock_run.call_args_list == expected_calls
+        mock_run.assert_has_calls(expected_calls)
 
     with patch(
         get_qualified_name(n.run_wrapper, n),
@@ -462,7 +465,7 @@ def test_get_nixpkgs_rev() -> None:
         ],
     ) as mock_run:
         assert n.get_nixpkgs_rev(path) == ".git.0f7c82403fd6M"
-        assert mock_run.call_args_list == expected_calls
+        mock_run.assert_has_calls(expected_calls)
 
 
 def test_get_generations(tmp_path: Path) -> None:
@@ -503,7 +506,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
             m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
         ]
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             ["nix-env", "-p", path, "--list-generations"],
             stdout=PIPE,
             remote=None,
@@ -521,7 +524,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             m.Generation(id=2083, current=False, timestamp="2024-11-07 22:59:41"),
             m.Generation(id=2084, current=True, timestamp="2024-11-07 23:54:17"),
         ]
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             ["nix-env", "-p", path, "--list-generations"],
             stdout=PIPE,
             remote=remote,
@@ -545,7 +548,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
         ),
     ],
 )
-def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
+def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
     # Probably better to test this function in a real system, this test is
     # mostly to make sure it doesn't break horribly
     assert n.list_generations(m.Profile("system", tmp_path)) == [
@@ -571,20 +574,18 @@ def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl(mock_run: Mock) -> None:
+def test_repl(mock_run: Any) -> None:
     n.repl("attr", m.BuildAttr("<nixpkgs/nixos>", None), {"nix_flag": True})
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["nix", "repl", "--file", "<nixpkgs/nixos>", "--nix-flag"]
     )
 
     n.repl("attr", m.BuildAttr(Path("file.nix"), "myAttr"))
-    assert mock_run.call_args == call(
-        ["nix", "repl", "--file", Path("file.nix"), "myAttr"]
-    )
+    mock_run.assert_called_with(["nix", "repl", "--file", Path("file.nix"), "myAttr"])
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl_flake(mock_run: Mock) -> None:
+def test_repl_flake(mock_run: Any) -> None:
     n.repl_flake("attr", m.Flake(Path("flake.nix"), "myAttr"), {"nix_flag": True})
     # See nixos-rebuild-ng.tests.repl for a better test,
     # this is mostly for sanity check
@@ -592,14 +593,14 @@ def test_repl_flake(mock_run: Mock) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
+def test_rollback(mock_run: Any, tmp_path: Path) -> None:
     path = tmp_path / "test"
     path.touch()
 
     profile = m.Profile("system", path)
 
     assert n.rollback(profile, None, False) == profile.path
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
         remote=None,
         sudo=False,
@@ -607,7 +608,7 @@ def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
 
     target_host = m.Remote("user@localhost", [], None)
     assert n.rollback(profile, target_host, True) == profile.path
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
         remote=target_host,
         sudo=True,
@@ -619,10 +620,8 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
     path.touch()
     profile = m.Profile("system", path)
 
-    with patch(
-        get_qualified_name(n.run_wrapper, n),
-        autospec=True,
-        return_value=CompletedProcess(
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
+        mock_run.return_value = CompletedProcess(
             [],
             0,
             stdout=textwrap.dedent("""\
@@ -630,13 +629,12 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
                 2083   2024-11-07 22:59:41
                 2084   2024-11-07 23:54:17   (current)
                 """),
-        ),
-    ) as mock_run:
+        )
         assert (
             n.rollback_temporary_profile(m.Profile("system", path), None, False)
             == path.parent / "system-2083-link"
         )
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             [
                 "nix-env",
                 "-p",
@@ -653,7 +651,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             n.rollback_temporary_profile(m.Profile("foo", path), target_host, True)
             == path.parent / "foo-2083-link"
         )
-        assert mock_run.call_args == call(
+        mock_run.assert_called_with(
             [
                 "nix-env",
                 "-p",
@@ -665,16 +663,13 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             sudo=True,
         )
 
-    with patch(
-        get_qualified_name(n.run_wrapper, n),
-        autospec=True,
-        return_value=CompletedProcess([], 0, stdout=""),
-    ) as mock_run:
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
+        mock_run.return_value = CompletedProcess([], 0, stdout="")
         assert n.rollback_temporary_profile(profile, None, False) is None
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_set_profile(mock_run: Mock) -> None:
+def test_set_profile(mock_run: Any) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
     n.set_profile(
@@ -684,7 +679,7 @@ def test_set_profile(mock_run: Mock) -> None:
         sudo=False,
     )
 
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["nix-env", "-p", profile_path, "--set", config_path],
         remote=None,
         sudo=False,
@@ -692,7 +687,7 @@ def test_set_profile(mock_run: Mock) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> None:
+def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
 
@@ -707,7 +702,7 @@ def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> No
             specialisation=None,
             install_bootloader=False,
         )
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [profile_path / "bin/switch-to-configuration", "switch"],
         extra_env={"NIXOS_INSTALL_BOOTLOADER": "0"},
         sudo=False,
@@ -741,7 +736,7 @@ def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> No
             install_bootloader=True,
             specialisation="special",
         )
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             config_path / "specialisation/special/bin/switch-to-configuration",
             "test",
@@ -762,17 +757,17 @@ def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> No
     ],
 )
 @patch(get_qualified_name(n.Path.is_dir, n), autospec=True, return_value=True)
-def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
+def test_upgrade_channels(mock_is_dir: Any, mock_glob: Any) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)
-    assert mock_run.call_args == call(["nix-channel", "--update", "nixos"], check=False)
-
-    mock_run.reset_mock()
+    mock_run.assert_called_with(["nix-channel", "--update", "nixos"], check=False)
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(True)
-    assert mock_run.call_args_list == [
-        call(["nix-channel", "--update", "nixos"], check=False),
-        call(["nix-channel", "--update", "nixos-hardware"], check=False),
-        call(["nix-channel", "--update", "home-manager"], check=False),
-    ]
+    mock_run.assert_has_calls(
+        [
+            call(["nix-channel", "--update", "nixos"], check=False),
+            call(["nix-channel", "--update", "nixos-hardware"], check=False),
+            call(["nix-channel", "--update", "home-manager"], check=False),
+        ]
+    )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -762,7 +762,7 @@ def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> No
 def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)
-    mock_run.assert_called_with(["nix-channel", "--update", "nixos"], check=False)
+    mock_run.assert_called_once_with(["nix-channel", "--update", "nixos"], check=False)
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 from subprocess import PIPE, CompletedProcess
 from typing import Any
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -20,7 +20,7 @@ from .helpers import get_qualified_name
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build(mock_run: Any) -> None:
+def test_build(mock_run: Mock) -> None:
     assert n.build(
         "config.system.build.attr",
         m.BuildAttr("<nixpkgs/nixos>", None),
@@ -52,7 +52,7 @@ def test_build(mock_run: Any) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
 
@@ -79,7 +79,9 @@ def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> N
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 @patch(get_qualified_name(n.uuid4, n), autospec=True)
-def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) -> None:
+def test_build_remote(
+    mock_uuid4: Mock, mock_run: Mock, monkeypatch: MonkeyPatch
+) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -168,7 +170,7 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) 
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
 def test_build_remote_flake(
-    mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path
+    mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
@@ -290,7 +292,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
     flake = m.Flake.parse(f"{tmpdir}#attr")
     n.edit(flake, {"commit_lock_file": True})
@@ -333,7 +335,7 @@ def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
+def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
     build_attr = m.BuildAttr("<nixpkgs/nixos>", None)
     assert n.get_build_image_variants(build_attr) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
@@ -396,7 +398,7 @@ def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
         """,
     ),
 )
-def test_get_build_image_variants_flake(mock_run: Any) -> None:
+def test_get_build_image_variants_flake(mock_run: Mock) -> None:
     flake = m.Flake(Path("flake.nix"), "myAttr")
     assert n.get_build_image_variants_flake(flake, {"eval_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
@@ -548,7 +550,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
         ),
     ],
 )
-def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
+def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
     # Probably better to test this function in a real system, this test is
     # mostly to make sure it doesn't break horribly
     assert n.list_generations(m.Profile("system", tmp_path)) == [
@@ -574,7 +576,7 @@ def test_list_generations(mock_get_generations: Any, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl(mock_run: Any) -> None:
+def test_repl(mock_run: Mock) -> None:
     n.repl("attr", m.BuildAttr("<nixpkgs/nixos>", None), {"nix_flag": True})
     mock_run.assert_called_with(
         ["nix", "repl", "--file", "<nixpkgs/nixos>", "--nix-flag"]
@@ -585,7 +587,7 @@ def test_repl(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_repl_flake(mock_run: Any) -> None:
+def test_repl_flake(mock_run: Mock) -> None:
     n.repl_flake("attr", m.Flake(Path("flake.nix"), "myAttr"), {"nix_flag": True})
     # See nixos-rebuild-ng.tests.repl for a better test,
     # this is mostly for sanity check
@@ -593,7 +595,7 @@ def test_repl_flake(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_rollback(mock_run: Any, tmp_path: Path) -> None:
+def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
     path = tmp_path / "test"
     path.touch()
 
@@ -669,7 +671,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_set_profile(mock_run: Any) -> None:
+def test_set_profile(mock_run: Mock) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
     n.set_profile(
@@ -687,7 +689,7 @@ def test_set_profile(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> None:
+def test_switch_to_configuration(mock_run: Mock, monkeypatch: MonkeyPatch) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
 
@@ -757,7 +759,7 @@ def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> Non
     ],
 )
 @patch(get_qualified_name(n.Path.is_dir, n), autospec=True, return_value=True)
-def test_upgrade_channels(mock_is_dir: Any, mock_glob: Any) -> None:
+def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)
     mock_run.assert_called_with(["nix-channel", "--update", "nixos"], check=False)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, call, patch
+from typing import Any
+from unittest.mock import patch
 
 from pytest import MonkeyPatch
 
@@ -9,9 +10,9 @@ from .helpers import get_qualified_name
 
 
 @patch(get_qualified_name(p.subprocess.run), autospec=True)
-def test_run(mock_run: Mock) -> None:
+def test_run(mock_run: Any) -> None:
     p.run_wrapper(["test", "--with", "flags"], check=True)
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["test", "--with", "flags"],
         check=True,
         text=True,
@@ -27,7 +28,7 @@ def test_run(mock_run: Mock) -> None:
             sudo=True,
             extra_env={"FOO": "bar"},
         )
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         ["sudo", "test", "--with", "flags"],
         check=False,
         text=True,
@@ -44,7 +45,7 @@ def test_run(mock_run: Mock) -> None:
         check=True,
         remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
     )
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "ssh",
             "--ssh",
@@ -70,7 +71,7 @@ def test_run(mock_run: Mock) -> None:
         extra_env={"FOO": "bar"},
         remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
     )
-    assert mock_run.call_args == call(
+    mock_run.assert_called_with(
         [
             "ssh",
             "--ssh",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/tests/repl.nix
@@ -13,7 +13,7 @@ let
   escapeExpect = lib.strings.escapeNixString;
 
   expectSetup = ''
-    set timeout 180
+    set timeout 300
     proc expect_simple { pattern } {
       puts "Expecting: $pattern"
       expect {
@@ -76,7 +76,7 @@ runCommand "test-nixos-rebuild-repl"
 
     expect ${writeText "test-nixos-rebuild-repl-expect" ''
       ${expectSetup}
-      spawn nixos-rebuild repl --fast
+      spawn nixos-rebuild repl --no-reexec
 
       expect "nix-repl> "
 
@@ -116,7 +116,7 @@ runCommand "test-nixos-rebuild-repl"
 
     expect ${writeText "test-nixos-rebuild-repl-absolute-path-expect" ''
       ${expectSetup}
-      spawn sh -c "nixos-rebuild repl --fast --flake path:\$HOME#testconf"
+      spawn sh -c "nixos-rebuild repl --no-reexec --flake path:\$HOME#testconf"
 
       expect_simple "nix-repl>"
 
@@ -146,7 +146,7 @@ runCommand "test-nixos-rebuild-repl"
     pushd "$HOME"
     expect ${writeText "test-nixos-rebuild-repl-relative-path-expect" ''
       ${expectSetup}
-      spawn sh -c "nixos-rebuild repl --fast --flake .#testconf"
+      spawn sh -c "nixos-rebuild repl --no-reexec --flake .#testconf"
 
       expect_simple "nix-repl>"
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add tests to `reexec` function in `nixos-rebuild-ng`, since it is a fairly critical function to ensure that it is working correctly.

Revert https://github.com/NixOS/nixpkgs/commit/d6e849ee03d1849bd5151c651e66a8731a0c4891, since it was a bad idea because the diffs are even worse once you have more than 2 calls. Instead add `pytest-mock` only for the devShell, and this brings much better diffs for the mocks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
