### PR TITLE
enumer: 1.5.9 -> 1.5.11; evcc: 0.133.0 -> 0.200.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -329,7 +329,7 @@ in {
   etcd-cluster = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./etcd/etcd-cluster.nix {};
   etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
-  evcc = handleTest ./evcc.nix {};
+  evcc = runTest ./evcc.nix;
   fail2ban = handleTest ./fail2ban.nix { };
   fakeroute = handleTest ./fakeroute.nix {};
   fancontrol = handleTest ./fancontrol.nix {};

--- a/nixos/tests/evcc.nix
+++ b/nixos/tests/evcc.nix
@@ -1,107 +1,103 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+{ pkgs, lib, ... }:
 
-  {
-    name = "evcc";
-    meta.maintainers = with lib.maintainers; [ hexa ];
+{
+  name = "evcc";
+  meta.maintainers = with lib.maintainers; [ hexa ];
 
-    nodes = {
-      machine =
-        { config, ... }:
-        {
-          services.evcc = {
-            enable = true;
-            settings = {
-              network = {
-                schema = "http";
-                host = "localhost";
-                port = 7070;
-              };
+  nodes = {
+    machine = {
+      services.evcc = {
+        enable = true;
+        settings = {
+          network = {
+            schema = "http";
+            host = "localhost";
+            port = 7070;
+          };
 
-              log = "info";
+          log = "info";
 
-              site = {
-                title = "NixOS Test";
-                meters = {
-                  grid = "grid";
-                  pv = "pv";
-                };
-              };
-
-              meters = [
-                {
-                  type = "custom";
-                  name = "grid";
-                  power = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo -4500'";
-                  };
-                }
-                {
-                  type = "custom";
-                  name = "pv";
-                  power = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo 7500'";
-                  };
-                }
-              ];
-
-              chargers = [
-                {
-                  name = "dummy-charger";
-                  type = "custom";
-                  status = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo charger status A'";
-                  };
-                  enabled = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo charger enabled state false'";
-                  };
-                  enable = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo set charger enabled state true'";
-                  };
-                  maxcurrent = {
-                    source = "script";
-                    cmd = "/bin/sh -c 'echo set charger max current 7200'";
-                  };
-                }
-              ];
-
-              loadpoints = [
-                {
-                  title = "Dummy";
-                  charger = "dummy-charger";
-                }
-              ];
+          site = {
+            title = "NixOS Test";
+            meters = {
+              grid = "grid";
+              pv = "pv";
             };
           };
+
+          meters = [
+            {
+              type = "custom";
+              name = "grid";
+              power = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo -4500'";
+              };
+            }
+            {
+              type = "custom";
+              name = "pv";
+              power = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo 7500'";
+              };
+            }
+          ];
+
+          chargers = [
+            {
+              name = "dummy-charger";
+              type = "custom";
+              status = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo charger status A'";
+              };
+              enabled = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo charger enabled state false'";
+              };
+              enable = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo set charger enabled state true'";
+              };
+              maxcurrent = {
+                source = "script";
+                cmd = "/bin/sh -c 'echo set charger max current 7200'";
+              };
+            }
+          ];
+
+          loadpoints = [
+            {
+              title = "Dummy";
+              charger = "dummy-charger";
+            }
+          ];
         };
+      };
     };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      machine.wait_for_unit("evcc.service")
-      machine.wait_for_open_port(7070)
+    machine.wait_for_unit("evcc.service")
+    machine.wait_for_open_port(7070)
 
-      with subtest("Check package version propagates into frontend"):
-          machine.fail(
-              "curl --fail http://localhost:7070 | grep '0.0.1-alpha'"
-          )
-          machine.succeed(
-              "curl --fail http://localhost:7070 | grep '${pkgs.evcc.version}'"
-          )
+    with subtest("Check package version propagates into frontend"):
+        machine.fail(
+            "curl --fail http://localhost:7070 | grep '0.0.1-alpha'"
+        )
+        machine.succeed(
+            "curl --fail http://localhost:7070 | grep '${pkgs.evcc.version}'"
+        )
 
-      with subtest("Check journal for errors"):
-          _, output = machine.execute("journalctl -o cat -u evcc.service")
-          assert "FATAL" not in output
+    with subtest("Check journal for errors"):
+        _, output = machine.execute("journalctl -o cat -u evcc.service")
+        assert "FATAL" not in output
 
-      with subtest("Check systemd hardening"):
-          _, output = machine.execute("systemd-analyze security evcc.service | grep -v '✓'")
-          machine.log(output)
-    '';
-  }
-)
+    with subtest("Check systemd hardening"):
+        _, output = machine.execute("systemd-analyze security evcc.service | grep -v '✓'")
+        machine.log(output)
+  '';
+}

--- a/pkgs/by-name/ev/evcc/package.nix
+++ b/pkgs/by-name/ev/evcc/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
   stdenv,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
   fetchNpmDeps,
   cacert,
   git,
-  go,
+  go_1_24,
+  gokrazy,
   enumer,
   mockgen,
   nodejs,
@@ -16,23 +17,23 @@
 }:
 
 let
-  version = "0.133.0";
+  version = "0.200.2";
 
   src = fetchFromGitHub {
     owner = "evcc-io";
     repo = "evcc";
     tag = version;
-    hash = "sha256-10xgw6zL49Hk7OH5c6lqeTsIhdkSOyRZCJjSkQox0XI=";
+    hash = "sha256-qSWSZ6luD6Wglmvf9zCoSNs3eVBY6Ket4GFEBKIh99c=";
   };
 
-  vendorHash = "sha256-aBTs6S7b+1JS9MNKWMpuUZ6AXb9ylfXnuAV7q9WnE9w=";
+  vendorHash = "sha256-sx04fyRXX9H2182yz8qvdLv/sSLXTrzhlwpf8lMSVew=";
 
   commonMeta = with lib; {
     license = licenses.mit;
     maintainers = with maintainers; [ hexa ];
   };
 
-  decorate = buildGoModule {
+  decorate = buildGo124Module {
     pname = "evcc-decorate";
     inherit version src vendorHash;
 
@@ -45,13 +46,13 @@ let
   };
 in
 
-buildGoModule rec {
+buildGo124Module rec {
   pname = "evcc";
   inherit version src vendorHash;
 
   npmDeps = fetchNpmDeps {
     inherit src;
-    hash = "sha256-AlwmMipGBnUSaqXxVBlC1c1IZ5utxLYx01T9byXOTrQ=";
+    hash = "sha256-VYAJO2HeswhBlCVKi08frkvhKc/AFepmrSGY4JccBZE=";
   };
 
   nativeBuildInputs = [
@@ -63,7 +64,8 @@ buildGoModule rec {
     nativeBuildInputs = [
       decorate
       enumer
-      go
+      go_1_24
+      gokrazy
       git
       cacert
       mockgen


### PR DESCRIPTION
https://github.com/dmarkham/enumer/compare/refs/tags/v1.5.9...v1.5.11
https://github.com/evcc-io/evcc/releases/tag/0.200.0
https://github.com/evcc-io/evcc/releases/tag/0.200.1
https://github.com/evcc-io/evcc/releases/tag/0.200.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
