### PR TITLE
opencl-clhpp: 2024.05.08 -> 2024.10.24, clpeak: 1.1.0 -> 1.1.4 and adoptions

### DIFF
--- a/pkgs/by-name/cl/clpeak/package.nix
+++ b/pkgs/by-name/cl/clpeak/package.nix
@@ -7,25 +7,17 @@
   opencl-clhpp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "clpeak";
-  version = "1.1.0";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "krrishnarraj";
     repo = "clpeak";
-    rev = version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
-    sha256 = "1wkjpvn4r89c3y06rv7gfpwpqw6ljmqwz0w0mljl9y5hn1r4pkx2";
+    hash = "sha256-unQLZ5EExL9lU2XuYLJjASeFzDA74+TnU0CQTWyNYiQ=";
   };
-
-  patches = [
-    # The cl.hpp header was removed from opencl-clhpp. This patch
-    # updates clpeak to use the new cp2.hpp header. The patch comes
-    # from the following PR and was updated to apply against more
-    # recent versions: https://github.com/krrishnarraj/clpeak/pull/46
-    ./clpeak-clhpp2.diff
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -34,11 +26,11 @@ stdenv.mkDerivation rec {
     opencl-clhpp
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool which profiles OpenCL devices to find their peak capacities";
     homepage = "https://github.com/krrishnarraj/clpeak/";
-    license = licenses.unlicense;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.xokdvium ];
     mainProgram = "clpeak";
   };
-}
+})

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "OpenCL Host API C++ bindings";
     homepage = "http://github.khronos.org/OpenCL-CLHPP/";
-    license = lib.licenses.mit;
+    license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.xokdvium ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -4,18 +4,21 @@
   fetchFromGitHub,
   cmake,
   python3,
+  ruby,
   opencl-headers,
+  khronos-ocl-icd-loader,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "opencl-clhpp";
   version = "2024.10.24";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-CLHPP";
-    rev = "v${version}";
-    sha256 = "sha256-b5f2qFJqLdGEMGnaUY8JmWj2vjZscwLua4FhgC4YP+k=";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-3RVZJIt03pRmjrPa9q6h6uqFCuTnxvEqjUGUmdwybbY=";
   };
 
   nativeBuildInputs = [
@@ -27,9 +30,13 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  doCheck = true;
+  checkInputs = [ khronos-ocl-icd-loader ];
+  nativeCheckInputs = [ ruby ];
+
   cmakeFlags = [
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_TESTS=OFF"
+    (lib.cmakeBool "OPENCL_CLHPP_BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_EXAMPLES" finalAttrs.finalPackage.doCheck)
   ];
 
   meta = {
@@ -39,4 +46,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.xokdvium ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -7,6 +7,7 @@
   ruby,
   opencl-headers,
   khronos-ocl-icd-loader,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,6 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OPENCL_CLHPP_BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "BUILD_EXAMPLES" finalAttrs.finalPackage.doCheck)
   ];
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "OpenCL-CLHPP" ];
+      # Package version does not match the pkg-config module version.
+    };
+  };
 
   meta = {
     description = "OpenCL Host API C++ bindings";

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "opencl-clhpp";
-  version = "2024.05.08";
+  version = "2024.10.24";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-CLHPP";
     rev = "v${version}";
-    sha256 = "sha256-bIm4tGqwWX0IPKH3BwLgkf0T7YFrkN6vemYvdPrqUpw=";
+    sha256 = "sha256-b5f2qFJqLdGEMGnaUY8JmWj2vjZscwLua4FhgC4YP+k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -32,10 +32,11 @@ stdenv.mkDerivation rec {
     "-DBUILD_TESTS=OFF"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "OpenCL Host API C++ bindings";
     homepage = "http://github.khronos.org/OpenCL-CLHPP/";
-    license = licenses.mit;
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.xokdvium ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/op/opencl-headers/package.nix
+++ b/pkgs/by-name/op/opencl-headers/package.nix
@@ -30,11 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Khronos OpenCL headers version ${finalAttrs.version}";
     homepage = "https://www.khronos.org/registry/cl/";
-    license = licenses.asl20;
-    platforms = platforms.unix ++ platforms.windows;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+    maintainers = [ lib.maintainers.xokdvium ];
   };
 })

--- a/pkgs/by-name/op/opencl-headers/package.nix
+++ b/pkgs/by-name/op/opencl-headers/package.nix
@@ -7,6 +7,7 @@
   ocl-icd,
   tesseract,
   testers,
+  opencl-clhpp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,7 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   passthru.tests = {
-    inherit ocl-icd tesseract hashcat;
+    inherit
+      ocl-icd
+      tesseract
+      hashcat
+      opencl-clhpp
+      ;
     pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
       moduleNames = [ "OpenCL-Headers" ];


### PR DESCRIPTION
- Sync `opencl-clhpp` headers to the same version as `opencl-headers`.
- Enable tests for `opencl-clhpp`, this should help us catch failures early.
- Bump `clpeak` to work with newer `opencl-clhpp`, update license starting from 1.1.3.
- Adopt `clpeak`, `opencl-clhpp` and `opencl-headers`.  (Seems to me that such a core package should not be an orphan)
- Fixed license for `opencl-hpp`.

Current situation is that we end with `clhpp` and `opencl-headers` that are wildly out of sync and don't have tests enabled. Ideally all khronos stuff should be bumped together.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
