### PR TITLE
bash-my-aws: 2020-01-11 -> 2025-01-22 and refactor

### DIFF
--- a/pkgs/by-name/ba/bash-my-aws/0001-update-paths-to-placeholders.patch
+++ b/pkgs/by-name/ba/bash-my-aws/0001-update-paths-to-placeholders.patch
@@ -1,0 +1,39 @@
+diff --git a/bin/bma b/bin/bma
+index 6144842..26965ce 100755
+--- a/bin/bma
++++ b/bin/bma
+@@ -13,7 +13,7 @@
+ #
+ # Assumes you have installed bash-my-aws to standard location
+ 
+-for f in "${BMA_HOME:-$HOME/.bash-my-aws}"/lib/*-functions; do source $f; done
++for f in @out@/lib/*-functions; do source $f; done
+ 
+ # Disable awcli client side pager
+ #
+diff --git a/scripts/build b/scripts/build
+index 54a786b..37a05df 100755
+--- a/scripts/build
++++ b/scripts/build
+@@ -41,7 +41,7 @@ funcs_after_bma=$(compgen -A function)
+ exclusions=('region')
+ 
+ for fnc in $(echo "${funcs_before_bma}" "${funcs_after_bma}" "${exclusions}" | tr ' ' '\n' | LC_ALL=C sort | uniq -u); do
+-  echo "alias $fnc='\${BMA_HOME:-\$HOME/.bash-my-aws}/bin/bma $fnc'" >> "$aliases_destination"
++  echo "alias $fnc='@out@/bin/bma $fnc'" >> "$aliases_destination"
+ done;
+ 
+ 
+diff --git a/scripts/build-completions b/scripts/build-completions
+index 2b5d49b..bf86af6 100755
+--- a/scripts/build-completions
++++ b/scripts/build-completions
+@@ -6,7 +6,7 @@ cat <<EOF
+ # DO NOT MANUALLY MODIFY THIS FILE.
+ # Use 'scripts/build' to regenerate if required.
+ 
+-bma_path="\${BMA_HOME:-\$HOME/.bash-my-aws}"
++bma_path="@out@"
+ EOF
+ 
+ # load in all the completions from scripts/completions

--- a/pkgs/by-name/ba/bash-my-aws/0002-fix-tests.patch
+++ b/pkgs/by-name/ba/bash-my-aws/0002-fix-tests.patch
@@ -1,0 +1,52 @@
+diff --git a/test/stack-spec.sh b/test/stack-spec.sh
+index f04a10c..1165953 100755
+--- a/test/stack-spec.sh
++++ b/test/stack-spec.sh
+@@ -72,28 +72,30 @@ describe "_bma_stack_template_arg:" "$(
+ 
+ )"
+ 
+-[[ -d cloudformation/params ]] || mkdir -p cloudformation/params
++TEST_DIR=$(mktemp -d)
++
++[[ -d "$TEST_DIR"/cloudformation/params ]] || mkdir -p "$TEST_DIR"/cloudformation/params
+ 
+ 
+ # templates
+ touch            \
+-  $(dirname $0)/cloudformation/great-app.json \
+-  $(dirname $0)/cloudformation/great-app.yml  \
+-  $(dirname $0)/cloudformation/great-app.yaml \
++  "$TEST_DIR"/cloudformation/great-app.json \
++  "$TEST_DIR"/cloudformation/great-app.yml  \
++  "$TEST_DIR"/cloudformation/great-app.yaml \
+ 
+ # params
+ 
+ [[ -d params ]] || mkdir params
+ 
+ touch                                      \
+-  $(dirname $0)/cloudformation/great-app-params.json                    \
+-  $(dirname $0)/cloudformation/great-app-params-staging.json            \
+-  $(dirname $0)/cloudformation/great-app-params-another-env.json        \
+-  $(dirname $0)/cloudformation/params/great-app-params.json             \
+-  $(dirname $0)/cloudformation/params/great-app-params-staging.json     \
+-  $(dirname $0)/cloudformation/params/great-app-params-another-env.json
++  "$TEST_DIR"/cloudformation/great-app-params.json                    \
++  "$TEST_DIR"/cloudformation/great-app-params-staging.json            \
++  "$TEST_DIR"/cloudformation/great-app-params-another-env.json        \
++  "$TEST_DIR"/cloudformation/params/great-app-params.json             \
++  "$TEST_DIR"/cloudformation/params/great-app-params-staging.json     \
++  "$TEST_DIR"/cloudformation/params/great-app-params-another-env.json
+ 
+-cd $(dirname $0)/cloudformation
++cd "$TEST_DIR"/cloudformation
+ 
+ describe "_bma_stack_args:" "$(
+   context "without an argument" "$(
+@@ -115,3 +117,5 @@ describe "_bma_stack_args:" "$(
+ )"
+ 
+ cd -
++
++rm -rf "$TEST_DIR"

--- a/pkgs/by-name/ba/bash-my-aws/package.nix
+++ b/pkgs/by-name/ba/bash-my-aws/package.nix
@@ -2,81 +2,95 @@
   lib,
   stdenv,
   makeWrapper,
-  awscli,
+  awscli2,
   jq,
   unixtools,
   fetchFromGitHub,
   installShellFiles,
   bashInteractive,
+  getopt,
+  python3,
 }:
-
+let
+  runtimeDeps = [
+    awscli2
+    jq
+    unixtools.column
+    bashInteractive
+    getopt
+    (python3.withPackages (ps: [ ps.jmespath ]))
+  ];
+in
 stdenv.mkDerivation rec {
   pname = "bash-my-aws";
-  version = "unstable-2020-01-11";
+  version = "0-unstable-2025-01-22";
 
   src = fetchFromGitHub {
     owner = "bash-my-aws";
     repo = "bash-my-aws";
-    rev = "5a97ce2c22affca1299022a5afa109d7b62242ba";
-    sha256 = "sha256-RZvaiyRK8FnZbHyLkWz5VrAcsnMtHCiIo64GpNZgvqY=";
+    rev = "d338b43cc215719c1853ec500c946db6b9caaa11";
+    sha256 = "sha256-PR52T6XCrakQsBOJXf0PaYpYE5oMcIz5UDA4I9B7C38=";
   };
 
   dontConfigure = true;
-  dontBuild = true;
 
-  propagatedBuildInputs = [
-    awscli
-    jq
-    unixtools.column
-    bashInteractive
-  ];
+  propagatedBuildInputs = runtimeDeps;
+
   nativeBuildInputs = [
     makeWrapper
     installShellFiles
+    bashInteractive
   ];
 
-  checkPhase = ''
-    pushd test
-    ./shared-spec.sh
-    ./stack-spec.sh
-    popd
+  patches = [
+    ./0001-update-paths-to-placeholders.patch
+    ./0002-fix-tests.patch
+  ];
+
+  postPatch = ''
+    patchShebangs --build ./scripts
+
+    substituteAllInPlace ./scripts/build
+    substituteAllInPlace ./scripts/build-completions
+    substituteAllInPlace ./bin/bma
   '';
+
+  buildPhase = ''
+    runHook preBuild
+    ./scripts/build
+    runHook postBuild
+  '';
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out
     cp -r . $out
-  '';
-  postFixup = ''
-    pushd $out
-    substituteInPlace scripts/build \
-        --replace '~/.bash-my-aws' $out
-    substituteInPlace scripts/build-completions \
-        --replace "{HOME}" $out \
-        --replace '~/.bash-my-aws' $out
-    ./scripts/build
-    ./scripts/build-completions
-    substituteInPlace bash_completion.sh \
-        --replace "{HOME}" $out \
-        --replace .bash-my-aws ""
-    substituteInPlace bin/bma \
-        --replace '~/.bash-my-aws' $out
-    wrapProgram $out/bin/bma --prefix PATH : ${
-      lib.makeBinPath [
-        awscli
-        jq
-        unixtools.column
-        bashInteractive
-      ]
-    }
-    installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
-    chmod +x $out/lib/*
-    patchShebangs --host $out/lib
-    installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
+
     cat > $out/bin/bma-init <<EOF
     echo source $out/aliases
-    echo source $out/bash_completion.sh
     EOF
     chmod +x $out/bin/bma-init
+
+    installShellCompletion --bash --name bash-my-aws.bash $out/bash_completion.sh
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    pushd $out
+    make test
     popd
+    runHook postInstallCheck
+  '';
+
+  preFixup = ''
+    wrapProgram $out/bin/bma --prefix PATH : ${lib.makeBinPath runtimeDeps}
+
+    # make lib file executable so they are picked up by patchShebangs
+    chmod +x $out/lib/*
   '';
 
   meta = with lib; {
@@ -84,5 +98,6 @@ stdenv.mkDerivation rec {
     description = "CLI commands for AWS";
     license = licenses.mit;
     maintainers = with maintainers; [ tomberek ];
+    mainProgram = "bma";
   };
 }


### PR DESCRIPTION
Pull to latest commit and refactor the derivation.

This is my first contribution to nixpkgs, so let me know if there's anything I can improve. I'm happy to add myself as a maintainer of this package if that is appropriate.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
