### PR TITLE
bicep: fix building on arm64-linux and x86_64-darwin by downgrading Grpc.Tools

### DIFF
--- a/pkgs/by-name/bi/bicep/0001-Revert-Bump-Grpc.Tools-from-2.68.1-to-2.69.0-16097.patch
+++ b/pkgs/by-name/bi/bicep/0001-Revert-Bump-Grpc.Tools-from-2.68.1-to-2.69.0-16097.patch
@@ -1,0 +1,33 @@
+diff --git a/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj b/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
+index e02412540..7e0fb5e90 100644
+--- a/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
++++ b/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
+@@ -17,7 +17,7 @@
+   <ItemGroup>
+     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+     <PackageReference Include="Google.Protobuf" Version="3.29.2" />
+-    <PackageReference Include="Grpc.Tools" Version="2.69.0">
++    <PackageReference Include="Grpc.Tools" Version="2.68.1">
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+     </PackageReference>
+diff --git a/src/Bicep.Local.Extension/packages.lock.json b/src/Bicep.Local.Extension/packages.lock.json
+index e7297d0af..c262f0849 100644
+--- a/src/Bicep.Local.Extension/packages.lock.json
++++ b/src/Bicep.Local.Extension/packages.lock.json
+@@ -32,9 +32,9 @@
+       },
+       "Grpc.Tools": {
+         "type": "Direct",
+-        "requested": "[2.69.0, )",
+-        "resolved": "2.69.0",
+-        "contentHash": "W5hW4R1h19FCzKb8ToqIJMI5YxnQqGmREEpV8E5XkfCtLPIK5MSHztwQ8gZUfG8qu9fg5MhItjzyPRqQBjnrbA=="
++        "requested": "[2.68.1, )",
++        "resolved": "2.68.1",
++        "contentHash": "BZ96s7ijKAhJoRpIK+pqCeLaGaSwyc5/CAZFwgCcBuAnkU2naYvH0P6qnYCkl0pWDY/JBOnE2RvX9IvRX1Yc5Q=="
+       },
+       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+         "type": "Direct",
+-- 
+2.47.2
+

--- a/pkgs/by-name/bi/bicep/deps.json
+++ b/pkgs/by-name/bi/bicep/deps.json
@@ -156,8 +156,8 @@
   },
   {
     "pname": "Grpc.Tools",
-    "version": "2.69.0",
-    "hash": "sha256-3nye4UcU2J7tnruKhoacD0S+fPN6d0A34K1yxlYrfxI="
+    "version": "2.68.1",
+    "hash": "sha256-sbJWCrzK2UAcHdWw/wRY+hmwcqoTc02+fYsFHG6tiFY="
   },
   {
     "pname": "Humanizer.Core",

--- a/pkgs/by-name/bi/bicep/package.nix
+++ b/pkgs/by-name/bi/bicep/package.nix
@@ -18,6 +18,10 @@ buildDotnetModule rec {
     hash = "sha256-5XrFIgblr2WIMBPoVwRZ6X2dokbXw+nS8J7WzhHEzpU=";
   };
 
+  patches = [
+    ./0001-Revert-Bump-Grpc.Tools-from-2.68.1-to-2.69.0-16097.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/Directory.Build.props --replace-fail "<TreatWarningsAsErrors>true</TreatWarningsAsErrors>" ""
   '';


### PR DESCRIPTION
This is currently failing to build for aarch64-linux, and might be transitively failing on x86_64-darwin. It appears to be due to an issue in the upstream dependency Grpc.Tools 2.69.0: https://github.com/grpc/grpc/issues/38538

This PR reverts the upstream dependency back to 2.68.1.

I tested this on x86_64-linux, aarch64-linux (Raspberry Pi 4), aarch64-darwin, and my friend @nadiaholmquist tested it on x86_64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
