### PR TITLE
rathole: fix test failures due to expired certs, fix darwin build

### DIFF
--- a/pkgs/by-name/ra/rathole/0001-no-more-vergen.patch
+++ b/pkgs/by-name/ra/rathole/0001-no-more-vergen.patch
@@ -1,0 +1,22 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index e7a944e..e6bae43 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -7,7 +7,6 @@ description = "A reverse proxy for NAT traversal"
+ license = "Apache-2.0"
+ repository = "https://github.com/rapiz1/rathole"
+ readme = "README.md"
+-build = "build.rs"
+ include = ["src/**/*", "LICENSE", "README.md", "build.rs"]
+ 
+ [features]
+@@ -130,9 +129,4 @@ p12 = { version = "0.6.3", optional = true }
+ openssl = { version = "0.10", features = ["vendored"], optional = true }
+ 
+ [build-dependencies]
+-vergen = { version = "7.4.2", default-features = false, features = [
+-    "build",
+-    "git",
+-    "cargo",
+-] }
+ anyhow = "1.0"

--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -33,6 +33,12 @@ rustPlatform.buildRustPackage {
 
   __darwinAllowLocalNetworking = true;
 
+  nativeCheckInputs = [ openssl ];
+  preCheck = ''
+    patchShebangs examples/tls/create_self_signed_cert.sh
+    (cd examples/tls && chmod +x create_self_signed_cert.sh && ./create_self_signed_cert.sh)
+  '';
+
   passthru.tests = {
     inherit (nixosTests) rathole;
   };

--- a/pkgs/by-name/ra/rathole/package.nix
+++ b/pkgs/by-name/ra/rathole/package.nix
@@ -3,13 +3,13 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
+  rustc,
   pkg-config,
   openssl,
   nixosTests,
-  darwin,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "rathole";
   version = "0.5.0-unstable-2024-06-06";
 
@@ -20,16 +20,27 @@ rustPlatform.buildRustPackage {
     hash = "sha256-C0/G4JOZ4pTAvcKZhRHsGvlLlwAyWBQ0rMScLvaLSuA=";
   };
 
+  # Get rid of git dependency on vergen. No reason to require libgit2-sys as
+  # well as libz-sys. Vendored c libraries for libgit2/zlib fail to build on
+  # darwin and using libs from nixpkgs seems excessive.
+  patches = [
+    ./0001-no-more-vergen.patch
+  ];
+
+  # Build script is only needed for vergen and does nothing when not in a git
+  # repo.
+  postPatch = ''
+    rm build.rs
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-IgPDe8kuWzJ6nF2DceUbN7fw0eGkoYhu1IGMdlSMFos=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ CoreServices ]);
+  buildInputs = [
+    openssl
+  ];
 
   __darwinAllowLocalNetworking = true;
 
@@ -38,6 +49,18 @@ rustPlatform.buildRustPackage {
     patchShebangs examples/tls/create_self_signed_cert.sh
     (cd examples/tls && chmod +x create_self_signed_cert.sh && ./create_self_signed_cert.sh)
   '';
+
+  env = {
+    VERGEN_BUILD_TIMESTAMP = "0";
+    VERGEN_BUILD_SEMVER = version;
+    VERGEN_GIT_COMMIT_TIMESTAMP = "0";
+    VERGEN_GIT_BRANCH = "main";
+    VERGEN_RUSTC_SEMVER = rustc.version;
+    VERGEN_RUSTC_CHANNEL = "stable";
+    VERGEN_CARGO_PROFILE = "release";
+    VERGEN_CARGO_FEATURES = "";
+    VERGEN_CARGO_TARGET_TRIPLE = "${stdenv.hostPlatform.rust.rustcTarget}";
+  };
 
   passthru.tests = {
     inherit (nixosTests) rathole;


### PR DESCRIPTION
Upstream dummy self-signed cert has expired and now tests fail. Yay for tests that fail based on the current time

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            1c:f6:27:75:97:e5:99:b0:d5:ff:7d:02:f8:11:d0:4a:23:6f:51:34
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN=MyOwnCA, C=US, L=San Fransisco
        Validity
            Not Before: Feb 15 05:04:49 2024 GMT
            Not After : Feb  5 05:04:49 2025 GMT
```

Fix darwin build by dropping the vergen build-time dependency, which requires libgit2-sys as well as libz-sys that fails to compile (thanks -sys crates for reinventing C/C++ build systems in a yet another hacky and broken way).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
