### PR TITLE
python312Packages.fsspec: 2024.12.0 -> 2025.2.0

### DIFF
--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -1,47 +1,51 @@
 {
   lib,
   stdenv,
-  aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
   hatch-vcs,
-  numpy,
-  paramiko,
-  pytest-asyncio,
-  pytest-mock,
-  pytest-vcr,
-  pytestCheckHook,
-  pythonOlder,
-  requests,
-  smbprotocol,
-  tqdm,
+
+  # optional-dependencies
   adlfs,
+  pyarrow,
   dask,
   distributed,
+  requests,
   dropbox,
+  aiohttp,
   fusepy,
   gcsfs,
   libarchive-c,
   ocifs,
   panel,
-  pyarrow,
+  paramiko,
   pygit2,
   s3fs,
+  smbprotocol,
+  tqdm,
+
+  # tests
+  numpy,
+  pytest-asyncio,
+  pytest-mock,
+  pytest-vcr,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "2024.12.0";
+  version = "2025.2.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "fsspec";
     repo = "filesystem_spec";
     tag = version;
-    hash = "sha256-Vc0vBayPg6zZ4+pxJsHChSGg0kjA0Q16+Gk0bO0IEpI=";
+    hash = "sha256-vJYnPbGbEMAe1p0EUBxSRZYtvBdJzjzDOesyTJsFJbU=";
   };
 
   build-system = [
@@ -110,11 +114,8 @@ buildPythonPackage rec {
     pytest-mock
     pytest-vcr
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -139,11 +140,6 @@ buildPythonPackage rec {
       # tries to access /home, ignores $HOME
       "test_directories"
     ];
-
-  disabledTestPaths = [
-    # JSON decoding issues
-    "fsspec/implementations/tests/test_dbfs.py"
-  ];
 
   pythonImportsCheck = [ "fsspec" ];
 


### PR DESCRIPTION
## Things done

Changelog: https://github.com/fsspec/filesystem_spec/raw/2025.2.0/docs/source/changelog.rst

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
