### PR TITLE
emitter: init at 3.1

### DIFF
--- a/pkgs/by-name/em/emitter/package.nix
+++ b/pkgs/by-name/em/emitter/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule rec {
+  pname = "emitter";
+  version = "3.1";
+
+  src = fetchFromGitHub {
+    owner = "emitter-io";
+    repo = "emitter";
+    tag = "v${version}";
+    hash = "sha256-eWBgRG0mLdiJj1TMSAxYPs+8CqLNaFUOW6/ghDn/zKE=";
+  };
+
+  vendorHash = "sha256-6K9KAvb+05nn2pFuVDiQ9IHZWpm+q01su6pl7CxXxBY=";
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  ldflags = [
+    "-X github.com/emitter-io/emitter/internal/command/version.version=${version}"
+    "-X github.com/emitter-io/emitter/internal/command/version.commit=${src.rev}"
+  ];
+
+  doCheck = true;
+
+  checkFlags = [
+    # Tests require network access
+    "-skip=^Test(NewClient|Statsd_BadSnapshot|Statsd_Configure|Join|Random)$"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "High performance, distributed and low latency publish-subscribe platform";
+    homepage = "https://emitter.io/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ sikmir ];
+    mainProgram = "emitter";
+  };
+}


### PR DESCRIPTION
[**emitter**](https://emitter.io/) - high performance, distributed and low latency publish-subscribe platform.

Listed in https://mqtt.org/software/

[![Packaging status](https://repology.org/badge/tiny-repos/emitter.svg)](https://repology.org/project/emitter/versions)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
