### PR TITLE
age-plugin-tpm: 0.2.0 -> 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11477,6 +11477,12 @@
     github = "josephsurin";
     githubId = 14977484;
   };
+  josh = {
+    name = "Joshua Peek";
+    email = "josh@joshpeek.com";
+    github = "josh";
+    githubId = 137;
+  };
   joshainglis = {
     name = "Josha Inglis";
     email = "joshainglis@gmail.com";

--- a/nixos/tests/age-plugin-tpm-decrypt.nix
+++ b/nixos/tests/age-plugin-tpm-decrypt.nix
@@ -1,0 +1,33 @@
+{ pkgs, lib, ... }:
+{
+  name = "age-plugin-tpm-decrypt";
+  meta = with lib.maintainers; {
+    maintainers = [
+      sgo
+      josh
+    ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation.tpm.enable = true;
+      environment.systemPackages = with pkgs; [
+        age
+        age-plugin-tpm
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.succeed("age-plugin-tpm --generate --output identity.txt")
+    machine.succeed("age-plugin-tpm --convert identity.txt --output recipient.txt")
+    machine.succeed("echo -n 'Hello World' >data.txt")
+
+    machine.succeed("age --encrypt --recipients-file recipient.txt --output data.age data.txt")
+    data = machine.succeed("age --decrypt --identity identity.txt data.age")
+
+    assert data == "Hello World"
+  '';
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -112,6 +112,7 @@ in {
   aesmd = runTestOn ["x86_64-linux"] ./aesmd.nix;
   agate = runTest ./web-servers/agate.nix;
   agda = handleTest ./agda.nix {};
+  age-plugin-tpm-decrypt = runTest ./age-plugin-tpm-decrypt.nix;
   agorakit = runTest ./web-apps/agorakit.nix;
   airsonic = handleTest ./airsonic.nix {};
   akkoma = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./akkoma.nix {};

--- a/pkgs/by-name/ag/age-plugin-tpm/package.nix
+++ b/pkgs/by-name/ag/age-plugin-tpm/package.nix
@@ -1,27 +1,31 @@
 {
   lib,
+  callPackage,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
   swtpm,
   openssl,
+  age,
 }:
 
 buildGoModule rec {
   pname = "age-plugin-tpm";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "Foxboron";
     repo = "age-plugin-tpm";
-    rev = "v${version}";
-    hash = "sha256-oTvK8U5j+llHgoChhGb+vcUrUf9doVYxd3d5MEuCNz8=";
+    tag = "v${version}";
+    hash = "sha256-yr1PSSmcUoOrQ8VMQEoaCLNvDO+3+6N7XXdNUyYVz9M=";
   };
 
   proxyVendor = true;
 
-  vendorHash = "sha256-veduD0K3Onkqvyg9E5v854a6/8UIRQZEH098lUepRNU=";
+  vendorHash = "sha256-VEx6qP02QcwETOQUkMsrqVb+cOElceXcTDaUr480ngs=";
 
   nativeCheckInputs = [
+    age
     swtpm
   ];
 
@@ -34,12 +38,17 @@ buildGoModule rec {
     "-w"
   ];
 
+  passthru.tests = {
+    encrypt = callPackage ./tests/encrypt.nix { };
+    decrypt = nixosTests.age-plugin-tpm-decrypt;
+  };
+
   meta = with lib; {
     description = "TPM 2.0 plugin for age (This software is experimental, use it at your own risk)";
     mainProgram = "age-plugin-tpm";
     homepage = "https://github.com/Foxboron/age-plugin-tpm";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [
       kranzes
       sgo

--- a/pkgs/by-name/ag/age-plugin-tpm/tests/encrypt.nix
+++ b/pkgs/by-name/ag/age-plugin-tpm/tests/encrypt.nix
@@ -1,0 +1,18 @@
+{
+  runCommand,
+  age,
+  age-plugin-tpm,
+}:
+runCommand "age-plugin-tpm-encrypt"
+  {
+    nativeBuildInputs = [
+      age
+      age-plugin-tpm
+    ];
+    # example pubkey from Foxboron/age-plugin-tpm README
+    env.AGE_RECIPIENT = "age1tpm1qg86fn5esp30u9h6jy6zvu9gcsvnac09vn8jzjxt8s3qtlcv5h2x287wm36";
+  }
+  ''
+    echo "Hello World" | age --encrypt --armor --recipient "$AGE_RECIPIENT"
+    touch $out
+  ''


### PR DESCRIPTION
Upgrades [age-plugin-tpm](https://github.com/Foxboron/age-plugin-tpm) to [0.3.0](https://github.com/Foxboron/age-plugin-tpm/releases/tag/v0.3.0).

What's really neat about this new version is it [adds support for encrypting secrets on machines without a TPM—or even non-Linux](https://github.com/Foxboron/age-plugin-tpm/issues/22). So you can encrypt secrets locally on a MacBook Pro and decrypt them only on your Linux server with that TPM. So I relaxed the Linux only platform requirement.

Other side note, it appears the test suite needs an age binary in the PATH, so I added that as a `nativeCheckInputs` dependency.

If maintainers think it would be useful, should I add a trivial `passthru.test.encrypt`?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
