### PR TITLE
pdftms: init at 0-unstable-2025-02-14

### DIFF
--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  gnumake,
+  gcc,
+  yaml-cpp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pdftms";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "pingponghero12";
+    repo = "pdftms";
+    rev = "main";
+    sha256 = "sha256-ig7L0/DOcTpKiODbWGfYMmLjlXgb4Am5sPQzf/Eo1hY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    gnumake
+    gcc
+    yaml-cpp
+  ];
+
+  # Use -B -S to avoid error with normal mkdir -p build etc
+  configurePhase = ''
+    cmake -B build -S .
+  '';
+
+  buildPhase = ''
+    make -C build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp build/pdftms $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "PDF TUI Managment System";
+    homepage = "https://github.com/pingponghero12/pdftms";
+    license = licenses.mit;
+    maintainers = [ maintainers.pingponghero12 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -5,10 +5,10 @@
   cmake,
   gnumake,
   gcc,
-  yaml-cpp
+  yaml-cpp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pdftms";
   version = "1.0.0";
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     description = "PDF TUI Managment System";
     homepage = "https://github.com/pingponghero12/pdftms";
     license = licenses.mit;
-    maintainers = [ maintainers.pingponghero12 ];
+    maintainers = with maintainers; [ pingponghero12 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -44,7 +44,6 @@ stdenv.mkDerivation {
     description = "PDF TUI Managment System";
     homepage = "https://github.com/pingponghero12/pdftms";
     license = licenses.mit;
-    maintainers = with maintainers; [ pingponghero12 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation {
   pname = "pdftms";
-  version = "1.0.0";
+  version = "0-unstable-2025-02-14";
 
   src = fetchFromGitHub {
     owner = "pingponghero12";

--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -36,8 +36,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp build/pdftms $out/bin/
+    install -Dm755 build/pdftms -t $out/bin
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/pd/pdftms/package.nix
+++ b/pkgs/by-name/pd/pdftms/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "pingponghero12";
     repo = "pdftms";
-    rev = "main";
+    rev = "c06fb29e9bd8d7cdd441c9d8e4ff05af0c0ed229";
     sha256 = "sha256-ig7L0/DOcTpKiODbWGfYMmLjlXgb4Am5sPQzf/Eo1hY=";
   };
 


### PR DESCRIPTION
[pdftms homepage](https://github.com/pingponghero12/pdftms)

PDF TUI Managment System

Simple TUI manager for obsidian-like vault of .pdf files. Uses fzf for blazingly fast opening files inside vault in your favourite pdf reader. All commands get things done thanks to fzf.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
