### PR TITLE
cemu: 2.4 -> 2.5

### DIFF
--- a/pkgs/by-name/ce/cemu/0002-cemu-imgui.patch
+++ b/pkgs/by-name/ce/cemu/0002-cemu-imgui.patch
@@ -1,0 +1,13 @@
+diff --git a/src/imgui/imgui_extension.cpp b/src/imgui/imgui_extension.cpp
+index f1c072f..e3e901d 100644
+--- a/src/imgui/imgui_extension.cpp
++++ b/src/imgui/imgui_extension.cpp
+@@ -129,8 +129,6 @@ void ImGui_UpdateWindowInformation(bool mainWindow)
+ 	io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+ #if BOOST_OS_WINDOWS
+ 	io.ImeWindowHandle = mainWindow ? g_window_info.window_main.hwnd : g_window_info.window_pad.hwnd;
+-#else
+-	io.ImeWindowHandle = nullptr;
+ #endif
+ 
+ 	io.MousePos = ImVec2(-FLT_MAX, -FLT_MAX);

--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -34,24 +34,25 @@
   wrapGAppsHook3,
   wxGTK32,
   zarchive,
+  bluez,
 }:
 
 let
-  # cemu doesn't build with imgui 1.90.2 or newer:
-  # error: 'struct ImGuiIO' has no member named 'ImeWindowHandle'
+  # cemu doesn't build with imgui 1.91.4 or newer:
+  # before v1.91.4 (2024/10/08) the default type for ImTextureID was void*.
   imgui' = imgui.overrideAttrs rec {
-    version = "1.90.1";
+    version = "1.91.3";
     src = fetchFromGitHub {
       owner = "ocornut";
       repo = "imgui";
       rev = "v${version}";
-      hash = "sha256-gf47uLeNiXQic43buB5ZnMqiotlUfIyAsP+3H7yJuFg=";
+      hash = "sha256-J4gz4rnydu8JlzqNC/OIoVoRcgeFd6B1Qboxu5drOKY=";
     };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cemu";
-  version = "2.4";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "cemu-project";
@@ -71,6 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/cemu-project/Cemu/commit/2b0cbf7f6b6c34c748585d255ee7756ff592a502.patch";
       hash = "sha256-jHB/9MWZ/oNfUgZtxtgkSN/OnRARSuGVfXFFB9ldDpI=";
     })
+    ./0002-cemu-imgui.patch
   ];
 
   nativeBuildInputs = [
@@ -106,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wxGTK32
     zarchive
+    bluez
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Updated cemu to 2.5 and increases imgui dependency to 1.91.3. (1.91.4 has multiple conflicts because of changes in typedefs.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

(I think my commit message fits CONTRIBUTING.MD. I am not 100% sure since I both incremented the version of Cemu and the vendored imgui dependency, and I'm not sure how that should be present in the commit message.)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
