### PR TITLE
qir-runner: init at 0.7.5

### DIFF
--- a/pkgs/by-name/qi/qir-runner/package.nix
+++ b/pkgs/by-name/qi/qir-runner/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  llvmPackages_19,
+  libffi,
+  zlib,
+  libxml2,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "qir-runner";
+  version = "0.7.5";
+
+  src = fetchFromGitHub {
+    owner = "qir-alliance";
+    repo = "qir-runner";
+    tag = "v${version}";
+    hash = "sha256-65ioZ+7Xo4ocpFFVvwtY6Hn1FKuI48hcAfbAjPnSYEs=";
+  };
+
+  nativeBuildInputs = [ llvmPackages_19.llvm ];
+  buildInputs = [
+    libffi
+    zlib
+    libxml2
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ciQ6TFl+LNBVrIwhCdpzbaQz72W7EC5wj85PW29UV0M=";
+
+  meta = {
+    description = "QIR bytecode runner to assist with QIR development and validation";
+    mainProgram = "qir-runner";
+    homepage = "https://qir-alliance.github.io/qir-runner";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bbenno ];
+    # llvm-sys crate locates llvm by calling llvm-config
+    # which is not available when cross compiling
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+  };
+}


### PR DESCRIPTION
[qir-runner](https://github.com/qir-alliance/qir-runner/tree/main) is a
> QIR bytecode runner to assist with QIR development and validation

Besides the runner binary, it contains libs for developing quantum algorithms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
