### PR TITLE
WIP: python312Packages.nicegui: update postPatch to fit to changed pyproject.toml

### DIFF
--- a/pkgs/development/python-modules/nicegui-highcharts/default.nix
+++ b/pkgs/development/python-modules/nicegui-highcharts/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "nicegui-highcharts";
-  version = "2.0.2";
+  version = "2.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "zauberzeug";
     repo = "nicegui-highcharts";
     tag = "v${version}";
-    hash = "sha256-r4X4faU7Nlq/FDbIYbTpvnC1w14XskpsNGtkEXtGrFo=";
+    hash = "sha256-9COui3gqLZqJSeZyzazxQcOc2oM9Li+dLBoy5VcEKBw=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -40,7 +40,7 @@
 
 buildPythonPackage rec {
   pname = "nicegui";
-  version = "2.9.1";
+  version = "2.11.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -49,13 +49,8 @@ buildPythonPackage rec {
     owner = "zauberzeug";
     repo = "nicegui";
     tag = "v${version}";
-    hash = "sha256-PrY+jNA+OYtFzyuRzUckZZntsQg/eovkEfPPO1PX/18=";
+    hash = "sha256-U7S4JQ92H0SYEpMsMw5inioO6ayQ1/NDA7vnvR4i7Mk=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"setuptools>=30.3.0",' ""
-  '';
 
   build-system = [
     poetry-core

--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail '"setuptools>=30.3.0,<50",' ""
+      --replace-fail '"setuptools>=30.3.0",' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -52,6 +52,15 @@ buildPythonPackage rec {
     hash = "sha256-U7S4JQ92H0SYEpMsMw5inioO6ayQ1/NDA7vnvR4i7Mk=";
   };
 
+  # the version in the pyproject.toml file is always the version (+ "-dev")
+  # before the version in the git tag
+  # this is also fixed in the github publish workflow in the project itself
+  postPatch = ''
+    sed --in-place \
+    's#^version = "[0-9]*\.[0-9]*\.[0-9]*-dev"$#version = "${version}"#' \
+    pyproject.toml
+  '';
+
   build-system = [
     poetry-core
     setuptools


### PR DESCRIPTION
The postPatch phase creates an error, documented in #383920 due to a change in the pyproject.toml upstream. This commit fits the replace string to the existing one.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
