### PR TITLE
lib.genAttrs: make argument's order curry-friendly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       libVersionInfoOverlay = import ./lib/flake-version-info.nix self;
       lib = (import ./lib).extend libVersionInfoOverlay;
 
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      forAllSystems = f: lib.genAttrs f lib.systems.flakeExposed;
 
       jobs = forAllSystems (system: import ./pkgs/top-level/release.nix {
         nixpkgs = self;

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -166,7 +166,7 @@ in
       # `lazyDerivation` caller knew a shortcut, be taken from there.
       meta = args.meta or checked.meta;
     }
-    // genAttrs outputs (outputName: checked.${outputName})
+    // genAttrs (outputName: checked.${outputName}) outputs
     // passthru;
 
   /**

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -3,7 +3,7 @@
 let
   commonH = hashTypes: rec {
     hashNames = [ "hash" ] ++ hashTypes;
-    hashSet = lib.genAttrs hashNames (lib.const { });
+    hashSet = lib.genAttrs (lib.const { }) hashNames;
   };
 
   fakeH = {
@@ -193,7 +193,7 @@ rec {
     }:
     fetcher:
     let
-      inherit (lib.attrsets) genAttrs intersectAttrs removeAttrs;
+      inherit (lib.attrsets) intersectAttrs removeAttrs;
       inherit (lib.trivial) const functionArgs setFunctionArgs;
 
       inherit (commonH hashTypes) hashSet;

--- a/lib/path/tests/prop.nix
+++ b/lib/path/tests/prop.nix
@@ -57,4 +57,4 @@ let
     if tryOnce.success then tryOnce.value else "";
 
 in
-lib.genAttrs strings normaliseAndCheck
+lib.genAttrs normaliseAndCheck strings

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -58,6 +58,7 @@ let
     foldr
     functionArgs
     generators
+    genAttrs
     genList
     getExe
     getExe'
@@ -1159,6 +1160,16 @@ runTests {
         world = false;
       };
     };
+  };
+
+  testGenAttrs = {
+    expr = genAttrs (name: "x_" + name) [ "foo" "bar" ];
+    expected = { foo = "x_foo"; bar = "x_bar"; };
+  };
+
+  testGenAttrsLegacyArgumentOrder = {
+    expr = genAttrs [ "foo" "bar" ] (name: "x_" + name);
+    expected = { foo = "x_foo"; bar = "x_bar"; };
   };
 
   # code from example


### PR DESCRIPTION
After [a little bit of discussion](https://matrix.to/#/!RRerllqmbATpmbJgCn:nixos.org/$oBX_RthIkxKX3Fr4Wwbn8GxvuBPaW9I6y1EPy87wrIM) in [the room](https://matrix.to/#/#users:nixos.org), @mjm came up with an idea for how to fix the uncommon order of arguments for the `lib.genAttrs`.

Basically, if you look into the definition of any map-like function, it has function (`lambda`) as its first argument, which enables currying. Not `getAttrs` though.

Since the argument types are different, it's very easy to support both correct and legacy order of arguments. This way we can have a better API while not breaking anyone's config.

But the problem is that I have no idea how to properly document this. I don't know if something like that happened before.

Also, I fixed all the occurrences inside the `lib/` and in `flake.nix`. Not sure if I should patch the rest of the repo. I can, if this is acceptable, it's just that the patch size will be much higher. If the CI can catch any funky stuff, then that would help ease the review. There are 66 matches left elsewhere.

I run `nix-build lib/tests/release.nix`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
