### PR TITLE
python310/python311: fix failing tests with openssl >= 3.4

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.10/raise-OSError-for-ERR_LIB_SYS.patch
+++ b/pkgs/development/interpreters/python/cpython/3.10/raise-OSError-for-ERR_LIB_SYS.patch
@@ -1,0 +1,28 @@
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index e637830..80728d2 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -656,6 +656,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
+                     errstr = "Some I/O error occurred";
+                 }
+             } else {
++                if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
++                    // A system error is being reported; reason is set to errno
++		    errno = ERR_GET_REASON(e);
++		    return PyErr_SetFromErrno(PyExc_OSError);
++                }
+                 p = PY_SSL_ERROR_SYSCALL;
+             }
+             break;
+@@ -681,6 +686,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
+                 errstr = "EOF occurred in violation of protocol";
+             }
+ #endif
++            if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
++                // A system error is being reported; reason is set to errno
++                errno = ERR_GET_REASON(e);
++                return PyErr_SetFromErrno(PyExc_OSError);
++            }
+             break;
+         }
+         default:

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -299,6 +299,15 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (pythonOlder "3.12") [
     # https://github.com/python/cpython/issues/90656
     ./loongarch-support.patch
+    # fix failing tests with openssl >= 3.4
+    # https://github.com/python/cpython/pull/127361
+  ] ++ optionals (pythonAtLeast "3.10" && pythonOlder "3.11") [
+    ./3.10/raise-OSError-for-ERR_LIB_SYS.patch
+  ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.12") [
+    (fetchpatch {
+      url = "https://github.com/python/cpython/commit/f4b31edf2d9d72878dab1f66a36913b5bcc848ec.patch";
+      sha256 = "sha256-w7zZMp0yqyi4h5oG8sK4z9BwNEkqg4Ar+en3nlWcxh0=";
+    })
   ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.13") [
     # backport fix for https://github.com/python/cpython/issues/95855
     ./platform-triplet-detection.patch


### PR DESCRIPTION
Backport fix from upstream to resolve failing test of `python311Packages.trio` and some other packages as well.

see: https://github.com/python/cpython/pull/127361

```
 > ----------------------------- Captured stdout call -----------------------------
       > ssl_echo_serve_sync got unexpected error: [SYS] unknown error (_ssl.c:2706)
       > =========================== short test summary info ============================
       > FAILED src/trio/_tests/test_ssl.py::test_ssl_client_basics[tls13] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_checkpoints[tls13] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_send_all_empty_string[tls13] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_ssl_client_basics[tls12] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_full_duplex_basics[tls12] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_checkpoints[tls12] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > FAILED src/trio/_tests/test_ssl.py::test_send_all_empty_string[tls12] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
       > ===== 7 failed, 733 passed, 38 skipped, 47 deselected, 2 xfailed in 5.34s ======
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
