### PR TITLE
ungoogled-chromium: 133.0.6943.53-1 -> 133.0.6943.98-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -791,7 +791,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "133.0.6943.53",
+    "version": "133.0.6943.98",
     "deps": {
       "depot_tools": {
         "rev": "423f1e1914ab4aa7b2bdf804e216d4c097853ba2",
@@ -802,16 +802,16 @@
         "hash": "sha256-T2dcISln9WCODoI/LsE2ldkRfFdMwVOmqqjQinAmZss="
       },
       "ungoogled-patches": {
-        "rev": "133.0.6943.53-1",
-        "hash": "sha256-8n0BST0sqQRcfv0lCiEflrvyxt8Agj/kK0O2fVzWqCY="
+        "rev": "133.0.6943.98-1",
+        "hash": "sha256-lSRJD8tKmZ89MJr6MkldV8/50iB/l8FEwl6ZM/KtZHA="
       },
       "npmHash": "sha256-oVoTruhxTymYiGkELd2Oa1wOfjGLtChQZozP4GzOO1A="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9a80935019b0925b01cc21d254da203bc3986f04",
-        "hash": "sha256-doJ/HygMtLxr04S73lhs5kTt8qC7SHrCxHbjAoFPv2M=",
+        "rev": "da53563ceb66412e2637507c8724bd0cab05e453",
+        "hash": "sha256-yltjJNXU+YQD/sFEa8+ZKqUJpVZ2Yi0YDx27bnekcng=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1366,8 +1366,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "c674dba647e81805158339785c0c7e3b57643f8c",
-        "hash": "sha256-2Z7Dg3IuxMB+xKFURo0Z7NztPQht7Fd+A1dX99gQ+A4="
+        "rev": "b57762c6c6ad261024f11fc724687593c03cce67",
+        "hash": "sha256-ksN/7volHAeQLJSFQMV/YOfkXyZ97GSawXp31uca4oc="
       },
       "src/third_party/perfetto": {
         "url": "https://android.googlesource.com/platform/external/perfetto.git",
@@ -1546,8 +1546,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "283b6ef9d3eabe5bb3ed7c9d6b6d211a92f9b6d0",
-        "hash": "sha256-KMyO88KoYiTHq+stdbc8vRYqeQbrqexDIiOeWbqytrU="
+        "rev": "cd3e2951ff0f36fa12bea747862c52533a2b39f3",
+        "hash": "sha256-5tdES3wILTC25Lvos5mWYlfT4ZnM2pBFy5LVACVMXEY="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1576,8 +1576,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "fe051262efbbd92479a08436f733eba9f756e008",
-        "hash": "sha256-l3hMgnhy2Ml6kExwGFWi+M6Oq4YFsOSIkRDCmji+syY="
+        "rev": "79c3c1ab7faee8247b740b4ec660a998f2881633",
+        "hash": "sha256-fmd2mIjJs6l9zRTJ2bFIMQNnApFN3epeS+57TBlF/Uk="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #381797

https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_12.html

This update includes 4 security fixes.

CVEs:
CVE-2025-0995 CVE-2025-0996 CVE-2025-0997 CVE-2025-0998

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
