### PR TITLE
Revert "lib.types.attrsWith: remove failing test"

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -398,6 +398,10 @@ checkConfigError 'infinite recursion encountered' config.nonLazyResult ./lazy-at
 checkConfigOutput '^"mergedName.<id>.nested"$' config.result ./name-merge-attrsWith-1.nix
 checkConfigError 'The option .mergedName. in .*\.nix. is already declared in .*\.nix' config.mergedName ./name-merge-attrsWith-2.nix
 
+# Test the attrsOf functor.wrapped warning
+# shellcheck disable=2016
+NIX_ABORT_ON_WARN=1 checkConfigError 'The deprecated `type.functor.wrapped` attribute of the option `mergedLazyLazy` is accessed, use `type.nestedTypes.elemType` instead.' options.mergedLazyLazy.type.functor.wrapped ./lazy-attrsWith.nix
+
 # Even with multiple assignments, a type error should be thrown if any of them aren't valid
 checkConfigError 'A definition for option .* is not of type .*' \
   config.value ./declare-int-unsigned-value.nix ./define-value-list.nix ./define-value-int-positive.nix


### PR DESCRIPTION
This reverts commit ce8f304bb68f88be5e32975c3299f2e16abe05c0.

The problem was simply a typo (nestedTypes.elemType -> type.nestedTypes.elemType) ! And CI didn't run for lib in the orginal PR which is why it didn't get caught.

This leads the way for PRs like https://github.com/NixOS/nixpkgs/pull/382848 and https://github.com/NixOS/nixpkgs/pull/375084 to also introduce similar tests.

## Things done

- [x] Ran `nix-build lib/tests/release.nix`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
