### PR TITLE
mdsf: init at 0.5.1

### DIFF
--- a/pkgs/by-name/md/mdsf/package.nix
+++ b/pkgs/by-name/md/mdsf/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+let
+  pname = "mdsf";
+  version = "0.5.1";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "hougesen";
+    repo = "mdsf";
+    tag = "v${version}";
+    hash = "sha256-KHTWE3ENRc/VHrgwAag6DsnEU3c8Nqw15jR5jWlNrk4=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-kgqRwYjDc/eV9wv1G6aAhfrGpoYDPCFfqaTm+T2p7uw=";
+
+  checkFlags = [
+    "--skip=tests::it_should_add_go_package_if_missing"
+    "--skip=tests::it_should_format_the_code"
+    "--skip=tests::it_should_format_the_codeblocks_that_start_with_whitespace"
+    "--skip=tests::it_should_not_care_if_go_package_is_set"
+    "--skip=tests::it_should_not_modify_outside_blocks"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for formatting a linting markdown code snippets using language specific tools";
+    homepage = "https://github.com/hougesen/mdsf";
+    changelog = "https://github.com/hougesen/mdsf/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
+    mainProgram = "mdsf";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #383833

[Release notes](https://github.com/hougesen/mdsf/releases/tag/v0.5.1) 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
