### PR TITLE
add service config for hayabusa

### DIFF
--- a/nixos/modules/services/misc/hayabusa.nix
+++ b/nixos/modules/services/misc/hayabusa.nix
@@ -4,33 +4,29 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.hayabusa;
-
 in
 {
-  meta.maintainers = with maintainers; [ crinklywrappr ];
+  meta.maintainers = with lib.maintainers; [ crinklywrappr ];
 
   options.services.hayabusa = {
-    enable = mkEnableOption "Hayabusa, a configurable sysfetch that uses a daemon to cache sysinfo and run fast!";
+    enable = lib.mkEnableOption "Hayabusa, a configurable sysfetch that uses a daemon to cache sysinfo and run fast!";
 
-    package = mkOption {
-      type = types.package;
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.hayabusa;
       description = "The package to use for hayabusa";
     };
 
-    flags = mkOption {
-      type = types.str;
+    flags = lib.mkOption {
+      type = lib.types.str;
       default = "-d";
       description = "Flags for the hayabusa daemon";
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     systemd = {
       services.hayabusa = {
@@ -41,10 +37,9 @@ in
         serviceConfig = {
           Restart = "always";
           Type = "simple";
-          ExecStart = "${cfg.package}/bin/hayabusa ${cfg.flags}";
+          ExecStart = "${lib.getExe cfg.package} ${cfg.flags}";
         };
       };
     };
   };
-
 }

--- a/nixos/modules/services/misc/hayabusa.nix
+++ b/nixos/modules/services/misc/hayabusa.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.hayabusa;
+
+in
+{
+  meta.maintainers = with maintainers; [ crinklywrappr ];
+
+  options.services.hayabusa = {
+    enable = mkEnableOption "Hayabusa, a configurable sysfetch that uses a daemon to cache sysinfo and run fast!";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.hayabusa;
+      description = "The package to use for hayabusa";
+    };
+
+    flags = mkOption {
+      type = types.str;
+      default = "-d";
+      description = "Flags for the hayabusa daemon";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    systemd = {
+      services.hayabusa = {
+        description = "the hayabusa daemon";
+        after = [ "network.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Restart = "always";
+          Type = "simple";
+          ExecStart = "${cfg.package}/bin/hayabusa ${cfg.flags}";
+        };
+      };
+    };
+  };
+
+}


### PR DESCRIPTION
Hayabusa (a fast fetch) has a daemon mode that needs to be managed by systemd.  This service config allows users to enable that service via their configuration.nix.

This is my first full service file contribution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
