### PR TITLE
nixos/gtklock: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -10,7 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -331,6 +331,7 @@
   ./programs/vivid.nix
   ./programs/wavemon.nix
   ./programs/wayland/cardboard.nix
+  ./programs/wayland/gtklock.nix
   ./programs/wayland/hyprland.nix
   ./programs/wayland/hyprlock.nix
   ./programs/wayland/labwc.nix

--- a/nixos/modules/programs/wayland/gtklock.nix
+++ b/nixos/modules/programs/wayland/gtklock.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.gtklock;
+  configFormat = pkgs.formats.ini {
+    listToValue = builtins.concatStringsSep ";";
+  };
+
+  inherit (lib)
+    types
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    ;
+in
+{
+  options.programs.gtklock = {
+    enable = mkEnableOption "gtklock, a GTK-based lockscreen for Wayland";
+
+    package = mkPackageOption pkgs "gtklock" { };
+
+    config = mkOption {
+      type = configFormat.type;
+      example = lib.literalExpression ''
+        {
+          main = {
+            idle-hide = true;
+            idle-timeout = 10;
+          };
+        }'';
+      description = ''
+        Configuration for gtklock.
+        See [`gtklock(1)`](https://github.com/jovanlanik/gtklock/blob/master/man/gtklock.1.scd) man page for details.
+      '';
+    };
+
+    style = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        CSS Stylesheet for gtklock.
+        See [gtklock's wiki](https://github.com/jovanlanik/gtklock/wiki#Styling) for details.
+      '';
+    };
+
+    modules = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs; [
+          gtklock-playerctl-module
+          gtklock-powerbar-module
+          gtklock-userinfo-module
+        ]'';
+      description = "gtklock modules to load.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.gtklock.config.main = {
+      style = lib.mkIf (cfg.style != null) "${pkgs.writeText "style.css" cfg.style}";
+
+      modules = lib.mkIf (cfg.modules != [ ]) (
+        map (pkg: "${pkg}/lib/gtklock/${lib.removePrefix "gtklock-" pkg.pname}.so") cfg.modules
+      );
+    };
+
+    environment.etc."xdg/gtklock/config.ini".source = configFormat.generate "config.ini" cfg.config;
+
+    environment.systemPackages = [ cfg.package ];
+
+    security.pam.services.gtklock = { };
+  };
+}


### PR DESCRIPTION
Add a NixOS module for configuring [gtklock](https://github.com/jovanlanik/gtklock).

Closes #240886

Package maintainer ping: @dit7ya @Aleksanaa

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
