### PR TITLE
linuxKernel.kernels.linux_{lqx,zen}: add axertheaxe as maintainer

### DIFF
--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -140,6 +140,7 @@ let
           maintainers = with lib.maintainers; [
             thiagokokada
             jerrysm64
+            axertheaxe
           ];
           description =
             "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads."


### PR DESCRIPTION
Hello, I would like to add myself as an maintainer for Zen and Lqx. I am a user of the LQZ kernel on NixOS and would like to be able to update the package regularly.

This PR just adds myself to the maintainers set of `zen-kernels.nix`.

I am already in `maintainer-list.nix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
