### PR TITLE
python312Packages.neurokit2: fix

### DIFF
--- a/pkgs/development/python-modules/neurokit2/default.nix
+++ b/pkgs/development/python-modules/neurokit2/default.nix
@@ -1,22 +1,26 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
   setuptools,
-  pytest,
-  scipy,
-  scikit-learn,
-  pandas,
+
+  # dependencies
   matplotlib,
+  numpy,
+  pandas,
   requests,
-  cvxopt,
-  biosppy,
-  pytest-cov-stub,
-  mock,
-  plotly,
+  scikit-learn,
+  scipy,
+
+  # tests
   astropy,
   coverage,
+  mock,
+  plotly,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -34,22 +38,20 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail '"pytest-runner"' '"pytest"'
+      --replace-fail '"pytest-runner", ' ""
   '';
 
   build-system = [
     setuptools
-    pytest
   ];
 
   dependencies = [
-    scipy
-    scikit-learn
-    pandas
     matplotlib
+    numpy
+    pandas
     requests
-    cvxopt
-    biosppy
+    scikit-learn
+    scipy
   ];
 
   nativeCheckInputs = [
@@ -68,23 +70,31 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Required dependencies not available in nixpkgs
-    "tests/tests_complexity.py"
-    "tests/tests_eeg.py"
-    "tests/tests_eog.py"
-    "tests/tests_ecg.py"
     "tests/tests_bio.py"
+    "tests/tests_complexity.py"
     "tests/tests_data.py"
-    "tests/tests_epochs.py"
+    "tests/tests_ecg.py"
+    "tests/tests_ecg_delineate.py"
     "tests/tests_ecg_findpeaks.py"
     "tests/tests_eda.py"
+    "tests/tests_eeg.py"
     "tests/tests_emg.py"
+    "tests/tests_eog.py"
+    "tests/tests_epochs.py"
     "tests/tests_hrv.py"
-    "tests/tests_rsp.py"
     "tests/tests_ppg.py"
+    "tests/tests_rsp.py"
     "tests/tests_signal.py"
 
     # Dependency is broken `mne-python`
     "tests/tests_microstates.py"
+  ];
+
+  pytestFlagsArray = [
+    # Otherwise, test collection fails with:
+    # AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_builtins_signature'. Did you mean: 'grey_dilation_signature'?
+    # https://github.com/scipy/scipy/issues/22236
+    "--assert=plain"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Things done

```
=========================== short test summary info ============================
ERROR tests/tests_ecg_delineate.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_ecg_delineate.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_events.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_events.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_signal_fixpeaks.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_signal_fixpeaks.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_stats.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
ERROR tests/tests_stats.py - AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_bu...
!!!!!!!!!!!!!!!!!!! Interrupted: 8 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 8 errors in 17.62s ==============================
```

Full error message:
```
/nix/store/bpwhvv3n6dkii8nfpqgpvh6ynbsgszik-python3.12-pytest-8.3.4/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
/nix/store/7bgsk6y3vh6bf264pq10wm9yqh2f5p5c-python3.12-scipy-1.15.1/lib/python3.12/site-packages/scipy/ndimage/_support_alternative_backends.py:65: in <module>
    delegator = getattr(_delegators, func_name + "_signature")
E   AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_builtins_signature'. Did you mean: 'grey_dilation_signature'?
```

cc @genga898 

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
