### PR TITLE
electron-bin: copy over fixes from electron-source, remove no longer needed version conditionals

### DIFF
--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  libXScrnSaver,
   makeWrapper,
   fetchurl,
   wrapGAppsHook3,
@@ -42,15 +41,13 @@ let
       yayayayaka
       teutat3s
     ];
-    platforms =
-      [
-        "x86_64-darwin"
-        "x86_64-linux"
-        "armv7l-linux"
-        "aarch64-linux"
-      ]
-      ++ optionals (versionAtLeast version "11.0.0") [ "aarch64-darwin" ]
-      ++ optionals (versionOlder version "19.0.0") [ "i686-linux" ];
+    platforms = [
+      "x86_64-darwin"
+      "x86_64-linux"
+      "armv7l-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     # https://www.electronjs.org/docs/latest/tutorial/electron-timelines
     knownVulnerabilities = optional (versionOlder version "32.0.0") "Electron version ${version} is EOL";
@@ -70,19 +67,13 @@ let
       sha256 = hash;
     };
 
-  tags =
-    {
-      x86_64-linux = "linux-x64";
-      armv7l-linux = "linux-armv7l";
-      aarch64-linux = "linux-arm64";
-      x86_64-darwin = "darwin-x64";
-    }
-    // lib.optionalAttrs (lib.versionAtLeast version "11.0.0") {
-      aarch64-darwin = "darwin-arm64";
-    }
-    // lib.optionalAttrs (lib.versionOlder version "19.0.0") {
-      i686-linux = "linux-ia32";
-    };
+  tags = {
+    x86_64-linux = "linux-x64";
+    armv7l-linux = "linux-armv7l";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
 
   get = as: platform: as.${platform.system} or (throw "Unsupported system: ${platform.system}");
 
@@ -92,44 +83,37 @@ let
     passthru.headers = headersFetcher version hashes.headers;
   };
 
-  electronLibPath = lib.makeLibraryPath (
-    [
-      alsa-lib
-      at-spi2-atk
-      cairo
-      cups
-      dbus
-      expat
-      gdk-pixbuf
-      glib
-      gtk3
-      nss
-      nspr
-      xorg.libX11
-      xorg.libxcb
-      xorg.libXcomposite
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXrandr
-      xorg.libxkbfile
-      pango
-      pciutils
-      stdenv.cc.cc
-      systemd
-    ]
-    ++ lib.optionals (lib.versionAtLeast version "9.0.0") [
-      libdrm
-      libgbm
-    ]
-    ++ lib.optionals (lib.versionOlder version "10.0.0") [ libXScrnSaver ]
-    ++ lib.optionals (lib.versionAtLeast version "11.0.0") [ libxkbcommon ]
-    ++ lib.optionals (lib.versionAtLeast version "12.0.0") [ libxshmfence ]
-    ++ lib.optionals (lib.versionAtLeast version "17.0.0") [
-      libGL
-      vulkan-loader
-    ]
-  );
+  electronLibPath = lib.makeLibraryPath [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    nss
+    nspr
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libxkbfile
+    pango
+    pciutils
+    stdenv.cc.cc
+    systemd
+    libdrm
+    libgbm
+    libxkbcommon
+    libxshmfence
+    libGL
+    vulkan-loader
+  ];
 
   # Fix read out of range on aarch64 16k pages builds
   # https://github.com/NixOS/nixpkgs/pull/365364
@@ -178,7 +162,7 @@ let
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${electronLibPath}:$out/libexec/electron" \
         $out/libexec/electron/.electron-wrapped \
-        ${lib.optionalString (lib.versionAtLeast version "15.0.0") "$out/libexec/electron/.chrome_crashpad_handler-wrapped"}
+        $out/libexec/electron/.chrome_crashpad_handler-wrapped
 
       # patch libANGLE
       patchelf \

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -6,6 +6,7 @@
   wrapGAppsHook3,
   glib,
   gtk3,
+  gtk4,
   unzip,
   at-spi2-atk,
   libdrm,
@@ -26,6 +27,11 @@
   pango,
   systemd,
   pciutils,
+  libnotify,
+  pipewire,
+  libsecret,
+  libpulseaudio,
+  speechd-minimal,
 }:
 
 version: hashes:
@@ -93,6 +99,7 @@ let
     gdk-pixbuf
     glib
     gtk3
+    gtk4
     nss
     nspr
     xorg.libX11
@@ -107,6 +114,11 @@ let
     pciutils
     stdenv.cc.cc
     systemd
+    libnotify
+    pipewire
+    libsecret
+    libpulseaudio
+    speechd-minimal
     libdrm
     libgbm
     libxkbcommon
@@ -126,6 +138,7 @@ let
     buildInputs = [
       glib
       gtk3
+      gtk4
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
- #303590 (461a23c756c31f0925159601e46b16072f9f8920, 044343966568b5a7ba61a84c61098521bb2c835a, 6a0cf40cf4f06538bee3d040f2101348e1f8526f, 280c094f629d24742cac23039ba8e5ded901e786, 92a452733de4e8b4457aeba14fd9dae67411ca57)
- #329658 (8e7a0982431b8ad99070695221bdb2d317e08030)
- #259157 (99515b5c5071b358062a382d8b455633e7bfc76d)

This should fix at least some issues with `electron-bin` on Linux like screen share (#380429).
Note that `electron-source` builds are likely slowly coming to an end, so we want to make sure the binary variant works.

Ref: https://github.com/NixOS/nixpkgs/pull/380991#issuecomment-2661314861 (cc @ImUrX)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (**x86_64-linux only!**) 
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
