### PR TITLE
mrpack-install: init at 0.16.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6944,6 +6944,12 @@
     githubId = 28287;
     name = "Jon Roberts";
   };
+  encode42 = {
+    name = "encode42";
+    email = "me@encode42.dev";
+    github = "encode42";
+    githubId = 34699884;
+  };
   enderger = {
     email = "endergeryt@gmail.com";
     github = "enderger";

--- a/pkgs/by-name/mr/mrpack-install/package.nix
+++ b/pkgs/by-name/mr/mrpack-install/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  buildPackages,
+  installShellFiles,
+  nix-update-script,
+}:
+
+let
+  version = "0.16.10";
+in
+buildGoModule {
+  pname = "mrpack-install";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "nothub";
+    repo = "mrpack-install";
+    tag = "v${version}";
+    hash = "sha256-mTAXFK97t10imdICpg0UI4YLF744oscJqoOIBG5GEkc=";
+  };
+
+  vendorHash = "sha256-az+NpP/hCIq2IfO8Bmn/qG3JVypeDljJ0jWg6yT6hks=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/nothub/mrpack-install/buildinfo.version=${version}"
+    "-X github.com/nothub/mrpack-install/buildinfo.date=1970-01-01T00:00:00Z"
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Skip tests that require network access
+        "TestFetchMetadata"
+        "TestClient_VersionFromHash"
+        "TestClient_GetDependencies"
+        "TestClient_GetProjectVersions_Count"
+        "TestClient_GetVersion"
+        "TestClient_CheckProjectValidity_Slug"
+        "Test_GetProject_404"
+        "TestClient_GetProjects_Count"
+        "TestClient_GetProjectVersions_Filter_NoResults"
+        "Test_GetProject_Success"
+        "TestClient_CheckProjectValidity_Id"
+        "TestClient_GetLatestGameVersion"
+        "TestClient_GetProjectVersions_Filter_Results"
+        "TestClient_GetProjects_Slug"
+        "TestClient_GetVersions"
+        "TestGetPlayerUuid"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall =
+    let
+      mrpack-install = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/mrpack-install";
+    in
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      installShellCompletion --cmd mrpack-install \
+        --bash <(${mrpack-install} completion bash) \
+        --fish <(${mrpack-install} completion fish) \
+        --zsh <(${mrpack-install} completion zsh)
+    '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI application for installing Minecraft servers and Modrinth modpacks";
+    homepage = "https://github.com/nothub/mrpack-install";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ encode42 ];
+    mainProgram = "mrpack-install";
+  };
+}


### PR DESCRIPTION
[mrpack-install](https://github.com/nothub/mrpack-install) is a command-line tool to create a ready-to-run Minecraft server based off of Modrinth mod packs.

The tool has been going through extensive major changes lately, so this package is initialized at the latest non-pre-release.

If this may seem niche, there aren't any other methods to extract Modrinth packs in command-based environments such as servers! As somebody who hosts various Minecraft servers based on various mod packs, I've used this very often on other distributions. However, if this is still seen as too niche, that'd be entirely understandable.

As this is the first package I've put together, reviews are highly appreciated! While I've read through the readme and contributing files, I'm still quite inexperienced with the Nix language and the ecosystem. I tried my best, but I'm always open to learning more!

I used the [packwiz package](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/pa/packwiz/package.nix) as a reference, as both of these tools function very similarly and are typically paired together.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
