### PR TITLE
lib/modules: mergeDefinitions; accept type error messages

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -53,6 +53,7 @@ let
     isOption
     mkOption
     showDefs
+    showDefsWith
     showFiles
     showOption
     unknownModule
@@ -887,9 +888,13 @@ let
     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
     mergedValue =
       if isDefined then
-        if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
-        else let allInvalid = filter (def: ! type.check def.value) defsFinal;
-        in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
+        # check returns either true or isTypeError def.value = false
+        if all (def: let checkRes = type.check def.value; in types.isTypeError checkRes == false && checkRes) defsFinal then type.merge loc defsFinal
+        else let allInvalid = filter (def: let checkRes = type.check def.value; in types.isTypeError checkRes || ! checkRes ) defsFinal;
+        in throw ''A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefsWith {
+          defs = allInvalid;
+          getMsg = def: let check = (type.check def.value); in if types.isTypeError check then check.msg else "";
+        }}''
       else
         # (nixos-option detects this specific error message and gives it special
         # handling.  If changed here, please change it there too.)

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -606,7 +606,7 @@ rec {
     in (concatStringsSep ".") (map escapeOptionPart parts);
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
 
-  showDefs = defs: concatMapStrings (def:
+  showDefsWith = {defs, getMsg ? _: "" }: concatMapStrings (def:
     let
       # Pretty print the value for display, if successful
       prettyEval = builtins.tryEval
@@ -616,14 +616,17 @@ rec {
       lines = filter (v: ! isList v) (builtins.split "\n" prettyEval.value);
       # Only display the first 5 lines, and indent them for better visibility
       value = concatStringsSep "\n    " (take 5 lines ++ optional (length lines > 5) "...");
+      msg = getMsg def;
       result =
         # Don't print any value if evaluating the value strictly fails
         if ! prettyEval.success then ""
         # Put it on a new line if it consists of multiple
         else if length lines > 1 then ":\n    " + value
         else ": " + value;
-    in "\n- In `${def.file}'${result}"
+    in "\n- In `${def.file}'${result} - ${msg}"
   ) defs;
+
+  showDefs = defs: showDefsWith { inherit defs; };
 
   /**
     Pretty prints all option definition locations

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -260,6 +260,13 @@ rec {
   # nixos/doc/manual/development/option-types.section.md!
   types = rec {
 
+    mkTypeError = {
+      msg,
+    }@error: setType "option-type-error" error;
+
+    isTypeError = isType "option-type-error";
+
+
     raw = mkOptionType {
       name = "raw";
       description = "raw value";
@@ -604,8 +611,32 @@ rec {
               else
                 isString x # Do not allow a true path, which could be copied to the store later on.
             );
+            checks = [
+              {
+                msg = "inStore";
+                value = inStore;
+                expected = isInStore;
+              }
+              {
+                msg = "absolute";
+                value = absolute;
+                expected = isAbsolute;
+              }
+              {
+                msg = "expected type: " + (if inStore == null || inStore then "stringLike" else "string") + " but got: " + builtins.typeOf x;
+                value = isExpectedType;
+                expected = true;
+              }
+            ];
+
+            result = isExpectedType && (inStore == null || inStore == isInStore) && (absolute == null || absolute == isAbsolute);
           in
-            isExpectedType && (inStore == null || inStore == isInStore) && (absolute == null || absolute == isAbsolute);
+            if result then result else
+            mkTypeError {
+              msg = builtins.foldl' (
+                res: check: if check.value != check.expected then res + "\n" + check.msg else res
+              ) " " checks;
+            };
           };
 
     listOf = elemType: mkOptionType rec {


### PR DESCRIPTION
 This PR improves error message handling.
 
 type.check could return `mkTypeError` instead of false.
 Every invalid definition is later shown with `showDefsWith` and a corresponding message.
 
This makes sense for more complex types such as in  `package`, `attrTag`, `optionType`, `deferedModule`, etc.
Where it is non-trivial why the value doesn't fit onto the expected type.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
