### PR TITLE
t3: init at 1.0.8

### DIFF
--- a/pkgs/by-name/t3/t3/package.nix
+++ b/pkgs/by-name/t3/t3/package.nix
@@ -1,0 +1,38 @@
+{
+  fetchFromGitHub,
+  help2man,
+  lib,
+  nix-update-script,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "t3";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "flox";
+    repo = "t3";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SaSBFqMh6zOty0mnYL4RJxAxbB1LJusKLdMn7Atv+As=";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "VERSION=${finalAttrs.version}"
+  ];
+  nativeBuildInputs = [ help2man ];
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Next generation tee with colorized output streams and precise time stamping";
+    homepage = "https://github.com/flox/t3";
+    changelog = "https://github.com/flox/t3/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ limeytexan ];
+    platforms = lib.platforms.unix;
+    mainProgram = "t3";
+  };
+})


### PR DESCRIPTION
The `t3` command parses the stdout and stderr streams of a command, writing colorized and precisely time-stamped output both to the calling process's own stdout and stderr streams, as well as to the provided filename. In that respect `t3` serves much the same purpose as `tee` while preserving the distinction between lines sent to stdout/stderr in its own output streams.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
