### PR TITLE
ocamlPackages.mopsa: 1.0 → 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/arg-complete/default.nix
+++ b/pkgs/development/ocaml-modules/arg-complete/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchurl,
+  ocaml,
+  buildDunePackage,
+  cppo,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "arg-complete";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://github.com/sim642/ocaml-arg-complete/releases/download/${version}/arg-complete-${version}.tbz";
+    hash = "sha256-SZvLaeeqY3j2LUvqxGs0Vw57JnnpdvAk1jnE3pk27QU=";
+  };
+
+  nativeBuildInputs = [ cppo ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  checkInputs = [ ounit2 ];
+
+  meta = {
+    description = "Bash completion support for OCaml Stdlib.Arg";
+    homepage = "https://sim642.github.io/ocaml-arg-complete/";
+    changelog = "https://raw.githubusercontent.com/sim642/ocaml-arg-complete/refs/tags/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/mopsa/default.nix
+++ b/pkgs/development/ocaml-modules/mopsa/default.nix
@@ -11,6 +11,7 @@
   ocaml,
   menhir,
   apron,
+  arg-complete,
   camlidl,
   yojson,
   zarith,
@@ -18,15 +19,15 @@
 
 buildDunePackage rec {
   pname = "mopsa";
-  version = "1.0";
+  version = "1.1";
 
-  minimalOCamlVersion = "4.12";
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitLab {
     owner = "mopsa";
     repo = "mopsa-analyzer";
-    rev = "v${version}";
-    hash = "sha256-nGnWwV7g3SYgShbXGUMooyOdFwXFrQHnQvlc8x9TAS4=";
+    tag = "v${version}";
+    hash = "sha256-lO5dtGAl1dq8oJco/hPXrAbN05rKc62Zrci/8CLrQ0c=";
   };
 
   nativeBuildInputs = [
@@ -36,6 +37,7 @@ buildDunePackage rec {
   ];
 
   buildInputs = [
+    arg-complete
     camlidl
     flint
     libclang

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -38,6 +38,8 @@ let
 
     apron = callPackage ../development/ocaml-modules/apron { };
 
+    arg-complete = callPackage ../development/ocaml-modules/arg-complete { };
+
     arp = callPackage ../development/ocaml-modules/arp { };
 
     asai = callPackage ../development/ocaml-modules/asai { };


### PR DESCRIPTION
Adds support for OCaml 5.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
