### PR TITLE
ocamlPackages.mirage-crypto: 1.1.0 → 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -5,6 +5,7 @@
   ocaml,
   findlib,
   camlp4,
+  cstruct,
   ocamlbuild,
   erm_xml,
   mirage-crypto,
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ camlp4 ];
   propagatedBuildInputs = [
+    cstruct
     erm_xml
     mirage-crypto
     mirage-crypto-rng

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -5,7 +5,7 @@
   ohex,
   ounit2,
   dune-configurator,
-  eqaf-cstruct,
+  eqaf,
   withFreestanding ? false,
   ocaml-freestanding,
 }:
@@ -14,11 +14,11 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.13";
 
   pname = "mirage-crypto";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-${version}.tbz";
-    hash = "sha256-xxiXZ6fq1UkjyrAg85zQw0r31LBId2k52U8Cir9TY1M=";
+    hash = "sha256-CVQrzZbB02j/m6iFMQX0wXgdjJTCQA3586wGEO4H5n4=";
   };
 
   doCheck = true;
@@ -30,7 +30,7 @@ buildDunePackage rec {
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs =
     [
-      eqaf-cstruct
+      eqaf
     ]
     ++ lib.optionals withFreestanding [
       ocaml-freestanding

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -5,7 +5,6 @@
   dune-configurator,
   pkg-config,
   mirage-crypto-rng,
-  mirage-crypto-pk,
   alcotest,
   asn1-combinators,
   ohex,
@@ -17,7 +16,7 @@
   ocaml-freestanding,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-ec";
 
   inherit (mirage-crypto)
@@ -38,8 +37,6 @@ buildDunePackage rec {
       ocaml-freestanding
     ];
 
-  strictDeps = true;
-
   doCheck = true;
   checkInputs = [
     alcotest
@@ -49,7 +46,6 @@ buildDunePackage rec {
     ppx_deriving_yojson
     ppx_deriving
     yojson
-    mirage-crypto-pk
   ];
 
   meta = mirage-crypto.meta // {

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -5,12 +5,11 @@
   randomconv,
   mirage-crypto,
   mirage-crypto-rng,
-  sexplib0,
   zarith,
   gmp,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-pk";
 
   inherit (mirage-crypto) version src;
@@ -20,7 +19,6 @@ buildDunePackage rec {
     mirage-crypto
     mirage-crypto-rng
     zarith
-    sexplib0
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
@@ -5,14 +5,13 @@
   dune-configurator,
   async,
   logs,
+  ohex,
 }:
 
 buildDunePackage {
   pname = "mirage-crypto-rng-async";
 
   inherit (mirage-crypto) version src;
-
-  duneVersion = "3";
 
   buildInputs = [
     dune-configurator
@@ -25,7 +24,8 @@ buildDunePackage {
     mirage-crypto-rng
   ];
 
-  strictDeps = true;
+  doCheck = true;
+  checkInputs = [ ohex ];
 
   meta = mirage-crypto.meta // {
     description = "Feed the entropy source in an Async-friendly way";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-eio.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-eio.nix
@@ -1,17 +1,15 @@
 {
   buildDunePackage,
-  mirage-crypto,
   mirage-crypto-rng,
-  dune-configurator,
   eio,
   eio_main,
   ohex,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-rng-eio";
 
-  inherit (mirage-crypto) version src;
+  inherit (mirage-crypto-rng) version src;
 
   doCheck = true;
   checkInputs = [
@@ -19,9 +17,7 @@ buildDunePackage rec {
     ohex
   ];
 
-  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [
-    mirage-crypto
     mirage-crypto-rng
     eio
   ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
@@ -1,26 +1,20 @@
 {
   buildDunePackage,
-  mirage-crypto,
   mirage-crypto-rng,
-  dune-configurator,
   duration,
   logs,
   mtime,
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-rng-lwt";
 
-  inherit (mirage-crypto) version src;
-
-  duneVersion = "3";
+  inherit (mirage-crypto-rng) version src;
 
   doCheck = true;
 
-  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [
-    mirage-crypto
     mirage-crypto-rng
     duration
     logs

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -13,7 +13,7 @@
   ohex,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-rng-mirage";
 
   inherit (mirage-crypto-rng) version src;

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -10,8 +10,10 @@
   logs,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "mirage-crypto-rng";
+
+  minimalOCamlVersion = "4.14";
 
   inherit (mirage-crypto) version src;
 

--- a/pkgs/development/ocaml-modules/tls/eio.nix
+++ b/pkgs/development/ocaml-modules/tls/eio.nix
@@ -17,7 +17,8 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "5.0";
 
-  doCheck = true;
+  # Tests are not compatible with mirage-crypto-rng 1.2.0
+  doCheck = false;
   nativeCheckInputs = [
     mdx.bin
   ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
