### PR TITLE
drum-machine: init at 1.0.0

### DIFF
--- a/pkgs/by-name/dr/drum-machine/package.nix
+++ b/pkgs/by-name/dr/drum-machine/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  appstream,
+  desktop-file-utils,
+  fetchFromGitHub,
+  glib,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  python3Packages,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "drum-machine";
+  version = "1.0.0";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Revisto";
+    repo = "drum-machine";
+    tag = "v${version}";
+    hash = "sha256-7D9Cda0HILRC/RLySC7jEJ7QhoO2KOQBFNZtn9wD+54=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    glib
+    gobject-introspection
+    gtk4 # For `gtk-update-icon-theme`
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [ libadwaita ];
+
+  dependencies = with python3Packages; [
+    mido
+    pygame
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  # NOTE: `postCheck` is intentionally not used here, as the entire checkPhase
+  # is skipped by `buildPythonApplication`
+  # https://github.com/NixOS/nixpkgs/blob/9d4343b7b27a3e6f08fc22ead568233ff24bbbde/pkgs/development/interpreters/python/mk-python-derivation.nix#L296
+  postInstallCheck = ''
+    mesonCheckPhase
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Modern and intuitive application for creating, playing, and managing drum patterns";
+    homepage = "https://apps.gnome.org/DrumMachine";
+    changelog = "https://github.com/Revisto/drum-machine/releases/tag/${src.tag}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = lib.teams.gnome-circle.members;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
[drum-machine](https://apps.gnome.org/DrumMachine) is a modern and intuitive application for creating, playing, and managing drum patterns.

It was recently [accepted into the GNOME Circle](https://thisweek.gnome.org/posts/2025/02/twig-187/#gnome-circle-apps-and-libraries)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
