### PR TITLE
nixos/clevis: fix luks support

### DIFF
--- a/nixos/modules/system/boot/clevis.nix
+++ b/nixos/modules/system/boot/clevis.nix
@@ -77,6 +77,9 @@ in
         copy_bin_and_libs ${pkgs.jose}/bin/jose
         copy_bin_and_libs ${pkgs.curl}/bin/curl
         copy_bin_and_libs ${pkgs.bashNonInteractive}/bin/bash
+        copy_bin_and_libs ${pkgs.cryptsetup}/bin/cryptsetup
+        copy_bin_and_libs ${pkgs.gnused}/bin/gnused
+        copy_bin_and_libs ${pkgs.gnugrep}/bin/gnugrep
 
         copy_bin_and_libs ${pkgs.tpm2-tools}/bin/.tpm2-wrapped
         mv $out/bin/{.tpm2-wrapped,tpm2}
@@ -103,13 +106,15 @@ in
       systemd = {
         extraBin = lib.mkIf systemd.enable {
           clevis = "${cfg.package}/bin/clevis";
-          curl = "${pkgs.curl}/bin/curl";
         };
 
         storePaths = lib.mkIf systemd.enable [
           cfg.package
           "${pkgs.jose}/bin/jose"
           "${pkgs.curl}/bin/curl"
+          "${pkgs.cryptsetup}/bin/cryptsetup"
+          "${pkgs.gnused}/bin/sed"
+          "${pkgs.gnugrep}/bin/grep"
           "${pkgs.tpm2-tools}/bin/tpm2_createprimary"
           "${pkgs.tpm2-tools}/bin/tpm2_flushcontext"
           "${pkgs.tpm2-tools}/bin/tpm2_load"


### PR DESCRIPTION
Add missing packages when clevis is used for luks unlock It is not needed to expose all execuables via extraBin, therefor removed curl.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
