### PR TITLE
nixos/step-ca: use `pathWith` for `intermediatePasswordFile`

### DIFF
--- a/nixos/modules/services/security/step-ca.nix
+++ b/nixos/modules/services/security/step-ca.nix
@@ -60,7 +60,10 @@ in
         '';
       };
       intermediatePasswordFile = lib.mkOption {
-        type = lib.types.path;
+        type = lib.types.pathWith {
+          inStore = false;
+          absolute = true;
+        };
         example = "/run/keys/smallstep-password";
         description = ''
           Path to the file containing the password for the intermediate
@@ -86,17 +89,6 @@ in
       );
     in
     {
-      assertions = [
-        {
-          assertion = !lib.isStorePath cfg.intermediatePasswordFile;
-          message = ''
-            <option>services.step-ca.intermediatePasswordFile</option> points to
-            a file in the Nix store. You should use a quoted absolute path to
-            prevent this.
-          '';
-        }
-      ];
-
       systemd.packages = [ cfg.package ];
 
       # configuration file indirection is needed to support reloading

--- a/nixos/tests/step-ca.nix
+++ b/nixos/tests/step-ca.nix
@@ -14,12 +14,13 @@ import ./make-test-python.nix ({ pkgs, ... }:
       {
         caserver =
           { config, pkgs, ... }: {
+            environment.etc.password-file.source = "${test-certificates}/intermediate-password-file";
             services.step-ca = {
               enable = true;
               address = "[::]";
               port = 8443;
               openFirewall = true;
-              intermediatePasswordFile = "${test-certificates}/intermediate-password-file";
+              intermediatePasswordFile = "/etc/${config.environment.etc.password-file.target}";
               settings = {
                 dnsNames = [ "caserver" ];
                 root = "${test-certificates}/root_ca.crt";


### PR DESCRIPTION
This lets us remove an assertion, because `pathWith` can require that a
file not be in the store.

Note that the old assertion didn't quite do what we wanted: it prevented
you from using top level store paths (such as
`/nix/store/gg8578vvbcf1wpqvk85bigi5s4pvylkk-test-certificates`), but was
ok with sub-files (such as
`/nix/store/gg8578vvbcf1wpqvk85bigi5s4pvylkk-test-certificates/intermediate-password-file`).

Now that we're stricter, we need some way to populate
`intermediatePasswordFile` in our test without making the type unhappy.
I opted to solve that by creating a file in `/etc`.

refs: https://github.com/Thaigersprint/thaigersprint-2025/issues/1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
