### PR TITLE
nixos/syncthing: define and handle encryptionPassword option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -933,8 +933,6 @@
 
 - `buildNimSbom` was added as an alternative to `buildNimPackage`. `buildNimSbom` uses [SBOMs](https://cyclonedx.org/) to generate packages whereas `buildNimPackage` uses a custom JSON lockfile format.
 
-- `services.syncthing.folders.<name>.devices` now accepts an `attrset`, allowing to set `encryptionPassword` file for a device.
-
 ## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -933,6 +933,8 @@
 
 - `buildNimSbom` was added as an alternative to `buildNimPackage`. `buildNimSbom` uses [SBOMs](https://cyclonedx.org/) to generate packages whereas `buildNimPackage` uses a custom JSON lockfile format.
 
+- `services.syncthing.folders.<name>.devices` now accepts an `attrset`, allowing to set `encryptionPassword` file for a device.
+
 ## Detailed Migration Information {#sec-release-24.11-migration}
 
 ### `sound` options removal {#sec-release-24.11-migration-sound}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1219,7 +1219,7 @@ in
   syncthing-no-settings = handleTest ./syncthing-no-settings.nix { };
   syncthing-init = handleTest ./syncthing-init.nix { };
   syncthing-many-devices = handleTest ./syncthing-many-devices.nix { };
-  syncthing-folders = handleTest ./syncthing-folders.nix { };
+  syncthing-folders = runTest ./syncthing-folders.nix;
   syncthing-relay = handleTest ./syncthing-relay.nix { };
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
   systemd = handleTest ./systemd.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1219,6 +1219,7 @@ in
   syncthing-no-settings = handleTest ./syncthing-no-settings.nix { };
   syncthing-init = handleTest ./syncthing-init.nix { };
   syncthing-many-devices = handleTest ./syncthing-many-devices.nix { };
+  syncthing-folders = handleTest ./syncthing-folders.nix { };
   syncthing-relay = handleTest ./syncthing-relay.nix { };
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
   systemd = handleTest ./systemd.nix { };

--- a/nixos/tests/syncthing-folders.nix
+++ b/nixos/tests/syncthing-folders.nix
@@ -1,24 +1,26 @@
-import ../make-test-python.nix (
-  { lib, pkgs, ... }:
-  let
-    genNodeId =
-      name:
-      pkgs.runCommand "syncthing-test-certs-${name}" { } ''
-        mkdir -p $out
-        ${pkgs.syncthing}/bin/syncthing generate --config=$out
-        ${pkgs.libxml2}/bin/xmllint --xpath 'string(configuration/device/@id)' $out/config.xml > $out/id
-      '';
-    idA = genNodeId "a";
-    idB = genNodeId "b";
-    idC = genNodeId "c";
-    testPasswordFile = pkgs.writeText "syncthing-test-password" "it's a secret";
-  in
-  {
-    name = "syncthing";
-    meta.maintainers = with pkgs.lib.maintainers; [ zarelit ];
+{ lib, pkgs, ... }:
+let
+  genNodeId =
+    name:
+    pkgs.runCommand "syncthing-test-certs-${name}" { } ''
+      mkdir -p $out
+      ${pkgs.syncthing}/bin/syncthing generate --config=$out
+      ${pkgs.libxml2}/bin/xmllint --xpath 'string(configuration/device/@id)' $out/config.xml > $out/id
+    '';
+  idA = genNodeId "a";
+  idB = genNodeId "b";
+  idC = genNodeId "c";
+  testPassword = "it's a secret";
+in
+{
+  name = "syncthing";
+  meta.maintainers = with pkgs.lib.maintainers; [ zarelit ];
 
-    nodes = {
-      a = {
+  nodes = {
+    a =
+      { config, ... }:
+      {
+        environment.etc.bar-encryption-password.text = testPassword;
         services.syncthing = {
           enable = true;
           openDefaultPorts = true;
@@ -33,12 +35,20 @@ import ../make-test-python.nix (
             };
             folders.bar = {
               path = "/var/lib/syncthing/bar";
-              devices.c.encryptionPassword = "${testPasswordFile}";
+              devices = [
+                {
+                  name = "c";
+                  encryptionPasswordFile = "/etc/${config.environment.etc.bar-encryption-password.target}";
+                }
+              ];
             };
           };
         };
       };
-      b = {
+    b =
+      { config, ... }:
+      {
+        environment.etc.bar-encryption-password.text = testPassword;
         services.syncthing = {
           enable = true;
           openDefaultPorts = true;
@@ -53,68 +63,73 @@ import ../make-test-python.nix (
             };
             folders.bar = {
               path = "/var/lib/syncthing/bar";
-              devices.c.encryptionPassword = "${testPasswordFile}";
+              devices = [
+                {
+                  name = "c";
+                  encryptionPasswordFile = "/etc/${config.environment.etc.bar-encryption-password.target}";
+                }
+              ];
             };
           };
         };
       };
-      c = {
-        services.syncthing = {
-          enable = true;
-          openDefaultPorts = true;
-          cert = "${idC}/cert.pem";
-          key = "${idC}/key.pem";
-          settings = {
-            devices.a.id = lib.fileContents "${idA}/id";
-            devices.b.id = lib.fileContents "${idB}/id";
-            folders.bar = {
-              path = "/var/lib/syncthing/bar";
-              devices = [
-                "a"
-                "b"
-              ];
-              type = "receiveencrypted";
-            };
+    c = {
+      services.syncthing = {
+        enable = true;
+        openDefaultPorts = true;
+        cert = "${idC}/cert.pem";
+        key = "${idC}/key.pem";
+        settings = {
+          devices.a.id = lib.fileContents "${idA}/id";
+          devices.b.id = lib.fileContents "${idB}/id";
+          folders.bar = {
+            path = "/var/lib/syncthing/bar";
+            devices = [
+              "a"
+              "b"
+            ];
+            type = "receiveencrypted";
           };
         };
       };
     };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      a.wait_for_unit("syncthing.service")
-      b.wait_for_unit("syncthing.service")
-      c.wait_for_unit("syncthing.service")
-      a.wait_for_open_port(22000)
-      b.wait_for_open_port(22000)
-      c.wait_for_open_port(22000)
+    a.wait_for_unit("syncthing.service")
+    b.wait_for_unit("syncthing.service")
+    c.wait_for_unit("syncthing.service")
+    a.wait_for_open_port(22000)
+    b.wait_for_open_port(22000)
+    c.wait_for_open_port(22000)
 
-      # Test foo
+    # Test foo
 
-      a.wait_for_file("/var/lib/syncthing/foo")
-      b.wait_for_file("/var/lib/syncthing/foo")
+    a.wait_for_file("/var/lib/syncthing/foo")
+    b.wait_for_file("/var/lib/syncthing/foo")
 
-      a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
-      b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+    a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
+    b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
 
-      a.wait_for_file("/var/lib/syncthing/foo/b2a")
-      b.wait_for_file("/var/lib/syncthing/foo/a2b")
+    a.wait_for_file("/var/lib/syncthing/foo/b2a")
+    b.wait_for_file("/var/lib/syncthing/foo/a2b")
 
-      # Test bar
+    # Test bar
 
-      a.wait_for_file("/var/lib/syncthing/bar")
-      b.wait_for_file("/var/lib/syncthing/bar")
-      c.wait_for_file("/var/lib/syncthing/bar")
+    a.wait_for_file("/var/lib/syncthing/bar")
+    b.wait_for_file("/var/lib/syncthing/bar")
+    c.wait_for_file("/var/lib/syncthing/bar")
 
-      a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
+    a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
 
-      # B should be able to decrypt, check that content of file matches
-      b.wait_for_file("/var/lib/syncthing/bar/plainname")
-      b.succeed("grep plaincontent /var/lib/syncthing/bar/plainname")
+    # B should be able to decrypt, check that content of file matches
+    b.wait_for_file("/var/lib/syncthing/bar/plainname")
+    file_contents = b.succeed("cat /var/lib/syncthing/bar/plainname")
+    assert "plaincontent\n" == file_contents, f"Unexpected file contents: {file_contents=}"
 
-      # Bar on C is untrusted, check that content is not in cleartext
-      c.fail("grep -R plaincontent /var/lib/syncthing/bar")
-    '';
-  }
-)
+    # Bar on C is untrusted, check that content is not in cleartext
+    c.fail("grep -R plaincontent /var/lib/syncthing/bar")
+  '';
+}

--- a/nixos/tests/syncthing-folders.nix
+++ b/nixos/tests/syncthing-folders.nix
@@ -10,6 +10,8 @@ import ../make-test-python.nix (
       '';
     idA = genNodeId "a";
     idB = genNodeId "b";
+    idC = genNodeId "c";
+    testPasswordFile = pkgs.writeText "syncthing-test-password" "it's a secret";
   in
   {
     name = "syncthing";
@@ -23,12 +25,15 @@ import ../make-test-python.nix (
           cert = "${idA}/cert.pem";
           key = "${idA}/key.pem";
           settings = {
-            devices.b = {
-              id = lib.fileContents "${idB}/id";
-            };
+            devices.b.id = lib.fileContents "${idB}/id";
+            devices.c.id = lib.fileContents "${idC}/id";
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "b" ];
+            };
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices.c.encryptionPassword = "${testPasswordFile}";
             };
           };
         };
@@ -40,12 +45,35 @@ import ../make-test-python.nix (
           cert = "${idB}/cert.pem";
           key = "${idB}/key.pem";
           settings = {
-            devices.a = {
-              id = lib.fileContents "${idA}/id";
-            };
+            devices.a.id = lib.fileContents "${idA}/id";
+            devices.c.id = lib.fileContents "${idC}/id";
             folders.foo = {
               path = "/var/lib/syncthing/foo";
               devices = [ "a" ];
+            };
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices.c.encryptionPassword = "${testPasswordFile}";
+            };
+          };
+        };
+      };
+      c = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idC}/cert.pem";
+          key = "${idC}/key.pem";
+          settings = {
+            devices.a.id = lib.fileContents "${idA}/id";
+            devices.b.id = lib.fileContents "${idB}/id";
+            folders.bar = {
+              path = "/var/lib/syncthing/bar";
+              devices = [
+                "a"
+                "b"
+              ];
+              type = "receiveencrypted";
             };
           };
         };
@@ -54,16 +82,39 @@ import ../make-test-python.nix (
 
     testScript = ''
       start_all()
+
       a.wait_for_unit("syncthing.service")
       b.wait_for_unit("syncthing.service")
+      c.wait_for_unit("syncthing.service")
       a.wait_for_open_port(22000)
       b.wait_for_open_port(22000)
+      c.wait_for_open_port(22000)
+
+      # Test foo
+
       a.wait_for_file("/var/lib/syncthing/foo")
       b.wait_for_file("/var/lib/syncthing/foo")
+
       a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
       b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+
       a.wait_for_file("/var/lib/syncthing/foo/b2a")
       b.wait_for_file("/var/lib/syncthing/foo/a2b")
+
+      # Test bar
+
+      a.wait_for_file("/var/lib/syncthing/bar")
+      b.wait_for_file("/var/lib/syncthing/bar")
+      c.wait_for_file("/var/lib/syncthing/bar")
+
+      a.succeed("echo plaincontent > /var/lib/syncthing/bar/plainname")
+
+      # B should be able to decrypt, check that content of file matches
+      b.wait_for_file("/var/lib/syncthing/bar/plainname")
+      b.succeed("grep plaincontent /var/lib/syncthing/bar/plainname")
+
+      # Bar on C is untrusted, check that content is not in cleartext
+      c.fail("grep -R plaincontent /var/lib/syncthing/bar")
     '';
   }
 )

--- a/nixos/tests/syncthing-folders.nix
+++ b/nixos/tests/syncthing-folders.nix
@@ -1,0 +1,69 @@
+import ../make-test-python.nix (
+  { lib, pkgs, ... }:
+  let
+    genNodeId =
+      name:
+      pkgs.runCommand "syncthing-test-certs-${name}" { } ''
+        mkdir -p $out
+        ${pkgs.syncthing}/bin/syncthing generate --config=$out
+        ${pkgs.libxml2}/bin/xmllint --xpath 'string(configuration/device/@id)' $out/config.xml > $out/id
+      '';
+    idA = genNodeId "a";
+    idB = genNodeId "b";
+  in
+  {
+    name = "syncthing";
+    meta.maintainers = with pkgs.lib.maintainers; [ zarelit ];
+
+    nodes = {
+      a = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idA}/cert.pem";
+          key = "${idA}/key.pem";
+          settings = {
+            devices.b = {
+              id = lib.fileContents "${idB}/id";
+            };
+            folders.foo = {
+              path = "/var/lib/syncthing/foo";
+              devices = [ "b" ];
+            };
+          };
+        };
+      };
+      b = {
+        services.syncthing = {
+          enable = true;
+          openDefaultPorts = true;
+          cert = "${idB}/cert.pem";
+          key = "${idB}/key.pem";
+          settings = {
+            devices.a = {
+              id = lib.fileContents "${idA}/id";
+            };
+            folders.foo = {
+              path = "/var/lib/syncthing/foo";
+              devices = [ "a" ];
+            };
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+      a.wait_for_unit("syncthing.service")
+      b.wait_for_unit("syncthing.service")
+      a.wait_for_open_port(22000)
+      b.wait_for_open_port(22000)
+      a.wait_for_file("/var/lib/syncthing/foo")
+      b.wait_for_file("/var/lib/syncthing/foo")
+      a.succeed("echo a2b > /var/lib/syncthing/foo/a2b")
+      b.succeed("echo b2a > /var/lib/syncthing/foo/b2a")
+      a.wait_for_file("/var/lib/syncthing/foo/b2a")
+      b.wait_for_file("/var/lib/syncthing/foo/a2b")
+    '';
+  }
+)


### PR DESCRIPTION
Many thanks to @h33p for the PR this was based on: https://github.com/NixOS/nixpkgs/pull/342138.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
