### PR TITLE
lomiri.lomiri-indicator-transfer: init at 1.2.0

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -154,7 +154,10 @@ in
           )
           ++ (
             with pkgs.lomiri;
-            [ lomiri-telephony-service ]
+            [
+              lomiri-indicator-transfer
+              lomiri-telephony-service
+            ]
             ++ lib.optionals config.networking.networkmanager.enable [ lomiri-indicator-network ]
           );
       };

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -43,6 +43,7 @@ in
           ]
           ++ (with pkgs.lomiri; [
             lomiri-indicator-network
+            lomiri-indicator-transfer
             lomiri-telephony-service
           ]);
       };

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -807,9 +807,10 @@ in
     # messages normally has no contents
     ({
       name = "display";
-      left = 6;
+      left = 7;
       ocr = [ "Lock" ];
     })
+    # transfer normally has no contents
     ({
       name = "bluetooth";
       left = 5;

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -64,6 +64,7 @@ let
       lomiri-download-manager = callPackage ./services/lomiri-download-manager { };
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
+      lomiri-indicator-transfer-unwrapped = callPackage ./services/lomiri-indicator-transfer { };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -65,6 +65,9 @@ let
       lomiri-history-service = callPackage ./services/lomiri-history-service { };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-indicator-transfer-unwrapped = callPackage ./services/lomiri-indicator-transfer { };
+      lomiri-indicator-transfer-buteo =
+        callPackage ./services/lomiri-indicator-transfer/plugins/lomiri-indicator-transfer-buteo.nix
+          { };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -68,6 +68,7 @@ let
       lomiri-indicator-transfer-buteo =
         callPackage ./services/lomiri-indicator-transfer/plugins/lomiri-indicator-transfer-buteo.nix
           { };
+      lomiri-indicator-transfer = callPackage ./services/lomiri-indicator-transfer/wrapper.nix { };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
       lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/2001-Handle-plugin-location-via-wrapper.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/2001-Handle-plugin-location-via-wrapper.patch
@@ -1,0 +1,169 @@
+From c9ba906c9878f3b8c8c876438d82ec5d4c90af4c Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 20 Feb 2025 20:07:18 +0100
+Subject: [PATCH] Handle plugin location via wrapper
+
+---
+ CMakeLists.txt                            | 11 +++++++++--
+ data/CMakeLists.txt                       |  2 --
+ data/lomiri-indicator-transfer.desktop.in |  2 +-
+ data/lomiri-indicator-transfer.pc.in      |  3 ++-
+ data/lomiri-indicator-transfer.service.in |  2 +-
+ src/CMakeLists.txt                        |  8 +++++---
+ src/dm-plugin/CMakeLists.txt              |  2 +-
+ src/main.cpp                              | 14 +++++++++++++-
+ 8 files changed, 32 insertions(+), 12 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b4397bc..dc59965 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,8 +21,15 @@ if (EXISTS "/etc/debian_version") # Workaround for libexecdir on debian
+   set (CMAKE_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBDIR}")
+   set (CMAKE_INSTALL_FULL_LIBEXECDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+ endif ()
+-set (CMAKE_INSTALL_PKGLIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
+-set (CMAKE_INSTALL_FULL_PKGLIBEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
++
++set (PLUGINDIR "${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
++set (PLUGINDIR_SUFFIX "${PLUGINDIR}")
++
++if (CMAKE_VERSION VERSION_LESS "3.20")
++    file (RELATIVE_PATH PLUGINDIR_SUFFIX "${CMAKE_INSTALL_PREFIX}" "${PLUGINDIR}")
++else()
++    cmake_path (RELATIVE_PATH PLUGINDIR_SUFFIX BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
++endif()
+ 
+ ##
+ ## Version
+diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
+index e5e5b85..b356d40 100644
+--- a/data/CMakeLists.txt
++++ b/data/CMakeLists.txt
+@@ -11,7 +11,6 @@ set (SYSTEMD_USER_FILE "${CMAKE_CURRENT_BINARY_DIR}/${SYSTEMD_USER_NAME}")
+ set (SYSTEMD_USER_FILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/${SYSTEMD_USER_NAME}.in")
+ 
+ # build it
+-set (pkglibexecdir "${CMAKE_INSTALL_FULL_PKGLIBEXECDIR}")
+ configure_file ("${SYSTEMD_USER_FILE_IN}" "${SYSTEMD_USER_FILE}")
+ 
+ # install it
+@@ -31,7 +30,6 @@ set (XDG_AUTOSTART_FILE "${CMAKE_CURRENT_BINARY_DIR}/${XDG_AUTOSTART_NAME}")
+ set (XDG_AUTOSTART_FILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/${XDG_AUTOSTART_NAME}.in")
+ 
+ # build it
+-set (pkglibexecdir "${CMAKE_INSTALL_FULL_PKGLIBEXECDIR}")
+ configure_file ("${XDG_AUTOSTART_FILE_IN}" "${XDG_AUTOSTART_FILE}")
+ 
+ # install it
+diff --git a/data/lomiri-indicator-transfer.desktop.in b/data/lomiri-indicator-transfer.desktop.in
+index 384c088..08c0847 100644
+--- a/data/lomiri-indicator-transfer.desktop.in
++++ b/data/lomiri-indicator-transfer.desktop.in
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Type=Application
+ Name=Lomiri Indicator Transfer
+-Exec=@pkglibexecdir@/lomiri-indicator-transfer-service
++Exec=@PLUGINDIR@/lomiri-indicator-transfer-service
+ OnlyShowIn=Unity;GNOME;
+ NoDisplay=true
+ StartupNotify=false
+diff --git a/data/lomiri-indicator-transfer.pc.in b/data/lomiri-indicator-transfer.pc.in
+index 5ed09c0..c7d1eff 100644
+--- a/data/lomiri-indicator-transfer.pc.in
++++ b/data/lomiri-indicator-transfer.pc.in
+@@ -1,6 +1,7 @@
++prefix=@CMAKE_INSTALL_PREFIX@
+ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@CMAKE_PROJECT_NAME@
+-plugindir=@CMAKE_INSTALL_FULL_PKGLIBEXECDIR@
++plugindir=${prefix}/@PLUGINDIR_SUFFIX@
+ 
+ Name: @CMAKE_PROJECT_NAME@
+ Description: Developer files for @CMAKE_PROJECT_NAME@
+diff --git a/data/lomiri-indicator-transfer.service.in b/data/lomiri-indicator-transfer.service.in
+index 8ebc933..86386d0 100644
+--- a/data/lomiri-indicator-transfer.service.in
++++ b/data/lomiri-indicator-transfer.service.in
+@@ -4,7 +4,7 @@ PartOf=graphical-session.target
+ PartOf=lomiri-indicators.target
+ 
+ [Service]
+-ExecStart=@pkglibexecdir@/lomiri-indicator-transfer-service
++ExecStart=@PLUGINDIR@/lomiri-indicator-transfer-service
+ Restart=on-failure
+ 
+ [Install]
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d42b087..f668b8b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -33,13 +33,15 @@ link_directories (${SERVICE_DEPS_LIBRARY_DIRS})
+ set (SERVICE_EXEC_HANDWRITTEN_SOURCES main.cpp)
+ add_executable (${SERVICE_EXEC} ${SERVICE_EXEC_HANDWRITTEN_SOURCES})
+ target_link_libraries (${SERVICE_EXEC} ${SERVICE_LIB} ${SERVICE_DEPS_LIBRARIES} ${GCOV_LIBS})
+-install (TARGETS ${SERVICE_EXEC} RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_PKGLIBEXECDIR})
++install (TARGETS ${SERVICE_EXEC} RUNTIME DESTINATION ${PLUGINDIR})
+ 
+ # add warnings/coverage info on handwritten files
+ # but not the generated ones...
+ set_property (SOURCE ${SERVICE_LIB_HANDWRITTEN_SOURCES} ${SERVICE_EXEC_HANDWRITTEN_SOURCES}
+-              APPEND_STRING PROPERTY COMPILE_FLAGS " -std=c++11 -fPIC -g ${CXX_WARNING_ARGS} ${GCOV_FLAGS}")
++              APPEND_STRING PROPERTY COMPILE_FLAGS " -fPIC -g ${CXX_WARNING_ARGS} ${GCOV_FLAGS}")
+ 
+-set_property (SOURCE main.cpp APPEND PROPERTY COMPILE_DEFINITIONS PLUGINDIR="${CMAKE_INSTALL_FULL_PKGLIBEXECDIR}")
++set_property (SOURCE main.cpp APPEND PROPERTY COMPILE_DEFINITIONS
++              PLUGINDIR_FALLBACK="${CMAKE_INSTALL_PREFIX}"
++              PLUGINDIR_SUFFIX="${PLUGINDIR_SUFFIX}")
+ 
+ add_subdirectory (dm-plugin)
+diff --git a/src/dm-plugin/CMakeLists.txt b/src/dm-plugin/CMakeLists.txt
+index ee6505b..ab59ccd 100644
+--- a/src/dm-plugin/CMakeLists.txt
++++ b/src/dm-plugin/CMakeLists.txt
+@@ -15,7 +15,7 @@ target_link_libraries (${DM_LIB}
+     ${SERVICE_DEPS_LIBRARIES}
+     ${GCOV_LIBS})
+ 
+-install(TARGETS ${DM_LIB} LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_PKGLIBEXECDIR})
++install(TARGETS ${DM_LIB} LIBRARY DESTINATION ${PLUGINDIR})
+ 
+ set_property (SOURCE ${DM_SOURCES}
+               APPEND_STRING PROPERTY COMPILE_FLAGS " -fPIC -g ${CXX_WARNING_ARGS} ${GCOV_FLAGS}")
+diff --git a/src/main.cpp b/src/main.cpp
+index 385add9..095c336 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -25,6 +25,9 @@
+ #include <glib/gi18n.h> // bindtextdomain()
+ #include <gio/gio.h>
+ 
++#include <cstdlib>
++#include <cstring>
++#include <filesystem>
+ #include <locale.h>
+ 
+ using namespace lomiri::indicator::transfer;
+@@ -43,8 +46,17 @@ main(int /*argc*/, char** /*argv*/)
+ 
+     auto loop = g_main_loop_new(nullptr, false);
+ 
++    // Find out where we should look for plugins
++		std::filesystem::path pluginDir(PLUGINDIR_FALLBACK);
++
++    const char* pluginDirEnv = std::getenv("LOMIRI_INDICATOR_TRANSFER_PLUGINDIR");
++    if(std::strlen(pluginDirEnv) > 0)
++        pluginDir = pluginDirEnv;
++
++    pluginDir /= PLUGINDIR_SUFFIX;
++
+     // run until we lose the busname
+-    auto source = std::make_shared<PluginSource>(PLUGINDIR);
++    auto source = std::make_shared<PluginSource>(pluginDir.string());
+     auto controller = std::make_shared<Controller>(source);
+     GMenuView menu_view (controller);
+     // FIXME: listen for busname-lost
+-- 
+2.47.2
+

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/default.nix
@@ -1,0 +1,124 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  testers,
+  cmake,
+  cmake-extras,
+  dbus,
+  dbus-test-runner,
+  gettext,
+  glib,
+  gtest,
+  json-glib,
+  lomiri-app-launch,
+  pkg-config,
+  properties-cpp,
+  systemdLibs,
+  ubports-click,
+  valgrind,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-indicator-transfer-unwrapped";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-indicator-transfer";
+    tag = finalAttrs.version;
+    hash = "sha256-tho1W3SU92p2o8ZqI55FgWFW7VgwbRMaRrqUlBeO5P4=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Only pass suffix, wrapping will set the prefix under which plugins are collected
+    ./2001-Handle-plugin-location-via-wrapper.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})' \
+      --replace-fail '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+  ];
+
+  buildInputs = [
+    glib
+    json-glib
+    lomiri-app-launch
+    properties-cpp
+    systemdLibs
+    ubports-click
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    valgrind
+  ];
+
+  checkInputs = [
+    cmake-extras
+    dbus-test-runner
+    gtest
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "enable_tests" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "enable_lcov" false)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (
+      let
+        disabledTests =
+          [
+            # Errors on untouched code in tests, maybe hasn't been run in awhile by upstream
+            "cppcheck"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+            # https://gitlab.com/ubports/development/core/lomiri-indicator-transfer/-/issues/3
+            "test-multisource"
+          ];
+      in
+      lib.optionalString (lib.lists.length disabledTests > 0) (
+        lib.concatStringsSep ";" [
+          "-E"
+          (lib.strings.escapeShellArg "^(${lib.concatStringsSep "|" disabledTests})")
+        ]
+      )
+    ))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      # version is major.0.0
+      versionCheck = false;
+    };
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Indicator which shows file/data transfers in the indicator bar";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-indicator-transfer";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-indicator-transfer/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    pkgConfigModules = [
+      "lomiri-indicator-transfer"
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/plugins/1001-lomiri-indicator-transfer-buteo-Drop-qt5_use_modules-usage.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/plugins/1001-lomiri-indicator-transfer-buteo-Drop-qt5_use_modules-usage.patch
@@ -1,0 +1,38 @@
+From 59734a33cebb317f06af2342cadea792cba69bd0 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 20 Feb 2025 19:42:49 +0100
+Subject: [PATCH] tests/CMakeLists.txt: Drop qt5_use_modules usage
+
+---
+ tests/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 75a9712..00a3df9 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -1,3 +1,5 @@
++find_package(Qt5Test REQUIRED)
++
+ add_executable(tst-transfer-plugin
+     tst-transfer-plugin.cpp
+     ${CMAKE_SOURCE_DIR}/src/buteo-source.cpp
+@@ -7,6 +9,7 @@ add_executable(tst-transfer-plugin
+ target_link_libraries(tst-transfer-plugin
+     Qt5::Core
+     Qt5::DBus
++    Qt5::Test
+     Qt5::Xml
+     ${GMODULE_LIBRARIES}
+     ${TRANSFER_INDICATOR_LIBRARIES}
+@@ -22,7 +25,6 @@ include_directories(
+     ${ACCOUNTS_QT5_INCLUDE_DIRS}
+ )
+ 
+-qt5_use_modules(tst-transfer-plugin Core Test)
+ add_definitions(-std=c++11)
+ 
+ find_program(DBUS_RUNNER_BIN dbus-test-runner)
+-- 
+2.47.2
+

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/plugins/lomiri-indicator-transfer-buteo.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/plugins/lomiri-indicator-transfer-buteo.nix
@@ -1,0 +1,101 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  accounts-qt,
+  cmake,
+  dbus,
+  dbus-test-runner,
+  gettext,
+  gobject-introspection,
+  lomiri-indicator-transfer-unwrapped,
+  lomiri-url-dispatcher,
+  pkg-config,
+  properties-cpp,
+  python3,
+  qtbase,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-indicator-transfer-buteo";
+  version = "0.4";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-indicator-transfer-buteo";
+    tag = finalAttrs.version;
+    hash = "sha256-2T7fUakO0KYGEO3Ggjw1MAugnFGYzqlS+xZejbkVDVA=";
+  };
+
+  patches = [
+    ./1001-lomiri-indicator-transfer-buteo-Drop-qt5_use_modules-usage.patch
+  ];
+
+  postPatch =
+    ''
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail 'pkg-config --variable=plugindir lomiri-indicator-transfer' 'pkg-config --define-variable=prefix=''${CMAKE_INSTALL_PREFIX} --variable=plugindir lomiri-indicator-transfer'
+    ''
+    + (
+      if finalAttrs.finalPackage.doCheck then
+        ''
+          patchShebangs tests/buteo-syncfw.py
+        ''
+      else
+        ''
+          substituteInPlace CMakeLists.txt \
+            --replace-fail 'add_subdirectory(tests)' '# add_subdirectory(tests)'
+        ''
+    );
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    pkg-config
+  ];
+
+  buildInputs = [
+    accounts-qt
+    lomiri-indicator-transfer-unwrapped
+    lomiri-url-dispatcher
+    properties-cpp
+    qtbase
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    dbus-test-runner
+    gobject-introspection
+    (python3.withPackages (
+      ps: with ps; [
+        dbus-python
+        pygobject3
+      ]
+    ))
+  ];
+
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # To make accounts-qt abit happier
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
+
+  meta = {
+    description = "Buteo plugin for the Lomiri Transfer Indicator";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-indicator-transfer-buteo";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-indicator-transfer-buteo/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/wrapper.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-transfer/wrapper.nix
@@ -1,0 +1,98 @@
+{
+  stdenvNoCC,
+  lib,
+  nixosTests,
+  glib,
+  lndir,
+  lomiri-indicator-transfer-unwrapped,
+  lomiri-indicator-transfer-buteo,
+  wrapGAppsHook3,
+  wrapQtAppsHook,
+  plugins ? [
+    lomiri-indicator-transfer-buteo
+  ],
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lomiri-indicator-transfer";
+  inherit (lomiri-indicator-transfer-unwrapped) version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    lndir
+    wrapGAppsHook3
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    glib # schema hook
+    lomiri-indicator-transfer-unwrapped
+  ] ++ plugins;
+
+  installPhase = ''
+    runHook preInstall
+
+    for inheritedPath in share/ayatana; do
+      mkdir -p $out/$inheritedPath
+      lndir ${lomiri-indicator-transfer-unwrapped}/$inheritedPath $out/$inheritedPath
+    done
+
+    for updatedFile in \
+      etc/xdg/autostart/lomiri-indicator-transfer.desktop \
+      share/systemd/user/lomiri-indicator-transfer.service
+    do
+      mkdir -p "$(dirname $out/$updatedFile)"
+      cp ${lomiri-indicator-transfer-unwrapped}/$updatedFile $out/$updatedFile
+      substituteInPlace $out/$updatedFile \
+        --replace-fail '${lomiri-indicator-transfer-unwrapped}' "$out"
+    done
+
+    for mergedPath in libexec/lomiri-indicator-transfer share/locale; do
+      mkdir -p $out/$mergedPath
+      for lssPart in ${lomiri-indicator-transfer-unwrapped} ${lib.strings.concatStringsSep " " plugins}; do
+        lndir $lssPart/$mergedPath $out/$mergedPath
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  # Both apply wrapping to solibs in libexec
+  dontWrapGApps = true;
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --set LOMIRI_INDICATOR_TRANSFER_PLUGINDIR "$out"
+    )
+  '';
+
+  postFixup = ''
+    wrapQtApp $out/libexec/lomiri-indicator-transfer/lomiri-indicator-transfer-service
+  '';
+
+  passthru = {
+    ayatana-indicators = {
+      lomiri-indicator-transfer = [ "lomiri" ];
+    };
+    tests.vm = nixosTests.ayatana-indicators;
+  };
+
+  meta = {
+    inherit (lomiri-indicator-transfer-unwrapped.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      platforms
+      ;
+    description = lomiri-indicator-transfer-unwrapped.meta.description + " (wrapped)";
+    priority = (lomiri-indicator-transfer-unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
+  };
+})


### PR DESCRIPTION
WIP.

Has the base indicator, a `buteo-syncfw` plugin, and a wrapper that lets the indicator actually find plugins from Nixpkgs.

Everything should build with tests enabled, and the basic ayatana-indicator VM test passes, but:
- I haven't tested the graphical/Lomiri side of it, partly because dealing with the mouse inside of our interactive VM setup is a major PITA
- our `buteo-syncfw` setup may be lacking abit, will need to check if we need to include any patches from Debian/UBtouch for the plugin to properly interact with it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
