### PR TITLE
technitium-dns-server: fix inaccessible state directory

### DIFF
--- a/nixos/modules/services/networking/technitium-dns-server.nix
+++ b/nixos/modules/services/networking/technitium-dns-server.nix
@@ -7,7 +7,6 @@
 
 let
   cfg = config.services.technitium-dns-server;
-  stateDir = "/var/lib/technitium-dns-server";
   inherit (lib)
     mkEnableOption
     mkPackageOption
@@ -61,13 +60,11 @@ in
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/technitium-dns-server ${stateDir}";
+        ExecStart = "${cfg.package}/bin/technitium-dns-server $STATE_DIRECTORY";
 
         DynamicUser = true;
 
         StateDirectory = "technitium-dns-server";
-        WorkingDirectory = stateDir;
-        BindPaths = stateDir;
 
         Restart = "always";
         RestartSec = 10;

--- a/nixos/tests/technitium-dns-server.nix
+++ b/nixos/tests/technitium-dns-server.nix
@@ -6,6 +6,8 @@
     machine =
       { pkgs, ... }:
       {
+        systemd.services.technitium-dns-server.serviceConfig.Restart = lib.mkForce "no";
+
         services.technitium-dns-server = {
           enable = true;
           openFirewall = true;


### PR DESCRIPTION
Currently `nixosTests.technitium-dns-server` is failing with:

```
machine # [    9.912872] technitium-dns-server[856]: System.UnauthorizedAccessException: Access to the path '/var/lib/technitium-dns-server/blocklists' is denied.
machine # [    9.915965] technitium-dns-server[856]:  ---> System.IO.IOException: Permission denied
machine # [    9.917113] technitium-dns-server[856]:    --- End of inner exception stack trace ---
machine # [    9.919060] technitium-dns-server[856]:    at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
machine # [    9.921461] technitium-dns-server[856]:    at System.IO.Directory.CreateDirectory(String path)
machine # [    9.923070] technitium-dns-server[856]:    at DnsServerCore.DnsWebService..ctor(String configFolder, Uri updateCheckUri, Uri appStoreUri) in /build/technitium-dns-server-13.2/DnsServerCore/DnsWebService.cs:line 140
machine # [    9.928459] technitium-dns-server[856]:    at DnsServerApp.Program.Main(String[] args) in /build/technitium-dns-server-13.2/DnsServerApp/Program.cs:line 54
```

This seems to be due to `BindPaths` specifically, but I'm still trying to figure out exactly what's going wrong.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
