### PR TITLE
Heroic Games Launcher: various fixes

### DIFF
--- a/pkgs/by-name/le/legendary-heroic/package.nix
+++ b/pkgs/by-name/le/legendary-heroic/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  gitUpdater,
+  fetchFromGitHub,
+  python3Packages,
+}:
+let
+  version = "0.20.36";
+in
+python3Packages.buildPythonApplication {
+  pname = "legendary-heroic";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Heroic-Games-Launcher";
+    repo = "legendary";
+    rev = version;
+    sha256 = "sha256-+aywgd5RZfkmVuA0MaF2/Ie4a5If/zQxvVCcTfGpQpE=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    filelock
+  ];
+
+  disabled = python3Packages.pythonOlder "3.8";
+
+  pythonImportsCheck = [ "legendary" ];
+
+  meta = with lib; {
+    description = "Free and open-source Epic Games Launcher alternative";
+    longDescription = ''
+      This is the Heroic Games Launcher's fork of legendary.
+    '';
+    homepage = "https://github.com/Heroic-Games-Launcher/legendary";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ aidalgol ];
+    mainProgram = "legendary";
+  };
+
+  passthru.updateScript = gitUpdater { };
+}

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -10,7 +10,7 @@
   electron,
   vulkan-helper,
   gogdl,
-  legendary-gl,
+  legendary-heroic,
   nile,
   comet-gog,
 }:
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/opt/heroic/resources/app.asar.unpacked/build/bin/x64/linux"
     ln -s \
       "${lib.getExe gogdl}" \
-      "${lib.getExe legendary-gl}" \
+      "${lib.getExe legendary-heroic}" \
       "${lib.getExe nile}" \
       "${lib.getExe comet-gog}" \
       "${lib.getExe vulkan-helper}" \

--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -31,6 +31,7 @@ buildFHSEnv {
       nettools
       opencl-headers
       p7zip
+      pciutils
       perl
       psmisc
       python3


### PR DESCRIPTION
- Add `legendary-heroic`, Heroic's fork of `legendary-gl`.
- `heroic` now uses this package instead.
- Add `pciutils` to the FHSenv wrapper.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
