### PR TITLE
python3Packages.pytest-doctestplus: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/pytest-doctestplus/default.nix
+++ b/pkgs/development/python-modules/pytest-doctestplus/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-doctestplus";
-  version = "1.3.0";
+  version = "1.4.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "scientific-python";
     repo = "pytest-doctestplus";
     tag = "v${version}";
-    hash = "sha256-jXT+b0aMZo8byAXNR4WcmNkMNYtwkTwsthPVXvAO2K8=";
+    hash = "sha256-hKxTniN7BHDdIHqxNGOuvD7Rk5ChSh1Zn6fo6G+Uty4=";
   };
 
   postPatch = ''
@@ -58,6 +58,7 @@ buildPythonPackage rec {
     "test_remote_data_ellipsis"
     "test_remote_data_requires"
     "test_remote_data_ignore_warnings"
+    "test_remote_data_all"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Resolves build error:

`nix-build -A python311Packages.pytest-doctestplus`

```
       > plugins: doctestplus-1.3.0
       > collected 1 item / 1 error
       >
       > ==================================== ERRORS ====================================
       > ________ ERROR collecting build/lib.linux-x86_64-cpython-311/module2.py ________
       > /build/source/pytest_doctestplus/plugin.py:302: in collect
       >     for test in finder.find(module):
       > /build/source/pytest_doctestplus/plugin.py:851: in find
       >     tests += doctest.DocTestFinder.find(
       > /nix/store/gzl581vkwymk2iys5zz6k1k1zdf03ba1-python3-3.11.11/lib/python3.11/doctest.py:942: in find
       >     self._find(tests, obj, name, module, source_lines, globs, {})
       > /nix/store/gzl581vkwymk2iys5zz6k1k1zdf03ba1-python3-3.11.11/lib/python3.11/doctest.py:1004: in _find
       >     test = self._get_test(obj, name, module, globs, source_lines)
       > /nix/store/gzl581vkwymk2iys5zz6k1k1zdf03ba1-python3-3.11.11/lib/python3.11/doctest.py:1072: in _get_test
       >     lineno = self._find_lineno(obj, source_lines)
       > /nix/store/gzl581vkwymk2iys5zz6k1k1zdf03ba1-python3-3.11.11/lib/python3.11/doctest.py:1121: in _find_lineno
       >     obj = inspect.unwrap(obj).__code__
       > E   AttributeError: 'numpy.ufunc' object has no attribute '__code__'
       > =========================== short test summary info ============================
       > ERROR build/lib.linux-x86_64-cpython-311/module2.py - AttributeError: 'numpy....
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > =============================== 1 error in 0.23s ===============================
       > =========================== short test summary info ============================
       > FAILED tests/test_doctestplus.py::test_ufunc - AssertionError: ([], [], [<CollectReport 'build/lib.linux-x86_64-cpython-31...
       > ============ 1 failed, 44 passed, 6 deselected, 1 xfailed in 6.35s =============
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
