### PR TITLE
serial-studio: 1.1.7 -> 3.0.6 + fixes

### DIFF
--- a/pkgs/by-name/se/serial-studio/0001-CMake-Deploy-Fix.patch
+++ b/pkgs/by-name/se/serial-studio/0001-CMake-Deploy-Fix.patch
@@ -1,0 +1,45 @@
+diff --git a/app/CMakeLists.txt b/app/CMakeLists.txt
+index e69150cd..c4ce7975 100644
+--- a/app/CMakeLists.txt
++++ b/app/CMakeLists.txt
+@@ -257,16 +257,16 @@ elseif(APPLE)
+   MACOSX_BUNDLE_INFO_PLIST ${INFO_MACOSX}
+  )
+ elseif(UNIX)
+- install(TARGETS ${PROJECT_EXECUTABLE} RUNTIME DESTINATION /usr/bin)
++ install(TARGETS ${PROJECT_EXECUTABLE} RUNTIME DESTINATION bin)
+ 
+  install(
+   FILES ${CMAKE_CURRENT_SOURCE_DIR}/deploy/linux/serial-studio.png
+-  DESTINATION /usr/share/pixmaps
++  DESTINATION share/pixmaps
+  )
+ 
+ install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/deploy/linux/serial-studio.desktop
+- DESTINATION /usr/share/applications
++ DESTINATION share/applications
+ )
+ endif()
+ 
+@@ -289,17 +289,6 @@ elseif(WIN32)
+  set(deploy_tool_options_arg --no-compiler-runtime -force-openssl --release)
+ endif()
+ 
+-qt_generate_deploy_qml_app_script(
+- TARGET ${PROJECT_EXECUTABLE}
+- OUTPUT_SCRIPT deploy_script
+- MACOS_BUNDLE_POST_BUILD
+- NO_UNSUPPORTED_PLATFORM_ERROR
+- DEPLOY_USER_QML_MODULES_ON_UNSUPPORTED_PLATFORM
+- DEPLOY_TOOL_OPTIONS ${deploy_tool_options_arg}
+-)
+-
+-install(SCRIPT ${deploy_script})
+-
+ #-------------------------------------------------------------------------------
+ # Packaging
+ #-------------------------------------------------------------------------------
+-- 
+2.47.2
+

--- a/pkgs/by-name/se/serial-studio/0002-Connect-Button-Fix.patch
+++ b/pkgs/by-name/se/serial-studio/0002-Connect-Button-Fix.patch
@@ -1,0 +1,16 @@
+diff --git a/app/qml/MainWindow/Panes/Toolbar.qml b/app/qml/MainWindow/Panes/Toolbar.qml
+index 9b59c0c2..fa428a2f 100644
+--- a/app/qml/MainWindow/Panes/Toolbar.qml
++++ b/app/qml/MainWindow/Panes/Toolbar.qml
+@@ -320,7 +320,7 @@ Rectangle {
+       font: Cpp_Misc_CommonFonts.boldUiFont
+       Layout.minimumWidth: metrics.width + 16
+       Layout.maximumWidth: metrics.width + 16
+-      enabled: Cpp_IO_Manager.configurationOk && !Cpp_CSV_Player.isOpen && !Cpp_MQTT_Client.isSubscribed
++      enabled: Cpp_IO_Manager.configurationOk && !Cpp_CSV_Player.isOpen
+       text: checked ? qsTr("Disconnect") : qsTr("Connect")
+       icon.source: checked ? "qrc:/rcc/icons/toolbar/connect.svg" :
+                              "qrc:/rcc/icons/toolbar/disconnect.svg"
+-- 
+2.47.2
+

--- a/pkgs/by-name/se/serial-studio/package.nix
+++ b/pkgs/by-name/se/serial-studio/package.nix
@@ -2,34 +2,44 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
-  qtquickcontrols2,
-  qtserialport,
-  qtsvg,
-  wrapQtAppsHook,
+  cmake,
+  qt6,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
   pname = "serial-studio";
-  version = "1.1.7";
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "Serial-Studio";
     repo = "Serial-Studio";
     rev = "v${version}";
-    hash = "sha256-Tsd1PGB7cO8h3HDifOtB8jsnj+fS4a/o5nfLoohVLM4=";
+    hash = "sha256-q3RWy3HRs5NG0skFb7PSv8jK5pI5rtbccP8j38l8kjM=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    qmake
-    wrapQtAppsHook
+    cmake
+    qt6.wrapQtAppsHook
+    pkg-config
   ];
 
   buildInputs = [
-    qtquickcontrols2
-    qtserialport
-    qtsvg
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.qtgraphs
+    qt6.qtlocation
+    qt6.qtconnectivity
+    qt6.qttools
+    qt6.qtserialport
+    qt6.qtpositioning
+  ];
+
+  patches = [
+    ./0001-CMake-Deploy-Fix.patch
+    ./0002-Connect-Button-Fix.patch
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18086,8 +18086,6 @@ with pkgs;
     pinentry = pinentry-curses;
   };
 
-  serial-studio = libsForQt5.callPackage ../applications/misc/serial-studio { };
-
   maphosts = callPackage ../tools/networking/maphosts { };
 
   tora = libsForQt5.callPackage ../development/tools/tora { };


### PR DESCRIPTION
* Update serial-studio from 1.1.7 to 3.0.6
* Update dependencies to QT6
* Fix some deployment issues interfering with Nix QT handling
* Fix an issue where the "Connect" button would not become available after selecting a serial port due to a missing MQTT reference, that one was actually also present when using the official AppImage for me and might be an upstream issue (Edit: [Issue raised with upstream](https://github.com/Serial-Studio/Serial-Studio/issues/269))
* Moved to `pkgs/by-name`

* Tested for correct functionality with a small serial project of my own

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
