### PR TITLE
python3Packages.dahlia: fix build and enable tests

### DIFF
--- a/pkgs/development/python-modules/dahlia/default.nix
+++ b/pkgs/development/python-modules/dahlia/default.nix
@@ -2,7 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
+  hatchling,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -17,8 +18,10 @@ buildPythonPackage rec {
     hash = "sha256-489wI0SoC6EU9lC2ISYsLOJUC8g+kLA7UpOrDiBCBmo=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
   pythonImportsCheck = [ "dahlia" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     changelog = "https://github.com/dahlia-lib/dahlia/blob/${src.tag}/CHANGELOG.md";


### PR DESCRIPTION
Required for #377152 to build.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).