### PR TITLE
sage: remove optional jmol dep (and thus also jre8)

### DIFF
--- a/pkgs/by-name/sa/sage/env-locations.nix
+++ b/pkgs/by-name/sa/sage/env-locations.nix
@@ -9,7 +9,6 @@
   polytopes_db,
   gap,
   combinatorial_designs,
-  jmol,
   mathjax,
   three,
   cysignals,
@@ -37,8 +36,6 @@ writeTextFile rec {
     export ECLDIR='${maxima.lisp-compiler}/lib/${maxima.lisp-compiler.pname}-${maxima.lisp-compiler.version}/'
     export COMBINATORIAL_DESIGN_DATA_DIR="${combinatorial_designs}/share/combinatorial_designs"
     export CREMONA_MINI_DATA_DIR="${elliptic_curves}/share/cremona"
-    export JMOL_DIR="${jmol}/share/jmol" # point to the directory that contains JmolData.jar
-    export JSMOL_DIR="${jmol}/share/jsmol"
     export MATHJAX_DIR="${mathjax}/lib/node_modules/mathjax"
     export THREEJS_DIR="${three}/lib/node_modules/three"
     export SAGE_INCLUDE_DIRECTORIES="${cysignals}/${cysignals.pythonModule.sitePackages}"

--- a/pkgs/by-name/sa/sage/sage-env.nix
+++ b/pkgs/by-name/sa/sage/sage-env.nix
@@ -31,7 +31,6 @@
   rWrapper,
   gfan,
   cddlib,
-  jmol,
   tachyon,
   glpk,
   eclib,
@@ -50,7 +49,6 @@
   zlib,
   gsl,
   ntl,
-  jre8,
   less,
 }:
 
@@ -87,7 +85,6 @@ let
       rWrapper
       gfan
       cddlib
-      jmol
       tachyon
       glpk
       eclib
@@ -98,7 +95,6 @@ let
       ecm
       lcalc
       rubiks
-      jre8 # only needed for `jmol` (https://sourceforge.net/p/jmol/mailman/message/58818762/), which will be optional in sage 10.5
       less # needed to prevent transient test errors until https://github.com/ipython/ipython/pull/11864 is resolved
     ])
   );
@@ -176,7 +172,6 @@ writeTextFile rec {
                 eclib
                 gsl
                 ntl
-                jmol
                 sympow
               ]
             )


### PR DESCRIPTION
We are now past Sage 10.5, and jmol is now optional so unneeded in the default env.

See https://github.com/sagemath/sage/issues/31027


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested basic CLI usage.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>cantor</li>
    <li>labplot</li>
    <li>sage</li>
    <li>sageWithDoc</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
