### PR TITLE
tracelinks: init at 1.0.1

### DIFF
--- a/pkgs/by-name/tr/tracelinks/package.nix
+++ b/pkgs/by-name/tr/tracelinks/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  help2man,
+  lib,
+  nix-update-script,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tracelinks";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "flox";
+    repo = "tracelinks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GftF2s2eRrkfzw2NpzTZ6Uhehcg2tMSOcsjHJssQJzU=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "VERSION=${finalAttrs.version}"
+  ];
+  nativeBuildInputs = [ help2man ];
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Report on symbolic links encountered in path traversals";
+    homepage = "https://github.com/flox/tracelinks";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ limeytexan ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
The `tracelinks` command accepts a list of paths and traverses each one in turn, reporting on symbolic links encountered along the way and flagging dangling and circular links as errors. When reporting the final element encountered in the path traversal `tracelinks` prints the realpath of the file along with its file type.

It is particularly useful when identifying packages accessed by way of Nix profiles, e.g.
```
$ result/bin/tracelinks `which nixos-rebuild`
/run/current-system -> /nix/store/811611n5fspjl1v65grsf3wzbflrm2jm-nixos-system-treehouse-25.05.20250121.9e4d519
  /nix/store/811611n5fspjl1v65grsf3wzbflrm2jm-nixos-system-treehouse-25.05.20250121.9e4d519/sw -> /nix/store/0w3p8z0100xidzx2dr2mkjp1ijgz75f3-system-path
    /nix/store/0w3p8z0100xidzx2dr2mkjp1ijgz75f3-system-path/bin/nixos-rebuild -> /nix/store/jdjxinr65v0hp1pb6jk1vdvp97azspgc-nixos-rebuild/bin/nixos-rebuild
      /nix/store/jdjxinr65v0hp1pb6jk1vdvp97azspgc-nixos-rebuild/bin/nixos-rebuild: regular file
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
