### PR TITLE
fwupd: 2.0.5 -> 2.0.6

### DIFF
--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -6,6 +6,7 @@
   lib,
   fetchFromGitHub,
   gi-docgen,
+  writableTmpDirAsHomeHook,
   pkg-config,
   gobject-introspection,
   gettext,
@@ -182,6 +183,9 @@ stdenv.mkDerivation (finalAttrs: {
       vala
       gobject-introspection
       gi-docgen
+
+      # jcat-tool at buildtime requires a home directory
+      writableTmpDirAsHomeHook
     ]
     ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       mesonEmulatorHook
@@ -285,11 +289,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # in nixos test tries to chmod 0777 $out/share/installed-tests/fwupd/tests/redfish.conf
     sed -i "s/get_option('tests')/false/" plugins/redfish/meson.build
-  '';
-
-  preBuild = ''
-    # jcat-tool at buildtime requires a home directory
-    export HOME="$(mktemp -d)"
   '';
 
   preCheck = ''

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -312,6 +312,10 @@ stdenv.mkDerivation (finalAttrs: {
     PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
   };
 
+  nativeCheckInputs = [
+    polkit
+  ];
+
   preCheck = ''
     addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
 

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -117,7 +117,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.0.5";
+  version = "2.0.6";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -135,7 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     tag = finalAttrs.version;
-    hash = "sha256-V07alPn2+bOkKx+oh8qoX4Ie6/5ujO6h/TDzvL3UhvQ=";
+    hash = "sha256-//y2kkCrj6E3kKxZIEK2bBUiZezB9j4xzR6WrBdcpqQ=";
   };
 
   patches = [

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -256,39 +256,39 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags =
     [
-      "-Ddocs=enabled"
+      (lib.mesonEnable "docs" true)
       # We are building the official releases.
-      "-Dsupported_build=enabled"
-      "-Dlaunchd=disabled"
-      "-Dsystemd_root_prefix=${placeholder "out"}"
-      "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+      (lib.mesonEnable "supported_build" true)
+      (lib.mesonEnable "launchd" false)
+      (lib.mesonOption "systemd_root_prefix" "${placeholder "out"}")
+      (lib.mesonOption "installed_test_prefix" "${placeholder "installedTests"}")
       "--localstatedir=/var"
       "--sysconfdir=/etc"
-      "-Dsysconfdir_install=${placeholder "out"}/etc"
-      "-Defi_os_dir=nixos"
-      "-Dplugin_modem_manager=enabled"
-      "-Dvendor_metadata=true"
-      "-Dplugin_uefi_capsule_splash=false"
+      (lib.mesonOption "sysconfdir_install" "${placeholder "out"}/etc")
+      (lib.mesonOption "efi_os_dir" "nixos")
+      (lib.mesonEnable "plugin_modem_manager" true)
+      (lib.mesonBool "vendor_metadata" true)
+      (lib.mesonBool "plugin_uefi_capsule_splash" false)
       # TODO: what should this be?
-      "-Dvendor_ids_dir=${hwdata}/share/hwdata"
-      "-Dumockdev_tests=disabled"
+      (lib.mesonOption "vendor_ids_dir" "${hwdata}/share/hwdata")
+      (lib.mesonEnable "umockdev_tests" false)
       # We do not want to place the daemon into lib (cyclic reference)
       "--libexecdir=${placeholder "out"}/libexec"
     ]
     ++ lib.optionals (!enablePassim) [
-      "-Dpassim=disabled"
+      (lib.mesonEnable "passim" false)
     ]
     ++ lib.optionals (!haveDell) [
-      "-Dplugin_synaptics_mst=disabled"
+      (lib.mesonEnable "plugin_synaptics_mst" false)
     ]
     ++ lib.optionals (!haveRedfish) [
-      "-Dplugin_redfish=disabled"
+      (lib.mesonEnable "plugin_redfish" false)
     ]
     ++ lib.optionals (!haveFlashrom) [
-      "-Dplugin_flashrom=disabled"
+      (lib.mesonEnable "plugin_flashrom" false)
     ]
     ++ lib.optionals (!haveMSR) [
-      "-Dplugin_msr=disabled"
+      (lib.mesonEnable "plugin_msr" false)
     ];
 
   # TODO: wrapGAppsHook3 wraps efi capsule even though it is not ELF

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -182,15 +182,18 @@ stdenv.mkDerivation (finalAttrs: {
     ./efi-app-path.patch
   ];
 
-  postPatch = ''
-    patchShebangs \
-      contrib/generate-version-script.py \
-      contrib/generate-man.py \
-      po/test-deps
-
+  postPatch =
+    ''
+      patchShebangs \
+        contrib/generate-version-script.py \
+        contrib/generate-man.py \
+        po/test-deps
+    ''
     # in nixos test tries to chmod 0777 $out/share/installed-tests/fwupd/tests/redfish.conf
-    sed -i "s/get_option('tests')/false/" plugins/redfish/meson.build
-  '';
+    + ''
+      substituteInPlace plugins/redfish/meson.build \
+        --replace-fail "get_option('tests')" "false"
+    '';
 
   strictDeps = true;
 


### PR DESCRIPTION
## Things done

- **fwupd: 2.0.5 -> 2.0.6**
- **fwupd: use writableTmpDirAsHomeHook**
- **fwupd: cleanup**

Changelog: https://github.com/fwupd/fwupd/releases/tag/2.0.6

cc @R-VdP

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
