### PR TITLE
[24.11] playwright: 1.47.0 -> 1.50.1

### DIFF
--- a/nixos/tests/playwright-python.nix
+++ b/nixos/tests/playwright-python.nix
@@ -25,19 +25,20 @@ import ./make-test-python.nix (
               from playwright.sync_api import expect
 
               browsers = {
-                "chromium": ["--headless", "--disable-gpu"],
-                "firefox": [],
-                "webkit": []
+                "chromium": {'args': ["--headless", "--disable-gpu"], 'channel': 'chromium'},
+                "firefox": {},
+                "webkit": {}
               }
               if len(sys.argv) != 3 or sys.argv[1] not in browsers.keys():
                   print(f"usage: {sys.argv[0]} [{'|'.join(browsers.keys())}] <url>")
                   sys.exit(1)
               browser_name = sys.argv[1]
               url = sys.argv[2]
-              browser_args = browsers.get(browser_name)
-              print(f"Running test on {browser_name} {' '.join(browser_args)}")
+              browser_kwargs = browsers.get(browser_name)
+              args = ' '.join(browser_kwargs.get('args', []))
+              print(f"Running test on {browser_name} {args}")
               with sync_playwright() as p:
-                  browser = getattr(p, browser_name).launch(args=browser_args)
+                  browser = getattr(p, browser_name).launch(**browser_kwargs)
                   context = browser.new_context()
                   page = context.new_page()
                   page.goto(url)

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,15 +22,15 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.49.1";
+  version = "1.50.0";
   pyproject = true;
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-RwUjFofC/scwVClKncYWp3RbIUeKsWokVjcGibdrrtc=";
+    hash = "sha256-g32QwEA4Ofzh7gVEsC++uA/XqT1eIrUH+fQi15SRxko=";
   };
 
   patches = [
@@ -52,13 +52,12 @@ buildPythonPackage rec {
     git commit -m "workaround setuptools-scm"
 
     substituteInPlace pyproject.toml \
-      --replace 'requires = ["setuptools==75.5.0", "setuptools-scm==8.1.0", "wheel==0.45.0", "auditwheel==6.1.0"]' \
-                'requires = ["setuptools", "setuptools-scm", "wheel"]'
+      --replace-fail 'requires = ["setuptools==75.6.0", "setuptools-scm==8.1.0", "wheel==0.45.1", "auditwheel==6.2.0"]' \
+                     'requires = ["setuptools", "setuptools-scm", "wheel"]'
 
-    # Skip trying to download and extract the driver.
+    # setup.py downloads and extracts the driver.
     # This is done manually in postInstall instead.
-    substituteInPlace setup.py \
-      --replace "self._download_and_extract_local_driver(base_wheel_bundles)" ""
+    rm setup.py
 
     # Set the correct driver path with the help of a patch in patches
     substituteInPlace playwright/_impl/_driver.py \
@@ -101,6 +100,9 @@ buildPythonPackage rec {
       // lib.optionalAttrs stdenv.hostPlatform.isLinux {
         inherit (nixosTests) playwright-python;
       };
+    # Package and playwright driver versions are tightly coupled.
+    # Use the update script to ensure synchronized updates.
+    skipBulkUpdate = true;
     updateScript = ./update.sh;
   };
 

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,7 +22,7 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.47.0";
+  version = "1.48.0";
   pyproject = true;
   disabled = pythonOlder "3.7";
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-C/spH54hhLI0Egs2jjTjQ5BH1pIw1syrfSyUvVQRoKM=";
+    hash = "sha256-ZWVySGehR5r6s0y6qCZuFI8SobYbjWP+A6Rgfug2JEE=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -22,7 +22,7 @@ in
 buildPythonPackage rec {
   pname = "playwright";
   # run ./pkgs/development/python-modules/playwright/update.sh to update
-  version = "1.48.0";
+  version = "1.49.1";
   pyproject = true;
   disabled = pythonOlder "3.7";
 
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "microsoft";
     repo = "playwright-python";
     tag = "v${version}";
-    hash = "sha256-ZWVySGehR5r6s0y6qCZuFI8SobYbjWP+A6Rgfug2JEE=";
+    hash = "sha256-RwUjFofC/scwVClKncYWp3RbIUeKsWokVjcGibdrrtc=";
   };
 
   patches = [
@@ -51,12 +51,8 @@ buildPythonPackage rec {
     git config --global user.name "nixpkgs"
     git commit -m "workaround setuptools-scm"
 
-    substituteInPlace setup.py \
-      --replace "setuptools-scm==8.1.0" "setuptools-scm" \
-      --replace-fail "wheel==0.42.0" "wheel"
-
     substituteInPlace pyproject.toml \
-      --replace 'requires = ["setuptools==68.2.2", "setuptools-scm==8.1.0", "wheel==0.42.0", "auditwheel==5.4.0"]' \
+      --replace 'requires = ["setuptools==75.5.0", "setuptools-scm==8.1.0", "wheel==0.45.0", "auditwheel==6.1.0"]' \
                 'requires = ["setuptools", "setuptools-scm", "wheel"]'
 
     # Skip trying to download and extract the driver.

--- a/pkgs/development/python-modules/playwright/driver-location.patch
+++ b/pkgs/development/python-modules/playwright/driver-location.patch
@@ -3,8 +3,8 @@ index 22b53b8..2d86626 100644
 --- a/playwright/_impl/_driver.py
 +++ b/playwright/_impl/_driver.py
 @@ -23,14 +23,7 @@ from playwright._repo_version import version
-
-
+ 
+ 
  def compute_driver_executable() -> Tuple[str, str]:
 -    driver_path = Path(inspect.getfile(playwright)).parent / "driver"
 -    cli_path = str(driver_path / "package" / "cli.js")
@@ -15,36 +15,26 @@ index 22b53b8..2d86626 100644
 -        )
 -    return (os.getenv("PLAYWRIGHT_NODEJS_PATH", str(driver_path / "node")), cli_path)
 +    return "@node@", "@driver@"
-
-
+ 
+ 
  def get_driver_env() -> dict:
 diff --git a/setup.py b/setup.py
-index 8709e52..59784dd 100644
+index f4c93dc..15c2d06 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -141,25 +141,8 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
+@@ -113,7 +113,6 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
+         super().run()
+         os.makedirs("driver", exist_ok=True)
+         os.makedirs("playwright/driver", exist_ok=True)
+-        self._download_and_extract_local_driver()
+ 
+         wheel = None
+         if os.getenv("PLAYWRIGHT_TARGET_WHEEL", None):
+@@ -139,6 +138,7 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
+         self,
+         wheel_bundle: Dict[str, str],
+     ) -> None:
++        return
+         assert self.dist_dir
          base_wheel_location: str = glob.glob(os.path.join(self.dist_dir, "*.whl"))[0]
          without_platform = base_wheel_location[:-7]
-         for wheel_bundle in wheels:
--            download_driver(wheel_bundle["zip_name"])
--            zip_file = (
--                f"driver/playwright-{driver_version}-{wheel_bundle['zip_name']}.zip"
--            )
--            with zipfile.ZipFile(zip_file, "r") as zip:
--                extractall(zip, f"driver/{wheel_bundle['zip_name']}")
-             wheel_location = without_platform + wheel_bundle["wheel"]
-             shutil.copy(base_wheel_location, wheel_location)
--            with zipfile.ZipFile(wheel_location, "a") as zip:
--                driver_root = os.path.abspath(f"driver/{wheel_bundle['zip_name']}")
--                for dir_path, _, files in os.walk(driver_root):
--                    for file in files:
--                        from_path = os.path.join(dir_path, file)
--                        to_path = os.path.relpath(from_path, driver_root)
--                        zip.write(from_path, f"playwright/driver/{to_path}")
--                zip.writestr(
--                    "playwright/driver/README.md",
--                    f"{wheel_bundle['wheel']} driver package",
--                )
-         os.remove(base_wheel_location)
-         if InWheel:
-             for whlfile in glob.glob(os.path.join(self.dist_dir, "*.whl")):

--- a/pkgs/development/python-modules/playwright/driver-location.patch
+++ b/pkgs/development/python-modules/playwright/driver-location.patch
@@ -18,23 +18,3 @@ index 22b53b8..2d86626 100644
  
  
  def get_driver_env() -> dict:
-diff --git a/setup.py b/setup.py
-index f4c93dc..15c2d06 100644
---- a/setup.py
-+++ b/setup.py
-@@ -113,7 +113,6 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
-         super().run()
-         os.makedirs("driver", exist_ok=True)
-         os.makedirs("playwright/driver", exist_ok=True)
--        self._download_and_extract_local_driver()
- 
-         wheel = None
-         if os.getenv("PLAYWRIGHT_TARGET_WHEEL", None):
-@@ -139,6 +138,7 @@ class PlaywrightBDistWheelCommand(BDistWheelCommand):
-         self,
-         wheel_bundle: Dict[str, str],
-     ) -> None:
-+        return
-         assert self.dist_dir
-         base_wheel_location: str = glob.glob(os.path.join(self.dist_dir, "*.whl"))[0]
-         without_platform = base_wheel_location[:-7]

--- a/pkgs/development/python-modules/playwright/update.sh
+++ b/pkgs/development/python-modules/playwright/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused common-updater-scripts jq prefetch-npm-deps unzip
+#!nix-shell -i bash -p curl gnused common-updater-scripts jq prefetch-npm-deps unzip nix-prefetch
 set -euo pipefail
 
 root="$(dirname "$(readlink -f "$0")")"
@@ -30,18 +30,38 @@ replace_sha() {
 }
 
 prefetch_browser() {
-    nix store prefetch-file --json --hash-type sha256 --unpack "$1" | jq -r .hash
+  # nix-prefetch is used to obtain sha with `stripRoot = false`
+  # doesn't work on macOS https://github.com/msteen/nix-prefetch/issues/53
+  nix-prefetch -q "{ stdenv, fetchzip }: stdenv.mkDerivation rec { name=\"browser\"; src = fetchzip { url = \"$1\"; stripRoot = $2; }; }"
 }
 
 update_browser() {
     name="$1"
-    suffix="$2"
-    arm64_suffix="${3:-$2-arm64}"
+    platform="$2"
+    stripRoot="false"
+    if [ "$platform" = "darwin" ]; then
+        if [ "$name" = "webkit" ]; then
+            suffix="mac-14"
+        else
+            suffix="mac"
+        fi
+    else
+        if [ "$name" = "ffmpeg" ]; then
+            suffix="linux"
+        elif [ "$name" = "firefox" ]; then
+            stripRoot="true"
+            suffix="ubuntu-22.04"
+        else
+            suffix="ubuntu-22.04"
+        fi
+    fi
+    aarch64_suffix="$suffix-arm64"
+
     revision="$(jq -r ".browsers.$name.revision" "$playwright_dir/browsers.json")"
-    replace_sha "$playwright_dir/$name.nix" "x86_64-linux" \
-        "$(prefetch_browser "https://playwright.azureedge.net/builds/$name/$revision/$name-$suffix.zip")"
-    replace_sha "$playwright_dir/$name.nix" "aarch64-linux" \
-        "$(prefetch_browser "https://playwright.azureedge.net/builds/$name/$revision/$name-$arm64_suffix.zip")"
+    replace_sha "$playwright_dir/$name.nix" "x86_64-$platform" \
+        "$(prefetch_browser "https://playwright.azureedge.net/builds/$name/$revision/$name-$suffix.zip" $stripRoot)"
+    replace_sha "$playwright_dir/$name.nix" "aarch64-$platform" \
+        "$(prefetch_browser "https://playwright.azureedge.net/builds/$name/$revision/$name-$aarch64_suffix.zip" $stripRoot)"
 }
 
 curl -fsSl \
@@ -58,10 +78,14 @@ curl -fsSl \
 
 # We currently use Chromium from nixpkgs, so we don't need to download it here
 # Likewise, darwin can be ignored here atm as we are using an impure install anyway.
-update_browser "firefox" "ubuntu-22.04"
-update_browser "webkit" "ubuntu-22.04"
+update_browser "firefox" "linux"
+update_browser "webkit" "linux"
 update_browser "ffmpeg" "linux"
 
+update_browser "chromium" "darwin"
+update_browser "firefox" "darwin"
+update_browser "webkit" "darwin"
+update_browser "ffmpeg" "darwin"
 
 # Update package-lock.json files for all npm deps that are built in playwright
 

--- a/pkgs/development/web/playwright/browsers.json
+++ b/pkgs/development/web/playwright/browsers.json
@@ -2,27 +2,31 @@
   "comment": "This file is kept up to date via update.sh",
   "browsers": {
     "chromium": {
-      "revision": "1140",
-      "browserVersion": "130.0.6723.31"
+      "revision": "1155",
+      "browserVersion": "133.0.6943.16"
     },
     "firefox": {
-      "revision": "1465",
-      "browserVersion": "131.0"
+      "revision": "1471",
+      "browserVersion": "134.0"
     },
     "webkit": {
-      "revision": "2083",
+      "revision": "2123",
       "revisionOverrides": {
+        "debian11-x64": "2105",
+        "debian11-arm64": "2105",
         "mac10.14": "1446",
         "mac10.15": "1616",
         "mac11": "1816",
         "mac11-arm64": "1816",
         "mac12": "2009",
-        "mac12-arm64": "2009"
+        "mac12-arm64": "2009",
+        "ubuntu20.04-x64": "2092",
+        "ubuntu20.04-arm64": "2092"
       },
-      "browserVersion": "18.0"
+      "browserVersion": "18.2"
     },
     "ffmpeg": {
-      "revision": "1010",
+      "revision": "1011",
       "revisionOverrides": {
         "mac12": "1010",
         "mac12-arm64": "1010"

--- a/pkgs/development/web/playwright/browsers.json
+++ b/pkgs/development/web/playwright/browsers.json
@@ -2,15 +2,15 @@
   "comment": "This file is kept up to date via update.sh",
   "browsers": {
     "chromium": {
-      "revision": "1134",
-      "browserVersion": "129.0.6668.29"
+      "revision": "1140",
+      "browserVersion": "130.0.6723.31"
     },
     "firefox": {
-      "revision": "1463",
-      "browserVersion": "130.0"
+      "revision": "1465",
+      "browserVersion": "131.0"
     },
     "webkit": {
-      "revision": "2070",
+      "revision": "2083",
       "revisionOverrides": {
         "mac10.14": "1446",
         "mac10.15": "1616",
@@ -22,7 +22,11 @@
       "browserVersion": "18.0"
     },
     "ffmpeg": {
-      "revision": "1010"
+      "revision": "1010",
+      "revisionOverrides": {
+        "mac12": "1010",
+        "mac12-arm64": "1010"
+      }
     }
   }
 }

--- a/pkgs/development/web/playwright/chromium-headless-shell.nix
+++ b/pkgs/development/web/playwright/chromium-headless-shell.nix
@@ -1,0 +1,81 @@
+{
+  fetchzip,
+  revision,
+  suffix,
+  system,
+  throwSystem,
+  stdenv,
+  autoPatchelfHook,
+  patchelfUnstable,
+
+  alsa-lib,
+  at-spi2-atk,
+  glib,
+  libXcomposite,
+  libXdamage,
+  libXfixes,
+  libXrandr,
+  libgcc,
+  libxkbcommon,
+  nspr,
+  nss,
+  mesa,
+  ...
+}:
+let
+  linux = stdenv.mkDerivation {
+    name = "playwright-chromium-headless-shell";
+    src = fetchzip {
+      url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-headless-shell-${suffix}.zip";
+      stripRoot = false;
+      hash =
+        {
+          x86_64-linux = "sha256-UNLSiI9jWLev2YwqiXuoHwJfdB4teNhEfQjQRBEo8uY=";
+          aarch64-linux = "sha256-aVGLcJHFER09frJdKsGW/pKPl5MXoXef2hy5WTA8rS4=";
+        }
+        .${system} or throwSystem;
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelfUnstable
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      glib
+      libXcomposite
+      libXdamage
+      libXfixes
+      libXrandr
+      mesa
+      libgcc.lib
+      libxkbcommon
+      nspr
+      nss
+    ];
+
+    buildPhase = ''
+      cp -R . $out
+    '';
+  };
+
+  darwin = fetchzip {
+    url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-headless-shell-${suffix}.zip";
+    stripRoot = false;
+    hash =
+      {
+        x86_64-darwin = "sha256-c26ubAgM9gQPaYqobQyS3Y7wvMUmmdpDlrYmZJrUgho=";
+        aarch64-darwin = "sha256-XRFqlhVx+GuDxz/kDP8TtyPQfR0JbFD0qu5OSywGTX8=";
+      }
+      .${system} or throwSystem;
+  };
+in
+{
+  x86_64-linux = linux;
+  aarch64-linux = linux;
+  x86_64-darwin = darwin;
+  aarch64-darwin = darwin;
+}
+.${system} or throwSystem

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -34,8 +34,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-N/uh3Q2ivqeraAqRt80deVz1XEPyLTYI8L3DBfNQGWg=";
-        aarch64-darwin = "sha256-tR9PwGanPcsDQwi1BijeYJd9LhNIWgEoXs5u3gZpghU=";
+        x86_64-darwin = "sha256-seMHD+TmxrfgsN6sLN2Bp3WgAooDnlSxGN6CPw1Q790=";
+        aarch64-darwin = "sha256-SsIRzxTIuf/mwsYvRM2mv8PzWQAAflxOyoK5TuyhMAU=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -34,8 +34,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-G9DPo/pXFuaZICT47TSE+bvncS//ydylJVpnfQYp68U=";
-        aarch64-darwin = "sha256-2JedruJ/y7Zidn6oRfUxi0MleaH5Cp6XQ+F7ImSCTjA=";
+        x86_64-darwin = "sha256-N/uh3Q2ivqeraAqRt80deVz1XEPyLTYI8L3DBfNQGWg=";
+        aarch64-darwin = "sha256-tR9PwGanPcsDQwi1BijeYJd9LhNIWgEoXs5u3gZpghU=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -3,22 +3,47 @@
   makeWrapper,
   fontconfig_file,
   chromium,
+  fetchzip,
+  revision,
+  suffix,
+  system,
+  throwSystem,
   ...
 }:
-runCommand "playwright-chromium"
-  {
-    nativeBuildInputs = [
-      makeWrapper
-    ];
-  }
-  ''
-    mkdir -p $out/chrome-linux
+let
+  chromium-linux =
+    runCommand "playwright-chromium"
+      {
+        nativeBuildInputs = [
+          makeWrapper
+        ];
+      }
+      ''
+        mkdir -p $out/chrome-linux
 
-    # See here for the Chrome options:
-    # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
-    # We add --disable-gpu to be able to run in gpu-less environments such
-    # as headless nixos test vms.
-    makeWrapper ${chromium}/bin/chromium $out/chrome-linux/chrome \
-      --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
-      --set-default FONTCONFIG_FILE ${fontconfig_file}
-  ''
+        # See here for the Chrome options:
+        # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
+        # We add --disable-gpu to be able to run in gpu-less environments such
+        # as headless nixos test vms.
+        makeWrapper ${chromium}/bin/chromium $out/chrome-linux/chrome \
+          --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+          --set-default FONTCONFIG_FILE ${fontconfig_file}
+      '';
+  chromium-darwin = fetchzip {
+    url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
+    stripRoot = false;
+    hash =
+      {
+        x86_64-darwin = "sha256-G9DPo/pXFuaZICT47TSE+bvncS//ydylJVpnfQYp68U=";
+        aarch64-darwin = "sha256-2JedruJ/y7Zidn6oRfUxi0MleaH5Cp6XQ+F7ImSCTjA=";
+      }
+      .${system} or throwSystem;
+  };
+in
+{
+  x86_64-linux = chromium-linux;
+  aarch64-linux = chromium-linux;
+  x86_64-darwin = chromium-darwin;
+  aarch64-darwin = chromium-darwin;
+}
+.${system} or throwSystem

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -27,20 +27,20 @@ let
     }
     .${system} or throwSystem;
 
-  version = "1.47.0";
+  version = "1.48.1";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
     repo = "playwright";
     rev = "v${version}";
-    hash = "sha256-cKjVDy1wFo8NlF8v+8YBuQUF2OUYjCmv27uhEoVUrno=";
+    hash = "sha256-VMp/Tjd5w2v+IHD+CMaR/XdMJHkS/u7wFe0hNxa1TbE=";
   };
 
   babel-bundle = buildNpmPackage {
     pname = "babel-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/babel";
-    npmDepsHash = "sha256-HrDTkP2lHl2XKD8aGpmnf6YtSe/w9UePH5W9QfbaoMg=";
+    npmDepsHash = "sha256-kHuNFgxmyIoxTmvT+cyzDRfKNy18zzeUH3T+gJopWeA=";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -50,7 +50,7 @@ let
     pname = "expect-bundle";
     inherit version src;
     sourceRoot = "${src.name}/packages/playwright/bundles/expect";
-    npmDepsHash = "sha256-qnFx/AQZtmxNFrrabfOpsWy6I64DFJf3sWrJzL1wfU4=";
+    npmDepsHash = "sha256-KwxNqPefvPPHG4vbco2O4G8WlA7l33toJdfNWHMTDOQ=";
     dontNpmBuild = true;
     installPhase = ''
       cp -r . "$out"
@@ -92,7 +92,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}"; # update.sh depends on sourceRoot presence
-    npmDepsHash = "sha256-FaDTJmIiaaOCvq6tARfiWX5IBTTNOJ/iVkRsO4D8aqc=";
+    npmDepsHash = "sha256-cmUmYuUL7zfB7WEBKft43r69f7vaZDEjku8uwR3RZ1A=";
 
     nativeBuildInputs = [ cacert ];
 

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -159,15 +159,11 @@ let
 
     passthru = {
       browsersJSON = (lib.importJSON ./browsers.json).browsers;
-      browsers =
-        {
-          x86_64-linux = browsers-linux { };
-          aarch64-linux = browsers-linux { };
-          x86_64-darwin = browsers-mac;
-          aarch64-darwin = browsers-mac;
-        }
-        .${system} or throwSystem;
-      browsers-chromium = browsers-linux { };
+      browsers = browsers { };
+      browsers-chromium = browsers {
+        withFirefox = false;
+        withWebkit = false;
+      };
     };
   });
 
@@ -196,28 +192,7 @@ let
     };
   });
 
-  browsers-mac = stdenv.mkDerivation {
-    pname = "playwright-browsers";
-    inherit (playwright) version;
-
-    dontUnpack = true;
-
-    nativeBuildInputs = [ cacert ];
-
-    installPhase = ''
-      runHook preInstall
-
-      export PLAYWRIGHT_BROWSERS_PATH=$out
-      ${playwright-core}/cli.js install
-      rm -r $out/.links
-
-      runHook postInstall
-    '';
-
-    meta.platforms = lib.platforms.darwin;
-  };
-
-  browsers-linux = lib.makeOverridable (
+  browsers = lib.makeOverridable (
     {
       withChromium ? true,
       withFirefox ? true,

--- a/pkgs/development/web/playwright/ffmpeg.nix
+++ b/pkgs/development/web/playwright/ffmpeg.nix
@@ -10,10 +10,10 @@ fetchzip {
   stripRoot = false;
   hash =
     {
-      x86_64-linux = "sha256-FEm62UvMv0h6Sav93WmbPLw3CW1L1xg4nD26ca5ol38=";
-      aarch64-linux = "sha256-jtQ+NS++VHRiKoIV++PIxEnyVnYtVwUyNlSILKSH4A4=";
-      x86_64-darwin = "sha256-ED6noxSDeEUt2DkIQ4gNe/kL+zHVeb2AD5klBk93F88=";
-      aarch64-darwin = "sha256-3Adnvb7zvMXKFOhb8uuj5kx0wEIFicmckYx9WLlNNf0=";
+      x86_64-linux = "sha256-AWTiui+ccKHxsIaQSgc5gWCJT5gYwIWzAEqSuKgVqZU=";
+      aarch64-linux = "sha256-1mOKO2lcnlwLsC6ob//xKnKrCOp94pw8X14uBxCdj0Q=";
+      x86_64-darwin = "sha256-zJ8BMzdneV6LlEt4I034l5u86dwW4UmO/UazWikpKV4=";
+      aarch64-darwin = "sha256-ky10UQj+XPVGpaWAPvKd51C5brml0y9xQ6iKcrxAMRc=";
     }
     .${system} or throwSystem;
 }

--- a/pkgs/development/web/playwright/ffmpeg.nix
+++ b/pkgs/development/web/playwright/ffmpeg.nix
@@ -12,6 +12,8 @@ fetchzip {
     {
       x86_64-linux = "sha256-FEm62UvMv0h6Sav93WmbPLw3CW1L1xg4nD26ca5ol38=";
       aarch64-linux = "sha256-jtQ+NS++VHRiKoIV++PIxEnyVnYtVwUyNlSILKSH4A4=";
+      x86_64-darwin = "sha256-ED6noxSDeEUt2DkIQ4gNe/kL+zHVeb2AD5klBk93F88=";
+      aarch64-darwin = "sha256-3Adnvb7zvMXKFOhb8uuj5kx0wEIFicmckYx9WLlNNf0=";
     }
     .${system} or throwSystem;
 }

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -17,8 +17,8 @@ let
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-L/CJVtj9bVXKuKSLWw0wAdNICiRTg5ek+fw4togBoSI=";
-          aarch64-linux = "sha256-DgCuX+6KSnoHNFoFUli6S20GGHOExARasiJY9fy3CCE=";
+          x86_64-linux = "sha256-53DXgD/OzGo7fEp/DBX1TiBBpFSHwiluqBji6rFKTtE=";
+          aarch64-linux = "sha256-CBg2PgAXU1ZWUob73riEkQmn/EmIqhvOgBPSAphkAyM=";
         }
         .${system} or throwSystem;
     };
@@ -41,8 +41,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-HJ0jBmTW/Zz2fkmSo1gEv5P58PGyhXKnJVxJ12Q4IiM=";
-        aarch64-darwin = "sha256-YnnG8BX06vQlJmzZGaCKq1wKGp3yRaUQ4RF+tEWoK6U=";
+        x86_64-darwin = "sha256-GbrbNMFv1dT8Duo2otoZvmZk4Sgj81aRNwPAGKkRlnI=";
+        aarch64-darwin = "sha256-/e51eJTCqr8zEeWWJNS2UgPT9Y+a33Dj619JkCVVeRs=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -17,8 +17,8 @@ let
       }.zip";
       hash =
         {
-          x86_64-linux = "sha256-Hd9LlSRLW51gDoFyszqvg46Q/sMizLRsVKAN9atbwsw=";
-          aarch64-linux = "sha256-SEXH3gLOfNjOcnNWQjQ5gaaow47veVs0BoTYSgXw+24=";
+          x86_64-linux = "sha256-L/CJVtj9bVXKuKSLWw0wAdNICiRTg5ek+fw4togBoSI=";
+          aarch64-linux = "sha256-DgCuX+6KSnoHNFoFUli6S20GGHOExARasiJY9fy3CCE=";
         }
         .${system} or throwSystem;
     };
@@ -41,8 +41,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-tclyoXGK0oc40ppqFVHJEGOtiFpc/D8wB37tBHhYhjg=";
-        aarch64-darwin = "sha256-EEY3cxZaZwNbWwkWy8m9hSDgEV3hotcDPD1ehiQWFig=";
+        x86_64-darwin = "sha256-HJ0jBmTW/Zz2fkmSo1gEv5P58PGyhXKnJVxJ12Q4IiM=";
+        aarch64-darwin = "sha256-YnnG8BX06vQlJmzZGaCKq1wKGp3yRaUQ4RF+tEWoK6U=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/development/web/playwright/firefox.nix
+++ b/pkgs/development/web/playwright/firefox.nix
@@ -9,31 +9,48 @@
   throwSystem,
 }:
 let
-  suffix' =
-    if lib.hasPrefix "linux" suffix then "ubuntu-22.04" + (lib.removePrefix "linux" suffix) else suffix;
-in
-stdenv.mkDerivation {
-  name = "playwright-firefox";
-  src = fetchzip {
-    url = "https://playwright.azureedge.net/builds/firefox/${revision}/firefox-${suffix'}.zip";
+  firefox-linux = stdenv.mkDerivation {
+    name = "playwright-firefox";
+    src = fetchzip {
+      url = "https://playwright.azureedge.net/builds/firefox/${revision}/firefox-${
+        "ubuntu-22.04" + (lib.removePrefix "linux" suffix)
+      }.zip";
+      hash =
+        {
+          x86_64-linux = "sha256-Hd9LlSRLW51gDoFyszqvg46Q/sMizLRsVKAN9atbwsw=";
+          aarch64-linux = "sha256-SEXH3gLOfNjOcnNWQjQ5gaaow47veVs0BoTYSgXw+24=";
+        }
+        .${system} or throwSystem;
+    };
+
+    inherit (firefox-bin.unwrapped)
+      nativeBuildInputs
+      buildInputs
+      runtimeDependencies
+      appendRunpaths
+      patchelfFlags
+      ;
+
+    buildPhase = ''
+      mkdir -p $out/firefox
+      cp -R . $out/firefox
+    '';
+  };
+  firefox-darwin = fetchzip {
+    url = "https://playwright.azureedge.net/builds/firefox/${revision}/firefox-${suffix}.zip";
+    stripRoot = false;
     hash =
       {
-        x86_64-linux = "sha256-Hd9LlSRLW51gDoFyszqvg46Q/sMizLRsVKAN9atbwsw=";
-        aarch64-linux = "sha256-SEXH3gLOfNjOcnNWQjQ5gaaow47veVs0BoTYSgXw+24=";
+        x86_64-darwin = "sha256-tclyoXGK0oc40ppqFVHJEGOtiFpc/D8wB37tBHhYhjg=";
+        aarch64-darwin = "sha256-EEY3cxZaZwNbWwkWy8m9hSDgEV3hotcDPD1ehiQWFig=";
       }
       .${system} or throwSystem;
   };
-
-  inherit (firefox-bin.unwrapped)
-    nativeBuildInputs
-    buildInputs
-    runtimeDependencies
-    appendRunpaths
-    patchelfFlags
-    ;
-
-  buildPhase = ''
-    mkdir -p $out/firefox
-    cp -R . $out/firefox
-  '';
+in
+{
+  x86_64-linux = firefox-linux;
+  aarch64-linux = firefox-linux;
+  x86_64-darwin = firefox-darwin;
+  aarch64-darwin = firefox-darwin;
 }
+.${system} or throwSystem

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -74,8 +74,8 @@ let
       stripRoot = false;
       hash =
         {
-          x86_64-linux = "sha256-pHYGQYwu47jdOAD+/mLrP6Dd+2aDMHENddVwAu0uEfI=";
-          aarch64-linux = "sha256-0UeYWjeFnQ8yVa3juWg7Z7VF1GDbP4pJ9OUJRbv1OJw=";
+          x86_64-linux = "sha256-vz/c2Bzr1NWRZZL5hIRwnor2Wte61gS++8rRfmy9T+0=";
+          aarch64-linux = "sha256-dS4Hsy/lGZWgznviwkslSk5oBYdUIBxeQPfaEyLNXyc=";
         }
         .${system} or throwSystem;
     };
@@ -141,8 +141,8 @@ let
     stripRoot = false;
     hash =
       {
-        x86_64-darwin = "sha256-sP7MxAMDkrBTN7HR44xrxKPdCF2HzsL5GiaCMHQcqeU=";
-        aarch64-darwin = "sha256-Sw2+w6HT/e0rdLp7jXj5g3C1Uh05JnP9MznIgg7Glyc=";
+        x86_64-darwin = "sha256-lOAHJaDXtt80RhqFNaO1JhaJH5WAu6+rpoR+IsfzGeM=";
+        aarch64-darwin = "sha256-GrjTnMGTPBdRI3xE5t9HbXLrvgOjCdqbJGElTKhUoA4=";
       }
       .${system} or throwSystem;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Playwrights chromium headless mode is broken on stable, because of changes in newer chromium versions.
The current 1.47.0 doesn't support our current chromium version, so we should upgrade playwright.

Backports of the following PRs:
https://github.com/NixOS/nixpkgs/pull/349469
https://github.com/NixOS/nixpkgs/pull/358638

Cherry-Pick CI check is expected to fail, since I had to resolve a conflict from the mesa -> libgbm change, which is not in stable.

I successfully ran nixosTests.playwright-python.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
