### PR TITLE
python313Packages.mathutils: fix on python 3.13

### DIFF
--- a/pkgs/development/python-modules/mathutils/default.nix
+++ b/pkgs/development/python-modules/mathutils/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  pythonAtLeast,
 
   # build-system
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "mathutils";
   version = "3.3.0";
   pyproject = true;
@@ -19,16 +20,23 @@ buildPythonPackage rec {
     hash = "sha256-c28kt2ADw4wHNLN0CBPcJU/kqm6g679QRaICk4WwaBc=";
   };
 
+  # error: implicit declaration of function ‘_PyLong_AsInt’; did you mean ‘PyLong_AsInt’? [-Wimplicit-function-declaration]
+  # https://github.com/python/cpython/issues/108444
+  postPatch = lib.optionalString (pythonAtLeast "3.13") ''
+    substituteInPlace src/generic/py_capi_utils.{c,h} \
+      --replace-fail "_PyLong_AsInt" "PyLong_AsInt"
+  '';
+
   build-system = [
     setuptools
   ];
 
   pythonImportsCheck = [ "mathutils" ];
 
-  meta = with lib; {
-    description = "A general math utilities library providing Matrix, Vector, Quaternion, Euler and Color classes, written in C for speed";
+  meta = {
+    description = "General math utilities library providing Matrix, Vector, Quaternion, Euler and Color classes, written in C for speed";
     homepage = "https://gitlab.com/ideasman42/blender-mathutils";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ autra ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ autra ];
   };
 }


### PR DESCRIPTION
## Things done

```
In file included from src/generic/py_capi_utils.c:22:
src/generic/py_capi_utils.h: In function ‘PyC_Long_AsI32’:
src/generic/py_capi_utils.h:260:19: error: implicit declaration of function ‘_PyLong_AsInt’; did you mean ‘PyLong_AsInt’? [-Wimplicit-function-declaration]
  260 |   return (int32_t)_PyLong_AsInt(value);
      |                   ^~~~~~~~~~~~~
      |                   PyLong_AsInt
src/generic/py_capi_utils.c: At top level:
src/generic/py_capi_utils.c:1626: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
 1626 | #  pragma warning(push)
src/generic/py_capi_utils.c:1718: warning: ignoring ‘#pragma warning ’ [-Wunknown-pragmas]
 1718 | #  pragma warning(pop)
error: command '/nix/store/ii75mhh7sxl11167m1b86p0qrjsjyjmd-gcc-wrapper-14-20241116/bin/gcc' failed with exit code 1
```

cc @autra

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
