### PR TITLE
jsonschema-cli: init at 0.29.0

### DIFF
--- a/pkgs/by-name/js/jsonschema-cli/package.nix
+++ b/pkgs/by-name/js/jsonschema-cli/package.nix
@@ -4,9 +4,6 @@
   rustPlatform,
   versionCheckHook,
   nix-update-script,
-  runCommand,
-  testers,
-  jsonschema-cli,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,30 +25,7 @@ rustPlatform.buildRustPackage rec {
   versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
   versionCheckProgramArg = [ "--version" ];
 
-  passthru = {
-    tests = {
-      simple = runCommand "${pname}-test" { } ''
-        ${lib.getExe jsonschema-cli} <(echo '{"maxLength": 5}') --instance <(echo '"exact"') > $out
-      '';
-
-      failed =
-        runCommand "${pname}-fail"
-          {
-            failed = testers.testBuildFailure (
-              runCommand "fail" { } ''
-                ${lib.getExe jsonschema-cli} <(echo '{"maxLength": 5}') --instance <(echo '"longer"') > $out
-              ''
-            );
-          }
-          ''
-            grep -F '"longer" is longer than 5 characters' $failed/result
-            [[ 1 = $(cat $failed/testBuildFailure.exit) ]]
-            touch $out
-          '';
-    };
-
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Fast command-line tool for JSON Schema validation";

--- a/pkgs/by-name/js/jsonschema-cli/package.nix
+++ b/pkgs/by-name/js/jsonschema-cli/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A fast command-line tool for JSON Schema validation";
+    description = "Fast command-line tool for JSON Schema validation";
     homepage = "https://github.com/Stranger6667/jsonschema";
     changelog = "https://github.com/Stranger6667/jsonschema/releases/tag/rust-v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/js/jsonschema-cli/package.nix
+++ b/pkgs/by-name/js/jsonschema-cli/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+  runCommand,
+  testers,
+  jsonschema-cli,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jsonschema-cli";
+  version = "0.29.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-kpdvvCnMsHfogXmAqNeo1Cl1hZtCPHqkfhYm8ipWToo=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Yti1KKJDRXMhDo84/ymZk2AkWp9HtU2LW2h63gfzIGY=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    tests = {
+      simple = runCommand "${pname}-test" { } ''
+        ${lib.getExe jsonschema-cli} <(echo '{"maxLength": 5}') --instance <(echo '"exact"') > $out
+      '';
+
+      failed =
+        runCommand "${pname}-fail"
+          {
+            failed = testers.testBuildFailure (
+              runCommand "fail" { } ''
+                ${lib.getExe jsonschema-cli} <(echo '{"maxLength": 5}') --instance <(echo '"longer"') > $out
+              ''
+            );
+          }
+          ''
+            grep -F '"longer" is longer than 5 characters' $failed/result
+            [[ 1 = $(cat $failed/testBuildFailure.exit) ]]
+            touch $out
+          '';
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "A fast command-line tool for JSON Schema validation";
+    homepage = "https://github.com/Stranger6667/jsonschema";
+    changelog = "https://github.com/Stranger6667/jsonschema/releases/tag/rust-v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "jsonschema-cli";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to introduce https://github.com/Stranger6667/jsonschema/tree/rust-v0.29.0/crates/jsonschema-cli as a new package.

```
A fast command-line tool for JSON Schema validation, powered by the jsonschema crate.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
