### PR TITLE
bend: 0.2.36 -> 0.2.37, hvm: 2.0.19 -> 2.0.22

### DIFF
--- a/pkgs/by-name/be/bend/package.nix
+++ b/pkgs/by-name/be/bend/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "Bend";
-  version = "0.2.36";
+  version = "0.2.37";
 
   src = fetchFromGitHub {
     owner = "HigherOrderCO";
     repo = "Bend";
     tag = version;
-    hash = "sha256-j4YMdeSxIbhp7xT42L42/y0ZncFPKBkxTh0LgO/RjkY=";
+    hash = "sha256-8uBEI9GKUETk8t6Oanb0OECe3MlJ486QnccOuhIxPuY=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-mGpH08VMmqoxXm8EUPdsBvSW/CFyRPY4bfyr8JI1es0=";
+  cargoHash = "sha256-xac5Gb0hcamT3vymq6SKaMiuEn8NU9Bfhu+t/dcjhTE=";
 
   nativeBuildInputs = [
     hvm

--- a/pkgs/by-name/hv/hvm/package.nix
+++ b/pkgs/by-name/hv/hvm/package.nix
@@ -6,15 +6,15 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hvm";
-  version = "2.0.19";
+  version = "2.0.22";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-+Cx+2v4JrQflDBaNZ9Fu8734Zr4rrgtnojUS4dkx7Ck=";
+    hash = "sha256-AD8mv47m4E6H8BVkxTExyhrR7VEnuB/KxnRl2puPnX4=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-HpQQLFb9vUAGIEKrkGKOfUUNALYGnKCR3/HqA+qvamw=";
+  cargoHash = "sha256-nLcT+o6xrxPmQqK7FQpCqTlxOOUA1FzqRGQIypcq4fo=";
 
   meta = with lib; {
     description = "Massively parallel, optimal functional runtime in Rust";


### PR DESCRIPTION
These updates are coupled because bend depends on exact hvm version.

[Changelog](https://github.com/HigherOrderCO/Bend/blob/main/CHANGELOG.md) for Bend 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
