### PR TITLE
Revert "nixos/profiles/hardened: don't enable by default"

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -22,7 +22,10 @@ let
     ;
 in
 {
-  options.profiles.hardened = mkEnableOption "hardened";
+  options.profiles.hardened = mkEnableOption "hardened" // {
+    default = true;
+    example = false;
+  };
   config = mkIf config.profiles.hardened {
     meta = {
       maintainers = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#383422

Actually wait, this is also wrong, because now people that included the file will not have it enabled.