### PR TITLE
obj2tiles: init at 1.0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14264,6 +14264,12 @@
     githubId = 50797868;
     name = "Shaolong Chen";
   };
+  mapperfr = {
+    email = "jeremy@mapper.fr";
+    github = "mapperfr";
+    githubId = 3398608;
+    name = "Jérémy Garniaux";
+  };
   maralorn = {
     email = "mail@maralorn.de";
     matrix = "@maralorn:maralorn.de";

--- a/pkgs/by-name/ob/obj2tiles/deps.json
+++ b/pkgs/by-name/ob/obj2tiles/deps.json
@@ -1,0 +1,17 @@
+[
+  {
+    "pname": "CommandLineParser",
+    "version": "2.9.1",
+    "hash": "sha256-ApU9y1yX60daSjPk3KYDBeJ7XZByKW8hse9NRZGcjeo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "SixLabors.ImageSharp",
+    "version": "3.1.5",
+    "hash": "sha256-3UehX9T+I81nfgv2dTHlpoPgYzXFk7kHr1mmlQOCBfw="
+  }
+]

--- a/pkgs/by-name/ob/obj2tiles/package.nix
+++ b/pkgs/by-name/ob/obj2tiles/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildDotnetModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildDotnetModule (finalAttrs: {
+  pname = "obj2tiles";
+  version = "1.0.13";
+  src = fetchFromGitHub {
+    owner = "OpenDroneMap";
+    repo = "Obj2Tiles";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GLMLBmkVhuh8iYAxjD2XXnOvkw8dMuKTH49vvvSNHBI=";
+  };
+  projectFile = "Obj2Tiles/Obj2Tiles.csproj";
+  nugetDeps = ./deps.json;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/Obj2Tiles";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+  meta = {
+    description = "Converts OBJ files to OGC 3D tiles by performing splitting, decimation and conversion";
+    homepage = "https://github.com/OpenDroneMap/Obj2Tiles";
+    changelog = "https://github.com/OpenDroneMap/Obj2Tiles/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ mapperfr ];
+    mainProgram = "Obj2Tiles";
+  };
+})


### PR DESCRIPTION
Obj2Tiles converts OBJ files to OGC 3D tiles by performing splitting, decimation and conversion. See the [source code](https://github.com/OpenDroneMap/Obj2Tiles).  
Opening a PR following @drupol's advice [here](https://github.com/NixOS/nixpkgs/issues/383412#issuecomment-2669056699)

The PR covers the [package init commit](https://github.com/NixOS/nixpkgs/commit/a33231372eba7ac0a34ae20c5f2b4a7dbaeca9fe) and a commit to [add myself as a maintainer](https://github.com/NixOS/nixpkgs/commit/00aadaea3e9c1df975f904ca1b1e1023f7cc4998).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
