### PR TITLE
insomnia: add aarch64-darwin build, sandbox builds

### DIFF
--- a/pkgs/by-name/in/insomnia/package.nix
+++ b/pkgs/by-name/in/insomnia/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   appimageTools,
+  undmg,
 }:
 let
   pname = "insomnia";
@@ -11,6 +12,10 @@ let
   src =
     fetchurl
       {
+        aarch64-darwin = {
+          url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
+          hash = "sha256-Yny5Rwt8XHTM77DH4AXmY8VtZ92F7jAdNW+polPePJk=";
+        };
         x86_64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
           hash = "sha256-Yny5Rwt8XHTM77DH4AXmY8VtZ92F7jAdNW+polPePJk=";
@@ -29,6 +34,7 @@ let
     changelog = "https://github.com/Kong/insomnia/releases/tag/core@${version}";
     license = licenses.asl20;
     platforms = [
+      "aarch64-darwin"
       "x86_64-linux"
       "x86_64-darwin"
     ];
@@ -49,23 +55,7 @@ if stdenv.hostPlatform.isDarwin then
       ;
     sourceRoot = ".";
 
-    unpackCmd = ''
-      echo "Creating temp directory"
-      mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-      function finish {
-        echo "Ejecting temp directory"
-        /usr/bin/hdiutil detach $mnt -force
-        rm -rf $mnt
-      }
-      # Detach volume when receiving SIG "0"
-      trap finish EXIT
-      # Mount DMG file
-      echo "Mounting DMG file into \"$mnt\""
-      /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $curSrc
-      # Copy content to local dir for later use
-      echo 'Copying extracted content into "sourceRoot"'
-      cp -a $mnt/Insomnia.app $PWD/
-    '';
+    nativeBuildInputs = [ undmg ];
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
Insomnia has been supported on apple silicon [since 2022](https://github.com/Kong/insomnia/pull/4140), so nixpkgs should support it too.

Switch to using `undmg` to unpack the source `.dmg` file instead of mounting it, so sandboxed builds complete successfully on macos.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
