### PR TITLE
soapysdr: fix searchPath

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -18,7 +18,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "soapysdr";
   # Don't forget to change passthru.abiVersion
-  version = "0.8.2-pre";
+  version = "0.8.1-unstable-2024-12-22";
 
   src = fetchFromGitHub {
     owner = "pothosware";
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Instead of applying several patches for Python 3.12 compat, just take the latest, from:
     # use old get python lib for v2 (#437)
-    rev = "8c6cb7c5223fad995e355486527589c63aa3b21e";
-    hash = "sha256-CKasL1mlpeuxXyPe6VDdAvb1l5a1cwWgyP7XX1aM73I=";
+    rev = "309335ec6a52eb712387ed025d705a3c0f7a1e24";
+    hash = "sha256-a9414gX4fUAPQaKKqrWgSlFHZH0BWqbgHzhVCKnIn2M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -17,6 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "soapysdr";
+  # Don't forget to change passthru.abiVersion
   version = "0.8.2-pre";
 
   src = fetchFromGitHub {
@@ -66,7 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    searchPath = "lib/SoapySDR/modules${lib.versions.majorMinor finalAttrs.version}";
+    # SOAPY_SDR_ABI_VERSION defined in include/SoapySDR/Version.h
+    abiVersion = "0.8-3";
+    searchPath = "lib/SoapySDR/modules${finalAttrs.passthru.abiVersion}";
   };
 
   meta = with lib; {


### PR DESCRIPTION
SOAPY_SDR_ABI_VERSION isn't necessarily `major.minor`. Even among stable versions, it can be something else.

```shellsession
$ git grep 'define SOAPY_SDR_ABI_VERSION' $(git tag) -- include/SoapySDR/Version.h
soapy-sdr-0.1.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.1-3"
soapy-sdr-0.1.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.1-3"
soapy-sdr-0.2.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.2-3"
soapy-sdr-0.2.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.2-3"
soapy-sdr-0.2.2:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.2-3"
soapy-sdr-0.2.3:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.2-3"
soapy-sdr-0.3.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.3-0"
soapy-sdr-0.3.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.3-0"
soapy-sdr-0.4.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.4-2"
soapy-sdr-0.4.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.4-2"
soapy-sdr-0.4.2:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.4-2"
soapy-sdr-0.4.3:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.4-2"
soapy-sdr-0.4.4:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.4-2"
soapy-sdr-0.5.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.5.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.5.2:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.5.3:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.5.4:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.5.5:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.5-2"
soapy-sdr-0.6.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.6"
soapy-sdr-0.6.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.6"
soapy-sdr-0.7.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.7"
soapy-sdr-0.7.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.7"
soapy-sdr-0.7.2:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.7"
soapy-sdr-0.8.0:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.8"
soapy-sdr-0.8.1:include/SoapySDR/Version.h:#define SOAPY_SDR_ABI_VERSION "0.8"
```

PR #356651 updated soapysdr to a git version without updating `searchPath`, causing soapysdr blocks in GNU Radio to be unable to find any drivers.

```
Executing: /nix/store/vkcb8aj6rr1nhplhgab0mlmxad7jvy81-python3-3.11.11-env/bin/python3.11 -u /home/chuang/idk.py

Traceback (most recent call last):
  File "/home/chuang/idk.py", line 173, in <module>
    main()
  File "/home/chuang/idk.py", line 150, in main
    tb = top_block_cls()
         ^^^^^^^^^^^^^^^
  File "/home/chuang/idk.py", line 76, in __init__
    self.soapy_hackrf_source_0 = soapy.source(dev, "fc32", 1, '',
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: SoapySDR::Device::make() no match
```

Fixes https://discourse.nixos.org/t/gnu-radio-soapysdr-doesnt-detect-rtl-sdr/57310

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
