### PR TITLE
python3Packages.whisperx: init at 3.3.2

### DIFF
--- a/pkgs/by-name/wh/whisperx/package.nix
+++ b/pkgs/by-name/wh/whisperx/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication whisperx

--- a/pkgs/development/python-modules/whisperx/default.nix
+++ b/pkgs/development/python-modules/whisperx/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  ctranslate2,
+  faster-whisper,
+  nltk,
+  pandas,
+  pyannote-audio,
+  torch,
+  torchaudio,
+  transformers,
+
+  # native packages
+  ffmpeg,
+  ctranslate2-cpp, # alias for `pkgs.ctranslate2`, required due to colliding with the `ctranslate2` Python module.
+
+  # enable GPU support
+  cudaSupport ? torch.cudaSupport,
+}:
+
+let
+  ctranslate = ctranslate2.override {
+    ctranslate2-cpp = ctranslate2-cpp.override {
+      withCUDA = cudaSupport;
+      withCuDNN = cudaSupport;
+    };
+  };
+in
+buildPythonPackage rec {
+  pname = "whisperx";
+  version = "3.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "m-bain";
+    repo = "whisperX";
+    tag = "v${version}";
+    hash = "sha256-JJa8gUQjIcgJ5lug3ULGkHxkl66qnXkiUA3SwwUVpqk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    ctranslate
+    faster-whisper
+    nltk
+    pandas
+    pyannote-audio # Missing from pyproject.toml, but used in `whisperx/vad.py`
+    torch
+    torchaudio
+    transformers
+  ];
+
+  # As `makeWrapperArgs` does not apply to the module, and whisperx depends on `ffmpeg`,
+  # we replace the `"ffmpeg"` string in `subprocess.run` with the full path to the binary.
+  # This works for both the program and the module.
+  # Every update, the codebase should be checked for further instances of `ffmpeg` calls.
+  postPatch = ''
+    substituteInPlace whisperx/audio.py --replace-fail \
+      '"ffmpeg"' '"${lib.getExe ffmpeg}"'
+  '';
+
+  # > Checking runtime dependencies for whisperx-3.3.2-py3-none-any.whl
+  # >   - faster-whisper==1.1.0 not satisfied by version 1.1.1
+  # This has been updated on main, so we expect this clause to be removed upon the next update.
+  pythonRelaxDeps = [ "faster-whisper" ];
+
+  pythonImportsCheck = [ "whisperx" ];
+
+  # No tests in repository
+  doCheck = false;
+
+  meta = {
+    mainProgram = "whisperx";
+    description = "Automatic Speech Recognition with Word-level Timestamps (& Diarization)";
+    homepage = "https://github.com/m-bain/whisperX";
+    changelog = "https://github.com/m-bain/whisperX/releases/tag/${src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.bengsparks ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18756,6 +18756,11 @@ self: super: with self; {
 
   whispers = callPackage ../development/python-modules/whispers { };
 
+  whisperx = callPackage ../development/python-modules/whisperx {
+    inherit (pkgs) ffmpeg;
+    ctranslate2-cpp = pkgs.ctranslate2;
+  };
+
   whitenoise = callPackage ../development/python-modules/whitenoise { };
 
   whodap = callPackage ../development/python-modules/whodap { };


### PR DESCRIPTION
Closes #372412.

This package has only been run on aarch64-darwin, and without GPU support. I have attached example output generated using the built package.
I would be very grateful for reviewers who are capable for providing other platforms, especially GPU access!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
