### PR TITLE
pkgsStatic.haskellPackages: fix TemplateHaskell

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -335,7 +335,9 @@ let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
   # TODO(@Ericson2314) Make unconditional
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (
+    targetPlatform.config != hostPlatform.config
+  ) "${targetPlatform.config}-";
 
   hadrianSettings =
     # -fexternal-dynamic-refs apparently (because it's not clear from the


### PR DESCRIPTION
TLDR: Compiling haskell in `pkgsStatic` only worked by accident, so far - because `pkgsStatic` also implied a different libc, so "true" cross. Given a "just static, same libc" setup, it failed - this is fixed here.

---

Nesting `pkgsStatic` inside `pkgsMusl` results in:
- build platform: musl, shared libs
- host/target platform: musl, static libs

We consider this cross, because of the difference in shared vs static libs. However, GHC does not - it only looks at the system triple, which is identical. Thus GHC will not prefix its binaries and folders. We need to compensate for that by applying the `targetPrefix` only when *GHC thinks we are cross*, and not when we do.

This then leads to the next problem: Since we're adding both `ghc` and `systemGhc` to PATH and they are both without prefix... naturally either the build of Setup.hs or the main build will fail, because it uses the wrong compiler for the package-db. This leads to either trying to statically link `Setup.hs`, when only shared libs are available - or to trying to dynamically link the main package, when only static libs are available.

The simplest solution for this is, to just use the host compiler for `Setup.hs`, as long as we can run the code it produces. With the canExecute check we only provide a single GHC whenever we're compiling "native cross".

**Important observation: Template Haskell in `pkgsMusl.pkgsStatic` with GHC 9.6+ works fine!** (#275304)

---

Based on the above, I added one more commit to just tell Hadrian, that as long was we can execute the code we built, it should **not** treat the build as a "cross compilation". This makes TemplateHaskell work.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin: `pkgsStatic.haskell.packages.native-bignum.ghc96.th-orphans`
  - [x] aarch64-darwin: `pkgsStatic.haskell.packages.native-bignum.ghc98.th-orphans`
  - [x] aarch64-darwin: `pkgsStatic.haskell.packages.native-bignum.ghc910.th-orphans`
  - [x] aarch64-darwin: `pkgsStatic.haskell.packages.native-bignum.ghc912.th-orphans`
  - [x] aarch64-darwin: `pkgsStatic.haskell.packages.native-bignum.ghcHEAD.th-orphans`
  - [x] aarch64-darwin: `haskellPackages.th-orphans`
  - [ ] aarch64-darwin: `pkgsCross.x86_64-darwin.haskellPackages.hello` :x: (also fails on master)
  - [x] aarch64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc96.th-orphans`
  - [x] aarch64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc98.th-orphans`
  - [x] aarch64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc910.th-orphans`
  - [x] aarch64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc912.th-orphans`
  - [x] aarch64-linux: `pkgsStatic.haskell.packages.native-bignum.ghcHEAD.th-orphans`
  - [x] aarch64-linux: `haskellPackages.th-orphans`
  - [ ] aarch64-linux: `pkgsMusl.pkgsStatic.haskell.packages.native-bignum.ghc96.th-orphans` :x: (failing dependency)
  - [x] aarch64-linux: `pkgsCross.gnu64.haskellPackages.hello`
  - [x] aarch64-linux: `pkgsCross.gnu64.pkgsStatic.haskell.packages.native-bignum.ghc96.hello`
  - [x] x86_64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc96.th-orphans`
  - [x] x86_64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc98.th-orphans`
  - [x] x86_64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc910.th-orphans`
  - [x] x86_64-linux: `pkgsStatic.haskell.packages.native-bignum.ghc912.th-orphans`
  - [x] x86_64-linux: `pkgsStatic.haskell.packages.native-bignum.ghcHEAD.th-orphans`
  - [x] x86_64-linux: `haskellPackages.th-orphans`
  - [ ] x86_64-linux: `pkgsMusl.pkgsStatic.haskell.packages.native-bignum.ghc96.th-orphans` :x: (failing dependency)
  - [x] x86_64-linux: `pkgsCross.aarch64-multiplatform.haskellPackages.hello`
  - [x] x86_64-linux: `pkgsCross.aarch64-multiplatform.pkgsStatic.haskell.packages.native-bignum.ghc96.hello`
  - [x] x86_64-linux: `pkgsCross.x86_64-freebsd.haskellPackages.hello`
  - [ ] x86_64-linux: `pkgsCross.x86_64-freebsd.pkgsStatic.haskell.packages.native-bignum.ghc96.hello` :x: (fails during configure due to FreeBSD stdenv pkgsStatic limitations, same on master)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
