### PR TITLE
quarto: use --set instead of --prefix

### DIFF
--- a/pkgs/development/libraries/quarto/default.nix
+++ b/pkgs/development/libraries/quarto/default.nix
@@ -18,6 +18,24 @@
   sysctl,
   which,
 }:
+
+let
+  rWithPackages = rWrapper.override {
+    packages = [
+      rPackages.rmarkdown
+    ] ++ extraRPackages;
+  };
+
+  pythonWithPackages = python3.withPackages (
+    ps:
+    with ps;
+    [
+      jupyter
+      ipython
+    ]
+    ++ (extraPythonPackages ps)
+  );
+in
 stdenv.mkDerivation (final: {
   pname = "quarto";
   version = "1.7.30";
@@ -40,30 +58,13 @@ stdenv.mkDerivation (final: {
 
   preFixup = ''
     wrapProgram $out/bin/quarto \
-      --prefix QUARTO_DENO : ${lib.getExe deno} \
-      --prefix QUARTO_PANDOC : ${lib.getExe pandoc} \
-      --prefix QUARTO_ESBUILD : ${lib.getExe esbuild} \
-      --prefix QUARTO_DART_SASS : ${lib.getExe dart-sass} \
-      --prefix QUARTO_TYPST : ${lib.getExe typst} \
-      ${
-        lib.optionalString (rWrapper != null)
-          "--prefix QUARTO_R : ${
-            rWrapper.override { packages = [ rPackages.rmarkdown ] ++ extraRPackages; }
-          }/bin/R"
-      } \
-      ${lib.optionalString (python3 != null)
-        "--prefix QUARTO_PYTHON : ${
-          python3.withPackages (
-            ps:
-            with ps;
-            [
-              jupyter
-              ipython
-            ]
-            ++ (extraPythonPackages ps)
-          )
-        }/bin/python3"
-      }
+      --set QUARTO_DENO ${lib.getExe deno} \
+      --set QUARTO_PANDOC ${lib.getExe pandoc} \
+      --set QUARTO_ESBUILD ${lib.getExe esbuild} \
+      --set QUARTO_DART_SASS ${lib.getExe dart-sass} \
+      --set QUARTO_TYPST ${lib.getExe typst} \
+      ${lib.optionalString (rWrapper != null) "--set QUARTO_R ${rWithPackages}/bin/R"} \
+      ${lib.optionalString (python3 != null) "--set QUARTO_PYTHON ${pythonWithPackages}/bin/python3"}
   '';
 
   installPhase = ''


### PR DESCRIPTION
Using `--set` or `--set-default` is the correct way to set environment variables with makeWrapper.

`--prefix` just happened to work, since the `:` delimiter only ever actually appears when there are at least two things concatenated in the list.

Since the auto-formatting was horrible on the `python3` and `rWrapper` sections, I also extracted them into a `let in` block.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
