### PR TITLE
python312Packages.pytensor: 2.26.4 -> 2.28.0; python312Packages.pymc: 5.20.0 -> 5.20.1

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -19,6 +19,7 @@
   blackjax,
   numpyro,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -58,14 +59,15 @@ buildPythonPackage rec {
     blackjax
     numpyro
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   disabledTests =
     [
+      # AssertionError: assert (<xarray.DataArray 'yield' ()> Size: 1B\narray(False) & <xarray.DataArray 'yield' ()> Size: 1B\narray(False))
+      # https://github.com/bambinos/bambi/issues/888
+      "test_beta_regression"
+
       # Tests require network access
       "test_alias_equal_to_name"
       "test_average_by"

--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "pymc";
-  version = "5.20.0";
+  version = "5.20.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
     repo = "pymc";
     tag = "v${version}";
-    hash = "sha256-5iHm+q4ykXhCntUpZmEfZc1805+GoCQR3yrkQGJ2qQg=";
+    hash = "sha256-Vc+yjMd5XCM97Y0JIfII+PfNz0rx1hi9N370mgBbO+8=";
   };
 
   postPatch = ''
@@ -40,6 +40,10 @@ buildPythonPackage rec {
   build-system = [
     setuptools
     versioneer
+  ];
+
+  pythonRelaxDeps = [
+    "pytensor"
   ];
 
   dependencies = [
@@ -64,7 +68,7 @@ buildPythonPackage rec {
   meta = {
     description = "Bayesian estimation, particularly using Markov chain Monte Carlo (MCMC)";
     homepage = "https://github.com/pymc-devs/pymc";
-    changelog = "https://github.com/pymc-devs/pymc/releases/tag/${src.tag}";
+    changelog = "https://github.com/pymc-devs/pymc/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       nidabdella

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -25,21 +25,21 @@
   pytest-mock,
   pytestCheckHook,
   tensorflow-probability,
-  pythonAtLeast,
+  writableTmpDirAsHomeHook,
 
   nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.26.4";
+  version = "2.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
     repo = "pytensor";
     tag = "rel-${version}";
-    hash = "sha256-pREyBedkF9MW7g3Bctnk8C9vVbRTsLLreldxlqDdHVI=";
+    hash = "sha256-jwx7fcMiFNvnwP746nM2rqo2BD6PEbKkfEwIz8MenN4=";
   };
 
   pythonRelaxDeps = [
@@ -69,11 +69,8 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
     tensorflow-probability
+    writableTmpDirAsHomeHook
   ];
-
-  preBuild = ''
-    export HOME=$(mktemp -d)
-  '';
 
   pythonImportsCheck = [ "pytensor" ];
 
@@ -94,6 +91,10 @@ buildPythonPackage rec {
 
       # Failure reported upstream: https://github.com/pymc-devs/pytensor/issues/980
       "test_choose_signature"
+
+      # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
+      # Mismatched elements: 9 / 81 (11.1%)
+      "test_jax_pad"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # pytensor.link.c.exceptions.CompileError: Compilation failed (return status=1)
@@ -111,6 +112,7 @@ buildPythonPackage rec {
       "test_NoOutputFromInplace"
       "test_OpFromGraph"
       "test_adv_sub1_sparse_grad"
+      "test_alloc"
       "test_binary"
       "test_borrow_input"
       "test_borrow_output"
@@ -136,6 +138,7 @@ buildPythonPackage rec {
       "test_mul_s_v_grad"
       "test_multiple_outputs"
       "test_not_inplace"
+      "test_numba_Cholesky_grad"
       "test_numba_pad"
       "test_optimizations_preserved"
       "test_overided_function"
@@ -146,6 +149,7 @@ buildPythonPackage rec {
       "test_scan_err1"
       "test_scan_err2"
       "test_shared"
+      "test_solve_triangular_grad"
       "test_structured_add_s_v_grad"
       "test_structureddot_csc_grad"
       "test_structureddot_csr_grad"
@@ -157,18 +161,29 @@ buildPythonPackage rec {
       "test_update_equiv"
       "test_update_same"
     ]
-    ++ lib.optionals (pythonAtLeast "3.12") [
-      # Flaky: TypeError: cannot pickle 'PyCapsule' object
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # Fatal Python error: Segmentation fault
+      # pytensor/link/basic.py", line 665 in thunk
+      "test_Unique"
+      "test_aligned_RandomVariable"
       "test_blockwise"
-      "test_blockwise_benchmark"
+      "test_mvnormal_cov_decomposition_method"
+      "test_unnatural_batched_dims"
     ];
 
-  disabledTestPaths = [
-    # Don't run the most compute-intense tests
-    "tests/scan/"
-    "tests/tensor/"
-    "tests/sparse/sandbox/"
-  ];
+  disabledTestPaths =
+    [
+      # Don't run the most compute-intense tests
+      "tests/scan/"
+      "tests/tensor/"
+      "tests/sparse/sandbox/"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # Fatal Python error: Segmentation fault
+      # pytensor/link/basic.py", line 665 in thunk
+      "tests/link/numba/test_nlinalg.py"
+      "tests/link/numba/test_slinalg.py"
+    ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [
@@ -187,8 +202,5 @@ buildPythonPackage rec {
       bcdarwin
       ferrine
     ];
-    # Not yet compatible with numpy >= 2.0
-    # https://github.com/pymc-devs/pytensor/issues/688
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- **python312Packages.pytensor: 2.26.4 -> 2.28.0**
- **python312Packages.pymc: 5.20.0 -> 5.20.1**

cc @bcdarwin @ferrine @nidabdella

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
