### PR TITLE
Xfce updates 2025-02-17

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
@@ -18,10 +18,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-notifyd";
-  version = "0.9.6";
+  version = "0.9.7";
   odd-unstable = false;
 
-  sha256 = "sha256-TxVz9fUvuS5bl9eq9isalez3/Pro366TGFMBQ2DfIVI=";
+  sha256 = "sha256-pgdoy3mZOGMOBwK/cYEl8fre4fZo2lfyWzZnrSYlQ64=";
 
   buildInputs = [
     dbus

--- a/pkgs/desktops/xfce/core/xfdesktop/default.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   mkXfceDerivation,
-  fetchpatch,
   exo,
   gtk3,
   libxfce4ui,
@@ -18,18 +17,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfdesktop";
-  version = "4.20.0";
+  version = "4.20.1";
 
-  sha256 = "sha256-80g3lk1TkQI0fbYf2nXs36TrPlaGTHgH6k/TGOzRd3w=";
-
-  patches = [
-    # Fix monitor chooser UI resource path
-    # https://gitlab.xfce.org/xfce/xfdesktop/-/merge_requests/181
-    (fetchpatch {
-      url = "https://gitlab.xfce.org/xfce/xfdesktop/-/commit/699e21b062f56bdc0db192bfe036420b2618612e.patch";
-      hash = "sha256-YTtXF+OJMHn6KY2xui1qGZ04np9a60asne+8ZS/dujs=";
-    })
-  ];
+  sha256 = "sha256-QBzsHXEdTGj8PlgB+L/TJjxAVksKqf+9KrRN3YaBf44=";
 
   buildInputs = [
     exo


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

