### PR TITLE
[24.11] postgresql: 13.18 -> 13.20, 14.15 -> 14.17, 15.10 -> 15.12, 16.6 -> 16.8, 17.2 -> 17.4, fix CVE-2025-1094

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "13.20";
-  # "Stamp 13.20"
-  rev = "c8f198c3acb59ed858b5b9b88b4fbc55cece544e";
+  rev = "refs/tags/REL_13_20";
   hash = "sha256-GkDtzqwjMJipvr0wykM9Z5Tb0R7WgJA/PGPTVUXxf7Q=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "13.18";
-  rev = "ref/tags/REL_13_18";
-  hash = "sha256-Lw8rd6MAvKZ7/Y1a0ccauL7K6lHxsp5huK4QFun9wcc=";
+  version = "13.20";
+  # "Stamp 13.20"
+  rev = "c8f198c3acb59ed858b5b9b88b4fbc55cece544e";
+  hash = "sha256-GkDtzqwjMJipvr0wykM9Z5Tb0R7WgJA/PGPTVUXxf7Q=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,6 +1,7 @@
 import ./generic.nix {
   version = "13.18";
-  hash = "sha256-zuqSq+4qjBlAjSeLaN5qeLa9PbtPotZT+nynRdZmqrE=";
+  rev = "ref/tags/REL_13_18";
+  hash = "sha256-Lw8rd6MAvKZ7/Y1a0ccauL7K6lHxsp5huK4QFun9wcc=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "14.17";
-  # "Stamp 14.17"
-  rev = "e5cabe28006995d90cc9ebc613dad072c44c7f4a";
+  rev = "refs/tags/REL_14_17";
   hash = "sha256-BvmfxHHTcxRkWZoawvHanQeAuqHnQIh77RQjxPo5fuI=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,6 +1,7 @@
 import ./generic.nix {
   version = "14.15";
-  hash = "sha256-AuiR4xS06e4ky9eAKNq3xz+cG6PjCDW8vvcf4iBAH8U=";
+  rev = "ref/tags/REL_14_15";
+  hash = "sha256-slb6UiJyIzDaNS782/ZDVztBw4B4qTY6OuEWI+HZ+Ds=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "14.15";
-  rev = "ref/tags/REL_14_15";
-  hash = "sha256-slb6UiJyIzDaNS782/ZDVztBw4B4qTY6OuEWI+HZ+Ds=";
+  version = "14.17";
+  # "Stamp 14.17"
+  rev = "e5cabe28006995d90cc9ebc613dad072c44c7f4a";
+  hash = "sha256-BvmfxHHTcxRkWZoawvHanQeAuqHnQIh77RQjxPo5fuI=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "15.12";
-  # "Stamp 15.12"
-  rev = "50d3d22baba63613d1f1406b2ed460dc9b03c3fc";
+  rev = "refs/tags/REL_15_12";
   hash = "sha256-6my9UzW05iYwTWR9y/VTZ1RQVNudavMFfUT9dpUQ15o=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "15.10";
-  rev = "ref/tags/REL_15_10";
-  hash = "sha256-5RNcoqcmcYCCBK8bmz2Wruky1mzDh5SrDF3OOV31GMw=";
+  version = "15.12";
+  # "Stamp 15.12"
+  rev = "50d3d22baba63613d1f1406b2ed460dc9b03c3fc";
+  hash = "sha256-6my9UzW05iYwTWR9y/VTZ1RQVNudavMFfUT9dpUQ15o=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,6 +1,7 @@
 import ./generic.nix {
   version = "15.10";
-  hash = "sha256-VavnONRB8OWGWLPsb4gJenE7XjtzE59iMNe1xMOJ5XM=";
+  rev = "ref/tags/REL_15_10";
+  hash = "sha256-5RNcoqcmcYCCBK8bmz2Wruky1mzDh5SrDF3OOV31GMw=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "16.8";
-  # "Stamp 16.8"
-  rev = "71eb35c0b18de96537bd3876ec9bf8075bfd484f";
+  rev = "refs/tags/REL_16_8";
   hash = "sha256-nVUGBuvCDFXozTyEDAAQa+IR3expCdztH90J68FhAXQ=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "16.6";
-  rev = "ref/tags/REL_16_6";
-  hash = "sha256-cw/bSR9ZI6HFtbSTQxvuB7ng7V6g5SZZ7B0oMCz4E7Q=";
+  version = "16.8";
+  # "Stamp 16.8"
+  rev = "71eb35c0b18de96537bd3876ec9bf8075bfd484f";
+  hash = "sha256-nVUGBuvCDFXozTyEDAAQa+IR3expCdztH90J68FhAXQ=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,6 +1,7 @@
 import ./generic.nix {
   version = "16.6";
-  hash = "sha256-Izac2szUUnCsXcww+p2iBdW+M/pQXh8XoEGNLK7KR3s=";
+  rev = "ref/tags/REL_16_6";
+  hash = "sha256-cw/bSR9ZI6HFtbSTQxvuB7ng7V6g5SZZ7B0oMCz4E7Q=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "17.4";
-  # "Stamp 17.4"
-  rev = "f8554dee417ffc4540c94cf357f7bf7d4b6e5d80";
+  rev = "refs/tags/REL_17_4";
   hash = "sha256-TEpvX28chR3CXiOQsNY12t8WfM9ywoZVX1e/6mj9DqE=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,6 +1,7 @@
 import ./generic.nix {
   version = "17.2";
-  hash = "sha256-gu8nwK83UWldf2Ti2WNYMAX7tqDD32PQ5LQiEdcCEWQ=";
+  rev = "ref/tags/REL_17_2";
+  hash = "sha256-P7IwvMcOI6vW14PiB2R0NEzAEPeaKg0zaUKTw2GJ5DA=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "17.2";
-  rev = "ref/tags/REL_17_2";
-  hash = "sha256-P7IwvMcOI6vW14PiB2R0NEzAEPeaKg0zaUKTw2GJ5DA=";
+  version = "17.4";
+  # "Stamp 17.4"
+  rev = "f8554dee417ffc4540c94cf357f7bf7d4b6e5d80";
+  hash = "sha256-TEpvX28chR3CXiOQsNY12t8WfM9ywoZVX1e/6mj9DqE=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -4,9 +4,10 @@ let
     # dependencies
     {
       stdenv,
-      lib,
-      fetchurl,
+      fetchFromGitHub,
       fetchpatch,
+      fetchurl,
+      lib,
       makeWrapper,
       glibc,
       zlib,
@@ -48,6 +49,7 @@ let
       version,
       hash,
       muslPatches ? { },
+      rev,
 
       # for tests
       testers,
@@ -90,9 +92,12 @@ let
       inherit version;
       pname = pname + lib.optionalString jitSupport "-jit";
 
-      src = fetchurl {
-        url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";
-        inherit hash;
+      src = fetchFromGitHub {
+        owner = "postgres";
+        repo = "postgres";
+        # rev, not tag, on purpose: allows updating when new versions
+        # are "stamped" a few days before release (tag).
+        inherit hash rev;
       };
 
       __structuredAttrs = true;
@@ -157,21 +162,20 @@ let
 
       nativeBuildInputs =
         [
+          bison
+          docbook-xsl-nons
+          docbook_xml_dtd_45
+          flex
+          libxml2
+          libxslt
           makeWrapper
+          perl
           pkg-config
           removeReferencesTo
         ]
         ++ lib.optionals jitSupport [
           llvmPackages.llvm.dev
           nukeReferences
-        ]
-        ++ lib.optionals (atLeast "17") [
-          bison
-          flex
-          perl
-          docbook_xml_dtd_45
-          docbook-xsl-nons
-          libxslt
         ];
 
       enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Backport of #382282, #383713.
cc @mweinelt @vcunat, since I'd submit this straight to staging-next.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
