### PR TITLE
treewide: migrate to pytest-cov-stub

### DIFF
--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
     [
       flexmock
       pytestCheckHook
-      pytest-cov
+      pytest-cov-stub
     ]
     ++ optional-dependencies.apprise;
 
@@ -36,11 +36,6 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     "test_borgmatic_version_matches_news_version"
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '--cov-fail-under=100' ""
-  '';
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/python-modules/adguardhome/default.nix
+++ b/pkgs/development/python-modules/adguardhome/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   poetry-core,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   yarl,
@@ -27,7 +28,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "--cov" "" \
       --replace-fail '"0.0.0"' '"${version}"'
   '';
 
@@ -43,6 +43,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aresponses
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aioconsole/default.nix
+++ b/pkgs/development/python-modules/aioconsole/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -32,13 +33,14 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail " --cov aioconsole --strict-markers --count 2 -vv" ""
+      --replace-fail " --strict-markers --count 2 -vv" ""
   '';
 
   build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiocron/default.nix
+++ b/pkgs/development/python-modules/aiocron/default.nix
@@ -7,6 +7,7 @@
   croniter,
   tzlocal,
   pytestCheckHook,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -28,11 +29,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     tzlocal
   ];
 
   postPatch = ''
-    sed -i "/--cov/d" setup.cfg
     sed -i "/--ignore/d" setup.cfg
   '';
 

--- a/pkgs/development/python-modules/aiohttp-jinja2/default.nix
+++ b/pkgs/development/python-modules/aiohttp-jinja2/default.nix
@@ -5,6 +5,7 @@
   fetchPypi,
   jinja2,
   pytest-aiohttp,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -31,15 +32,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-aiohttp
+    pytest-cov-stub
     pytestCheckHook
   ];
 
   __darwinAllowLocalNetworking = true;
-
-  postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace-fail "--cov=aiohttp_jinja2/ --cov=tests/ --cov-report term" ""
-  '';
 
   pytestFlagsArray = [
     "-W"

--- a/pkgs/development/python-modules/aiohue/default.nix
+++ b/pkgs/development/python-modules/aiohue/default.nix
@@ -8,6 +8,7 @@
   pytestCheckHook,
   pytest-aiohttp,
   pytest-asyncio,
+  pytest-cov-stub,
   pythonOlder,
   setuptools,
 }:
@@ -28,8 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'version = "0.0.0"' 'version = "${version}"' \
-      --replace-fail "--cov" ""
+      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
   '';
 
   build-system = [ setuptools ];
@@ -44,6 +44,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
     pytest-aiohttp
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
   tenacity,
 }:
@@ -23,7 +24,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tox.ini \
-      --replace "--cov --cov-append --cov-fail-under=30 --cov-report=" "" \
       --replace "--mypy" ""
   '';
 
@@ -32,7 +32,10 @@ buildPythonPackage rec {
     tenacity
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pytestFlagsArray = [ "tests" ];
   pythonImportsCheck = [ "aiokef" ];

--- a/pkgs/development/python-modules/aiolimiter/default.nix
+++ b/pkgs/development/python-modules/aiolimiter/default.nix
@@ -5,6 +5,7 @@
   poetry-core,
   importlib-metadata,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   toml,
@@ -30,14 +31,10 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
     toml
   ];
-
-  postPatch = ''
-    substituteInPlace tox.ini \
-      --replace " --cov=aiolimiter --cov-config=tox.ini --cov-report term-missing" ""
-  '';
 
   pythonImportsCheck = [ "aiolimiter" ];
 

--- a/pkgs/development/python-modules/aiopvpc/default.nix
+++ b/pkgs/development/python-modules/aiopvpc/default.nix
@@ -7,6 +7,7 @@
   poetry-core,
   pytest-asyncio,
   pytest-timeout,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   python-dotenv,
@@ -26,11 +27,6 @@ buildPythonPackage rec {
     hash = "sha256-1xeXfhoXRfJ7vrpRPeYmwcAGjL09iNCOm/f4pPvuZLU=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail " --cov --cov-report term --cov-report html" ""
-  '';
-
   build-system = [ poetry-core ];
 
   dependencies = [
@@ -41,6 +37,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytest-timeout
+    pytest-cov-stub
     pytestCheckHook
     python-dotenv
   ];

--- a/pkgs/development/python-modules/aioshutil/default.nix
+++ b/pkgs/development/python-modules/aioshutil/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools-scm,
@@ -22,15 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-hSUNx43sIUPs4YfQ+H39FXTpj3oCMUqRzDdHX2OdRdE=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace-fail " --cov aioshutil --cov-report xml" ""
-  '';
-
   nativeBuildInputs = [ setuptools-scm ];
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiosignal/default.nix
+++ b/pkgs/development/python-modules/aiosignal/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   frozenlist,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -26,13 +27,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "filterwarnings = error" "" \
-      --replace "--cov=aiosignal" ""
+      --replace "filterwarnings = error" ""
   '';
 
   pythonImportsCheck = [ "aiosignal" ];

--- a/pkgs/development/python-modules/aiosonic/default.nix
+++ b/pkgs/development/python-modules/aiosonic/default.nix
@@ -18,6 +18,7 @@
   proxy-py,
   pytest-aiohttp,
   pytest-asyncio,
+  pytest-cov-stub,
   pytest-django,
   pytest-mock,
   pytest-sugar,
@@ -51,8 +52,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini --replace-fail \
-      "addopts = --black --cov=aiosonic --cov-report term --cov-report html --doctest-modules" \
-      "addopts = --doctest-modules"
+      "addopts = --black " \
+      "addopts = "
   '';
 
   build-system = [ poetry-core ];
@@ -74,6 +75,7 @@ buildPythonPackage rec {
     proxy-py
     pytest-aiohttp
     pytest-asyncio
+    pytest-cov-stub
     pytest-django
     pytest-mock
     pytest-sugar

--- a/pkgs/development/python-modules/aiosteamist/default.nix
+++ b/pkgs/development/python-modules/aiosteamist/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   poetry-core,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
   xmltodict,
 }:
@@ -23,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-e7Nt/o2A1qn2nSpWv6ZsZHn/WpcXKzol+f+JNJaSb4w=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov=aiosteamist" ""
-  '';
-
   build-system = [ poetry-core ];
 
   dependencies = [
@@ -37,6 +33,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "aiosteamist" ];

--- a/pkgs/development/python-modules/aioweenect/default.nix
+++ b/pkgs/development/python-modules/aioweenect/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   hatchling,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -26,7 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "--cov --cov-report term-missing --cov=src/aioweenect --asyncio-mode=auto" ""
+      --replace-fail "--asyncio-mode=auto" ""
   '';
 
   pythonRelaxDeps = [ "aiohttp" ];
@@ -38,6 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aresponses
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiozoneinfo/default.nix
+++ b/pkgs/development/python-modules/aiozoneinfo/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   poetry-core,
   pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   tzdata,
@@ -23,17 +24,13 @@ buildPythonPackage rec {
     hash = "sha256-7qd6Yk/K4BLocu8eQK0hLaw2r1jhWIHBr9W4KsAvmx8=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov=aiozoneinfo --cov-report=term-missing:skip-covered" ""
-  '';
-
   build-system = [ poetry-core ];
 
   dependencies = [ tzdata ];
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/async-modbus/default.nix
+++ b/pkgs/development/python-modules/async-modbus/default.nix
@@ -4,7 +4,7 @@
   connio,
   fetchFromGitHub,
   fetchpatch,
-  pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -35,8 +35,6 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"--cov=async_modbus",' "" \
-      --replace '"--cov-report=html", "--cov-report=term",' "" \
       --replace '"--durations=2", "--verbose"' ""
   '';
 
@@ -48,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest-asyncio
+    pytest-cov-stub
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/bitlist/default.nix
+++ b/pkgs/development/python-modules/bitlist/default.nix
@@ -6,6 +6,7 @@
   wheel,
   parts,
   pytestCheckHook,
+  pytest-cov-stub,
   pythonOlder,
 }:
 
@@ -21,11 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-+/rBno+OH7yEiN4K9VC6BCEPuOv8nNp0hU+fWegjqPw=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '--cov=bitlist --cov-report term-missing' ""
-  '';
-
   build-system = [
     setuptools
     wheel
@@ -35,7 +31,10 @@ buildPythonPackage rec {
 
   dependencies = [ parts ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pythonImportsCheck = [ "bitlist" ];
 

--- a/pkgs/development/python-modules/bluetooth-sensor-state-data/default.nix
+++ b/pkgs/development/python-modules/bluetooth-sensor-state-data/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   home-assistant-bluetooth,
   poetry-core,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   sensor-state-data,
@@ -23,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-W+gU9YlxoCh5zRht44Ovq3Doms8UtCvUNLlSUpzsQwA=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail " --cov=bluetooth_sensor_state_data --cov-report=term-missing:skip-covered" ""
-  '';
-
   build-system = [ poetry-core ];
 
   dependencies = [
@@ -35,7 +31,10 @@ buildPythonPackage rec {
     sensor-state-data
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "bluetooth_sensor_state_data" ];
 

--- a/pkgs/development/python-modules/brunt/default.nix
+++ b/pkgs/development/python-modules/brunt/default.nix
@@ -5,6 +5,7 @@
   fetchPypi,
   aiohttp,
   requests,
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -21,16 +22,15 @@ buildPythonPackage rec {
     sha256 = "e704627dc7b9c0a50c67ae90f1d320b14f99f2b2fc9bf1ef0461b141dcf1bce9";
   };
 
-  postPatch = ''
-    sed -i '/--cov/d' setup.cfg
-  '';
-
   propagatedBuildInputs = [
     aiohttp
     requests
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   # tests require Brunt hardware
   doCheck = false;

--- a/pkgs/development/python-modules/certauth/default.nix
+++ b/pkgs/development/python-modules/certauth/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   pyopenssl,
   tldextract,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -24,11 +25,6 @@ buildPythonPackage rec {
     hash = "sha256-Rso5N0jb9k7bdorjPIUMNiZZPnzwbkxFNiTpsJ9pco0=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "--cov certauth " ""
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
@@ -36,7 +32,10 @@ buildPythonPackage rec {
     tldextract
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "certauth" ];
 

--- a/pkgs/development/python-modules/cfn-flip/default.nix
+++ b/pkgs/development/python-modules/cfn-flip/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
   pyyaml,
@@ -29,11 +30,10 @@ buildPythonPackage rec {
     six
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  postPatch = ''
-    sed -i "/--cov/d" tox.ini
-  '';
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   disabledTests = [
     # TypeError: load() missing 1 required positional argument: 'Loader'

--- a/pkgs/development/python-modules/cftime/default.nix
+++ b/pkgs/development/python-modules/cftime/default.nix
@@ -4,6 +4,7 @@
   cython,
   fetchPypi,
   numpy,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
 }:
@@ -20,10 +21,6 @@ buildPythonPackage rec {
     hash = "sha256-UKx2zJ8Qq3vUbkSnHFGmknBRtJm0QH308pqxPXQblC8=";
   };
 
-  postPatch = ''
-    sed -i "/--cov/d" setup.cfg
-  '';
-
   nativeBuildInputs = [
     cython
     numpy
@@ -31,7 +28,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "cftime" ];
 

--- a/pkgs/development/python-modules/chacha20poly1305-reuseable/default.nix
+++ b/pkgs/development/python-modules/chacha20poly1305-reuseable/default.nix
@@ -13,6 +13,7 @@
   cryptography,
 
   # tests
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -46,12 +47,10 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "chacha20poly1305_reuseable" ];
 
-  preCheck = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "--cov=chacha20poly1305_reuseable --cov-report=term-missing:skip-covered" ""
-  '';
-
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "ChaCha20Poly1305 that is reuseable for asyncio";

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -10,6 +10,7 @@
   path,
   portend,
   pyopenssl,
+  pytest-cov-stub,
   pytest-forked,
   pytest-services,
   pytestCheckHook,
@@ -38,10 +39,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Disable doctest plugin because times out
     substituteInPlace pytest.ini \
-      --replace-fail "--doctest-modules" "-vvv" \
-      --replace-fail "-p pytest_cov" "" \
-      --replace-fail "--no-cov-on-fail" ""
-    sed -i "/--cov/d" pytest.ini
+      --replace-fail "--doctest-modules" "-vvv"
   '';
 
   build-system = [ setuptools-scm ];
@@ -57,6 +55,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     objgraph
     path
+    pytest-cov-stub
     pytest-forked
     pytest-services
     pytestCheckHook

--- a/pkgs/development/python-modules/click-repl/default.nix
+++ b/pkgs/development/python-modules/click-repl/default.nix
@@ -12,6 +12,7 @@
   six,
 
   # tests
+  pytest-cov-stub,
   pytestCheckHook,
 }:
 
@@ -27,10 +28,6 @@ buildPythonPackage rec {
     hash = "sha256-xCT3w0DDY73dtDL5jbssXM05Zlr44OOcy4vexgHyWiE=";
   };
 
-  postPatch = ''
-    sed -i '/--cov=/d' pyproject.toml
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
@@ -39,7 +36,10 @@ buildPythonPackage rec {
     six
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/click-contrib/click-repl";


### PR DESCRIPTION
I migrated a small handfull, there are `rg -l  -- --cov pkgs/ | wc -l` -> 152 files remaining
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
