### PR TITLE
[haskell-updates] haskellPackages: bump hackage to 2025-02-15

### DIFF
--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "29f8cb511c67543742be59bb99a4265b1c8e1cae",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/29f8cb511c67543742be59bb99a4265b1c8e1cae.tar.gz",
-  "sha256": "1vrx4dq7vwbpnpnh5plh45azv7qix5hqmhznf9ww7ias1mccvwcc",
-  "msg": "Update from Hackage at 2025-02-10T08:47:10Z"
+  "commit": "264a7959091df9d0be29b5ef12a0a4155e8d55a7",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/264a7959091df9d0be29b5ef12a0a4155e8d55a7.tar.gz",
+  "sha256": "0m0imbi3pd7j2484qc45wr2iknm922rdn0pd8fyz4n2dz7bjr5hb",
+  "msg": "Update from Hackage at 2025-02-15T14:17:54Z"
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2585,9 +2585,6 @@ self: super: {
   # libfuse3 fails to mount fuse file systems within the build environment
   libfuse3 = dontCheck super.libfuse3;
 
-  # Bogus constraint on tls (<2.0)
-  pinboard-notes-backup = doJailbreak super.pinboard-notes-backup;
-
   # Merged upstream, but never released. Allows both intel and aarch64 darwin to build.
   # https://github.com/vincenthz/hs-gauge/pull/106
   gauge = appendPatch (pkgs.fetchpatch {


### PR DESCRIPTION
Supersedes #382191. Fixes matrix-client.