### PR TITLE
Set prefetch-npm-deps link correctly

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -220,7 +220,7 @@ If these are not defined, `npm pack` may miss some files, and no binaries will b
 
 #### Arguments {#javascript-buildNpmPackage-arguments}
 
-* `npmDepsHash`: The output hash of the dependencies for this project. Can be calculated in advance with [`prefetch-npm-deps`](#javascript-buildNpmPackage-prefetch-npm-deps).
+* `npmDepsHash`: The output hash of the dependencies for this project. Can be calculated in advance with [`prefetch-npm-deps`](#prefetch-npm-deps-javascript-buildnpmpackage-prefetch-npm-deps).
 * `makeCacheWritable`: Whether to make the cache writable prior to installing dependencies. Don't set this unless npm tries to write to the cache directory, as it can slow down the build.
 * `npmBuildScript`: The script to run to build the project. Defaults to `"build"`.
 * `npmWorkspace`: The workspace directory within the project to build and install.


### PR DESCRIPTION
The MR aims to set correct link for `prefetch-npm-deps` in  https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#arguments-javascript-buildnpmpackage-arguments