### PR TITLE
nix-your-shell: Add generate-config script

### DIFF
--- a/pkgs/by-name/ni/nix-your-shell/package.nix
+++ b/pkgs/by-name/ni/nix-your-shell/package.nix
@@ -2,30 +2,45 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  runCommand,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
-  pname = "nix-your-shell";
+let
+  generate-config =
+    shell:
+    runCommand "nix-your-shell-config" { } ''
+      ${lib.getExe pkg} ${lib.escapeShellArg shell} >> "$out"
+    '';
+
   version = "1.4.6";
 
-  src = fetchFromGitHub {
-    owner = "MercuryTechnologies";
-    repo = "nix-your-shell";
-    rev = "v${version}";
-    hash = "sha256-FjGjLq/4qeZz9foA7pfz1hiXvsdmbnzB3BpiTESLE1c=";
+  pkg = rustPlatform.buildRustPackage {
+    pname = "nix-your-shell";
+    version = "1.4.6";
+
+    src = fetchFromGitHub {
+      owner = "MercuryTechnologies";
+      repo = "nix-your-shell";
+      tag = "v${version}";
+      hash = "sha256-FjGjLq/4qeZz9foA7pfz1hiXvsdmbnzB3BpiTESLE1c=";
+    };
+
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-zQpK13iudyWDZbpAN8zm9kKmz8qy3yt8JxT4lwq4YF0=";
+
+    passthru = {
+      inherit generate-config;
+      updateScript = nix-update-script { };
+    };
+
+    meta = {
+      mainProgram = "nix-your-shell";
+      description = "`nix` and `nix-shell` wrapper for shells other than `bash`";
+      homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
+      changelog = "https://github.com/MercuryTechnologies/nix-your-shell/releases/tags/v${version}";
+      license = [ lib.licenses.mit ];
+      maintainers = with lib.maintainers; [ _9999years ];
+    };
   };
-
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-zQpK13iudyWDZbpAN8zm9kKmz8qy3yt8JxT4lwq4YF0=";
-
-  meta = {
-    mainProgram = "nix-your-shell";
-    description = "`nix` and `nix-shell` wrapper for shells other than `bash`";
-    homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
-    changelog = "https://github.com/MercuryTechnologies/nix-your-shell/releases/tags/v${version}";
-    license = [ lib.licenses.mit ];
-    maintainers = with lib.maintainers; [ _9999years ];
-  };
-
-  passthru.updateScript = nix-update-script { };
-}
+in
+pkg


### PR DESCRIPTION
This lets users generate a shell configuration file from Nix, for use with `home-manager` and similar:

    { config, pkgs, ... }: {
      home.file."${config.xdg.configHome}/nushell/nix-your-shell.nu".source =
        pkgs.nix-your-shell.generate-config "nu";
    }

This increases parity with the upstream packaging.

See: https://github.com/MercuryTechnologies/nix-your-shell/issues/81


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
