### PR TITLE
pipenv: 2024.2.0 -> 2024.4.0

### DIFF
--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -6,6 +6,8 @@
   installShellFiles,
   pipenv,
   runCommand,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
 
 with python3.pkgs;
@@ -32,7 +34,7 @@ in
 buildPythonApplication rec {
   pname = "pipenv";
   version = "2024.4.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
@@ -43,10 +45,12 @@ buildPythonApplication rec {
 
   env.LC_ALL = "en_US.UTF-8";
 
+  build-system = [
+    setuptools
+  ];
+
   nativeBuildInputs = [
     installShellFiles
-    setuptools
-    wheel
   ];
 
   postPatch = ''
@@ -60,10 +64,6 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = runtimeDeps python3.pkgs;
 
-  preCheck = ''
-    export HOME="$TMPDIR"
-  '';
-
   nativeCheckInputs = [
     mock
     pytestCheckHook
@@ -71,7 +71,11 @@ buildPythonApplication rec {
     pytest-cov-stub
     pytz
     requests
+    writableTmpDirAsHomeHook
+    versionCheckHook
   ];
+
+  versionCheckProgramArg = [ "--version" ];
 
   disabledTests = [
     # this test wants access to the internet
@@ -104,10 +108,11 @@ buildPythonApplication rec {
       --fish <(_PIPENV_COMPLETE=fish_source $out/bin/pipenv)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Python Development Workflow for Humans";
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ berdario ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ berdario ];
+    mainProgram = "pipenv";
   };
 }

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -6,8 +6,8 @@
   installShellFiles,
   pipenv,
   runCommand,
-  writableTmpDirAsHomeHook,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 with python3.pkgs;
@@ -71,10 +71,9 @@ buildPythonApplication rec {
     pytest-cov-stub
     pytz
     requests
-    writableTmpDirAsHomeHook
     versionCheckHook
+    writableTmpDirAsHomeHook
   ];
-
   versionCheckProgramArg = [ "--version" ];
 
   disabledTests = [

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -68,7 +68,7 @@ buildPythonApplication rec {
     mock
     pytestCheckHook
     pytest-xdist
-    pytest-cov
+    pytest-cov-stub
     pytz
     requests
   ];

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -31,14 +31,14 @@ let
 in
 buildPythonApplication rec {
   pname = "pipenv";
-  version = "2024.2.0";
+  version = "2024.4.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "pipenv";
     tag = "v${version}";
-    hash = "sha256-5gq1kXVNAMH/AeovpUStcZffXN4GfXj3wJ7lW4qebRM=";
+    hash = "sha256-SyRkOKZ1q1j37hqdkNkEZI5e/WbBgLL5iglrvT2V5Fs=";
   };
 
   env.LC_ALL = "en_US.UTF-8";
@@ -68,6 +68,7 @@ buildPythonApplication rec {
     mock
     pytestCheckHook
     pytest-xdist
+    pytest-cov
     pytz
     requests
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
This PR updates the pipenv package from version 2024.2.0 to 2024.4.0. This update includes bug fixes and improvements that enhance the functionality of pipenv and ensure compatibility with the latest environment setups. It is necessary to stay up-to-date with the newest release for continued support and to avoid issues that may arise with older versions.
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
