### PR TITLE
h5glance: init at 0.9

### DIFF
--- a/pkgs/by-name/h5/h5glance/package.nix
+++ b/pkgs/by-name/h5/h5glance/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "h5glance";
+  version = "0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "European-XFEL";
+    repo = "h5glance";
+    tag = version;
+    hash = "sha256-20gSaNZrH3AeFTGLho6sbWljfqln9SQEVdvEVe/WaYY=";
+  };
+
+  build-system = [
+    python3.pkgs.flit-core
+  ];
+
+  dependencies = with python3.pkgs; [
+    h5py
+    htmlgen
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "h5glance"
+  ];
+
+  meta = {
+    description = "Explore HDF5 files in terminal & HTML views";
+    homepage = "https://github.com/European-XFEL/h5glance";
+    changelog = "https://github.com/European-XFEL/h5glance/blob/${src.rev}/CHANGES.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "h5glance";
+  };
+}

--- a/pkgs/development/python-modules/asserts/default.nix
+++ b/pkgs/development/python-modules/asserts/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  typing-extensions,
+
+  # tests
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "asserts";
+  version = "0.13.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "srittau";
+    repo = "python-asserts";
+    tag = "v${version}";
+    hash = "sha256-hjTzGCcURI0NH9pgZ6KB0J3tSbgIaneDnWr8zrLVG6M=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "asserts"
+  ];
+
+  meta = {
+    description = "Stand-alone Assertions for Python";
+    homepage = "https://github.com/srittau/python-asserts";
+    changelog = "https://github.com/srittau/python-asserts/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/htmlgen/default.nix
+++ b/pkgs/development/python-modules/htmlgen/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  asserts,
+  mypy,
+}:
+
+buildPythonPackage rec {
+  pname = "htmlgen";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "srittau";
+    repo = "python-htmlgen";
+    tag = "v${version}";
+    hash = "sha256-RmJKaaTB+xvsJ+9jM21ZUNVTlr7ebPW785A8OXrpDoY=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    mypy
+  ];
+
+  nativeCheckInputs = [
+    asserts
+  ];
+  # From some reason, using unittestCheckHook doesn't work, and the list of
+  # test files have to be used explicitly, and also without the `discover`
+  # argument.
+  checkPhase = ''
+    runHook preCheck
+
+    python -m unittest test_htmlgen/*.py
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "htmlgen"
+  ];
+
+  meta = {
+    description = "Python HTML 5 Generator";
+    homepage = "https://github.com/srittau/python-htmlgen";
+    changelog = "https://github.com/srittau/python-htmlgen/blob/v${version}/NEWS.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -894,6 +894,8 @@ self: super: with self; {
 
   assay = callPackage ../development/python-modules/assay { };
 
+  asserts = callPackage ../development/python-modules/asserts { };
+
   assertpy = callPackage ../development/python-modules/assertpy { };
 
   asterisk-mbox = callPackage ../development/python-modules/asterisk-mbox { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6062,6 +6062,8 @@ self: super: with self; {
 
   htmldate = callPackage ../development/python-modules/htmldate { };
 
+  htmlgen = callPackage ../development/python-modules/htmlgen { };
+
   htmllistparse = callPackage ../development/python-modules/htmllistparse { };
 
   htmlmin = callPackage ../development/python-modules/htmlmin { };


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
