### PR TITLE
pandoc-mustache: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2352,6 +2352,12 @@
     githubId = 97070581;
     name = "averagebit";
   };
+  averdow = {
+    email = "aaron@verdow.com";
+    github = "AaronVerDow";
+    githubId = 2530548;
+    name = "Aaron VerDow";
+  };
   averelld = {
     email = "averell+nixos@rxd4.com";
     github = "averelld";

--- a/pkgs/by-name/pa/pandoc-mustache/package.nix
+++ b/pkgs/by-name/pa/pandoc-mustache/package.nix
@@ -1,0 +1,47 @@
+{
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  callPackage,
+  lib,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pandoc-mustache";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "michaelstepner";
+    repo = "pandoc-mustache";
+    tag = "${version}";
+    hash = "sha256-lgbQV4X2N4VuIEtjeSA542yqGdIs5QQ7+bdCoy/aloE=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    pyparsing
+  ];
+
+  dependencies = with python3Packages; [
+    panflute
+    pystache
+    pyyaml
+    future
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = callPackage ./tests { };
+  };
+
+  meta = {
+    description = "Pandoc Mustache Filter";
+    homepage = "https://github.com/michaelstepner/pandoc-mustache";
+    changelog = "https://github.com/michaelstepner/pandoc-mustache/releases/tag/${version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ averdow ];
+    license = with lib.licenses; [
+      cc-by-10
+    ];
+  };
+}

--- a/pkgs/by-name/pa/pandoc-mustache/tests/default.nix
+++ b/pkgs/by-name/pa/pandoc-mustache/tests/default.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  pandoc-mustache,
+  runCommand,
+}:
+let
+  vars = pkgs.writeText "vars.yaml" ''
+    place: Montreal
+    temperature: '7'
+  '';
+  markdown = pkgs.writeText "markdown.md" ''
+    ---
+    title: My Report
+    author: Jane Smith
+    mustache: ${vars}
+    ---
+    The temperature in {{place}} was {{temperature}} degrees.
+  '';
+in
+runCommand "pandoc-mustache-test"
+  {
+    nativeBuildInputs = [
+      pandoc-mustache
+      pkgs.pandoc
+    ];
+  }
+  ''
+    pandoc --filter pandoc-mustache ${markdown} --to plain | grep 'The temperature in Montreal was 7 degrees.' || exit 1
+    touch $out
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init package for pandoc-mustache, a pandoc filter that adds mustache templates.  This allows the use of variables when building LaTeX documents from markdown.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
