### PR TITLE
fiddler-everywhere: init at 6.1.0

### DIFF
--- a/pkgs/by-name/fi/fiddler-everywhere/package.nix
+++ b/pkgs/by-name/fi/fiddler-everywhere/package.nix
@@ -1,0 +1,64 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  makeWrapper,
+  writeScript,
+}:
+
+let
+  pname = "fiddler-everywhere";
+  version = "6.1.0";
+
+  src = fetchurl {
+    url = "https://downloads.getfiddler.com/linux/fiddler-everywhere-${version}.AppImage";
+    hash = "sha256-fxGwOt/+3T7LDK69H/Nm1dyGiT588YhSR4D5xO36xKk=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      substituteInPlace $out/fiddler-everywhere.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=fiddler-everywhere'
+    '';
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [ pkgs.icu ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/fiddler-everywhere.desktop $out/share/applications/fiddler-everywhere.desktop
+    for i in 16 24 32 48 64 96 128 256 512 1024; do
+      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/''${i}x''${i}/apps/fiddler-everywhere.png \
+        $out/share/icons/hicolor/''${i}x''${i}/apps/fiddler-everywhere.png
+    done
+    wrapProgram $out/bin/fiddler-everywhere --set DESKTOPINTEGRATION false
+  '';
+
+  passthru.updateScript = writeScript "update-fiddler-everywhere" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl pcre2 common-updater-scripts
+
+    set -eu -o pipefail
+
+    version="$(curl -si https://api.getfiddler.com/linux/latest-linux \
+      | grep -Fi 'Location:' \
+      | pcre2grep -o1 'https://downloads.getfiddler.com/linux/fiddler-everywhere-(([0-9]\.?)+).AppImage')"
+    update-source-version fiddler-everywhere "$version"
+  '';
+
+  meta = {
+    description = "Web debugging proxy by Telerik";
+    homepage = "https://www.telerik.com/fiddler/fiddler-everywhere";
+    downloadPage = "https://www.telerik.com/download/fiddler-everywhere";
+    changelog = "https://www.telerik.com/support/whats-new/fiddler-everywhere/release-history";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ RoGreat ];
+    mainProgram = "fiddler-everywhere";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
"Progress® Telerik® Fiddler Everywhere is a web-debugging tool that monitors, inspects, edits, and logs all HTTPS traffic, issues requests between your computer and the Internet, and fiddles with incoming and outgoing data. It is a high-performance, cross-platform proxy for any browser, system, or platform."

https://docs.telerik.com/fiddler-everywhere/introduction#welcome-to-fiddler-everywhere

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
