### PR TITLE
[staging-next] gnupg: don't use autoreconfHook

### DIFF
--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -4,7 +4,6 @@
   fetchurl,
   fetchFromGitLab,
   buildPackages,
-  autoreconfHook,
   pkg-config,
   texinfo,
   gettext,
@@ -45,7 +44,12 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
-    autoreconfHook
+    # XXX: do not add autoreconfHook without very careful testing!
+    # Problems that were identified during the last attempt:
+    #  • Prints a warning about being a development version not
+    #    suitable for production use.
+    #  • Smartcards do not work, at least without pcscd.
+
     pkg-config
     texinfo
     libgpg-error

--- a/pkgs/tools/security/gnupg/static.patch
+++ b/pkgs/tools/security/gnupg/static.patch
@@ -1,4 +1,4 @@
-From 440ccccb02ec438b4077b5885e5a1483e12c38b1 Mon Sep 17 00:00:00 2001
+From 6a426b8093cf6633425d08a2d33ed24d200473a0 Mon Sep 17 00:00:00 2001
 From: Alyssa Ross <hi@alyssa.is>
 Date: Sun, 9 Feb 2025 08:51:32 +0100
 Subject: [PATCH] build: use pkg-config to find tss2-esys
@@ -8,11 +8,188 @@ won't be linked when tss2-esys is a static library.
 ---
 Link: https://dev.gnupg.org/D606
 
- configure.ac | 5 ++---
- 1 file changed, 2 insertions(+), 3 deletions(-)
+ configure    | 131 +++++++++++++++++++++++++++++----------------------
+ configure.ac |   5 +-
+ 2 files changed, 76 insertions(+), 60 deletions(-)
 
+diff --git a/configure b/configure
+index 59f027d..f53c99d 100755
+--- a/configure
++++ b/configure
+@@ -669,12 +669,12 @@ TEST_LIBTSS_FALSE
+ TEST_LIBTSS_TRUE
+ HAVE_LIBTSS_FALSE
+ HAVE_LIBTSS_TRUE
+-LIBTSS_CFLAGS
+-LIBTSS_LIBS
+ SWTPM
+ TSSSTARTUP
+ TPMSERVER
+ TSS_INCLUDE
++LIBTSS_LIBS
++LIBTSS_CFLAGS
+ W32SOCKLIBS
+ NETLIBS
+ CROSS_COMPILING_FALSE
+@@ -1005,7 +1005,9 @@ PKG_CONFIG_LIBDIR
+ SQLITE3_CFLAGS
+ SQLITE3_LIBS
+ LIBGNUTLS_CFLAGS
+-LIBGNUTLS_LIBS'
++LIBGNUTLS_LIBS
++LIBTSS_CFLAGS
++LIBTSS_LIBS'
+ 
+ 
+ # Initialize some variables set by options.
+@@ -1771,6 +1773,9 @@ Some influential environment variables:
+               C compiler flags for LIBGNUTLS, overriding pkg-config
+   LIBGNUTLS_LIBS
+               linker flags for LIBGNUTLS, overriding pkg-config
++  LIBTSS_CFLAGS
++              C compiler flags for LIBTSS, overriding pkg-config
++  LIBTSS_LIBS linker flags for LIBTSS, overriding pkg-config
+ 
+ Use these variables to override the choices made by `configure' or to help
+ it to find libraries and programs with nonstandard names/locations.
+@@ -15465,64 +15470,77 @@ else
+ fi
+ 
+   elif test "$with_tss" = intel; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing Esys_Initialize" >&5
+-$as_echo_n "checking for library containing Esys_Initialize... " >&6; }
+-if ${ac_cv_search_Esys_Initialize+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_func_search_save_LIBS=$LIBS
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+ 
+-/* Override any GCC internal prototype to avoid an error.
+-   Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
+-#ifdef __cplusplus
+-extern "C"
+-#endif
+-char Esys_Initialize ();
+-int
+-main ()
+-{
+-return Esys_Initialize ();
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_lib in '' tss2-esys; do
+-  if test -z "$ac_lib"; then
+-    ac_res="none required"
+-  else
+-    ac_res=-l$ac_lib
+-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+-  fi
+-  if ac_fn_c_try_link "$LINENO"; then :
+-  ac_cv_search_Esys_Initialize=$ac_res
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext
+-  if ${ac_cv_search_Esys_Initialize+:} false; then :
+-  break
+-fi
+-done
+-if ${ac_cv_search_Esys_Initialize+:} false; then :
++pkg_failed=no
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBTSS" >&5
++$as_echo_n "checking for LIBTSS... " >&6; }
+ 
++if test -n "$LIBTSS_CFLAGS"; then
++    pkg_cv_LIBTSS_CFLAGS="$LIBTSS_CFLAGS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_CFLAGS=`$PKG_CONFIG --cflags "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
+ else
+-  ac_cv_search_Esys_Initialize=no
++  pkg_failed=yes
+ fi
+-rm conftest.$ac_ext
+-LIBS=$ac_func_search_save_LIBS
++ else
++    pkg_failed=untried
+ fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_Esys_Initialize" >&5
+-$as_echo "$ac_cv_search_Esys_Initialize" >&6; }
+-ac_res=$ac_cv_search_Esys_Initialize
+-if test "$ac_res" != no; then :
+-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+-  have_libtss=Intel
++if test -n "$LIBTSS_LIBS"; then
++    pkg_cv_LIBTSS_LIBS="$LIBTSS_LIBS"
++ elif test -n "$PKG_CONFIG"; then
++    if test -n "$PKG_CONFIG" && \
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"tss2-esys tss2-mu tss2-rc tss2-tctildr\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "tss2-esys tss2-mu tss2-rc tss2-tctildr") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++  pkg_cv_LIBTSS_LIBS=`$PKG_CONFIG --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>/dev/null`
++		      test "x$?" != "x0" && pkg_failed=yes
+ else
+-  as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++  pkg_failed=yes
++fi
++ else
++    pkg_failed=untried
+ fi
+ 
++
++
++if test $pkg_failed = yes; then
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++
++if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
++        _pkg_short_errors_supported=yes
++else
++        _pkg_short_errors_supported=no
++fi
++        if test $_pkg_short_errors_supported = yes; then
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        else
++	        LIBTSS_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "tss2-esys tss2-mu tss2-rc tss2-tctildr" 2>&1`
++        fi
++	# Put the nasty error message in config.log where it belongs
++	echo "$LIBTSS_PKG_ERRORS" >&5
++
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++elif test $pkg_failed = untried; then
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++	as_fn_error $? "Intel TPM Software Stack requested but not found" "$LINENO" 5
++else
++	LIBTSS_CFLAGS=$pkg_cv_LIBTSS_CFLAGS
++	LIBTSS_LIBS=$pkg_cv_LIBTSS_LIBS
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++	have_libtss=Intel
++fi
+   else
+     as_fn_error $? "Invalid TPM Software Stack requested: $with_tss" "$LINENO" 5
+   fi
+@@ -15616,7 +15634,6 @@ $as_echo "$as_me: WARNING: Need Esys_TR_GetTpmHandle API (usually requires Intel
+ 
+ fi
+ 
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+ 
+ $as_echo "#define HAVE_INTEL_TSS 1" >>confdefs.h
+ 
 diff --git a/configure.ac b/configure.ac
-index dc444657f..a60c1820c 100644
+index dc44465..92880e6 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1574,8 +1574,8 @@ if test "$build_tpm2d" = "yes"; then
@@ -35,4 +212,5 @@ index dc444657f..a60c1820c 100644
    fi
    LIBS="$_save_libs"
 -- 
-2.47.0
+2.47.2
+


### PR DESCRIPTION
This was added because the static patch modified configure.ac, requiring configure to be regenerated.  For reasons we don't totally understand, regenerating configure has all sorts of other undesirable side effects.  So to unbreak things, instead of regenerating configure, we can include just the configure changes relevant to the static patch in the patch file.

Fixes: 35c9771eee0e ("gnupg: fix static")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
