### PR TITLE
python312Packages.python-on-whales: Fix pydantic dependency check

### DIFF
--- a/pkgs/development/python-modules/python-on-whales/default.nix
+++ b/pkgs/development/python-modules/python-on-whales/default.nix
@@ -34,6 +34,12 @@ buildPythonPackage rec {
     typer
   ];
 
+  # pythonRuntimeDepsCheck evaluates the more complex expression to 1.10.16 (!) and fails
+  configurePhase = ''
+    substituteInPlace requirements.txt \
+      --replace-fail "pydantic>=2,<3,!=2.0.*" "pydantic>=2.10.0,<3"
+  '';
+
   doCheck = false; # majority of tests require Docker and/or network access
 
   pythonImportsCheck = [ "python_on_whales" ];


### PR DESCRIPTION
When building python-on-whales, `nixpkgs-review` is getting Pydantic 1 despite asking for Pydantic 2:
```
 > Executing pythonRuntimeDepsCheck
 > Checking runtime dependencies for python_on_whales-0.75.1-py3-none-any.whl
 >   - pydantic!=2.0.*,<3,>=2 not satisfied by version 1.10.21
```

This replaces the expression with a more straightforward one. 

Fixes https://github.com/NixOS/nixpkgs/issues/379906

## Notes

1. ~~This seems to be an issue primarily on Darwin~~ I'm seeing it on x86_64-linux as well, running `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 382206"`
2. A previous PR for this was closed with the likelihood it was a stale cache, but the problem has returned.
3. Apologies for the lack of `nixpkgs-review`, my network can't afford the enormous download required.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
