### PR TITLE
plasma-panel-colorizer: fix presets not being listed

### DIFF
--- a/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [ kdePackages.plasma-desktop ];
-
+  propagatedUserEnvPkgs = [ glib ];
   dontWrapQtApps = true;
   strictDeps = true;
 

--- a/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
@@ -6,7 +6,6 @@
   kdePackages,
   nix-update-script,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "plasma-panel-colorizer";
   version = "2.4.1";
@@ -23,10 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.extra-cmake-modules
   ];
 
-  buildInputs = [
-    kdePackages.plasma-desktop
-  ];
+  buildInputs = [ kdePackages.plasma-desktop ];
 
+  dontWrapQtApps = true;
   strictDeps = true;
 
   cmakeFlags = [
@@ -35,16 +33,19 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "Qt6_DIR" "${kdePackages.qtbase}/lib/cmake/Qt6")
   ];
 
-  dontWrapQtApps = true;
+  postInstall = ''
+    chmod 755 $out/share/plasma/plasmoids/luisbocanegra.panel.colorizer/contents/ui/tools/list_presets.sh
+  '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/luisbocanegra/plasma-panel-colorizer/blob/main/CHANGELOG.md";
     description = "Fully-featured widget to bring Latte-Dock and WM status bar customization features to the default KDE Plasma panel";
     homepage = "https://github.com/luisbocanegra/plasma-panel-colorizer";
-    changelog = "https://github.com/luisbocanegra/plasma-panel-colorizer/blob/main/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ HeitorAugustoLN ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
     inherit (kdePackages.kwindowsystem.meta) platforms;
   };
 })

--- a/pkgs/by-name/pl/plasma-panel-colorizer/use-dbus-service-directly.patch
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/use-dbus-service-directly.patch
@@ -1,0 +1,12 @@
+--- a/package/contents/ui/DBusServiceModel.qml
++++ b/package/contents/ui/DBusServiceModel.qml
+@@ -14,7 +14,7 @@ Item {
+     property string toolsDir: Qt.resolvedUrl("./tools").toString().substring(7) + "/"
+     property string serviceUtil: toolsDir+"service.py"
+     property string pythonExecutable: plasmoid.configuration.pythonExecutable
+-    property string serviceCmd: pythonExecutable + " '" + serviceUtil + "' " + Plasmoid.containment.id + " " + Plasmoid.id
++    property string serviceCmd: serviceUtil + " " + Plasmoid.containment.id + " " + Plasmoid.id
+
+     readonly property string service: Plasmoid.metaData.pluginId + ".c" + Plasmoid.containment.id + ".w" + Plasmoid.id
+     readonly property string path: "/preset"
+


### PR DESCRIPTION
The script for listing presets didn't have execute permissions. This commit adds executable permission for the script

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
