### PR TITLE
openbsd.rc: work around rc_bg bug when /bin/sh is bash

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/rc/binsh-is-bash.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rc/binsh-is-bash.patch
@@ -1,0 +1,19 @@
+When /bin/sh is bash, this code doesn't work right - bash has a "tail call"
+optimization where the last command in a finite script will be run as if with
+exec instead of forking a new shell. rc here expects `pkill -P $$` (kill all
+processes with parent pid == shell) to effectively background a process, but
+instead it kills it!
+
+diff --git a/etc/rc.d/rc.subr b/etc/rc.d/rc.subr
+index 1f872f0ebc8..0c32b00e2ef 100644
+--- a/etc/rc.d/rc.subr
++++ b/etc/rc.d/rc.subr
+@@ -178,7 +178,7 @@ rc_exec() {
+ 		${daemon_execdir:+cd ${daemon_execdir} && } \
+ 		$@ \
+ 		${daemon_logger:+ 2>&1 |
+-			logger -isp ${daemon_logger} -t ${_name}}"
++			logger -isp ${daemon_logger} -t ${_name}}; exit"
+ }
+ 
+ rc_start() {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rc/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rc/package.nix
@@ -5,7 +5,10 @@ mkDerivation {
   pname = "rc";
   path = "etc";
 
-  patches = [ ./boot-phases.patch ];
+  patches = [
+    ./boot-phases.patch
+    ./binsh-is-bash.patch
+  ];
 
   buildPhase = ":";
 


### PR DESCRIPTION
See patch header.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
