### PR TITLE
python3Packages.llm-anthropic: init at 0.12

### DIFF
--- a/pkgs/development/python-modules/llm-anthropic/default.nix
+++ b/pkgs/development/python-modules/llm-anthropic/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  llm,
+  anthropic,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-recording,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "llm-anthropic";
+  version = "0.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "llm-anthropic";
+    tag = version;
+    hash = "sha256-7+5j5jZBFfaaqnfjvLTI+mz1PUuG8sB5nD59UCpJuR4=";
+  };
+
+  build-system = [
+    setuptools
+    llm
+  ];
+  dependencies = [ anthropic ];
+
+  # Otherwise tests will fail to create directory
+  # Permission denied: '/homeless-shelter'
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-recording
+  ];
+
+  pythonImportsCheck = [ "llm_anthropic" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "LLM access to models by Anthropic, including the Claude series";
+    homepage = "https://github.com/simonw/llm-anthropic";
+    changelog = "https://github.com/simonw/llm-anthropic/releases/tag/${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aos ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7697,6 +7697,8 @@ self: super: with self; {
 
   llm = callPackage ../development/python-modules/llm { };
 
+  llm-anthropic = callPackage ../development/python-modules/llm-anthropic { };
+
   llm-cmd = callPackage ../development/python-modules/llm-cmd { };
 
   llm-gguf = callPackage ../development/python-modules/llm-gguf { };


### PR DESCRIPTION
Closes #327800
Closes #372713

(Note: This is just #373495 upgraded to `0.12`. Seems like something happened with git/Github and my PR was automatically closed.)

This is a plugin for the already packaged `llm` software. There exists 2 PRs related to this:
- #327800: the original
- #372713: forks the original and updates as it had no activity for multiple months

As helpfully pointed out by @ShaddyDC (https://github.com/NixOS/nixpkgs/pull/372713#issuecomment-2586795561) this is now superseded by `llm-anthropic`, of which this is meant to package.

(We also have other PRs that have been commited that add similr plugins at #359379 and #344746.)

CC: @ShaddyDC @Erethon 

Tested with:
```
nix-shell -E 'with import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/pull/382108/head.tar.gz") {}; mkShell { buildInputs = [ (python3.withPackages (ps: [ ps.llm ps.llm-anthropic ])) ]; }'

llm prompt --model claude-3.5-sonnet "give me some random text"

Here's some random text:

The purple elephant danced gracefully through fields of neon mushrooms while juggling watermelons and reciting ancient poetry.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
