### PR TITLE
[24.11] xonsh 0.19.1 -> 0.19.2

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "xonsh";
-  version = "0.19.1";
+  version = "0.19.2";
   pyproject = true;
 
   # PyPI package ships incomplete tests
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "xonsh";
     repo = "xonsh";
     tag = version;
-    hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
+    hash = "sha256-h5WK/7PZQKHajiaj3BTHLeW4TYhSB/IV0eRZPCSD6qg=";
   };
 
   build-system = [

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -1,130 +1,135 @@
 {
   lib,
-  coreutils,
+  buildPythonPackage,
   fetchFromGitHub,
-  gitMinimal,
-  glibcLocales,
-  nix-update-script,
-  pythonPackages,
+
+  setuptools,
+  ply,
+  prompt-toolkit,
+  pygments,
+
   addBinToPathHook,
   writableTmpDirAsHomeHook,
+  gitMinimal,
+  glibcLocales,
+  pip,
+  pyte,
+  pytest-mock,
+  pytest-subprocess,
+  pytestCheckHook,
+  requests,
+
+  coreutils,
+
+  nix-update-script,
+  python,
 }:
 
-let
+buildPythonPackage rec {
+  pname = "xonsh";
+  version = "0.19.1";
+  pyproject = true;
 
-  argset = {
-    pname = "xonsh";
-    version = "0.19.1";
-    pyproject = true;
-
-    # PyPI package ships incomplete tests
-    src = fetchFromGitHub {
-      owner = "xonsh";
-      repo = "xonsh";
-      tag = argset.version;
-      hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
-    };
-
-    nativeBuildInputs = with pythonPackages; [
-      setuptools
-      wheel
-    ];
-
-    propagatedBuildInputs = (
-      with pythonPackages;
-      [
-        ply
-        prompt-toolkit
-        pygments
-      ]
-    );
-
-    nativeCheckInputs =
-      [
-        addBinToPathHook
-        gitMinimal
-        glibcLocales
-        writableTmpDirAsHomeHook
-      ]
-      ++ (with pythonPackages; [
-        pip
-        pyte
-        pytest-mock
-        pytest-subprocess
-        pytestCheckHook
-        requests
-      ]);
-
-    disabledTests = [
-      # fails on sandbox
-      "test_colorize_file"
-      "test_loading_correctly"
-      "test_no_command_path_completion"
-      "test_bsd_man_page_completions"
-      "test_xonsh_activator"
-
-      # fails on non-interactive shells
-      "test_capture_always"
-      "test_casting"
-      "test_command_pipeline_capture"
-      "test_dirty_working_directory"
-      "test_man_completion"
-      "test_vc_get_branch"
-      "test_bash_and_is_alias_is_only_functional_alias"
-
-      # flaky tests
-      "test_script"
-      "test_alias_stability"
-      "test_alias_stability_exception"
-      "test_complete_import"
-      "test_subproc_output_format"
-
-      # https://github.com/xonsh/xonsh/issues/5569
-      "test_spec_decorator_alias_output_format"
-
-      # Broken test
-      "test_repath_backslash"
-    ];
-
-    disabledTestPaths = [
-      # fails on sandbox
-      "tests/completers/test_command_completers.py"
-      "tests/shell/test_ptk_highlight.py"
-      # fails on non-interactive shells
-      "tests/prompt/test_gitstatus.py"
-      "tests/completers/test_bash_completer.py"
-    ];
-
-    # https://github.com/NixOS/nixpkgs/issues/248978
-    dontWrapPythonPrograms = true;
-
-    env.LC_ALL = "en_US.UTF-8";
-
-    postPatch = ''
-      sed -ie 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
-      sed -ie 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
-
-      for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
-        sed -ie 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
-      done
-      patchShebangs .
-    '';
-
-    passthru = {
-      shellPath = "/bin/xonsh";
-      python = pythonPackages.python; # To the wrapper
-      wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
-      updateScript = nix-update-script { };
-    };
-
-    meta = {
-      homepage = "https://xon.sh/";
-      description = "Python-ish, BASHwards-compatible shell";
-      changelog = "https://github.com/xonsh/xonsh/raw/main/CHANGELOG.rst";
-      license = with lib.licenses; [ bsd3 ];
-      mainProgram = "xonsh";
-      maintainers = with lib.maintainers; [ samlukeyes123 ];
-    };
+  # PyPI package ships incomplete tests
+  src = fetchFromGitHub {
+    owner = "xonsh";
+    repo = "xonsh";
+    tag = version;
+    hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
   };
-in
-pythonPackages.buildPythonPackage argset
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    ply
+    prompt-toolkit
+    pygments
+  ];
+
+  nativeCheckInputs = [
+    addBinToPathHook
+    writableTmpDirAsHomeHook
+    gitMinimal
+    glibcLocales
+    pip
+    pyte
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTests = [
+    # fails on sandbox
+    "test_bsd_man_page_completions"
+    "test_colorize_file"
+    "test_loading_correctly"
+    "test_no_command_path_completion"
+    "test_xonsh_activator"
+
+    # fails on non-interactive shells
+    "test_bash_and_is_alias_is_only_functional_alias"
+    "test_capture_always"
+    "test_casting"
+    "test_command_pipeline_capture"
+    "test_dirty_working_directory"
+    "test_man_completion"
+    "test_vc_get_branch"
+
+    # flaky tests
+    "test_alias_stability"
+    "test_alias_stability_exception"
+    "test_complete_import"
+    "test_script"
+    "test_subproc_output_format"
+
+    # broken tests
+    "test_repath_backslash"
+
+    # https://github.com/xonsh/xonsh/issues/5569
+    "test_spec_decorator_alias_output_format"
+  ];
+
+  disabledTestPaths = [
+    # fails on sandbox
+    "tests/completers/test_command_completers.py"
+    "tests/shell/test_ptk_highlight.py"
+
+    # fails on non-interactive shells
+    "tests/prompt/test_gitstatus.py"
+    "tests/completers/test_bash_completer.py"
+  ];
+
+  # https://github.com/NixOS/nixpkgs/issues/248978
+  dontWrapPythonPrograms = true;
+
+  env.LC_ALL = "en_US.UTF-8";
+
+  postPatch = ''
+    sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
+    sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
+
+    for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
+      sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
+    done
+    patchShebangs .
+  '';
+
+  passthru = {
+    inherit python;
+    shellPath = "/bin/xonsh";
+    wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://xon.sh/";
+    description = "Python-ish, BASHwards-compatible shell";
+    changelog = "https://github.com/xonsh/xonsh/raw/main/CHANGELOG.rst";
+    license = with lib.licenses; [ bsd3 ];
+    mainProgram = "xonsh";
+    maintainers = with lib.maintainers; [ samlukeyes123 ];
+  };
+}


### PR DESCRIPTION
Backport commits a229520681acc90fd74805598fb64a698c1b2702 and 23c5bd55d4b41c7c55f46c259a1e769ff04ee2c4 (https://github.com/NixOS/nixpkgs/pull/382223)

Upstream release: https://github.com/xonsh/xonsh/releases/tag/0.19.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
