### PR TITLE
age-plugin-se: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18055,6 +18055,12 @@
     githubId = 817073;
     name = "Yc. Shen";
   };
+  onnimonni = {
+    email = "onni@flaky.build";
+    github = "onnimonni";
+    githubId = 5691777;
+    name = "Onni Hakala";
+  };
   onny = {
     email = "onny@project-insanity.org";
     github = "onny";
@@ -20385,6 +20391,11 @@
     github = "remexre";
     githubId = 4196789;
     name = "Nathan Ringo";
+  };
+  remko = {
+    github = "remko";
+    githubId = 12300;
+    name = "Remko Tronçon";
   };
   remyvv = {
     name = "Remy van Velthuijsen";

--- a/pkgs/by-name/ag/age-plugin-se/package.nix
+++ b/pkgs/by-name/ag/age-plugin-se/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  swiftPackages,
+  swift,
+  swiftpm,
+  nix-update-script,
+}:
+let
+  inherit (swiftPackages) stdenv;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "age-plugin-se";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "remko";
+    repo = "age-plugin-se";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sg73DzlW4aXNbIIePZox4JkF10OfsMtPw0q/0DWwgDk=";
+  };
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  postPatch =
+    let
+      swift-crypto = fetchFromGitHub {
+        owner = "apple";
+        repo = "swift-crypto";
+        # FIXME: Update to a newer version once https://github.com/NixOS/nixpkgs/issues/343210 is fixed
+        # This is the last version to support swift tools 5.8 which is newest version supported by nixpkgs:
+        # https://github.com/apple/swift-crypto/commit/35703579f63c2518fc929a1ce49805ba6134137c
+        tag = "3.7.1";
+        hash = "sha256-zxmHxTryAezgqU5qjXlFFThJlfUsPxb1KRBan4DSm9A=";
+      };
+    in
+    ''
+      ln -s ${swift-crypto} swift-crypto
+      substituteInPlace Package.swift --replace-fail 'url: "https://github.com/apple/swift-crypto.git"' 'path: "./swift-crypto"), //'
+    '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "RELEASE=1"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Age plugin for Apple's Secure Enclave";
+    homepage = "https://github.com/remko/age-plugin-se/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      onnimonni
+      remko
+    ];
+    mainProgram = "age-plugin-se";
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/ag/age/package.nix
+++ b/pkgs/by-name/ag/age/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   age-plugin-tpm,
+  age-plugin-se,
   age-plugin-sss,
   age-plugin-ledger,
   age-plugin-yubikey,
@@ -59,6 +60,7 @@ buildGoModule (final: {
   passthru.plugins = {
     inherit
       age-plugin-tpm
+      age-plugin-se
       age-plugin-sss
       age-plugin-ledger
       age-plugin-yubikey


### PR DESCRIPTION
Added a plugin for [age](https://github.com/FiloSottile/age) to create and use private keys using Apple's secure enclave coprocessor. This is my first time packaging anything into nix but I was able to see how others were using `swift-crypto` and swift programs in general and the make flags from [corresponding homebrew formula](https://github.com/Homebrew/homebrew-core/blob/a2abb29891dfa464594a3f1d538489adfcd09e31/Formula/a/age-plugin-se.rb).

Please teach me if there's a better way to reference the `swift-crypto` dependency.

I builded this on my machine and it works fine. Closes #382877.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
