### PR TITLE
ocamlPackages.camlimages: 5.0.4 → 5.0.5

### DIFF
--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -50,13 +50,16 @@ stdenv.mkDerivation rec {
     ]);
 
   postPatch = ''
-    for f in callbacks*/Makefile src/Makefile; do
-      substituteInPlace "$f" --replace "+camlp4" \
+    for f in callbacks*/Makefile; do
+      substituteInPlace "$f" --replace-warn "+camlp4" \
         "${ocamlPackages.camlp4}/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/camlp4"
     done
 
     # Fatal error: exception Sys_error("Mutex.unlock: Operation not permitted")
     sed -i "/gl_started/d" src/draw.ml* src/main.ml
+
+    # Compatibility with camlimages ≥ 5.0.5
+    substituteInPlace src/Makefile --replace-warn camlimages.all_formats camlimages.core
   '';
 
   installPhase = ''

--- a/pkgs/development/ocaml-modules/camlimages/camlimages.patch
+++ b/pkgs/development/ocaml-modules/camlimages/camlimages.patch
@@ -1,5 +1,5 @@
 diff --git a/config/xConfigurator.ml b/config/xConfigurator.ml
-index 268df4a..73e1850 100644
+index 766a35c..1d1aff5 100644
 --- a/config/xConfigurator.ml
 +++ b/config/xConfigurator.ml
 @@ -8,7 +8,7 @@ let (!%) fmt = Printf.sprintf fmt
@@ -30,8 +30,8 @@ index 268df4a..73e1850 100644
    let find_program prog =
      let prog = prog ^ exe in
 @@ -45,13 +45,13 @@ module Configurator = struct
-     | s -> 
-         (* findlib 1.7.3 installs META file for graphics 
+     | s ->
+         (* findlib 1.7.3 installs META file for graphics
             even when there is no graphics library installed. *)
 -        let dest = Caml.Filename.temp_file "test" ".cma" in
 -        let res = match Caml.Sys.command & !% "ocamlfind ocamlc -package %s -o %s -linkpkg" n dest with
@@ -72,32 +72,6 @@ index 268df4a..73e1850 100644
 -    let fcalls = Caml.List.map (!% "  ( (void(*)()) (%s) )();") fnames in
 +    let includes = Stdlib.List.map (!% "#include <%s>") headers in
 +    let fcalls = Stdlib.List.map (!% "  ( (void(*)()) (%s) )();") fnames in
-     let code = 
-       String.concat ~sep:"\n" 
-       & includes 
-diff --git a/core/images.ml b/core/images.ml
-index 563ab7e..a53a6a4 100644
---- a/core/images.ml
-+++ b/core/images.ml
-@@ -102,7 +102,7 @@ let get_extension s =
-   | _ -> s, ""
- 
- let guess_extension s =
--  let s = String.lowercase s in
-+  let s = String.lowercase_ascii s in
-   match s with
-   | "gif" -> Gif
-   | "bmp" -> Bmp
-diff --git a/core/units.ml b/core/units.ml
-index 634bc9c..ddd6eae 100644
---- a/core/units.ml
-+++ b/core/units.ml
-@@ -30,7 +30,7 @@ let parse_length s = (* return in pt *)
-     let digit,unit =
-       if l > 2 then String.sub s 0 2, String.sub s (l-2) 2 else "", "" in
-     try
--      (List.assoc (String.lowercase unit) units) *. float_of_string digit
-+      (List.assoc (String.lowercase_ascii unit) units) *. float_of_string digit
-     with
-     | Not_found -> (* think it is in "pt" *)
-       float_of_string s in
+     let code =
+       String.concat ~sep:"\n"
+       & includes

--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -12,7 +12,7 @@
 
 buildDunePackage rec {
   pname = "camlimages";
-  version = "5.0.4";
+  version = "5.0.5";
 
   minimalOCamlVersion = "4.07";
 
@@ -20,10 +20,10 @@ buildDunePackage rec {
     owner = "camlspotter";
     repo = pname;
     rev = version;
-    sha256 = "1m2c76ghisg73dikz2ifdkrbkgiwa0hcmp21f2fm2rkbf02rq3f4";
+    hash = "sha256-/Dkj8IBVPjGCJCXrLOuJtuaa+nD/a9e8/N+TN9ukw4k=";
   };
 
-  # stdio v0.17 compatibility; also replaces `String.lowercase` with `String.lowercase_ascii`
+  # stdio v0.17 compatibility
   patches = [ ./camlimages.patch ];
 
   nativeBuildInputs = [ cppo ];

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -48,6 +48,9 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace src/lang/dune \
       --replace-warn "(run git rev-parse --short HEAD)" "(run echo -n nixpkgs)"
+    # Compatibility with camlimages 5.0.5
+    substituteInPlace src/core/dune \
+      --replace-warn camlimages.all_formats camlimages.core
   '';
 
   dontConfigure = true;


### PR DESCRIPTION
Brings support for OCaml 5.3.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
