### PR TITLE
musl: apply patch for CVE-2025-26519

### DIFF
--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -78,6 +78,16 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/openwrt/openwrt/87606e25afac6776d1bbc67ed284434ec5a832b4/toolchain/musl/patches/300-relative.patch";
       sha256 = "0hfadrycb60sm6hb6by4ycgaqc9sgrhh42k39v8xpmcvdzxrsq2n";
     })
+    (fetchurl {
+      name = "CVE-2025-26519_0.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/1";
+      hash = "sha256-CJb821El2dByP04WXxPCCYMOcEWnXLpOhYBgg3y3KS4=";
+    })
+    (fetchurl {
+      name = "CVE-2025-26519_1.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/2";
+      hash = "sha256-BiD87k6KTlLr4ep14rUdIZfr2iQkicBYaSTq+p6WBqE=";
+    })
   ];
   CFLAGS = [
     "-fstack-protector-strong"


### PR DESCRIPTION
https://www.openwall.com/lists/musl/2025/02/13/1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 382587`

---
### `aarch64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:x: 8 packages failed to build:</summary>
  <ul>
    <li>graalvmPackages.graalvm-ce-musl</li>
    <li>nixStatic</li>
    <li>nixStatic.dev</li>
    <li>nixStatic.doc</li>
    <li>nixStatic.man</li>
    <li>nixVersions.nix_2_26.dev</li>
    <li>wrangler</li>
    <li>zon2nix</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 222 packages built:</summary>
  <ul>
    <li>appvm</li>
    <li>attic-client</li>
    <li>attic-server</li>
    <li>bower2nix</li>
    <li>bundix</li>
    <li>busybox-sandbox-shell</li>
    <li>busybox-sandbox-shell.debug</li>
    <li>cabal2nix</li>
    <li>cached-nix-shell</li>
    <li>cachix (cachix.bin ,cachix.doc ,haskellPackages.cachix.bin)</li>
    <li>chirpstack-concentratord</li>
    <li>colmena</li>
    <li>common-updater-scripts</li>
    <li>crate2nix</li>
    <li>crystal2nix</li>
    <li>devenv</li>
    <li>disko</li>
    <li>dub-to-nix</li>
    <li>dydisnix</li>
    <li>fusionInventory</li>
    <li>gcalcli</li>
    <li>gcalcli.dist</li>
    <li>getoptions</li>
    <li>git-unroll</li>
    <li>glpi-agent</li>
    <li>gns3-server</li>
    <li>gns3-server.dist</li>
    <li>haskellPackages.cabal2nix-unstable</li>
    <li>haskellPackages.cachix</li>
    <li>haskellPackages.cachix.doc</li>
    <li>haskellPackages.cli-nix</li>
    <li>haskellPackages.cli-nix.doc</li>
    <li>haskellPackages.hercules-ci-agent</li>
    <li>haskellPackages.hercules-ci-agent.doc</li>
    <li>haskellPackages.hercules-ci-cli</li>
    <li>haskellPackages.hercules-ci-cli.doc</li>
    <li>haskellPackages.hercules-ci-cnix-expr</li>
    <li>haskellPackages.hercules-ci-cnix-expr.doc</li>
    <li>haskellPackages.hercules-ci-cnix-store</li>
    <li>haskellPackages.hercules-ci-cnix-store.doc</li>
    <li>haskellPackages.niv</li>
    <li>haskellPackages.niv.bin</li>
    <li>haskellPackages.niv.data</li>
    <li>haskellPackages.niv.doc</li>
    <li>haskellPackages.nix-paths</li>
    <li>haskellPackages.nix-paths.doc</li>
    <li>haskellPackages.nix-serve-ng</li>
    <li>haskellPackages.nix-serve-ng.doc</li>
    <li>haskellPackages.nix-thunk</li>
    <li>haskellPackages.nix-thunk.doc</li>
    <li>haskellPackages.nvfetcher</li>
    <li>haskellPackages.nvfetcher.doc</li>
    <li>haskellPackages.update-nix-fetchgit</li>
    <li>haskellPackages.update-nix-fetchgit.doc</li>
    <li>hci</li>
    <li>hercules-ci-agent</li>
    <li>home-manager</li>
    <li>hydra</li>
    <li>hydra.doc</li>
    <li>jetbrains.clion</li>
    <li>jetbrains.idea-ultimate</li>
    <li>jetbrains.phpstorm</li>
    <li>jetbrains.pycharm-professional</li>
    <li>jetbrains.rider</li>
    <li>jetbrains.ruby-mine</li>
    <li>jetbrains.webstorm</li>
    <li>jetbrains.writerside</li>
    <li>kcl</li>
    <li>libnixxml</li>
    <li>lix (lixVersions.latest ,lixVersions.lix_2_91 ,lixVersions.stable)</li>
    <li>lix.debug (lixVersions.latest.debug ,lixVersions.lix_2_91.debug ,lixVersions.stable.debug)</li>
    <li>lix.dev (lixVersions.latest.dev ,lixVersions.lix_2_91.dev ,lixVersions.stable.dev)</li>
    <li>lix.devdoc (lixVersions.latest.devdoc ,lixVersions.lix_2_91.devdoc ,lixVersions.stable.devdoc)</li>
    <li>lix.doc (lixVersions.latest.doc ,lixVersions.lix_2_91.doc ,lixVersions.stable.doc)</li>
    <li>lix.man (lixVersions.latest.man ,lixVersions.lix_2_91.man ,lixVersions.stable.man)</li>
    <li>lixStatic</li>
    <li>lixStatic.dev</li>
    <li>lixVersions.lix_2_90</li>
    <li>lixVersions.lix_2_90.debug</li>
    <li>lixVersions.lix_2_90.dev</li>
    <li>lixVersions.lix_2_90.devdoc</li>
    <li>lixVersions.lix_2_90.doc</li>
    <li>lixVersions.lix_2_90.man</li>
    <li>lua51Packages.luarocks-nix</li>
    <li>luarocks-nix (luaPackages.luarocks-nix)</li>
    <li>lua53Packages.luarocks-nix</li>
    <li>lua54Packages.luarocks-nix</li>
    <li>luajitPackages.luarocks-nix</li>
    <li>luarocks-packages-updater</li>
    <li>luarocks-packages-updater.dist</li>
    <li>mmseqs2</li>
    <li>musl</li>
    <li>musl.bin</li>
    <li>musl.debug</li>
    <li>musl.dev</li>
    <li>muslCross</li>
    <li>muslCross.bin</li>
    <li>muslCross.debug</li>
    <li>muslCross.dev</li>
    <li>nil</li>
    <li>nim_lk</li>
    <li>niv (niv.bin ,niv.data)</li>
    <li>nix (nixVersions.nix_2_24 ,nixVersions.stable)</li>
    <li>nix-bundle</li>
    <li>nix-direnv</li>
    <li>nix-du</li>
    <li>nix-eval-jobs</li>
    <li>nix-fast-build</li>
    <li>nix-fast-build.dist</li>
    <li>nix-forecast</li>
    <li>nix-index</li>
    <li>nix-init</li>
    <li>nix-inspect</li>
    <li>nix-pin</li>
    <li>nix-plugin-pijul</li>
    <li>nix-plugins</li>
    <li>nix-prefetch</li>
    <li>nix-prefetch-bzr</li>
    <li>nix-prefetch-cvs</li>
    <li>nix-prefetch-docker</li>
    <li>nix-prefetch-git</li>
    <li>nix-prefetch-hg</li>
    <li>nix-prefetch-scripts</li>
    <li>nix-prefetch-svn</li>
    <li>nix-required-mounts</li>
    <li>nix-required-mounts.dist</li>
    <li>nix-serve</li>
    <li>nix-serve-ng</li>
    <li>nix-template</li>
    <li>nix-unit</li>
    <li>nix-update</li>
    <li>nix-update-source</li>
    <li>nix-update-source.dist</li>
    <li>nix-update.dist</li>
    <li>nix-visualize</li>
    <li>nix-visualize.dist</li>
    <li>nix-web</li>
    <li>nix.debug (nixVersions.nix_2_24.debug ,nixVersions.stable.debug)</li>
    <li>nix.dev (nixVersions.nix_2_24.dev ,nixVersions.stable.dev)</li>
    <li>nix.doc (nixVersions.nix_2_24.doc ,nixVersions.stable.doc)</li>
    <li>nix.man (nixVersions.nix_2_24.man ,nixVersions.stable.man)</li>
    <li>nixVersions.git</li>
    <li>nixVersions.git.debug</li>
    <li>nixVersions.git.dev</li>
    <li>nixVersions.git.doc</li>
    <li>nixVersions.git.man</li>
    <li>nixVersions.latest (nixVersions.nix_2_25)</li>
    <li>nixVersions.latest.debug (nixVersions.nix_2_25.debug)</li>
    <li>nixVersions.latest.dev (nixVersions.nix_2_25.dev)</li>
    <li>nixVersions.latest.doc (nixVersions.nix_2_25.doc)</li>
    <li>nixVersions.latest.man (nixVersions.nix_2_25.man)</li>
    <li>nixVersions.minimum (nixVersions.nix_2_3)</li>
    <li>nixVersions.minimum.debug (nixVersions.nix_2_3.debug)</li>
    <li>nixVersions.minimum.dev (nixVersions.nix_2_3.dev)</li>
    <li>nixVersions.minimum.doc (nixVersions.nix_2_3.doc)</li>
    <li>nixVersions.minimum.man (nixVersions.nix_2_3.man)</li>
    <li>nixVersions.nix_2_26</li>
    <li>nixVersions.nix_2_26.devdoc</li>
    <li>nixVersions.nix_2_26.doc</li>
    <li>nixci</li>
    <li>nixd</li>
    <li>nixos-anywhere</li>
    <li>nixos-generators</li>
    <li>nixos-option</li>
    <li>nixos-rebuild</li>
    <li>nixos-rebuild-ng</li>
    <li>nixos-rebuild-ng.dist</li>
    <li>nixos-shell</li>
    <li>nixpkgs-hammering</li>
    <li>nixpkgs-manual</li>
    <li>nixpkgs-review</li>
    <li>nixpkgs-review.dist</li>
    <li>nixt</li>
    <li>nixt.dev</li>
    <li>nixtract</li>
    <li>node2nix</li>
    <li>npins</li>
    <li>nps</li>
    <li>nuget-to-json</li>
    <li>nuget-to-nix</li>
    <li>nurl</li>
    <li>nvfetcher</li>
    <li>outline</li>
    <li>pkgsMusl.stdenv</li>
    <li>pkgsStatic.stdenv</li>
    <li>prefetch-yarn-deps</li>
    <li>python312Packages.nix-kernel</li>
    <li>python312Packages.nix-kernel.dist</li>
    <li>python312Packages.nixpkgs</li>
    <li>python312Packages.nixpkgs-updaters-library</li>
    <li>python312Packages.nixpkgs-updaters-library.dist</li>
    <li>python312Packages.nixpkgs.dist</li>
    <li>python312Packages.pythonix</li>
    <li>python313Packages.nix-kernel</li>
    <li>python313Packages.nix-kernel.dist</li>
    <li>python313Packages.nixpkgs</li>
    <li>python313Packages.nixpkgs-updaters-library</li>
    <li>python313Packages.nixpkgs-updaters-library.dist</li>
    <li>python313Packages.nixpkgs.dist</li>
    <li>python313Packages.pythonix</li>
    <li>sbomnix</li>
    <li>sbomnix.dist</li>
    <li>sonarr</li>
    <li>swiftpm2nix (swiftPackages.swiftpm2nix)</li>
    <li>terranix</li>
    <li>tests.devShellTools.nixos</li>
    <li>tests.haskell.cabalSdist.hercules-ci-cnix-store</li>
    <li>tests.haskell.cabalSdist.hercules-ci-cnix-store.doc</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
    <li>tests.testers.nixosTest-example</li>
    <li>tests.testers.runNixOSTest-example</li>
    <li>tests.trivial-builders.references</li>
    <li>typescript-language-server</li>
    <li>update-nix-fetchgit</li>
    <li>update-python-libraries</li>
    <li>vimPluginsUpdater</li>
    <li>vulnix</li>
    <li>vulnix.dist</li>
    <li>vulnix.doc</li>
    <li>vulnix.man</li>
    <li>wp4nix</li>
    <li>yarn2nix</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
