### PR TITLE
lib.systems: add page size

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -251,6 +251,17 @@ let
         else if final.isAarch64 then "aa64"
         else final.parsed.cpu.name;
 
+      pageSize = let
+        pageSizeArg = args.pageSize or {};
+        checkValue = value: assert parse.types.pageSize.check value; value;
+      in {
+        min = checkValue (pageSizeArg.min or parse.pageSizes."4k");
+        max = checkValue (pageSizeArg.max or parse.pageSizes."64k");
+        range = builtins.attrValues (lib.filterAttrs
+          (_: v: v >= final.pageSize.min && v <= final.pageSize.max)
+            (builtins.removeAttrs parse.pageSizes [ "_type" ]));
+      };
+
       darwinArch = {
         armv7a  = "armv7";
         aarch64 = "arm64";
@@ -318,7 +329,7 @@ let
 
     }) // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
-      // args // {
+      // builtins.removeAttrs args [ "pageSize" ] // {
         rust = rust // {
           # Once args.rustc.platform.target-family is deprecated and
           # removed, there will no longer be any need to modify any

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -424,6 +424,24 @@ rec {
 
   ################################################################################
 
+  types.openPageSize = mkOptionType {
+    name = "pageSize";
+    description = "4k aligned page size value";
+    merge = mergeOneOption;
+    check = x: (x / 4096) > 0;
+  };
+
+  types.pageSize = enum (attrValues pageSizes);
+
+  pageSizes = setType types.openPageSize {
+    "4k" = 4096;
+    "16k" = 16384;
+    "32k" = 32768;
+    "64k" = 65536;
+  };
+
+  ################################################################################
+
   types.parsedPlatform = mkOptionType {
     name = "system";
     description = "fully parsed representation of llvm- or nix-style platform tuple";

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -56,7 +56,7 @@ let
       ++ map (x: "gccarch-${x}") (
         systems.architectures.inferiors.${pkgs.stdenv.hostPlatform.gcc.arch} or [ ]
       )
-    );
+    ) ++ map (v: "pages-${builtins.toString (v / 1024)}") pkgs.stdenv.hostPlatform.pageSize.range;
 
   legacyConfMappings = {
     useSandbox = "sandbox";

--- a/pkgs/by-name/bu/bun/package.nix
+++ b/pkgs/by-name/bu/bun/package.nix
@@ -121,7 +121,9 @@ stdenvNoCC.mkDerivation rec {
     platforms = builtins.attrNames passthru.sources;
     # Broken for Musl at 2024-01-13, tracking issue:
     # https://github.com/NixOS/nixpkgs/issues/280716
-    broken = stdenvNoCC.hostPlatform.isMusl;
+    # Broken on systems with page sizes > 16k
+    # https://github.com/oven-sh/bun/issues/6241
+    broken = stdenvNoCC.hostPlatform.isMusl || stdenvNoCC.hostPlatform.pageSize.min > 16384;
 
     # Hangs when run via Rosetta 2 on Apple Silicon
     hydraPlatforms = lib.lists.remove "x86_64-darwin" lib.platforms.all;

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -167,6 +167,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
+    # Versions older than 0.14 do not have a runtime page size feature.
+    broken =
+      lib.versionOlder finalAttrs.version "0.14"
+      && stdenv.hostPlatform.pageSize.min > 4096
+      && !stdenv.hostPlatform.isDarwin;
     description = "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
     homepage = "https://ziglang.org/";
     changelog = "https://ziglang.org/download/${finalAttrs.version}/release-notes.html";

--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -48,7 +48,16 @@ stdenv.mkDerivation rec {
     ]
     # AArch64 has configurable page size up to 64k. The default configuration
     # for jemalloc only supports 4k page sizes.
-    ++ lib.optional stdenv.hostPlatform.isAarch64 "--with-lg-page=16"
+    ++ lib.optional stdenv.hostPlatform.isAarch64 "--with-lg-page=${
+      {
+        "4" = "12";
+        "8" = "13";
+        "16" = "14";
+        "32" = "15";
+        "64" = "16";
+      }
+      ."${builtins.toString (stdenv.hostPlatform.pageSize.min / 1024)}"
+    }"
     # See https://github.com/jemalloc/jemalloc/issues/1997
     # Using a value of 48 should work on both emulated and native x86_64-darwin.
     ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) "--with-lg-vaddr=48";

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1436,7 +1436,23 @@ let
 
         # Enable Intel Turbo Boost Max 3.0
         INTEL_TURBO_MAX_3 = yes;
-      };
+      }
+      //
+        lib.optionalAttrs (stdenv.hostPlatform.system == "aarch64-linux" || stdenv.hostPlatform.isPower)
+          (
+            let
+              key =
+                if stdenv.hostPlatform.isPower then
+                  "PPC"
+                else if stdenv.hostPlatform.isAarch64 then
+                  "ARM64"
+                else
+                  throw "Not supported";
+            in
+            {
+              "${key}_${builtins.toString (stdenv.hostPlatform.pageSize.min / 1024)}K_PAGES" = yes;
+            }
+          );
 
     accel = {
       # Build DRM accelerator devices


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds a new page size platform value. This changes packages like the Linux kernel and jemalloc to switch page sizes easily. When a package does not support a specific page size, it can be marked as broken. The page size system feature comes from https://github.com/NixOS/nix/pull/12446.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
