### PR TITLE
qgis: add update script

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -21,7 +21,7 @@ let
 in
 symlinkJoin rec {
 
-  inherit (qgis-unwrapped) version;
+  inherit (qgis-unwrapped) version src;
   name = "qgis-${version}";
 
   paths = [ qgis-unwrapped ];
@@ -47,6 +47,10 @@ symlinkJoin rec {
   passthru = {
     unwrapped = qgis-unwrapped;
     tests.qgis = nixosTests.qgis;
+    updateScript = [
+      ./update.sh
+      "qgis"
+    ];
   };
 
   meta = qgis-unwrapped.meta;

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -21,7 +21,7 @@ let
 in
 symlinkJoin rec {
 
-  inherit (qgis-ltr-unwrapped) version;
+  inherit (qgis-ltr-unwrapped) version src;
   name = "qgis-${version}";
 
   paths = [ qgis-ltr-unwrapped ];
@@ -48,6 +48,10 @@ symlinkJoin rec {
   passthru = {
     unwrapped = qgis-ltr-unwrapped;
     tests.qgis-ltr = nixosTests.qgis-ltr;
+    updateScript = [
+      ./update.sh
+      "qgis-ltr"
+    ];
   };
 
   inherit (qgis-ltr-unwrapped) meta;

--- a/pkgs/applications/gis/qgis/update.sh
+++ b/pkgs/applications/gis/qgis/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl jq
+
+set -eu -o pipefail
+
+url="https://version.qgis.org/version.json"
+
+package="$1"
+
+function make_version {
+    jq --raw-output '[.major, .minor, .patch] | join(".")'
+}
+
+if [ "$package" == "qgis" ]; then
+    version="$(curl --silent $url | jq '.latest' | make_version)"
+elif [ "$package" == "qgis-ltr" ]; then
+    version="$(curl --silent $url | jq '.ltr' | make_version)"
+fi
+
+update-source-version "$package" "$version"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add update script for QGIS and QGIS LTR.

Script was tested by hand and it looks working correctly:

```
$ nix-shell maintainers/scripts/update.nix --argstr package qgis

Going to be running update for following packages:
 - qgis-3.40.3

Press Enter key to continue...

Running update for:
 - qgis-3.40.3: UPDATING ...
 - qgis-3.40.3: DONE.

Packages updated!
```

Which results in the exact same change as done in https://github.com/NixOS/nixpkgs/pull/384036 .
```
git --no-pager diff
diff --git a/pkgs/applications/gis/qgis/unwrapped.nix b/pkgs/applications/gis/qgis/unwrapped.nix
index da82c9a94fc3..a178250bbb6a 100644
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -80,14 +80,14 @@ let
     urllib3
   ];
 in mkDerivation rec {
-  version = "3.40.3";
+  version = "3.42.0";
   pname = "qgis-unwrapped";

   src = fetchFromGitHub {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-AUDohf71NIuEjFrzRQ8QsdvmEjYsZK9aI4j0msVJgcQ=";
+    hash = "sha256-vqT6ffqY1M6/2eW08VghysC+v7ZI9Yz0Zhk9UY/izZc=";
   };

   passthru = {
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
