### PR TITLE
libjaylink: Rework package and init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -195,6 +195,8 @@
 
 - rename package `wtf` to `wtfutil`.
 
+- The udev rules of the libjaylink package require users to be in the `jlink` instead of `plugdev` group now, since the `plugdev` group is very uncommon for NixOS. Alternatively, access is granted to seat sessions.
+
 - `python3Packages.beancount` was updated to 3.1.0. Previous major version remains available as `python3Packages.beancount_2`.
 
 - `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.

--- a/nixos/modules/hardware/libjaylink.nix
+++ b/nixos/modules/hardware/libjaylink.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hardware.libjaylink;
+in
+{
+  options.hardware.libjaylink = {
+    enable = lib.mkEnableOption ''
+      udev rules for devices supported by libjaylink.
+      Add users to the `jlink` group in order to grant
+      them access
+    '';
+    package = lib.mkPackageOption pkgs "libjaylink" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.jlink = { };
+    services.udev.packages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ felixsinger ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -80,6 +80,7 @@
   ./hardware/ksm.nix
   ./hardware/ledger.nix
   ./hardware/libftdi.nix
+  ./hardware/libjaylink.nix
   ./hardware/logitech.nix
   ./hardware/mcelog.nix
   ./hardware/network/ath-user-regd.nix

--- a/pkgs/by-name/li/libjaylink/package.nix
+++ b/pkgs/by-name/li/libjaylink/package.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs autogen.sh
+
+    substituteInPlace contrib/60-libjaylink.rules \
+      --replace-fail 'GROUP="plugdev"' 'GROUP="jlink"'
   '';
 
   postInstall = ''

--- a/pkgs/by-name/li/libjaylink/package.nix
+++ b/pkgs/by-name/li/libjaylink/package.nix
@@ -1,8 +1,9 @@
 {
-  autoreconfHook,
   fetchFromGitLab,
   lib,
   libusb1,
+  meson,
+  ninja,
   nix-update-script,
   pkg-config,
   stdenv,
@@ -21,20 +22,20 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
     pkg-config
   ];
+
   buildInputs = [ libusb1 ];
 
   postPatch = ''
-    patchShebangs autogen.sh
-
     substituteInPlace contrib/60-libjaylink.rules \
       --replace-fail 'GROUP="plugdev"' 'GROUP="jlink"'
   '';
 
   postInstall = ''
-    install -Dm644 contrib/60-libjaylink.rules $out/lib/udev/rules.d/60-libjaylink.rules
+    install -Dm644 ../contrib/60-libjaylink.rules $out/lib/udev/rules.d/60-libjaylink.rules
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
