### PR TITLE
treewide: replace gitUpdater with nix-update-script (part 1)

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   melpaBuild,
   replaceVars,
-  gitUpdater,
+  nix-update-script,
 }:
 
 melpaBuild {
@@ -24,7 +24,7 @@ melpaBuild {
     })
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Free, ultrafast Copilot alternative for Emacs";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/idris2-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/idris2-mode/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   melpaBuild,
   prop-menu,
-  gitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -24,7 +24,7 @@ melpaBuild {
     prop-menu
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/idris-community/idris2-mode";

--- a/pkgs/applications/misc/ausweisapp/default.nix
+++ b/pkgs/applications/misc/ausweisapp/default.nix
@@ -12,7 +12,7 @@
   qttools,
   qtwayland,
   qtwebsockets,
-  gitUpdater,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ausweisapp";
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
       package = finalAttrs.finalPackage;
       command = "QT_QPA_PLATFORM=offscreen ${finalAttrs.meta.mainProgram} --version";
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/applications/misc/kiwix/tools.nix
+++ b/pkgs/applications/misc/kiwix/tools.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   icu,
   libkiwix,
   meson,
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     libkiwix
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Command line Kiwix tools: kiwix-serve, kiwix-manage, ..";

--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -10,7 +10,7 @@
   conf ? null,
   patches ? [ ],
   # update script dependencies
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://tools.suckless.org/slstatus/";

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -6,7 +6,7 @@
   ninja,
   wrapGAppsHook3,
   pkg-config,
-  gitUpdater,
+  nix-update-script,
   appstream-glib,
   json-glib,
   desktop-file-utils,
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://pwmt.org/projects/zathura";

--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -3,7 +3,7 @@
 , buildGoModule
 , fetchFromGitHub
 , callPackage
-, gitUpdater
+, nix-update-script
 }:
 
 buildGoModule rec {
@@ -73,7 +73,7 @@ buildGoModule rec {
 
   passthru = {
     tests.simple = callPackage ./tests.nix { inherit version; };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/applications/science/math/mpsolve/default.nix
+++ b/pkgs/applications/science/math/mpsolve/default.nix
@@ -4,7 +4,7 @@
 , autoreconfHook
 , bison
 , flex
-, gitUpdater
+, nix-update-script
 , gmp
 , gtk3
 , pkg-config
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://numpi.dm.unipi.it/scientific-computing-libraries/mpsolve/";

--- a/pkgs/applications/system/timed/default.nix
+++ b/pkgs/applications/system/timed/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   libiodata,
   pcre-cpp,
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
       # Version fields exclude patch-level

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -5,7 +5,7 @@
   pbr,
   requests,
   setuptools,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonApplication rec {
@@ -45,7 +45,7 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "git_review" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Tool to submit code to Gerrit";

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   pkg-config,
   glib,
   mpv-unwrapped,
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-vZIO6ILatIWa9nJYOp4AMKwvaZLahqYWRLMDOizyBI0=";
   };
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -2,7 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   python3,
 }:
 
@@ -16,7 +16,7 @@ buildLua rec {
     rev = version;
     sha256 = "sha256-nflavx25skLj9kitneL6Uz3zI2DyMMhQC595npofzbQ=";
   };
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ python3 ];
   postPatch = "patchShebangs concat_files.py";

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   makeFontsConf,
   buildLua,
   buildGoModule,
@@ -18,7 +18,7 @@ buildLua (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-UbSEJGlLSX5wZpfj+Cb3LfWw17pnjxIJUNtP8dclKoU=";
   };
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   tools = buildGoModule {
     pname = "uosc-bin";

--- a/pkgs/by-name/_9/_9pfs/package.nix
+++ b/pkgs/by-name/_9/_9pfs/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   fuse,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ fuse ];
   enableParallelBuilding = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/ftrvxmtrx/9pfs";

--- a/pkgs/by-name/a2/a2jmidid/package.nix
+++ b/pkgs/by-name/a2/a2jmidid/package.nix
@@ -10,7 +10,7 @@
   python3Packages,
   meson,
   ninja,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/a2j --replace "a2j_control" "$out/bin/a2j_control"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system";

--- a/pkgs/by-name/ab/abuild/package.nix
+++ b/pkgs/by-name/ab/abuild/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   makeWrapper,
   pkg-config,
   file,
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Alpine Linux build tools";

--- a/pkgs/by-name/ai/aisleriot/package.nix
+++ b/pkgs/by-name/ai/aisleriot/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   pkg-config,
   itstool,
   gtk3,
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [ "-Dtheme_kde=false" ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ar/arp-scan-rs/package.nix
+++ b/pkgs/by-name/ar/arp-scan-rs/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   rustPlatform,
   versionCheckHook,
 }:
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "ARP scan tool for fast local network scans";

--- a/pkgs/by-name/as/ascii/package.nix
+++ b/pkgs/by-name/as/ascii/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   asciidoctor,
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -vp "$out/bin" "$out/share/man/man1"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Interactive ASCII name and synonym chart";

--- a/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   cmake,
   gettext,
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.vm = nixosTests.ayatana-indicators;
   };
 

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   ayatana-indicator-messages,
   cmake,
@@ -139,7 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       inherit (nixosTests) ayatana-indicators;
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gitUpdater,
+  nix-update-script,
   fetchFromGitHub,
   nixosTests,
   accountsservice,
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   testers,
   accountsservice,
@@ -153,7 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-power/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-power/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gitUpdater,
+  nix-update-script,
   fetchFromGitHub,
   nixosTests,
   cmake,
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-session/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-session/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   cmake,
   dbus,
@@ -85,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gitUpdater,
+  nix-update-script,
   fetchFromGitHub,
   nixosTests,
   accountsservice,
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ba/badchars/package.nix
+++ b/pkgs/by-name/ba/badchars/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   python3,
 }:
 
@@ -22,7 +22,7 @@ python3.pkgs.buildPythonApplication rec {
   # no tests are available and it can't be imported (it's only a script, not a module)
   doCheck = false;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "HEX badchar generator for different programming languages";

--- a/pkgs/by-name/bl/blockattack/package.nix
+++ b/pkgs/by-name/bl/blockattack/package.nix
@@ -8,7 +8,7 @@
   cmake,
   fetchFromGitHub,
   gettext,
-  gitUpdater,
+  nix-update-script,
   ninja,
   physfs,
   pkg-config,
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/bl/bluez-alsa/package.nix
+++ b/pkgs/by-name/bl/bluez-alsa/package.nix
@@ -8,7 +8,7 @@
   dbus,
   fdk_aac,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   glib,
   libbsd,
   ncurses,
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeatureAs true "dbusconfdir" "${placeholder "out"}/share/dbus-1/system.d")
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/Arkq/bluez-alsa";

--- a/pkgs/by-name/bu/buteo-syncfw/package.nix
+++ b/pkgs/by-name/bu/buteo-syncfw/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   dbus,
   doxygen,
@@ -108,7 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
       # Version is hardcoded to 1.0.0

--- a/pkgs/by-name/cl/cloud-utils/package.nix
+++ b/pkgs/by-name/cl/cloud-utils/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   makeWrapper,
   gawk,
   gnused,
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Useful set of utilities for interacting with a cloud";

--- a/pkgs/by-name/co/colloid-icon-theme/package.nix
+++ b/pkgs/by-name/co/colloid-icon-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gtk3,
   hicolor-icon-theme,
   jdupes,
@@ -86,7 +86,7 @@ lib.checkListOfEnum "${pname}: scheme variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Colloid icon theme";

--- a/pkgs/by-name/co/coost/package.nix
+++ b/pkgs/by-name/co/coost/package.nix
@@ -5,7 +5,7 @@
   cmake,
   curl,
   openssl,
-  gitUpdater,
+  nix-update-script,
   withCurl ? true,
   withOpenSSL ? true,
 }:
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
   ];
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Tiny boost library in C++11";

--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -16,7 +16,7 @@
   pcre,
 
   versionCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   boost186,
   cmake,
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   makeBinaryWrapper,
   pkg-config,
   asciidoc,
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     }
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/dracutdevs/dracut/wiki";

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   python3Packages,
   gnutar,
   unzip,
@@ -59,7 +59,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ python3Packages.invoke ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Do The Right Extraction: A tool for taking the hassle out of extracting archives";

--- a/pkgs/by-name/en/endeavour/package.nix
+++ b/pkgs/by-name/en/endeavour/package.nix
@@ -18,7 +18,7 @@
   evolution-data-server-gtk4,
   libical,
   itstool,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/en/entwine/package.nix
+++ b/pkgs/by-name/en/entwine/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   cmake,
   pdal,
   curl,
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Point cloud organization for massive datasets";

--- a/pkgs/by-name/et/ethercat/package.nix
+++ b/pkgs/by-name/et/ethercat/package.nix
@@ -4,7 +4,7 @@
   pkg-config,
   stdenv,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ethercat";
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-kernel=no"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "IgH EtherCAT Master for Linux";

--- a/pkgs/by-name/fa/famistudio/package.nix
+++ b/pkgs/by-name/fa/famistudio/package.nix
@@ -14,7 +14,7 @@
   portaudio,
   rtmidi,
   _experimental-update-script-combinators,
-  gitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -153,7 +153,7 @@ buildDotnetModule (finalAttrs: {
   '';
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
-    (gitUpdater { }).command
+    (nix-update-script { }).command
     (finalAttrs.passthru.fetch-deps)
   ];
 

--- a/pkgs/by-name/fb/fbmenugen/package.nix
+++ b/pkgs/by-name/fb/fbmenugen/package.nix
@@ -8,7 +8,7 @@
   substituteAll,
   xorg,
   wrapGAppsHook3,
-  gitUpdater,
+  nix-update-script,
 }:
 
 perlPackages.buildPerlPackage rec {
@@ -67,7 +67,7 @@ perlPackages.buildPerlPackage rec {
     wrapProgram "$out/bin/${pname}" --prefix PERL5LIB : "$PERL5LIB"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/trizen/fbmenugen";

--- a/pkgs/by-name/fl/fluent-gtk-theme/package.nix
+++ b/pkgs/by-name/fl/fluent-gtk-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gnome-themes-extra,
   gtk-engine-murrine,
   jdupes,
@@ -98,7 +98,7 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = {
       description = "Fluent design gtk theme";

--- a/pkgs/by-name/fn/fnott/package.nix
+++ b/pkgs/by-name/fn/fnott/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gitUpdater,
+  nix-update-script,
   fetchFromGitea,
   pkg-config,
   meson,
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     fcft
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://codeberg.org/dnkl/fnott";

--- a/pkgs/by-name/ge/geticons/package.nix
+++ b/pkgs/by-name/ge/geticons/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromSourcehut,
-  gitUpdater,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-V3e3boIzn76irAfn9fF9MycPRAWorUUSD/CUZhgKv0E=";
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "CLI utility to get icons for apps on your system or other generic icons by name";

--- a/pkgs/by-name/gp/gpodder/package.nix
+++ b/pkgs/by-name/gp/gpodder/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   glibcLocales,
   adwaita-icon-theme,
   gobject-introspection,
@@ -84,7 +84,7 @@ python311Packages.buildPythonApplication rec {
 
   makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ xdg-utils ]}" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Podcatcher written in python";

--- a/pkgs/by-name/gr/graphite-gtk-theme/package.nix
+++ b/pkgs/by-name/gr/graphite-gtk-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gnome-themes-extra,
   gtk-engine-murrine,
   jdupes,
@@ -121,7 +121,7 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Flat Gtk+ theme based on Elegant Design";

--- a/pkgs/by-name/gr/greed/package.nix
+++ b/pkgs/by-name/gr/greed/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   ncurses,
   asciidoctor,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/gx/gxml/package.nix
+++ b/pkgs/by-name/gx/gxml/package.nix
@@ -10,7 +10,7 @@
   glib,
   libgee,
   libxml2,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "GXml provides a GObject API for manipulating XML and a Serializable framework from GObject to XML";

--- a/pkgs/by-name/ho/hostmux/package.nix
+++ b/pkgs/by-name/ho/hostmux/package.nix
@@ -5,7 +5,7 @@
   installShellFiles,
   openssh,
   tmux,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Small wrapper script for tmux to easily connect to a series of hosts via ssh and open a split pane for each of the hosts";

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -13,7 +13,7 @@
   writeText,
   runCommand,
   validatePkgConfig,
-  gitUpdater,
+  nix-update-script,
   buildPackages,
   perlPackages,
 }:
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
         '';
       };
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/jw/jwt-cli/package.nix
+++ b/pkgs/by-name/jw/jwt-cli/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   installShellFiles,
   rustPlatform,
 }:
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
       | grep -q 'John Doe'
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Super fast CLI tool to decode and encode JWTs";

--- a/pkgs/by-name/ke/keyscope/package.nix
+++ b/pkgs/by-name/ke/keyscope/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   openssl,
   pkg-config,
   rustPlatform,
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   # Test require network access
   doCheck = false;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Key and secret workflow (validation, invalidation, etc.) tool";

--- a/pkgs/by-name/ko/kokkos/package.nix
+++ b/pkgs/by-name/ko/kokkos/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   cmake,
   python3,
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doCheck = true;
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "C++ Performance Portability Programming EcoSystem";

--- a/pkgs/by-name/lc/lcevcdec/package.nix
+++ b/pkgs/by-name/lc/lcevcdec/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   fmt,
   git,
-  gitUpdater,
+  nix-update-script,
   gtest,
   lib,
   makePkgconfigItem,
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 

--- a/pkgs/by-name/li/libayatana-common/package.nix
+++ b/pkgs/by-name/li/libayatana-common/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   glib,
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/li/libgedit-amtk/package.nix
+++ b/pkgs/by-name/li/libgedit-amtk/package.nix
@@ -11,7 +11,7 @@
   gobject-introspection,
   gtk-doc,
   docbook-xsl-nons,
-  gitUpdater,
+  nix-update-script,
   dbus,
   xvfb-run,
 }:
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/World/gedit/libgedit-amtk";

--- a/pkgs/by-name/li/libgedit-gtksourceview/package.nix
+++ b/pkgs/by-name/li/libgedit-gtksourceview/package.nix
@@ -11,7 +11,7 @@
 , glib
 , gtk3
 , shared-mime-info
-, gitUpdater
+, nix-update-script
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     shared-mime-info
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Source code editing widget for GTK";

--- a/pkgs/by-name/li/liquidprompt/package.nix
+++ b/pkgs/by-name/li/liquidprompt/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Full-featured & carefully designed adaptive prompt for Bash & Zsh";

--- a/pkgs/by-name/lu/luau/package.nix
+++ b/pkgs/by-name/lu/luau/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  gitUpdater,
+  nix-update-script,
   llvmPackages,
 }:
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Fast, small, safe, gradually typed embeddable scripting language derived from Lua";

--- a/pkgs/by-name/ma/marwaita-mint/package.nix
+++ b/pkgs/by-name/ma/marwaita-mint/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gdk-pixbuf,
   gtk-engine-murrine,
   gtk_engines,
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Variation for marwaita GTK theme based on linux mint color scheme";

--- a/pkgs/by-name/ma/marwaita-orange/package.nix
+++ b/pkgs/by-name/ma/marwaita-orange/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   gtk_engines,
   librsvg,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Ubuntu Style of Marwaita GTK theme";

--- a/pkgs/by-name/ma/marwaita-red/package.nix
+++ b/pkgs/by-name/ma/marwaita-red/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   gtk_engines,
   librsvg,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Marwaita GTK theme with Peppermint Os Linux style";

--- a/pkgs/by-name/ma/marwaita-teal/package.nix
+++ b/pkgs/by-name/ma/marwaita-teal/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   gtk_engines,
   librsvg,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Manjaro Style of Marwaita GTK theme";

--- a/pkgs/by-name/ma/marwaita-yellow/package.nix
+++ b/pkgs/by-name/ma/marwaita-yellow/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   gtk_engines,
   librsvg,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Marwaita GTK theme with Pop_os Linux style";

--- a/pkgs/by-name/ma/marwaita/package.nix
+++ b/pkgs/by-name/ma/marwaita/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   gtk_engines,
   librsvg,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "GTK theme supporting Budgie, Pantheon, Mate, Xfce4 and GNOME desktops";

--- a/pkgs/by-name/ma/matcha-gtk-theme/package.nix
+++ b/pkgs/by-name/ma/matcha-gtk-theme/package.nix
@@ -6,7 +6,7 @@
   gtk-engine-murrine,
   jdupes,
   librsvg,
-  gitUpdater,
+  nix-update-script,
   colorVariants ? [ ], # default: all
   themeVariants ? [ ], # default: blue
 }:
@@ -68,7 +68,7 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] col
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Stylish flat Design theme for GTK based desktop environments";

--- a/pkgs/by-name/mi/mission-planner/package.nix
+++ b/pkgs/by-name/mi/mission-planner/package.nix
@@ -6,7 +6,7 @@
   makeWrapper,
   unzip,
   mono,
-  gitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "ArduPilot ground station";

--- a/pkgs/by-name/mk/mkcal/package.nix
+++ b/pkgs/by-name/mk/mkcal/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   doxygen,
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
       # version field doesn't exactly match current version

--- a/pkgs/by-name/mo/mojave-gtk-theme/package.nix
+++ b/pkgs/by-name/mo/mojave-gtk-theme/package.nix
@@ -17,7 +17,7 @@
   opacityVariants ? [ ], # default to all
   themeVariants ? [ ], # default to MacOS blue
   wallpapers ? false,
-  gitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -164,7 +164,7 @@ lib.checkListOfEnum "${pname}: button size variants" [ "standard" "small" ] butt
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = {
       description = "Mac OSX Mojave like theme for GTK based desktop environments";

--- a/pkgs/by-name/mo/moodle-dl/package.nix
+++ b/pkgs/by-name/mo/moodle-dl/package.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub, gitUpdater }:
+{ lib, python3Packages, fetchFromGitHub, nix-update-script }:
 
 python3Packages.buildPythonApplication rec {
   pname = "moodle-dl";
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication rec {
   # upstream has no tests
   doCheck = false;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/C0D3D3V/Moodle-Downloader-2";

--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/issues/5
   boost186,
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/ni/nix-prefetch/package.nix
+++ b/pkgs/by-name/ni/nix-prefetch/package.nix
@@ -23,7 +23,7 @@
   nix,
 
   versionCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/nu/numix-gtk-theme/package.nix
+++ b/pkgs/by-name/nu/numix-gtk-theme/package.nix
@@ -7,7 +7,7 @@
   libxml2,
   gdk-pixbuf,
   gtk-engine-murrine,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Modern flat theme with a combination of light and dark elements (GNOME, Unity, Xfce and Openbox)";

--- a/pkgs/by-name/nu/numix-icon-theme-circle/package.nix
+++ b/pkgs/by-name/nu/numix-icon-theme-circle/package.nix
@@ -5,7 +5,7 @@
   gtk3,
   numix-icon-theme,
   hicolor-icon-theme,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Numix icon theme (circle version)";

--- a/pkgs/by-name/nu/numix-icon-theme-square/package.nix
+++ b/pkgs/by-name/nu/numix-icon-theme-square/package.nix
@@ -5,7 +5,7 @@
   gtk3,
   numix-icon-theme,
   hicolor-icon-theme,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Numix icon theme (square version)";

--- a/pkgs/by-name/pc/pc/package.nix
+++ b/pkgs/by-name/pc/pc/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   byacc,
   fetchFromSourcehut,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Programmer's calculator";

--- a/pkgs/by-name/pe/pegtl/package.nix
+++ b/pkgs/by-name/pe/pegtl/package.nix
@@ -1,7 +1,7 @@
 {
   cmake,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   lib,
   ninja,
   stdenv,
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/taocpp/pegtl";

--- a/pkgs/by-name/pe/persistent-cache-cpp/package.nix
+++ b/pkgs/by-name/pe/persistent-cache-cpp/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   boost,
   cmake,
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/pf/pfetch/package.nix
+++ b/pkgs/by-name/pf/pfetch/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   versionCheckHook,
 }:
 
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ph/photini/package.nix
+++ b/pkgs/by-name/ph/photini/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
-  gitUpdater,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -35,7 +35,7 @@ python3Packages.buildPythonApplication rec {
     toml
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/jim-easterbrook/Photini";

--- a/pkgs/by-name/pi/picotool/package.nix
+++ b/pkgs/by-name/pi/picotool/package.nix
@@ -8,7 +8,7 @@
   pico-sdk,
   mbedtls_2,
   versionCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/pl/platform-folders/package.nix
+++ b/pkgs/by-name/pl/platform-folders/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "C++ library to look for standard platform directories so that you do not need to write platform-specific code";

--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -8,7 +8,7 @@
   fetchFromGitLab,
   sudo,
   python3Packages,
-  gitUpdater,
+  nix-update-script,
   util-linux,
   versionCheckHook,
 }:
@@ -69,7 +69,7 @@ python3Packages.buildPythonApplication rec {
     }"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Sophisticated chroot/build/flash tool to develop and install postmarketOS";

--- a/pkgs/by-name/pr/process-cpp/package.nix
+++ b/pkgs/by-name/pr/process-cpp/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitLab,
   testers,
-  gitUpdater,
+  nix-update-script,
   cmake,
   coreutils,
   boost,
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/pr/properties-cpp/package.nix
+++ b/pkgs/by-name/pr/properties-cpp/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   pkg-config,
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/qo/qogir-icon-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-icon-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gtk3,
   hicolor-icon-theme,
   jdupes,
@@ -64,7 +64,7 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "dark" "all" ] color
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Flat colorful design icon theme";

--- a/pkgs/by-name/qo/qogir-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gdk-pixbuf,
   gnome-themes-extra,
   gtk-engine-murrine,
@@ -82,7 +82,7 @@ lib.checkListOfEnum "${pname}: theme variants" [ "default" "manjaro" "ubuntu" "a
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Flat Design theme for GTK based desktop environments";

--- a/pkgs/by-name/r1/r128gain/package.nix
+++ b/pkgs/by-name/r1/r128gain/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   replaceVars,
   ffmpeg,
   python3Packages,
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
   # sandbox to be disabled.
   doCheck = false;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Fast audio loudness scanner & tagger (ReplayGain v2 / R128)";

--- a/pkgs/by-name/re/reversal-icon-theme/package.nix
+++ b/pkgs/by-name/re/reversal-icon-theme/package.nix
@@ -7,7 +7,7 @@
   adwaita-icon-theme,
   hicolor-icon-theme,
   numix-icon-theme-circle,
-  gitUpdater,
+  nix-update-script,
   allColorVariants ? false,
   colorVariants ? [ ],
 }:
@@ -83,7 +83,7 @@ lib.checkListOfEnum "${pname}: color variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Colorful Design Rectangle icon theme";

--- a/pkgs/by-name/re/revup/package.nix
+++ b/pkgs/by-name/re/revup/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchPypi,
-  gitUpdater,
+  nix-update-script,
   python3Packages,
   testers,
 }:
@@ -40,7 +40,7 @@ let
     ];
 
     passthru = {
-      updateScript = gitUpdater { };
+      updateScript = nix-update-script { };
       tests.version = testers.testVersion {
         package = self;
       };

--- a/pkgs/by-name/rp/rpiboot/package.nix
+++ b/pkgs/by-name/rp/rpiboot/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   libusb1,
   pkg-config,
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     cp -r msd firmware eeprom-erase mass-storage-gadget* recovery* secure-boot* rpi-imager-embedded $out/share/rpiboot
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/raspberrypi/usbboot";

--- a/pkgs/by-name/rt/rtabmap/package.nix
+++ b/pkgs/by-name/rt/rtabmap/package.nix
@@ -28,7 +28,7 @@
   hidapi,
 
   # passthru
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [ "-Wno-dev" ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ru/runelite/package.nix
+++ b/pkgs/by-name/ru/runelite/package.nix
@@ -7,7 +7,7 @@
   jdk17,
   jre,
   xorg,
-  gitUpdater,
+  nix-update-script,
   libGL,
 }:
 
@@ -59,7 +59,7 @@ maven.buildMavenPackage rec {
       --add-flags "-jar $out/share/RuneLite.jar"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open source Old School RuneScape client";

--- a/pkgs/by-name/sa/sailfish-access-control/package.nix
+++ b/pkgs/by-name/sa/sailfish-access-control/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   glib,
   libsForQt5,
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests = {
       pkg-config = testers.hasPkgConfigModules {
         package = finalAttrs.finalPackage;

--- a/pkgs/by-name/sa/sanjuuni/package.nix
+++ b/pkgs/by-name/sa/sanjuuni/package.nix
@@ -7,7 +7,7 @@
   poco,
   ocl-icd,
   opencl-clhpp,
-  gitUpdater,
+  nix-update-script,
   callPackage,
 }:
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     tests = {
       run-on-nixos-artwork = callPackage ./tests/run-on-nixos-artwork.nix { };
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/se/serpl/package.nix
+++ b/pkgs/by-name/se/serpl/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   makeWrapper,
   ripgrep,
 }:
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage {
       --prefix PATH : "${lib.strings.makeBinPath [ ripgrep ]}"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Simple terminal UI for search and replace, ala VS Code";

--- a/pkgs/by-name/sm/smap/package.nix
+++ b/pkgs/by-name/sm/smap/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -25,7 +25,7 @@ buildGoModule rec {
     "-w"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Drop-in replacement for Nmap powered by shodan.io";

--- a/pkgs/by-name/so/sov/package.nix
+++ b/pkgs/by-name/so/sov/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fetchpatch2,
   freetype,
-  gitUpdater,
+  nix-update-script,
   libglvnd,
   libxkbcommon,
   meson,
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/milgra/sov";

--- a/pkgs/by-name/sw/sweet-nova/package.nix
+++ b/pkgs/by-name/sw/sweet-nova/package.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   lib,
   stdenvNoCC,
 }:
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Dark and colorful, blurry theme for the KDE Plasma desktop";

--- a/pkgs/by-name/ub/ubports-click/package.nix
+++ b/pkgs/by-name/ub/ubports-click/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   lib,
   stdenv,
   testers,
@@ -146,7 +146,7 @@ let
     '';
 
     passthru = {
-      updateScript = gitUpdater { };
+      updateScript = nix-update-script { };
     };
 
     meta = {

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -3,7 +3,7 @@
   fetchpatch,
   python3,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   makeWrapper,
   e2fsprogs,
   jefferson,
@@ -113,7 +113,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     # helpful to easily add these to a nix-shell environment
     inherit runtimeDeps;
   };

--- a/pkgs/by-name/un/unbook/package.nix
+++ b/pkgs/by-name/un/unbook/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   calibre,
-  gitUpdater,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/unbook --prefix PATH : ${lib.makeBinPath [ calibre ]}
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Ebook to self-contained-HTML converter";

--- a/pkgs/by-name/up/upscaler/package.nix
+++ b/pkgs/by-name/up/upscaler/package.nix
@@ -5,7 +5,7 @@
   gtk4,
   meson,
   ninja,
-  gitUpdater,
+  nix-update-script,
   desktop-file-utils,
   appstream,
   blueprint-compiler,
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-WjhefFyd1hnngD/uIvgjAI4i6AyoldDJKWocvotGw9g=";
   };
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   postPatch = ''
     substituteInPlace upscaler/window.py \

--- a/pkgs/by-name/vi/vimix-gtk-themes/package.nix
+++ b/pkgs/by-name/vi/vimix-gtk-themes/package.nix
@@ -7,7 +7,7 @@
   gtk_engines,
   jdupes,
   sassc,
-  gitUpdater,
+  nix-update-script,
   themeVariants ? [ ], # default: doder (blue)
   colorVariants ? [ ], # default: all
   sizeVariants ? [ ], # default: standard
@@ -86,7 +86,7 @@ lib.checkListOfEnum "${pname}: theme variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Flat Material Design theme for GTK based desktop environments";

--- a/pkgs/by-name/vi/vimix-icon-theme/package.nix
+++ b/pkgs/by-name/vi/vimix-icon-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gtk3,
   hicolor-icon-theme,
   jdupes,
@@ -70,7 +70,7 @@ lib.checkListOfEnum "${pname}: color variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Material Design icon theme based on Paper icon theme";

--- a/pkgs/by-name/wa/waycorner/package.nix
+++ b/pkgs/by-name/wa/waycorner/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   fetchFromGitHub,
   wayland,
-  gitUpdater,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "waycorner";
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ wayland ]}
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Hot corners for Wayland";

--- a/pkgs/by-name/wh/whitesur-gtk-theme/package.nix
+++ b/pkgs/by-name/wh/whitesur-gtk-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   dialog,
   glib,
   gnome-themes-extra,
@@ -154,7 +154,7 @@ lib.checkListOfEnum "${pname}: window control buttons variants" [ "normal" "alt"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = {
       description = "MacOS BigSur like Gtk+ theme based on Elegant Design";

--- a/pkgs/by-name/wl/wl-kbptr/package.nix
+++ b/pkgs/by-name/wl/wl-kbptr/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gtk3,
   libxkbcommon,
   meson,
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/wl/wlogout/package.nix
+++ b/pkgs/by-name/wl/wlogout/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   gtk-layer-shell,
   gtk3,
   libxkbcommon,
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/xd/xdgmenumaker/package.nix
+++ b/pkgs/by-name/xd/xdgmenumaker/package.nix
@@ -8,7 +8,7 @@
   python3Packages,
   txt2tags,
   wrapGAppsHook3,
-  gitUpdater,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -53,7 +53,7 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Command line tool that generates XDG menus for several window managers";

--- a/pkgs/by-name/xs/xsct/package.nix
+++ b/pkgs/by-name/xs/xsct/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   libX11,
   libXrandr,
 }:
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${placeholder "out"}"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Set color temperature of screen";

--- a/pkgs/by-name/zc/zchunk/package.nix
+++ b/pkgs/by-name/zc/zchunk/package.nix
@@ -4,7 +4,7 @@
   callPackage,
   curl,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   meson,
   ninja,
   pkg-config,
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests = lib.packagesFromDirectoryRecursive {
       inherit callPackage;
       directory = ./tests;

--- a/pkgs/by-name/zs/zsh-you-should-use/package.nix
+++ b/pkgs/by-name/zs/zsh-you-should-use/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, ncurses, fetchFromGitHub, gitUpdater }:
+{ lib, stdenvNoCC, ncurses, fetchFromGitHub, nix-update-script }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "zsh-you-should-use";
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -D you-should-use.plugin.zsh $out/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/MichaelAquilina/zsh-you-should-use";

--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -7,7 +7,7 @@
   breeze-icons,
   gnome-icon-theme,
   hicolor-icon-theme,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -49,7 +49,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Numix icon theme";

--- a/pkgs/data/icons/papirus-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-icon-theme/default.nix
@@ -9,7 +9,7 @@
   papirus-folders,
   color ? null,
   withElementary ? false,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -55,7 +55,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Pixel perfect icon theme for Linux";

--- a/pkgs/data/icons/tela-circle-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-circle-icon-theme/default.nix
@@ -7,7 +7,7 @@
   gtk3,
   hicolor-icon-theme,
   jdupes,
-  gitUpdater,
+  nix-update-script,
   allColorVariants ? false,
   circularFolder ? false,
   colorVariants ? [ ], # default is standard
@@ -82,7 +82,7 @@ lib.checkListOfEnum "${pname}: color variants"
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Flat and colorful personality icon theme";

--- a/pkgs/data/icons/zafiro-icons/default.nix
+++ b/pkgs/data/icons/zafiro-icons/default.nix
@@ -9,7 +9,7 @@
   numix-icon-theme-circle,
   hicolor-icon-theme,
   jdupes,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Icon pack flat with light colors";

--- a/pkgs/data/themes/colloid-kde/default.nix
+++ b/pkgs/data/themes/colloid-kde/default.nix
@@ -5,7 +5,7 @@
   kdeclarative,
   plasma-framework,
   plasma-workspace,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation rec {
       >> $sddm/nix-support/propagated-user-env-packages
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Clean and concise theme for KDE Plasma desktop";

--- a/pkgs/data/themes/graphite-kde-theme/default.nix
+++ b/pkgs/data/themes/graphite-kde-theme/default.nix
@@ -5,7 +5,7 @@
   kdeclarative,
   plasma-framework,
   plasma-workspace,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Flat Design theme for KDE Plasma desktop";

--- a/pkgs/data/themes/layan-kde/default.nix
+++ b/pkgs/data/themes/layan-kde/default.nix
@@ -5,7 +5,7 @@
   kdeclarative,
   plasma-framework,
   plasma-workspace,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Flat Design theme for KDE Plasma desktop";

--- a/pkgs/data/themes/whitesur-kde/default.nix
+++ b/pkgs/data/themes/whitesur-kde/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
 }:
 
 # NOTE:
@@ -66,7 +66,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "MacOS big sur like theme for KDE Plasma desktop";

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   cmake,
   gettext,
@@ -148,7 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.vm = nixosTests.lomiri-mediaplayer-app;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   accountsservice,
   ayatana-indicator-datetime,
@@ -190,7 +190,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   fetchpatch,
   fetchpatch2,
-  gitUpdater,
+  nix-update-script,
   linkFarm,
   replaceVars,
   nixosTests,
@@ -274,7 +274,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     etcLayoutsFile = "lomiri/keymaps";
     tests = nixosTests.lomiri;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     greeter = linkFarm "lomiri-greeter" [
       {
         path = "${finalAttrs.finalPackage}/share/lightdm/greeters/lomiri-greeter.desktop";

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   cmake,
   gettext,
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests = {
       # Test of morph-browser itself
       standalone = nixosTests.morph-browser;

--- a/pkgs/desktops/lomiri/data/lomiri-schemas/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-schemas/default.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   bash,
   cmake,
@@ -80,7 +80,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       # "lomiri-touch"
     ];
     tests.lomiri = nixosTests.lomiri;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/data/lomiri-sounds/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-sounds/default.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
 }:
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Wallpapers for the Lomiri Operating Environment, gathered from people of the Ubuntu Touch / UBports community";

--- a/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
+++ b/pkgs/desktops/lomiri/data/suru-icon-theme/default.nix
@@ -2,7 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   gtk3,
   hicolor-icon-theme,
   ubuntu-themes,
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   dontDropIconThemeCache = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Suru Icon Theme for Lomiri Operating Environment";

--- a/pkgs/desktops/lomiri/development/deviceinfo/default.nix
+++ b/pkgs/desktops/lomiri/development/deviceinfo/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   pkg-config,
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   buildPackages,
   cmake,
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   makeFontsConf,
   testers,
   cmake,
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-app-launch/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -141,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   # dbus-cpp not compatible with Boost 1.87
   # https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/8
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/development/u1db-qt/default.nix
+++ b/pkgs/desktops/lomiri/development/u1db-qt/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   dbus-test-runner,
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-action-api/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   dbus,
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/qml/lomiri-notifications/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-notifications/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   cmake,
   dbus,
   libqtdbustest,
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Free Desktop Notification server QML implementation for Lomiri";

--- a/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-settings-components/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   cmake,
   cmake-extras,
   pkg-config,
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "QML settings components for the Lomiri Desktop Environment";

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-extras/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-extras/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   cmake,
   cmake-extras,
   cups,
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   substituteAll,
   testers,
   dbus-test-runner,
@@ -218,7 +218,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
+++ b/pkgs/desktops/lomiri/qml/qqc2-suru-style/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   qmake,
   qtdeclarative,
   qtquickcontrols2,
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Suru Style for QtQuick Controls 2";

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   # https://gitlab.com/ubports/development/core/biometryd/-/issues/8
   boost186,
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/desktops/lomiri/services/hfd-service/default.nix
+++ b/pkgs/desktops/lomiri/services/hfd-service/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   accountsservice,
   cmake,
   cmake-extras,
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "DBus-activated service that manages human feedback devices such as LEDs and vibrators on mobile devices";

--- a/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   boost,
   cmake,
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-history-service/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-history-service/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   dbus,
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   testers,
   cmake,
@@ -128,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       vm = nixosTests.ayatana-indicators;
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   cmake,
   cmake-extras,
   dbus,
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Parallelism breaks dbus during tests
   enableParallelChecking = false;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Policy kit agent for the Lomiri desktop";

--- a/pkgs/desktops/lomiri/services/lomiri-telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-telephony-service/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   runCommand,
   ayatana-indicator-messages,
@@ -207,7 +207,7 @@ stdenv.mkDerivation (finalAttrs: {
       lomiri-indicator-telephony-service = [ "lomiri" ];
     };
     tests.vm = nixosTests.ayatana-indicators;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   testers,
   boost,
@@ -183,7 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-url-dispatcher/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
   testers,
   # dbus-cpp not compatible with Boost 1.87
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/desktops/lxde/core/lxtask/default.nix
+++ b/pkgs/desktops/lxde/core/lxtask/default.nix
@@ -7,7 +7,7 @@
   intltool,
   libintl,
   pkg-config,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--enable-gtk3" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://lxde.sourceforge.net/";

--- a/pkgs/desktops/lxqt/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/compton-conf/default.nix
@@ -10,7 +10,7 @@
   qttools,
   qtx11extras,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       --replace-fail "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg" \
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/desktops/lxqt/libdbusmenu-lxqt/default.nix
+++ b/pkgs/desktops/lxqt/libdbusmenu-lxqt/default.nix
@@ -5,7 +5,7 @@
   cmake,
   qtbase,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -15,7 +15,7 @@
   pkg-config,
   qttools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   version ? "2.1.0",
   qtx11extras ? null,
 }:
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     pcre
   ] ++ (lib.optionals (lib.versionAtLeast "2.0.0" version) [ qtx11extras ]);
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/libfm-qt";

--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  gitUpdater,
+  nix-update-script,
   kwindowsystem,
   libXScrnSaver,
   libqtxdg,
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     sed -i "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" CMakeLists.txt
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Core utility library for all LXQt components";

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -7,7 +7,7 @@
   qtsvg,
   lxqt-build-tools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   version ? "4.1.0",
 }:
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/libqtxdg";

--- a/pkgs/desktops/lxqt/libsysstat/default.nix
+++ b/pkgs/desktops/lxqt/libsysstat/default.nix
@@ -6,7 +6,7 @@
   qtbase,
   lxqt-build-tools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/desktops/lxqt/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/lximage-qt/default.nix
@@ -16,7 +16,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lximage-qt";

--- a/pkgs/desktops/lxqt/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-about/default.nix
@@ -11,7 +11,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-about";

--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -12,7 +12,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-admin";

--- a/pkgs/desktops/lxqt/lxqt-archiver/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-archiver/default.nix
@@ -13,7 +13,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-archiver/";

--- a/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-build-tools/default.nix
@@ -9,7 +9,7 @@
   glib,
   perl,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   version ? "2.1.0",
 }:
 
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     cp ${./LXQtConfigVars.cmake} $out/share/cmake/lxqt${lib.optionalString (lib.versionAtLeast version "2.0.0") "2"}-build-tools/modules/LXQtConfigVars.cmake
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-build-tools";

--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -23,7 +23,7 @@
   wrapQtAppsHook,
   xf86inputlibinput,
   xkeyboard_config,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
                 '${xkeyboard_config}/share/X11/xkb/rules/base.lst'
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-config";

--- a/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
@@ -11,7 +11,7 @@
   liblxqt,
   libqtxdg,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     libqtxdg
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-globalkeys";

--- a/pkgs/desktops/lxqt/lxqt-menu-data/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-menu-data/default.nix
@@ -6,7 +6,7 @@
   lxqt-build-tools,
   qttools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-menu-data";

--- a/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
@@ -13,7 +13,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-notificationd";

--- a/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
@@ -12,7 +12,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-openssh-askpass";

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -31,7 +31,7 @@
   qtwayland,
   solid,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     solid
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-panel";

--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -16,7 +16,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-policykit";

--- a/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
@@ -15,7 +15,7 @@
   qtwayland,
   solid,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     solid
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-powermanagement";

--- a/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-qtplugin/default.nix
@@ -8,7 +8,7 @@
   libfm-qt,
   libqtxdg,
   lxqt-build-tools,
-  gitUpdater,
+  nix-update-script,
   qtbase,
   qtsvg,
   qttools,
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       --replace-fail "DESTINATION \"\''${QT_PLUGINS_DIR}" "DESTINATION \"$qtPluginPrefix"
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-qtplugin";

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -18,7 +18,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-runner";

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -19,7 +19,7 @@
   qtxdg-tools,
   wrapQtAppsHook,
   xdg-user-dirs,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     xdg-user-dirs
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-session";

--- a/pkgs/desktops/lxqt/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-sudo/default.nix
@@ -13,7 +13,7 @@
   qtwayland,
   sudo,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     sudo
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-sudo";

--- a/pkgs/desktops/lxqt/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-themes/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   lxqt-build-tools,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     lxqt-build-tools
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/lxqt-themes";

--- a/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-wayland-session/default.nix
@@ -15,7 +15,7 @@
   qtxdg-tools,
   xdg-user-dirs,
   xkeyboard_config,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/lxqt/lxqt-wayland-session";

--- a/pkgs/desktops/lxqt/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/obconf-qt/default.nix
@@ -14,7 +14,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/lxqt/obconf-qt";

--- a/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
@@ -11,7 +11,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/lxqt/pavucontrol-qt";

--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -16,7 +16,7 @@
   qtwayland,
   qtsvg,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     qtsvg
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   postPatch = ''
     substituteInPlace config/pcmanfm-qt/lxqt/settings.conf.in --replace-fail @LXQT_SHARE_DIR@ /run/current-system/sw/share/lxqt

--- a/pkgs/desktops/lxqt/qlipper/default.nix
+++ b/pkgs/desktops/lxqt/qlipper/default.nix
@@ -6,7 +6,7 @@
   qtbase,
   qttools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Cross-platform clipboard history applet";

--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -12,7 +12,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/qps";

--- a/pkgs/desktops/lxqt/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/qterminal/default.nix
@@ -10,7 +10,7 @@
   qttools,
   qtwayland,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
 }:
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   passthru.tests.test = nixosTests.terminal-emulators.qterminal;
 

--- a/pkgs/desktops/lxqt/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/qtermwidget/default.nix
@@ -7,7 +7,7 @@
   qttools,
   lxqt-build-tools,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   version ? "2.1.0",
 }:
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     qtbase
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/desktops/lxqt/qtxdg-tools/default.nix
+++ b/pkgs/desktops/lxqt/qtxdg-tools/default.nix
@@ -8,7 +8,7 @@
   qtbase,
   qtsvg,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     qtsvg
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/qtxdg-tools";

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   autoPatchelfHook,
-  gitUpdater,
+  nix-update-script,
   kwindowsystem,
   libXdmcp,
   libpthreadstubs,
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     qtsvg
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/screengrab";

--- a/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
+++ b/pkgs/desktops/lxqt/xdg-desktop-portal-lxqt/default.nix
@@ -10,7 +10,7 @@
   menu-cache,
   qtbase,
   wrapQtAppsHook,
-  gitUpdater,
+  nix-update-script,
   extraQtStyles ? [ ],
 }:
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     qtbase
   ] ++ extraQtStyles;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/lxqt/xdg-desktop-portal-lxqt";

--- a/pkgs/desktops/mate/mate-tweak/default.nix
+++ b/pkgs/desktops/mate/mate-tweak/default.nix
@@ -10,7 +10,7 @@
   gobject-introspection,
   wrapGAppsHook3,
   glib,
-  gitUpdater,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -74,7 +74,7 @@ python3Packages.buildPythonApplication rec {
     done
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Tweak tool for the MATE Desktop";

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -8,7 +8,7 @@
   cmake,
   ninja,
   xfce,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/Jeinzi/thunar-dropbox";

--- a/pkgs/development/libraries/libiodata/default.nix
+++ b/pkgs/development/libraries/libiodata/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
-  gitUpdater,
+  nix-update-script,
   bison,
   flex,
   qmake,
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.IODATA_VERSION = "${finalAttrs.version}";
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Library for reading and writing simple structured data";

--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -6,7 +6,7 @@
   duktape,
   fetchFromGitHub,
   gi-docgen,
-  gitUpdater,
+  nix-update-script,
   glib,
   gobject-introspection,
   gsettings-desktop-schemas,
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     updateScript =
       let
-        updateSource = gitUpdater { };
+        updateSource = nix-update-script { };
         updatePatch = _experimental-update-script-combinators.copyAttrOutputToFile "libproxy.hardcodeGsettingsPatch" ./hardcode-gsettings.patch;
       in
       _experimental-update-script-combinators.sequence [

--- a/pkgs/development/libraries/libqofono/default.nix
+++ b/pkgs/development/libraries/libqofono/default.nix
@@ -3,7 +3,7 @@
   substituteAll,
   mkDerivation,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   mobile-broadband-provider-info,
   qmake,
   qtbase,
@@ -49,7 +49,7 @@ mkDerivation rec {
     qtdeclarative
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Library for accessing the ofono daemon, and declarative plugin for it";

--- a/pkgs/development/libraries/qmenumodel/default.nix
+++ b/pkgs/development/libraries/qmenumodel/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   testers,
   cmake,
   cmake-extras,
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/yaml-cpp/default.nix
+++ b/pkgs/development/libraries/yaml-cpp/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   cmake,
   static ? stdenv.hostPlatform.isStatic,
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "YAML parser and emitter for C++";

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -7,7 +7,7 @@
   alcotest,
   bigstringaf,
   ppx_let,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildDunePackage rec {
@@ -31,7 +31,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [ bigstringaf ];
   doCheck = lib.versionAtLeast ocaml.version "4.08";
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/inhabitedtype/angstrom";

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -15,7 +15,7 @@
   path_glob,
   ppx_deriving_yojson,
   ppx_optcomp,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildDunePackage rec {
@@ -48,7 +48,7 @@ buildDunePackage rec {
     ppx_optcomp
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/hackwaly/ocamlearlybird";

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchurl, buildDunePackage, ocaml, findlib
 , alcotest
 , astring, cppo, fmt, logs, ocaml-version, camlp-streams, lwt, re, csexp
-, gitUpdater
+, nix-update-script
 }:
 
 buildDunePackage rec {
@@ -31,7 +31,7 @@ buildDunePackage rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Executable OCaml code blocks inside markdown files";

--- a/pkgs/development/ocaml-modules/patch/default.nix
+++ b/pkgs/development/ocaml-modules/patch/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   buildDunePackage,
-  gitUpdater,
+  nix-update-script,
   alcotest,
   crowbar,
 }:
@@ -25,7 +25,7 @@ buildDunePackage rec {
     crowbar
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Patch library purely in OCaml";

--- a/pkgs/development/ocaml-modules/raylib/default.nix
+++ b/pkgs/development/ocaml-modules/raylib/default.nix
@@ -6,7 +6,7 @@
   ctypes,
   integers,
   patch,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildDunePackage rec {
@@ -29,7 +29,7 @@ buildDunePackage rec {
     patch
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "OCaml bindings for Raylib (5.0.0)";

--- a/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
+++ b/pkgs/development/perl-modules/WWW-YoutubeViewer/default.nix
@@ -8,7 +8,7 @@
   LWPProtocolHttps,
   DataDump,
   JSON,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPerlPackage rec {
@@ -33,7 +33,7 @@ buildPerlPackage rec {
     shortenPerlShebang $out/bin/youtube-viewer
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Lightweight application for searching and streaming videos from YouTube";

--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -8,7 +8,7 @@
   ArchiveCpio,
   SubOverride,
   shortenPerlShebang,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPerlPackage rec {
@@ -66,7 +66,7 @@ buildPerlPackage rec {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cobble/default.nix
+++ b/pkgs/development/python-modules/cobble/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     "test_sub_sub_classes_are_included_in_abc"
   ];
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "Create Python data objects";

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -4,7 +4,7 @@
   exiv2,
   gettext,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   buildPythonPackage,
   setuptools,
   toml,
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     "-v"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Low level Python interface to the Exiv2 C++ library";

--- a/pkgs/development/python-modules/funk/default.nix
+++ b/pkgs/development/python-modules/funk/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   precisely,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   # Disabling tests, they rely on Nose which is outdated and not supported
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "A mocking framework for Python, influenced by JMock";

--- a/pkgs/development/python-modules/jsonslicer/default.nix
+++ b/pkgs/development/python-modules/jsonslicer/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   pytestCheckHook,
   unittestCheckHook,
   setuptools,
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jsonslicer" ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Stream JSON parser for Python";

--- a/pkgs/development/python-modules/mammoth/default.nix
+++ b/pkgs/development/python-modules/mammoth/default.nix
@@ -8,7 +8,7 @@
   pytestCheckHook,
   spur,
   tempman,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     export PATH=$out/bin:$PATH
   '';
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "Convert Word documents (.docx files) to HTML";

--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -20,7 +20,7 @@
   speechrecognition,
   youtube-transcript-api,
   pytestCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage {
@@ -65,7 +65,7 @@ buildPythonPackage {
     "test_markitdown_remote"
   ];
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "Python tool for converting files and office documents to Markdown";

--- a/pkgs/development/python-modules/orange-canvas-core/default.nix
+++ b/pkgs/development/python-modules/orange-canvas-core/default.nix
@@ -27,7 +27,7 @@
   pytestCheckHook,
 
   stdenv,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -88,7 +88,7 @@ buildPythonPackage rec {
     "test_widgettoolgrid"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   disabledTestPaths = [ "orangecanvas/canvas/items/tests/test_graphicstextitem.py" ];
 

--- a/pkgs/development/python-modules/orange-widget-base/default.nix
+++ b/pkgs/development/python-modules/orange-widget-base/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  gitUpdater,
+  nix-update-script,
   stdenv,
   buildPythonPackage,
   setuptools,
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     "orangewidget/tests/test_widget.py"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Implementation of the base OWBaseWidget class and utilities for use in Orange Canvas workflows";

--- a/pkgs/development/python-modules/orange3/default.nix
+++ b/pkgs/development/python-modules/orange3/default.nix
@@ -49,7 +49,7 @@
   makeDesktopItem,
 
   # passthru
-  gitUpdater,
+  nix-update-script,
   python,
   pytest-qt,
   pytestCheckHook,
@@ -171,7 +171,7 @@ let
     '';
 
     passthru = {
-      updateScript = gitUpdater { };
+      updateScript = nix-update-script { };
       tests.unittests = stdenv.mkDerivation {
         name = "${self.name}-tests";
         inherit (self) src;

--- a/pkgs/development/python-modules/precisely/default.nix
+++ b/pkgs/development/python-modules/precisely/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   # Tests are outdated and based on Nose, which is not supported anymore.
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "Matcher library for Python";

--- a/pkgs/development/python-modules/tempman/default.nix
+++ b/pkgs/development/python-modules/tempman/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   # Disabling tests, they rely on dependencies that are outdated and not supported
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScripts = nix-update-script { };
 
   meta = {
     description = "Create and clean up temporary directories";

--- a/pkgs/development/python-modules/trubar/default.nix
+++ b/pkgs/development/python-modules/trubar/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  gitUpdater,
+  nix-update-script,
   pytestCheckHook,
   libcst,
   pyyaml,
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Utility for translation of strings and f-strings in Python files";

--- a/pkgs/development/python-modules/xmpppy/default.nix
+++ b/pkgs/development/python-modules/xmpppy/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   six,
   setuptools,
 }:
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Python 2/3 implementation of XMPP";

--- a/pkgs/development/tools/analysis/clazy/default.nix
+++ b/pkgs/development/tools/analysis/clazy/default.nix
@@ -6,7 +6,7 @@
   cmake,
   makeWrapper,
   versionCheckHook,
-  gitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/development/tools/ocaml/ocaml-recovery-parser/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-recovery-parser/default.nix
@@ -6,7 +6,7 @@
   fix,
   menhirLib,
   menhirSdk,
-  gitUpdater,
+  nix-update-script,
 }:
 
 lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
@@ -33,7 +33,7 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
       menhirSdk
     ];
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = nix-update-script { };
 
     meta = with lib; {
       description = "Simple fork of OCaml parser with support for error recovery";

--- a/pkgs/games/legendary-gl/default.nix
+++ b/pkgs/games/legendary-gl/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  gitUpdater,
+  nix-update-script,
   fetchFromGitHub,
   buildPythonApplication,
   pythonOlder,
@@ -39,5 +39,5 @@ buildPythonApplication rec {
     mainProgram = "legendary";
   };
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 }

--- a/pkgs/games/openxray/default.nix
+++ b/pkgs/games/openxray/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   cmake,
   glew,
   liblockfile,
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
   # dlopens its own libraries, relies on rpath not having its prefix stripped
   dontPatchELF = true;
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     mainProgram = "xr_3da";

--- a/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   pkg-config,
   postgresql,
   libversion,
@@ -28,7 +28,7 @@ buildPostgresqlExtension (finalAttrs: {
     libversion
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "PostgreSQL extension with support for version string comparison";

--- a/pkgs/servers/tang/default.nix
+++ b/pkgs/servers/tang/default.nix
@@ -13,7 +13,7 @@
   makeWrapper,
   testers,
   tang,
-  gitUpdater,
+  nix-update-script,
   nixosTests,
 }:
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
         version = "tangd ${version}";
       };
     };
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/tools/games/alice-tools/default.nix
+++ b/pkgs/tools/games/alice-tools/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  gitUpdater,
+  nix-update-script,
   testers,
   fetchFromGitHub,
   meson,
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    updateScript = gitUpdater { };
+    updateScript = nix-update-script { };
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
       command =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

nix-update-script is much more popular than gitUpdater ([1600](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+nix-update-script&type=code) vs [580](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+%22+gitUpdater%22&type=code) usages) and also has many more features so there will be less refactorings later

In this part i only replace gitUpdater without any arguments


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
