### PR TITLE
pythonRelaxBuildDepsHook: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -538,6 +538,8 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
 - `pytestCheckHook` to run tests with `pytest`. See [example usage](#using-pytestcheckhook).
 - `pythonCatchConflictsHook` to fail if the package depends on two different versions of the same dependency.
 - `pythonImportsCheckHook` to check whether importing the listed modules works.
+- `pythonRelaxBuildDepsHook` will relax Python dependencies restrictions for the package.
+  See [example usage](#using-pythonrelaxbuilddepshook).
 - `pythonRelaxDepsHook` will relax Python dependencies restrictions for the package.
   See [example usage](#using-pythonrelaxdepshook).
 - `pythonRemoveBinBytecode` to remove bytecode from the `/bin` folder.
@@ -1431,6 +1433,27 @@ For ease of use, both `buildPythonPackage` and `buildPythonApplication` will
 automatically add `pythonRelaxDepsHook` if either `pythonRelaxDeps` or
 `pythonRemoveDeps` is specified.
 
+#### Using pythonRelaxBuildDepsHook {#using-pythonrelaxbuilddepshook}
+
+`pythonRelaxBuildDepsHook` is analogous to `pythonRelaxDepsHook` but removes
+or relaxes build dependencies from `pyproject.toml`, as specified in its
+`build-system.requires` entry.
+
+It requires `__structuredAttrs` to be true, and expects either of two attributes:
+- `pythonRelaxBuildDeps`, a list of [PEP 508 dependency specifier][pep508-dep-spec] strings ;
+- `pythonRemoveBuildDeps`, a list of distribution names.
+
+Each `build-system.requires` entry will be:
+- removed if its distribution name is in `pythonRemoveBuildDeps` ;
+- replaced by the `pythonRelaxBuildDeps` entry with the same distribution name, if any ;
+- otherwise kept as-is.
+
+Whenever either of those entries is set, `mkPythonDerivation` adds `pythonRelaxBuildDepsHook`
+to the default `nativeBuildInputs`.
+
+[pep508-dep-spec]: https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers
+
+
 #### Using unittestCheckHook {#using-unittestcheckhook}
 
 `unittestCheckHook` is a hook which will set up (or configure) a [`checkPhase`](#ssec-check-phase) to run `python -m unittest discover`:
@@ -2062,6 +2085,8 @@ The following rules are desired to be respected:
 * Only unversioned attributes (e.g. `pydantic`, but not `pypdantic_1`) can be included in `dependencies`,
   since due to `PYTHONPATH` limitations we can only ever support a single version for libraries
   without running into duplicate module name conflicts.
+* The version restrictions of `build-dependencies` can be relaxed by [`pythonRelaxBuildDepsHook`](#using-pythonrelaxbuilddepshook),
+  if specified in `pyproject.toml`.
 * The version restrictions of `dependencies` can be relaxed by [`pythonRelaxDepsHook`](#using-pythonrelaxdepshook).
 * Make sure the tests are enabled using for example [`pytestCheckHook`](#using-pytestcheckhook) and, in the case of
   libraries, are passing for all interpreters. If certain tests fail they can be

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -3580,6 +3580,9 @@
   "using-pythonimportscheck": [
     "index.html#using-pythonimportscheck"
   ],
+  "using-pythonrelaxbuilddepshook": [
+    "index.html#using-pythonrelaxbuilddepshook"
+  ],
   "using-pythonrelaxdepshook": [
     "index.html#using-pythonrelaxdepshook"
   ],

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -277,6 +277,30 @@ in
     } ./python-recompile-bytecode-hook.sh
   ) { };
 
+  pythonRelaxBuildDepsHook = callPackage (
+    {
+      makePythonHook,
+      writeTextFile,
+      packaging,
+      tomlkit,
+    }:
+    makePythonHook
+      {
+        name = "python-relax-build-deps-hook";
+      }
+      (writeTextFile {
+        name = "python-relax-build-deps-hook.sh";
+        text = ''
+          _pythonRelaxBuildDepsHook() {
+            PYTHONPATH="${packaging}/${pythonSitePackages}:${tomlkit}/${pythonSitePackages}:$PYTHONPATH" \
+              ${pythonInterpreter} ${./python-relax-build-deps-hook.py}
+          }
+
+          preConfigureHooks+=(_pythonRelaxBuildDepsHook)
+        '';
+      })
+  ) { };
+
   pythonRelaxDepsHook = callPackage (
     { makePythonHook, wheel }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/hooks/python-relax-build-deps-hook.py
+++ b/pkgs/development/interpreters/python/hooks/python-relax-build-deps-hook.py
@@ -5,24 +5,28 @@ from pathlib import Path
 import json, tomlkit
 
 
+# JSON input is expected, so the derivation must set __structuredAttrs
 nixAttrs = json.load(Path(environ['NIX_ATTRS_JSON_FILE']).open())
 removeDeps = frozenset(nixAttrs.get("pythonRemoveBuildDeps", []))
 
-relaxDeps = nixAttrs.get("pythonRelaxBuildDeps", {})
-if isinstance(relaxDeps, list):
-    relaxDeps = { req.name: req for req in map(Requirement, relaxDeps) }
-else:
-    # No support (yet?) for `pythonRelaxBuildDeps.foo = ">1, <2";`; see
-    #  https://github.com/NixOS/nixpkgs/pull/382125#discussion_r1956658253
-    raise ValueError(f"Expected a list for `pythonRelaxBuildDeps`, was '{type(relaxDeps)}'")
+match nixAttrs.get("pythonRelaxBuildDeps", []):
+    case [ *requirements ]:
+        relaxDeps = { req.name: req for req in map(Requirement, requirements) }
+    case _:
+        # No support (yet?) for `pythonRelaxBuildDeps.foo = ">1, <2";`; see
+        #  https://github.com/NixOS/nixpkgs/pull/382125#discussion_r1956658253
+        raise ValueError(f"Expected a list for `pythonRelaxBuildDeps`, was '{type(relaxDeps)}'")
 
-overlappingDeps = removeDeps.intersection(relaxDeps)
-if overlappingDeps:
-    raise ValueError(
-        "The following dependencies occur in both 'pythonRelaxBuildDeps` and 'pythonRemoveBuildDeps`: " + \
-        ", ".join(overlappingDeps)
-    )
+# Quick input validation
+match removeDeps.intersection(relaxDeps):
+    case []: pass
+    case [ *overlap ]:
+        raise ValueError(
+            "The following dependencies occur in both 'pythonRelaxBuildDeps` and 'pythonRemoveBuildDeps`: " + \
+            ", ".join(overlappingDeps)
+        )
 
+# Parse pyproject.toml, update as needed, and write back out
 pyPrjPath = Path("pyproject.toml")
 pyProject = tomlkit.load(pyPrjPath.open())
 

--- a/pkgs/development/interpreters/python/hooks/python-relax-build-deps-hook.py
+++ b/pkgs/development/interpreters/python/hooks/python-relax-build-deps-hook.py
@@ -1,0 +1,35 @@
+from os import environ
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from pathlib import Path
+import json, tomlkit
+
+
+nixAttrs = json.load(Path(environ['NIX_ATTRS_JSON_FILE']).open())
+removeDeps = frozenset(nixAttrs.get("pythonRemoveBuildDeps", []))
+
+relaxDeps = nixAttrs.get("pythonRelaxBuildDeps", {})
+if isinstance(relaxDeps, list):
+    relaxDeps = { req.name: req for req in map(Requirement, relaxDeps) }
+else:
+    # No support (yet?) for `pythonRelaxBuildDeps.foo = ">1, <2";`; see
+    #  https://github.com/NixOS/nixpkgs/pull/382125#discussion_r1956658253
+    raise ValueError(f"Expected a list for `pythonRelaxBuildDeps`, was '{type(relaxDeps)}'")
+
+overlappingDeps = removeDeps.intersection(relaxDeps)
+if overlappingDeps:
+    raise ValueError(
+        "The following dependencies occur in both 'pythonRelaxBuildDeps` and 'pythonRemoveBuildDeps`: " + \
+        ", ".join(overlappingDeps)
+    )
+
+pyPrjPath = Path("pyproject.toml")
+pyProject = tomlkit.load(pyPrjPath.open())
+
+pyProject['build-system']['requires'] = [
+    str(relaxDeps[req.name]) if req.name in relaxDeps else orig
+    for req, orig in ((Requirement(orig), orig) for orig in pyProject['build-system']['requires'])
+    if req.name not in removeDeps
+]
+
+tomlkit.dump(pyProject, pyPrjPath.open("w"))

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -18,6 +18,7 @@
   pythonImportsCheckHook,
   pythonNamespacesHook,
   pythonOutputDistHook,
+  pythonRelaxBuildDepsHook,
   pythonRelaxDepsHook,
   pythonRemoveBinBytecodeHook,
   pythonRemoveTestsDirHook,
@@ -219,6 +220,9 @@ let
         else
           "setuptools";
 
+      relaxBuildDeps =
+        finalAttrs.pythonRelaxBuildDeps or [ ] != [ ] || finalAttrs.pythonRemoveBuildDeps or [ ] != [ ];
+
       withDistOutput = withDistOutput' format';
 
       validatePythonMatches =
@@ -302,6 +306,12 @@ let
         ]
         ++ optionals (attrs ? pythonRelaxDeps || attrs ? pythonRemoveDeps) [
           pythonRelaxDepsHook
+        ]
+        ++ optionals relaxBuildDeps [
+          (extendDerivation (
+            !finalAttrs.__structuredAttrs
+            -> throw "${getName finalAttrs}: pythonRelaxBuildDepsHook requires __structuredAttrs = true."
+          ) { } pythonRelaxBuildDepsHook)
         ]
         ++ optionals removeBinBytecode [
           pythonRemoveBinBytecodeHook

--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -48,15 +48,6 @@ buildPythonPackage rec {
       --replace "[python," "["
 
     patchShebangs --build packaging/cli-doc/build.py
-
-    SETUPTOOLS_PATTERN='"setuptools[0-9 <>=.,]+"'
-    PYPROJECT=$(cat pyproject.toml)
-    if [[ "$PYPROJECT" =~ $SETUPTOOLS_PATTERN ]]; then
-      echo "setuptools replace: ''${BASH_REMATCH[0]}"
-      echo "''${PYPROJECT//''${BASH_REMATCH[0]}/'"setuptools"'}" > pyproject.toml
-    else
-      exit 2
-    fi
   '';
 
   nativeBuildInputs = [
@@ -89,6 +80,8 @@ buildPythonPackage rec {
     xmltodict
   ] ++ lib.optionals windowsSupport [ pywinrm ];
 
+  __structuredAttrs = true;  # required for pyRelaxBuildDeps
+  pythonRelaxBuildDeps = [ "setuptools" ];
   pythonRelaxDeps = [ "resolvelib" ];
 
   postInstall = ''

--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     xmltodict
   ] ++ lib.optionals windowsSupport [ pywinrm ];
 
-  __structuredAttrs = true;  # required for pyRelaxBuildDeps
+  __structuredAttrs = true; # required for pyRelaxBuildDeps
   pythonRelaxBuildDeps = [ "setuptools" ];
   pythonRelaxDeps = [ "resolvelib" ];
 


### PR DESCRIPTION
- [x] `pythonRelaxBuildDepsHook`: init
  new setup hooks which rewrites `pyproject.toml`'s `build-system.requires`
  - [x] implementation comments
  - [x] documentation
  - [ ] tests
- [x] `mkPythonDerivation`: add `pythonRelaxBuildDepsHook` when its attributes are set
  analoguous to the existing `pythonRelaxDepsHook`
- [x] `ansible`: cleanup using the new hook

## Rationale

This was first devised in #381523, to replace regex-based `pyproject.toml` rewrites:
- using actual parsers for TOML and PEP 508 dependencies specifications, is a lot more robust ;
- a quick search through nixpkgs finds a huge number of derivations which could be cleaned up this way ;
  there are also many dependencies performing other types of rewrites in `pyproject.toml`,
  but this may best be left to another tool (or extending this hook in a future PR)

Regarding implementation choices:
- `tomlkit` was chosen as it preserves formatting and comments, making diff-based inspection simpler ;
- comments on substituted `build-system.requires` entries aren't preserved, to keep the implementation simpler.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of `pythonRelaxBuildDepsHook`
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
