### PR TITLE
mesa: remove references to opencl output in drivers output

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -308,6 +308,7 @@ in stdenv.mkDerivation {
 
   postInstall = ''
     # Move driver-related bits to $drivers
+    moveToOutput "lib/gallium-pipe" $drivers
     moveToOutput "lib/gbm" $drivers
     moveToOutput "lib/lib*_mesa*" $drivers
     moveToOutput "lib/libgallium*" $drivers
@@ -339,7 +340,6 @@ in stdenv.mkDerivation {
 
     moveToOutput bin/intel_clc $driversdev
     moveToOutput bin/mesa_clc $driversdev
-    moveToOutput lib/gallium-pipe $opencl
     moveToOutput "lib/lib*OpenCL*" $opencl
     moveToOutput "lib/libOSMesa*" $osmesa
     moveToOutput bin/spirv2dxil $spirv2dxil
@@ -392,7 +392,7 @@ in stdenv.mkDerivation {
 
   env.NIX_CFLAGS_COMPILE = toString ([
     "-UPIPE_SEARCH_DIR"
-    "-DPIPE_SEARCH_DIR=\"${placeholder "opencl"}/lib/gallium-pipe\""
+    "-DPIPE_SEARCH_DIR=\"${placeholder "drivers"}/lib/gallium-pipe\""
   ]);
 
   passthru = {


### PR DESCRIPTION
~~As nothing is actually linked from the `opencl` output, I believe this is unnecessary~~

```console
$ nix why-depends --all --precise --file . mesa.drivers mesa.opencl
/nix/store/pzr5nvrk6l9f635inynvh66wmzj0zz4p-mesa-24.3.4-drivers
└───lib/libEGL_mesa.so.0.0.0: …se nearest filtering./nix/store/mwy556rx53hwpspb9lg9ydjgx5iphqz3-mesa-24.3.4-opencl/lib/gallium-…
    lib/libGLX_mesa.so.0.0.0: …se nearest filtering./nix/store/mwy556rx53hwpspb9lg9ydjgx5iphqz3-mesa-24.3.4-opencl/lib/gallium-…
    → /nix/store/mwy556rx53hwpspb9lg9ydjgx5iphqz3-mesa-24.3.4-opencl
```

A solid GB is shaved off the runtime closure

```console
$ nvd diff /nix/store/pzr5nvrk6l9f635inynvh66wmzj0zz4p-mesa-24.3.4-drivers/ /nix/store/5sh0xzw5f957b30q1p36wi5685710ky6-mesa-24.3.4-drivers/
<<< /nix/store/pzr5nvrk6l9f635inynvh66wmzj0zz4p-mesa-24.3.4-drivers
>>> /nix/store/5sh0xzw5f957b30q1p36wi5685710ky6-mesa-24.3.4-drivers
Version changes:
[C*]  #1  mesa  24.3.4, 24.3.4-drivers, 24.3.4-opencl -> 24.3.4, 24.3.4-drivers
Removed packages:
[R.]  #1  SPIRV-LLVM-Translator  19.1.0
[R.]  #2  clang                  19.1.7-lib
[R.]  #3  libclc                 19.1.7, 19.1.7-dev
Closure size: 59 -> 54 (2 paths added, 7 paths removed, delta -5, disk usage -959.9MiB).
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
