### PR TITLE
obs-studio-plugins.obs-hyperion: patch obs_frontend_get_global_config

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-hyperion/check-state-changed.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-hyperion/check-state-changed.patch
@@ -1,13 +1,31 @@
 diff --git a/src/HyperionProperties.cpp b/src/HyperionProperties.cpp
-index b585702..3fd308c 100644
+index b585702..6db56b5 100644
 --- a/src/HyperionProperties.cpp
 +++ b/src/HyperionProperties.cpp
+@@ -20,7 +20,7 @@ HyperionProperties::HyperionProperties(QWidget *parent)
+ 	ui->setupUi(this);
+ 	this->setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+ 
+-	config_t* config = obs_frontend_get_global_config();
++	config_t* config = obs_frontend_get_user_config();
+ 	if (config_has_user_value(config, CONFIG_SECTION, OBS_SETTINGS_AUTOSTART))
+ 	{
+ 		bool autostart = config_get_bool(config, CONFIG_SECTION, OBS_SETTINGS_AUTOSTART);
 @@ -59,7 +59,7 @@ HyperionProperties::HyperionProperties(QWidget *parent)
  	signal_handler_connect(handler, "log", logger_message, this);
  
  	connect(ui->ButtonStart, &QPushButton::clicked, this, &HyperionProperties::saveSettings);
 -	connect(ui->AutoStart, &QCheckBox::stateChanged, this, &HyperionProperties::saveSettings);
-+	connect(ui->AutoStart, &QCheckBox::checkStateChanged, this, &HyperionProperties::saveSettings);
++  connect(ui->AutoStart, &QCheckBox::checkStateChanged, this, &HyperionProperties::saveSettings);
  
  	connect(ui->ButtonStart, &QPushButton::clicked, this, &HyperionProperties::onStart);
  	connect(ui->ButtonStop, &QPushButton::clicked, this, &HyperionProperties::onStop);
+@@ -106,7 +106,7 @@ void HyperionProperties::clearLog()
+ 
+ void HyperionProperties::saveSettings()
+ {
+-	config_t* config = obs_frontend_get_global_config();
++	config_t* config = obs_frontend_get_user_config();
+ 	if(config != nullptr)
+ 	{
+ 		bool autostart = ui->AutoStart->isChecked();


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Small API change in obs breaks the current version of the `obs-hyperion` plugin. We can use `obs_frontend_get_user_config` as a replacement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
