### PR TITLE
ocamlPackages.lambdapi: 2.3.1 → 2.6.0; ocamlPackages.pratter: 2.0.0 → 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/lambdapi/default.nix
+++ b/pkgs/development/ocaml-modules/lambdapi/default.nix
@@ -7,6 +7,8 @@
   bindlib,
   camlp-streams,
   cmdliner,
+  dream,
+  lwt_ppx,
   menhir,
   pratter,
   sedlex,
@@ -18,20 +20,25 @@
 
 buildDunePackage rec {
   pname = "lambdapi";
-  version = "2.3.1";
+  version = "2.6.0";
 
   minimalOCamlVersion = "4.12";
 
   src = fetchurl {
     url = "https://github.com/Deducteam/lambdapi/releases/download/${version}/lambdapi-${version}.tbz";
-    hash = "sha256-7ww2TjVcbEQyfmLnnEhLGAjW4US9a4mdOfDJw6NR1fI=";
+    hash = "sha256-0B5fE9suq6bk/jMGZxSeAFnUiGxlH/nWtnLbLfyXZe0=";
   };
 
-  nativeBuildInputs = [ menhir ];
+  nativeBuildInputs = [
+    dream
+    menhir
+  ];
+  buildInputs = [ lwt_ppx ];
   propagatedBuildInputs = [
     bindlib
     camlp-streams
     cmdliner
+    dream
     pratter
     sedlex
     stdlib-shims

--- a/pkgs/development/ocaml-modules/pratter/default.nix
+++ b/pkgs/development/ocaml-modules/pratter/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromGitLab,
   buildDunePackage,
   camlp-streams,
   alcotest,
@@ -9,17 +9,17 @@
 }:
 
 buildDunePackage rec {
-  version = "2.0.0";
+  version = "3.0.0";
   pname = "pratter";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
-  src = fetchFromGitHub {
-    owner = "gabrielhdt";
+  src = fetchFromGitLab {
+    domain = "forge.tedomum.net";
+    owner = "koizel";
     repo = "pratter";
-    rev = version;
-    hash = "sha256-QEq8Zt2pfsRT04Zd+ugGKcHdzkqYcDDUg/iAFMMDdEE=";
+    tag = version;
+    hash = "sha256-O9loVYPJ9xoYf221vBbclqNNq2AA3ImUFGHxtfK3Jwc=";
   };
 
   propagatedBuildInputs = [ camlp-streams ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -984,9 +984,7 @@ let
     lambda-term = callPackage ../development/ocaml-modules/lambda-term { };
 
     lambdapi = callPackage ../development/ocaml-modules/lambdapi {
-      why3 = pkgs.why3.override { ocamlPackages = self;
-        version = "1.7.2"; coqPackages = pkgs.coqPackages_8_18;
-      };
+      why3 = pkgs.why3.override { ocamlPackages = self; };
     };
 
     lambdasoup = callPackage ../development/ocaml-modules/lambdasoup { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
