### PR TITLE
libfds: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10551,6 +10551,11 @@
     github = "jaredmontoya";
     githubId = 49511278;
   };
+  jaroslavpesek = {
+    name = "Jaroslav Pesek";
+    github = "jaroslavpesek";
+    githubId = 81391249;
+  };
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";

--- a/pkgs/by-name/li/libfds/package.nix
+++ b/pkgs/by-name/li/libfds/package.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  libxml2,
+  lz4,
+  zstd,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libfds";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "CESNET";
+    repo = "libfds";
+    tag = "v${version}";
+    hash = "sha256-rYEUjMnKPxE0HxPZZ58DwrhPb89NpIjEnftqbsfkvTU=";
+  };
+
+  buildInputs = [
+    libxml2
+    lz4
+    zstd
+  ];
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Components for parsing and processing IPFIX Messages";
+    homepage = "https://github.com/CESNET/libfds";
+    changelog = "https://github.com/CESNET/libfds/releases/tag/v${version}";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jaroslavpesek ];
+  };
+}


### PR DESCRIPTION
The library provides components for parsing and processing IPFIX Messages.

Available components:

- IPFIX Data structure parsers
- IPFIX Data Record iterators (with Biflow support)
- IPFIX Template manager
- IPFIX Data type coverters (e.g. getters, setters, and to string)
- Manager of Information Elements (i.e. id, name, type, etc. of IPFIX fields)
- Simple XML parser with data type check (implemented as a wrapper over libxml2)
- Flow file storage (beta)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
