### PR TITLE
bisq2: add coreutils and tor to PATH

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -1,7 +1,7 @@
 {
   stdenvNoCC,
   lib,
-  makeWrapper,
+  makeBinaryWrapper,
   runtimeShell,
   fetchurl,
   makeDesktopItem,
@@ -14,6 +14,7 @@
   tor,
   zip,
   gnupg,
+  coreutils,
 }:
 
 let
@@ -24,11 +25,6 @@ let
   bisq-launcher =
     args:
     writeShellScript "bisq-launcher" ''
-      # This is just a comment to convince Nix that Tor is a
-      # runtime dependency; The Tor binary is in a *.jar file,
-      # whereas Nix only scans for hashes in uncompressed text.
-      # ${lib.getExe' tor "tor"}
-
       rm -fR $HOME/.local/share/Bisq2/tor
 
       exec "${lib.getExe jdk}" -Djpackage.app-version=@version@ -classpath @out@/lib/app/desktop-app-launcher.jar:@out@/lib/app/* ${args} bisq.desktop_app_launcher.DesktopAppLauncher "$@"
@@ -89,10 +85,9 @@ stdenvNoCC.mkDerivation rec {
     copyDesktopItems
     dpkg
     imagemagick
-    makeWrapper
+    makeBinaryWrapper
     zip
     gnupg
-    makeWrapper
   ];
 
   desktopItems = [
@@ -142,9 +137,21 @@ stdenvNoCC.mkDerivation rec {
 
     install -D -m 777 ${bisq-launcher ""} $out/bin/bisq2
     substituteAllInPlace $out/bin/bisq2
+    wrapProgram $out/bin/bisq2 --prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+        tor
+      ]
+    }
 
     install -D -m 777 ${bisq-launcher "-Dglass.gtk.uiScale=2.0"} $out/bin/bisq2-hidpi
     substituteAllInPlace $out/bin/bisq2-hidpi
+    wrapProgram $out/bin/bisq2-hidpi --prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+        tor
+      ]
+    }
 
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change addresses an impurity by modifying the bisq2 launcher script to add coreutils and tor to the $PATH.

When Bisq 2 executes Tor, it expects to have additional executables which come with the Tor package in the $PATH. I never noticed this since I have Tor installed system-wide.

I also added coreutils because it's needed for the `rm` command, which is used to clear out the directory where Bisq 2 saves Tor state data.

This change had the side-effect of removing the need to have a comment to reference the Tor package. I had this in place so that Nix identified Tor as a dependency.

While I was at it, I replaced `makeWrapper` with `makeBinaryWrapper`.

I tested the change by executing Bisq 2 with PATH set to "".

This impurity was brought to my attention on #383121, therefore I would like to have the change backported to 24.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
