### PR TITLE
gradle: Drop init-deps.gradle script

### DIFF
--- a/doc/languages-frameworks/gradle.section.md
+++ b/doc/languages-frameworks/gradle.section.md
@@ -163,7 +163,7 @@ The Gradle setup hook accepts the following environment variables:
   the package if `doCheck` is set to `true`. Defaults to `test`.
 - `gradleUpdateTask` - the Gradle task (or tasks) to be used for
   fetching all of the package's dependencies in
-  `mitmCache.updateScript`. Defaults to `nixDownloadDeps`.
+  `mitmCache.updateScript`. Defaults to `help --write-verification-metadata sha256`.
 - `gradleUpdateScript` - the code to run for fetching all of the
   package's dependencies in `mitmCache.updateScript`. Defaults to
   running the `preBuild` and `preGradleUpdate` hooks, running the

--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -125,8 +125,8 @@ stdenv.mkDerivation rec {
   gradleUpdateScript = ''
     runHook preBuild
 
-    gradle nixDownloadDeps -Dos.arch=amd64
-    gradle nixDownloadDeps -Dos.arch=aarch64
+    gradle --write-verification-metadata sha256 -Dos.arch=amd64
+    gradle --write-verification-metadata sha256 -Dos.arch=aarch64
   '';
 
   meta = with lib; {

--- a/pkgs/build-support/mitm-cache/default.nix
+++ b/pkgs/build-support/mitm-cache/default.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mitm-cache";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "chayleaf";
     repo = "mitm-cache";
     rev = "v${version}";
-    hash = "sha256-l9dnyA4Zo4jlbiCMRzUqW3NkiploVpmvxz9i896JkXU=";
+    hash = "sha256-eY8mgmQB8wXQ7YJbLvdjXEEgGD+/RDywjvehJYf7ckE=";
   };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-6554Tf5W+7OFQw8Zm4yBQ2/rHm31MQ0Q+vTbnmZTGMQ=";
+  cargoHash = "sha256-DTPlPCumkVI2naYoNdO8T3pQNSawBA0FZ9LxVpqKqN0=";
 
   setupHook = replaceVars ./setup-hook.sh {
     inherit openssl;

--- a/pkgs/by-name/at/atlauncher/deps.json
+++ b/pkgs/by-name/at/atlauncher/deps.json
@@ -3,12 +3,12 @@
  "!version": 1,
  "https://jitpack.io/com": {
   "github/ATLauncher/gradle-macappbundle#build/d22f8cdb94": {
-   "jar": "sha256-rBqYi12MUWdwuNbFSlYO0tREzcDpfXI3VRPVV/DRZ+c=",
-   "module": "sha256-JlSHpEtQuOO3/qIdidXBZ21IjieA7PE2b0ui7aimdxc=",
-   "pom": "sha256-ySbX7ZLlXt7l+JcGEqV/peu6T+h7oJp6s/d95XQdIVo="
+   "jar": "sha256-XGbB0YmVOlFzeMMuiQBUfrVV0jGTBH85Wm21cf8dyYY=",
+   "module": "sha256-25APuhfYsPYE1BvjyEeUVgYe6rltpVQWO8uez/tYlyg=",
+   "pom": "sha256-8MUNJG8NS3abzf9rXbna7Hb7AEnJ40BUWpWDuVH2u8E="
   },
   "github/ATLauncher/gradle-macappbundle#edu.sc.seis.macAppBundle.gradle.plugin/d22f8cdb94": {
-   "pom": "sha256-9LZJTFfyVUyMXTgn2ifGyXEPLfPJ6tmlY8qSWEO0YmU="
+   "pom": "sha256-h6uFT6m8D6PFne5X8OXRaB273/LKX4wD7WVsivFDEOM="
   },
   "github/MCRcortex#nekodetector/Version-1.1-pre": {
    "jar": "sha256-5K2d2tmaNRavJFLe9oIv1RxNUoSUsWbZla7B0Z+4f9U=",

--- a/pkgs/by-name/fa/fastddsgen/package.nix
+++ b/pkgs/by-name/fa/fastddsgen/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
     cd thirdparty/idl-parser
     # fix "Task 'submodulesUpdate' not found"
     gradleFlags=
-    gradle nixDownloadDeps
+    gradle --write-verification-metadata sha256
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ja/jadx/deps.json
+++ b/pkgs/by-name/ja/jadx/deps.json
@@ -421,6 +421,10 @@
    "jar": "sha256-R1eJEWW2mPvazo9NpvK8DpiOrvnvNnE1SIZajycGmv0=",
    "pom": "sha256-Y/6HvSI1sSlAnHIqCbYsIKe3eueQGeIgMSSK9zawPFQ="
   },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.0.21": {
+   "jar": "sha256-2Gv0M4pthBzM37v/LaBb0DpJw9uMP5erhed+AhrQhFs=",
+   "pom": "sha256-esgfO7B8TWqo+pj/WjmaR6vRzhx4bU8/rZbvKBIL34o="
+  },
   "org/jetbrains/kotlin#kotlin-native-utils/1.9.23": {
    "jar": "sha256-X9AUhb1z5he+VWv/SZL/ASquufDZwAhPN8tdiKO8rYQ=",
    "pom": "sha256-eCaL6luL9QqV7nYxKuNjzAvWqt1d9HQwrBNaIG7467Y="
@@ -510,6 +514,9 @@
    "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
    "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
    "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.0.21/all": {
+   "jar": "sha256-UP+t6yC00kVqUmWVpPep6FiJaCcVBz5s26Gx2A461Fg="
   },
   "org/jetbrains/kotlin#kotlin-tooling-core/1.9.23": {
    "jar": "sha256-iTjrl+NjINqj5vsqYP0qBbIy/0pVcXPFAZ8EW4gy2fQ=",

--- a/pkgs/by-name/js/json2cdn/deps.json
+++ b/pkgs/by-name/js/json2cdn/deps.json
@@ -1,196 +1,196 @@
 {
-  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
-  "!version": 1,
-  "https://plugins.gradle.org/m2": {
-    "com/fasterxml#oss-parent/38": {
-      "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
-    },
-    "com/fasterxml#oss-parent/50": {
-      "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
-    },
-    "com/fasterxml#oss-parent/58": {
-      "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
-    },
-    "com/fasterxml/jackson#jackson-bom/2.17.2": {
-      "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
-    },
-    "com/fasterxml/jackson#jackson-parent/2.17": {
-      "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
-    },
-    "com/fasterxml/woodstox#woodstox-core/6.5.1": {
-      "jar": "sha256-ySjWBmXGQV+xw5d1z5XPxE9/RYDPWrAbHDgOv/12iH8=",
-      "pom": "sha256-SDllThaxcU509Rq8s3jYNWgUq49NUnPR3S8c6KOQrdw="
-    },
-    "com/gradleup/shadow#com.gradleup.shadow.gradle.plugin/8.3.5": {
-      "pom": "sha256-bc9S5Y+1rG4aD6CVCbfashy3iqlLV3opZThgchAXjKY="
-    },
-    "com/gradleup/shadow#shadow-gradle-plugin/8.3.5": {
-      "jar": "sha256-VOCN0gqCd14zF6RyWhpeTsixscDzRt5wKknZ7UgVtzU=",
-      "module": "sha256-+kwoQEsU00woznA078s3q513u//7O6xbyLf7BGqtliI=",
-      "pom": "sha256-cIF5r4UBl3extKmnI2gPYIX67YERrJFJYeZ1S0lEG6k="
-    },
-    "commons-io#commons-io/2.17.0": {
-      "jar": "sha256-SqTKSPPf0wt4Igt4gdjLk+rECT7JQ2G2vvqUh5mKVQs=",
-      "pom": "sha256-SEqTn/9TELjLXGuQKcLc8VXT+TuLjWKF8/VrsroJ/Ek="
-    },
-    "jakarta/platform#jakarta.jakartaee-bom/9.1.0": {
-      "pom": "sha256-35jgJmIZ/buCVigm15o6IHdqi6Aqp4fw8HZaU4ZUyKQ="
-    },
-    "jakarta/platform#jakartaee-api-parent/9.1.0": {
-      "pom": "sha256-p3AsSHAmgCeEtXl7YjMKi41lkr8PRzeyXGel6sgmWcA="
-    },
-    "org/apache#apache/31": {
-      "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
-    },
-    "org/apache#apache/33": {
-      "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
-    },
-    "org/apache/ant#ant-launcher/1.10.15": {
-      "jar": "sha256-XIVRmQMHoDIzbZjdrtVJo5ponwfU1Ma5UGAb8is9ahs=",
-      "pom": "sha256-ea+EKil53F/gAivAc8SYgQ7q2DvGKD7t803E3+MNrJU="
-    },
-    "org/apache/ant#ant-parent/1.10.15": {
-      "pom": "sha256-SYhPGHPFEHzCN/QoXER3R5uwgEvwc3OUgBsI114rvrA="
-    },
-    "org/apache/ant#ant/1.10.15": {
-      "jar": "sha256-djrNpKaViMnqiBepUoUf8ML8S/+h0IHCVl3EB/KdV5Q=",
-      "pom": "sha256-R4DmHoeBbu4fIdGE7Jl7Zfk9tfS5BCwXitsp4j50JdY="
-    },
-    "org/apache/commons#commons-parent/74": {
-      "pom": "sha256-gOthsMh/3YJqBpMTsotnLaPxiFgy2kR7Uebophl+fss="
-    },
-    "org/apache/groovy#groovy-bom/4.0.22": {
-      "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
-      "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
-    },
-    "org/apache/logging#logging-parent/11.3.0": {
-      "pom": "sha256-pcmFtW/hxYQzOTtQkabznlufeFGN2PySE0aQWZtk19A="
-    },
-    "org/apache/logging/log4j#log4j-api/2.24.1": {
-      "jar": "sha256-bne7Ip/I3K8JA4vutekDCyLp4BtRtFiwGDzmaevMku8=",
-      "pom": "sha256-IzAaISnUEAiZJfSvQa7LUlhKPcxFJoI+EyNOyst+c+M="
-    },
-    "org/apache/logging/log4j#log4j-bom/2.24.1": {
-      "pom": "sha256-vGPPsrS5bbS9cwyWLoJPtpKMuEkCwUFuR3q1y3KwsNM="
-    },
-    "org/apache/logging/log4j#log4j-core/2.24.1": {
-      "jar": "sha256-ALzziEcsqApocBQYF2O2bXdxd/Isu/F5/WDhsaybybA=",
-      "pom": "sha256-JyQstBek3xl47t/GlYtFyJgg+WzH9NFtH0gr/CN24M0="
-    },
-    "org/apache/logging/log4j#log4j/2.24.1": {
-      "pom": "sha256-+NcAm1Rl2KhT0QuEG8Bve3JnXwza71OoDprNFDMkfto="
-    },
-    "org/apache/maven#maven-api-meta/4.0.0-alpha-9": {
-      "jar": "sha256-MsT1yturaAw0lS+ctXBFehODzOxMmlewOSYH1xkcaUk=",
-      "pom": "sha256-2ePDXW/aysuNGLn2QoYJDH/65yjWbLJq9aJmgZUNvnk="
-    },
-    "org/apache/maven#maven-api-xml/4.0.0-alpha-9": {
-      "jar": "sha256-KbJijQ8CgRlxWRaEnBnu1FsyzcZ+sTVReYxzr6SqI9Y=",
-      "pom": "sha256-N2bjAzOTTJIvUlj6M0uHXyi7ABJ/8D3vANl/KlOnrps="
-    },
-    "org/apache/maven#maven-api/4.0.0-alpha-9": {
-      "pom": "sha256-ZYvglXcymzX5TemWdb8O/HI26ZYbXHhfMyqkfyKUcfA="
-    },
-    "org/apache/maven#maven-bom/4.0.0-alpha-9": {
-      "pom": "sha256-4EfSnTUI/yd6Wsk1u5J/NUkQLMbTec5a4p4pYzeE0Rw="
-    },
-    "org/apache/maven#maven-parent/41": {
-      "pom": "sha256-di/N1M6GIcX6Ciz2SVrSaXKoCT60Mqo+QCvC1OJQDFM="
-    },
-    "org/apache/maven#maven-xml-impl/4.0.0-alpha-9": {
-      "jar": "sha256-JucCuIHVeuTuiNAsAJQLpkBjcF7mkgWuiVi/g5qLBrE=",
-      "pom": "sha256-us0USYVzbUMmuuRChHM78eMTKX3NolNGTkYpsddoGPc="
-    },
-    "org/apache/maven#maven/4.0.0-alpha-9": {
-      "pom": "sha256-5QzZ/zefQ3H3/ywsrFF5YfPS9n7fgJCHU8e9UGuRPX4="
-    },
-    "org/codehaus/plexus#plexus-utils/4.0.2": {
-      "jar": "sha256-iVcnTnX+LCeLFCjdFqDa7uHdOBUstu/4Fhd6wo/Mtpc=",
-      "pom": "sha256-UVHBO918w6VWlYOn9CZzkvAT/9MRXquNtfht5CCjZq8="
-    },
-    "org/codehaus/plexus#plexus-xml/4.0.4": {
-      "jar": "sha256-Bp54tTcQjcYSSmcHP8mYJkeR9rZJnpVaOOcrs+T+Gt8=",
-      "pom": "sha256-Ohb3yn7CRzFFtGHgpylREI1H4SThjIRMCFsaY3jGEVE="
-    },
-    "org/codehaus/plexus#plexus/18": {
-      "pom": "sha256-tD7onIiQueW8SNB5/LTETwgrUTklM1bcRVgGozw92P0="
-    },
-    "org/codehaus/woodstox#stax2-api/4.2.1": {
-      "jar": "sha256-Z4Vn5ItRpCxlxpnyZlOa09Z21LGlsK19iezoudV3JXk=",
-      "pom": "sha256-edpBDIwPRqP46K2zDWwkzNYGW272v96HvZfpiB6gouc="
-    },
-    "org/eclipse/ee4j#project/1.0.7": {
-      "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
-    },
-    "org/jdom#jdom2/2.0.6.1": {
-      "jar": "sha256-CyD0XjoP2PDRLNxTFrBndukCsTZdsAEYh2+RdcYPMCw=",
-      "pom": "sha256-VXleEBi4rmR7k3lnz4EKmbCFgsI3TnhzwShzTIyRS/M="
-    },
-    "org/junit#junit-bom/5.10.1": {
-      "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
-      "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
-    },
-    "org/junit#junit-bom/5.10.2": {
-      "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
-      "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
-    },
-    "org/junit#junit-bom/5.10.3": {
-      "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
-      "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
-    },
-    "org/junit#junit-bom/5.11.0": {
-      "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
-      "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
-    },
-    "org/mockito#mockito-bom/4.11.0": {
-      "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
-    },
-    "org/mockito#mockito-bom/5.7.0": {
-      "pom": "sha256-dlcAW89JAw1nzF1S3rxm3xj0jVTbs+1GZ/1yWwZ5+6A="
-    },
-    "org/ow2#ow2/1.5.1": {
-      "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
-    },
-    "org/ow2/asm#asm-commons/9.7.1": {
-      "jar": "sha256-mlebVNKSrZvhcdQxP9RznGNVksK1rDpFm70QSc3exqA=",
-      "pom": "sha256-C/HTHaDJ+djtwvJ9u/279z8acVtyzS+ijz8ZWZTXStE="
-    },
-    "org/ow2/asm#asm-tree/9.7.1": {
-      "jar": "sha256-mSmIH1nra4QOhtVFcMd7Wc5yHRBObf16QJeJkcLTtB8=",
-      "pom": "sha256-E7kF9l5/1DynZ09Azao3Z5ukhYxsnZ+48Xp6/ZuqvJ4="
-    },
-    "org/ow2/asm#asm/9.7.1": {
-      "jar": "sha256-jK3UOsXrbQneBfrsyji5F6BAu5E5x+3rTMgcdAtxMoE=",
-      "pom": "sha256-cimwOzCnPukQCActnkVppR2FR/roxQ9SeEGu9MGwuqg="
-    },
-    "org/springframework#spring-framework-bom/5.3.39": {
-      "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
-      "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
-    },
-    "org/vafer#jdependency/2.11": {
-      "jar": "sha256-zdoDAD+pVRMVpMw/wWPxhJXxkbSaj3CjquIy8Emn/dA=",
-      "pom": "sha256-2mymcCFlPxUMHVNDLKxApzkH0tkqjzR65eRAHk+iJ+c="
-    }
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://plugins.gradle.org/m2": {
+  "com/fasterxml#oss-parent/38": {
+   "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
   },
-  "https://repo.maven.apache.org/maven2": {
-    "net/dzikoysk#cdn/1.14.5": {
-      "jar": "sha256-b6UUnYLuivwmm7smUNf640+AlL9lqwAICy/9/2jPVSQ=",
-      "module": "sha256-UsikplDNlyOU1/kC+he0WhKRygBXeXbdV54TzyuYEdE=",
-      "pom": "sha256-5A7plAKWPAECL6CzHPirlqCFF90zbQyDnT8QIkqUcWM="
-    },
-    "org/jetbrains#annotations/24.0.0": {
-      "jar": "sha256-/xEvVM6HS4romc/WjwMV2WyfQGozi47KgMdtEOLlovc=",
-      "pom": "sha256-q4eN2sP6teB48NqVHqvWf77d09KvFzn+t/lHFgJ1Xws="
-    },
-    "org/panda-lang#expressible/1.3.0": {
-      "jar": "sha256-gTSJ4Qw1ZLhKDz7/9PFquzQEvm4Q57sNV0VR4x17zy8=",
-      "module": "sha256-A0rSBhKjKa4hZwBB4XGvrA7CW9TIe7AM9PC2PQr9wYU=",
-      "pom": "sha256-esOPx5+wqc/E4fC8crQokrZY9xGBiBIz8D5xlxLqlQA="
-    },
-    "org/panda-lang#panda-utilities/0.5.3-alpha": {
-      "jar": "sha256-cFc+CXSX74ATKBCJWK6Y/+FjoxsztrtluF1yoRQ9wBk=",
-      "module": "sha256-jurn7hW9iI+bP4zjiVolcYEdufYA5OVm3aqe0o4OPBI=",
-      "pom": "sha256-LwKg1mw25wyVN2y/JwxGyDNLvedgarSOtuRAJdKjJVc="
-    }
+  "com/fasterxml#oss-parent/50": {
+   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  },
+  "com/fasterxml#oss-parent/58": {
+   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.17.2": {
+   "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.17": {
+   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  },
+  "com/fasterxml/woodstox#woodstox-core/6.5.1": {
+   "jar": "sha256-ySjWBmXGQV+xw5d1z5XPxE9/RYDPWrAbHDgOv/12iH8=",
+   "pom": "sha256-SDllThaxcU509Rq8s3jYNWgUq49NUnPR3S8c6KOQrdw="
+  },
+  "com/gradleup/shadow#com.gradleup.shadow.gradle.plugin/8.3.5": {
+   "pom": "sha256-bc9S5Y+1rG4aD6CVCbfashy3iqlLV3opZThgchAXjKY="
+  },
+  "com/gradleup/shadow#shadow-gradle-plugin/8.3.5": {
+   "jar": "sha256-VOCN0gqCd14zF6RyWhpeTsixscDzRt5wKknZ7UgVtzU=",
+   "module": "sha256-+kwoQEsU00woznA078s3q513u//7O6xbyLf7BGqtliI=",
+   "pom": "sha256-cIF5r4UBl3extKmnI2gPYIX67YERrJFJYeZ1S0lEG6k="
+  },
+  "commons-io#commons-io/2.17.0": {
+   "jar": "sha256-SqTKSPPf0wt4Igt4gdjLk+rECT7JQ2G2vvqUh5mKVQs=",
+   "pom": "sha256-SEqTn/9TELjLXGuQKcLc8VXT+TuLjWKF8/VrsroJ/Ek="
+  },
+  "jakarta/platform#jakarta.jakartaee-bom/9.1.0": {
+   "pom": "sha256-35jgJmIZ/buCVigm15o6IHdqi6Aqp4fw8HZaU4ZUyKQ="
+  },
+  "jakarta/platform#jakartaee-api-parent/9.1.0": {
+   "pom": "sha256-p3AsSHAmgCeEtXl7YjMKi41lkr8PRzeyXGel6sgmWcA="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache/ant#ant-launcher/1.10.15": {
+   "jar": "sha256-XIVRmQMHoDIzbZjdrtVJo5ponwfU1Ma5UGAb8is9ahs=",
+   "pom": "sha256-ea+EKil53F/gAivAc8SYgQ7q2DvGKD7t803E3+MNrJU="
+  },
+  "org/apache/ant#ant-parent/1.10.15": {
+   "pom": "sha256-SYhPGHPFEHzCN/QoXER3R5uwgEvwc3OUgBsI114rvrA="
+  },
+  "org/apache/ant#ant/1.10.15": {
+   "jar": "sha256-djrNpKaViMnqiBepUoUf8ML8S/+h0IHCVl3EB/KdV5Q=",
+   "pom": "sha256-R4DmHoeBbu4fIdGE7Jl7Zfk9tfS5BCwXitsp4j50JdY="
+  },
+  "org/apache/commons#commons-parent/74": {
+   "pom": "sha256-gOthsMh/3YJqBpMTsotnLaPxiFgy2kR7Uebophl+fss="
+  },
+  "org/apache/groovy#groovy-bom/4.0.22": {
+   "module": "sha256-Ul0/SGvArfFvN+YAL9RlqygCpb2l9MZWf778copo5mY=",
+   "pom": "sha256-Hh9rQiKue/1jMgA+33AgGDWZDb1GEGsWzduopT4832U="
+  },
+  "org/apache/logging#logging-parent/11.3.0": {
+   "pom": "sha256-pcmFtW/hxYQzOTtQkabznlufeFGN2PySE0aQWZtk19A="
+  },
+  "org/apache/logging/log4j#log4j-api/2.24.1": {
+   "jar": "sha256-bne7Ip/I3K8JA4vutekDCyLp4BtRtFiwGDzmaevMku8=",
+   "pom": "sha256-IzAaISnUEAiZJfSvQa7LUlhKPcxFJoI+EyNOyst+c+M="
+  },
+  "org/apache/logging/log4j#log4j-bom/2.24.1": {
+   "pom": "sha256-vGPPsrS5bbS9cwyWLoJPtpKMuEkCwUFuR3q1y3KwsNM="
+  },
+  "org/apache/logging/log4j#log4j-core/2.24.1": {
+   "jar": "sha256-ALzziEcsqApocBQYF2O2bXdxd/Isu/F5/WDhsaybybA=",
+   "pom": "sha256-JyQstBek3xl47t/GlYtFyJgg+WzH9NFtH0gr/CN24M0="
+  },
+  "org/apache/logging/log4j#log4j/2.24.1": {
+   "pom": "sha256-+NcAm1Rl2KhT0QuEG8Bve3JnXwza71OoDprNFDMkfto="
+  },
+  "org/apache/maven#maven-api-meta/4.0.0-alpha-9": {
+   "jar": "sha256-MsT1yturaAw0lS+ctXBFehODzOxMmlewOSYH1xkcaUk=",
+   "pom": "sha256-2ePDXW/aysuNGLn2QoYJDH/65yjWbLJq9aJmgZUNvnk="
+  },
+  "org/apache/maven#maven-api-xml/4.0.0-alpha-9": {
+   "jar": "sha256-KbJijQ8CgRlxWRaEnBnu1FsyzcZ+sTVReYxzr6SqI9Y=",
+   "pom": "sha256-N2bjAzOTTJIvUlj6M0uHXyi7ABJ/8D3vANl/KlOnrps="
+  },
+  "org/apache/maven#maven-api/4.0.0-alpha-9": {
+   "pom": "sha256-ZYvglXcymzX5TemWdb8O/HI26ZYbXHhfMyqkfyKUcfA="
+  },
+  "org/apache/maven#maven-bom/4.0.0-alpha-9": {
+   "pom": "sha256-4EfSnTUI/yd6Wsk1u5J/NUkQLMbTec5a4p4pYzeE0Rw="
+  },
+  "org/apache/maven#maven-parent/41": {
+   "pom": "sha256-di/N1M6GIcX6Ciz2SVrSaXKoCT60Mqo+QCvC1OJQDFM="
+  },
+  "org/apache/maven#maven-xml-impl/4.0.0-alpha-9": {
+   "jar": "sha256-JucCuIHVeuTuiNAsAJQLpkBjcF7mkgWuiVi/g5qLBrE=",
+   "pom": "sha256-us0USYVzbUMmuuRChHM78eMTKX3NolNGTkYpsddoGPc="
+  },
+  "org/apache/maven#maven/4.0.0-alpha-9": {
+   "pom": "sha256-5QzZ/zefQ3H3/ywsrFF5YfPS9n7fgJCHU8e9UGuRPX4="
+  },
+  "org/codehaus/plexus#plexus-utils/4.0.2": {
+   "jar": "sha256-iVcnTnX+LCeLFCjdFqDa7uHdOBUstu/4Fhd6wo/Mtpc=",
+   "pom": "sha256-UVHBO918w6VWlYOn9CZzkvAT/9MRXquNtfht5CCjZq8="
+  },
+  "org/codehaus/plexus#plexus-xml/4.0.4": {
+   "jar": "sha256-Bp54tTcQjcYSSmcHP8mYJkeR9rZJnpVaOOcrs+T+Gt8=",
+   "pom": "sha256-Ohb3yn7CRzFFtGHgpylREI1H4SThjIRMCFsaY3jGEVE="
+  },
+  "org/codehaus/plexus#plexus/18": {
+   "pom": "sha256-tD7onIiQueW8SNB5/LTETwgrUTklM1bcRVgGozw92P0="
+  },
+  "org/codehaus/woodstox#stax2-api/4.2.1": {
+   "jar": "sha256-Z4Vn5ItRpCxlxpnyZlOa09Z21LGlsK19iezoudV3JXk=",
+   "pom": "sha256-edpBDIwPRqP46K2zDWwkzNYGW272v96HvZfpiB6gouc="
+  },
+  "org/eclipse/ee4j#project/1.0.7": {
+   "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
+  },
+  "org/jdom#jdom2/2.0.6.1": {
+   "jar": "sha256-CyD0XjoP2PDRLNxTFrBndukCsTZdsAEYh2+RdcYPMCw=",
+   "pom": "sha256-VXleEBi4rmR7k3lnz4EKmbCFgsI3TnhzwShzTIyRS/M="
+  },
+  "org/junit#junit-bom/5.10.1": {
+   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
+   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.10.3": {
+   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
+   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  },
+  "org/junit#junit-bom/5.11.0": {
+   "module": "sha256-9+2+Z/IgQnCMQQq8VHQI5cR29An1ViNqEXkiEnSi7S0=",
+   "pom": "sha256-5nRZ1IgkJKxjdPQNscj0ouiJRrNAugcsgL6TKivkZE0="
+  },
+  "org/mockito#mockito-bom/4.11.0": {
+   "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
+  },
+  "org/mockito#mockito-bom/5.7.0": {
+   "pom": "sha256-dlcAW89JAw1nzF1S3rxm3xj0jVTbs+1GZ/1yWwZ5+6A="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-commons/9.7.1": {
+   "jar": "sha256-mlebVNKSrZvhcdQxP9RznGNVksK1rDpFm70QSc3exqA=",
+   "pom": "sha256-C/HTHaDJ+djtwvJ9u/279z8acVtyzS+ijz8ZWZTXStE="
+  },
+  "org/ow2/asm#asm-tree/9.7.1": {
+   "jar": "sha256-mSmIH1nra4QOhtVFcMd7Wc5yHRBObf16QJeJkcLTtB8=",
+   "pom": "sha256-E7kF9l5/1DynZ09Azao3Z5ukhYxsnZ+48Xp6/ZuqvJ4="
+  },
+  "org/ow2/asm#asm/9.7.1": {
+   "jar": "sha256-jK3UOsXrbQneBfrsyji5F6BAu5E5x+3rTMgcdAtxMoE=",
+   "pom": "sha256-cimwOzCnPukQCActnkVppR2FR/roxQ9SeEGu9MGwuqg="
+  },
+  "org/springframework#spring-framework-bom/5.3.39": {
+   "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
+   "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
+  },
+  "org/vafer#jdependency/2.11": {
+   "jar": "sha256-zdoDAD+pVRMVpMw/wWPxhJXxkbSaj3CjquIy8Emn/dA=",
+   "pom": "sha256-2mymcCFlPxUMHVNDLKxApzkH0tkqjzR65eRAHk+iJ+c="
   }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "net/dzikoysk#cdn/1.14.5": {
+   "jar": "sha256-b6UUnYLuivwmm7smUNf640+AlL9lqwAICy/9/2jPVSQ=",
+   "module": "sha256-UsikplDNlyOU1/kC+he0WhKRygBXeXbdV54TzyuYEdE=",
+   "pom": "sha256-5A7plAKWPAECL6CzHPirlqCFF90zbQyDnT8QIkqUcWM="
+  },
+  "org/jetbrains#annotations/24.0.0": {
+   "jar": "sha256-/xEvVM6HS4romc/WjwMV2WyfQGozi47KgMdtEOLlovc=",
+   "pom": "sha256-q4eN2sP6teB48NqVHqvWf77d09KvFzn+t/lHFgJ1Xws="
+  },
+  "org/panda-lang#expressible/1.3.0": {
+   "jar": "sha256-gTSJ4Qw1ZLhKDz7/9PFquzQEvm4Q57sNV0VR4x17zy8=",
+   "module": "sha256-A0rSBhKjKa4hZwBB4XGvrA7CW9TIe7AM9PC2PQr9wYU=",
+   "pom": "sha256-esOPx5+wqc/E4fC8crQokrZY9xGBiBIz8D5xlxLqlQA="
+  },
+  "org/panda-lang#panda-utilities/0.5.3-alpha": {
+   "jar": "sha256-cFc+CXSX74ATKBCJWK6Y/+FjoxsztrtluF1yoRQ9wBk=",
+   "module": "sha256-jurn7hW9iI+bP4zjiVolcYEdufYA5OVm3aqe0o4OPBI=",
+   "pom": "sha256-LwKg1mw25wyVN2y/JwxGyDNLvedgarSOtuRAJdKjJVc="
+  }
+ }
 }

--- a/pkgs/by-name/ke/keyboard-layout-editor/package.nix
+++ b/pkgs/by-name/ke/keyboard-layout-editor/package.nix
@@ -37,10 +37,10 @@ stdenv.mkDerivation rec {
   gradleUpdateScript = ''
     runHook preBuild
 
-    gradle nixDownloadDeps -Dos.family=linux -Dos.arch=amd64
-    gradle nixDownloadDeps -Dos.family=linux -Dos.arch=aarch64
-    gradle nixDownloadDeps -Dos.name='mac os x' -Dos.arch=amd64
-    gradle nixDownloadDeps -Dos.name='mac os x' -Dos.arch=aarch64
+    gradle --write-verification-metadata sha256 -Dos.family=linux -Dos.arch=amd64
+    gradle --write-verification-metadata sha256 -Dos.family=linux -Dos.arch=aarch64
+    gradle --write-verification-metadata sha256 -Dos.name='mac os x' -Dos.arch=amd64
+    gradle --write-verification-metadata sha256 -Dos.name='mac os x' -Dos.arch=aarch64
   '';
 
   mitmCache = gradle_8.fetchDeps {

--- a/pkgs/by-name/li/libeufin/deps.json
+++ b/pkgs/by-name/li/libeufin/deps.json
@@ -985,9 +985,6 @@
    "jar": "sha256-ZzHCVkuXOXGDWCVJAUC3rZ63Jtk4/gzvTr7y7Fkt6wM=",
    "pom": "sha256-rVSg2nLxASl08e7sdp2EopMnzzfMrVUxt4cT/GD0tnY="
   },
-  "org/jetbrains/kotlin#kotlin-native-prebuilt/2.0.20": {
-   "pom": "sha256-xYoRfPul4AVC+QrYLytqsh4Z46Ifzvy0mLq5k69FDwY="
-  },
   "org/jetbrains/kotlin#kotlin-native-utils/2.0.20": {
    "jar": "sha256-wWbyBR6R0ZnpYP/HsnZEhcFRDNF2dN17jOPC/NBqhys=",
    "pom": "sha256-mISZMftwkWhS6qfCDm2Pr1IsUNd627r9k2T1JrfN7EI="
@@ -1113,9 +1110,6 @@
   },
   "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.0.20": {
    "pom": "sha256-JyOoqUP6SkTTcD8VTEW31UcMcZ1OYKvz4ixzt3s4i5M="
-  },
-  "org/jetbrains/kotlin/kotlin-native-prebuilt/2.0.20/kotlin-native-prebuilt-2.0.20-linux-x86_64": {
-   "tar.gz": "sha256-soKRi19RWLL41bU94ICTpyIG/CO5E4Lh3dJjDHIChCc="
   },
   "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.0.20": {
    "pom": "sha256-0s2V9THwNRgW+fg0bsbWB2xxyt9jLz6PZX3dft+RukE="

--- a/pkgs/by-name/mi/mindustry/deps.json
+++ b/pkgs/by-name/mi/mindustry/deps.json
@@ -109,6 +109,24 @@
    "jar": "sha256-Ia8wySJnvWEiwOC00gzMtmQaN+r5VsZUDsRx1YTmSns=",
    "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
   },
+  "com/mobidevelop/robovm#robovm-cocoatouch/2.3.19": {
+   "jar": "sha256-MzL/BVRVj9OX9srPtETdRnu6TNLlcWYrRqmwCniNEbE=",
+   "pom": "sha256-34/5PQpo7Frvb/oYiN/qNJjDUhnfA/ZDsR8Abl5avIE="
+  },
+  "com/mobidevelop/robovm#robovm-compiler-parent/2.3.19": {
+   "pom": "sha256-d1foZZrj7unVxDucbULdegtpt5GiFM/d9ImD5RLq0ck="
+  },
+  "com/mobidevelop/robovm#robovm-objc/2.3.19": {
+   "jar": "sha256-JB+9I88rmYqI0eiAo6cEGuAM0vkPtKTIsWBpCaK/c68=",
+   "pom": "sha256-X9QCf+vyW3Hce1zRPKe+/L69wltqFIu8OdBhEzMkPkc="
+  },
+  "com/mobidevelop/robovm#robovm-parent/2.3.19": {
+   "pom": "sha256-Cp0xGgBOmb87gCs2EZxoVEV08GbyP+/69GwV4Cu5za4="
+  },
+  "com/mobidevelop/robovm#robovm-rt/2.3.19": {
+   "jar": "sha256-Rt6LAMDwERIIjTqVxx4op/zwrPU08IJkMLgsFG2yahg=",
+   "pom": "sha256-zg/I7a4XJYD3omYV7hiQRZNG6HYSIS9uBIg0o1HhUFA="
+  },
   "com/squareup#javapoet/1.12.1": {
    "jar": "sha256-g/D9S66+w78p7jrSwCSzBl3e+CWlqin33PXBifn6KWI=",
    "pom": "sha256-pxrD2PJ8ua0yyHtdiVnyLWca60YMejVdCfV35MV+TF8="
@@ -116,6 +134,10 @@
   "de/undercouch#gradle-download-task/4.1.1": {
    "jar": "sha256-6wi1cOQI1GRnBecKlJYU1DnqKxFFXxZSqwMw3olU2rk=",
    "pom": "sha256-heZgcmDbvbXoXxmIhAsNmsS+kRnd6QobrKjqd1ZGQVo="
+  },
+  "junit#junit/4.11": {
+   "jar": "sha256-kKjhYD7spI5+h586+8lWBxUyKYXzmidPb2BwtD+dBv4=",
+   "pom": "sha256-GK2LCunmWpGV0E4lQn3+i1gXWrza6HWlpAau44vd+yY="
   },
   "net/java/dev/jna#jna/5.6.0": {
    "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
@@ -128,6 +150,13 @@
   "org/checkerframework#checker-qual/2.11.1": {
    "jar": "sha256-AVIkpLHcbebaBTJz1Np9Oc/qIOYwOBafxFrA0dycWTg=",
    "pom": "sha256-zy4MkNj3V0VfSiWOpglzkFNmO9XaannZvVP5NaR955w="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
   },
   "org/jetbrains#annotations/13.0": {
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",

--- a/pkgs/by-name/mu/mucommander/deps.json
+++ b/pkgs/by-name/mu/mucommander/deps.json
@@ -86,8 +86,8 @@
    "jar": "sha256-FOCaeJa+5u8uAFtI/FVg/iKZpXqCa8TB8cbUMALwUSw=",
    "pom": "sha256-OQogrYWjQk0RPwyNj2ZNenc15gXEUwyuaxs/qz3EdQU="
   },
-  "ch/qos/logback#logback-core/1.5.12": {
-   "pom": "sha256-q9tuWJh422jJrYYSyt8KIQm3hYd8ZGZnBafxaiTlouA="
+  "ch/qos/logback#logback-core/1.5.16": {
+   "pom": "sha256-Z6n5D3mGkdzVd2xRk6b/QSa6lFsDRiv67dZXoUZ2IZU="
   },
   "ch/qos/logback#logback-parent/1.2.3": {
    "pom": "sha256-ec0CHa/HsCVdPN0/1wy6pjjfc5lXSaNI7oLEVjXqsmo="
@@ -95,14 +95,14 @@
   "ch/qos/logback#logback-parent/1.4.0": {
    "pom": "sha256-ybgE3cIX34pXkK2CP+5lVTGWzxnpVnn9Jc91LexG5Jo="
   },
-  "ch/qos/logback#logback-parent/1.5.12": {
-   "pom": "sha256-5mDh8HDVA4UK4HUhcOBVzgLrb4KVb0wq816AFMPuWtU="
+  "ch/qos/logback#logback-parent/1.5.16": {
+   "pom": "sha256-PrpFA3BWtKOwfxEwviXXpd1NRpH+uTlGbzFs7PlmTmg="
   },
   "ch/qos/logback/logback-core/maven-metadata": {
    "xml": {
     "groupId": "ch.qos.logback",
-    "lastUpdated": "20241025204506",
-    "release": "1.5.12"
+    "lastUpdated": "20250105220716",
+    "release": "1.5.16"
    }
   },
   "ch/randelshofer#fastdoubleparser/0.8.0": {
@@ -761,8 +761,8 @@
    "jar": "sha256-s+n21jp5AQm/DQVmEfvtHPaQVYJt7+uYlKcTadJG7WM=",
    "pom": "sha256-yG7hmKNaNxVIeGD0Gcv2Qufk2ehxR3eUfb5qTjogq1g="
   },
-  "commons-codec#commons-codec/1.17.1": {
-   "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
+  "commons-codec#commons-codec/1.18.0": {
+   "pom": "sha256-dLkW2ksDhMYZ5t1MGN7+iqQ4f3lSBSU8+0u7L0WM3c4="
   },
   "commons-codec#commons-codec/1.3": {
    "jar": "sha256-G6/S7OLojbTN+DWn+PDeZfq1sRR5d6XcxZt8G4xvUIA=",
@@ -775,8 +775,8 @@
   "commons-codec/commons-codec/maven-metadata": {
    "xml": {
     "groupId": "commons-codec",
-    "lastUpdated": "20240715222428",
-    "release": "1.17.1"
+    "lastUpdated": "20250127175540",
+    "release": "1.18.0"
    }
   },
   "commons-el#commons-el/1.0": {
@@ -1202,8 +1202,8 @@
   "org/apache#apache/31": {
    "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
   },
-  "org/apache#apache/32": {
-   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
   },
   "org/apache#apache/4": {
    "pom": "sha256-npMjomuo6yOU7+8MltMbcN9XCAhjDcFHyrHnNUHMUZQ="
@@ -1250,8 +1250,8 @@
   "org/apache/commons#commons-parent/69": {
    "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
   },
-  "org/apache/commons#commons-parent/71": {
-   "pom": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+  "org/apache/commons#commons-parent/79": {
+   "pom": "sha256-Yo3zAUis08SRz8trc8euS1mJ5VJqsTovQo3qXUrRDXo="
   },
   "org/apache/commons#commons-vfs2-project/2.3": {
    "pom": "sha256-esuoQCmKFoMHNgZkPcGX0+XwIoOrIMuUyLbjB18pU7E="
@@ -1583,9 +1583,9 @@
    "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
    "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
   },
-  "org/junit#junit-bom/5.11.0-M2": {
-   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
-   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+  "org/junit#junit-bom/5.11.4": {
+   "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
+   "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
   "org/junit#junit-bom/5.9.1": {
    "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",

--- a/pkgs/by-name/si/signald/package.nix
+++ b/pkgs/by-name/si/signald/package.nix
@@ -89,10 +89,10 @@ stdenv.mkDerivation {
   gradleUpdateScript = ''
     runHook preBuild
 
-    SIGNALD_TARGET=x86_64-unknown-linux-gnu gradle nixDownloadDeps
-    SIGNALD_TARGET=aarch64-unknown-linux-gnu gradle nixDownloadDeps
-    SIGNALD_TARGET=x86_64-apple-darwin gradle nixDownloadDeps
-    SIGNALD_TARGET=aarch64-apple-darwin gradle nixDownloadDeps
+    SIGNALD_TARGET=x86_64-unknown-linux-gnu gradle --write-verification-metadata sha256
+    SIGNALD_TARGET=aarch64-unknown-linux-gnu gradle --write-verification-metadata sha256
+    SIGNALD_TARGET=x86_64-apple-darwin gradle --write-verification-metadata sha256
+    SIGNALD_TARGET=aarch64-apple-darwin gradle --write-verification-metadata sha256
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/sl/slimevr-server/deps.json
+++ b/pkgs/by-name/sl/slimevr-server/deps.json
@@ -850,9 +850,6 @@
    "jar": "sha256-ZzHCVkuXOXGDWCVJAUC3rZ63Jtk4/gzvTr7y7Fkt6wM=",
    "pom": "sha256-rVSg2nLxASl08e7sdp2EopMnzzfMrVUxt4cT/GD0tnY="
   },
-  "org/jetbrains/kotlin#kotlin-native-prebuilt/2.0.20": {
-   "pom": "sha256-xYoRfPul4AVC+QrYLytqsh4Z46Ifzvy0mLq5k69FDwY="
-  },
   "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
    "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
    "pom": "sha256-V5BVJCdKAK4CiqzMJyg/a8WSWpNKBGwcxdBsjuTW1ak="
@@ -920,9 +917,6 @@
   },
   "org/jetbrains/kotlin#kotlin-test/2.0.20/all": {
    "jar": "sha256-2iho+pWj+4814rTjMcouKTIUhnAZZex2a66CD5jgJ3w="
-  },
-  "org/jetbrains/kotlin/kotlin-native-prebuilt/2.0.20/kotlin-native-prebuilt-2.0.20-linux-x86_64": {
-   "tar.gz": "sha256-soKRi19RWLL41bU94ICTpyIG/CO5E4Lh3dJjDHIChCc="
   },
   "org/jetbrains/kotlinx#atomicfu/0.23.1": {
    "jar": "sha256-fbhmDr5LkbtHjts2FsTjpQulnAfcpRfR4ShMA/6GrFc=",

--- a/pkgs/development/tools/build-managers/gradle/init-deps.gradle
+++ b/pkgs/development/tools/build-managers/gradle/init-deps.gradle
@@ -2,8 +2,7 @@ gradle.projectsLoaded {
   rootProject.allprojects {
     task nixDownloadDeps {
       doLast {
-        configurations.findAll{it.canBeResolved}.each{it.resolve()}
-        buildscript.configurations.findAll{it.canBeResolved}.each{it.resolve()}
+        throw new RuntimeException("nixDownloadDeps is deprecated. Please use `--write-dependency-metadata sha256` instead, or if the project you're building has dependency verification turned on use `--write-dependency-metadata pgp,sha56`.")
       }
     }
   }

--- a/pkgs/development/tools/build-managers/gradle/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gradle/setup-hook.sh
@@ -54,7 +54,15 @@ gradleUpdateScript() {
     runHook preBuild
     runHook preGradleUpdate
 
-    gradle ${enableParallelUpdating:+--parallel} ${gradleUpdateTask:-nixDownloadDeps}
+    # Use Gradle dependency verification feature to force downloading all dependencies.
+    # For projects that have dependency verification turned on run with the `pgp` flag, so that Gradle will
+    # also download asc files for all dependencies. Otherwise signatures would be missing when the project is
+    # build later causing dependency verification to fail.
+    local verificationFlags=sha256
+    if [ -f gradle/verification-metadata.xml ]; then
+        verificationFlags="pgp,sha256"
+    fi
+    gradle ${enableParallelUpdating:+--parallel} ${gradleUpdateTask:-help --write-verification-metadata $verificationFlags}
 
     runHook postGradleUpdate
 }

--- a/pkgs/development/tools/build-managers/gradle/update-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/update-deps.nix
@@ -116,6 +116,7 @@ lib.makeOverridable (
         record \
         --reject '\.(md5|sha(1|256|512:?):?)$' \
         --forget-redirects-from '.*' \
+        --forget '.pks/lookup$' \
         --record-text '/maven-metadata\.xml$' >/dev/null 2>/dev/null &
       MITM_CACHE_PID="$!"
       # wait for mitm-cache to fully start


### PR DESCRIPTION
Instead of injecting a tasks into all projects, the gradle build support now runs `--write-verification-metadata` which according to [this forum post](https://discuss.gradle.org/t/force-resolving-and-downloading-all-dependencies/35942/5) is a way of resolving all dependencies that have been declared correctly.

For projects that have dependency verification turned off, we run `--write-verification-metadata sha256` as this is enough to force a download of all dependencies in the project. Projects that have dependency verification turned on require to run `--write-verification-metadata pgp,sha256`. This is because the `pgp` will also force a download of asc signature files, which are required at dependency verification when the build runs later. Without the `pgp` flag the signature files would be missing in the lock file which results in the build failing due to dependency verification.

I ran the dependency update for all Gradle packages that I could find via grep, and rebuilt the ones that had changes in the dependency file. Lockfiles for most packages did not change which indicates that this approach works.

Resolves #381969 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
