### PR TITLE
python312Packages.lmnr: init at 0.4.60

### DIFF
--- a/pkgs/development/python-modules/lmnr/default.nix
+++ b/pkgs/development/python-modules/lmnr/default.nix
@@ -1,0 +1,156 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  aiohttp,
+  argparse,
+  grpcio,
+  opentelemetry-api,
+  opentelemetry-exporter-otlp-proto-grpc,
+  opentelemetry-exporter-otlp-proto-http,
+  opentelemetry-instrumentation-requests,
+  opentelemetry-instrumentation-sqlalchemy,
+  opentelemetry-instrumentation-threading,
+  opentelemetry-instrumentation-urllib3,
+  opentelemetry-sdk,
+  opentelemetry-semantic-conventions-ai,
+  pydantic,
+  python-dotenv,
+  requests,
+  tenacity,
+  tqdm,
+  # opentelemetry-instrumentation-alephalpha,
+  # opentelemetry-instrumentation-anthropic,
+  # opentelemetry-instrumentation-bedrock,
+  # opentelemetry-instrumentation-chromadb,
+  # opentelemetry-instrumentation-cohere,
+  # opentelemetry-instrumentation-google-generativeai,
+  # opentelemetry-instrumentation-groq,
+  # opentelemetry-instrumentation-haystack,
+  # opentelemetry-instrumentation-lancedb,
+  # opentelemetry-instrumentation-langchain,
+  # opentelemetry-instrumentation-llamaindex,
+  # opentelemetry-instrumentation-marqo,
+  # opentelemetry-instrumentation-milvus,
+  # opentelemetry-instrumentation-mistralai,
+  # opentelemetry-instrumentation-ollama,
+  # opentelemetry-instrumentation-openai,
+  # opentelemetry-instrumentation-pinecone,
+  # opentelemetry-instrumentation-qdrant,
+  # opentelemetry-instrumentation-replicate,
+  # opentelemetry-instrumentation-sagemaker,
+  # opentelemetry-instrumentation-together,
+  # opentelemetry-instrumentation-transformers,
+  # opentelemetry-instrumentation-vertexai,
+  # opentelemetry-instrumentation-watsonx,
+  # opentelemetry-instrumentation-weaviate,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "lmnr";
+  version = "0.4.60";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-CcFjyEaWO+4P+HnFP0iWfE5nOlmDuJQ8xulFsE23B/Y=";
+  };
+
+  build-system = [ poetry-core ];
+
+  # there is no need to pin grpcio, see the upstream comment
+  # https://github.com/lmnr-ai/lmnr-python/blob/bbf5d9c83fb1dbc96adb9e09be5f7326c8c93c65/pyproject.toml#L34-L35
+  # > explicitly freeze grpcio. Since 1.68.0, grpcio writes a warning message
+  # > that looks scary, but is harmless.
+  pythonRelaxDeps = [ "grpcio" ];
+
+  pythonRemoveDeps = [ "argparse" ];
+
+  dependencies = [
+    aiohttp
+    grpcio
+    opentelemetry-api
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-instrumentation-requests
+    opentelemetry-instrumentation-sqlalchemy
+    opentelemetry-instrumentation-threading
+    opentelemetry-instrumentation-urllib3
+    opentelemetry-sdk
+    opentelemetry-semantic-conventions-ai
+    pydantic
+    python-dotenv
+    requests
+    tenacity
+    tqdm
+  ];
+
+  optional-dependencies = {
+    # alephalpha = [ opentelemetry-instrumentation-alephalpha ];
+    all = [
+      # opentelemetry-instrumentation-alephalpha
+      # opentelemetry-instrumentation-anthropic
+      # opentelemetry-instrumentation-bedrock
+      # opentelemetry-instrumentation-chromadb
+      # opentelemetry-instrumentation-cohere
+      # opentelemetry-instrumentation-google-generativeai
+      # opentelemetry-instrumentation-groq
+      # opentelemetry-instrumentation-haystack
+      # opentelemetry-instrumentation-lancedb
+      # opentelemetry-instrumentation-langchain
+      # opentelemetry-instrumentation-llamaindex
+      # opentelemetry-instrumentation-marqo
+      # opentelemetry-instrumentation-milvus
+      # opentelemetry-instrumentation-mistralai
+      # opentelemetry-instrumentation-ollama
+      # opentelemetry-instrumentation-openai
+      # opentelemetry-instrumentation-pinecone
+      # opentelemetry-instrumentation-qdrant
+      # opentelemetry-instrumentation-replicate
+      # opentelemetry-instrumentation-sagemaker
+      # opentelemetry-instrumentation-together
+      # opentelemetry-instrumentation-transformers
+      # opentelemetry-instrumentation-vertexai
+      # opentelemetry-instrumentation-watsonx
+      # opentelemetry-instrumentation-weaviate
+    ];
+    # anthropic = [ opentelemetry-instrumentation-anthropic ];
+    # bedrock = [ opentelemetry-instrumentation-bedrock ];
+    # chromadb = [ opentelemetry-instrumentation-chromadb ];
+    # cohere = [ opentelemetry-instrumentation-cohere ];
+    # google-generativeai = [ opentelemetry-instrumentation-google-generativeai ];
+    # groq = [ opentelemetry-instrumentation-groq ];
+    # haystack = [ opentelemetry-instrumentation-haystack ];
+    # lancedb = [ opentelemetry-instrumentation-lancedb ];
+    # langchain = [ opentelemetry-instrumentation-langchain ];
+    # llamaindex = [ opentelemetry-instrumentation-llamaindex ];
+    # marqo = [ opentelemetry-instrumentation-marqo ];
+    # milvus = [ opentelemetry-instrumentation-milvus ];
+    # mistralai = [ opentelemetry-instrumentation-mistralai ];
+    # ollama = [ opentelemetry-instrumentation-ollama ];
+    # openai = [ opentelemetry-instrumentation-openai ];
+    # pinecone = [ opentelemetry-instrumentation-pinecone ];
+    # qdrant = [ opentelemetry-instrumentation-qdrant ];
+    # replicate = [ opentelemetry-instrumentation-replicate ];
+    # sagemaker = [ opentelemetry-instrumentation-sagemaker ];
+    # together = [ opentelemetry-instrumentation-together ];
+    # transformers = [ opentelemetry-instrumentation-transformers ];
+    # vertexai = [ opentelemetry-instrumentation-vertexai ];
+    # watsonx = [ opentelemetry-instrumentation-watsonx ];
+    # weaviate = [ opentelemetry-instrumentation-weaviate ];
+  };
+
+  pythonImportsCheck = [ "lmnr" ];
+
+  # pypi tarball has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Python SDK for Laminar";
+    homepage = "https://github.com/lmnr-ai/lmnr-python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-sqlalchemy/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  aiosqlite,
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  opentelemetry-semantic-conventions,
+  packaging,
+  sqlalchemy,
+  wrapt,
+
+  # tests
+  opentelemetry-test-utils,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-sqlalchemy";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/${pname}";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiosqlite
+    opentelemetry-api
+    opentelemetry-instrumentation
+    opentelemetry-semantic-conventions
+    packaging
+    sqlalchemy
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.sqlalchemy" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/${pname}";
+    description = "sqlalchemy instrumentation for OpenTelemetry";
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-threading/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-threading/default.nix
@@ -1,0 +1,46 @@
+{
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  wrapt,
+
+  # tests
+  opentelemetry-test-utils,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-threading";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/${pname}";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    opentelemetry-api
+    opentelemetry-instrumentation
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.threading" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/${pname}";
+    description = "Threading instrumentation for OpenTelemetry";
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-urllib3/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-urllib3/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPythonPackage,
+  pythonOlder,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  httpretty,
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  opentelemetry-semantic-conventions,
+  opentelemetry-util-http,
+  urllib3,
+  wrapt,
+
+  # tests
+  opentelemetry-test-utils,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-urllib3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/${pname}";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    httpretty
+    opentelemetry-api
+    opentelemetry-instrumentation
+    opentelemetry-semantic-conventions
+    opentelemetry-util-http
+    urllib3
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.urllib3" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/${pname}";
+    description = "OpenTelemetry urllib3 instrumentation";
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-semantic-conventions-ai";
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "opentelemetry_semantic_conventions_ai";
+    inherit version;
+    hash = "sha256-kLlpx9g44D4wqRUP/kZUPY5Y6dc3DHIh/TDUzk16G5Y=";
+  };
+
+  build-system = [ poetry-core ];
+
+  pythonImportsCheck = [ "opentelemetry.semconv_ai" ];
+
+  # no tests
+  doCheck = false;
+
+  meta = {
+    description = "OpenTelemetry Semantic Conventions Extension for Large Language Models";
+    homepage = "https://pypi.org/project/opentelemetry-semantic-conventions-ai";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9849,6 +9849,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation-redis = callPackage ../development/python-modules/opentelemetry-instrumentation-redis { };
 
+  opentelemetry-instrumentation-sqlalchemy = callPackage ../development/python-modules/opentelemetry-instrumentation-sqlalchemy { };
+
   opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
 
   opentelemetry-propagator-aws-xray = callPackage ../development/python-modules/opentelemetry-propagator-aws-xray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9863,6 +9863,8 @@ self: super: with self; {
 
   opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };
 
+  opentelemetry-semantic-conventions-ai = callPackage ../development/python-modules/opentelemetry-semantic-conventions-ai { };
+
   opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
 
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9851,6 +9851,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation-sqlalchemy = callPackage ../development/python-modules/opentelemetry-instrumentation-sqlalchemy { };
 
+  opentelemetry-instrumentation-threading = callPackage ../development/python-modules/opentelemetry-instrumentation-threading { };
+
   opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
 
   opentelemetry-propagator-aws-xray = callPackage ../development/python-modules/opentelemetry-propagator-aws-xray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7716,6 +7716,8 @@ self: super: with self; {
 
   lmnotify = callPackage ../development/python-modules/lmnotify { };
 
+  lmnr = callPackage ../development/python-modules/lmnr { };
+
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
   lnkparse3 = callPackage ../development/python-modules/lnkparse3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9841,6 +9841,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation-grpc = callPackage ../development/python-modules/opentelemetry-instrumentation-grpc { };
 
+  opentelemetry-instrumentation-urllib3 = callPackage ../development/python-modules/opentelemetry-instrumentation-urllib3 { };
+
   opentelemetry-instrumentation-logging = callPackage ../development/python-modules/opentelemetry-instrumentation-logging { };
 
   opentelemetry-instrumentation-psycopg2 = callPackage ../development/python-modules/opentelemetry-instrumentation-psycopg2 { };


### PR DESCRIPTION
https://github.com/lmnr-ai/lmnr-python
[Laminar](https://www.lmnr.ai/) is an open-source platform for engineering LLM products. Trace, evaluate, annotate, and analyze LLM data. Bring LLM applications to production with confidence.

https://pypi.org/project/opentelemetry-semantic-conventions-ai/
OpenTelemetry Semantic Conventions Extension for Large Language Models

blocked by https://github.com/NixOS/nixpkgs/pull/379424, https://github.com/NixOS/nixpkgs/pull/379699 and https://github.com/NixOS/nixpkgs/pull/379698
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
