### PR TITLE
ocamlPackages.wasm_of_ocaml-compiler: init at 6.0.1

### DIFF
--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler-wasm.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler-wasm.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildDunePackage,
+  binaryen,
+  cmdliner,
+  js_of_ocaml-compiler,
+  menhir,
+  menhirLib,
+  ppxlib,
+  sedlex,
+  yojson,
+}:
+
+buildDunePackage {
+  pname = "wasm_of_ocaml-compiler";
+  inherit (js_of_ocaml-compiler) version src;
+  minimalOCamlVersion = "4.12";
+
+  nativeBuildInputs = [
+    binaryen
+    menhir
+  ];
+
+  buildInputs = [
+    cmdliner
+    ppxlib
+  ];
+
+  propagatedBuildInputs = [
+    js_of_ocaml-compiler
+    menhirLib
+    sedlex
+    yojson
+  ];
+
+  meta = js_of_ocaml-compiler.meta // {
+    description = "Compiler from OCaml bytecode to WebAssembly";
+    mainProgram = "wasm_of_ocaml";
+    maintainers = [ lib.maintainers.stepbrobd ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2012,6 +2012,8 @@ let
 
     wasm = callPackage ../development/ocaml-modules/wasm { };
 
+    wasm_of_ocaml-compiler = callPackage ../development/tools/ocaml/js_of_ocaml/compiler-wasm.nix { };
+
     wayland = callPackage ../development/ocaml-modules/wayland { };
 
     webbrowser = callPackage ../development/ocaml-modules/webbrowser { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

wasm_of_ocaml-compiler was merged into js_ocaml in https://github.com/ocsigen/js_of_ocaml/pull/1724 and released along in [6.0.1](https://github.com/ocsigen/js_of_ocaml/releases/tag/6.0.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
