### PR TITLE
ftb-app: init at 1.27.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16013,6 +16013,12 @@
     name = "Daniel Nagy";
     keys = [ { fingerprint = "F6AE 2C60 9196 A1BC ECD8  7108 1B8E 8DCB 576F B671"; } ];
   };
+  nagymathev = {
+    name = "Viktor Nagymathe";
+    email = "nagymathev@gmail.com";
+    github = "nagymathev";
+    githubId = 49335802;
+  };
   naho = {
     github = "trueNAHO";
     githubId = 90870942;

--- a/pkgs/by-name/ft/ftb-app/package.nix
+++ b/pkgs/by-name/ft/ftb-app/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  nix-update-script,
+}:
+let
+  pname = "ftb-app";
+  version = "1.27.2";
+
+  src =
+    let
+      src' =
+        {
+          aarch64-linux = {
+            url = "https://piston.feed-the-beast.com/app/ftb-app-linux-${version}-arm64.AppImage";
+            hash = "sha256-il7DIY1c5TDmRSzc86BTOCn4P20P3Wd4STkLGyFm2+c=";
+          };
+          x86_64-linux = {
+            url = "https://piston.feed-the-beast.com/app/ftb-app-linux-${version}-x86_64.AppImage";
+            hash = "sha256-35GEI1OBvVkUvHvQAzzGz8ux9h+5W3acH0Wr5VkqyBw=";
+          };
+        }
+        .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    in
+    fetchurl src';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Feed the Beast desktop app";
+    homepage = "https://www.feed-the-beast.com/ftb-app";
+    changelog = "https://www.feed-the-beast.com/ftb-app/changes#${version}";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ nagymathev ];
+    mainProgram = "ftb-app"; # This might need a change for darwin
+    platforms = with lib.platforms; linux;
+  };
+in
+let
+  appimageContents = appimageTools.extractType2 { inherit pname src version; };
+in
+appimageTools.wrapType2 {
+  inherit
+    pname
+    src
+    version
+    passthru
+    meta
+    ;
+
+  extraInstallCommands = ''
+    for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
+      install -Dm644 ${appimageContents}/usr/share/icons/hicolor/$size/apps/ftb-app.png \
+        $out/share/icons/hicolor/$size/apps/ftb-app.png
+    done
+
+    install -Dm644 ${appimageContents}/ftb-app.desktop \
+      $out/share/applications/ftb-app.desktop
+    substituteInPlace $out/share/applications/ftb-app.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=ftb-app'
+  '';
+}


### PR DESCRIPTION
Adds the [FTB App](https://www.feed-the-beast.com/ftb-app) Minecraft launcher that I use to play their modpacks, as those are not available on other platforms such as CurseForge that I would otherwise use with PrismLauncher.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
