### PR TITLE
doc: remove redundant fetchCargoVendor section

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -461,17 +461,6 @@ also be used:
   the `Cargo.lock`/`Cargo.toml` files need to be patched before
   vendoring.
 
-In case the lockfile contains cargo `git` dependencies, you can use
-`fetchCargoVendor` instead.
-```nix
-{
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    hash = "sha256-RqPVFovDaD2rW31HyETJfQ0qVwFxoGEvqkIgag3H6KU=";
-  };
-}
-```
-
 If a `Cargo.lock` file is available, you can alternatively use the
 `importCargoLock` function. In contrast to `fetchCargoVendor`, this
 function does not require a hash (unless git dependencies are used)


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/377006

The removed example is effectively identical to the example one paragraph earlier, and discussing cargo `git` dependencies no longer seems necessary unless `importCargoLock` is used.

cc @alyssais @drupol @zowoq

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
