### PR TITLE
python312Packages.atproto: init at 0.0.59

### DIFF
--- a/pkgs/development/python-modules/atproto/default.nix
+++ b/pkgs/development/python-modules/atproto/default.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  nix-update-script,
+
+  # build-system
+  poetry-core,
+  poetry-dynamic-versioning,
+
+  # dependencies
+  click,
+  cryptography,
+  dnspython,
+  httpx,
+  libipld,
+  pydantic,
+  typing-extensions,
+  websockets,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+  pytest-asyncio,
+  coverage,
+}:
+
+buildPythonPackage rec {
+  pname = "atproto";
+  version = "0.0.59";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  # use GitHub, pypi does not include tests
+  src = fetchFromGitHub {
+    owner = "MarshalX";
+    repo = "atproto";
+    tag = "v${version}";
+    hash = "sha256-Q+ZJMbchz3u7kXAR9fJpzJd6Zdc44LkntPmEE7IeW6A=";
+  };
+
+  POETRY_DYNAMIC_VERSIONING_BYPASS = version;
+
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  dependencies = [
+    click
+    cryptography
+    dnspython
+    httpx
+    libipld
+    pydantic
+    typing-extensions
+    websockets
+  ];
+
+  pythonRelaxDeps = [
+    "websockets"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    coverage
+  ];
+
+  disabledTestPaths = [
+    # the required `_PATH_TO_LEXICONS` is outside the package tree
+    "tests/test_atproto_lexicon/test_lexicon_parser.py"
+    # touches network
+    "tests/test_atproto_identity/test_atproto_data.py"
+    "tests/test_atproto_identity/test_async_atproto_data.py"
+    "tests/test_atproto_identity/test_did_resolver.py"
+    "tests/test_atproto_identity/test_async_did_resolver.py"
+    "tests/test_atproto_identity/test_did_resolver_cache.py"
+    "tests/test_atproto_identity/test_async_did_resolver_cache.py"
+    "tests/test_atproto_identity/test_handle_resolver.py"
+    "tests/test_atproto_identity/test_async_handle_resolver.py"
+    "tests/test_atproto_server/auth/test_custom_feed_auth.py"
+  ];
+
+  pythonImportsCheck = [
+    "atproto"
+    "atproto_cli"
+    "atproto_client"
+    "atproto_codegen"
+    "atproto_core"
+    "atproto_crypto"
+    "atproto_firehose"
+    "atproto_identity"
+    "atproto_lexicon"
+    "atproto_server"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "AT Protocol (Bluesky) SDK for Python";
+    homepage = "https://github.com/MarshalX/atproto";
+    changelog = "https://github.com/MarshalX/atproto/blob/v${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vji ];
+  };
+}

--- a/pkgs/development/python-modules/libipld/default.nix
+++ b/pkgs/development/python-modules/libipld/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-KXB1LecOX9ysRkaQDN76oNygjbm11ZxAtUltmeO/+mQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-e/YydaaIJslCWxVVOicU+/wZQUNXB+CiqetCMZbJtjI=";
+    hash = "sha256-V/UGTO+VEBtv5gwKR/fZmmhbeYILsIVc7Mq/Rl6E4Dw=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/libipld/default.nix
+++ b/pkgs/development/python-modules/libipld/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  pythonOlder,
+  rustPlatform,
+  nix-update-script,
+
+  # build-system
+  maturin,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+  pytest-benchmark,
+  pytest-codspeed,
+  pytest-xdist,
+}:
+
+buildPythonPackage rec {
+  pname = "libipld";
+  version = "3.0.1";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  # use pypi, GitHub does not include Cargo.lock
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KXB1LecOX9ysRkaQDN76oNygjbm11ZxAtUltmeO/+mQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    hash = "sha256-e/YydaaIJslCWxVVOicU+/wZQUNXB+CiqetCMZbJtjI=";
+  };
+
+  build-system = [
+    maturin
+  ];
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-benchmark
+    pytest-codspeed
+    pytest-xdist
+  ];
+
+  disabledTests = [
+    # touches network
+    "test_decode_car"
+  ];
+
+  pythonImportsCheck = [ "libipld" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast Python library to work with IPLD: DAG-CBOR, CID, CAR, multibase";
+    homepage = "https://github.com/MarshalX/python-libipld";
+    changelog = "https://github.com/MarshalX/python-libipld/blob/v${version}/CHANGES.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vji ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -998,6 +998,8 @@ self: super: with self; {
 
   atomman = callPackage ../development/python-modules/atomman { };
 
+  atproto = callPackage ../development/python-modules/atproto { };
+
   atpublic = callPackage ../development/python-modules/atpublic { };
 
   atsim-potentials = callPackage ../development/python-modules/atsim-potentials { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7391,6 +7391,8 @@ self: super: with self; {
     inherit python;
   })).python;
 
+  libipld = callPackage ../development/python-modules/libipld { };
+
   libkeepass = callPackage ../development/python-modules/libkeepass { };
 
   libknot = callPackage ../development/python-modules/libknot { };


### PR DESCRIPTION
`atproto` is an AT Protocol (Bluesky) SDK for Python ([Documentation](https://atproto.blue/en/latest/))

This PR also packages `libipld`, a dependency by the same author.
`libipld` wraps Rust code, which I’m not very familiar with, so I’d appreciate it if someone with more expertise could help co-maintain it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
