### PR TITLE
slimevr: fix libappindicator patching

### DIFF
--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -91,7 +91,7 @@ rustPlatform.buildRustPackage rec {
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       # Both libappindicator-rs and SlimeVR need to know where Nix's appindicator lib is.
-      pushd $cargoDepsCopy/libappindicator-sys
+      pushd $cargoDepsCopy/libappindicator-sys-*
       oldHash=$(sha256sum src/lib.rs | cut -d " " -f 1)
       substituteInPlace src/lib.rs \
         --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"


### PR DESCRIPTION
This fixes the slimevr build that has been broken since some of the recent cargo vendor changes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
