### PR TITLE
opcua-commander: fix build on darwin

### DIFF
--- a/pkgs/by-name/op/opcua-commander/package.nix
+++ b/pkgs/by-name/op/opcua-commander/package.nix
@@ -28,16 +28,11 @@ buildNpmPackage rec {
 
   postPatch =
     let
-      esbuildPrefix = lib.concatStringsSep " " (
-        [
-          "esbuild"
-        ]
-        ++ lib.optionals stdenv.hostPlatform.isDarwin [
-          # Workaround for 'No loader is configured for ".node" files: node_modules/fsevents/fsevents.node'
-          # esbuild issue is https://github.com/evanw/esbuild/issues/1051
-          "--external:fsevents"
-        ]
-      );
+      esbuildPrefix =
+        "esbuild"
+        # Workaround for 'No loader is configured for ".node" files: node_modules/fsevents/fsevents.node'
+        # esbuild issue is https://github.com/evanw/esbuild/issues/1051
+        + lib.optionalString stdenv.hostPlatform.isDarwin " --external:fsevents";
     in
     ''
       substituteInPlace package.json \

--- a/pkgs/by-name/op/opcua-commander/package.nix
+++ b/pkgs/by-name/op/opcua-commander/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   typescript,
@@ -25,10 +26,23 @@ buildNpmPackage rec {
     makeWrapper
   ];
 
-  postPatch = ''
-    substituteInPlace package.json \
-      --replace-warn "npx -y esbuild" "esbuild"
-  '';
+  postPatch =
+    let
+      esbuildPrefix = lib.concatStringsSep " " (
+        [
+          "esbuild"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          # Workaround for 'No loader is configured for ".node" files: node_modules/fsevents/fsevents.node'
+          # esbuild issue is https://github.com/evanw/esbuild/issues/1051
+          "--external:fsevents"
+        ]
+      );
+    in
+    ''
+      substituteInPlace package.json \
+        --replace-fail 'npx -y esbuild' '${esbuildPrefix}'
+    '';
 
   # We need to add `nodejs` to PATH for `opcua-commander` to properly work
   # when connected to an OPC-UA server.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to resolve following build error on darwin.

```
No loader is configured for ".node" files: node_modules/fsevents/fsevents.node

    node_modules/fsevents/fsevents.js:13:23:
      13 │ const Native = require("./fsevents.node");
         ╵                        ~~~~~~~~~~~~~~~~~

1 error

ERROR: `npm build` failed
```

It looks like it failed since packaging https://github.com/NixOS/nixpkgs/pull/298088#issuecomment-2015972979.
And now, it has appeared in esbuild updating PRs. https://github.com/NixOS/nixpkgs/pull/380372#pullrequestreview-2615560253

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @jonboh @sikmir

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
