### PR TITLE
freebsd.{jail,jls,jexec}: init

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/jail-use-path.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/jail-use-path.patch
@@ -1,0 +1,112 @@
+In a NixOS-like system, it doesn't make sense to hardcode these absolute paths.
+They even already use execvp!
+
+diff --git a/usr.sbin/jail/command.c b/usr.sbin/jail/command.c
+index 9eabcc5ff53c..2024f6bfb97a 100644
+--- a/usr.sbin/jail/command.c
++++ b/usr.sbin/jail/command.c
+@@ -363,7 +363,7 @@ run_command(struct cfjail *j)
+ 		}
+ 
+ 		argv = alloca((8 + argc) * sizeof(char *));
+-		argv[0] = _PATH_IFCONFIG;
++		argv[0] = "ifconfig";
+ 		if ((cs = strchr(val, '|'))) {
+ 			argv[1] = acs = alloca(cs - val + 1);
+ 			strlcpy(acs, val, cs - val + 1);
+@@ -420,7 +420,7 @@ run_command(struct cfjail *j)
+ 		}
+ 
+ 		argv = alloca((8 + argc) * sizeof(char *));
+-		argv[0] = _PATH_IFCONFIG;
++		argv[0] = "ifconfig";
+ 		if ((cs = strchr(val, '|'))) {
+ 			argv[1] = acs = alloca(cs - val + 1);
+ 			strlcpy(acs, val, cs - val + 1);
+@@ -454,7 +454,7 @@ run_command(struct cfjail *j)
+ 
+ 	case IP_VNET_INTERFACE:
+ 		argv = alloca(5 * sizeof(char *));
+-		argv[0] = _PATH_IFCONFIG;
++		argv[0] = "ifconfig";
+ 		argv[1] = comstring->s;
+ 		argv[2] = down ? "-vnet" : "vnet";
+ 		jidstr = string_param(j->intparams[KP_JID]);
+@@ -490,7 +490,7 @@ run_command(struct cfjail *j)
+ 		if (down) {
+ 			argv[4] = NULL;
+ 			argv[3] = argv[1];
+-			argv[0] = "/sbin/umount";
++			argv[0] = "umount";
+ 		} else {
+ 			if (argc == 4) {
+ 				argv[7] = NULL;
+@@ -503,7 +503,7 @@ run_command(struct cfjail *j)
+ 				argv[4] = argv[1];
+ 				argv[3] = argv[0];
+ 			}
+-			argv[0] = _PATH_MOUNT;
++			argv[0] = "mount";
+ 		}
+ 		argv[1] = "-t";
+ 		break;
+@@ -521,11 +521,11 @@ run_command(struct cfjail *j)
+ 		    down ? "devfs" : NULL) < 0)
+ 			return -1;
+ 		if (down) {
+-			argv[0] = "/sbin/umount";
++			argv[0] = "umount";
+ 			argv[1] = devpath;
+ 			argv[2] = NULL;
+ 		} else {
+-			argv[0] = _PATH_MOUNT;
++			argv[0] = "mount";
+ 			argv[1] = "-t";
+ 			argv[2] = "devfs";
+ 			ruleset = string_param(j->intparams[KP_DEVFS_RULESET]);
+@@ -552,11 +552,11 @@ run_command(struct cfjail *j)
+ 		    down ? "fdescfs" : NULL) < 0)
+ 			return -1;
+ 		if (down) {
+-			argv[0] = "/sbin/umount";
++			argv[0] = "umount";
+ 			argv[1] = devpath;
+ 			argv[2] = NULL;
+ 		} else {
+-			argv[0] = _PATH_MOUNT;
++			argv[0] = "mount";
+ 			argv[1] = "-t";
+ 			argv[2] = "fdescfs";
+ 			argv[3] = ".";
+@@ -578,11 +578,11 @@ run_command(struct cfjail *j)
+ 		    down ? "procfs" : NULL) < 0)
+ 			return -1;
+ 		if (down) {
+-			argv[0] = "/sbin/umount";
++			argv[0] = "umount";
+ 			argv[1] = devpath;
+ 			argv[2] = NULL;
+ 		} else {
+-			argv[0] = _PATH_MOUNT;
++			argv[0] = "mount";
+ 			argv[1] = "-t";
+ 			argv[2] = "procfs";
+ 			argv[3] = ".";
+@@ -610,7 +610,7 @@ run_command(struct cfjail *j)
+ 		if ((cs = strpbrk(comstring->s, "!\"$&'()*;<>?[\\]`{|}~")) &&
+ 		    !(cs[0] == '&' && cs[1] == '\0')) {
+ 			argv = alloca(4 * sizeof(char *));
+-			argv[0] = _PATH_BSHELL;
++			argv[0] = "sh";
+ 			argv[1] = "-c";
+ 			argv[2] = comstring->s;
+ 			argv[3] = NULL;
+@@ -763,7 +763,7 @@ run_command(struct cfjail *j)
+ 		setenv("USER", pwd->pw_name, 1);
+ 		setenv("HOME", pwd->pw_dir, 1);
+ 		setenv("SHELL",
+-		    *pwd->pw_shell ? pwd->pw_shell : _PATH_BSHELL, 1);
++		    *pwd->pw_shell ? pwd->pw_shell : "sh", 1);
+ 		if (clean && chdir(pwd->pw_dir) < 0) {
+ 			jail_warnx(j, "chdir %s: %s",
+ 			    pwd->pw_dir, strerror(errno));

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jail.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jail.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  mkDerivation,
+  flex,
+  byacc,
+  libjail,
+}:
+mkDerivation {
+  path = "usr.sbin/jail";
+  extraNativeBuildInputs = [
+    flex
+    byacc
+  ];
+  buildInputs = [
+    libjail
+  ];
+  MK_TESTS = "no";
+  meta.mainProgram = "jail";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jexec.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jexec.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  mkDerivation,
+  libjail,
+}:
+mkDerivation {
+  path = "usr.sbin/jexec";
+  buildInputs = [
+    libjail
+  ];
+  meta.mainProgram = "jexec";
+  meta.platforms = lib.platforms.freebsd;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/jls.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/jls.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  mkDerivation,
+  libjail,
+  libxo,
+}:
+mkDerivation {
+  path = "usr.sbin/jls";
+  buildInputs = [
+    libjail
+    libxo
+  ];
+  meta.mainProgram = "jls";
+  meta.platforms = lib.platforms.freebsd;
+}


### PR DESCRIPTION
It works!

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
