### PR TITLE
xfce.thunar-vcs-plugin: init at 0.3.0

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -43,6 +43,8 @@ makeScopeWithSplicing' {
 
       thunar-media-tags-plugin = callPackage ./thunar-plugins/media-tags { };
 
+      thunar-vcs-plugin = callPackage ./thunar-plugins/vcs { };
+
       tumbler = callPackage ./core/tumbler { };
 
       xfce4-panel = callPackage ./core/xfce4-panel { };

--- a/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  mkXfceDerivation,
+  thunar,
+  exo,
+  libxfce4util,
+  subversion,
+  apr,
+  aprutil,
+  withSubversion ? false,
+}:
+mkXfceDerivation {
+  category = "thunar-plugins";
+  pname = "thunar-vcs-plugin";
+  version = "0.3.0";
+  odd-unstable = false;
+
+  sha256 = "sha256-e9t6lIsvaV/2AAL/7I4Pbcokvy7Lp2+D9sJefTZqB1g=";
+
+  buildInputs =
+    [
+      thunar
+      exo
+      libxfce4util
+    ]
+    ++ lib.optionals withSubversion [
+      apr
+      aprutil
+      subversion
+    ];
+
+  meta = {
+    description = "Thunar plugin providing support for Subversion and Git";
+    maintainers = with lib.maintainers; [ lordmzte ] ++ lib.teams.xfce.members;
+  };
+}

--- a/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
@@ -4,6 +4,8 @@
   thunar,
   exo,
   libxfce4util,
+  gtk3,
+  glib,
   subversion,
   apr,
   aprutil,
@@ -22,6 +24,8 @@ mkXfceDerivation {
       thunar
       exo
       libxfce4util
+      gtk3
+      glib
     ]
     ++ lib.optionals withSubversion [
       apr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds [thunar-vcs-plugin](https://gitlab.xfce.org/thunar-plugins/thunar-vcs-plugin/) to the `xfce` package group. The plugin adds functionality for Git and Subversion to Thunar.

Closes #334093

A review by the Xfce team would be appreciated!
@bobby285271 @romildo @muscaln

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc