### PR TITLE
buildRustPackage: support fixed-point arguments via lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -18,6 +18,18 @@
   windows,
 }:
 
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
+    "depsExtraArgs"
+    "cargoUpdateHook"
+    "cargoDeps"
+    "cargoLock"
+  ];
+
+  extendDrvArgs =
+    finalAttrs:
 {
   name ? "${args.pname}-${args.version}",
 
@@ -119,15 +131,7 @@ let
   target = stdenv.hostPlatform.rust.rustcTargetSpec;
   targetIsJSON = lib.hasSuffix ".json" target;
 in
-
-stdenv.mkDerivation (
-  (removeAttrs args [
-    "depsExtraArgs"
-    "cargoUpdateHook"
-    "cargoDeps"
-    "cargoLock"
-  ])
-  // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
+  lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
     RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
   }
   // {
@@ -194,5 +198,5 @@ stdenv.mkDerivation (
       # default to Rust's platforms
       platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
     };
-  }
-)
+  };
+}

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -30,173 +30,173 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? "${args.pname}-${args.version}",
+    {
+      name ? "${args.pname}-${args.version}",
 
-  # Name for the vendored dependencies tarball
-  cargoDepsName ? name,
+      # Name for the vendored dependencies tarball
+      cargoDepsName ? name,
 
-  src ? null,
-  srcs ? null,
-  preUnpack ? null,
-  unpackPhase ? null,
-  postUnpack ? null,
-  cargoPatches ? [ ],
-  patches ? [ ],
-  sourceRoot ? null,
-  cargoRoot ? null,
-  logLevel ? "",
-  buildInputs ? [ ],
-  nativeBuildInputs ? [ ],
-  cargoUpdateHook ? "",
-  cargoDepsHook ? "",
-  buildType ? "release",
-  meta ? { },
-  useFetchCargoVendor ? false,
-  cargoDeps ? null,
-  cargoLock ? null,
-  cargoVendorDir ? null,
-  checkType ? buildType,
-  buildNoDefaultFeatures ? false,
-  checkNoDefaultFeatures ? buildNoDefaultFeatures,
-  buildFeatures ? [ ],
-  checkFeatures ? buildFeatures,
-  useNextest ? false,
-  auditable ? !cargo-auditable.meta.broken,
+      src ? null,
+      srcs ? null,
+      preUnpack ? null,
+      unpackPhase ? null,
+      postUnpack ? null,
+      cargoPatches ? [ ],
+      patches ? [ ],
+      sourceRoot ? null,
+      cargoRoot ? null,
+      logLevel ? "",
+      buildInputs ? [ ],
+      nativeBuildInputs ? [ ],
+      cargoUpdateHook ? "",
+      cargoDepsHook ? "",
+      buildType ? "release",
+      meta ? { },
+      useFetchCargoVendor ? false,
+      cargoDeps ? null,
+      cargoLock ? null,
+      cargoVendorDir ? null,
+      checkType ? buildType,
+      buildNoDefaultFeatures ? false,
+      checkNoDefaultFeatures ? buildNoDefaultFeatures,
+      buildFeatures ? [ ],
+      checkFeatures ? buildFeatures,
+      useNextest ? false,
+      auditable ? !cargo-auditable.meta.broken,
 
-  depsExtraArgs ? { },
+      depsExtraArgs ? { },
 
-  # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
-  # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
-  # case for `rustfmt`/etc from the `rust-sources).
-  # Otherwise, everything from the tarball would've been built/tested.
-  buildAndTestSubdir ? null,
-  ...
-}@args:
+      # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
+      # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
+      # case for `rustfmt`/etc from the `rust-sources).
+      # Otherwise, everything from the tarball would've been built/tested.
+      buildAndTestSubdir ? null,
+      ...
+    }@args:
 
-let
+    let
 
-  cargoDeps' =
-    if cargoVendorDir != null then
-      null
-    else if cargoDeps != null then
-      cargoDeps
-    else if cargoLock != null then
-      importCargoLock cargoLock
-    else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
-      throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
-    else if useFetchCargoVendor then
-      fetchCargoVendor (
-        {
-          inherit
-            src
-            srcs
-            sourceRoot
-            cargoRoot
-            preUnpack
-            unpackPhase
-            postUnpack
-            ;
-          name = cargoDepsName;
-          patches = cargoPatches;
-          hash = args.cargoHash;
-        }
-        // depsExtraArgs
-      )
-    else
-      fetchCargoTarball (
-        {
-          inherit
-            src
-            srcs
-            sourceRoot
-            cargoRoot
-            preUnpack
-            unpackPhase
-            postUnpack
-            cargoUpdateHook
-            ;
-          name = cargoDepsName;
-          patches = cargoPatches;
-        }
-        // lib.optionalAttrs (args ? cargoHash) {
-          hash = args.cargoHash;
-        }
-        // lib.optionalAttrs (args ? cargoSha256) {
-          sha256 = lib.warn "cargoSha256 is deprecated. Please use cargoHash with SRI hash instead" args.cargoSha256;
-        }
-        // depsExtraArgs
-      );
+      cargoDeps' =
+        if cargoVendorDir != null then
+          null
+        else if cargoDeps != null then
+          cargoDeps
+        else if cargoLock != null then
+          importCargoLock cargoLock
+        else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
+          throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
+        else if useFetchCargoVendor then
+          fetchCargoVendor (
+            {
+              inherit
+                src
+                srcs
+                sourceRoot
+                cargoRoot
+                preUnpack
+                unpackPhase
+                postUnpack
+                ;
+              name = cargoDepsName;
+              patches = cargoPatches;
+              hash = args.cargoHash;
+            }
+            // depsExtraArgs
+          )
+        else
+          fetchCargoTarball (
+            {
+              inherit
+                src
+                srcs
+                sourceRoot
+                cargoRoot
+                preUnpack
+                unpackPhase
+                postUnpack
+                cargoUpdateHook
+                ;
+              name = cargoDepsName;
+              patches = cargoPatches;
+            }
+            // lib.optionalAttrs (args ? cargoHash) {
+              hash = args.cargoHash;
+            }
+            // lib.optionalAttrs (args ? cargoSha256) {
+              sha256 = lib.warn "cargoSha256 is deprecated. Please use cargoHash with SRI hash instead" args.cargoSha256;
+            }
+            // depsExtraArgs
+          );
 
-  target = stdenv.hostPlatform.rust.rustcTargetSpec;
-  targetIsJSON = lib.hasSuffix ".json" target;
-in
-  lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
-    RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
-  }
-  // {
-    cargoDeps = cargoDeps';
-    inherit buildAndTestSubdir;
+      target = stdenv.hostPlatform.rust.rustcTargetSpec;
+      targetIsJSON = lib.hasSuffix ".json" target;
+    in
+    lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
+      RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
+    }
+    // {
+      cargoDeps = cargoDeps';
+      inherit buildAndTestSubdir;
 
-    cargoBuildType = buildType;
+      cargoBuildType = buildType;
 
-    cargoCheckType = checkType;
+      cargoCheckType = checkType;
 
-    cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
+      cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
 
-    cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
+      cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
 
-    cargoBuildFeatures = buildFeatures;
+      cargoBuildFeatures = buildFeatures;
 
-    cargoCheckFeatures = checkFeatures;
+      cargoCheckFeatures = checkFeatures;
 
-    nativeBuildInputs =
-      nativeBuildInputs
-      ++ lib.optionals auditable [
-        (buildPackages.cargo-auditable-cargo-wrapper.override {
-          inherit cargo cargo-auditable;
-        })
-      ]
-      ++ [
-        cargoBuildHook
-        (if useNextest then cargoNextestHook else cargoCheckHook)
-        cargoInstallHook
-        cargoSetupHook
-        rustc
-        cargo
-      ];
+      nativeBuildInputs =
+        nativeBuildInputs
+        ++ lib.optionals auditable [
+          (buildPackages.cargo-auditable-cargo-wrapper.override {
+            inherit cargo cargo-auditable;
+          })
+        ]
+        ++ [
+          cargoBuildHook
+          (if useNextest then cargoNextestHook else cargoCheckHook)
+          cargoInstallHook
+          cargoSetupHook
+          rustc
+          cargo
+        ];
 
-    buildInputs =
-      buildInputs
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
-      ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
+      buildInputs =
+        buildInputs
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
+        ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
 
-    patches = cargoPatches ++ patches;
+      patches = cargoPatches ++ patches;
 
-    PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+      PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
 
-    postUnpack =
-      ''
-        eval "$cargoDepsHook"
+      postUnpack =
+        ''
+          eval "$cargoDepsHook"
 
-        export RUST_LOG=${logLevel}
-      ''
-      + (args.postUnpack or "");
+          export RUST_LOG=${logLevel}
+        ''
+        + (args.postUnpack or "");
 
-    configurePhase =
-      args.configurePhase or ''
-        runHook preConfigure
-        runHook postConfigure
-      '';
+      configurePhase =
+        args.configurePhase or ''
+          runHook preConfigure
+          runHook postConfigure
+        '';
 
-    doCheck = args.doCheck or true;
+      doCheck = args.doCheck or true;
 
-    strictDeps = true;
+      strictDeps = true;
 
-    meta = meta // {
-      badPlatforms = meta.badPlatforms or [ ] ++ rustc.badTargetPlatforms;
-      # default to Rust's platforms
-      platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
+      meta = meta // {
+        badPlatforms = meta.badPlatforms or [ ] ++ rustc.badTargetPlatforms;
+        # default to Rust's platforms
+        platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
+      };
     };
-  };
 }

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -62,12 +62,6 @@
   ...
 }@args:
 
-assert
-  cargoVendorDir == null && cargoDeps == null && cargoLock == null
-  ->
-    !(args ? cargoSha256 && args.cargoSha256 != null) && !(args ? cargoHash && args.cargoHash != null)
-  -> throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set";
-
 let
 
   cargoDeps' =
@@ -77,6 +71,8 @@ let
       cargoDeps
     else if cargoLock != null then
       importCargoLock cargoLock
+    else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
+      throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
     else if useFetchCargoVendor then
       fetchCargoVendor (
         {

--- a/pkgs/by-name/ui/uiua/package.nix
+++ b/pkgs/by-name/ui/uiua/package.nix
@@ -30,77 +30,75 @@ let
     .${uiua_versionType};
 in
 
-# buildRustPackage doesn't support finalAttrs, so we can't use finalPackage for the tests
-lib.fix (
-  uiua:
-  rustPlatform.buildRustPackage rec {
-    pname = "uiua";
-    inherit (versionInfo) version cargoHash;
-    useFetchCargoVendor = true;
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "uiua";
+  inherit (versionInfo) version cargoHash;
+  useFetchCargoVendor = true;
 
-    src = fetchFromGitHub {
-      owner = "uiua-lang";
-      repo = "uiua";
-      inherit (versionInfo) tag hash;
-    };
+  src = fetchFromGitHub {
+    owner = "uiua-lang";
+    repo = "uiua";
+    inherit (versionInfo) tag hash;
+  };
 
-    nativeBuildInputs =
-      lib.optionals (webcamSupport || stdenv.hostPlatform.isDarwin) [ rustPlatform.bindgenHook ]
-      ++ lib.optionals audioSupport [ pkg-config ];
+  nativeBuildInputs =
+    lib.optionals (webcamSupport || stdenv.hostPlatform.isDarwin) [ rustPlatform.bindgenHook ]
+    ++ lib.optionals audioSupport [ pkg-config ];
 
-    buildInputs =
-      [ libffi ] # we force dynamic linking our own libffi below
-      ++ lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
+  buildInputs =
+    [ libffi ] # we force dynamic linking our own libffi below
+    ++ lib.optionals (audioSupport && stdenv.hostPlatform.isLinux) [ alsa-lib ];
 
-    buildFeatures =
-      [ "libffi/system" ] # force libffi to be linked dynamically instead of rebuilding it
-      ++ lib.optional audioSupport "audio"
-      ++ lib.optional webcamSupport "webcam"
-      ++ lib.optional windowSupport "window";
+  buildFeatures =
+    [ "libffi/system" ] # force libffi to be linked dynamically instead of rebuilding it
+    ++ lib.optional audioSupport "audio"
+    ++ lib.optional webcamSupport "webcam"
+    ++ lib.optional windowSupport "window";
 
-    postFixup =
-      let
-        runtimeDependencies = lib.optionals windowSupport [
-          libGL
-          libxkbcommon
-          wayland
-          xorg.libX11
-          xorg.libXcursor
-          xorg.libXi
-          xorg.libXrandr
-        ];
-      in
-      lib.optionalString (runtimeDependencies != [ ] && stdenv.hostPlatform.isLinux) ''
-        patchelf --add-rpath ${lib.makeLibraryPath runtimeDependencies} $out/bin/uiua
-      '';
-
-    nativeInstallCheckInputs = [ versionCheckHook ];
-    versionCheckProgramArg = "--version";
-    doInstallCheck = true;
-
-    passthru.updateScript = versionInfo.updateScript;
-    passthru.tests.run = runCommand "uiua-test-run" { nativeBuildInputs = [ uiua ]; } ''
-      uiua init
-      diff -U3 --color=auto <(uiua run main.ua) <(echo '"Hello, World!"')
-      touch $out
+  postFixup =
+    let
+      runtimeDependencies = lib.optionals windowSupport [
+        libGL
+        libxkbcommon
+        wayland
+        xorg.libX11
+        xorg.libXcursor
+        xorg.libXi
+        xorg.libXrandr
+      ];
+    in
+    lib.optionalString (runtimeDependencies != [ ] && stdenv.hostPlatform.isLinux) ''
+      patchelf --add-rpath ${lib.makeLibraryPath runtimeDependencies} $out/bin/uiua
     '';
 
-    meta = {
-      changelog = "https://github.com/uiua-lang/uiua/blob/${src.rev}/changelog.md";
-      description = "Stack-oriented array programming language with a focus on simplicity, beauty, and tacit code";
-      longDescription = ''
-        Uiua combines the stack-oriented and array-oriented paradigms in a single
-        language. Combining these already terse paradigms results in code with a very
-        high information density and little syntactic noise.
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = versionInfo.updateScript;
+  passthru.tests.run =
+    runCommand "uiua-test-run" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+      ''
+        uiua init
+        diff -U3 --color=auto <(uiua run main.ua) <(echo '"Hello, World!"')
+        touch $out
       '';
-      homepage = "https://www.uiua.org/";
-      license = lib.licenses.mit;
-      mainProgram = "uiua";
-      maintainers = with lib.maintainers; [
-        cafkafk
-        tomasajt
-        defelo
-      ];
-    };
-  }
-)
+
+  meta = {
+    changelog = "https://github.com/uiua-lang/uiua/blob/${finalAttrs.src.rev}/changelog.md";
+    description = "Stack-oriented array programming language with a focus on simplicity, beauty, and tacit code";
+    longDescription = ''
+      Uiua combines the stack-oriented and array-oriented paradigms in a single
+      language. Combining these already terse paradigms results in code with a very
+      high information density and little syntactic noise.
+    '';
+    homepage = "https://www.uiua.org/";
+    license = lib.licenses.mit;
+    mainProgram = "uiua";
+    maintainers = with lib.maintainers; [
+      cafkafk
+      tomasajt
+      defelo
+    ];
+  };
+})


### PR DESCRIPTION
This PR enables `buildRustPackage` to take `finalAttrs: { ... }` with the help of `lib.extendMkDerivation` introduced in #234651.

The large diff block is due to indentation changes, while the effective diff is minimal. Commit-by-commit review would be much easier.

I cherry-picked the `uiua` package transition from #354999 to validate the implementation. Other transition examples in #194475 and #354999 seems no longer relevant.

This PR doesn't address the existing overriding issues of the `buildRustPackage` arguments (such as `cargoHash`). They will be addressed in subsequent PRs with the help of `finalAttrs`, just like #225051 and #379602.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (Ne rebuilds or clean-ups.)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
