### PR TITLE
rstudio: fix loading of project-specific .Rprofile

### DIFF
--- a/pkgs/development/r-modules/wrapper-rstudio.nix
+++ b/pkgs/development/r-modules/wrapper-rstudio.nix
@@ -32,7 +32,7 @@ runCommand (rstudio.name + "-wrapper")
     # with the wrapped one, however, RStudio internally overrides
     # R_LIBS_SITE.  The below works around this by turning R_LIBS_SITE
     # into an R file (fixLibsR) which achieves the same effect, then
-    # uses R_PROFILE_USER to load this code at startup in RStudio.
+    # uses R_PROFILE to load this code at startup in RStudio.
     fixLibsR = "fix_libs.R";
   }
   (
@@ -48,7 +48,7 @@ runCommand (rstudio.name + "-wrapper")
       if rstudio.server then
         ''
           makeWrapper ${rstudio}/bin/rsession $out/bin/rsession \
-            --set R_PROFILE_USER $out/$fixLibsR --set FONTCONFIG_FILE ${fontconfig.out}/etc/fonts/fonts.conf
+            --set R_PROFILE $out/$fixLibsR --set FONTCONFIG_FILE ${fontconfig.out}/etc/fonts/fonts.conf
 
           makeWrapper ${rstudio}/bin/rserver $out/bin/rserver \
             --add-flags --rsession-path=$out/bin/rsession
@@ -63,7 +63,7 @@ runCommand (rstudio.name + "-wrapper")
           ''}
 
           makeWrapper ${rstudio}/bin/rstudio $out/bin/rstudio \
-            --set R_PROFILE_USER $out/$fixLibsR
+            --set R_PROFILE $out/$fixLibsR
         ''
     )
   )


### PR DESCRIPTION
Addresses #85840

to reproduce the bug: create a project-specific .Rprofile and start RStudio in that folder: the .Rprofile will be ignored. It seems that is because in the wrapper, `R_PROFILE_USER` is hard-coded, and so a project-specific .Rprofile cannot get loaded. Using `R_PROFILE` instead in the wrapper frees up `R_PROFILE_USER`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
