### PR TITLE
pkgs/top-level/release-lib.nix: support cross system

### DIFF
--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,7 +1,7 @@
 {
   supportedSystems,
   system ? builtins.currentSystem,
-  packageSet ? (import ../..),
+  packageSet ? (import ./default.nix),
   scrubJobs ? true,
   # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? {
@@ -43,7 +43,12 @@ let
 
   pkgs = packageSet (
     recursiveUpdate {
-      inherit system;
+      localSystem = {
+        inherit system;
+      };
+      crossSystem = {
+        inherit system;
+      };
       config.allowUnsupportedSystem = true;
     } nixpkgsArgs
   );
@@ -58,7 +63,24 @@ let
   mkPkgsFor =
     crossSystem:
     let
-      packageSet' = args: packageSet (args // { inherit crossSystem; } // nixpkgsArgs);
+      packageSet' =
+        args:
+        let
+          args' =
+            args
+            // nixpkgsArgs
+            // {
+              localSystem = (nixpkgsArgs.localSystem or { }) // {
+                inherit system;
+              };
+            };
+        in
+        packageSet (
+          args'
+          // lib.optionalAttrs (args' ? crossSystem || crossSystem != null) {
+            crossSystem = (args'.crossSystem or { }) // crossSystem;
+          }
+        );
 
       pkgs_x86_64_linux = packageSet' { system = "x86_64-linux"; };
       pkgs_i686_linux = packageSet' { system = "i686-linux"; };
@@ -110,7 +132,8 @@ let
       examplesByConfig = flip mapAttrs' systems.examples (
         _: crossSystem:
         nameValuePair crossSystem.config {
-          inherit crossSystem;
+          crossSystem =
+            lib.optionalAttrs (crossSystem != null) crossSystem // (nixpkgsArgs.crossSystem or { });
           pkgsFor = mkPkgsFor crossSystem;
         }
       );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This somewhat makes it possible to do a cross release. The idea is to be able to support pkgsLLVM via this method.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
