### PR TITLE
nixos/systemd-resolved: add mDNS support option, open firewall

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -116,8 +116,7 @@ in
       default = { };
       type = mdnsLlmnrOpts "mDNS";
       description = ''
-        Controls support for Multicast DNS (mDNS, RFC 6762[2]) on the local
-        host.
+        Controls support for Multicast DNS (mDNS, RFC 6762[2]).
       '';
     };
 
@@ -131,8 +130,7 @@ in
         ]
       );
       description = ''
-        Controls support for Link-Local Multicast Name Resolution
-        (LLMNR, RFC 4795) on the local host.
+        Controls support for Link-Local Multicast Name Resolution (LLMNR, RFC 4795).
       '';
     };
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -275,7 +275,7 @@ in
             allowedUDPPorts = [ 5353 ];
           })
 
-          (mkIf (if lib.isAttrs cfg.llmnr then fromAttrs cfg.llmnr else false) {
+          (mkIf (lib.isAttrs cfg.llmnr && fromAttrs cfg.llmnr) {
             allowedUDPPorts = [ 5355 ];
           })
         ];

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -270,12 +270,14 @@ in
         let
           fromAttrs = { enable, openFirewall, ... }: enable && openFirewall;
         in
-        [
-          {
-            allowedUDPPorts =
-              (lib.optional (fromAttrs cfg.mdns) 5353)
-              ++ (lib.optional (lib.isAttrs cfg.llmnr && fromAttrs cfg.llmnr) 5355);
-          }
+        lib.mkMerge [
+          (mkIf (fromAttrs cfg.mdns) {
+            allowedUDPPorts = [ 5353 ];
+          })
+
+          (mkIf (if lib.isAttrs cfg.llmnr then mkZeroConf cfg.llmnr else false) {
+            allowedUDPPorts = [ 5355 ];
+          })
         ];
     })
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -275,7 +275,7 @@ in
             allowedUDPPorts = [ 5353 ];
           })
 
-          (mkIf (if lib.isAttrs cfg.llmnr then mkZeroConf cfg.llmnr else false) {
+          (mkIf (if lib.isAttrs cfg.llmnr then fromAttrs cfg.llmnr else false) {
             allowedUDPPorts = [ 5355 ];
           })
         ];

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -116,8 +116,8 @@ in
       default = { };
       type = mdnsLlmnrOpts "mDNS";
       description = ''
-        Controls Multicast DNS (mDNS) support
-        (RFC 6762[2]) on the local host.
+        Controls support for Multicast DNS (mDNS, RFC 6762[2]) on the local
+        host.
       '';
     };
 
@@ -131,8 +131,8 @@ in
         ]
       );
       description = ''
-        Controls Link-Local Multicast Name Resolution (LLMNR) support
-        (RFC 4795) on the local host.
+        Controls support for Link-Local Multicast Name Resolution
+        (LLMNR, RFC 4795) on the local host.
       '';
     };
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -15,21 +15,21 @@ let
     name:
     types.submodule {
       options = {
-        enable = {
+        enable = mkOption {
           default = true;
           type = types.bool;
           description = ''
             Whether to enable ${name} support.
           '';
         };
-        resolveOnly = {
+        resolveOnly = mkOption {
           default = false;
           type = types.bool;
           description = ''
             Only resolve, do not respond to incoming queries.
           '';
         };
-        openFirewall = {
+        openFirewall = mkOption {
           default = true;
           type = types.bool;
           description = ''


### PR DESCRIPTION
Based on #211169, this PR does three things:
- Adds a `services.resolved.mdns` option with sub-options to configure mDNS in systemd-resolved.
- Amends the `services.resolved.llmnr` so that it supports the same sub-options as mDNS.
- Adds options to open a port on the firewall for these two services.

For `services.resolved.llmnr`, the old enum-based value was retained but considered deprecated. I don't know if it's possible to mark use of this as explicitly deprecated, so I used `types.either`. This way, previous user configurations will at least continue working.

For the firewall port, I opted to make the default to open it. This follows the example of `services.avahi.openFirewall`, which is also enabled by default, and also makes general sense because most people will want this port open if they are going to use the service (otherwise it doesn't work). However, if a user's config specifies an old enum value instead of the new sub-options, then the firewall is not opened, which preserves the old behaviour to a degree.

To preserve backwards compatibility, I made both mDNS and LLMNR enabled by default. That is the default configuration for systemd-resolved, and in the case of mDNS that was therefore used for all previous configurations. However, I personally think that it is better for these two settings to be opt-in, so that the user is not "surprised" by services they didn't explicitly ask for. I can make them opt-in by default, but that would be a larger breaking change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
