### PR TITLE
{postgresql*,libpq}: replace rev with tag

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "13.20";
-  # "Stamp 13.20"
-  rev = "c8f198c3acb59ed858b5b9b88b4fbc55cece544e";
+  rev = "refs/tags/REL_13_20";
   hash = "sha256-GkDtzqwjMJipvr0wykM9Z5Tb0R7WgJA/PGPTVUXxf7Q=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "14.17";
-  # "Stamp 14.17"
-  rev = "e5cabe28006995d90cc9ebc613dad072c44c7f4a";
+  rev = "refs/tags/REL_14_17";
   hash = "sha256-BvmfxHHTcxRkWZoawvHanQeAuqHnQIh77RQjxPo5fuI=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "15.12";
-  # "Stamp 15.12"
-  rev = "50d3d22baba63613d1f1406b2ed460dc9b03c3fc";
+  rev = "refs/tags/REL_15_12";
   hash = "sha256-6my9UzW05iYwTWR9y/VTZ1RQVNudavMFfUT9dpUQ15o=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "16.8";
-  # "Stamp 16.8"
-  rev = "71eb35c0b18de96537bd3876ec9bf8075bfd484f";
+  rev = "refs/tags/REL_16_8";
   hash = "sha256-nVUGBuvCDFXozTyEDAAQa+IR3expCdztH90J68FhAXQ=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "17.4";
-  # "Stamp 17.4"
-  rev = "f8554dee417ffc4540c94cf357f7bf7d4b6e5d80";
+  rev = "refs/tags/REL_17_4";
   hash = "sha256-TEpvX28chR3CXiOQsNY12t8WfM9ywoZVX1e/6mj9DqE=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "postgres";
     repo = "postgres";
     # rev, not tag, on purpose: see generic.nix.
-    rev = "f8554dee417ffc4540c94cf357f7bf7d4b6e5d80";
+    rev = "refs/tags/REL_17_4";
     hash = "sha256-TEpvX28chR3CXiOQsNY12t8WfM9ywoZVX1e/6mj9DqE=";
   };
 


### PR DESCRIPTION
We had set the "stamped" commit in #382282, a few days before the tags appeared. The tags are now there, so we can replace them. The hashes stay the same.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
