### PR TITLE
nixForLinking: init

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -17,7 +17,7 @@
   makeSetupHook,
   cacert,
   callPackage,
-  nix,
+  nixForLinking,
 }:
 
 let
@@ -54,7 +54,7 @@ in
           lib.makeBinPath [
             coreutils
             nix-prefetch-git
-            nix
+            nixForLinking
           ]
         }
 

--- a/pkgs/by-name/at/attic-client/package.nix
+++ b/pkgs/by-name/at/attic-client/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  nix,
+  nixForLinking,
   nixosTests,
   boost,
   pkg-config,
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs =
     [
-      nix
+      nixForLinking
       boost
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage {
   useFetchCargoVendor = true;
 
   ATTIC_DISTRIBUTOR = "nixpkgs";
-  NIX_INCLUDE_PATH = "${lib.getDev nix}/include";
+  NIX_INCLUDE_PATH = "${lib.getDev nixForLinking}/include";
 
   # Attic interacts with Nix directly and its tests require trusted-user access
   # to nix-daemon to import NARs, which is not possible in the build sandbox.

--- a/pkgs/by-name/nu/nurl/package.nix
+++ b/pkgs/by-name/nu/nurl/package.nix
@@ -8,7 +8,7 @@
   darwin,
   gitMinimal,
   mercurial,
-  nix,
+  nixForLinking,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
         lib.makeBinPath [
           gitMinimal
           mercurial
-          nix
+          nixForLinking
         ]
       }
     installManPage artifacts/nurl.1

--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -8,7 +8,7 @@
   llvmPackages,
   meson,
   ninja,
-  nix,
+  nixForLinking,
   nix-update-script,
   nixd,
   nixf,
@@ -101,12 +101,12 @@ in
       ];
 
       buildInputs = [
-        nix
+        nixForLinking
         gtest
         boost
       ];
 
-      env.CXXFLAGS = "-include ${nix.dev}/include/nix/config.h";
+      env.CXXFLAGS = "-include ${nixForLinking.dev}/include/nix/config.h";
 
       passthru.tests.pkg-config = testers.hasPkgConfigModules {
         package = nixt;
@@ -127,7 +127,7 @@ in
       sourceRoot = "${common.src.name}/nixd";
 
       buildInputs = [
-        nix
+        nixForLinking
         nixf
         nixt
         llvmPackages.llvm
@@ -137,7 +137,7 @@ in
 
       nativeBuildInputs = common.nativeBuildInputs ++ [ cmake ];
 
-      env.CXXFLAGS = "-include ${nix.dev}/include/nix/config.h";
+      env.CXXFLAGS = "-include ${nixForLinking.dev}/include/nix/config.h";
 
       # See https://github.com/nix-community/nixd/issues/519
       doCheck = false;

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
-  nix,
+  nixForLinking,
   nlohmann_json,
   boost,
   graphviz,
@@ -27,13 +27,13 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = true;
   nativeCheckInputs = [
-    nix
+    nixForLinking
     graphviz
   ];
 
   buildInputs = [
     boost
-    nix
+    nixForLinking
     nlohmann_json
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -1,5 +1,18 @@
 { lib, stdenv, makeWrapper, buildEnv
-, bash, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial, nix, subversion
+, bash, breezy, coreutils, cvs, findutils, gawk, git, git-lfs, gnused, mercurial
+, # FIXME: These scripts should not depend on Nix, they should depend on a
+  # `.nar` hasher compatible with Nix.
+  #
+  # The fact that these scripts depend on Nix means that e.g. Chromium depends
+  # on Nix.
+  #
+  # Also should be fixed:
+  # - prefetch-yarn-deps
+  # - nurl, nix-init
+  #
+  # Gridlock is one such candidate: https://github.com/lf-/gridlock
+  nixForLinking
+, subversion
 }:
 
 let mkPrefetchScript = tool: src: deps:
@@ -15,7 +28,7 @@ let mkPrefetchScript = tool: src: deps:
     installPhase = ''
       install -vD ${src} $out/bin/$name;
       wrapProgram $out/bin/$name \
-        --prefix PATH : ${lib.makeBinPath (deps ++ [ coreutils gnused nix ])} \
+        --prefix PATH : ${lib.makeBinPath (deps ++ [ coreutils gnused nixForLinking ])} \
         --set HOME /homeless-shelter
     '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17562,6 +17562,16 @@ with pkgs;
 
   nix = nixVersions.stable;
 
+  # Overlays for CppNix nightly, Lix, or Tvix want to change the default Nix
+  # implementation in Nixpkgs by overriding `pkgs.nix`. However, some packages
+  # link against the internal/unstable CppNix APIs directly, and these packages
+  # will break if built with different versions or implementations of Nix.
+  #
+  # If you want to swap out the Nix implementation in your package set, you
+  # don't want these packages to break. Therefore, some packages will refer to
+  # `nixForLinking` explicitly, at least until these dependencies can be sorted out.
+  nixForLinking = nixVersions.stable;
+
   nixStatic = pkgsStatic.nix;
 
   lixVersions = recurseIntoAttrs (callPackage ../tools/package-management/lix {


### PR DESCRIPTION
Overlays for CppNix nightly, Lix, or Tvix want to change the default Nix implementation in Nixpkgs by overriding `pkgs.nix`. However, some packages link against the internal/unstable CppNix APIs directly, and these packages will break if built with different versions or implementations of Nix.

If you want to swap out the Nix implementation in your package set, you don't want these packages to break. Therefore, some packages will refer to `nixForLinking` explicitly, at least until these dependencies can be sorted out.

The addition of an explicit `nixForLinking` attribute decoupled from `nix`, which is just "a Nix implementation", will help Nix implementation maintainers test Nix implementations in Nixpkgs with minimal hassle.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
