### PR TITLE
delve: unbreak `go version -m dlv`

### DIFF
--- a/pkgs/by-name/de/delve/disable-fortify.diff
+++ b/pkgs/by-name/de/delve/disable-fortify.diff
@@ -1,0 +1,13 @@
+diff --git a/cmd/dlv/main.go b/cmd/dlv/main.go
+index 2207708e..a7e8a3c2 100644
+--- a/cmd/dlv/main.go
++++ b/cmd/dlv/main.go
+@@ -21,6 +21,8 @@ func main() {
+ 		version.DelveVersion.Build = Build
+ 	}
+ 
++	os.Setenv("disableHardening", "fortify "+os.Getenv("disableHardening"))
++
+ 	const cgoCflagsEnv = "CGO_CFLAGS"
+ 	if os.Getenv(cgoCflagsEnv) == "" {
+ 		os.Setenv(cgoCflagsEnv, "-O0 -g")

--- a/pkgs/by-name/de/delve/package.nix
+++ b/pkgs/by-name/de/delve/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  makeWrapper,
   stdenv,
 }:
 
@@ -17,11 +16,13 @@ buildGoModule rec {
     hash = "sha256-R1MTMRAIceHv9apKTV+k4d8KoBaRJSZCflxqhgfQWu4=";
   };
 
+  patches = [
+    ./disable-fortify.diff
+  ];
+
   vendorHash = null;
 
   subPackages = [ "cmd/dlv" ];
-
-  nativeBuildInputs = [ makeWrapper ];
 
   hardeningDisable = [ "fortify" ];
 
@@ -38,10 +39,6 @@ buildGoModule rec {
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   postInstall = ''
-    # fortify source breaks build since delve compiles with -O0
-    wrapProgram $out/bin/dlv \
-      --prefix disableHardening " " fortify
-
     # add symlink for vscode golang extension
     # https://github.com/golang/vscode-go/blob/master/docs/debugging.md#manually-installing-dlv-dap
     ln $out/bin/dlv $out/bin/dlv-dap


### PR DESCRIPTION
This is used by vscode to determine the go version the tool was compiled with.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
