### PR TITLE
xremap: init at 0.10.10

### DIFF
--- a/pkgs/by-name/xr/xremap/package.nix
+++ b/pkgs/by-name/xr/xremap/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+}:
+let
+  pname = "xremap";
+  version = "0.10.10";
+
+  src = fetchFromGitHub {
+    owner = "xremap";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-U2TSx0O2T53lUiJNpSCUyvkG4Awa0+a4N6meFn09LbI=";
+  };
+
+  cargoHash = "sha256-8IVexszltzlBBShGkjZwyDKs02udrVpZEOwfzRzAraU=";
+
+  buildXremap =
+    {
+      suffix ? "",
+      features ? [ ],
+      descriptionSuffix ? "",
+    }:
+    assert descriptionSuffix != "" && features != [ ];
+    rustPlatform.buildRustPackage {
+      pname = "${pname}${suffix}";
+      inherit version src cargoHash;
+
+      nativeBuildInputs = [ pkg-config ];
+
+      buildNoDefaultFeatures = true;
+      buildFeatures = features;
+
+      useFetchCargoVendor = true;
+
+      meta = {
+        description =
+          "Key remapper for X11 and Wayland"
+          + lib.optionalString (descriptionSuffix != "") " (${descriptionSuffix} support)";
+        homepage = "https://github.com/xremap/xremap";
+        changelog = "https://github.com/xremap/xremap/blob/${src.tag}/CHANGELOG.md";
+        license = lib.licenses.mit;
+        mainProgram = "xremap";
+        maintainers = [ lib.maintainers.hakan-demirli ];
+        platforms = lib.platforms.linux;
+      };
+    };
+
+  variants = {
+    x11 = buildXremap {
+      features = [ "x11" ];
+      descriptionSuffix = "X11";
+    };
+    gnome = buildXremap {
+      suffix = "-gnome";
+      features = [ "gnome" ];
+      descriptionSuffix = "Gnome";
+    };
+    kde = buildXremap {
+      suffix = "-kde";
+      features = [ "kde" ];
+      descriptionSuffix = "KDE";
+    };
+    wlroots = buildXremap {
+      suffix = "-wlroots";
+      features = [ "wlroots" ];
+      descriptionSuffix = "wlroots";
+    };
+    hyprland = buildXremap {
+      suffix = "-hyprland";
+      features = [ "hypr" ];
+      descriptionSuffix = "Hyprland";
+    };
+  };
+
+in
+variants.wlroots.overrideAttrs (finalAttrs: {
+  passthru = {
+    gnome = variants.gnome;
+    kde = variants.kde;
+    wlroots = variants.wlroots;
+    hyprland = variants.hyprland;
+    x11 = variants.x11;
+  };
+})


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/283278
Closes https://github.com/NixOS/nixpkgs/issues/234076
* Bumps xremap
* Addresses reviews
* Adds hyprland support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
