### PR TITLE
nixos/doc: convert links to manpages

### DIFF
--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -56,7 +56,7 @@ let
         };
         description = ''
           Specify the repart options for a partiton as a structural setting.
-          See <https://www.freedesktop.org/software/systemd/man/repart.d.html>
+          See {manpage}`repart.d(5)`
           for all available options.
         '';
       };

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -189,9 +189,9 @@ in
         description = ''
           Image identifier.
 
-          This corresponds to the IMAGE_ID field in os-release. See the
+          This corresponds to the `IMAGE_ID` field in {manpage}`os-release(5)`. See the
           upstream docs for more details on valid characters for this field:
-          https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_ID=
+          <https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_ID=>
 
           You would only want to set this option if you're build NixOS appliance images.
         '';
@@ -203,9 +203,9 @@ in
         description = ''
           Image version.
 
-          This corresponds to the IMAGE_VERSION field in os-release. See the
+          This corresponds to the `IMAGE_VERSION` field in {manpage}`os-release(5)`. See the
           upstream docs for more details on valid characters for this field:
-          https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_VERSION=
+          <https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_VERSION=>
 
           You would only want to set this option if you're build NixOS appliance images.
         '';

--- a/nixos/modules/services/games/mchprs.nix
+++ b/nixos/modules/services/games/mchprs.nix
@@ -77,7 +77,7 @@ in
         description = ''
           Automatically restart the server after
           {option}`services.mchprs.maxRuntime`.
-          The time span format is described here:
+          The {manpage}`systemd.time(7)` time span format is described here:
           <https://www.freedesktop.org/software/systemd/man/systemd.time.html#Parsing%20Time%20Spans>.
           If `null`, then the server is not restarted automatically.
         '';

--- a/nixos/modules/services/networking/networkd-dispatcher.nix
+++ b/nixos/modules/services/networking/networkd-dispatcher.nix
@@ -63,7 +63,7 @@ in
                 default = null;
                 description = ''
                   List of names of the systemd-networkd operational states which
-                  should trigger the script. See <https://www.freedesktop.org/software/systemd/man/networkctl.html>
+                  should trigger the script. See {manpage}`networkctl(1)`
                   for a description of the specific state type.
                 '';
               };

--- a/nixos/modules/services/web-servers/static-web-server.nix
+++ b/nixos/modules/services/web-servers/static-web-server.nix
@@ -18,7 +18,7 @@ in
         default = "[::]:8787";
         type = lib.types.str;
         description = ''
-          The "ListenStream" used in static-web-server.socket.
+          The {manpage}`systemd.socket(5)` "ListenStream" used in static-web-server.socket.
           This is equivalent to SWS's "host" and "port" options.
           See here for specific syntax: <https://www.freedesktop.org/software/systemd/man/systemd.socket.html#ListenStream=>
         '';

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -64,8 +64,7 @@ in
 
         Note that the effective rate limit is multiplied by a factor derived
         from the available free disk space for the journal as described on
-        [
-        journald.conf(5)](https://www.freedesktop.org/software/systemd/man/journald.conf.html).
+        {manpage}`journald.conf(5)`.
 
         Note that the total amount of logs stored is limited by journald settings
         such as `SystemMaxUse`, which defaults to 10% the file system size

--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -42,10 +42,10 @@ in
         when the user logs out.  If true, the scope unit corresponding
         to the session and all processes inside that scope will be
         terminated.  If false, the scope is "abandoned"
-        (see [systemd.scope(5)](https://www.freedesktop.org/software/systemd/man/systemd.scope.html#)),
+        (see {manpage}`systemd.scope(5)`),
         and processes are not killed.
 
-        See [logind.conf(5)](https://www.freedesktop.org/software/systemd/man/logind.conf.html#KillUserProcesses=)
+        See {manpage}`logind.conf(5)`
         for more details.
       '';
     };

--- a/nixos/modules/system/boot/systemd/repart.nix
+++ b/nixos/modules/system/boot/systemd/repart.nix
@@ -109,8 +109,7 @@ in
         description = ''
           Specify partitions as a set of the names of the definition files as the
           key and the partition configuration as its value. The partition
-          configuration can use all upstream options. See <link
-          xlink:href="https://www.freedesktop.org/software/systemd/man/repart.d.html"/>
+          configuration can use all upstream options. See {manpage}`repart.d(5)`
           for all available options.
         '';
       };

--- a/nixos/modules/system/boot/systemd/sysupdate.nix
+++ b/nixos/modules/system/boot/systemd/sysupdate.nix
@@ -24,9 +24,7 @@ in
         If enabled, updates are triggered in regular intervals via a
         `systemd.timer` unit.
 
-        Please see
-        <https://www.freedesktop.org/software/systemd/man/systemd-sysupdate.html>
-        for more details.
+        Please see {manpage}`systemd-sysupdate(8)` for more details.
       '';
     };
 
@@ -108,8 +106,7 @@ in
       description = ''
         Specify transfers as a set of the names of the transfer files as the
         key and the configuration as its value. The configuration can use all
-        upstream options. See
-        <https://www.freedesktop.org/software/systemd/man/sysupdate.d.html>
+        upstream options. See {manpage}`sysupdate.d(5)`
         for all available options.
       '';
     };

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -43,7 +43,7 @@ let
 
           Please see the upstream documentation for the available types and
           more details:
-          <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
+          {manpage}`tmpfiles.d(5)`
         '';
       };
       options.mode = mkOption {
@@ -102,7 +102,7 @@ let
 
           Please see the upstream documentation for the meaning of this
           parameter in different situations:
-          <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
+          {manpage}`tmpfiles.d(5)`
         '';
       };
     }))));

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -53,8 +53,7 @@ in
         '';
         description = ''
           Extra config options for systemd-timesyncd. See
-          [
-          timesyncd.conf(5)](https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html) for available options.
+          {manpage}`timesyncd.conf(5)` for available options.
         '';
       };
     };


### PR DESCRIPTION

These links are listed in `doc/manpage-urls.json`, hence this is no removal of information.

Nixos html manual diff: https://gist.github.com/pbsds/b785055b02c5c6ba263890dc86e3c315



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
