### PR TITLE
ragenix: init at 0-unstable-2024-09-19

### DIFF
--- a/pkgs/by-name/ra/ragenix/package.nix
+++ b/pkgs/by-name/ra/ragenix/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix,
+  installShellFiles,
+}:
+rustPlatform.buildRustPackage {
+  pname = "ragenix";
+  version = "0-unstable-2024-09-19";
+
+  src = fetchFromGitHub {
+    owner = "yaxitech";
+    repo = "ragenix";
+    rev = "687ee92114bce9c4724376cf6b21235abe880bfa";
+    hash = "sha256-03XIEjHeZEjHXctsXYUB+ZLQmM0WuhR6qWQjwekFk/M=";
+  };
+
+  cargoHash = "sha256-NO0VpLZTGjddh1aESulAx4pP4k1vdDm1+oCmf/ybuO4=";
+  useFetchCargoVendor = true;
+
+  RAGENIX_NIX_BIN_PATH = lib.getExe nix;
+
+  checkNoDefaultFeatures = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    set -euo pipefail
+
+    # Provide a symlink from `agenix` to `ragenix` for compat
+    ln -sr "$out/bin/ragenix" "$out/bin/agenix"
+
+    # Stdout of build.rs
+    buildOut=$(grep -m 1 -Rl 'RAGENIX_COMPLETIONS_BASH=/' target/ | head -n 1)
+    printf "found build script output at %s\n" "$buildOut"
+
+    set +u # required due to `installShellCompletion`'s implementation
+    installShellCompletion --bash "$(grep -oP 'RAGENIX_COMPLETIONS_BASH=\K.+' "$buildOut")"
+    installShellCompletion --zsh  "$(grep -oP 'RAGENIX_COMPLETIONS_ZSH=\K.+'  "$buildOut")"
+    installShellCompletion --fish "$(grep -oP 'RAGENIX_COMPLETIONS_FISH=\K.+' "$buildOut")"
+    set -x
+
+    installManPage docs/ragenix.1
+  '';
+
+  meta = {
+    description = "Age-encrypted secrets for NixOS, drop-in replacement for agenix";
+    homepage = "https://github.com/yaxitech/ragenix";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      aciceri
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "ragenix";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Upstream derivation: https://github.com/yaxitech/ragenix/blob/main/default.nix

Worked on this at the [Thaigersprint](https://github.com/Thaigersprint/thaigersprint-2025/issues/1)