### PR TITLE
treewide: cleanup Python packages' setuptoolsCheckHook-relade attributes

### DIFF
--- a/pkgs/applications/misc/sl1-to-photon/default.nix
+++ b/pkgs/applications/misc/sl1-to-photon/default.nix
@@ -31,7 +31,6 @@ buildPythonApplication rec {
   ];
 
   format = "setuptools";
-  dontUseSetuptoolsCheck = true;
 
   installPhase = ''
     install -D -m 0755 SL1_to_Photon.py $out/bin/${pname}

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -83,7 +83,6 @@ buildPythonPackage rec {
 
   PKGVER = version;
 
-  dontUseSetuptoolsCheck = true;
   pythonImportsCheck = [ "srht" ];
 
   meta = with lib; {

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -37,8 +37,6 @@ buildPythonPackage rec {
     export PKGVER=${version}
   '';
 
-  dontUseSetuptoolsCheck = true;
-
   pythonImportsCheck = [ "scmsrht" ];
 
   meta = with lib; {

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -72,8 +72,6 @@ buildPythonPackage rec {
     pytest
     factory-boy
   ];
-
-  dontUseSetuptoolsCheck = true;
   pythonImportsCheck = [ "todosrht" ];
 
   meta = with lib; {

--- a/pkgs/by-name/hi/hifiscan/package.nix
+++ b/pkgs/by-name/hi/hifiscan/package.nix
@@ -20,8 +20,6 @@ python3Packages.buildPythonApplication {
     pyqtgraph
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   src = fetchPypi {
     inherit pname version hash;
   };

--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -232,8 +232,6 @@ let
                 setup.py
             '';
 
-          dontUseSetuptoolsCheck = true;
-
           preCheck = ''
             export HOME=$(mktemp -d)
             rm pytest.ini

--- a/pkgs/by-name/pe/persepolis/package.nix
+++ b/pkgs/by-name/pe/persepolis/package.nix
@@ -38,15 +38,6 @@ python3.pkgs.buildPythonApplication rec {
     "\${qtWrapperArgs[@]}"
   ];
 
-  # The presence of these dependencies is checked during setuptoolsCheckPhase,
-  # but apart from that, they're not required during build, only runtime
-  nativeCheckInputs = [
-    libnotify
-    pulseaudio
-    sound-theme-freedesktop
-    ffmpeg
-  ];
-
   propagatedBuildInputs = [
     pulseaudio
     sound-theme-freedesktop

--- a/pkgs/by-name/wa/waydroid/package.nix
+++ b/pkgs/by-name/wa/waydroid/package.nix
@@ -57,7 +57,6 @@ python3Packages.buildPythonApplication rec {
 
   dontUseSetuptoolsBuild = true;
   dontUsePipInstall = true;
-  dontUseSetuptoolsCheck = true;
   dontWrapPythonPrograms = true;
   dontWrapGApps = true;
 

--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -92,10 +92,6 @@ buildPythonPackage rec {
   # TODO: Write a NixOS VM test?
   doCheck = false;
 
-  # Fails with: TypeError: don't know how to make test from:
-  # <blivet.static_data.luks_data.LUKS_Data object at 0x7ffff4a34b90>
-  dontUseSetuptoolsCheck = true;
-
   meta = {
     description = "Python module for system storage configuration";
     homepage = "https://github.com/storaged-project/blivet";

--- a/pkgs/development/python-modules/eventkit/default.nix
+++ b/pkgs/development/python-modules/eventkit/default.nix
@@ -15,7 +15,6 @@ buildPythonPackage {
   src = fetchPypi { inherit pname version hash; };
 
   propagatedBuildInputs = [ numpy ];
-  dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/erdewit/eventkit";

--- a/pkgs/development/python-modules/fastdtw/default.nix
+++ b/pkgs/development/python-modules/fastdtw/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fastdtw.fastdtw" ];
   nativeCheckInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true; # looks for pytest-runner
   preCheck = ''
     echo "Temporarily moving tests to $OUT to find cython modules"
     export PACKAGEDIR=$out/${python.sitePackages}

--- a/pkgs/development/python-modules/fastjsonschema/default.nix
+++ b/pkgs/development/python-modules/fastjsonschema/default.nix
@@ -33,8 +33,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  dontUseSetuptoolsCheck = true;
-
   disabledTests =
     [
       "benchmark"

--- a/pkgs/development/python-modules/h5netcdf/default.nix
+++ b/pkgs/development/python-modules/h5netcdf/default.nix
@@ -34,8 +34,6 @@ buildPythonPackage rec {
     netcdf4
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   pythonImportsCheck = [ "h5netcdf" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -95,7 +95,6 @@ buildPythonPackage rec {
 
   dontUseSetuptoolsBuild = true;
   dontUsePipInstall = true;
-  dontUseSetuptoolsCheck = true;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/mnist/default.nix
+++ b/pkgs/development/python-modules/mnist/default.nix
@@ -24,8 +24,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  dontUseSetuptoolsCheck = true;
-
   # disable tests which fail due to socket related errors
   disabledTests = [
     "test_test_images_has_right_size"

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -99,8 +99,6 @@ mkDerivationWith buildPythonPackage rec {
     wrapt
   ] ++ dask.optional-dependencies.array;
 
-  dontUseSetuptoolsCheck = true;
-
   postFixup = ''
     wrapQtApp $out/bin/napari
   '';

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -142,8 +142,6 @@ buildPythonPackage rec {
 
   disabledTests = [ "GcsFileSystem" ];
 
-  dontUseSetuptoolsCheck = true;
-
   preCheck =
     ''
       shopt -s extglob

--- a/pkgs/development/python-modules/pycoin/default.nix
+++ b/pkgs/development/python-modules/pycoin/default.nix
@@ -25,8 +25,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  dontUseSetuptoolsCheck = true;
-
   # Disable tests depending on online services
   disabledTests = [
     "ServicesTest"

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -70,8 +70,6 @@ buildPythonPackage rec {
     "-v"
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   preCheck = ''
     export HOME=$TEMPDIR
   '';

--- a/pkgs/development/python-modules/pyphotonfile/default.nix
+++ b/pkgs/development/python-modules/pyphotonfile/default.nix
@@ -13,7 +13,6 @@ buildPythonPackage {
   format = "setuptools";
   inherit version;
 
-  dontUseSetuptoolsCheck = true;
   propagatedBuildInputs = [
     pillow
     numpy

--- a/pkgs/development/python-modules/python-constraint/default.nix
+++ b/pkgs/development/python-modules/python-constraint/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
     description = "Constraint Solving Problem resolver for Python";

--- a/pkgs/development/python-modules/python3-eventlib/default.nix
+++ b/pkgs/development/python-modules/python3-eventlib/default.nix
@@ -28,8 +28,6 @@ buildPythonPackage rec {
     greenlet
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   pythonImportsCheck = [ "eventlib" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/development/python-modules/qiskit-ignis/default.nix
@@ -50,7 +50,6 @@ buildPythonPackage rec {
 
   # Tests
   pythonImportsCheck = [ "qiskit.ignis" ];
-  dontUseSetuptoolsCheck = true;
   preCheck = ''
     export HOME=$TMPDIR
   '';

--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -28,8 +28,6 @@ buildPythonPackage rec {
     sphinx
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   disabledTests = [
     # https://github.com/readthedocs/recommonmark/issues/164
     "test_lists"

--- a/pkgs/development/python-modules/three-merge/default.nix
+++ b/pkgs/development/python-modules/three-merge/default.nix
@@ -17,8 +17,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ diff-match-patch ];
 
-  dontUseSetuptoolsCheck = true;
-
   pythonImportsCheck = [ "three_merge" ];
 
   meta = with lib; {

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -93,9 +93,6 @@ let
       rm $out/example-config.yaml
     '';
 
-    # Setuptools is trying to do python -m maubot test
-    dontUseSetuptoolsCheck = true;
-
     pythonImportsCheck = [
       "maubot"
     ];

--- a/pkgs/tools/networking/s3cmd/default.nix
+++ b/pkgs/tools/networking/s3cmd/default.nix
@@ -22,8 +22,6 @@ buildPythonApplication rec {
     python-dateutil
   ];
 
-  dontUseSetuptoolsCheck = true;
-
   meta = with lib; {
     homepage = "https://s3tools.org/s3cmd";
     description = "Command line tool for managing Amazon S3 and CloudFront services";


### PR DESCRIPTION
`setuptoolsCheckHook` has been removed following the deprecation of the `setup.py check` command. (See commit 0b0dd33e0ad51b5059008fdfdfdef1510bc049dd ("python312Packages.setuptoolsCheckHook: remove"))

This PR cleans up the remaining, no longer effective, `setuptoolsCheckHook`-related attributes passing to `buildPythonPackage` and `buildPythonApplication`. Most of them are `dontUseSetuptoolsCheck = true;`, while one of them are `nativeCheckInputs` for `setuptoolsCheckPhase`.

Surpasses #124002

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (Built persepolis, whose `nativeCheckInputs` is removed by this PR.)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
