### PR TITLE
textual: disable failing test

### DIFF
--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -92,6 +92,8 @@ buildPythonPackage rec {
       # https://github.com/Textualize/textual/issues/5327
       "test_cursor_page_up"
       "test_cursor_page_down"
+
+      "test_async_reactive_watch_callbacks_go_on_the_watcher"
     ];
 
   # Some tests in groups require state from previous tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

After rebuilding, `textual` fails with:

```
sudo nixos-rebuild switch --flake .#
building the system configuration...
warning: download buffer is full; consider increasing the 'download-buffer-size' setting
error: builder for '/nix/store/hdyg3h05wyc0cgfzmf79zdczqvnl15pr-python3.12-textual-1.0.0.drv' failed with exit code 1;
       last 25 log lines:
       > >           raise RuntimeError('There is no current event loop in thread %r.'
       >                                % threading.current_thread().name)
       > E           RuntimeError: There is no current event loop in thread 'MainThread'.
       >
       > /nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/asyncio/events.py:702: RuntimeError
       > =============================== warnings summary ===============================
       > tests/test_reactive.py::test_sync_reactive_watch_callbacks_go_on_the_watcher
       >   /nix/store/zzwjr042ldvbl7f4nwadw2y3gmdn0pd2-python3.12-textual-1.0.0/lib/python3.12/site-packages/textual/strip.py:106: RuntimeWarning: coroutine 'test_async_reactive_watch_callbacks_go_on_the_watcher.<locals>.MyApp.callback' was never awaited
       >     ] = FIFOCache(4)
       >   Enable tracemalloc to get traceback where the object was allocated.
       >   See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > FAILED tests/test_focus.py::test_focus_chain - RuntimeError: There is no current event loop in thread 'MainThread'.
       > FAILED tests/test_focus.py::test_allow_focus - RuntimeError: There is no current event loop in thread 'MainThread'.
       > FAILED tests/test_focus.py::test_focus_next_and_previous_with_type_selector_without_self - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_focus_previous_wrap_around - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_wrap_around_selector - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_no_focus_empty_selector - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_focus_next_and_previous_with_type_selector - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_focus_next_and_previous - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_focus_next_and_previous_with_str_selector - RuntimeError: There is no current event loop in thread 'MainThread'.
       > ERROR tests/test_focus.py::test_focus_next_and_previous_with_str_selector_without_self - RuntimeError: There is no current event loop in thread 'MainThread'.
       > = 3 failed, 2734 passed, 1 skipped, 4 xfailed, 1 warning, 7 errors in 98.93s (0:01:38) =
       For full logs, run 'nix log /nix/store/hdyg3h05wyc0cgfzmf79zdczqvnl15pr-python3.12-textual-1.0.0.drv'.
error: 1 dependencies of derivation '/nix/store/26yhndfzc35gmqfvg4c7a9digradzgcx-oterm-0.8.3.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Disable the failing test: `test_async_reactive_watch_callbacks_go_on_the_watcher`

Fixes https://github.com/NixOS/nixpkgs/issues/382423

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
