### PR TITLE
 gopro-tool: init at 0-unstable-2024-04-18 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26072,6 +26072,12 @@
     github = "zmitchell";
     githubId = 10246891;
   };
+  ZMon3y = {
+    name = "Matt Szafir";
+    email = "mattszafir+nix@gmail.com";
+    github = "ZMon3y";
+    githubId = 9386488;
+  };
   znaniye = {
     email = "zn4niye@proton.me";
     github = "znaniye";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -404,6 +404,7 @@ in {
   gollum = handleTest ./gollum.nix {};
   gonic = handleTest ./gonic.nix {};
   google-oslogin = handleTest ./google-oslogin {};
+  gopro-tool = handleTest ./gopro-tool.nix {};
   goss = handleTest ./goss.nix {};
   gotenberg = handleTest ./gotenberg.nix {};
   gotify-server = handleTest ./gotify-server.nix {};

--- a/nixos/tests/gopro-tool.nix
+++ b/nixos/tests/gopro-tool.nix
@@ -1,0 +1,41 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+
+  let
+    testScript = ''
+      start_all()
+
+      machine.wait_for_unit("multi-user.target")
+
+      # Check that gopro-tool is installed
+      machine.succeed("which gopro-tool")
+
+      # Check that the v4l2loopback module is available
+      machine.succeed("lsmod | grep v4l2loopback || echo 'Module not found'")
+
+      # Check that VLC is installed
+      machine.succeed("which vlc")
+    '';
+  in
+  {
+    name = "gopro-tool";
+    meta.maintainers = with lib.maintainers; [ ZMon3y ];
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        # Ensure dependencies are installed
+        environment.systemPackages = with pkgs; [
+          gopro-tool
+          vlc
+        ];
+
+        # Load kernel module for testing
+        boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+
+        # Enable module loading
+        boot.kernelModules = [ "v4l2loopback" ];
+      };
+
+    testScript = testScript;
+  }
+)

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  ffmpeg,
+  vlc,
+  jq,
+}:
+
+stdenv.mkDerivation {
+  pname = "gopro-tool";
+  version = "0-unstable-2024-04-18";
+
+  src = fetchFromGitHub {
+    owner = "juchem";
+    repo = "gopro-tool";
+    rev = "a678f0ea65e24dca9b8d848b245bd2d487d3c8ca";
+    sha256 = "0sh3s38m17pci24x4kdlmlhn0gwgm28aaa6p7qs16wysk0q0h6wz";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/gopro-tool $out/bin/gopro-tool
+    chmod +x $out/bin/gopro-tool
+
+    wrapProgram $out/bin/gopro-tool \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ffmpeg
+          vlc
+          jq
+        ]
+      }
+  '';
+
+  meta = {
+    description = "A tool to control GoPro webcam mode in Linux (requires v4l2loopback kernel module and a firewall rule)";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ZMon3y ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6222,6 +6222,11 @@ with pkgs;
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
+  gopro-tool = callPackage ../by-name/go/gopro-tool/package.nix {
+    vlc =
+      vlc.overrideAttrs (old: { buildInputs = old.buildInputs ++ [ x264 ]; });
+  };
+
   gwe = callPackage ../tools/misc/gwe {
     nvidia_x11 = linuxPackages.nvidia_x11;
   };


### PR DESCRIPTION
This is a tool to allow the use of a GoPro camera as a webcam. 
https://github.com/juchem/gopro-tool

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
