### PR TITLE
python312Packages.annoy: cleanup & mark as broken on darwin

### DIFF
--- a/pkgs/development/python-modules/annoy/default.nix
+++ b/pkgs/development/python-modules/annoy/default.nix
@@ -2,19 +2,22 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # nativeBuildInputs
   h5py,
+
+  # tests
   numpy,
   pytestCheckHook,
-  pythonOlder,
-  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "annoy";
   version = "1.17.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "spotify";
@@ -48,11 +51,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "annoy" ];
 
-  meta = with lib; {
+  meta = {
     description = "Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk";
     homepage = "https://github.com/spotify/annoy";
     changelog = "https://github.com/spotify/annoy/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ timokau ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ timokau ];
+    badPlatforms = [
+      # Several tests fail with AssertionError
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }


### PR DESCRIPTION
## Things done

```
=========================== short test summary info ============================
FAILED test/angular_index_test.py::test_get_nns_by_vector - assert [1] == [2, 1, 0]
FAILED test/angular_index_test.py::test_get_nns_by_item - assert [1] == [0, 1, 2]
FAILED test/angular_index_test.py::test_large_index - assert [1] == [0, 1]
FAILED test/angular_index_test.py::test_precision_1 - assert 0.0 >= 0.98
FAILED test/angular_index_test.py::test_precision_10 - assert 0.1 >= 0.98
FAILED test/angular_index_test.py::test_precision_100 - assert 0.01 >= 0.98
FAILED test/angular_index_test.py::test_precision_1000 - assert 0.001 >= 0.98
FAILED test/angular_index_test.py::test_get_nns_search_k - assert [1] == [0, 1, 2]
FAILED test/angular_index_test.py::test_include_dists - assert [1] == [0, 1]
FAILED test/angular_index_test.py::test_include_dists_check_ranges - assert 1.450364589691162 == 0.0 ± 1.0e-12
FAILED test/dot_index_test.py::test_get_nns_by_vector - assert [1] == [2, 1, 0]
FAILED test/dot_index_test.py::test_get_nns_by_item - assert [1] == [2, 1, 0]
FAILED test/dot_index_test.py::test_recall_at_10 - assert 0.0004400000000000001 >= 0.65
FAILED test/dot_index_test.py::test_recall_at_100 - assert 0.0009919999999999877 >= 0.95
FAILED test/dot_index_test.py::test_recall_at_1000 - assert 0.0010000000000000009 >= 0.99
FAILED test/dot_index_test.py::test_recall_at_1000_fewer_trees - assert 0.0010000000000000009 >= 0.99
FAILED test/dot_index_test.py::test_get_nns_with_distances - assert [0] == [0, 1, 2]
FAILED test/dot_index_test.py::test_include_dists - assert [0] == [0, 1]
FAILED test/dot_index_test.py::test_distance_consistency - assert -0.005714664701372385 == -0.00571462230374209 ± 5.7e-09
FAILED test/euclidean_index_test.py::test_get_nns_by_vector - assert [1] == [2, 1, 0]
FAILED test/euclidean_index_test.py::test_get_nns_by_item - assert [1] == [0, 1, 2]
FAILED test/euclidean_index_test.py::test_large_index - assert [1] == [0, 1]
FAILED test/euclidean_index_test.py::test_precision_10 - assert 0.1 >= 0.98
FAILED test/euclidean_index_test.py::test_precision_100 - assert 0.01 >= 0.98
FAILED test/euclidean_index_test.py::test_precision_1000 - assert 0.001 >= 0.98
FAILED test/euclidean_index_test.py::test_get_nns_with_distances - assert [0] == [0, 1, 2]
FAILED test/euclidean_index_test.py::test_include_dists - assert [0] == [0, 1]
FAILED test/holes_test.py::test_root_one_child - assert set() == {100000}
FAILED test/holes_test.py::test_root_two_children - assert set() == {100000, 100001}
FAILED test/holes_test.py::test_root_some_children - AssertionError: assert set() == {100000, 1000..., 100005, ...}
FAILED test/holes_test.py::test_root_many_children - AssertionError: assert set() == {100000, 1000..., 100005, ...}
FAILED test/index_test.py::test_binary_compatibility - assert [1] == [0, 85, 42, 11, 54, 38, ...]
FAILED test/index_test.py::test_item_vector_after_save - assert {1} == {1, 2, 3}
FAILED test/index_test.py::test_prefault - assert [1] == [0, 85, 42, 11, 54, 38, ...]
FAILED test/manhattan_index_test.py::test_get_nns_by_vector - assert [1] == [2, 1, 0]
FAILED test/manhattan_index_test.py::test_get_nns_by_item - assert [1] == [0, 1, 2]
FAILED test/manhattan_index_test.py::test_large_index - assert [1] == [0, 1]
FAILED test/manhattan_index_test.py::test_precision_10 - assert 0.1 >= 0.98
FAILED test/manhattan_index_test.py::test_precision_100 - assert 0.01 >= 0.98
FAILED test/manhattan_index_test.py::test_precision_1000 - assert 0.001 >= 0.98
FAILED test/manhattan_index_test.py::test_get_nns_with_distances - assert [0] == [0, 1, 2]
FAILED test/manhattan_index_test.py::test_include_dists - assert [0] == [0, 1]
FAILED test/on_disk_build_test.py::test_on_disk - assert [1] == [2, 1, 0]
======= 43 failed, 60 passed, 1 skipped, 1 warning in 120.32s (0:02:00) ========
```

cc @timokau

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
