### PR TITLE
lomiri.lomiri-system-settings-unwrapped: Fix ICU >74 compat, back out of ICU 76

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   testers,
   accountsservice,
@@ -17,7 +18,7 @@
   gnome-desktop,
   gsettings-qt,
   gtk3,
-  icu,
+  icu75,
   intltool,
   json-glib,
   libqofono,
@@ -62,7 +63,17 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  patches = [ ./2000-Support-wrapping-for-Nixpkgs.patch ];
+  patches = [
+    # Fixes compat with newer ICU
+    # Remove when version > 1.3.0
+    (fetchpatch {
+      name = "0001-lomiri-system-settings-unwrapped-Unpin-Cxx-standard.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/c0b1c773237b28ea50850810b8844033b13fb666.patch";
+      hash = "sha256-M73gQxstKyuzzx1VxdOiNYyfQbSZPIy2gxiCtKcdS1M=";
+    })
+
+    ./2000-Support-wrapping-for-Nixpkgs.patch
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -110,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     gnome-desktop
     gsettings-qt
     gtk3
-    icu
+    icu75
     json-glib
     polkit
     qtbase


### PR DESCRIPTION
1. ICUs >74 need a C++ standard newer than C++11, apply patch to allow ICU 75 and up
2. …and immediately pin ICU to version 75, because 76's pc files seem borked and don't propagate their link dependencies properly
    ```
    [100%] Linking CXX shared module libLomiriLanguagePlugin.so
    /nix/store/9g4gsby96w4cx1i338kplaap0x37apdf-binutils-2.43.1/bin/ld: CMakeFiles/LomiriLanguagePlugin.dir/keyboard-layout.cpp.o: undefined reference to symbol '_ZN6icu_768ByteSinkD2Ev'
    /nix/store/9g4gsby96w4cx1i338kplaap0x37apdf-binutils-2.43.1/bin/ld: /nix/store/jbnm36wq89c7iws6xx6xvv75h0drv48x-icu4c-76.1/lib/libicuuc.so.76: error adding symbols: DSO missing from command line
    ```
    - It's been noted before that something odd is going on with those pkg-config flags in https://github.com/NixOS/nixpkgs/pull/345289#discussion_r1780828747, @wolfgangwalther, did you end up looking into this by chance?
    - [Debian is applying a revert](https://sources.debian.org/src/icu/76.1-2/debian/patches/reverse_of_ICU-22610.patch/) of [the commit that caused this](https://github.com/unicode-org/icu/commit/199bc827021ffdb43b6579d68e5eecf54c7f6f56) to fix this for all reverse dependencies, maybe we should do something similar?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
