### PR TITLE
electron{-source,-bin,-chromedriver}: 32.3.0 -> 32.3.1, 33.4.0 -> 33.4.1, 34.1.1 -> 34.2.0

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -78,14 +78,14 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "90044a7aa13f18ca4077a33131190b55fdf3ca5cb0704c537ca630fd0e06369e",
-            "aarch64-linux": "6542b3152ea9d8dd005a1b8f55b6971dee0f954b3b4e0bab4d625d501a946093",
-            "armv7l-linux": "95d79d2d2a154783fa6435d937a3e98b4408f2ce75f6706e5781d0d7e2e49d44",
-            "headers": "00v71c9fy3na040bnp5llp6951fsqls6hnlvbds5gckw3wfdcymc",
-            "x86_64-darwin": "d66a1400fe3c446f93eabf51b9520a300cdd25805a03d96a4528bda089f4988e",
-            "x86_64-linux": "f854ceb7362f7eeafdcdfc4a8898493adb72e3433595c59f072427912115d41b"
+            "aarch64-darwin": "6613ca0dc9f4e0a4488113efcb9a6d81ea32b18842eaac879d2d15f6f6776b8d",
+            "aarch64-linux": "194c26e79668ba176e1a641a8a0184cc7c0509b3eda9db64137a33f7b29f23a2",
+            "armv7l-linux": "78ebab80ea5f9b0407179fdbf65a6a533e9e8cc67324eba1916d197a0f163c51",
+            "headers": "1qlsrljlw08253hpiiccmb0kafnbihyxc7hlvakbhnbwils393xr",
+            "x86_64-darwin": "723dd6e1b136fc6a4c00432769114fcae80a261a985934311ce730910d0c4df1",
+            "x86_64-linux": "91950f2c5bd17f03920a20d6e2d57676f341c7ad27fb828570f4e00a1566f407"
         },
-        "version": "33.4.0"
+        "version": "33.4.1"
     },
     "34": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -89,13 +89,13 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "a38a624bee92ee601777c20e6bdbf040d1b2a5506ba1ccac8be1447b1c6b0bfd",
-            "aarch64-linux": "37d68cef35888c8ca8bbe2002be0a122e8e8ccaf762b60ade1af5e71918e080b",
-            "armv7l-linux": "741374570bd9e435037f41b42aea7ab640f7ef1e75afb4705cc12344f43ed04c",
-            "headers": "0b0djna1bprfff0y1pb2wdzsx82v1c1zk20gl2vivgjhslxf0igl",
-            "x86_64-darwin": "a2ba4f91882819801da2d499de3426dbb191a22f2fe4a6ec92b756f1a0dc2de8",
-            "x86_64-linux": "9fbca20baea84800f7f50a9b245302dddbfab3425dd762c482d79e867a5a6dbe"
+            "aarch64-darwin": "ee447c17b2ac545e48083113d7e39a916821c1316f60f42cbcbee4fffe7c022a",
+            "aarch64-linux": "818c91309da8ff948c43df58a996c05c0d27daa690e1d659355d9db01e351919",
+            "armv7l-linux": "0c75996c6bf2d37d0441d3e1021386a9348f8d21783d75571cdb10ede606424f",
+            "headers": "17f06fx4yidshmkdicis6k4azph95mxs1rwpm0ll53szpcs7rdss",
+            "x86_64-darwin": "8ef741819c8a5370dabc3b9df5e6ac217366477c5d5c656ed23c800bc984d887",
+            "x86_64-linux": "f12a02d86cc657500978d263ec6d1841b6e2085cd3bd4d30a97cfe14685396f3"
         },
-        "version": "34.1.1"
+        "version": "34.2.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -67,14 +67,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "7b0071f5162fe81cc020e76b3e71aa18e5e888edacca6a0c92f389199097534c",
-            "aarch64-linux": "292740690b445bf8e3b13c37c74ff2c9820e8d30f6d0ac8e03a62421746f189c",
-            "armv7l-linux": "efc6bfdbd92e76cde23bfa0967809593ae32e74ed1897765f1105e3761db9478",
-            "headers": "0pmgcns26pvvp7ihqkl9llpdr8l871p7m6r72scia93siwnyvrvv",
-            "x86_64-darwin": "a7070ea98e5a4c5d53b2184229428d29109682165be62b17faf0bcdd9547174f",
-            "x86_64-linux": "8fb72c1d19a51552438eb42fdaae915643c2e310fa3090d8d5293ad6fc94b8c5"
+            "aarch64-darwin": "9d2de7531f8b4baa513c8622f37415855c889b0e99e59cbdc9570f8056f148fe",
+            "aarch64-linux": "63aca27373f86044d82bb54a531288d94cb5a248438d222ee3fe4e2282667ea7",
+            "armv7l-linux": "d6152c0e36ddeea3d23fd945c6c382507fdb95bf8f0a4d2f2b00966ce59aca66",
+            "headers": "0j87666by9hbqkb3c0wxcjp5g8b7da807al9j4gjrspzp3r96a91",
+            "x86_64-darwin": "9221ca22b8902508092581c59c9910abd9324e9234699107566e5913bccebc1b",
+            "x86_64-linux": "4619dd27038abd1165c4f84caa013a0826445428c11cc29d524c5737476edaa3"
         },
-        "version": "32.3.0"
+        "version": "32.3.1"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "0b87f00cf22d2c73a795af554cf9548e0204769d22ffdc7f28183572d4f7fef0",
-            "aarch64-linux": "5387c7a22c93dfcac348ea5ec604fb8350926e8e2681ca189e0500ff993d58d0",
-            "armv7l-linux": "53e1fa127812bcfb5a095f781368ee2d9cceb4a91d83dcb32a7ecf072cf39034",
-            "headers": "00v71c9fy3na040bnp5llp6951fsqls6hnlvbds5gckw3wfdcymc",
-            "x86_64-darwin": "9a8ec97a21d41b146b010dfe7e4df71907a23bdf0500619036de623b4ddb1ce1",
-            "x86_64-linux": "ea57c5bafecd8502fa95df73c977efb2a061068eac965d97f99b824479d55de2"
+            "aarch64-darwin": "df7713ab2e4a7d3b059c507abcd1bb5ec8b71274407035658100529555a6ac65",
+            "aarch64-linux": "e6f369ceebe049c7c119f943cc36617de3094b45eaf495259599ef65352d2eb5",
+            "armv7l-linux": "41f9241f412c842027128f1260bb2f07799ddb0e6dfd22171296ccfc5c1d3ce6",
+            "headers": "1qlsrljlw08253hpiiccmb0kafnbihyxc7hlvakbhnbwils393xr",
+            "x86_64-darwin": "1fda63a3a64d68cb83c6619dafbf4ba4434b99b1c273c3ecdc3cc8de0ff2f422",
+            "x86_64-linux": "e3d6fd631f5c1ff63850b7f0af8f3cf325200f66bdf3371c911b8f14f8a44673"
         },
-        "version": "33.4.0"
+        "version": "33.4.1"
     },
     "34": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "679a286100f2121a3566f7d0988894611628e93920843c873de36d3e37f1b0e9",
-            "aarch64-linux": "6a297a8db6f64ac3c95ddc17d2a9f95bff3d2fddef2aae565ebf91bcca960f3a",
-            "armv7l-linux": "c76c9ec01fff88a9cda3aedfd8251880a835d326c349b108f09e02a419dd9a52",
-            "headers": "0pmgcns26pvvp7ihqkl9llpdr8l871p7m6r72scia93siwnyvrvv",
-            "x86_64-darwin": "495b3f0e0459badba8f6e3406edd4bcf7e688eb9d11d4b544426fb25d1e22f43",
-            "x86_64-linux": "af9e3a6aac492827e1ace64fc50744f82523f09842b2414ad00d9a97f06d7a85"
+            "aarch64-darwin": "606a20ba0c4ca3ff5143d84114c76701866da9d6ca5563c4f230024a9fad107b",
+            "aarch64-linux": "027d2c4bafbce2903a52bef70a8aadce6bdee8f32cf3e9aa043cef58114bf4f1",
+            "armv7l-linux": "2084fe0130e0d32a94d7181b9ee0d38b67e38852efe72a44768bfd541074d631",
+            "headers": "0j87666by9hbqkb3c0wxcjp5g8b7da807al9j4gjrspzp3r96a91",
+            "x86_64-darwin": "8846b009c7f86dd40630fde6b914dbcd7e1acaf79bfbf6c69b5408a0c91f22f3",
+            "x86_64-linux": "53f7ca0ee2bc52d7e22d75c3c3815f62f1616e82cfe030b11399549beb85f623"
         },
-        "version": "32.3.0"
+        "version": "32.3.1"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "c2aa24978fbe0c3dfb8ae36816633a75f498b4af5052b059631a626925951e41",
-            "aarch64-linux": "df87d6f0b91a549996c764bb60eaf692c59e087496406562e3bcbb3f90a52d50",
-            "armv7l-linux": "74b53fff1d210066024476ebbfef7476b05c2c71cd141953b5b7e0a35d129a02",
-            "headers": "0b0djna1bprfff0y1pb2wdzsx82v1c1zk20gl2vivgjhslxf0igl",
-            "x86_64-darwin": "95239f35723eeca036ed1e29f7871a4de843c6eda16bccc04436402dddd938aa",
-            "x86_64-linux": "62734cb681a6da3c73b20504f49c7759c9dbb1c923e250d67c11888426e3cad0"
+            "aarch64-darwin": "c0a187acca68906c4a6387e8fabd052cb031ace6132d60a71001d9a0e891958e",
+            "aarch64-linux": "61e03d4fa570976d80f740637f56192b6448a05a73d1fba9717900b29f2b1b4d",
+            "armv7l-linux": "ec774d9b1a1b828a0db1502a1017fcab1dfed99b1b6b2fd2308dd600a1efa98a",
+            "headers": "17f06fx4yidshmkdicis6k4azph95mxs1rwpm0ll53szpcs7rdss",
+            "x86_64-darwin": "fa5a46d752267d8497d375e19079e8b6a8df70c234a79b2d6b48f5862e1a0abc",
+            "x86_64-linux": "cc15a6e6206485a2d96649ceb60509b9da04fa2811c4824b2e0eb43d1f4b1417"
         },
-        "version": "34.1.1"
+        "version": "34.2.0"
     }
 }

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -161,13 +161,14 @@ in
 
   env =
     base.env
-    // lib.optionalAttrs (lib.versionOlder info.version "33" && stdenv.hostPlatform.isAarch64) {
+    // lib.optionalAttrs (lib.versionOlder info.version "33") {
       # Hydra fails to build electron_32.aarch64-linux as of 2025-01-05 due to
       # clang spamming deprecation warnings mid-build, causing the build log to
       # grow beyond the limit of 64mb and then getting killed by Hydra. This
       # renders our clang both too old for the latest chromium without the use
       # of -Wno-unknown-warning-option and also too new for electron_32 (M128).
-      # For some reason, this is exclusively happening on aarch64-linux. To
+      # For some reason, the log size limit appears to only be enforced on
+      # aarch64-linux. x86_64-linux happily succeeds to build with ~180mb. To
       # unbreak the build on h.n.o, we simply disable those warnings for now.
       # https://hydra.nixos.org/build/283952243
       NIX_CFLAGS_COMPILE = base.env.NIX_CFLAGS_COMPILE + " -Wno-deprecated";

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -988,10 +988,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-1Sl36LYp/tePk5ChWKv9ZCVcoEZECMEDKKiKvpO8ea8=",
+                "hash": "sha256-cOiflmkAzX0U7wFoGwxYDKMMrmSdjn18oXvguS6RSeY=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v33.4.0"
+                "rev": "v33.4.1"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1891,6 +1891,6 @@
         "electron_yarn_hash": "0bzsswcg62b39xinq5vikk7qz7d15276s2vc15v1gcb5wvh05ff8",
         "modules": "130",
         "node": "20.18.1",
-        "version": "33.4.0"
+        "version": "33.4.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -47,10 +47,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-pOWNw6MLjy7ucMGtF/sVPNmlmje0ozqRhEwOPkfW1oM=",
+                "hash": "sha256-3W6F30x90mLX1BdL9zY/YLShFRUGirokadzEg5QX6TU=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v32.3.0"
+                "rev": "v32.3.1"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -938,7 +938,7 @@
         "electron_yarn_hash": "122y1vnizwg0rwz8qf37mvpa0i78141y98wn4h11l6b9gyshrs65",
         "modules": "128",
         "node": "20.18.1",
-        "version": "32.3.0"
+        "version": "32.3.1"
     },
     "33": {
         "chrome": "130.0.6723.191",


### PR DESCRIPTION
- https://github.com/electron/electron/releases/tag/v32.3.1
- https://github.com/electron/electron/releases/tag/v33.4.1
- https://github.com/electron/electron/releases/tag/v34.2.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
