### PR TITLE
teleport_15: 15.4.26 -> 15.4.29; teleport_16: 16.4.14 -> 16.4.16; teleport_17: 17.2.1 -> 17.2.8

### DIFF
--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -2,10 +2,10 @@ args:
 import ../generic.nix (
   args
   // {
-    version = "15.4.26";
-    hash = "sha256-LxMwCI/8otH32bRJvz9p1zWw4QzF/wrqeboZ6B3aw9o=";
-    vendorHash = "sha256-VG9b1M3zdtRXY3eCFC7izejSSs4nTjtR9/wOc36PFnA=";
-    yarnHash = "sha256-kmjY7KQfSzmlNS7ZK25YItZct/Tg7CWKfoRfubFBGlY=";
-    cargoHash = "sha256-IQi11Hpavj4pImwjxU6uoHQ+vjwc/++NuWXREcIKH3s=";
+    version = "15.4.29";
+    hash = "sha256-FL7u7icwTS8V7ZodKjN/9vRTzXgJ0MCRgAz23eA+kfA=";
+    vendorHash = "sha256-LL18GI5w9kJdBJf2al9rK3dBwib2mLG/deZgSsmZv0U=";
+    yarnHash = "sha256-63JX0rAMyZA58CdaqHlTXlL7npvKcYnhVIh1NaJEmBk=";
+    cargoHash = "sha256-2lIhtIWl26xoH7XxhPEmG/2FpfwgTC7kmahCim1W4To=";
   }
 )

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,10 +2,10 @@ args:
 import ../generic.nix (
   args
   // {
-    version = "16.4.14";
-    hash = "sha256-9X4PLN5y1pJMNGL7o+NR/b3yUYch/VVEMmGmWbEO1CA=";
-    vendorHash = "sha256-nJdtllxjem+EA77Sb1XKmrAaWh/8WrL3AuvVxgBRkxI=";
-    pnpmHash = "sha256-+eOfGS9m3c9i7ccOS8q6KM0IrBIJZKlxx7h3qqxTJHE=";
-    cargoHash = "sha256-6JYSW65ou8iC4/7AJVZ9+vpItxpJtaGFA4Nm3fgyHIs=";
+    version = "16.4.16";
+    hash = "sha256-0nag5T+qv00uA//N9ZDuCqarCfXYn76Ycxd97FfILpE=";
+    vendorHash = "sha256-5fSMbmvnbJ4zQuTBsmN/Ym3syn819hRmxv0aRzDnRFU=";
+    pnpmHash = "sha256-OpCUYn69UNs6cplM74oNO4hQ5wiYBbjqGN3bJfbrsqk=";
+    cargoHash = "sha256-oavJSszi6uWfUIzD+wRZL3wAFgmPvFwGeNHZexOlup4=";
   }
 )

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "17.2.1";
-    hash = "sha256-QlBj3zGnELgQJMIMSZK1YVE3H2hO09Xgdtcw0BML7KQ=";
-    vendorHash = "sha256-Y3og6oifpQIZxkKR1qgD3l06YaCFpSlh/+jN3w0gq7M=";
-    pnpmHash = "sha256-ChRWq0acDzHhm6JK2W3V6LZHlq4vXMxa1AMqiCPIouc=";
-    cargoHash = "sha256-GDwH/2aiqvTbLC8/x/n0yLuU8IEBVpyacN2B+EGwBgE=";
+    version = "17.2.8";
+    hash = "sha256-VjYC5q4hYU+YYW4sgPDpdHKoD4CJtGvIGWSOUGZ5hpQ=";
+    vendorHash = "sha256-i/U1Zy8wEfhLet9FSj/z9lvWE8gI6Hpz/5GZYbmu1j4=";
+    pnpmHash = "sha256-wiLpxIxqIYM/DDW9DpUyIvt+5Vf51uVceRxVGA2q9wI=";
+    cargoHash = "sha256-FiPfeDnb/FTemE1ZO2Ydg2KUjNmw7U3SCNu6cOqalOM=";
   }
 )

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -2,7 +2,6 @@
   callPackages,
   lib,
   wasm-bindgen-cli_0_2_95,
-  buildGo122Module,
   wasm-bindgen-cli_0_2_100,
   buildGo123Module,
   ...
@@ -21,7 +20,7 @@ let
       args
       // {
         wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
-        buildGoModule = buildGo122Module;
+        buildGoModule = buildGo123Module;
       }
     );
     teleport = teleport_16;
@@ -40,7 +39,6 @@ callPackages f' (
   builtins.removeAttrs args [
     "callPackages"
     "wasm-bindgen-cli_0_2_95"
-    "buildGo122Module"
     "wasm-bindgen-cli_0_2_100"
     "buildGo123Module"
   ]

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -1,9 +1,9 @@
 {
   callPackages,
   lib,
-  wasm-bindgen-cli_0_2_92,
   wasm-bindgen-cli_0_2_95,
   buildGo122Module,
+  wasm-bindgen-cli_0_2_100,
   buildGo123Module,
   ...
 }@args:
@@ -13,8 +13,8 @@ let
     teleport_15 = import ./15 (
       args
       // {
-        wasm-bindgen-cli = wasm-bindgen-cli_0_2_92;
-        buildGoModule = buildGo122Module;
+        wasm-bindgen-cli = wasm-bindgen-cli_0_2_100;
+        buildGoModule = buildGo123Module;
       }
     );
     teleport_16 = import ./16 (
@@ -39,9 +39,9 @@ in
 callPackages f' (
   builtins.removeAttrs args [
     "callPackages"
-    "wasm-bindgen-cli_0_2_92"
     "wasm-bindgen-cli_0_2_95"
     "buildGo122Module"
+    "wasm-bindgen-cli_0_2_100"
     "buildGo123Module"
   ]
 )


### PR DESCRIPTION
https://github.com/gravitational/teleport/releases/tag/v15.4.29
https://github.com/gravitational/teleport/releases/tag/v16.4.16
https://github.com/gravitational/teleport/releases/tag/v17.2.7 https://github.com/gravitational/teleport/releases/tag/v17.2.8

Contains a fix for a security issue with arbitrary file reads on SSH nodes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
