### PR TITLE
switch-to-configuration-ng: don't block when the lockfile is already locked

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -95,7 +95,7 @@ if (!-f "/etc/NIXOS" && (read_file("/etc/os-release", err_mode => "quiet") // ""
 
 make_path("/run/nixos", { mode => oct(755) });
 open(my $stc_lock, '>>', '/run/nixos/switch-to-configuration.lock') or die "Could not open lock - $!";
-flock($stc_lock, LOCK_EX) or die "Could not acquire lock - $!";
+flock($stc_lock, LOCK_EX|LOCK_NB) or die "Could not acquire lock - $!";
 openlog("nixos", "", LOG_USER);
 
 # run pre-switch checks

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -732,6 +732,23 @@ in {
         out = switch_to_specialisation("${machine}", "modifiedSystemConf")
         assert_contains(out, "starting the following units: ${dbusService}\n")
 
+    with subtest("aborts on already locked lock file"):
+        (exitcode, _) = machine.execute(
+            'flock -x --nb /run/nixos/switch-to-configuration.lock -c "${otherSystem}/bin/switch-to-configuration test"',
+            timeout=5
+        )
+        # See man timeout, exit codes above 124 come from the timeout command
+        # We want to make sure that stc actually exited with an error code,
+        # if instead we hit the timeout, then it means that stc hangs, which is
+        # what we don't want
+        # TODO: We cannot match on the exact exit code since it's not consistent between
+        # stc and stc-ng, since errno/last_os_error is not a very stable interface,
+        # we should probably get rid of that in stc-ng once we got rid of the
+        # perl implementation
+        assert exitcode < 124, \
+          "switch-to-configuration did not abort as expected, " + \
+          f"probably it timed out instead (exit code: {exitcode}), 124 means timeout"
+
     with subtest("fstab mounts"):
         switch_to_specialisation("${machine}", "")
         # add a mountpoint

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -1037,7 +1037,7 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
         die();
     };
 
-    let Ok(_lock) = Flock::lock(lock, FlockArg::LockExclusive) else {
+    let Ok(_lock) = Flock::lock(lock, FlockArg::LockExclusiveNonblock) else {
         eprintln!("Could not acquire lock");
         die();
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
When the lockfile is already locked, stc-ng currently blocks without any message indicating what is going on.
This is very confusing to users, especially because most will not know about the lockfile.
Since the current call blocks, we actually never end up in the else branch.

Switching to a non-blocking call, makes sure that we print out an error and exit in case the lockfile is already locked by another process, which makes it a lot clearer what's going on and gives the user a clue as to what to do to unblock the situation.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
