### PR TITLE
firebase tools: 13.30.0 -> 13.31.2

### DIFF
--- a/pkgs/by-name/fi/firebase-tools/package.nix
+++ b/pkgs/by-name/fi/firebase-tools/package.nix
@@ -8,16 +8,16 @@
 }:
 buildNpmPackage rec {
   pname = "firebase-tools";
-  version = "13.30.0";
+  version = "13.32.0";
 
   src = fetchFromGitHub {
     owner = "firebase";
     repo = "firebase-tools";
     tag = "v${version}";
-    hash = "sha256-QeFkZJAdXs9+buE1qQqKZkEh9LYTlR1IQiueLx3rUbs=";
+    hash = "sha256-KImt8se4pf/W1XAV8PprYmJRWQqMIAH9FVCEFSV/3Ys=";
   };
 
-  npmDepsHash = "sha256-IIYHtePMsgh3WfuspYaQEGMYnn9KrAg0pE39mlhldO8=";
+  npmDepsHash = "sha256-/EWfXiITSV1r4zVvnHk+9U7MpcUlp7/MNUBJWRw3wRk=";
 
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json


### PR DESCRIPTION
### Replaced by #386207

## 13.30.0 -> 13.31.2
* Switched Data Connect from v1beta API to v1 API.
* Added code generation of React hooks for Data Connect
* Genkit init improvements around gcloud login and flow input values.
* Added new command apps:init under experimental flag (appsinit) that automatically detects what SDK to download and places the file in the corresponding place.
* Removed dependencies on some packages and methods that caused deprecation warnings on Node 22.
* Fixes symbol generation when uploading Unity 6 symbols to Crashlytics. (https://github.com/firebase/firebase-tools/issues/7867)
* Fixed SSR issues in Angular 19 by adding support for default and reqHandler exports. (https://github.com/firebase/firebase-tools/pull/8145)
* Added Angular 19 as supported version. (https://github.com/firebase/firebase-tools/pull/8145)
* Fixed appdistribution:testers:list raising an error when a tester is not part of any group. (https://github.com/firebase/firebase-tools/issues/8191)
Updated the Firebase Data Connect local toolkit to v1.8.0, which includes several changes: (https://github.com/firebase/firebase-tools/pull/8210)
  * Adds support for the v1 Data Connect API in the emulator
  * Adds support for generated React SDKs
  * Fixes @check to also be evaluated for admin auth
  * Fixes CEL expressions to be able to access @redact fields
  * Fixed issue where firebase init dataconnect would crash on React-based web apps.
* Updated the Firebase Data Connect local toolkit to v.1.8.1, which:
  * Fixed issue where users who are using a version lower than 11.3.0 of firebase get a "missing import" error.

Enabled auto-updates via `passthru.updateScript`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
