### PR TITLE
go-bindata-assetfs: unstable-2022-04-12 -> unstable-2025-02-01

### DIFF
--- a/pkgs/by-name/go/go-bindata-assetfs/package.nix
+++ b/pkgs/by-name/go/go-bindata-assetfs/package.nix
@@ -2,17 +2,20 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+
+  go-bindata,
+  makeWrapper,
 }:
 
 buildGoModule rec {
   pname = "go-bindata-assetfs";
-  version = "unstable-2022-04-12";
+  version = "unstable-2025-02-01";
 
   src = fetchFromGitHub {
-    owner = "elazarl";
+    owner = "elezarl";
     repo = "go-bindata-assetfs";
-    rev = "de3be3ce9537d87338bf26ac211d02d4fa568bb8";
-    hash = "sha256-yQgIaTl06nmIu8BfmQzrvEnlPQ2GQ/2nnvTmYXCL1oI=";
+    rev = "d06c361cdac6293509ed6ecb3d8ef0d46066a0f7";
+    hash = "sha256-rLeQbcv6V0Uc8iBEGMMnqxXcDJ2e91K96ZeYEYG6UCI=";
   };
 
   vendorHash = null;
@@ -21,6 +24,15 @@ buildGoModule rec {
     "-s"
     "-w"
   ];
+
+  nativeBuildInputs = [
+    go-bindata
+    makeWrapper
+  ];
+  postInstall = ''
+    wrapProgram $out/bin/go-bindata-assetfs \
+      --prefix PATH : ${go-bindata}/bin
+  '';
 
   meta = with lib; {
     description = "Serve embedded files from jteeuwen/go-bindata";


### PR DESCRIPTION
`go-bindata-assetfs` has had multiple recent improvements (expanded test suite, bug fixes) upstream. There's also been a bit of a packaging issue on the `nixpkgs` side: `go-bindata-assetfs` depends on `go-bindata` being in `$PATH`, so as a Nix package, it should bake in a dependency on a pinned version of `go-bindata`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
