### PR TITLE
incus.ui: 0.7 -> incus-0.14.6, rename to incus-ui-canonical

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -270,12 +270,9 @@ in
       };
 
       ui = {
-        enable = lib.mkEnableOption "(experimental) Incus UI";
+        enable = lib.mkEnableOption "Incus Web UI";
 
-        package = lib.mkPackageOption pkgs [
-          "incus"
-          "ui"
-        ] { };
+        package = lib.mkPackageOption pkgs [ "incus-ui-canonical" ] { };
       };
     };
   };

--- a/pkgs/by-name/in/incus-ui-canonical/package.nix
+++ b/pkgs/by-name/in/incus-ui-canonical/package.nix
@@ -11,7 +11,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "incus-ui";
+  pname = "incus-ui-canonical";
   version = "0.14.6";
 
   src = fetchFromGitHub {
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   passthru.tests.default = nixosTests.incus.ui;
 
   meta = {
-    description = "Web user interface for Incus, based on LXD webui";
+    description = "Web user interface for Incus";
     homepage = "https://github.com/zabbly/incus-ui-canonical";
     license = lib.licenses.gpl3;
     maintainers = lib.teams.lxc.members;

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -14,6 +14,7 @@
   fetchFromGitHub,
   acl,
   cowsql,
+  incus-ui-canonical,
   libcap,
   lxc,
   pkg-config,
@@ -126,7 +127,7 @@ buildGoModule rec {
 
     tests = if lts then nixosTests.incus-lts.all else nixosTests.incus.all;
 
-    ui = callPackage ./ui.nix { };
+    ui = lib.warnOnInstantiate "`incus.ui` renamed to `incus-ui-canonical`" incus-ui-canonical;
 
     updateScript = nix-update-script {
       extraArgs = nixUpdateExtraArgs;

--- a/pkgs/by-name/in/incus/ui.nix
+++ b/pkgs/by-name/in/incus/ui.nix
@@ -12,32 +12,28 @@
 
 stdenv.mkDerivation rec {
   pname = "incus-ui";
-  version = "0.7";
+  version = "0.14.6";
 
   src = fetchFromGitHub {
-    owner = "canonical";
-    repo = "lxd-ui";
-    rev = "refs/tags/${version}";
-    hash = "sha256-DJLkXZpParmEYHbTpl6KFC9l9y5DqzUTrC0pb2dJXI4=";
+    owner = "zabbly";
+    repo = "incus-ui-canonical";
+    tag = "incus-${version}";
+    hash = "sha256-An2mhIj3D2EdB1Bgnry1l2m6r/GIKTee4anSYNTq8B8=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-ckTWE/czzvxbGOF8fsJ3W1sal7+NaHquoSjZSPjkGj4=";
+    hash = "sha256-dkATFNjAPhrPbXhcJ/R4eIpcagKEwBSnRfLwqTPIe6c=";
   };
 
   zabbly = fetchFromGitHub {
     owner = "zabbly";
     repo = "incus";
-    rev = "c83023587eb0e3b01c99ba26e63f757ac15c6f9c";
-    hash = "sha256-cWKp4ALrae6nEBLvWcOM1T+Aca7eHLwsRguH9aSb10Y=";
+    rev = "36714d7c38eb3cc3e4e821c7aed44e066e1e84ca";
+    hash = "sha256-H6gjXmwCv3oGXrzn1NENfgO3CWXMnmp94GdJv2Q8n0w=";
   };
 
   patchPhase = ''
-    for p in $zabbly/patches/ui-canonical*patch; do
-      echo "applying patch $p"
-      git apply -p1 "$p"
-    done
     sed -i -f "$zabbly/patches/ui-canonical-renames.sed" src/*/*.ts* src/*/*/*.ts* src/*/*/*/*.ts*
   '';
 
@@ -80,7 +76,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Web user interface for Incus, based on LXD webui";
-    homepage = "https://github.com/canonical/lxd-ui";
+    homepage = "https://github.com/zabbly/incus-ui-canonical";
     license = lib.licenses.gpl3;
     maintainers = lib.teams.lxc.members;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
This updates the Incus web ui from the Canonical version (0.7) to the Zabbly fork as per https://github.com/zabbly/incus/commit/60b24e2672051e9b738da886398f9b26c2814f5c which was moved from a list of patches to a fork. The latest version is now `incus-0.14.6`.
Removed the patch code as it's no longer needed. (the patches upstream have been removed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
