### PR TITLE
veridian: init at 0-unstable-2024-12-25

### DIFF
--- a/pkgs/by-name/ve/veridian/package.nix
+++ b/pkgs/by-name/ve/veridian/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  cmake,
+  makeWrapper,
+  pkg-config,
+
+  boost,
+  fmt_11,
+  openssl,
+  sv-lang,
+  mimalloc,
+
+  verible,
+  verilator,
+}:
+rustPlatform.buildRustPackage {
+  pname = "veridian";
+  version = "0-unstable-2024-12-25";
+
+  src = fetchFromGitHub {
+    owner = "vivekmalneedi";
+    repo = "veridian";
+    rev = "d094c9d2fa9745b2c4430eef052478c64d5dd3b6";
+    hash = "sha256-3KjUunXTqdesvgDSeQMoXL0LRGsGQXZJGDt+xLWGovM=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-qJQD9HjSrrHdppbLNgLnXCycgzbmPePydZve3A8zGtU=";
+
+  buildFeatures = [ "slang" ];
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    fmt_11
+    openssl
+    sv-lang
+    mimalloc
+  ];
+
+  # the tests also need these to be on the PATH
+  nativeCheckInputs = [
+    verible
+    verilator
+  ];
+
+  postInstall =
+    let
+      runtimePathDeps = [
+        verible
+        verilator
+      ];
+    in
+    ''
+      wrapProgram $out/bin/veridian \
+        --prefix PATH : ${lib.makeBinPath runtimePathDeps}
+    '';
+
+  env = {
+    OPENSSL_NO_VENDOR = "1";
+    RUSTFLAGS = "-C link-args=-lmimalloc";
+    # this is needed so that veridian doesn't try to build the sv-lang package itself
+    SLANG_INSTALL_PATH = sv-lang;
+  };
+
+  meta = {
+    description = "SystemVerilog Language Server";
+    homepage = "https://github.com/vivekmalneedi/veridian";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.hakan-demirli ];
+  };
+}


### PR DESCRIPTION
Adds https://github.com/vivekmalneedi/veridian LSP server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
