### PR TITLE
recaf-launcher: init at 0.8.1

### DIFF
--- a/pkgs/by-name/re/recaf-launcher/package.nix
+++ b/pkgs/by-name/re/recaf-launcher/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  buildFHSEnv,
+}:
+let
+  version = "0.8.1";
+  jar = fetchurl {
+    url = "https://github.com/Col-E/Recaf-Launcher/releases/download/${version}/recaf-gui-${version}.jar";
+    hash = "sha256-RHsI8z/orwR9b9s+LrrOHpxpr82J6YOpnfik3dnlsvI=";
+  };
+in
+buildFHSEnv {
+  pname = "recaf-launcher";
+  inherit version;
+
+  targetPkgs =
+    p: with p; [
+      jar
+
+      openjdk23
+      xorg.libX11
+      at-spi2-atk
+      cairo
+      gdk-pixbuf
+      glib
+      gtk3
+      pango
+      xorg.libXtst
+      xorg.libX11
+      xorg_sys_opengl
+    ];
+
+  runScript = "java -jar ${jar}";
+
+  meta = {
+    description = "Simple launcher for Recaf 4.X and above - a modern Java bytecode editor";
+    homepage = "https://recaf.coley.software";
+    changelog = "https://github.com/Col-E/Recaf-Launcher/releases/tag/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tudbut ];
+    mainProgram = "recaf-launcher";
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}


### PR DESCRIPTION
This is a simple FHS-based package for [the Recaf launcher](https://github.com/Col-E/Recaf-Launcher). 

[Recaf](https://github.com/Col-E/Recaf) is a Java bytecode editor: It lets users decompile and recompile java .class files, along with editing the underlying bytecode directly, and stuff like that.#

Works towards: #267124


I would've packaged this more cleanly, but the JavaFX that the launcher downloads ships with unpatched libraries. 

A package for the recaf directly, not the launcher, is only really feasible for Recaf 2, since Recaf 4 is, at least right now, rolling release.

Using nixpkgs's openjfx also does not seem possible due to Recaf expecting it to be in jars and in the same directory as itself. This would likely prove difficult without patching the source.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
