### PR TITLE
otb: fix build for unstable branch 

### DIFF
--- a/pkgs/by-name/ot/otb/itk-1-fftw-all.diff
+++ b/pkgs/by-name/ot/otb/itk-1-fftw-all.diff
@@ -1,0 +1,32 @@
+diff -burN ITK-5.0.0.orig/CMake/FindFFTW.cmake ITK-5.0.0/CMake/FindFFTW.cmake
+--- ITK-5.0.0.orig/CMake/FindFFTW.cmake	2019-05-22 17:54:36.000000000 +0200
++++ ITK-5.0.0/CMake/FindFFTW.cmake	2019-06-24 16:45:46.316235664 +0200
+@@ -59,7 +59,7 @@
+   if(ITK_USE_CUFFTW)
+     find_path(CUFFTW_INCLUDE_PATH cufftw.h ${FFTW_INC_SEARCHPATH})
+   else()
+-    find_path(FFTW_INCLUDE_PATH fftw3.h ${FFTW_INC_SEARCHPATH})
++    find_path(FFTW_INCLUDE_PATH fftw3.h NO_DEFAULT_PATH)
+   endif()
+ 
+   if(FFTW_INCLUDE_PATH)
+@@ -183,7 +189,7 @@
+     if(ITK_USE_FFTWD)
+       mark_as_advanced(FFTWD_BASE_LIB FFTWD_THREADS_LIB FFTWD_LIBRARIES)
+-      find_library(FFTWD_BASE_LIB fftw3 ${FFTW_LIB_SEARCHPATH}) #Double Precision Lib
+-      find_library(FFTWD_THREADS_LIB fftw3_threads ${FFTW_LIB_SEARCHPATH}) #Double Precision Lib only if compiled with threads support
++      find_library(FFTWD_BASE_LIB fftw3 ${FFTW_LIB_SEARCHPATH}  NO_DEFAULT_PATH) #Double Precision Lib
++      find_library(FFTWD_THREADS_LIB fftw3_threads ${FFTW_LIB_SEARCHPATH}  NO_DEFAULT_PATH) #Double Precision Lib only if compiled with threads support
+ 
+       if(FFTWD_BASE_LIB)
+         set(FFTWD_FOUND 1)
+@@ -203,7 +209,7 @@
+     if(ITK_USE_FFTWF)
+       mark_as_advanced(FFTWF_BASE_LIB FFTWF_THREADS_LIB FFTWF_LIBRARIES)
+-      find_library(FFTWF_BASE_LIB fftw3f ${FFTW_LIB_SEARCHPATH}) #Single Precision Lib
+-      find_library(FFTWF_THREADS_LIB fftw3f_threads ${FFTW_LIB_SEARCHPATH}) #Single Precision Lib only if compiled with threads support
++      find_library(FFTWF_BASE_LIB fftw3f ${FFTW_LIB_SEARCHPATH}  NO_DEFAULT_PATH) #Single Precision Lib
++      find_library(FFTWF_THREADS_LIB fftw3f_threads ${FFTW_LIB_SEARCHPATH}  NO_DEFAULT_PATH) #Single Precision Lib only if compiled with threads support
+ 
+       if(FFTWF_BASE_LIB)
+         set(FFTWF_FOUND 1)

--- a/pkgs/by-name/ot/otb/itk-2-totalprogress-all.diff
+++ b/pkgs/by-name/ot/otb/itk-2-totalprogress-all.diff
@@ -1,0 +1,9 @@
+diff -burN ITK-5.3.0.orig/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx ITK-5.3.0/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx
+--- ITK-5.3.0.orig/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx	2024-08-23 17:54:36.000000000 +0200
++++ ITK-5.3.0/Modules/Filtering/MathematicalMorphology/include/itkVanHerkGilWermanErodeDilateImageFilter.hxx	2024-08-23 16:45:46.316235664 +0200
+@@ -21,4 +21,4 @@
+#include "itkImageRegionIterator.h"
+
+#include "itkVanHerkGilWermanUtilities.h"
+-
++#include "itkTotalProgressReporter.h"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The OTB 9.1.0 package is currently broken. [c.f](https://hydra.nixos.org/job/nixpkgs/trunk/otb.x86_64-linux/all). However the 9.1.0 cannot be build with the current version of the packages available in Nixpkgs. So here I have updated the OTB to `unstable version` based on the `develop` branch which seems to build fine.

Thanks to @SomeoneSerge for the suggested changes, I have refactored the `itk` package needed for OTB using override as it was suggested earlier. [c.f](https://github.com/NixOS/nixpkgs/pull/325630#issuecomment-2233701914)  and [c.f](https://github.com/NixOS/nixpkgs/pull/325630#issuecomment-2233701914).

However the python has been disabled for OTB as there seems to be some issue. [c.f](https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2451).

cc https://github.com/Thaigersprint/thaigersprint-2025/issues/1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
