### PR TITLE
mxnet: remove cuda support

### DIFF
--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -12,22 +12,15 @@
   gomp,
   llvmPackages,
   perl,
+  # mxnet cuda support is turned off, but dependencies like opencv can still be built with cudaSupport
+  # and fail to compile without the cudatoolkit
+  # mxnet cuda support will not be availaible, as mxnet requires version <=11
   cudaSupport ? config.cudaSupport,
   cudaPackages ? { },
-  nvidia_x11,
-  cudnnSupport ? cudaSupport,
 }:
 
-let
-  inherit (cudaPackages)
-    backendStdenv
-    cudatoolkit
-    cudaFlags
-    cudnn
-    ;
-in
-
-assert cudnnSupport -> cudaSupport;
+# mxnet is not maintained, and other projects are migrating away from it.
+# https://github.com/apache/mxnet/issues/21206
 
 stdenv.mkDerivation rec {
   pname = "mxnet";
@@ -67,27 +60,16 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional stdenv.cc.isGNU gomp
     ++ lib.optional stdenv.cc.isClang llvmPackages.openmp
-    # FIXME: when cuda build is fixed, remove nvidia_x11, and use /run/opengl-driver/lib
     ++ lib.optionals cudaSupport [
-      cudatoolkit
-      nvidia_x11
-    ]
-    ++ lib.optional cudnnSupport cudnn;
+      # needed for OpenCV cmake module
+      cudaPackages.cudatoolkit
+    ];
 
-  cmakeFlags =
-    [ "-DUSE_MKL_IF_AVAILABLE=OFF" ]
-    ++ (
-      if cudaSupport then
-        [
-          "-DUSE_OLDCMAKECUDA=ON" # see https://github.com/apache/incubator-mxnet/issues/10743
-          "-DCUDA_ARCH_NAME=All"
-          "-DCUDA_HOST_COMPILER=${backendStdenv.cc}/bin/cc"
-          "-DMXNET_CUDA_ARCH=${builtins.concatStringsSep ";" cudaFlags.realArches}"
-        ]
-      else
-        [ "-DUSE_CUDA=OFF" ]
-    )
-    ++ lib.optional (!cudnnSupport) "-DUSE_CUDNN=OFF";
+  cmakeFlags = [
+    "-DUSE_MKL_IF_AVAILABLE=OFF"
+    "-DUSE_CUDA=OFF"
+    "-DUSE_CUDNN=OFF"
+  ];
 
   env.NIX_CFLAGS_COMPILE = toString [
     # Needed with GCC 12
@@ -107,24 +89,11 @@ stdenv.mkDerivation rec {
     rm "$out"/lib/*.a
   '';
 
-  # used to mark cudaSupport in python310Packages.mxnet as broken;
-  # other attributes exposed for consistency
-  passthru = {
-    inherit
-      cudaSupport
-      cudnnSupport
-      cudatoolkit
-      cudnn
-      ;
-  };
-
   meta = with lib; {
     description = "Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler";
     homepage = "https://mxnet.incubator.apache.org/";
     maintainers = with maintainers; [ abbradar ];
     license = licenses.asl20;
     platforms = platforms.unix;
-    # Build failures when linking mxnet_unit_tests: https://gist.github.com/6d17447ee3557967ec52c50d93b17a1d
-    broken = cudaSupport;
   };
 }

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -94,6 +94,6 @@ stdenv.mkDerivation rec {
     homepage = "https://mxnet.incubator.apache.org/";
     maintainers = with maintainers; [ abbradar ];
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/mxnet/default.nix
+++ b/pkgs/development/python-modules/mxnet/default.nix
@@ -9,7 +9,6 @@
   graphviz,
   python,
   isPy3k,
-  isPy310,
 }:
 
 buildPythonPackage {
@@ -51,7 +50,5 @@ buildPythonPackage {
     ln -s ${pkgs.mxnet}/lib/libmxnet.so $out/${python.sitePackages}/mxnet
   '';
 
-  meta = pkgs.mxnet.meta // {
-    broken = (pkgs.mxnet.broken or false) || (isPy310 && pkgs.mxnet.cudaSupport);
-  };
+  meta = pkgs.mxnet.meta;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17313,9 +17313,7 @@ with pkgs;
     lisp-compiler = ecl;
   };
 
-  mxnet = callPackage ../applications/science/math/mxnet {
-    inherit (linuxPackages) nvidia_x11;
-  };
+  mxnet = callPackage ../applications/science/math/mxnet { };
 
   wxmaxima = callPackage ../applications/science/math/wxmaxima {
     wxGTK = wxGTK32.override {


### PR DESCRIPTION
mxnet is unmaintained, and requires cuda<=11 to compile. Currently, compiling mxnet with `cudaSupport = true` is marked broken. Instead, removed support completely from mxnet. Most projects are migrating away from mxnet, and nixpkgs will soon stop supporting these old cuda versions, so continued cuda functionality is not feasible.

mxnet with `cudaSupport = false` is unchanged.

However, mxnet still needs to have the cudatoolkit available or I get this error:
```
       > -- Compiling with OpenMP
       > -- Found OpenMP_C: -fopenmp (found version "4.5")
       > -- Found OpenMP_CXX: -fopenmp (found version "4.5")
       > -- Found OpenMP: TRUE (found version "4.5")
       > -- Found OpenBLAS libraries: /nix/store/zmdhvlpir63mv275pd2plh2qcpy2xv7x-openblas-0.3.28/lib/libopenblas.so
       > -- Found OpenBLAS include: /nix/store/w21yg93n8a7fz7xfrwyrpn236w5cadfr-openblas-0.3.28-dev/include
       > CMake Warning (dev) at /nix/store/r76f7ypmx49xi0fjrcvhxd42rdv3316x-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:86 (find_package):
       >   Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
       >   --help-policy CMP0146" for policy details.  Use the cmake_policy command to
       >   set the policy and suppress this warning.
       >
       > Call Stack (most recent call first):
       >   /nix/store/r76f7ypmx49xi0fjrcvhxd42rdv3316x-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:108 (find_host_package)
       >   CMakeLists.txt:420 (find_package)
       > This warning is for project developers.  Use -Wno-dev to suppress it.
       >
       > CMake Error at /nix/store/z3jpria4alpdl17nadqplcx5mdh05pkp-cmake-3.31.3/share/cmake-3.31/Modules/FindCUDA.cmake:883 (message):
       >   Specify CUDA_TOOLKIT_ROOT_DIR
       > Call Stack (most recent call first):
       >   /nix/store/r76f7ypmx49xi0fjrcvhxd42rdv3316x-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:86 (find_package)
       >   /nix/store/r76f7ypmx49xi0fjrcvhxd42rdv3316x-opencv-4.9.0/lib/cmake/opencv4/OpenCVConfig.cmake:108 (find_host_package)
       >   CMakeLists.txt:420 (find_package)
```

I spent time time trying to fix this without adding cudatoolkit to mxnet, but I was not successful. I have tested that I can still compile `mxnet` and `python3Packages.mxnet` with `cudaSupport = true`

On the quest to run immich with cuda enabled: https://github.com/NixOS/nixpkgs/issues/352113


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
