### PR TITLE
ocamlPackages.melange: 4.0.1 → 5.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/reason-react/default.nix
+++ b/pkgs/development/ocaml-modules/reason-react/default.nix
@@ -1,5 +1,6 @@
 {
   buildDunePackage,
+  fetchpatch,
   melange,
   reason,
   reason-react-ppx,
@@ -8,6 +9,14 @@
 buildDunePackage {
   pname = "reason-react";
   inherit (reason-react-ppx) version src;
+  patches = [
+    # Makes tests compatible with melange 5.0.0
+    (fetchpatch {
+      url = "https://github.com/reasonml/reason-react/commit/661e93553ae48af410895477c339be4f0a203437.patch";
+      includes = [ "test/*" ];
+      hash = "sha256-khxPxC/GpByjcEZDoQ1NdXoM/yQBAKmnUnt/d2k6WfQ=";
+    })
+  ];
   nativeBuildInputs = [
     reason
     melange

--- a/pkgs/development/tools/ocaml/melange/default.nix
+++ b/pkgs/development/tools/ocaml/melange/default.nix
@@ -21,22 +21,27 @@
 let
   pname = "melange";
   versionHash =
-    if lib.versionAtLeast ocaml.version "5.2" then
+    if lib.versionAtLeast ocaml.version "5.3" then
       {
-        version = "4.0.1-52";
-        hash = "sha256-kUlChqQtLX7zh90GK23ibMqyI/MIp0sMYLjkPX9vdTc=";
+        version = "5.0.0-53";
+        hash = "sha256-ZZ3/TdhEJQ74Q3wJkWqoiONEfV6x77z0Sbr8cAirXbA=";
+      }
+    else if lib.versionAtLeast ocaml.version "5.2" then
+      {
+        version = "5.0.0-52";
+        hash = "sha256-DyjBiMvnCHufFepk8xHMMmVU+j/yECvV7My4WeAW4WQ=";
       }
     else if lib.versionAtLeast ocaml.version "5.1" then
       {
-        version = "4.0.0-51";
-        hash = "sha256-940Yzp1ZXnN6mKVWY+nqKjn4qtBUJR5eHE55OTjGvdU=";
+        version = "5.0.0-51";
+        hash = "sha256-rPU6pqzEDo5heGkHhMGfwsF8elDohoptNbbZyGcWLKA=";
       }
     else if lib.versionAtLeast ocaml.version "5.0" then
       throw "melange is not available for OCaml ${ocaml.version}"
     else
       {
-        version = "4.0.0-414";
-        hash = "sha256-PILDOXYIyLvfv1sSwP6WSdCiXfpYdnct7WMw3jHBLJM=";
+        version = "5.0.0-414";
+        hash = "sha256-07+tEx6b5dUY949VF2K22HqRSoKmvBwnxo7B/Gqb+ro=";
       };
   version = versionHash.version;
   hash = versionHash.hash;


### PR DESCRIPTION
Adds support for OCaml 5.3.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
