### PR TITLE
fetchFromGitHub: expose tag/release changelogs in meta

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -31,6 +31,9 @@ let
   } // lib.optionalAttrs (position != null) {
     # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
     position = "${position.file}:${toString position.line}";
+  } // {
+    # GitHub exposes tag/release descriptions suitable for referencing
+    changelog = meta.changelog or (if tag != null then "${baseUrl}/releases/tag/${tag}/CHANGELOG.md" else []);
   };
   passthruAttrs = removeAttrs args [ "owner" "repo" "tag" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
   varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,103 +1,169 @@
-{ lib, fetchgit, fetchzip }:
+{
+  lib,
+  fetchgit,
+  fetchzip,
+}:
 
 lib.makeOverridable (
-{ owner, repo
-, tag ? null
-, rev ? null
-, name ? "source"
-, fetchSubmodules ? false, leaveDotGit ? null
-, deepClone ? false, private ? false, forceFetchGit ? false
-, fetchLFS ? false
-, sparseCheckout ? []
-, githubBase ? "github.com", varPrefix ? null
-, meta ? { }
-, ... # For hash agility
-}@args:
+  {
+    owner,
+    repo,
+    tag ? null,
+    rev ? null,
+    name ? "source",
+    fetchSubmodules ? false,
+    leaveDotGit ? null,
+    deepClone ? false,
+    private ? false,
+    forceFetchGit ? false,
+    fetchLFS ? false,
+    sparseCheckout ? [ ],
+    githubBase ? "github.com",
+    varPrefix ? null,
+    meta ? { },
+    ... # For hash agility
+  }@args:
 
-assert (lib.assertMsg (lib.xor (tag == null) (rev == null)) "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both).");
-
-let
-
-  position = (if args.meta.description or null != null
-    then builtins.unsafeGetAttrPos "description" args.meta
-    else if tag != null then
-      builtins.unsafeGetAttrPos "tag" args
-    else
-      builtins.unsafeGetAttrPos "rev" args
+  assert (
+    lib.assertMsg (lib.xor (tag == null) (
+      rev == null
+    )) "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both)."
   );
-  baseUrl = "https://${githubBase}/${owner}/${repo}";
-  newMeta = meta // {
-    homepage = meta.homepage or baseUrl;
-  } // lib.optionalAttrs (position != null) {
-    # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
-    position = "${position.file}:${toString position.line}";
-  } // {
-    # GitHub exposes tag/release descriptions suitable for referencing
-    changelog = meta.changelog or (if tag != null then "${baseUrl}/releases/tag/${tag}/CHANGELOG.md" else []);
-  };
-  passthruAttrs = removeAttrs args [ "owner" "repo" "tag" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
-  varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
-  useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || fetchLFS || (sparseCheckout != []);
-  # We prefer fetchzip in cases we don't need submodules as the hash
-  # is more stable in that case.
-  fetcher =
-    if useFetchGit then fetchgit
-    # fetchzip may not be overridable when using external tools, for example nix-prefetch
-    else if fetchzip ? override then fetchzip.override { withUnzip = false; }
-    else fetchzip;
-  privateAttrs = lib.optionalAttrs private {
-    netrcPhase =
-      # When using private repos:
-      # - Fetching with git works using https://github.com but not with the GitHub API endpoint
-      # - Fetching a tarball from a private repo requires to use the GitHub API endpoint
-      let machineName = if githubBase == "github.com" && !useFetchGit then "api.github.com" else githubBase;
-      in ''
-        if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
-          echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
-          exit 1
-        fi
-        cat > netrc <<EOF
-        machine ${machineName}
-                login ''$${varBase}USERNAME
-                password ''$${varBase}PASSWORD
-        EOF
-      '';
-    netrcImpureEnvVars = [ "${varBase}USERNAME" "${varBase}PASSWORD" ];
-  };
 
-  gitRepoUrl = "${baseUrl}.git";
+  let
 
-  revWithTag = if tag != null then "refs/tags/${tag}" else rev;
-
-  fetcherArgs = (if useFetchGit
-    then {
-      inherit tag rev deepClone fetchSubmodules sparseCheckout fetchLFS; url = gitRepoUrl;
-    } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
-    else {
-      # Use the API endpoint for private repos, as the archive URI doesn't
-      # support access with GitHub's fine-grained access tokens.
-      #
-      # Use the archive URI for non-private repos, as the API endpoint has
-      # relatively restrictive rate limits for unauthenticated users.
-      url =
-        if private then
-          let
-            endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
-          in
-          if githubBase == "github.com" then
-            "https://api.github.com${endpoint}"
-          else
-            "https://${githubBase}/api/v3${endpoint}"
-        else
-          "${baseUrl}/archive/${revWithTag}.tar.gz";
-      extension = "tar.gz";
-
-      passthru = {
-        inherit gitRepoUrl;
+    position = (
+      if args.meta.description or null != null then
+        builtins.unsafeGetAttrPos "description" args.meta
+      else if tag != null then
+        builtins.unsafeGetAttrPos "tag" args
+      else
+        builtins.unsafeGetAttrPos "rev" args
+    );
+    baseUrl = "https://${githubBase}/${owner}/${repo}";
+    newMeta =
+      meta
+      // {
+        homepage = meta.homepage or baseUrl;
+      }
+      // lib.optionalAttrs (position != null) {
+        # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
+        position = "${position.file}:${toString position.line}";
+      }
+      // {
+        # GitHub exposes tag/release descriptions suitable for referencing
+        changelog =
+          meta.changelog or (if tag != null then "${baseUrl}/releases/tag/${tag}/CHANGELOG.md" else [ ]);
       };
-    }
-  ) // privateAttrs // passthruAttrs // { inherit name; };
-in
+    passthruAttrs = removeAttrs args [
+      "owner"
+      "repo"
+      "tag"
+      "rev"
+      "fetchSubmodules"
+      "forceFetchGit"
+      "private"
+      "githubBase"
+      "varPrefix"
+    ];
+    varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_GITHUB_PRIVATE_";
+    useFetchGit =
+      fetchSubmodules
+      || (leaveDotGit == true)
+      || deepClone
+      || forceFetchGit
+      || fetchLFS
+      || (sparseCheckout != [ ]);
+    # We prefer fetchzip in cases we don't need submodules as the hash
+    # is more stable in that case.
+    fetcher =
+      if useFetchGit then
+        fetchgit
+      # fetchzip may not be overridable when using external tools, for example nix-prefetch
+      else if fetchzip ? override then
+        fetchzip.override { withUnzip = false; }
+      else
+        fetchzip;
+    privateAttrs = lib.optionalAttrs private {
+      netrcPhase =
+        # When using private repos:
+        # - Fetching with git works using https://github.com but not with the GitHub API endpoint
+        # - Fetching a tarball from a private repo requires to use the GitHub API endpoint
+        let
+          machineName = if githubBase == "github.com" && !useFetchGit then "api.github.com" else githubBase;
+        in
+        ''
+          if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
+            echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+            exit 1
+          fi
+          cat > netrc <<EOF
+          machine ${machineName}
+                  login ''$${varBase}USERNAME
+                  password ''$${varBase}PASSWORD
+          EOF
+        '';
+      netrcImpureEnvVars = [
+        "${varBase}USERNAME"
+        "${varBase}PASSWORD"
+      ];
+    };
 
-fetcher fetcherArgs // { meta = newMeta; inherit owner repo tag; rev = revWithTag; }
+    gitRepoUrl = "${baseUrl}.git";
+
+    revWithTag = if tag != null then "refs/tags/${tag}" else rev;
+
+    fetcherArgs =
+      (
+        if useFetchGit then
+          {
+            inherit
+              tag
+              rev
+              deepClone
+              fetchSubmodules
+              sparseCheckout
+              fetchLFS
+              ;
+            url = gitRepoUrl;
+          }
+          // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
+        else
+          {
+            # Use the API endpoint for private repos, as the archive URI doesn't
+            # support access with GitHub's fine-grained access tokens.
+            #
+            # Use the archive URI for non-private repos, as the API endpoint has
+            # relatively restrictive rate limits for unauthenticated users.
+            url =
+              if private then
+                let
+                  endpoint = "/repos/${owner}/${repo}/tarball/${revWithTag}";
+                in
+                if githubBase == "github.com" then
+                  "https://api.github.com${endpoint}"
+                else
+                  "https://${githubBase}/api/v3${endpoint}"
+              else
+                "${baseUrl}/archive/${revWithTag}.tar.gz";
+            extension = "tar.gz";
+
+            passthru = {
+              inherit gitRepoUrl;
+            };
+          }
+      )
+      // privateAttrs
+      // passthruAttrs
+      // {
+        inherit name;
+      };
+  in
+
+  fetcher fetcherArgs
+  // {
+    meta = newMeta;
+    inherit owner repo tag;
+    rev = revWithTag;
+  }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I recently learned from @ethancedwards8  that a package `meta` should provide a `changelog` attribute if possible and that GitHub exposes changelogs for releases/tags. So I thought the reasonable thing to do is to implement this as a default for all packages relying on `fetchFromGitHub`.

You would use it in a derivation like this:
```nix
...
src = fetchFromGitHub {
  ...
  tag = "v1.4.6";
};
...
meta = src.meta // {...};
```

## Things done

Much of these things don't really apply and test building everything locally depending on `fetchFromGitHub` seems a bit excessive but I'm open to test recommendations.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
