### PR TITLE
buildbox: init at 1.3.7

### DIFF
--- a/pkgs/by-name/bu/buildbox/package.nix
+++ b/pkgs/by-name/bu/buildbox/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  bubblewrap,
+  makeBinaryWrapper,
+  cmake,
+  pkg-config,
+  ninja,
+  grpc,
+  gbenchmark,
+  gtest,
+  protobuf,
+  glog,
+  nlohmann_json,
+  zlib,
+  openssl,
+  libuuid,
+  tomlplusplus,
+  fuse3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "buildbox";
+  version = "1.3.7";
+
+  src = fetchFromGitLab {
+    owner = "BuildGrid";
+    repo = "buildbox/buildbox";
+    tag = finalAttrs.version;
+    hash = "sha256-US0qJrKoAYR4rMmolC8jx7IpQ2PiHZy7L2bog+I3G48=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    bubblewrap
+    fuse3
+    gbenchmark
+    glog
+    grpc
+    gtest
+    libuuid
+    nlohmann_json
+    openssl
+    protobuf
+    tomlplusplus
+    zlib
+  ];
+
+  postFixup = ''
+    makeWrapper $out/bin/buildbox-run-bubblewrap $out/bin/buildbox-run --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
+  '';
+
+  meta = {
+    description = "Set of tools for remote worker build execution";
+    homepage = "https://gitlab.com/BuildGrid/buildbox/";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ shymega ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `BuildBox` as a prerequisite of `Buildstream` which is used in projects such as GNOME OS or freedesktop-sdk.

I haven't yet tested on Darwin or arm64 Linux, as I do not own machines with that specification.

Buildbox is essentially remote worker build execution tooling: https://gitlab.com/BuildGrid/buildbox, and Buildstream uses it internally for remote builds.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
