### PR TITLE
nrfconnect: Refactor BLE module

### DIFF
--- a/pkgs/by-name/nr/nrfconnect-bluetooth-low-energy/package.nix
+++ b/pkgs/by-name/nr/nrfconnect-bluetooth-low-energy/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+  segger-jlink-headless,
+  libxshmfence,
+}:
+
+let
+  pname = "nrfconnect-bluetooth-low-energy";
+  version = "4.0.4";
+
+  src = fetchurl {
+    url = "https://github.com/NordicPlayground/pc-nrfconnect-ble-standalone/releases/download/v${version}/nrfconnect-bluetooth-low-energy-${version}-x86_64.AppImage";
+    hash = "sha256-mL8ky/cYjNgfUJgE7W5LFK/w7Ky9Xx6E84UT668HRAk=";
+    name = "${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    segger-jlink-headless
+    libxshmfence
+  ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/nrfconnect-bluetooth-low-energy.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/512x512/apps/nrfconnect-bluetooth-low-energy.png \
+      -t $out/share/icons/hicolor/512x512/apps
+    substituteInPlace $out/share/applications/nrfconnect-bluetooth-low-energy.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=nrfconnect-bluetooth-low-energy'
+  '';
+
+  meta = {
+    description = "Nordic Semiconductor Bluetooth low energy app for nRF Connect for Desktop";
+    homepage = "https://docs.nordicsemi.com/bundle/nrf-connect-ble/page/index.html";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ stargate01 ];
+    mainProgram = "nrfconnect-bluetooth-low-energy";
+  };
+}

--- a/pkgs/by-name/nr/nrfconnect/package.nix
+++ b/pkgs/by-name/nr/nrfconnect/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   fetchurl,
   appimageTools,
+  segger-jlink-headless,
 }:
 
 let
@@ -23,7 +25,7 @@ appimageTools.wrapType2 {
   inherit pname version src;
 
   extraPkgs = pkgs: [
-    pkgs.segger-jlink-headless
+    segger-jlink-headless
   ];
 
   extraInstallCommands = ''
@@ -31,7 +33,7 @@ appimageTools.wrapType2 {
     install -Dm444 ${appimageContents}/usr/share/icons/hicolor/512x512/apps/nrfconnect.png \
       -t $out/share/icons/hicolor/512x512/apps
     substituteInPlace $out/share/applications/nrfconnect.desktop \
-      --replace 'Exec=AppRun' 'Exec=nrfconnect'
+      --replace-fail 'Exec=AppRun' 'Exec=nrfconnect'
   '';
 
   meta = {

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -115,16 +115,16 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/opt
+    mkdir -p $out/opt/SEGGER/JLink
 
     ${lib.optionalString (!headless) ''
-      # Install binaries and runtime files into /opt/
-      mv J* ETC GDBServer Firmwares $out/opt
+      # Install binaries and runtime files into /opt/SEGGER/JLink
+      mv J* ETC GDBServer Firmwares $out/opt/SEGGER/JLink
 
       # Link executables into /bin/
       mkdir -p $out/bin
-      for binr in $out/opt/*Exe; do
-        binrlink=''${binr#"$out/opt/"}
+      for binr in $out/opt/SEGGER/JLink/*Exe; do
+        binrlink=''${binr#"$out/opt/SEGGER/JLink/"}
         ln -s $binr $out/bin/$binrlink
         # Create additional symlinks without "Exe" suffix
         binrlink=''${binrlink/%Exe}
@@ -132,7 +132,7 @@ stdenv.mkDerivation {
       done
 
       # Copy special alias symlinks
-      for slink in $(find $out/opt/. -type l); do
+      for slink in $(find $out/opt/SEGGER/JLink/. -type l); do
         cp -P -n $slink $out/bin || true
         rm $slink
       done
@@ -141,7 +141,7 @@ stdenv.mkDerivation {
     # Install libraries
     install -Dm444 libjlinkarm.so* -t $out/lib
     for libr in $out/lib/libjlinkarm.*; do
-      ln -s $libr $out/opt
+      ln -s $libr $out/opt/SEGGER/JLink
     done
 
     # Install docs and examples


### PR DESCRIPTION
This PR is a follow up / fix for #381576 . Apparently the Bluetooth low energy module is now being shipped as a standalone module (see https://github.com/NordicSemiconductor/pc-nrfconnect-ble?tab=readme-ov-file#installation), so I packed it into its own package. 

The hub app would want to download and run the BLE module as an AppImage to `$HOME/opt/`, which cannot be changed (see https://github.com/NordicSemiconductor/pc-nrfconnect-ble/issues/258 ). I gave up on linking the two packages due to this.

Also, some other modules (Like the "Quick Start" one) expect canonical SEGGER paths in `segger-jlink`. So I adjusted these as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
