### PR TITLE
zstd: 1.5.6 -> 1.5.7

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   bash,
   gnugrep,
@@ -27,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "zstd";
-  version = "1.5.6";
+  version = "1.5.7";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "zstd";
     rev = "v${version}";
-    hash = "sha256-qcd92hQqVBjMT3hyntjcgk29o9wGQsg5Hg7HE5C0UNc=";
+    hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
   };
 
   nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
@@ -43,6 +44,15 @@ stdenv.mkDerivation rec {
     # This patches makes sure we do not attempt to use the MD5 implementation
     # of the host platform when running the tests
     ./playtests-darwin.patch
+
+    # Pull missing manpages update:
+    #   https://github.com/facebook/zstd/pull/4302
+    # TODO: remove with 1.5.8 release
+    (fetchpatch {
+      name = "man-fix.patch";
+      url = "https://github.com/facebook/zstd/commit/6af3842118ea5325480b403213b2a9fbed3d3d74.patch";
+      hash = "sha256-i+iv+owUXbKU3UtZBsjfj86kFB3TDlpcVDNsDX8dyZE=";
+    })
   ];
 
   postPatch = lib.optionalString (!static) ''

--- a/pkgs/tools/compression/zstd/playtests-darwin.patch
+++ b/pkgs/tools/compression/zstd/playtests-darwin.patch
@@ -1,11 +1,10 @@
 --- a/tests/playTests.sh
 +++ b/tests/playTests.sh
-@@ -112,29 +112,19 @@ case "$OS" in
+@@ -119,16 +119,10 @@ case "$OS" in
  esac
  
  case "$UNAME" in
 -  Darwin) MD5SUM="md5 -r" ;;
--  FreeBSD) MD5SUM="gmd5sum" ;;
 -  NetBSD) MD5SUM="md5 -n" ;;
 -  OpenBSD) MD5SUM="md5" ;;
    *) MD5SUM="md5sum" ;;
@@ -18,9 +17,7 @@
  
  assertSameMTime() {
      MT1=$($MTIME "$1")
-     MT2=$($MTIME "$2")
-     echo MTIME $MT1 $MT2
-     [ "$MT1" = "$MT2" ] || die "mtime on $1 doesn't match mtime on $2 ($MT1 != $MT2)"
+@@ -138,9 +132,6 @@ assertSameMTime() {
  }
  
  GET_PERMS="stat -c %a"
@@ -30,7 +27,7 @@
  
  assertFilePermissions() {
      STAT1=$($GET_PERMS "$1")
-@@ -967,7 +957,6 @@ $MD5SUM dirTestDict/* > tmph1
+@@ -1155,7 +1146,6 @@ $MD5SUM dirTestDict/* > tmph1
  zstd -f --rm dirTestDict/* -D tmpDictC
  zstd -d --rm dirTestDict/*.zst -D tmpDictC  # note : use internal checksum by default
  case "$UNAME" in


### PR DESCRIPTION
Changes: https://github.com/facebook/zstd/releases/tag/v1.5.7


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
