### PR TITLE
[24.11] nixos/postgresql/citus: fix syscall filter and add test

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -716,10 +716,16 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           SystemCallArchitectures = "native";
-          SystemCallFilter = [
-            "@system-service"
-            "~@privileged @resources"
-          ] ++ lib.optionals (any extensionInstalled [ "plv8" ]) [ "@pkey" ];
+          SystemCallFilter =
+            [
+              "@system-service"
+              "~@privileged @resources"
+            ]
+            ++ lib.optionals (any extensionInstalled [ "plv8" ]) [ "@pkey" ]
+            ++ lib.optionals (any extensionInstalled [ "citus" ]) [
+              "getpriority"
+              "setpriority"
+            ];
           UMask = if groupAccessAvailable then "0027" else "0077";
         }
         (mkIf (cfg.dataDir != "/var/lib/postgresql/${cfg.package.psqlSchema}") {

--- a/nixos/tests/postgresql/citus.nix
+++ b/nixos/tests/postgresql/citus.nix
@@ -1,0 +1,76 @@
+{
+  pkgs,
+  makeTest,
+}:
+
+let
+  inherit (pkgs) lib;
+
+  test-sql = pkgs.writeText "postgresql-test" ''
+    CREATE EXTENSION citus;
+
+    CREATE TABLE examples (
+      id bigserial,
+      shard_key int,
+      PRIMARY KEY (id, shard_key)
+    );
+
+    SELECT create_distributed_table('examples', 'shard_key');
+
+    INSERT INTO examples (shard_key) SELECT shard % 10 FROM generate_series(1,1000) shard;
+  '';
+
+  makeTestFor =
+    package:
+    makeTest {
+      name = "citus-${package.name}";
+      meta = with lib.maintainers; {
+        maintainers = [ typetetris ];
+      };
+
+      nodes.machine =
+        { ... }:
+        {
+          services.postgresql = {
+            inherit package;
+            enable = true;
+            enableJIT = lib.hasInfix "-jit-" package.name;
+            extensions =
+              ps: with ps; [
+                citus
+              ];
+            settings = {
+              shared_preload_libraries = "citus";
+            };
+          };
+        };
+
+      testScript = ''
+        def check_count(statement, lines):
+            return 'test $(sudo -u postgres psql postgres -tAc "{}") -eq {}'.format(
+                statement, lines
+            )
+
+
+        machine.start()
+        machine.wait_for_unit("postgresql")
+
+        with subtest("Postgresql with extension citus is available just after unit start"):
+            machine.succeed(
+                "sudo -u postgres psql -f ${test-sql}"
+            )
+
+        machine.succeed(check_count("SELECT count(*) FROM examples;", 1000))
+
+        machine.shutdown()
+      '';
+    };
+in
+lib.recurseIntoAttrs (
+  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
+    lib.filterAttrs (_: p: !p.pkgs.citus.meta.broken) pkgs.postgresqlVersions
+  )
+  // {
+    passthru.override = p: makeTestFor p;
+  }
+)

--- a/nixos/tests/postgresql/default.nix
+++ b/nixos/tests/postgresql/default.nix
@@ -18,6 +18,7 @@ in
 
   # extensions
   anonymizer = importWithArgs ./anonymizer.nix;
+  citus = importWithArgs ./citus.nix;
   pgjwt = importWithArgs ./pgjwt.nix;
   pgvecto-rs = importWithArgs ./pgvecto-rs.nix;
   timescaledb = importWithArgs ./timescaledb.nix;


### PR DESCRIPTION
Backport of #379769

(cherry picked from commit 37372eb227a7324a1b03900d8776b013076d87dd)

cc @jflanglois .
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
