### PR TITLE
stig: fix evaluation dropping check dependency `python3Packages.asynctest`

### DIFF
--- a/pkgs/by-name/st/stig/package.nix
+++ b/pkgs/by-name/st/stig/package.nix
@@ -30,34 +30,17 @@ python3Packages.buildPythonApplication rec {
     setproctitle
   ];
 
-  nativeCheckInputs = with python3Packages; [
-    asynctest
-    pytestCheckHook
-  ];
-
-  preCheck = ''
-    export LC_ALL=C
-  '';
-
-  disabledTestPaths = [
-    # Almost all tests fail in this file, it is reported upstream in:
-    # https://github.com/rndusr/stig/issues/214 , and upstream fails to
-    # reproduce the issue unfortunately.
-    "tests/client_test/aiotransmission_test/api_settings_test.py"
-  ];
-  disabledTests = [
-    # Another failure with similar circumstances to the above
-    "test_candidates_are_sorted_case_insensitively"
-  ];
+  # According to the upstream author,
+  # stig no longer has working tests
+  # since asynctest (former test dependency) got abandoned.
+  # See https://github.com/rndusr/stig/issues/206#issuecomment-2669636320
+  doCheck = false;
 
   passthru.tests = testers.testVersion {
     package = stig;
     command = "stig -v";
     version = "stig version ${version}";
   };
-
-  # https://github.com/rndusr/stig/issues/214#issuecomment-1995651219
-  dontUsePytestCheck = true;
 
   meta = with lib; {
     description = "TUI and CLI for the BitTorrent client Transmission";

--- a/pkgs/by-name/st/stig/package.nix
+++ b/pkgs/by-name/st/stig/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
   fetchFromGitHub,
-  python310Packages,
+  python3Packages,
   testers,
   stig,
 }:
 
-python310Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "stig";
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
@@ -19,7 +19,7 @@ python310Packages.buildPythonApplication rec {
     sha256 = "sha256-lSFI4/DxWl17KFgLXZ7c5nW/e5IUGN7s8Gm6wTM5ZWg=";
   };
 
-  propagatedBuildInputs = with python310Packages; [
+  propagatedBuildInputs = with python3Packages; [
     urwid
     urwidtrees
     aiohttp
@@ -30,7 +30,7 @@ python310Packages.buildPythonApplication rec {
     setproctitle
   ];
 
-  nativeCheckInputs = with python310Packages; [
+  nativeCheckInputs = with python3Packages; [
     asynctest
     pytestCheckHook
   ];

--- a/pkgs/by-name/st/stig/package.nix
+++ b/pkgs/by-name/st/stig/package.nix
@@ -35,8 +35,6 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   preCheck = ''
     export LC_ALL=C
   '';

--- a/pkgs/by-name/st/stig/package.nix
+++ b/pkgs/by-name/st/stig/package.nix
@@ -11,6 +11,7 @@ python3Packages.buildPythonApplication rec {
   # This project has a different concept for pre release / alpha,
   # Read the project's README for details: https://github.com/rndusr/stig#stig
   version = "0.12.10a0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rndusr";
@@ -19,7 +20,11 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-lSFI4/DxWl17KFgLXZ7c5nW/e5IUGN7s8Gm6wTM5ZWg=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
     urwid
     urwidtrees
     aiohttp


### PR DESCRIPTION
The `python3Packages.asynctest` package is unmaintained by the upstream (see issue Martiusweb/asynctest#158), and it doesn't support Python 3.10 or later. Starting from the commit 9ba1a70f7f49ed6651c0430387bc30e325de2039 ("python313Packages.yarl: 1.13.1 -> 1.17.1"), `stig` starts to depend on `python3Packages.propcache`, and the latter requires Python 3.11 or later.

While the stig upstream is working on the transition (see issue comment https://github.com/rndusr/stig/issues/206#issuecomment-939248021), this PR fixes the evaluation of `stig` by specifying `doCheck = false` and dropping the `checkInputs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
