### PR TITLE
audiothekar: init at 1.0.1

### DIFF
--- a/pkgs/by-name/au/audiothekar/deps.json
+++ b/pkgs/by-name/au/audiothekar/deps.json
@@ -1,0 +1,57 @@
+[
+  {
+    "pname": "GraphQL",
+    "version": "7.8.0",
+    "hash": "sha256-/wyyrDN/0FFoHF1abjUGccEFAYsH5sj3QnPXsKPbqsI="
+  },
+  {
+    "pname": "GraphQL-Parser",
+    "version": "8.4.2",
+    "hash": "sha256-wcXfsK4sQENAj3oRX9+5GlSAtyqA94l8Y5pSnyLCYHM="
+  },
+  {
+    "pname": "GraphQL.Analyzers",
+    "version": "7.8.0",
+    "hash": "sha256-6O9A1dBIbUzUNXdQT1hv0x9QnpYCFFmGL6r3LCkAjbg="
+  },
+  {
+    "pname": "GraphQL.Client",
+    "version": "6.1.0",
+    "hash": "sha256-snZ/7uvNQUwy1+p6X3m558Tl50J8W1C+HX5AA28gIv4="
+  },
+  {
+    "pname": "GraphQL.Client.Abstractions",
+    "version": "6.1.0",
+    "hash": "sha256-qRiGaJbKcCXY/78TTT38x02ljmWoIx82xG4ZZGbWqSU="
+  },
+  {
+    "pname": "GraphQL.Client.Abstractions.Websocket",
+    "version": "6.1.0",
+    "hash": "sha256-EmPuIS+gAwmsoh0EkQ3mO8tQACuxza6W4xR3DWiMyhw="
+  },
+  {
+    "pname": "GraphQL.Client.Serializer.SystemTextJson",
+    "version": "6.1.0",
+    "hash": "sha256-5U29jAhTkbsLQsZeSonSRFZzoVp9dmE7IoCVnr3TLT8="
+  },
+  {
+    "pname": "GraphQL.Primitives",
+    "version": "6.1.0",
+    "hash": "sha256-giNMmftzJu5LChFNU8Xqm6+q6l4vtXIEVF9LBKThBuI="
+  },
+  {
+    "pname": "GraphQL.SystemTextJson",
+    "version": "7.8.0",
+    "hash": "sha256-1/AjzAbg1jCYm0lTf20rVURMjm+m0ODeFkqdWqbH3aI="
+  },
+  {
+    "pname": "Spectre.Console",
+    "version": "0.49.1",
+    "hash": "sha256-tqSVojyuQjuB34lXo759NOcyLgNIw815mKXJPq5JFDo="
+  },
+  {
+    "pname": "System.Reactive",
+    "version": "6.0.0",
+    "hash": "sha256-hXB18OsiUHSCmRF3unAfdUEcbXVbG6/nZxcyz13oe9Y="
+  }
+]

--- a/pkgs/by-name/au/audiothekar/package.nix
+++ b/pkgs/by-name/au/audiothekar/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDotnetModule,
+  dotnetCorePackages,
+  audiothekar,
+  testers,
+}:
+
+buildDotnetModule rec {
+  pname = "audiothekar";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "fxsth";
+    repo = "audiothekar";
+    tag = "v${version}";
+    sha256 = "sha256-DZ4E8numXJdkvX5WYM6cioW5J89YuD9Hi8NfK+Z39cY=";
+  };
+
+  projectFile = "Audiothekar.sln";
+
+  doCheck = false;
+
+  nugetDeps = ./deps.json;
+
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+
+  postInstall = ''
+    install -m 644 -D -t "$out/share/doc/${pname}" License.md
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests.version = testers.testVersion {
+      package = audiothekar;
+      command = "audiothekar-cli --version";
+    };
+  };
+
+  meta = with lib; {
+    description = "Download-Client für die ARD-Audiothek";
+    longDescription = ''
+      Audiothekar is a command line client to browse and download programs from
+      German public broadcast online offering at https://www.ardaudiothek.de/.
+    '';
+    homepage = "https://github.com/fxsth/Audiothekar";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      wamserma
+    ];
+    platforms = [ "x86_64-linux" ]; # needs some work to enable dotnet-sdk.meta.platforms;
+    mainProgram = "audiothekar-cli";
+  };
+}

--- a/pkgs/by-name/au/audiothekar/update.sh
+++ b/pkgs/by-name/au/audiothekar/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    https://api.github.com/repos/fxsth/audiothekar/releases/latest | jq -e -r .tag_name | tail -c +2)
+old_version=$(nix-instantiate --eval -A audiothekar.version | jq -e -r)
+
+if [[ $version == "$old_version" ]]; then
+    echo "New version same as old version, nothing to do." >&2
+    exit 0
+fi
+
+update-source-version audiothekar "$version"
+
+$(nix-build -A audiothekar.fetch-deps --no-out-link)


### PR DESCRIPTION
Init the Audiothekar CLI tool, a download helper for ARD Audiothek (German public broadcast)

https://github.com/fxsth/audiothekar


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
