### PR TITLE
python312Packages.textual: skip flaky tests also on linux

### DIFF
--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -107,6 +107,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Textualize/textual";
     changelog = "https://github.com/Textualize/textual/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ gepbird ];
   };
 }

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -59,15 +59,14 @@ buildPythonPackage rec {
     tree-sitter
   ];
 
-  disabledTestPaths =
-    [
-      # Snapshot tests require syrupy<4
-      "tests/snapshot_tests/test_snapshots.py"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # RuntimeError: There is no current event loop in thread 'MainThread'.
-      "tests/test_focus.py"
-    ];
+  disabledTestPaths = [
+    # Snapshot tests require syrupy<4
+    "tests/snapshot_tests/test_snapshots.py"
+
+    # Flaky
+    # RuntimeError: There is no current event loop in thread 'MainThread'.
+    "tests/test_focus.py"
+  ];
 
   disabledTests =
     [

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -1,22 +1,29 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  jinja2,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
   markdown-it-py,
   platformdirs,
-  poetry-core,
+  rich,
+  typing-extensions,
+
+  # optional-dependencies
+  tree-sitter,
+  tree-sitter-languages,
+
+  # tests
+  jinja2,
   pytest-aiohttp,
   pytest-xdist,
   pytestCheckHook,
-  pythonAtLeast,
-  rich,
   syrupy,
   time-machine,
-  tree-sitter,
-  tree-sitter-languages,
-  typing-extensions,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -35,8 +42,8 @@ buildPythonPackage rec {
 
   dependencies =
     [
-      platformdirs
       markdown-it-py
+      platformdirs
       rich
       typing-extensions
     ]
@@ -63,7 +70,7 @@ buildPythonPackage rec {
     # Snapshot tests require syrupy<4
     "tests/snapshot_tests/test_snapshots.py"
 
-    # Flaky
+    # Flaky: https://github.com/Textualize/textual/issues/5511
     # RuntimeError: There is no current event loop in thread 'MainThread'.
     "tests/test_focus.py"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python312Packages.textual: skip flaky tests also on linux**
- **python312Packages.textual: cleanup**

cc @gepbird

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
