### PR TITLE
another-redis-desktop-manager: init at 1.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11501,6 +11501,12 @@
     githubId = 3170771;
     name = "Jo Vandeginste";
   };
+  joyanhui = {
+    email = "leiyanhui@gmail.com";
+    github = "joyanhui";
+    githubId = 40133116;
+    name = "Lei Yanhui";
+  };
   jpagex = {
     name = "Jérémy Pagé";
     email = "contact@jeremypage.me";

--- a/pkgs/by-name/an/another-redis-desktop-manager/package.nix
+++ b/pkgs/by-name/an/another-redis-desktop-manager/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+  appimageTools,
+  libxshmfence,
+}:
+let
+  pname = "another-redis-desktop-manager";
+  version = "1.7.1";
+  src =
+    fetchurl
+      {
+        x86_64-linux = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-linux-${version}-x86_64.AppImage";
+          hash = "sha256-XuS4jsbhUproYUE2tncT43R6ErYB9WTg6d7s16OOxFQ=";
+        };
+        aarch64-linux = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-linux-${version}-arm64.AppImage";
+          hash = "sha256-0WXWl0UAQBqJlvt2MNpNHuqmEAlIlvY0FfHXu4LKkcY=";
+        };
+        x86_64-darwin = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-mac-${version}-x64.dmg";
+          hash = "sha256-LjmZCauxwk+WP80L9i5JOr12s212fX+p4xveZgCPM7w=";
+        };
+        aarch64-darwin = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-mac-${version}-arm64.dmg";
+          hash = "sha256-GDPhU819nGbMbYjsFEiwgd/rXBIsPGW8rke+HE12AjU=";
+        };
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.system}");
+  meta = {
+    description = "A faster, better and more stable redis desktop manager";
+    longDescription = ''
+      Faster, better, more stable Redis Desktop (GUI) management client, compatible with Windows, Mac, Linux, superior performance, easy to load massive key values.
+      Supports Sentinel, clustering, ssh channels, ssl authentication, stream, subscribe, tree view, command line, and dark mode; A variety of formatting methods, and even the ability to customize formatting scripts,
+    '';
+    homepage = "https://github.com/qishibo/AnotherRedisDesktopManager";
+    changelog = "https://github.com/qishibo/AnotherRedisDesktopManager?tab=readme-ov-file#feature-log";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      joyanhui
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "another-redis-desktop-manager";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+if stdenv.hostPlatform.isDarwin then
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+    nativeBuildInputs = [ undmg ];
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications/
+      runHook postInstall
+    '';
+  }
+else
+  appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+    extraPkgs = pkgs: [
+      libxshmfence
+    ];
+    extraInstallCommands = ''
+      mkdir -p $out/share/${pname}
+      cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
+      cp -a ${appimageContents}/usr/share/icons $out/share/
+      install -Dm 444 ${appimageContents}/${pname}.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
+    '';
+  }


### PR DESCRIPTION
Adds the Another RedisDesktop Manager package at 1.7.1. Also adds @joyanhui as a maintainer of the package.

Another Redis Desktop Manager offers functionalities similar to RedisInsight, yet it provides more user-friendly and convenient management for JSON and other formatted string keys.

Another RedisDesktop Manager : https://github.com/qishibo/AnotherRedisDesktopManager

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
