### PR TITLE
tinyssh: 20241201 -> 20250201; clean up

### DIFF
--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -1,6 +1,7 @@
-{ lib
-, stdenv
-, fetchFromGitHub
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -23,12 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   DESTDIR = placeholder "out";
 
-  meta = with lib; {
+  meta = {
     description = "Minimalistic SSH server";
     homepage = "https://tinyssh.org";
     changelog = "https://github.com/janmojzis/tinyssh/releases/tag/${finalAttrs.version}";
-    license = licenses.cc0;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ kaction ];
+    license = lib.licenses.cc0;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ kaction ];
   };
 })

--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -16,14 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-bcQDKDpd7HFnmJAyqcO+BQMGV1pCHuS+OhFPJSOMInI=";
   };
 
-  preConfigure = ''
-    echo /bin       > conf-bin
-    echo /share/man > conf-man
-  '';
-
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration";
 
-  DESTDIR = placeholder "out";
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinyssh";
-  version = "20241201";
+  version = "20250201";
 
   src = fetchFromGitHub {
     owner = "janmojzis";
     repo = "tinyssh";
     tag = finalAttrs.version;
-    hash = "sha256-bcQDKDpd7HFnmJAyqcO+BQMGV1pCHuS+OhFPJSOMInI=";
+    hash = "sha256-HX531QjRrDG4dshqzR03naZptUYnoZLEdv/CGpKOaD0=";
   };
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration";

--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -3,14 +3,14 @@
 , fetchFromGitHub
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tinyssh";
   version = "20241201";
 
   src = fetchFromGitHub {
     owner = "janmojzis";
     repo = "tinyssh";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-bcQDKDpd7HFnmJAyqcO+BQMGV1pCHuS+OhFPJSOMInI=";
   };
 
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Minimalistic SSH server";
     homepage = "https://tinyssh.org";
-    changelog = "https://github.com/janmojzis/tinyssh/releases/tag/${version}";
+    changelog = "https://github.com/janmojzis/tinyssh/releases/tag/${finalAttrs.version}";
     license = licenses.cc0;
     platforms = platforms.unix;
     maintainers = with maintainers; [ kaction ];
   };
-}
+})

--- a/pkgs/by-name/ti/tinyssh/package.nix
+++ b/pkgs/by-name/ti/tinyssh/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration";
 
   DESTDIR = placeholder "out";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Minimalistic SSH server";


### PR DESCRIPTION
- use `finalAttrs` pattern instead of `rec`
- remove use of `with lib;`
- re‐format according to RFC 166
- provide update script
- update to version 20250201

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
