### PR TITLE
jbang: add support for custom extra packages

### DIFF
--- a/pkgs/by-name/jb/jbang/package.nix
+++ b/pkgs/by-name/jb/jbang/package.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   coreutils,
   curl,
+  extraPackages ? [ ],
 }:
 
 stdenv.mkDerivation rec {
@@ -26,12 +27,15 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/jbang \
       --set JAVA_HOME ${jdk} \
       --set PATH ${
-        lib.makeBinPath [
-          (placeholder "out")
-          coreutils
-          jdk
-          curl
-        ]
+        lib.makeBinPath (
+          [
+            (placeholder "out")
+            coreutils
+            jdk
+            curl
+          ]
+          ++ extraPackages
+        )
       }
     runHook postInstall
   '';


### PR DESCRIPTION
Support adding custom extra packages to the runtime path of jbang.

Previously, I was able to add custom packages to the runtime path of jbang by using the postInstall hook like so:

```nix
jbang.overrideAttrs (oldAttrs: {
  postInstall = ''
        wrapProgram $out/bin/jbang \
          --set JAVA_HOME ${jdk} \
          --set PATH ${
            lib.makeBinPath [
              (placeholder "out")
              coreutils
              jdk
              curl
              git # extra package used by jbang script
            ]
          }
  '';
})
```
However this stopped working. Currently, I have to override (and duplicate) the whole installPhase.

Example jbang script, requiring extra dependencies:

```java
///usr/bin/env jbang "$0" "$@" ; exit $?

import static java.lang.System.*;

public class hello {

    public static void main(String... args) throws Exception {
	Process process = Runtime.getRuntime().exec("git status");
	int exitCode = process.waitFor();
    }
}
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@moaxcp Please let me know what you think! Is there a better way to achieve this?