### PR TITLE
treewide (Python packages): Use the buildPythonPackage-provided locale specification whenever appropriate

### DIFF
--- a/pkgs/by-name/gp/gpodder/package.nix
+++ b/pkgs/by-name/gp/gpodder/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   gitUpdater,
-  glibcLocales,
   adwaita-icon-theme,
   gobject-introspection,
   gtk3,
@@ -35,7 +34,6 @@ python311Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     intltool
     wrapGAppsHook3
-    glibcLocales
     gobject-introspection
   ];
 
@@ -72,10 +70,6 @@ python311Packages.buildPythonApplication rec {
     "share/applications/gpodder.desktop"
     "share/dbus-1/services/org.gpodder.service"
   ];
-
-  preBuild = ''
-    export LC_ALL="en_US.UTF-8"
-  '';
 
   installCheckPhase = ''
     LC_ALL=C PYTHONPATH=src/:$PYTHONPATH pytest --ignore=tests --ignore=src/gpodder/utilwin32ctypes.py --doctest-modules src/gpodder/util.py src/gpodder/jsonconfig.py

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -7,7 +7,6 @@
   coursier,
   dotnet-sdk,
   gitMinimal,
-  glibcLocales,
   go,
   nodejs,
   perl,
@@ -52,7 +51,6 @@ buildPythonApplication rec {
     [
       cargo
       gitMinimal
-      glibcLocales
       go
       libiconv # For rust tests on Darwin
       perl
@@ -101,7 +99,7 @@ buildPythonApplication rec {
     + ''
       export GIT_AUTHOR_NAME=test GIT_COMMITTER_NAME=test \
              GIT_AUTHOR_EMAIL=test@example.com GIT_COMMITTER_EMAIL=test@example.com \
-             VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1 LANG=en_US.UTF-8
+             VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1
     ''
     + lib.optionalString (!i686Linux) ''
       # Resolve `.NET location: Not found` errors for dotnet tests

--- a/pkgs/development/python-modules/cligj/default.nix
+++ b/pkgs/development/python-modules/cligj/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   click,
   pytest,
-  glibcLocales,
 }:
 
 buildPythonPackage rec {
@@ -23,11 +22,10 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest
-    glibcLocales
   ];
 
   checkPhase = ''
-    LC_ALL=en_US.utf-8 pytest tests
+    pytest tests
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/configparser/default.nix
+++ b/pkgs/development/python-modules/configparser/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -26,10 +25,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  preConfigure = ''
-    export LC_ALL=${if stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8
-  '';
 
   meta = with lib; {
     description = "Updated configparser from Python 3.7 for Python 2.6+";

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   fetchFromRepoOrCz,
   buildPythonPackage,
@@ -34,13 +33,9 @@ let
 
     nativeCheckInputs = [ pillow ];
 
-    # Only Darwin needs LANG, but we could set it in general.
-    # It's done here conditionally to prevent mass-rebuilds.
-    checkPhase =
-      lib.optionalString stdenv.hostPlatform.isDarwin ''LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" ''
-      + ''
-        ${python.interpreter} test/alltests.py
-      '';
+    checkPhase = ''
+      ${python.interpreter} test/alltests.py
+    '';
 
     # Create symlinks lacking a ".py" suffix, many programs depend on these names
     postFixup = ''

--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  glibcLocales,
   pytest,
 }:
 
@@ -17,13 +16,12 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    glibcLocales
     pytest
   ];
 
   # JPLTest uses assets not distributed in package
   checkPhase = ''
-    LC_ALL="en_US.UTF-8" pytest --pyargs ephem.tests -k "not JPLTest"
+    pytest --pyargs ephem.tests -k "not JPLTest"
   '';
 
   pythonImportsCheck = [ "ephem" ];

--- a/pkgs/development/python-modules/gruut/default.nix
+++ b/pkgs/development/python-modules/gruut/default.nix
@@ -22,7 +22,6 @@
   rapidfuzz,
 
   # checks
-  glibcLocales,
   pytestCheckHook,
 }:
 
@@ -91,7 +90,6 @@ buildPythonPackage rec {
     ]);
 
   nativeCheckInputs = [
-    glibcLocales
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
@@ -103,10 +101,6 @@ buildPythonPackage rec {
     "test_fa"
     "test_ar"
   ];
-
-  preCheck = ''
-    export LC_ALL=en_US.utf-8
-  '';
 
   pythonImportsCheck = [ "gruut" ];
 

--- a/pkgs/development/python-modules/jieba/default.nix
+++ b/pkgs/development/python-modules/jieba/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  glibcLocales,
   python,
   isPy3k,
 }:
@@ -20,15 +19,12 @@ buildPythonPackage rec {
     sha256 = "028vmd6sj6wn9l1ilw7qfmlpyiysnlzdgdlhwxs6j4fvq0gyrwxk";
   };
 
-  nativeCheckInputs = [ glibcLocales ];
-
   # UnicodeEncodeError
   doCheck = isPy3k;
 
   # Citing https://github.com/fxsjy/jieba/issues/384: "testcases is in a mess"
   # So just picking random ones that currently work
   checkPhase = ''
-    export LC_ALL=en_US.UTF-8
     ${python.interpreter} test/test.py
     ${python.interpreter} test/test_tokenize.py
   '';

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
   doCheck = !stdenv.hostPlatform.isDarwin;
   # ignore tests which incorrect fail to detect xvfb
   checkPhase = ''
-    LC_ALL="en_US.UTF-8" pytest nipype/tests -k 'not display and not test_no_et_multiproc'
+    pytest nipype/tests -k 'not display and not test_no_et_multiproc'
   '';
   pythonImportsCheck = [ "nipype" ];
 

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -53,7 +53,6 @@
   # tests
   adv_cmds,
   glibc,
-  glibcLocales,
   hypothesis,
   pytestCheckHook,
   pytest-xdist,
@@ -179,7 +178,6 @@ let
 
     nativeCheckInputs =
       [
-        glibcLocales
         hypothesis
         pytest-asyncio
         pytest-xdist
@@ -231,7 +229,6 @@ let
     preCheck =
       ''
         export HOME=$TMPDIR
-        export LC_ALL="en_US.UTF-8"
         cd $out/${python.sitePackages}/pandas
       ''
       # TODO: Get locale and clipboard support working on darwin.

--- a/pkgs/development/python-modules/pathlib2/default.nix
+++ b/pkgs/development/python-modules/pathlib2/default.nix
@@ -5,7 +5,6 @@
   six,
   pythonOlder,
   scandir ? null,
-  glibcLocales,
   typing,
 }:
 
@@ -25,11 +24,6 @@ buildPythonPackage rec {
       scandir
       typing
     ];
-  nativeCheckInputs = [ glibcLocales ];
-
-  preCheck = ''
-    export LC_ALL="en_US.UTF-8"
-  '';
 
   meta = with lib; {
     description = "This module offers classes representing filesystem paths with semantics appropriate for different operating systems";

--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
+  stdenv,
 
   # build-system
   setuptools,
@@ -53,6 +54,10 @@ buildPythonPackage rec {
   preCheck = ''
     # necessary on darwin to pass the testsuite
     export LANG=en_US.UTF-8
+  '';
+
+  postCheck = ''
+    export LANG=${if stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -6,7 +6,6 @@
   libmediainfo,
   setuptools-scm,
   pytest,
-  glibcLocales,
   pythonOlder,
 }:
 
@@ -35,12 +34,10 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools-scm ];
 
   nativeCheckInputs = [
-    glibcLocales
     pytest
   ];
 
   checkPhase = ''
-    export LC_ALL=en_US.UTF-8
     py.test -k 'not test_parse_url' tests
   '';
 

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -51,10 +51,6 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  preCheck = ''
-    export LANG="en_US.UTF-8"
-  '';
-
   disabledTests =
     [
       # https://github.com/pyca/pyopenssl/issues/692

--- a/pkgs/development/python-modules/pyrect/default.nix
+++ b/pkgs/development/python-modules/pyrect/default.nix
@@ -22,10 +22,6 @@ buildPythonPackage rec {
     pygame
   ];
 
-  preCheck = ''
-    export LC_ALL="en_US.UTF-8"
-  '';
-
   pythonImportsCheck = [ "pyrect" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -44,6 +44,10 @@ buildPythonPackage rec {
     export LC_ALL=en_US.UTF-8
   '';
 
+  postCheck = ''
+    unset LC_ALL
+  '';
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/reportlab/default.nix
+++ b/pkgs/development/python-modules/reportlab/default.nix
@@ -6,7 +6,6 @@
   freetype,
   pillow,
   setuptools,
-  glibcLocales,
   python,
   isPyPy,
 }:
@@ -49,12 +48,10 @@ buildPythonPackage rec {
     pillow
   ];
 
-  nativeCheckInputs = [ glibcLocales ];
-
   checkPhase = ''
     runHook preCheck
     pushd tests
-    LC_ALL="en_US.UTF-8" ${python.interpreter} runAll.py
+    ${python.interpreter} runAll.py
     popd
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -27,10 +27,6 @@ buildPythonPackage rec {
   doCheck = false;
   pythonImportsCheck = [ "sympy" ];
 
-  preCheck = ''
-    export LANG="en_US.UTF-8"
-  '';
-
   passthru.tests = {
     inherit sage;
   };

--- a/pkgs/development/tools/continuous-integration/buildbot/master.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/master.nix
@@ -41,7 +41,6 @@
   importlib-resources,
   packaging,
   unidiff,
-  glibcLocales,
   nixosTests,
 }:
 
@@ -136,7 +135,6 @@ buildPythonApplication rec {
     parameterized
     git
     openssh
-    glibcLocales
   ];
 
   patches = [
@@ -155,7 +153,6 @@ buildPythonApplication rec {
   doCheck = !stdenv.hostPlatform.isAarch64;
 
   preCheck = ''
-    export LC_ALL="en_US.UTF-8"
     export PATH="$out/bin:$PATH"
   '';
 


### PR DESCRIPTION
Use the locale specification provided by `buildPythonPackage` in commit 1fccd255953b6025a4d0342c2cf5641e5b6b6ced whenever appropriate.

For packages that requires custom locale settings during installCheckPhase, this PR ensures that they set it back at the end of the phase.

Continuation of #55826

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
