### PR TITLE
[staging-next] imv: pin icu to 7.5

### DIFF
--- a/pkgs/by-name/im/imv/package.nix
+++ b/pkgs/by-name/im/imv/package.nix
@@ -9,7 +9,7 @@
   meson,
   ninja,
   pkg-config,
-  icu,
+  icu75,
   pango,
   inih,
   withWindowSystem ? null,
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       cmocka
-      icu
+      icu75
       libxkbcommon
       pango
       inih


### PR DESCRIPTION
Linker errors with >=7.6

```

[96/107] Linking target imv-msg
FAILED: imv-msg 
gcc  -o imv-msg imv-msg.p/src_binds.c.o imv-msg.p/src_bitmap.c.o imv-msg.p/src_canvas.c.o imv-msg.p/src_commands.c.o imv-msg.p/src_console.c.o imv-msg.p/src_image.c.o imv-msg.p/src_imv.c.o imv-msg.p/src_ipc.c.o imv-msg.p/src_ipc_common.c.o imv-msg.p/src_keyboard.c.o imv-msg.p/src_list.c.o imv-msg.p/src_log.c.o imv-msg.p/src_navigator.c.o imv-msg.p/src_source.c.o imv-msg.p/src_vi>
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-msg.p/src_console.c.o: in function `prev_char':
console.c:(.text+0x40): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x5c): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x6c): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x78): undefined reference to `ubrk_preceding_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x8c): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x94): undefined reference to `utext_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-msg.p/src_console.c.o: in function `imv_console_key':
console.c:(.text+0x644): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x660): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x670): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x67c): undefined reference to `ubrk_following_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x690): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x698): undefined reference to `utext_close_76'
collect2: error: ld returned 1 exit status
[97/107] Linking target imv-wayland
FAILED: imv-wayland 
gcc  -o imv-wayland imv-wayland.p/src_wl_window.c.o imv-wayland.p/src_xdg-shell-protocol.c.o imv-wayland.p/src_binds.c.o imv-wayland.p/src_bitmap.c.o imv-wayland.p/src_canvas.c.o imv-wayland.p/src_commands.c.o imv-wayland.p/src_console.c.o imv-wayland.p/src_image.c.o imv-wayland.p/src_imv.c.o imv-wayland.p/src_ipc.c.o imv-wayland.p/src_ipc_common.c.o imv-wayland.p/src_keyboard.c>
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-wayland.p/src_console.c.o: in function `prev_char':
console.c:(.text+0x40): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x5c): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x6c): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x78): undefined reference to `ubrk_preceding_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x8c): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x94): undefined reference to `utext_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-wayland.p/src_console.c.o: in function `imv_console_key':
console.c:(.text+0x644): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x660): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x670): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x67c): undefined reference to `ubrk_following_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x690): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x698): undefined reference to `utext_close_76'
collect2: error: ld returned 1 exit status
[98/107] Linking target imv-x11
FAILED: imv-x11 
gcc  -o imv-x11 imv-x11.p/src_x11_window.c.o imv-x11.p/src_binds.c.o imv-x11.p/src_bitmap.c.o imv-x11.p/src_canvas.c.o imv-x11.p/src_commands.c.o imv-x11.p/src_console.c.o imv-x11.p/src_image.c.o imv-x11.p/src_imv.c.o imv-x11.p/src_ipc.c.o imv-x11.p/src_ipc_common.c.o imv-x11.p/src_keyboard.c.o imv-x11.p/src_list.c.o imv-x11.p/src_log.c.o imv-x11.p/src_navigator.c.o imv-x11.p/sr>
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-x11.p/src_console.c.o: in function `prev_char':
console.c:(.text+0x40): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x5c): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x6c): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x78): undefined reference to `ubrk_preceding_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x8c): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x94): undefined reference to `utext_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: imv-x11.p/src_console.c.o: in function `imv_console_key':
console.c:(.text+0x644): undefined reference to `utext_openUTF8_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x660): undefined reference to `ubrk_open_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x670): undefined reference to `ubrk_setUText_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x67c): undefined reference to `ubrk_following_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x690): undefined reference to `ubrk_close_76'
/nix/store/z1wjd7cjf8a1fz87x4rf37a3cxxs7j56-binutils-2.43.1/bin/ld: console.c:(.text+0x698): undefined reference to `utext_close_76'
collect2: error: ld returned 1 exit status
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
