### PR TITLE
postgresqlTestHook: add sandbox profile for Darwin

### DIFF
--- a/pkgs/by-name/po/postgresqlTestHook/package.nix
+++ b/pkgs/by-name/po/postgresqlTestHook/package.nix
@@ -1,8 +1,15 @@
 { callPackage, makeSetupHook }:
 
-makeSetupHook {
+(makeSetupHook {
   name = "postgresql-test-hook";
   passthru.tests = {
     simple = callPackage ./test.nix { };
   };
-} ./postgresql-test-hook.sh
+} ./postgresql-test-hook.sh).overrideAttrs
+  # For shared memory on Darwin.
+  {
+    propagatedSandboxProfile = ''
+      (allow ipc-sysv-shm)
+      (allow ipc-sysv-sem)
+    '';
+  }

--- a/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
+++ b/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
@@ -12,6 +12,8 @@ postgresqlStart() {
   # Server variables:
   #  - only PGDATA: https://www.postgresql.org/docs/current/creating-cluster.html
 
+  export PGSSLMODE=${PGSSLMODE:-disable}
+
   if [[ "${PGDATA:-}" == "" ]]; then
     PGDATA="$NIX_BUILD_TOP/postgresql"
   fi

--- a/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
+++ b/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
@@ -54,7 +54,7 @@ EOF
     false
   fi
   echo 'initializing postgresql'
-  initdb -U postgres
+  initdb --username=postgres --auth=trust --no-sync --no-instructions
 
   echo "$postgresqlExtraSettings" >>"$PGDATA/postgresql.conf"
 
@@ -79,5 +79,5 @@ EOF
 
 postgresqlStop() {
   echo 'stopping postgresql'
-  pg_ctl stop
+  pg_ctl stop --mode=immediate
 }


### PR DESCRIPTION
Adds sandbox profile so that PostgreSQL can set up shared memory. Also makes it run faster by skipping sync during initdb and using immediate shutdown mode.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
