### PR TITLE
upbound-main: 0.38.0-0.rc.0.29.g59359e0 -> 0.39.0-0.rc.0.12.gfb799fcb

### DIFF
--- a/pkgs/by-name/up/upbound/sources-main.json
+++ b/pkgs/by-name/up/upbound/sources-main.json
@@ -8,38 +8,38 @@
   "fetchurlAttrSet": {
     "docker-credential-up": {
       "aarch64-darwin": {
-        "hash": "sha256-3fx/wjBoFxmeo55QbRw9cl4GFCFehGpZeVAw1bvooSk=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/darwin_arm64.tar.gz"
+        "hash": "sha256-Lb/PxAkuJsBit7e+k71kFbzSvkM1f+TBhHlXGwrOfjk=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/docker-credential-up/darwin_arm64.tar.gz"
       },
       "aarch64-linux": {
-        "hash": "sha256-FeF7D8WLpK8S6b7QCLaOI7Dm2EzbDqJVp9tfh13BJuU=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/linux_arm64.tar.gz"
+        "hash": "sha256-fpC2GQnILAuBFWC2SbwEF5dtNlgtyOHzPDh0aNxjhPM=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/docker-credential-up/linux_arm64.tar.gz"
       },
       "x86_64-darwin": {
-        "hash": "sha256-00y9wGMwu5ZsTzlNkSvdwEse5eV4xzLiwQjgSTnmW5w=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/darwin_amd64.tar.gz"
+        "hash": "sha256-fY9wg+HYZ8GLBV0NK6lLW8D8E9bmm1oFrJgbW7oh8ck=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/docker-credential-up/darwin_amd64.tar.gz"
       },
       "x86_64-linux": {
-        "hash": "sha256-oObO/T/2yOFDaNVJGQCqna130Tyx/sEOCAQMDYhVlNI=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/linux_amd64.tar.gz"
+        "hash": "sha256-mSXuxnpGKw1K7TDSofkVHxutryNsbtBZfDCzvzj1LKc=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/docker-credential-up/linux_amd64.tar.gz"
       }
     },
     "up": {
       "aarch64-darwin": {
-        "hash": "sha256-Bf6O6rsth3D5h5olxqHxULuxxPtNhxP+gN69mJnlQTg=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/darwin_arm64.tar.gz"
+        "hash": "sha256-t3+rLMVKUfLZe2WMB11Vn8udTcYHDPiK36MlPfFHHaE=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/up/darwin_arm64.tar.gz"
       },
       "aarch64-linux": {
-        "hash": "sha256-svTHCjw2ZrTEscNpizOmg9leQAbzhWcPfst3nMUhUXg=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/linux_arm64.tar.gz"
+        "hash": "sha256-qiBaAN4QLV6Lt20U01xA60tQ5iS5ugbM7Da0rVYCX14=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/up/linux_arm64.tar.gz"
       },
       "x86_64-darwin": {
-        "hash": "sha256-1LxqRHQjNlRFTGhEyOR9uW407LkqdpVjB3w57hNT/Zk=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/darwin_amd64.tar.gz"
+        "hash": "sha256-3abcm/+Oc0KUc9kmJoXK3Lx7jFPVisXuSsHMv1eeYf4=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/up/darwin_amd64.tar.gz"
       },
       "x86_64-linux": {
-        "hash": "sha256-ZLjhD7uCpBURYozX1IjUTJDzPuKFedIZQhRvMqMMsLY=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/linux_amd64.tar.gz"
+        "hash": "sha256-tRfyGsoQ1FMtC4GEnVuSCfk3Pcr3F6wJCIE11DMWeVw=",
+        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.1.4.g69633333/bundle/up/linux_amd64.tar.gz"
       }
     }
   },
@@ -49,5 +49,5 @@
     "x86_64-darwin",
     "x86_64-linux"
   ],
-  "version": "0.38.0-0.rc.0.29.g59359e0"
+  "version": "0.38.0-0.rc.1.4.g69633333"
 }


### PR DESCRIPTION
**upbound-main: 0.38.0-0.rc.0.29.g59359e0 -> 0.39.0-0.rc.0.12.gfb799fcb**
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Manual test after nixpkgs-review
```bash
[nix-shell:~/.cache/nixpkgs-review/rev-a6998f4ded80e31e2a67bd9e217801c654ec8cce/results/upbound-main-aarch64-darwin]$ tree
.
├── bin
│   ├── docker-credential-up
│   └── up
└── share
    └── bash-completion
        └── completions
            └── up

5 directories, 3 files

[nix-shell:~/.cache/nixpkgs-review/rev-a6998f4ded80e31e2a67bd9e217801c654ec8cce/results/upbound-main-aarch64-darwin]$ cd bin/

[nix-shell:~/.cache/nixpkgs-review/rev-a6998f4ded80e31e2a67bd9e217801c654ec8cce/results/upbound-main-aarch64-darwin/bin]$ lla
.r-xr-xr-x  32M root  1 Jan  1970  docker-credential-up
.r-xr-xr-x 127M root  1 Jan  1970  up

[nix-shell:~/.cache/nixpkgs-review/rev-a6998f4ded80e31e2a67bd9e217801c654ec8cce/results/upbound-main-aarch64-darwin/bin]$ ./up version
unable to get crossplane version. Is your kubecontext pointed at a control plane?
unable to get spaces version. Is your kubecontext pointed at a Space?
Client:
  Version:     v0.38.0-0.rc.1.4.g69633333
  Go Version:  go1.23.6
  Git Commit:  69633333
  OS/Arch:     darwin/arm64
Server:
  Crossplane Version:        unknown
  Spaces Controller Version: unknown

```
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
