### PR TITLE
mobilizon: 5.1.1 -> 5.1.2, restart service on failure

### DIFF
--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -393,6 +393,7 @@ in
       serviceConfig = {
         Type = "oneshot";
         User = config.services.postgresql.superUser;
+        Restart = "on-failure";
       };
     };
 

--- a/pkgs/servers/mobilizon/0001-fix-version.patch
+++ b/pkgs/servers/mobilizon/0001-fix-version.patch
@@ -7,7 +7,7 @@ index 8338abf8..883e6987 100644
    use Mix.Project
  
 -  @version "5.1.0"
-+  @version "5.1.1"
++  @version "5.1.2"
  
    def project do
      [

--- a/pkgs/servers/mobilizon/common.nix
+++ b/pkgs/servers/mobilizon/common.nix
@@ -1,13 +1,14 @@
-{ fetchFromGitLab }: rec {
+{ fetchFromGitLab }:
+rec {
 
   pname = "mobilizon";
-  version = "5.1.1";
+  version = "5.1.2";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "framasoft";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-zH/F+8rqzlMh0itVBOgDDzAx6n1nJH81lMzaBfjzhXU=";
+    tag = version;
+    sha256 = "sha256-5xHLk5/ogtRN3mfJPP1/gIVlALerT9KEUHjLA2Ou3aM=";
   };
 }

--- a/pkgs/servers/mobilizon/default.nix
+++ b/pkgs/servers/mobilizon/default.nix
@@ -8,6 +8,7 @@
   git,
   cmake,
   nixosTests,
+  nixfmt-rfc-style,
   mobilizon-frontend,
   ...
 }:
@@ -20,9 +21,8 @@ mixRelease rec {
   inherit (common) pname version src;
 
   patches = [
-    # Version 5.1.1 failed to bump their internal package version,
+    # Version 5.1.2 failed to bump their internal package version,
     # which causes issues with static file serving in the NixOS module.
-    # See https://github.com/NixOS/nixpkgs/pull/370277
     ./0001-fix-version.patch
     # Mobilizon uses chunked Transfer-Encoding for the media proxy but also
     # sets the Content-Length header. This is a HTTP/1.1 protocol violation
@@ -153,11 +153,12 @@ mixRelease rec {
   '';
 
   passthru = {
-    tests.smoke-test = nixosTests.mobilizon;
+    tests = { inherit (nixosTests) mobilizon; };
     updateScript = writeShellScriptBin "update.sh" ''
       set -eou pipefail
 
       ${mix2nix}/bin/mix2nix '${src}/mix.lock' > pkgs/servers/mobilizon/mix.nix
+      ${nixfmt-rfc-style}/bin/nixfmt pkgs/servers/mobilizon/mix.nix
     '';
     elixirPackage = beamPackages.elixir;
   };
@@ -165,6 +166,7 @@ mixRelease rec {
   meta = with lib; {
     description = "Mobilizon is an online tool to help manage your events, your profiles and your groups";
     homepage = "https://joinmobilizon.org/";
+    changelog = "https://framagit.org/framasoft/mobilizon/-/releases/${src.tag}";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [
       minijackson


### PR DESCRIPTION
The restart change proved increase stability of deployments, as sometimes postgresql signals to be up even though it doesn't accept connections yet, leading to the mobilizon service crashing without recovery.

[Changelog](https://framagit.org/framasoft/mobilizon/-/releases/5.1.2)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
