### PR TITLE
upbound-main: 0.38.0-0.rc.0.29.g59359e0 -> 0.39.0-0.rc.0.12.gfb799fcb

### DIFF
--- a/pkgs/by-name/up/upbound/sources-main.json
+++ b/pkgs/by-name/up/upbound/sources-main.json
@@ -8,38 +8,38 @@
   "fetchurlAttrSet": {
     "docker-credential-up": {
       "aarch64-darwin": {
-        "hash": "sha256-3fx/wjBoFxmeo55QbRw9cl4GFCFehGpZeVAw1bvooSk=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/darwin_arm64.tar.gz"
+        "hash": "sha256-TDfRDhOkVZdyp9fGGNtVqZ9EltSIgZv8DHog7OQ+tos=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/docker-credential-up/darwin_arm64.tar.gz"
       },
       "aarch64-linux": {
-        "hash": "sha256-FeF7D8WLpK8S6b7QCLaOI7Dm2EzbDqJVp9tfh13BJuU=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/linux_arm64.tar.gz"
+        "hash": "sha256-CpLQIagt4dMyWNc/2iy7MXHXnWxHax6eN1wwr/gyw8A=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/docker-credential-up/linux_arm64.tar.gz"
       },
       "x86_64-darwin": {
-        "hash": "sha256-00y9wGMwu5ZsTzlNkSvdwEse5eV4xzLiwQjgSTnmW5w=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/darwin_amd64.tar.gz"
+        "hash": "sha256-xS+KBa7P7AmaAzT+tMsSpxx5LCJd4Z3pSqGD1olp48c=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/docker-credential-up/darwin_amd64.tar.gz"
       },
       "x86_64-linux": {
-        "hash": "sha256-oObO/T/2yOFDaNVJGQCqna130Tyx/sEOCAQMDYhVlNI=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/docker-credential-up/linux_amd64.tar.gz"
+        "hash": "sha256-CRv5Vvxp4N5gy9OHi8FqRW5uBZQ46bDpTF2Fy/3WWxs=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/docker-credential-up/linux_amd64.tar.gz"
       }
     },
     "up": {
       "aarch64-darwin": {
-        "hash": "sha256-Bf6O6rsth3D5h5olxqHxULuxxPtNhxP+gN69mJnlQTg=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/darwin_arm64.tar.gz"
+        "hash": "sha256-KxDx2c90yJbM/9lgzzYFwczfBnfRQ61klYnSF9Z2/Ag=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/up/darwin_arm64.tar.gz"
       },
       "aarch64-linux": {
-        "hash": "sha256-svTHCjw2ZrTEscNpizOmg9leQAbzhWcPfst3nMUhUXg=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/linux_arm64.tar.gz"
+        "hash": "sha256-Rr2URDa0sWlkOGkrtfWrHfbxOIzntAaE9OAhPdeZqhQ=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/up/linux_arm64.tar.gz"
       },
       "x86_64-darwin": {
-        "hash": "sha256-1LxqRHQjNlRFTGhEyOR9uW407LkqdpVjB3w57hNT/Zk=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/darwin_amd64.tar.gz"
+        "hash": "sha256-po7P6qKzSPtrEETtS1k7NFKtVcwI4f3YQ6gD7IfzHQA=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/up/darwin_amd64.tar.gz"
       },
       "x86_64-linux": {
-        "hash": "sha256-ZLjhD7uCpBURYozX1IjUTJDzPuKFedIZQhRvMqMMsLY=",
-        "url": "https://cli.upbound.io/main/v0.38.0-0.rc.0.29.g59359e0/bundle/up/linux_amd64.tar.gz"
+        "hash": "sha256-3T0PiocXIBEhis2X4R9hWHgQvdRcrBbAxyGK8imyXUw=",
+        "url": "https://cli.upbound.io/main/v0.39.0-0.rc.0.12.gfb799fcb/bundle/up/linux_amd64.tar.gz"
       }
     }
   },
@@ -49,5 +49,5 @@
     "x86_64-darwin",
     "x86_64-linux"
   ],
-  "version": "0.38.0-0.rc.0.29.g59359e0"
+  "version": "0.39.0-0.rc.0.12.gfb799fcb"
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
```
--------- Report for 'aarch64-darwin' ---------
1 package built:
upbound-main

[nix-shell:~/.cache/nixpkgs-review/rev-ac572b56ed91074a0362162d661484b2b82d8295]$ tree ./results/upbound-main-aarch64-darwin/
./results/upbound-main-aarch64-darwin/
├── bin
│   ├── docker-credential-up
│   └── up
└── share
    └── bash-completion
        └── completions
            └── up

5 directories, 3 files

[nix-shell:~/.cache/nixpkgs-review/rev-ac572b56ed91074a0362162d661484b2b82d8295]$ ./results/upbound-main-aarch64-darwin/bin/up version
Client:
  Version:     v0.39.0-0.rc.0.12.gfb799fcb
  Go Version:  go1.23.6
  Git Commit:  fb799fcb
  OS/Arch:     darwin/arm64
Server:
  Crossplane Version:        v1.18.0-up.1
  Spaces Controller Version: Upbound Cloud Managed

```
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
