### PR TITLE
tiktok-uploader: init at 59dc978

### DIFF
--- a/pkgs/by-name/ti/tiktok-uploader/package.nix
+++ b/pkgs/by-name/ti/tiktok-uploader/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "tiktok-uploader";
+  version = "59dc978";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "wkaisertexas";
+    repo = "tiktok-uploader";
+    rev = version;
+    hash = "sha256-CYefyx6oWmHsXbVjFzulGEGFpFfOJpATjNolN9XryQU=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    pyperclip
+    selenium
+    webdriver-manager
+    toml
+    pytz
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "tiktok_uploader"
+  ];
+
+  meta = {
+    description = "Upload TikToks through Python using Selenium";
+    homepage = "https://github.com/wkaisertexas/tiktok-uploader";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ srghma ];
+    mainProgram = "tiktok-uploader";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Have problem

```sh
 ~/projects/nixpkgs  /nix/store/z62icv5pwcrbz9vvww34gsvbzbzdz529-tiktok-uploader-59dc978/bin/tiktok-auth --help
usage: tiktok-auth [-h] [-o OUTPUT] [-i INPUT] [-u USERNAME] [-p PASSWORD]

TikTok Auth is a program which can log you into multiple accounts sequentially

options:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        The output folder to save the cookies to
  -i INPUT, --input INPUT
                        A csv file with username and password
  -u USERNAME, --username USERNAME
                        Your TikTok email / username
  -p PASSWORD, --password PASSWORD
                        Your TikTok password
 ~/projects/nixpkgs  /nix/store/z62icv5pwcrbz9vvww34gsvbzbzdz529-tiktok-uploader-59dc978/bin/tiktok-uploader --help
Traceback (most recent call last):
  File "/nix/store/z62icv5pwcrbz9vvww34gsvbzbzdz529-tiktok-uploader-59dc978/bin/.tiktok-uploader-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/z62icv5pwcrbz9vvww34gsvbzbzdz529-tiktok-uploader-59dc978/lib/python3.11/site-packages/tiktok_uploader/cli.py", line 17, in main
    args = get_uploader_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/z62icv5pwcrbz9vvww34gsvbzbzdz529-tiktok-uploader-59dc978/lib/python3.11/site-packages/tiktok_uploader/cli.py", line 74, in get_uploader_args
    return parser.parse_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 1874, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 1907, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 2128, in _parse_known_args
    start_index = consume_optional(start_index)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 2068, in consume_optional
    take_action(action, args, option_string)
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 1983, in take_action
    action(self, namespace, argument_values, option_string)
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 1122, in __call__
    parser.print_help()
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 2611, in print_help
    self._print_message(self.format_help(), file)
                        ^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 2595, in format_help
    return formatter.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 287, in format_help
    help = self._root_section.format_help()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 217, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 217, in format_help
    item_help = join([func(*args) for func, args in self.items])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 217, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
                      ^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 546, in _format_action
    help_text = self._expand_help(action)
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/argparse.py", line 643, in _expand_help
    return self._get_help_string(action) % params
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
ValueError: unsupported format character 'Y' (0x59) at index 22
```

Could someone help?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
