### PR TITLE
intel-npu-driver: init at 1.26.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20468,6 +20468,12 @@
     matrix = "@pschmitt:one.ems.host";
     keys = [ { fingerprint = "9FBF 2ABF FB37 F7F3 F502  44E5 DC43 9C47 EACB 17F9"; } ];
   };
+  pseudocc = {
+    email = "pseudoc@163.com";
+    github = "pseudocc";
+    githubId = 85104110;
+    name = "Atlas Yu";
+  };
   pshirshov = {
     email = "pshirshov@eml.cc";
     github = "pshirshov";

--- a/nixos/modules/hardware/cpu/intel-npu.nix
+++ b/nixos/modules/hardware/cpu/intel-npu.nix
@@ -15,18 +15,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = config.hardware.graphics.enable;
-        message = "Intel NPU requires hardware.graphics.enable to be enabled";
-      }
-    ];
-
-    hardware.firmware = [ pkgs.intel-npu-driver.firmware ];
-    hardware.graphics.extraPackages = [ pkgs.intel-npu-driver ];
     environment.systemPackages = [
       pkgs.intel-npu-driver.validation
       pkgs.level-zero
     ];
+
+    hardware = {
+      firmware = [ pkgs.intel-npu-driver.firmware ];
+      graphics = {
+        enable = true;
+        extraPackages = [ pkgs.intel-npu-driver ];
+      };
+    };
   };
 }

--- a/nixos/modules/hardware/cpu/intel-npu.nix
+++ b/nixos/modules/hardware/cpu/intel-npu.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.cpu.intel.npu;
+in
+{
+  options = {
+    hardware.cpu.intel.npu = {
+      enable = lib.mkEnableOption "Intel NPU support";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.hardware.graphics.enable;
+        message = "Intel NPU requires hardware.graphics.enable to be enabled";
+      }
+    ];
+
+    hardware.firmware = [ pkgs.intel-npu-driver.firmware ];
+    hardware.graphics.extraPackages = [ pkgs.intel-npu-driver ];
+    environment.systemPackages = [
+      pkgs.intel-npu-driver.validation
+      pkgs.level-zero
+    ];
+  };
+}

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -220,6 +220,11 @@ sub pciCheck {
         ($device eq "0x4229" || $device eq "0x4230" ||
          $device eq "0x4222" || $device eq "0x4227");
 
+    push @attrs, "hardware.cpu.intel.npu.enable = true;" if
+        $vendor eq "0x8086" &&
+        ($device eq "0x7d1d" || $device eq "0xad1d" ||
+         $device eq "0x643e" || $device eq "0xb03e");
+
     # Assume that all NVIDIA cards are supported by the NVIDIA driver.
     # There may be exceptions (e.g. old cards).
     # FIXME: do we want to enable an unfree driver here?

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.22.0";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-GxmAmbf28hn/ragkTkFBYbM6Z+uFR6X4foMOyE8UVAc=";
+    hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
   };

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.19.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-TQfqBSSHHPck0srnezqcXPHaIIC3SymvwaYU6svI13c=";
+    hash = "sha256-GxmAmbf28hn/ragkTkFBYbM6Z+uFR6X4foMOyE8UVAc=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.23.0";
+  version = "1.24.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-Lc+FsW0bM2cIqEXpCd9+nvFh70xCbY6aMSHZIjESxhs=";
+    hash = "sha256-pnQ4OV+7bKivhS5lVmdz5Zb9kqaSJK0eK0lK+68wzYU=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  udev,
+  openssl,
+  boost,
+  cmake,
+  git,
+  level-zero,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "intel-npu-driver";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "linux-npu-driver";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-TQfqBSSHHPck0srnezqcXPHaIIC3SymvwaYU6svI13c=";
+  };
+
+  buildInputs = [
+    udev
+    openssl
+    boost
+    level-zero
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  outputs = [
+    "out"
+    "validation"
+    "firmware"
+  ];
+
+  postPatch = ''
+    rm -rf third_party/level-zero
+    rm third_party/cmake/level-zero.cmake
+    rm third_party/cmake/FindLevelZero.cmake
+    substituteInPlace third_party/CMakeLists.txt --replace-fail \
+      "include(cmake/level-zero.cmake)" \
+      ""
+    substituteInPlace third_party/level-zero-npu-extensions/ze_graph_ext.h --replace-fail \
+    "#include \"ze_api.h\"" \
+    "#include <level_zero/ze_api.h>"
+
+    substituteInPlace validation/{kmd-test,umd-test}/CMakeLists.txt --replace-fail \
+      "COMPONENT validation-npu" \
+      "DESTINATION $validation/bin COMPONENT validation-npu"
+
+    substituteInPlace firmware/CMakeLists.txt --replace-fail \
+      "DESTINATION /lib/firmware/updates/intel/vpu/" \
+      "DESTINATION $firmware/lib/firmware/intel/vpu/"
+  '';
+
+  installPhase = ''
+    cmake --install . --component level-zero-npu
+    cmake --install . --component validation-npu
+    cmake --install . --component fw-npu
+  '';
+
+  meta = {
+    homepage = "https://github.com/intel/linux-npu-driver";
+    description = "Intel NPU (Neural Processing Unit) Standalone Driver";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pseudocc ];
+  };
+}

--- a/pkgs/by-name/in/intel-npu-driver/package.nix
+++ b/pkgs/by-name/in/intel-npu-driver/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-npu-driver";
-  version = "1.24.0";
+  version = "1.26.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-npu-driver";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-pnQ4OV+7bKivhS5lVmdz5Zb9kqaSJK0eK0lK+68wzYU=";
+    hash = "sha256-f3GxvYBfCCK6EGASuHrevFEVcBAyKyWXaIvSNcNcSZQ=";
   };
 
   buildInputs = [
@@ -43,6 +43,11 @@ stdenv.mkDerivation rec {
     rm -rf third_party/level-zero
     rm third_party/cmake/level-zero.cmake
     rm third_party/cmake/FindLevelZero.cmake
+
+    substituteInPlace third_party/yaml-cpp/CMakeLists.txt --replace-fail \
+      "cmake_minimum_required" \
+      "# cmake_minimum_required"
+
     substituteInPlace third_party/CMakeLists.txt --replace-fail \
       "include(cmake/level-zero.cmake)" \
       ""


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packaging the [Intel NPU](https://github.com/intel/linux-npu-driver) firmware (for Linux kernel module: intel_vpu).

```
[nix-shell:~/.cache/nixpkgs-review/pr-382756-4]$ tree results/intel-npu-driver-x86_64-linux/
results/intel-npu-driver-x86_64-linux/
├── bin
│   ├── npu-kmd-test
│   └── npu-umd-test
└── lib
    ├── libze_intel_vpu.so -> libze_intel_vpu.so.1
    ├── libze_intel_vpu.so.1 -> libze_intel_vpu.so.1.13.0
    └── libze_intel_vpu.so.1.13.0

3 directories, 5 files

[nix-shell:~/.cache/nixpkgs-review/pr-382756-4]$ tree results/intel-npu-firmware-x86_64-linux
results/intel-npu-firmware-x86_64-linux
└── lib
    └── firmware
        └── intel
            └── vpu
                ├── mtl_vpu_v0.0.bin -> vpu_37xx_v0.0.bin
                ├── vpu_37xx_v0.0.bin
                └── vpu_40xx_v0.0.bin

5 directories, 3 files
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
