### PR TITLE
chromium,chromedriver: 133.0.6943.98 -> 133.0.6943.126

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "133.0.6943.98",
+    "version": "133.0.6943.126",
     "chromedriver": {
-      "hash_darwin": "sha256-OD/E+h4APHs8qBXdDyhBtZ42D3PvbBJHhbRXMxWY/34=",
-      "hash_darwin_aarch64": "sha256-H3JEby9RZPT2cCmuzOvc7n6+SOy1EMcH0v71g7Z1yio="
+      "hash_darwin": "sha256-UeRQgrMG89DHywbvWUnjjlhkkyKR9eFE1i3ESPAElls=",
+      "hash_darwin_aarch64": "sha256-cpJOw+f+AybAtLu7w+g+Vojmjkl+r3sHzt4x6TjbBJI="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "da53563ceb66412e2637507c8724bd0cab05e453",
-        "hash": "sha256-yltjJNXU+YQD/sFEa8+ZKqUJpVZ2Yi0YDx27bnekcng=",
+        "rev": "cffa127ce7b6be72885391527c15b452056a2e81",
+        "hash": "sha256-WOd3FsqaZlKEroWg763LQhQS5S1964vAoZWxstxGS3U=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -575,8 +575,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "b57762c6c6ad261024f11fc724687593c03cce67",
-        "hash": "sha256-ksN/7volHAeQLJSFQMV/YOfkXyZ97GSawXp31uca4oc="
+        "rev": "a6637ded97c46aa4879769b1a6b0f2128e6ea257",
+        "hash": "sha256-Y2quVCJS62YFwxBSB42Wg03QQ10M8C1GTrRvhr73IN8="
       },
       "src/third_party/perfetto": {
         "url": "https://android.googlesource.com/platform/external/perfetto.git",
@@ -785,8 +785,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "79c3c1ab7faee8247b740b4ec660a998f2881633",
-        "hash": "sha256-fmd2mIjJs6l9zRTJ2bFIMQNnApFN3epeS+57TBlF/Uk="
+        "rev": "4e04a09a1a0ef90841656e210e976bfc2a81ed57",
+        "hash": "sha256-XbeU9L2IRHMP5pTzM3MPW1L2PMHViNRP/6u/HcBq96M="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_18.html

This update includes 3 security fixes.

CVEs:
CVE-2025-0999 CVE-2025-1426 CVE-2025-1006

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
