### PR TITLE
gren: 0.5.2 -> 0.5.3, bootstrap from 0.4.5

### DIFF
--- a/pkgs/by-name/gr/gren/bootstrap/default.nix
+++ b/pkgs/by-name/gr/gren/bootstrap/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchNpmDeps,
+  npmHooks,
+  nodejs,
+  runCommand,
+  makeWrapper,
+}:
+
+let
+
+  version = "0.4.5";
+  fetchBootstrapBin =
+    { bin, hash }:
+    fetchurl {
+      url = "https://github.com/gren-lang/compiler/releases/download/${version}/${bin}";
+      inherit hash;
+    };
+
+  bootstrapBinaries = {
+    "x86_64-linux" = fetchBootstrapBin {
+      bin = "gren_linux";
+      hash = "sha256-et5EKG/Z/kiuTKfIyyTf5lKgU6SAPy47itUOn657W+s=";
+    };
+    # TODO: x86_64-darwin, aarch64-darwin
+  };
+
+  rawBinary = bootstrapBinaries.${stdenv.hostPlatform.system};
+
+  backend = runCommand "gren-backend" { meta.mainProgram = "gren"; } ''
+    install -Dm755 ${rawBinary} $out/bin/gren
+  '';
+in
+stdenv.mkDerivation rec {
+  pname = "gren-bootstrap-npm";
+  inherit version;
+
+  src = ./src;
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-HxMqoN1NtCCplxDaBP1uWM4P364K0/MRSo6zAuSZLIE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+    makeWrapper
+  ];
+
+  buildInputs = [ nodejs ];
+
+  installPhase = ''
+    mkdir -p $out/share/gren-bootstrap
+    cp -r node_modules $out/share/gren-bootstrap
+    makeWrapper $out/share/gren-bootstrap/node_modules/.bin/gren $out/bin/gren \
+      --set GREN_BIN ${lib.getExe backend}
+  '';
+
+  passthru = {
+    inherit backend;
+  };
+}

--- a/pkgs/by-name/gr/gren/bootstrap/src/package-lock.json
+++ b/pkgs/by-name/gr/gren/bootstrap/src/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "bootstrap",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "gren-lang": "^0.4.5"
+      }
+    },
+    "node_modules/gren-lang": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/gren-lang/-/gren-lang-0.4.5.tgz",
+      "integrity": "sha512-++hR3fUqPNA59iMgqMDRKQW2NsoeXhx31kUjuJlUB9AUlBa3bvrfpFiiNprU4UHQF7fA/5eSctHQ9U+V5vAg4A==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "gren": "index.js"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/gr/gren/bootstrap/src/package.json
+++ b/pkgs/by-name/gr/gren/bootstrap/src/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "gren-lang": "^0.4.5"
+  }
+}

--- a/pkgs/by-name/gr/gren/generated-package.nix
+++ b/pkgs/by-name/gr/gren/generated-package.nix
@@ -21,7 +21,6 @@
   indexed-traversable,
   lib,
   mtl,
-  prettyprint-avh4,
   process,
   raw-strings-qq,
   scientific,
@@ -32,16 +31,16 @@
 }:
 mkDerivation {
   pname = "gren";
-  version = "0.5.2";
+  version = "0.5.3";
   src = fetchgit {
     url = "https://github.com/gren-lang/compiler.git";
-    sha256 = "1mksfma6c1dn091ab4x794hs71v44bx294wbn80qfc5kgrrl5lf4";
-    rev = "ee19481f5715b78cad8be09e29e56dcb82d65f4f";
+    sha256 = "1kav6cw4m4ir5qghwv104f140qq25hj060yz1ijq72ia4yfx63cr";
+    rev = "94e8dcbaabeca498417414e6b3ae7b706917073f";
     fetchSubmodules = true;
   };
   isLibrary = false;
   isExecutable = true;
-  executableHaskellDepends = [
+  libraryHaskellDepends = [
     ansi-terminal
     ansi-wl-pprint
     base
@@ -57,7 +56,6 @@ mkDerivation {
     haskeline
     indexed-traversable
     mtl
-    prettyprint-avh4
     process
     raw-strings-qq
     scientific
@@ -65,34 +63,20 @@ mkDerivation {
     time
     utf8-string
     vector
+  ];
+  executableHaskellDepends = [
+    base
+    bytestring
   ];
   testHaskellDepends = [
-    ansi-terminal
-    ansi-wl-pprint
     base
-    base64-bytestring
-    binary
     bytestring
-    containers
-    directory
-    edit-distance
-    filelock
-    filepath
-    ghc-prim
-    haskeline
     hspec
-    indexed-traversable
-    mtl
-    prettyprint-avh4
-    process
-    raw-strings-qq
-    scientific
     text
-    time
     utf8-string
-    vector
   ];
   testToolDepends = [ hspec-discover ];
+  doHaddock = false;
   jailbreak = true;
   homepage = "https://gren-lang.org";
   description = "The `gren` command line interface";

--- a/pkgs/by-name/gr/gren/package.nix
+++ b/pkgs/by-name/gr/gren/package.nix
@@ -1,21 +1,122 @@
 {
   lib,
-  haskell,
+  callPackage,
   haskellPackages,
+  fetchFromGitHub,
+  buildNpmPackage,
+  git,
+  makeWrapper,
 }:
 
 let
-  inherit (haskell.lib.compose) overrideCabal;
+  bootstrap = callPackage ./bootstrap { };
 
-  raw-pkg = (haskellPackages.callPackage ./generated-package.nix { }).overrideScope (
+  backend = (haskellPackages.callPackage ./generated-package.nix { }).overrideScope (
     final: prev: {
       ansi-wl-pprint = final.ansi-wl-pprint_0_6_9;
     }
   );
 
-  overrides = {
-    maintainers = with lib.maintainers; [ tomasajt ];
-    passthru.updateScript = ./update.sh;
-  };
+  fetchGrenDep =
+    {
+      owner,
+      repo,
+      rev,
+      hash,
+    }:
+    fetchFromGitHub {
+      name = "${owner}-${repo}-${rev}";
+      leaveDotGit = true; # required for kernel code checks
+      inherit
+        owner
+        repo
+        rev
+        hash
+        ;
+    };
+
+  deps = [
+    (fetchGrenDep {
+      owner = "gren-lang";
+      repo = "core";
+      rev = "5.1.1";
+      hash = "sha256-vAHugCOS5icJ9l2ty18m7mwIRtGRG3G9QH4n/G+Wty4=";
+    })
+    (fetchGrenDep {
+      owner = "gren-lang";
+      repo = "node";
+      rev = "4.2.1";
+      hash = "sha256-Eevh5YJ4seRvmFM7sizAOAF7laQRCD7w5BNVKQmoSf4=";
+    })
+    (fetchGrenDep {
+      owner = "gren-lang";
+      repo = "compiler-node";
+      rev = "1.0.2";
+      hash = "sha256-55O88e4AWsaudwVettyoWBiwU/7vM+X5kl6556HFWJ8=";
+    })
+    (fetchGrenDep {
+      owner = "gren-lang";
+      repo = "url";
+      rev = "4.0.0";
+      hash = "sha256-y6taMjX/PJsUejs8QxdXcqZO0WxCMSwWaiQlRbtr6ik=";
+    })
+  ];
+
 in
-overrideCabal overrides raw-pkg
+
+buildNpmPackage {
+  pname = "gren";
+  inherit (backend) version src;
+
+  nativeBuildInputs = [
+    bootstrap
+    git
+    makeWrapper
+  ];
+
+  postPatch = ''
+    # use out own bootstrap binary instead of trying to download it here
+    substituteInPlace package.json \
+      --replace-fail 'npx --package=gren-lang@0.4.5 --yes -- gren ' 'gren '
+  '';
+
+  npmDepsHash = "sha256-KmJ1ImfPLbiXvAXQms3OhWMSuT9tNrFLf4ozUBfvY2U=";
+
+  postConfigure = ''
+    export HOME=$(mktemp -d)
+    pkgsDir="$HOME"/.cache/gren/${bootstrap.version}/packages
+
+    mkdir -p "$pkgsDir"
+
+    ${lib.concatMapStringsSep "\n" (dep: ''
+      mkdir -p "$pkgsDir"/${dep.owner}/${dep.repo}
+      cp -r ${dep} "$pkgsDir"/${dep.owner}/${dep.repo}/${dep.rev}
+
+      pushd "$pkgsDir"/${dep.owner}/${dep.repo}/${dep.rev}
+
+      chmod -R u+w .
+      git add . # why are things not added by default, wtf???
+
+      popd
+
+    '') deps}
+
+  '';
+
+  npmBuildScript = "prepublishOnly";
+
+  postInstall = ''
+    wrapProgram $out/bin/gren --set GREN_BIN ${lib.getExe backend}
+  '';
+
+  passthru = {
+    inherit bootstrap backend deps;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    inherit (backend.meta) description homepage license;
+    mainProgram = "gren";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
As mentioned in https://github.com/NixOS/nixpkgs/issues/344528#issuecomment-2657454543, gren no longer works just by the haskell package itself.

`gren` uses an older version of gren to build itself, in this case: `0.4.5`.

TODO: finish this description

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
