### PR TITLE
xfce.xfce4-whiskermenu-plugin: 2.9.0 -> 2.9.1

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-whiskermenu-plugin/default.nix
@@ -1,6 +1,7 @@
 {
   mkXfceDerivation,
   lib,
+  fetchpatch,
   cmake,
   accountsservice,
   exo,
@@ -18,10 +19,19 @@
 mkXfceDerivation {
   category = "panel-plugins";
   pname = "xfce4-whiskermenu-plugin";
-  version = "2.9.0";
+  version = "2.9.1";
   rev-prefix = "v";
   odd-unstable = false;
-  sha256 = "sha256-j2KatlML8NuUH+IKWodDT5VeG7XL27wwiqMKjurt9rM=";
+  sha256 = "sha256-CHxKCH8FcikNzhI3rUU2IH0bTbBGqEz85f/ST8PSnSo=";
+
+  patches = [
+    # Fix menu not shown on correct monitor
+    # https://gitlab.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/-/issues/154
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/-/commit/e13216dcaa455e08368dcde256a6896d6e8918a1.patch";
+      hash = "sha256-sRy1EgG8SaLgjdMH7XNSg97kj+tq2TI+G1P1d9aUXPc=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
https://gitlab.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/-/compare/v2.9.0...v2.9.1



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

