### PR TITLE
haskellPackages: when building with js backend, output jsexe directory alongside executable

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -514,6 +514,14 @@ let
 
   intermediatesDir = "share/haskell/${ghc.version}/${pname}-${version}/dist";
 
+  # On old ghcjs, the jsexe directories are the output but on the js backend they seem to be treated as intermediates
+  jsexe = rec {
+    shouldUseNode = isGhcjs;
+    shouldAdd = stdenv.hostPlatform.isGhcjs && isExecutable;
+    shouldCopy = shouldAdd && !doInstallIntermediates;
+    shouldSymlink = shouldAdd && doInstallIntermediates;
+  };
+
   # This is a script suitable for --test-wrapper of Setup.hs' test command
   # (https://cabal.readthedocs.io/en/3.12/setup-commands.html#cmdoption-runhaskell-Setup.hs-test-test-wrapper).
   # We use it to set some environment variables that the test suite may need,
@@ -820,7 +828,8 @@ lib.fix (
               find $packageConfDir -maxdepth 0 -empty -delete;
             ''
         }
-        ${optionalString isGhcjs ''
+
+        ${optionalString jsexe.shouldUseNode ''
           for exeDir in "${binDir}/"*.jsexe; do
             exe="''${exeDir%.jsexe}"
             printWords '#!${nodejs}/bin/node' > "$exe"
@@ -830,6 +839,14 @@ lib.fix (
           done
         ''}
         ${optionalString doCoverage "mkdir -p $out/share && cp -r dist/hpc $out/share"}
+
+        ${optionalString jsexe.shouldCopy ''
+          for jsexeDir in dist/build/*/*.jsexe; do
+            bn=$(basename $jsexeDir)
+            exe="''${bn%.jsexe}"
+            cp -r dist/build/$exe/$exe.jsexe ${binDir}
+          done
+        ''}
 
         ${optionalString enableSeparateDocOutput ''
           for x in ${docdir "$doc"}"/html/src/"*.html; do
@@ -849,6 +866,14 @@ lib.fix (
         mkdir -p "$installIntermediatesDir"
         cp -r dist/build "$installIntermediatesDir"
         runHook postInstallIntermediates
+
+        ${optionalString jsexe.shouldSymlink ''
+          for jsexeDir in $installIntermediatesDir/build/*/*.jsexe; do
+            bn=$(basename $jsexeDir)
+            exe="''${bn%.jsexe}"
+            (cd ${binDir} && ln -s $installIntermediatesDir/build/$exe/$exe.jsexe)
+          done
+        ''}
       '';
 
       passthru = passthru // rec {


### PR DESCRIPTION
```
$ tree $(nix-build -A haskell.packages.ghcjs810.hello)
/nix/store/q4i5jsyq8yfdi67k14v3599jgbzr2qqx-hello-1.0.0.2
└── bin
    ├── hello
    └── hello.jsexe
        ├── all.js
        ├── all.js.externs
        ├── index.html
        ├── lib.js
        ├── manifest.webapp
        ├── out.frefs.js
        ├── out.frefs.json
        ├── out.js
        ├── out.stats
        ├── rts.js
        └── runmain.js

$ tree $(nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.hello)
/nix/store/2rkkaz0fxn7cqmnhm2pxkzj31jnjgnms-hello-1.0.0.2
├── bin
│   └── hello
└── share
    └── doc
        └── javascript-ghcjs-ghc-9.12.1-inplace
            └── hello-1.0.0.2
                └── LICENSE
```

We do compilation of `*.jsexe` dirs into an executable for old GHCJS

https://github.com/NixOS/nixpkgs/blob/993a66fe2f934a4ee1c414f8ef3975d15608bd2c/pkgs/development/haskell-modules/generic-builder.nix#L668-L676

but in the JS backend that seems to be already handled, and we end up only getting the final executable

I'm not sure what causes this difference, but one workaround when `doInstallIntermediates = true` is to symlink to the intermediates. Maybe that's actually the correct behavior in that case, but there's extra stuff in there we don't want to bring along the ride with the `jsexe` dirs

```
├── bin
│   └── hello
└── share
    ├── doc
    │   └── javascript-ghcjs-ghc-9.12.1-inplace
    │       └── hello-1.0.0.2
    │           └── LICENSE
    └── haskell
        └── 9.12.1
            └── hello-1.0.0.2
                └── dist
                    └── build
                        └── hello
                            ├── autogen
                            │   ├── cabal_macros.h
                            │   ├── PackageInfo_hello.hs
                            │   └── Paths_hello.hs
                            ├── hello
                            ├── hello.jsexe
                            │   ├── all.externs.js
                            │   ├── all.js
                            │   ├── index.html
                            │   ├── lib.js
                            │   ├── out.frefs.js
                            │   ├── out.frefs.json
                            │   ├── out.js
                            │   ├── out.stats
                            │   ├── rts.js
                            │   └── runmain.js
                            └── hello-tmp
                                ├── Main.hi
                                └── Main.o
```

So maybe when `doInstallIntermediates = false` we should instead copy the `jsexe` dirs ourselves over from `dist` ?

I also wonder whether the original behavior of outputting both a executable and .js files is what we want. I'm not sure how to detect the [`GHCJS_BROWSER`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/javascript.html#writing-javascript-functions-to-be-nodejs-and-browser-aware) in the derivation, but that looks like it should determine which bits actually are placed in `bin` ?

Example output with multiple executables (tested on top of #380737) 
```
$ tree $(nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.miso-examples)
/nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0
├── bin
│   ├── canvas2d
│   ├── canvas2d.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/canvas2d/canvas2d.jsexe
│   ├── compose-update
│   ├── compose-update.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/compose-update/compose-update.jsexe
│   ├── file-reader
│   ├── file-reader.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/file-reader/file-reader.jsexe
│   ├── mario
│   ├── mario.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/mario/mario.jsexe
│   ├── mathml
│   ├── mathml.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/mathml/mathml.jsexe
│   ├── router
│   ├── router.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/router/router.jsexe
│   ├── svg
│   ├── svg.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/svg/svg.jsexe
│   ├── threejs
│   ├── threejs.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/threejs/threejs.jsexe
│   ├── todo-mvc
│   ├── todo-mvc.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/todo-mvc/todo-mvc.jsexe
│   ├── websocket
│   ├── websocket.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/websocket/websocket.jsexe
│   ├── xhr
│   └── xhr.jsexe -> /nix/store/da77rw6qgpjj3c4958dg4bsblr75x1hp-miso-examples-1.8.7.0/share/haskell/9.12.1/miso-examples-1.8.7.0/dist/build/xhr/xhr.jsexe
└── share
    ├── doc
    │   └── javascript-ghcjs-ghc-9.12.1-inplace
    │       └── miso-examples-1.8.7.0
    │           └── LICENSE
    └── haskell
        └── 9.12.1
            └── miso-examples-1.8.7.0
                └── dist
                    └── build
                        ├── canvas2d
                        │   ├── autogen
                        │   │   ├── cabal_macros.h
                        │   │   ├── PackageInfo_miso_examples.hs
                        │   │   └── Paths_miso_examples.hs
                        │   ├── canvas2d
                        │   ├── canvas2d.jsexe
                        │   │   ├── all.externs.js
...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
