### PR TITLE
snapcraft: 8.6.1 -> 8.7.0

### DIFF
--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -13,7 +13,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "snapcraft";
-  version = "8.6.1";
+  version = "8.7.0";
 
   pyproject = true;
 
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "snapcraft";
     tag = version;
-    hash = "sha256-SbxsgvDptkUl8gHAIrJvnzIPOh0/R81n8cgJWBH7BXQ=";
+    hash = "sha256-AFqCIqU3XAITrnRp0VzFzvW1LGSJPTFS6VWSR3qF1Pc=";
   };
 
   patches = [
@@ -43,15 +43,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail 'version=determine_version()' 'version="${version}"' \
-      --replace-fail 'gnupg' 'python-gnupg'
-
-    substituteInPlace requirements.txt \
-      --replace-fail 'gnupg==2.3.1' 'python-gnupg'
-
-    substituteInPlace snapcraft/__init__.py \
-      --replace-fail '__version__ = _get_version()' '__version__ = "${version}"'
+    substituteInPlace snapcraft/__init__.py --replace-fail "dev" "${version}"
 
     substituteInPlace snapcraft_legacy/__init__.py \
       --replace-fail '__version__ = _get_version()' '__version__ = "${version}"'
@@ -60,8 +52,7 @@ python3Packages.buildPythonApplication rec {
       --replace-fail 'arch_linker_path = Path(arch_config.dynamic_linker)' \
       'return str(Path("${glibc}/lib/ld-linux-x86-64.so.2"))'
 
-    substituteInPlace pyproject.toml \
-      --replace-fail '"pytest-cov>=4.0",' ""
+    substituteInPlace pyproject.toml --replace-fail 'gnupg' 'python-gnupg'
   '';
 
   nativeBuildInputs = [ makeWrapper ];
@@ -110,10 +101,11 @@ python3Packages.buildPythonApplication rec {
     validators
   ];
 
-  build-system = with python3Packages; [ setuptools ];
+  build-system = with python3Packages; [ setuptools-scm ];
 
   pythonRelaxDeps = [
     "craft-parts"
+    "cryptography"
     "docutils"
     "jsonschema"
     "pygit2"

--- a/pkgs/by-name/sn/snapcraft/snapcraft-data-dirs.patch
+++ b/pkgs/by-name/sn/snapcraft/snapcraft-data-dirs.patch
@@ -1,26 +1,16 @@
 diff --git a/snapcraft_legacy/internal/common.py b/snapcraft_legacy/internal/common.py
-index 6017b405..aacd99a5 100644
+index b3d40c265..c68c24d53 100644
 --- a/snapcraft_legacy/internal/common.py
 +++ b/snapcraft_legacy/internal/common.py
-@@ -34,14 +34,17 @@ from snaphelpers import SnapConfigOptions, SnapCtlError
+@@ -36,7 +36,10 @@ from snapcraft_legacy.internal import errors
  
- from snapcraft_legacy.internal import errors
+ SNAPCRAFT_FILES = ["parts", "stage", "prime"]
  
+-_DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
 +# Get the path to the Nix store entry for Snapcraft at runtime
 +drv = os.path.realpath(__file__).split("/")[3]
 +
- SNAPCRAFT_FILES = ["parts", "stage", "prime"]
--_DEFAULT_PLUGINDIR = os.path.join(sys.prefix, "share", "snapcraft", "plugins")
 +_DEFAULT_PLUGINDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "plugins")
  _plugindir = _DEFAULT_PLUGINDIR
--_DEFAULT_SCHEMADIR = os.path.join(sys.prefix, "share", "snapcraft", "schema")
-+_DEFAULT_SCHEMADIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "schema")
- _schemadir = _DEFAULT_SCHEMADIR
--_DEFAULT_EXTENSIONSDIR = os.path.join(sys.prefix, "share", "snapcraft", "extensions")
-+_DEFAULT_EXTENSIONSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "extensions")
- _extensionsdir = _DEFAULT_EXTENSIONSDIR
--_DEFAULT_KEYRINGSDIR = os.path.join(sys.prefix, "share", "snapcraft", "keyrings")
-+_DEFAULT_KEYRINGSDIR = os.path.join(os.sep, "nix", "store", drv, "share", "snapcraft", "keyrings")
- _keyringsdir = _DEFAULT_KEYRINGSDIR
  
- _DOCKERENV_FILE = "/.dockerenv"
+ _BASE_DIR = Path(__file__).parents[2]


### PR DESCRIPTION
## Things done

Bumps snapcraft to the latest revision: https://github.com/canonical/snapcraft/releases/tag/8.7.0https://github.com/canonical/snapcraft/releases/tag/8.7.0

Change to packaging methodology has actually resulted in slightly less patching, this time.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
