### PR TITLE
droidcam-obs: 2.0.2 -> 2.3.4; modernize

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
@@ -10,22 +10,22 @@
   libplist,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "droidcam-obs";
   version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "dev47apps";
     repo = "droidcam-obs-plugin";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-YtfWwgBhyQYx6QfrKld7p6qUf8BEV/kkQX4QcdHuaYU=";
   };
 
   postPatch = ''
     substituteInPlace ./linux/linux.mk \
-      --replace "-limobiledevice" "-limobiledevice-1.0" \
-      --replace "-I/usr/include/obs" "-I${obs-studio}/include/obs" \
-      --replace "-I/usr/include/ffmpeg" "-I${ffmpeg}/include"
+      --replace-fail "-limobiledevice" "-limobiledevice-1.0" \
+      --replace-fail "-I/usr/include/obs" "-I${obs-studio}/include/obs" \
+      --replace-fail "-I/usr/include/ffmpeg" "-I${ffmpeg}/include"
   '';
 
   preBuild = ''
@@ -61,12 +61,11 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "DroidCam OBS";
     homepage = "https://github.com/dev47apps/droidcam-obs-plugin";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ulrikstrid ];
-    platforms = platforms.linux;
-    broken = true;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ulrikstrid ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
@@ -8,8 +8,8 @@
   libimobiledevice,
   libusbmuxd,
   libplist,
+  pkg-config,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "droidcam-obs";
   version = "2.3.4";
@@ -34,13 +34,22 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
   ];
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  # Flag reference in regard to:
+  # https://github.com/dev47apps/droidcam-obs-plugin/blob/master/linux/linux.mk
   makeFlags = [
     "ALLOW_STATIC=no"
     "JPEG_DIR=${lib.getDev libjpeg}"
     "JPEG_LIB=${lib.getLib libjpeg}/lib"
-    "IMOBILEDEV_DIR=${libimobiledevice}"
+    "IMOBILEDEV_DIR=${lib.getDev libimobiledevice}"
+    "IMOBILEDEV_DIR=${lib.getLib libimobiledevice}"
     "LIBOBS_INCLUDES=${obs-studio}/include/obs"
     "FFMPEG_INCLUDES=${lib.getLib ffmpeg}"
+    "LIBUSBMUXD=libusbmuxd-2.0"
+    "LIBIMOBILEDEV=libimobiledevice-1.0"
   ];
 
   installPhase = ''

--- a/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
@@ -12,21 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "droidcam-obs";
-  version = "2.0.2";
+  version = "2.3.4";
 
   src = fetchFromGitHub {
     owner = "dev47apps";
     repo = "droidcam-obs-plugin";
     tag = finalAttrs.version;
-    sha256 = "sha256-YtfWwgBhyQYx6QfrKld7p6qUf8BEV/kkQX4QcdHuaYU=";
+    sha256 = "sha256-KWMLhddK561xA+EjvoG4tXRW4xoLil31JcTTfppblmA=";
   };
-
-  postPatch = ''
-    substituteInPlace ./linux/linux.mk \
-      --replace-fail "-limobiledevice" "-limobiledevice-1.0" \
-      --replace-fail "-I/usr/include/obs" "-I${obs-studio}/include/obs" \
-      --replace-fail "-I/usr/include/ffmpeg" "-I${ffmpeg}/include"
-  '';
 
   preBuild = ''
     mkdir ./build
@@ -46,6 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
     "JPEG_DIR=${lib.getDev libjpeg}"
     "JPEG_LIB=${lib.getLib libjpeg}/lib"
     "IMOBILEDEV_DIR=${libimobiledevice}"
+    "LIBOBS_INCLUDES=${obs-studio}/include/obs"
+    "FFMPEG_INCLUDES=${lib.getLib ffmpeg}"
   ];
 
   installPhase = ''

--- a/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/droidcam-obs/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "DroidCam OBS";
     homepage = "https://github.com/dev47apps/droidcam-obs-plugin";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ ulrikstrid ];
+    maintainers = with lib.maintainers; [ NotAShelf ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Gets rid of `rec` and nested `with lib`. Also replaces `rev` with `tag`.

Closes #382509, though that is moreso related to the update in obs-studio.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
