### PR TITLE
nixos/pocket-id: init, pocket-id: init at 0.45.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -166,6 +166,8 @@
 
 - [mqtt-exporter](https://github.com/kpetremann/mqtt-exporter/), a Prometheus exporter for exposing messages from MQTT. Available as [services.prometheus.exporters.mqtt](#opt-services.prometheus.exporters.mqtt.enable).
 
+- [pocket-id](https://pocket-id.org/), an OIDC provider with passkeys support. Available as [services.pocket-id](#opt-services.pocket-id.enable).
+
 - [nvidia-gpu](https://github.com/utkuozdemir/nvidia_gpu_exporter), a Prometheus exporter that scrapes `nvidia-smi` for GPU metrics. Available as [services.prometheus.exporters.nvidia-gpu](#opt-services.prometheus.exporters.nvidia-gpu.enable).
 
 - [OpenGamepadUI](https://github.com/ShadowBlip/OpenGamepadUI/), an open source gamepad-native game launcher and overlay for Linux. Available as [programs.opengamepadui](#opt-programs.opengamepadui.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1419,6 +1419,7 @@
   ./services/security/paretosecurity.nix
   ./services/security/pass-secret-service.nix
   ./services/security/physlock.nix
+  ./services/security/pocket-id.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
   ./services/security/sshguard.nix

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -1,0 +1,278 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    optionalAttrs
+    optional
+    mkPackageOption
+    ;
+  inherit (lib.types)
+    bool
+    path
+    str
+    submodule
+    ;
+
+  cfg = config.services.pocket-id;
+
+  format = pkgs.formats.keyValue { };
+  settingsFile = format.generate "pocket-id-env-vars" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    gepbird
+    ymstnt
+  ];
+
+  options.services.pocket-id = {
+    enable = mkEnableOption "Pocket ID server";
+
+    package = mkPackageOption pkgs "pocket-id" { };
+
+    environmentFile = mkOption {
+      type = path;
+      description = ''
+        Path to an environment file loaded for the Pocket ID service.
+
+        This can be used to securely store tokens and secrets outside of the world-readable Nix store.
+
+        Example contents of the file:
+        MAXMIND_LICENSE_KEY=your-license-key
+      '';
+      default = "/dev/null";
+      example = "/var/lib/secrets/pocket-id";
+    };
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = format.type;
+
+        options = {
+          PUBLIC_APP_URL = mkOption {
+            type = str;
+            description = ''
+              The URL where you will access the app.
+            '';
+            default = "http://localhost";
+          };
+
+          TRUST_PROXY = mkOption {
+            type = bool;
+            description = ''
+              Whether the app is behind a reverse proxy.
+            '';
+            default = false;
+          };
+        };
+      };
+
+      default = { };
+
+      description = ''
+        Environment variables that will be passed to Pocket ID, see
+        [configuration options](https://pocket-id.org/docs/configuration/environment-variables)
+        for supported values.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = path;
+      default = "/var/lib/pocket-id";
+      description = ''
+        The directory where Pocket ID will store its data, such as the database.
+      '';
+    };
+
+    user = mkOption {
+      type = str;
+      default = "pocket-id";
+      description = "User account under which Pocket ID runs.";
+    };
+
+    group = mkOption {
+      type = str;
+      default = "pocket-id";
+      description = "Group account under which Pocket ID runs.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = (
+      optional (cfg.settings ? MAXMIND_LICENSE_KEY)
+        "config.services.pocket-id.settings.MAXMIND_LICENSE_KEY will be stored as plaintext in the Nix store. Use config.services.pocket-id.environmentFile instead."
+    );
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 ${cfg.user} ${cfg.group}"
+    ];
+
+    systemd.services = {
+      pocket-id-backend = {
+        description = "Pocket ID backend";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [
+          cfg.package
+          cfg.environmentFile
+          settingsFile
+        ];
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.dataDir;
+          ExecStart = "${cfg.package}/bin/pocket-id-backend";
+          Restart = "always";
+          EnvironmentFile = [
+            cfg.environmentFile
+            settingsFile
+          ];
+
+          # Hardening
+          AmbientCapabilities = "";
+          CapabilityBoundingSet = "";
+          DeviceAllow = "";
+          DevicePolicy = "closed";
+          #IPAddressDeny = "any"; # communicates with the frontend
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateNetwork = false; # communicates with the frontend
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "full"; # needs to write in cfg.dataDir
+          RemoveIPC = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = lib.concatStringsSep " " [
+            "~"
+            "@clock"
+            "@cpu-emulation"
+            "@debug"
+            "@module"
+            "@mount"
+            "@obsolete"
+            "@privileged"
+            "@raw-io"
+            "@reboot"
+            #"@resources" # vm test segfaults
+            "@swap"
+          ];
+          UMask = "0077";
+        };
+      };
+
+      pocket-id-frontend = {
+        description = "Pocket ID frontend";
+        after = [
+          "network.target"
+          "pocket-id-backend.service"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [
+          cfg.package
+          cfg.environmentFile
+          settingsFile
+        ];
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = "${cfg.package}/bin/pocket-id-frontend";
+          Restart = "always";
+          EnvironmentFile = [
+            cfg.environmentFile
+            settingsFile
+          ];
+
+          # Hardening
+          AmbientCapabilities = "";
+          CapabilityBoundingSet = "";
+          DeviceAllow = "";
+          DevicePolicy = "closed";
+          #IPAddressDeny = "any"; # communicates with the backend and client
+          LockPersonality = true;
+          MemoryDenyWriteExecute = false; # V8_Fatal segfault
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateNetwork = false; # communicates with the backend and client
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          RemoveIPC = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = lib.concatStringsSep " " [
+            "~"
+            "@clock"
+            "@cpu-emulation"
+            "@debug"
+            "@module"
+            "@mount"
+            "@obsolete"
+            "@privileged"
+            "@raw-io"
+            "@reboot"
+            "@resources"
+            "@swap"
+          ];
+          UMask = "0077";
+        };
+      };
+    };
+
+    users.users = optionalAttrs (cfg.user == "pocket-id") {
+      pocket-id = {
+        isSystemUser = true;
+        group = cfg.group;
+        description = "Pocket ID backend user";
+        home = cfg.dataDir;
+      };
+    };
+
+    users.groups = optionalAttrs (cfg.group == "pocket-id") {
+      pocket-id = { };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1039,6 +1039,7 @@ in
   pleroma = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./pleroma.nix { };
   plikd = handleTest ./plikd.nix { };
   plotinus = handleTest ./plotinus.nix { };
+  pocket-id = handleTest ./pocket-id.nix { };
   podgrab = handleTest ./podgrab.nix { };
   podman = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./podman/default.nix { };
   podman-tls-ghostunnel = handleTestOn [

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -1,0 +1,47 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "pocket-id";
+    meta.maintainers = with lib.maintainers; [
+      gepbird
+      ymstnt
+    ];
+
+    nodes = {
+      machine =
+        { ... }:
+        {
+          services.pocket-id = {
+            enable = true;
+            settings = {
+              PORT = 10001;
+              INTERNAL_BACKEND_URL = "http://localhost:10002";
+              BACKEND_PORT = 10002;
+            };
+          };
+        };
+    };
+
+    testScript =
+      { nodes, ... }:
+      let
+        inherit (nodes.machine.services.pocket-id) settings;
+        inherit (builtins) toString;
+      in
+      ''
+        machine.wait_for_unit("pocket-id-backend.service")
+        machine.wait_for_open_port(${toString settings.BACKEND_PORT})
+        machine.wait_for_unit("pocket-id-frontend.service")
+        machine.wait_for_open_port(${toString settings.PORT})
+
+        backend_status = machine.succeed("curl -L -o /tmp/backend-output -w '%{http_code}' http://localhost:${toString settings.BACKEND_PORT}/api/users/me")
+        assert backend_status == "401"
+        machine.succeed("grep 'You are not signed in' /tmp/backend-output")
+
+        frontend_status = machine.succeed("curl -L -o /tmp/frontend-output -w '%{http_code}' http://localhost:${toString settings.PORT}")
+        assert frontend_status == "200"
+        machine.succeed("grep 'Sign in to Pocket ID' /tmp/frontend-output")
+      '';
+  }
+)

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  buildNpmPackage,
+  fetchurl,
+  makeWrapper,
+  nodejs,
+  stdenvNoCC,
+  nix-update-script,
+}:
+
+let
+  version = "0.45.0";
+  src = fetchFromGitHub {
+    owner = "pocket-id";
+    repo = "pocket-id";
+    tag = "v${version}";
+    hash = "sha256-x5Y3ArkIPxiE6avk9DNyFdfkc/pY6h3JH3PZCS8U/GM=";
+  };
+
+  backend = buildGoModule {
+    pname = "pocket-id-backend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/backend";
+
+    vendorHash = "sha256-mqpBP+A2X5ome1Ppg/Kki0C+A77jFtWzUjI/RN+ZCzg=";
+
+    preFixup = ''
+      mv $out/bin/cmd $out/bin/pocket-id-backend
+    '';
+  };
+
+  frontend = buildNpmPackage (finalAttrs: {
+    pname = "pocket-id-frontend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/frontend";
+
+    npmDepsHash = "sha256-cpmZzlz+wusfRLN4iIGdk+I4SWrX/gk2fbhg+Gg3paw=";
+    npmFlags = [ "--legacy-peer-deps" ];
+
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      # even though vite build creates most of the minified js files,
+      # it still needs a few packages from node_modules, try to strip that
+      npm prune --omit=dev --omit=optional $npmFlags
+      # larger seemingly unused packages
+      rm -r node_modules/{lucide-svelte,bits-ui,jiti,@swc,.bin}
+      # unused file types
+      for pattern in '*.map' '*.map.js' '*.ts'; do
+        find . -type f -name "$pattern" -exec rm {} +
+      done
+
+      mkdir -p $out/{bin,lib/pocket-id-frontend}
+      cp -r build $out/lib/pocket-id-frontend/dist
+      cp -r node_modules $out/lib/pocket-id-frontend/node_modules
+      makeWrapper ${lib.getExe nodejs} $out/bin/pocket-id-frontend \
+        --add-flags $out/lib/pocket-id-frontend/dist/index.js
+
+      runHook postInstall
+    '';
+  });
+
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "pocket-id";
+  inherit
+    version
+    src
+    backend
+    frontend
+    ;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${backend}/bin/pocket-id-backend $out/bin/pocket-id-backend
+    ln -s ${frontend}/bin/pocket-id-frontend $out/bin/pocket-id-frontend
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "backend"
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
+
+  meta = {
+    description = "OIDC provider with passkeys support";
+    homepage = "https://pocket-id.org";
+    changelog = "https://github.com/pocket-id/pocket-id/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      gepbird
+      ymstnt
+    ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   nodejs,
   stdenvNoCC,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -91,6 +92,9 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   passthru = {
+    tests = {
+      inherit (nixosTests) pocket-id;
+    };
     updateScript = nix-update-script {
       extraArgs = [
         "--subpackage"


### PR DESCRIPTION
Add a package and a NixOS module for [Pocket ID](https://pocket-id.org/), an OIDC auth provider.

We did some extra testing on our server using this module, works well so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
