### PR TITLE
ghidra, ghidra-bin: 11.3 -> 11.3.1

### DIFF
--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -20,7 +20,7 @@
 let
   pkg_path = "$out/lib/ghidra";
   pname = "ghidra";
-  version = "11.3";
+  version = "11.3.1";
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
@@ -28,7 +28,7 @@ let
     owner = "NationalSecurityAgency";
     repo = "Ghidra";
     rev = "Ghidra_${version}_build";
-    hash = "sha256-N4uwAGs/dnnskuBX960BxrMv0Z8vlKt6EPor4qRqgJk=";
+    hash = "sha256-2VOuEOLFDHMuN/xqhSofeCMVvCvLI7CGFq21qdwQetA=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -28,12 +28,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ghidra";
-  version = "11.3";
-  versiondate = "20250205";
+  version = "11.3.1";
+  versiondate = "20250219";
 
   src = fetchzip {
     url = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${version}_build/ghidra_${version}_PUBLIC_${versiondate}.zip";
-    hash = "sha256-PJc0N32KxDTbW21t/C1QUZ/C+tzKZe7/J55/8H6zGvk=";
+    hash = "sha256-9vGxHE4Z6J3Vkz9bo8BfgnZsN3sARFxB1CHBXDB02a8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/ghidra/deps.json
+++ b/pkgs/tools/security/ghidra/deps.json
@@ -103,7 +103,7 @@
    "tar.gz": "sha256-FzNmYFJZqD3BicQyf/TDclSv7WW0+GbL2KXvLqRJ6PM="
   }
  },
- "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_11.3": {
+ "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_11.3.1": {
   "FunctionID/vs2012_x64": {
    "fidb": "sha256-1OmKs/eQuDF5MhhDC7oNiySl+/TaZbDB/6jLDPvrDNw="
   },


### PR DESCRIPTION
Seems like a very minor update, none of the patches need rebasing, just bump versions/hashes/deps.

- [Release Page](https://github.com/NationalSecurityAgency/ghidra/releases/tag/Ghidra_11.3.1_build)
- [What's New](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.1_build/Ghidra/Configurations/Public_Release/src/global/docs/WhatsNew.md)
- [Change History](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.1_build/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.md)
- [Installation Guide](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.1_build/GhidraDocs/InstallationGuide.md)
- https://github.com/NationalSecurityAgency/ghidra/compare/Ghidra_11.3_build...Ghidra_11.3.1_build

Tested with all extensions on Linux x86-64 using:
```
$ nix repl
nix-repl> :l .
...
nix-repl> :u ghidra.withExtensions (a: (map (key: builtins.getAttr key a) (builtins.attrNames a)))
$ ghidra
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
