### PR TITLE
pkgs-lib: Make tests independent of Nix file contents

### DIFF
--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -96,7 +96,7 @@ in runBuildTests {
       str = "foo";
       attrs.foo = null;
       list = [ null null ];
-      path = ./formats.nix;
+      path = ./testfile;
     };
     expected = ''
       {
@@ -111,7 +111,7 @@ in runBuildTests {
           null
         ],
         "null": null,
-        "path": "${./formats.nix}",
+        "path": "${./testfile}",
         "str": "foo",
         "true": true
       }
@@ -128,7 +128,7 @@ in runBuildTests {
       str = "foo";
       attrs.foo = null;
       list = [ null null ];
-      path = ./formats.nix;
+      path = ./testfile;
       no = "no";
       time = "22:30:00";
     };
@@ -142,7 +142,7 @@ in runBuildTests {
       - null
       'no': 'no'
       'null': null
-      path: ${./formats.nix}
+      path: ${./testfile}
       str: foo
       time: '22:30:00'
       'true': true
@@ -547,7 +547,7 @@ in runBuildTests {
         1
         null
       ];
-      path = ./formats.nix;
+      path = ./testfile;
     };
     expected = ''
       attrs {
@@ -561,7 +561,7 @@ in runBuildTests {
         null
       ]
       "null": null
-      "path": "${./formats.nix}"
+      "path": "${./testfile}"
       "str": "foo"
       "true": true
     '';


### PR DESCRIPTION
Before, all of these tests would be rebuilt whenever formats.nix is modified, but there's no need for this :)

## Things done

- [x] Tested `nix-build -A tests.pkgs-lib`

---

This work is funded by [Antithesis](https://antithesis.com/) and [Tweag](https://tweag.io) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
