### PR TITLE
pulumi: 3.122.0 -> 3.152.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -147,11 +147,11 @@ buildGo122Module rec {
   };
 
   meta = {
-    homepage = "https://pulumi.io/";
+    homepage = "https://www.pulumi.com";
     description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     license = lib.licenses.asl20;
-    platforms = lib.platforms.unix;
+    mainProgram = "pulumi";
     maintainers = with lib.maintainers; [
       trundle
       veehaitch

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -1,6 +1,6 @@
 {
-  stdenv,
   lib,
+  stdenv,
   buildGo122Module,
   coreutils,
   fetchFromGitHub,
@@ -146,13 +146,13 @@ buildGo122Module rec {
         '';
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pulumi.io/";
     description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
-    sourceProvenance = [ sourceTypes.fromSource ];
-    license = licenses.asl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       trundle
       veehaitch
       tie

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -155,6 +155,7 @@ buildGo122Module rec {
     maintainers = with maintainers; [
       trundle
       veehaitch
+      tie
     ];
   };
 }

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -1,127 +1,105 @@
 {
   lib,
   stdenv,
-  buildGo122Module,
-  coreutils,
+  buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
   installShellFiles,
   git,
   # passthru
   runCommand,
   makeWrapper,
+  testers,
   pulumi,
   pulumiPackages,
 }:
-
-# Using go 1.22 as pulumi 3.122.0 will not build with 1.23.
-# Issue: https://github.com/NixOS/nixpkgs/issues/351955
-# Upgrading pulumi version should fix it, but requires more involved changes, so
-# this is a temporary workaround.
-# Upgrade: https://github.com/NixOS/nixpkgs/pull/352221
-buildGo122Module rec {
+buildGoModule rec {
   pname = "pulumi";
-  version = "3.122.0";
+  version = "3.152.0";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-5KHptoQliqPtJ6J5u23ZgRZOdO77BJhZbdc3Cty9Myk=";
+    owner = "pulumi";
+    repo = "pulumi";
+    tag = "v${version}";
+    hash = "sha256-/cRWj7y6d5sNQRUXg9l7eDAOkUqNGXTzgpWDQdPP8zw=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-1UyYbmNNHlAeaW6M6AkaQ5Hs25ziHenSs4QjlnUQGjs=";
-
-  patches = [
-    # Fix a test failure, can be dropped in next release (3.100.0)
-    (fetchpatch {
-      url = "https://github.com/pulumi/pulumi/commit/6dba7192d134d3b6f7e26dee9205711ccc736fa7.patch";
-      hash = "sha256-QRN6XnIR2rrqJ4UFYNt/YmIlokTSkGUvnBO/Q9UN8X8=";
-      stripLen = 1;
-    })
-  ];
+  vendorHash = "sha256-JhIyivD+YpUUr9T8roNpINb3Tx8ZElHa+BrpJkyFx60=";
 
   sourceRoot = "${src.name}/pkg";
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # Bundle release metadata
+  nativeCheckInputs = [ git ];
+
+  # https://github.com/pulumi/pulumi/blob/3ec1aa75d5bf7103b283f46297321a9a4b1a8a33/.goreleaser.yml#L20-L26
+  tags = [ "osusergo" ];
   ldflags = [
-    # Omit the symbol table and debug information.
     "-s"
-    # Omit the DWARF symbol table.
     "-w"
-  ] ++ importpathFlags;
-
-  importpathFlags = [
-    "-X github.com/pulumi/pulumi/pkg/v3/version.Version=v${version}"
+    "-X=github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=v${version}"
   ];
 
-  nativeCheckInputs = [
-    git
+  excludedPackages = [
+    "util/generate"
+    "codegen/gen_program_test"
   ];
 
-  preCheck =
-    ''
-      # The tests require `version.Version` to be unset
-      ldflags=''${ldflags//"$importpathFlags"/}
+  # Required for user.Current implementation with osusergo on Darwin.
+  preCheck = ''
+    export HOME=$TMPDIR USER=nixbld
+  '';
 
-      # Create some placeholders for plugins used in tests. Otherwise, Pulumi
-      # tries to donwload them and fails, resulting in really long test runs
-      dummyPluginPath=$(mktemp -d)
-      for name in pulumi-{resource-pkg{A,B},-pkgB}; do
-        ln -s ${coreutils}/bin/true "$dummyPluginPath/$name"
-      done
+  checkFlags = [
+    # The tests require `version.Version` (i.e. ldflags) to be unset.
+    "-ldflags="
+    # Skip tests that fail in Nix sandbox.
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        # Seems to require TTY.
+        "TestProgressEvents"
 
-      export PATH=$dummyPluginPath''${PATH:+:}$PATH
+        # Tries to clone repo: https://github.com/pulumi/test-repo.git
+        "TestValidateRelativeDirectory"
+        "TestRepoLookup"
+        "TestDSConfigureGit"
 
-      # Code generation tests also download dependencies from network
-      rm codegen/{docs,dotnet,go,nodejs,python,schema}/*_test.go
-      rm -R codegen/{dotnet,go,nodejs,python}/gen_program_test
-
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      export PULUMI_HOME=$(mktemp -d)
-    '';
-
-  checkFlags =
-    let
-      disabledTests = [
-        # Flaky test
-        "TestPendingDeleteOrder"
         # Tries to clone repo: github.com/pulumi/templates.git
         "TestGenerateOnlyProjectCheck"
-        # Following tests give this error, not quite sure why:
-        #     Error Trace:    /build/pulumi/pkg/engine/lifecycletest/update_plan_test.go:273
-        # Error:          Received unexpected error:
-        #                 Unexpected diag message: <{%reset%}>using pulumi-resource-pkgA from $PATH at /build/tmp.bS8caxmTx7/pulumi-resource-pkgA<{%reset%}>
-        # Test:           TestUnplannedDelete
-        "TestExpectedDelete"
-        "TestPlannedInputOutputDifferences"
-        "TestPlannedUpdateChangedStack"
-        "TestExpectedCreate"
-        "TestUnplannedDelete"
-        # Following test gives this  error, not sure why:
-        # --- Expected
-        # +++ Actual
-        # @@ -1 +1 @@
-        # -gcp
-        # +aws
-        "TestPluginMapper_MappedNamesDifferFromPulumiName"
-        "TestProtect"
-      ];
-    in
-    [ "-skip=^${lib.concatStringsSep "$|^" disabledTests}$" ];
+        "TestPulumiNewSetsTemplateTag"
+        "TestPulumiPromptRuntimeOptions"
+
+        # Connects to https://pulumi-testing.vault.azure.net/…
+        "TestAzureCloudManager"
+        "TestAzureKeyEditProjectStack"
+        "TestAzureKeyVaultAutoFix15329"
+        "TestAzureKeyVaultExistingKey"
+        "TestAzureKeyVaultExistingKeyState"
+        "TestAzureKeyVaultExistingState"
+
+        # Requires pulumi-yaml
+        "TestProjectNameDefaults"
+        "TestProjectNameOverrides"
+
+        # Downloads pulumi-resource-random from Pulumi plugin registry.
+        "TestPluginInstallCancellation"
+
+        # Requires language-specific tooling and/or Internet access.
+        "TestGenerateProgram"
+        "TestGenerateProgramVersionSelection"
+        "TestGeneratePackage"
+        "TestGeneratePackageOne"
+        "TestGeneratePackageThree"
+        "TestGeneratePackageTwo"
+        "TestParseAndRenderDocs"
+        "TestImportResourceRef"
+      ]
+    }$"
+  ];
 
   # Allow tests that bind or connect to localhost on macOS.
   __darwinAllowLocalNetworking = true;
-
-  doInstallCheck = true;
-  installCheckPhase = ''
-    PULUMI_SKIP_UPDATE_CHECK=1 $out/bin/pulumi version | grep v${version} > /dev/null
-  '';
 
   postInstall = ''
     installShellCompletion --cmd pulumi \
@@ -144,6 +122,13 @@ buildGo122Module rec {
             --suffix PATH : ${lib.makeBinPath (f pulumiPackages)} \
             --set LD_LIBRARY_PATH "${lib.getLib stdenv.cc.cc}/lib"
         '';
+    tests = {
+      version = testers.testVersion {
+        package = pulumi;
+        version = "v${version}";
+        command = "PULUMI_SKIP_UPDATE_CHECK=1 pulumi version";
+      };
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -1,71 +1,96 @@
 {
   lib,
+  pkgs,
+  pulumiPackages,
   buildPythonPackage,
+  pythonOlder,
+  hatchling,
   protobuf,
-  dill,
   grpcio,
-  pulumi,
-  isPy27,
-  semver,
-  pip,
-  pytestCheckHook,
-  pyyaml,
+  dill,
   six,
+  semver,
+  pyyaml,
+  debugpy,
+  pip,
+  pytest,
+  pytest-asyncio,
+  pytest-timeout,
+  python,
 }:
-buildPythonPackage rec {
-  inherit (pulumi) version src;
+let
+  inherit (pkgs.pulumi) pname version src;
+  inherit (pulumiPackages) pulumi-language-python;
+  sourceRoot = "${src.name}/sdk/python";
+in
+buildPythonPackage {
+  inherit
+    pname
+    version
+    src
+    sourceRoot
+    ;
 
-  pname = "pulumi";
-  format = "setuptools";
+  outputs = [
+    "out"
+    "dev"
+  ];
 
-  disabled = isPy27;
+  pyproject = true;
 
-  propagatedBuildInputs = [
-    semver
+  disabled = pythonOlder "3.9";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
     protobuf
-    dill
     grpcio
-    pyyaml
+    dill
     six
+    semver
+    pyyaml
+    debugpy
+    pip
+  ];
+
+  pythonRelaxDeps = [
+    "grpcio"
+    "pip"
+    "semver"
   ];
 
   nativeCheckInputs = [
-    pip
-    pulumi.pkgs.pulumi-language-python
-    pytestCheckHook
+    pytest
+    pytest-asyncio
+    pytest-timeout
+    pulumi-language-python
   ];
 
-  pytestFlagsArray = [ "test/" ];
-
-  sourceRoot = "${src.name}/sdk/python/lib";
-
-  # we apply the modifications done in the pulumi/sdk/python/Makefile
-  # but without the venv code
-  postPatch = ''
-    cp ../../README.md .
-    substituteInPlace setup.py \
-      --replace "3.0.0" "${version}" \
-      --replace "grpcio==1.56.2" "grpcio" \
-      --replace "semver~=2.13" "semver"
+  # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L10-L11
+  # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16
+  installCheckPhase = ''
+    runHook preInstallCheck
+    ${python.executable} -m pytest --ignore=lib/test/automation lib/test
+    pushd lib/test_with_mocks
+    ${python.executable} -m pytest
+    popd
+    runHook postInstallCheck
   '';
 
   # Allow local networking in tests on Darwin
   __darwinAllowLocalNetworking = true;
 
-  # Verify that the version substitution works
-  preCheck = ''
-    pip show "${pname}" | grep "Version: ${version}" > /dev/null \
-      || (echo "ERROR: Version substitution seems to be broken"; exit 1)
-  '';
-
   pythonImportsCheck = [ "pulumi" ];
 
-  meta = with lib; {
+  meta = {
     description = "Modern Infrastructure as Code. Any cloud, any language";
-    homepage = "https://github.com/pulumi/pulumi";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ teto ];
+    homepage = "https://www.pulumi.com";
+    license = lib.licenses.asl20;
     # https://github.com/pulumi/pulumi/issues/16828
-    broken = versionAtLeast protobuf.version "5";
+    broken = lib.versionAtLeast protobuf.version "5";
+    maintainers = with lib.maintainers; [
+      teto
+      tie
+    ];
   };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-eHsTEb4Vff2bfADScLSkZiotSSnT1q0bexlUMaWgqbg=";
+  vendorHash = "sha256-mhwmHxZ+I/IdNGpEzXYJWPDKt7Gnun3HuXsjmFme6GI=";
 
   ldflags = [
     "-s"

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -14,11 +14,19 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+    "-X=github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
   ];
 
-  # go: inconsistent vendoring in ...
-  doCheck = false;
+  checkFlags = [
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        "TestLanguage"
+        "TestPluginsAndDependencies_vendored"
+        "TestPluginsAndDependencies_subdir"
+        "TestPluginsAndDependencies_moduleMode"
+      ]
+    }$"
+  ];
 
   meta = {
     homepage = "https://www.pulumi.com/docs/iac/languages-sdks/go/";

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -20,10 +20,13 @@ buildGoModule rec {
   # go: inconsistent vendoring in ...
   doCheck = false;
 
-  meta = with lib; {
-    description = "Golang language host plugin for Pulumi";
+  meta = {
+    homepage = "https://www.pulumi.com/docs/iac/languages-sdks/go/";
+    description = "Language host for Pulumi programs written in Go";
+    license = lib.licenses.asl20;
     mainProgram = "pulumi-language-go";
-    homepage = "https://github.com/pulumi/pulumi/tree/master/sdk/go";
-    license = licenses.asl20;
+    maintainers = with lib.maintainers; [
+      tie
+    ];
   };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildGoModule,
   pulumi,
   nodejs,
@@ -28,4 +29,14 @@ buildGoModule rec {
   nativeCheckInputs = [
     nodejs
   ];
+
+  meta = {
+    homepage = "https://www.pulumi.com/docs/iac/languages-sdks/javascript/";
+    description = "Language host for Pulumi programs written in TypeScript & JavaScript (Node.js)";
+    license = lib.licenses.asl20;
+    mainProgram = "pulumi-language-nodejs";
+    maintainers = with lib.maintainers; [
+      tie
+    ];
+  };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -4,6 +4,7 @@
   pulumi,
   bash,
   nodejs,
+  python3,
 }:
 buildGoModule rec {
   pname = "pulumi-language-nodejs";
@@ -11,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-L91qIud8dWx7dWWEcknKUSTJe+f4OBL8wBg6dKUWgkQ=";
+  vendorHash = "sha256-vmFoMxWK5sj3vsBVFAji0Pz2wtf1H3MJhbrkHshDOno=";
 
   ldflags = [
     "-s"
@@ -23,11 +24,13 @@ buildGoModule rec {
     "-skip=^${
       lib.concatStringsSep "$|^" [
         "TestLanguage"
+        "TestGetProgramDependencies"
       ]
     }$"
   ];
 
   nativeCheckInputs = [
+    python3 # for TestNonblockingStdout
     nodejs
   ];
 

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-nodejs.nix
@@ -2,33 +2,45 @@
   lib,
   buildGoModule,
   pulumi,
+  bash,
   nodejs,
 }:
 buildGoModule rec {
-  inherit (pulumi) version src;
-
   pname = "pulumi-language-nodejs";
+  inherit (pulumi) version src;
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
   vendorHash = "sha256-L91qIud8dWx7dWWEcknKUSTJe+f4OBL8wBg6dKUWgkQ=";
 
-  postPatch = ''
-    # Gives github.com/pulumi/pulumi/pkg/v3: is replaced in go.mod, but not marked as replaced in vendor/modules.txt etc
-    substituteInPlace language_test.go \
-      --replace "TestLanguage" \
-                "SkipTestLanguage"
-  '';
-
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+    "-X=github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+  ];
+
+  checkFlags = [
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        "TestLanguage"
+      ]
+    }$"
   ];
 
   nativeCheckInputs = [
     nodejs
   ];
+
+  # For patchShebangsAuto (see scripts copied in postInstall).
+  buildInputs = [
+    bash
+  ];
+
+  postInstall = ''
+    cp -t "$out/bin" \
+      ../../dist/pulumi-resource-pulumi-nodejs \
+      ../../dist/pulumi-analyzer-policy
+  '';
 
   meta = {
     homepage = "https://www.pulumi.com/docs/iac/languages-sdks/javascript/";

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildGoModule,
   pulumi,
   python3,
@@ -33,4 +34,14 @@ buildGoModule rec {
     cp ../../dist/pulumi-resource-pulumi-python $out/bin
     cp ../../dist/pulumi-analyzer-policy-python $out/bin
   '';
+
+  meta = {
+    homepage = "https://www.pulumi.com/docs/iac/languages-sdks/python/";
+    description = "Language host for Pulumi programs written in Python";
+    license = lib.licenses.asl20;
+    mainProgram = "pulumi-language-python";
+    maintainers = with lib.maintainers; [
+      tie
+    ];
+  };
 }

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -2,37 +2,46 @@
   lib,
   buildGoModule,
   pulumi,
+  bash,
   python3,
 }:
 buildGoModule rec {
-  inherit (pulumi) version src;
-
   pname = "pulumi-language-python";
+  inherit (pulumi) version src;
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
   vendorHash = "sha256-Q8nnYJJN5+W2luY8JQJj1X9KIk9ad511FBywr+0wBNg=";
 
-  postPatch = ''
-    substituteInPlace main_test.go \
-      --replace "TestDeterminePulumiPackages" \
-                "SkipTestDeterminePulumiPackages"
-  '';
-
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+    "-X=github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+  ];
+
+  checkFlags = [
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        "TestDeterminePulumiPackages"
+      ]
+    }$"
   ];
 
   nativeCheckInputs = [
     python3
   ];
 
+  # For patchShebangsAuto (see scripts copied in postInstall).
+  buildInputs = [
+    bash
+    python3
+  ];
+
   postInstall = ''
-    cp ../pulumi-language-python-exec           $out/bin
-    cp ../../dist/pulumi-resource-pulumi-python $out/bin
-    cp ../../dist/pulumi-analyzer-policy-python $out/bin
+    cp -t "$out/bin" \
+      ../pulumi-language-python-exec \
+      ../../dist/pulumi-resource-pulumi-python \
+      ../../dist/pulumi-analyzer-policy-python
   '';
 
   meta = {

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-python.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-Q8nnYJJN5+W2luY8JQJj1X9KIk9ad511FBywr+0wBNg=";
+  vendorHash = "sha256-2K3EIG0xRcRRJES9h72Sk9V442T6dHZbYxz1uxxEKWI=";
 
   ldflags = [
     "-s"
@@ -22,6 +22,7 @@ buildGoModule rec {
   checkFlags = [
     "-skip=^${
       lib.concatStringsSep "$|^" [
+        "TestLanguage"
         "TestDeterminePulumiPackages"
       ]
     }$"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1460,7 +1460,7 @@ self: super: with self; {
 
   pueblo = callPackage ../development/python-modules/pueblo { };
 
-  pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };
+  pulumi = callPackage ../development/python-modules/pulumi { };
 
   pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
 


### PR DESCRIPTION
This PR updates Pulumi to the latest version (https://github.com/pulumi/pulumi/compare/v3.122.0...v3.152.0) and fixes cross-compilation.

Refactor and version bumps for `pulumiPackages` will be submitted in a follow up PRs.

<details>
<summary>Old description</summary>

https://github.com/NixOS/nixpkgs/compare/master...tie:nixpkgs:pulumi-packages-bump?expand=1

This PR updates Pulumi to the latest version (https://github.com/pulumi/pulumi/compare/v3.122.0...v3.152.0), along with significant refactor and updates for `pulumiPackages`. This PR fixes cross-compilation for Pulumi packages and uses correct Python package set for SDKs. All packages now have `passthru.updateScript` to ease updates in the future.

We also remove `mkPulumiPackage` helper function and use `buildGoModule` directly. While Pulumi packages have similar architecture, there are minor differences in build logic that would otherwise require a lot of special cases. Note that `mkPulumiPackage` was never exposed so it is a backwards compatible change.

There is an existing PR #352221, but it’s already outdated and seems to be unfinished (e.g. some packages fail to build).

Note that Pulumi requires `protobuf4` for Python packages. See also https://github.com/NixOS/nixpkgs/issues/351751#issuecomment-2462163436

Build all Pulumi packages, SDKs and tests with:
<details>

```
nix build --impure --expr 'with import ./. {
  config.allowAliases = false;
  overlays = [
    (_: prev: {
      pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
        (final: _: {
          protobuf = final.protobuf4;
        })
      ];
    })
  ];
};
linkFarmFromDrvs "pulumi-packages" (
  lib.concatLists (
    lib.mapAttrsToList (
      _: p:
      lib.optionals (lib.isDerivation p) (
        [ p ] ++ lib.attrValues (p.sdks or { }) ++ lib.attrValues (p.tests or { })
      )
    ) (pulumiPackages // { inherit pulumi; })
  )
)'
```
</details>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
