### PR TITLE
nixos/cloudflared: add option for cert.pem and use dynamic user

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -534,6 +534,8 @@
 
 - hddfancontrol has been updated to major release 2. See the [migration guide](https://github.com/desbma/hddfancontrol/tree/master?tab=readme-ov-file#migrating-from-v1x), as there are breaking changes.
 
+- `services.cloudflared` now uses a dynamic user, and its `user` and `group` options have been removed. If the user or group is still necessary, they can be created manually.
+
 - The Home Assistant module has new options {option}`services.home-assistant.blueprints.automation`, `services.home-assistant.blueprints.script`, and {option}`services.home-assistant.blueprints.template` that allow for the declarative installation of [blueprints](https://www.home-assistant.io/docs/blueprint/) into the appropriate configuration directories.
 
 - For matrix homeserver Synapse we are now following the upstream recommendation to enable jemalloc as the memory allocator by default.

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -7,6 +7,16 @@
 let
   cfg = config.services.cloudflared;
 
+  certificateFile = lib.mkOption {
+    type = with lib.types; nullOr path;
+    description = ''
+      Cert.pem file.
+
+      See [Cert.pem](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-useful-terms/#certpem).
+    '';
+    default = null;
+  };
+
   originRequest = {
     connectTimeout = lib.mkOption {
       type = with lib.types; nullOr str;
@@ -144,20 +154,38 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "services"
+        "cloudflared"
+        "user"
+      ]
+      ''
+        Cloudflared now uses a dynamic user, and this option no longer has any effect.
+
+        If the user is still necessary, please define it manually using users.users.cloudflared.
+      ''
+    )
+
+    (lib.mkRemovedOptionModule
+      [
+        "services"
+        "cloudflared"
+        "group"
+      ]
+      ''
+        Cloudflared now uses a dynamic user, and this option no longer has any effect.
+
+        If the group is still necessary, please define it manually using users.groups.cloudflared.
+      ''
+    )
+  ];
+
   options.services.cloudflared = {
+    inherit certificateFile;
+
     enable = lib.mkEnableOption "Cloudflare Tunnel client daemon (formerly Argo Tunnel)";
-
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "cloudflared";
-      description = "User account under which Cloudflared runs.";
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "cloudflared";
-      description = "Group under which cloudflared runs.";
-    };
 
     package = lib.mkPackageOption pkgs "cloudflared" { };
 
@@ -170,10 +198,10 @@ in
           { name, ... }:
           {
             options = {
-              inherit originRequest;
+              inherit certificateFile originRequest;
 
               credentialsFile = lib.mkOption {
-                type = lib.types.str;
+                type = lib.types.path;
                 description = ''
                   Credential file.
 
@@ -273,6 +301,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = lib.mapAttrsToList (name: tunnel: {
+      assertion =
+        tunnel.ingress == { } || (cfg.certificateFile != null || tunnel.certificateFile != null);
+      message = "Cloudflare Tunnel ${name} has a declarative configuration, but no certificate file was defined.";
+    }) cfg.tunnels;
+
     systemd.targets = lib.mapAttrs' (
       name: tunnel:
       lib.nameValuePair "cloudflared-tunnel-${name}" {
@@ -303,7 +337,7 @@ in
 
         fullConfig = filterConfig {
           tunnel = name;
-          "credentials-file" = tunnel.credentialsFile;
+          credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
           warp-routing = filterConfig tunnel.warp-routing;
           originRequest = filterConfig tunnel.originRequest;
           ingress =
@@ -322,8 +356,9 @@ in
         };
 
         mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
+        certFile = if (tunnel.certificateFile != null) then tunnel.certificateFile else cfg.certificateFile;
       in
-      lib.nameValuePair "cloudflared-tunnel-${name}" ({
+      lib.nameValuePair "cloudflared-tunnel-${name}" {
         after = [
           "network.target"
           "network-online.target"
@@ -334,24 +369,20 @@ in
         ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          User = cfg.user;
-          Group = cfg.group;
+          RuntimeDirectory = "cloudflared-tunnel-${name}";
+          RuntimeDirectoryMode = "0400";
+          LoadCredential = [
+            "credentials.json:${tunnel.credentialsFile}"
+          ] ++ (lib.optional (certFile != null) "cert.pem:certFile");
+
           ExecStart = "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
           Restart = "on-failure";
+          DynamicUser = true;
         };
-      })
+
+        environment.TUNNEL_ORIGIN_CERT = lib.mkIf (certFile != null) ''%d/cert.pem'';
+      }
     ) config.services.cloudflared.tunnels;
-
-    users.users = lib.mkIf (cfg.user == "cloudflared") {
-      cloudflared = {
-        group = cfg.group;
-        isSystemUser = true;
-      };
-    };
-
-    users.groups = lib.mkIf (cfg.group == "cloudflared") {
-      cloudflared = { };
-    };
   };
 
   meta.maintainers = with lib.maintainers; [


### PR DESCRIPTION
Changed the service to use `DynamicUser` and systemd credentials, and added the ability to load `cert.pem` files, to avoid having to place the file manually.

I also added assertions in case the certificate file is not provided and tunnels were set, which might break configs, but they would have been wrong anyway.

I tried creating a NixOS test, but I found no way to make it work in any reasonable way, since it would never be able to connect to the cloudflare backend without a private key. I tested it locally with my config and it's working, though.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
