### PR TITLE
ocserv: 1.2.4 -> 1.3.0

### DIFF
--- a/pkgs/by-name/oc/ocserv/package.nix
+++ b/pkgs/by-name/oc/ocserv/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   autoreconfHook,
   pkg-config,
+  ipcalc,
   nettle,
   gnutls,
   libev,
@@ -14,21 +15,20 @@
   gperf,
   readline,
   lz4,
-  libgssglue,
   ronn,
   pam,
   libxcrypt,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ocserv";
-  version = "1.2.4";
+  version = "1.3.0";
 
   src = fetchFromGitLab {
     owner = "openconnect";
     repo = "ocserv";
-    rev = version;
-    hash = "sha256-IYiYC9oAw35YjpptUEnhuZQqoDevku25r7qi6SG8xtk=";
+    tag = finalAttrs.version;
+    hash = "sha256-oZ1t1BTCdsq1jpa7LfzRGwQNTROHH9/lLBT2WAvj5h4=";
   };
 
   nativeBuildInputs = [
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     ronn
   ];
   buildInputs = [
+    ipcalc
     nettle
     gnutls
     libev
@@ -47,15 +48,14 @@ stdenv.mkDerivation rec {
     libseccomp
     readline
     lz4
-    libgssglue
     pam
     libxcrypt
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.com/openconnect/ocserv";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     description = "OpenConnect VPN server (ocserv), a server for the OpenConnect VPN client";
-    maintainers = with maintainers; [ neverbehave ];
+    maintainers = with lib.maintainers; [ neverbehave ];
   };
-}
+})


### PR DESCRIPTION
The package now requires `ipcalc` as dependency. Added that.
The `libgssglue` dependency doesn't seem required or change the output of the build if removed. Removed it therefore.
The `guile` dependency doesn't seem required. Well, at least it builds without. But the binary changes. As i'm not sure how everything interlinks i've left it there.

Version Changelog:

- Switch to https://github.com/nodejs/llhttp from http-parser. http-parser was a liability as an unmaintained project
- Bump the number of groups per account from 128 to 512
- Allow connecting users to select an authgroup by appending the group name to the URL, as in https://vpn.example.com/groupname; this introduces the select-group-by-url config option.
- Informational messages due to configuration loading are not printed during worker initialization.

Source: https://gitlab.com/openconnect/ocserv/-/blob/1.3.0/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
