### PR TITLE
home-assistant-custom-components.localtuya: init at 2025.2.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
@@ -5,21 +5,21 @@
 }:
 
 buildHomeAssistantComponent rec {
-  owner = "rospogrigio";
+  owner = "xZetsubou";
   domain = "localtuya";
-  version = "5.2.2";
+  version = "2025.2.1";
 
   src = fetchFromGitHub {
-    owner = "rospogrigio";
-    repo = "localtuya";
-    rev = "v${version}";
-    hash = "sha256-GexGUu4hevRDGF7gv7Jklr5YZJV+QH3kZN7p+eK9HlM=";
+    owner = "xZetsubou";
+    repo = "hass-localtuya";
+    rev = version;
+    hash = "sha256-on/KuZSJOCBGNRnGtxgGB5bquznjeJ+xMYNVnW67m0s=";
   };
 
   meta = with lib; {
-    changelog = "https://github.com/rospogrigio/localtuya/releases/tag/${version}";
-    description = "Home Assistant custom Integration for local handling of Tuya-based devices";
-    homepage = "https://github.com/rospogrigio/localtuya";
+    changelog = "https://github.com/xZetsubou/hass-localtuya/releases/tag/${version}";
+    description = "Home Assistant custom Integration for local handling of Tuya-based devices, fork from local-tuya";
+    homepage = "https://github.com/xZetsubou/hass-localtuya";
     maintainers = with maintainers; [ rhoriguchi ];
     license = licenses.gpl3Only;
   };


### PR DESCRIPTION
Replace #369945 with a newer version.

This replacement causes no issue with the current version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
