### PR TITLE
haskellPackages: re-enable tests for many packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1563,11 +1563,6 @@ self: super: {
   # See: https://github.com/robstewart57/rdf4h/issues/39
   rdf4h = dontCheck super.rdf4h;
 
-  # hasn't bumped upper bounds
-  # test fails because of a "Warning: Unused LANGUAGE pragma"
-  # https://github.com/ennocramer/monad-dijkstra/issues/4
-  monad-dijkstra = dontCheck super.monad-dijkstra;
-
   # Fixed upstream but not released to Hackage yet:
   # https://github.com/k0001/hs-libsodium/issues/2
   libsodium = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -433,7 +433,6 @@ self: super: {
 
   # check requires mysql server
   mysql-simple = dontCheck super.mysql-simple;
-  mysql-haskell = dontCheck super.mysql-haskell;
 
   # Test data missing
   # https://github.com/FPtje/GLuaFixer/issues/165
@@ -588,7 +587,6 @@ self: super: {
   dbmigrations = dontCheck super.dbmigrations;
   filestore = dontCheck super.filestore;
   graceful = dontCheck super.graceful;
-  HList = dontCheck super.HList;
   ide-backend = dontCheck super.ide-backend;
   marquise = dontCheck super.marquise;                  # https://github.com/anchor/marquise/issues/69
   memcached-binary = dontCheck super.memcached-binary;
@@ -662,15 +660,10 @@ self: super: {
   conduit-connection = dontCheck super.conduit-connection;
   craftwerk = dontCheck super.craftwerk;
   crc = dontCheck super.crc;                            # https://github.com/MichaelXavier/crc/issues/2
-  css-text = dontCheck super.css-text;
   damnpacket = dontCheck super.damnpacket;              # http://hydra.cryp.to/build/496923/log
-  data-hash = dontCheck super.data-hash;
   Deadpan-DDP = dontCheck super.Deadpan-DDP;            # http://hydra.cryp.to/build/496418/log/raw
   DigitalOcean = dontCheck super.DigitalOcean;
-  direct-sqlite = dontCheck super.direct-sqlite;
   directory-layout = dontCheck super.directory-layout;
-  dlist = dontCheck super.dlist;
-  docopt = dontCheck super.docopt;                      # http://hydra.cryp.to/build/499172/log/raw
   dom-selector = dontCheck super.dom-selector;          # http://hydra.cryp.to/build/497670/log/raw
   dotenv = dontCheck super.dotenv;                      # Tests fail because of missing test file on version 0.8.0.2 fixed on version 0.8.0.4
   dotfs = dontCheck super.dotfs;                        # http://hydra.cryp.to/build/498599/log/raw
@@ -689,17 +682,14 @@ self: super: {
   GLFW-b = dontCheck super.GLFW-b;                      # https://github.com/bsl/GLFW-b/issues/50
   hackport = dontCheck super.hackport;
   hadoop-formats = dontCheck super.hadoop-formats;
-  haeredes = dontCheck super.haeredes;
   hashed-storage = dontCheck super.hashed-storage;
   hashring = dontCheck super.hashring;
-  hath = dontCheck super.hath;
   haxl = dontCheck super.haxl;                          # non-deterministic failure https://github.com/facebook/Haxl/issues/85
   haxl-facebook = dontCheck super.haxl-facebook;        # needs facebook credentials for testing
   hdbi-postgresql = dontCheck super.hdbi-postgresql;
   hedis = dontCheck super.hedis;
   hedis-pile = dontCheck super.hedis-pile;
   hedis-tags = dontCheck super.hedis-tags;
-  hedn = dontCheck super.hedn;
   hgdbmi = dontCheck super.hgdbmi;
   hi = dontCheck super.hi;
   hierarchical-clustering = dontCheck super.hierarchical-clustering;
@@ -750,13 +740,9 @@ self: super: {
   lensref = dontCheck super.lensref;
   lvmrun = disableHardening ["format"] (dontCheck super.lvmrun);
   matplotlib = dontCheck super.matplotlib;
-  memcache = dontCheck super.memcache;
-  metrics = dontCheck super.metrics;
   milena = dontCheck super.milena;
   modular-arithmetic = dontCheck super.modular-arithmetic; # tests require a very old Glob (0.7.*)
   nats-queue = dontCheck super.nats-queue;
-  netpbm = dontCheck super.netpbm;
-  network = dontCheck super.network;
   network-dbus = dontCheck super.network-dbus;
   notcpp = dontCheck super.notcpp;
   ntp-control = dontCheck super.ntp-control;
@@ -769,7 +755,6 @@ self: super: {
   parameterized = dontCheck super.parameterized; # https://github.com/louispan/parameterized/issues/2
   persistent-redis = dontCheck super.persistent-redis;
   pipes-extra = dontCheck super.pipes-extra;
-  pipes-websockets = dontCheck super.pipes-websockets;
   posix-pty = dontCheck super.posix-pty; # https://github.com/merijn/posix-pty/issues/12
   postgresql-binary = dontCheck super.postgresql-binary; # needs a running postgresql server
   powerdns = dontCheck super.powerdns; # Tests require networking and external services
@@ -780,36 +765,25 @@ self: super: {
   redis-io = dontCheck super.redis-io;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;
-  safecopy = dontCheck super.safecopy;
   sai-shape-syb = dontCheck super.sai-shape-syb;
   scp-streams = dontCheck super.scp-streams;
   sdl2 = dontCheck super.sdl2; # the test suite needs an x server
   separated = dontCheck super.separated;
   shadowsocks = dontCheck super.shadowsocks;
   shake-language-c = dontCheck super.shake-language-c;
-  snap-core = dontCheck super.snap-core;
   sourcemap = dontCheck super.sourcemap;
   static-resources = dontCheck super.static-resources;
-  strive = dontCheck super.strive;                      # fails its own hlint test with tons of warnings
   svndump = dontCheck super.svndump;
   tar = dontCheck super.tar; #https://hydra.nixos.org/build/25088435/nixlog/2 (fails only on 32-bit)
-  th-printf = dontCheck super.th-printf;
   thumbnail-plus = dontCheck super.thumbnail-plus;
   tickle = dontCheck super.tickle;
   tpdb = dontCheck super.tpdb;
   translatable-intset = dontCheck super.translatable-intset;
   ua-parser = dontCheck super.ua-parser;
   unagi-chan = dontCheck super.unagi-chan;
-  wai-logger = dontCheck super.wai-logger;
   WebBits = dontCheck super.WebBits;                    # http://hydra.cryp.to/build/499604/log/raw
-  webdriver = dontCheck super.webdriver;
   webdriver-angular = dontCheck super.webdriver-angular;
   xsd = dontCheck super.xsd;
-  zip-archive = dontCheck super.zip-archive;  # https://github.com/jgm/zip-archive/issues/57
-
-  # These test suites run for ages, even on a fast machine. This is nuts.
-  Random123 = dontCheck super.Random123;
-  systemd = dontCheck super.systemd;
 
   # Allow template-haskell 2.22
   # https://github.com/well-typed/ixset-typed/pull/23
@@ -847,9 +821,6 @@ self: super: {
 
   # https://github.com/vincenthz/hs-crypto-pubkey/issues/20
   crypto-pubkey = dontCheck super.crypto-pubkey;
-
-  # https://github.com/Philonous/xml-picklers/issues/5
-  xml-picklers = dontCheck super.xml-picklers;
 
   # https://github.com/joeyadams/haskell-stm-delay/issues/3
   stm-delay = dontCheck super.stm-delay;
@@ -948,9 +919,6 @@ self: super: {
     "--ghc-option=-DCURL_DISABLE_TYPECHECK"
   ] super.curl;
 
-  # https://github.com/hvr/token-bucket/issues/3
-  token-bucket = dontCheck super.token-bucket;
-
   # https://github.com/alphaHeavy/lzma-enumerator/issues/3
   lzma-enumerator = dontCheck super.lzma-enumerator;
 
@@ -1038,7 +1006,6 @@ self: super: {
       mkdir -p $data/share/emacs
       ln -s $lispdir $data/share/emacs/site-lisp
     '';
-    doCheck = false; # https://github.com/chrisdone/hindent/issues/299
   }) super.hindent);
 
   # https://github.com/basvandijk/concurrent-extra/issues/12
@@ -1105,9 +1072,6 @@ self: super: {
     (self.generateOptparseApplicativeCompletions [ "idris" ])
   ];
 
-  # fails with sandbox
-  yi-keymap-vim = dontCheck super.yi-keymap-vim;
-
   # https://hydra.nixos.org/build/42769611/nixlog/1/raw
   # note: the library is unmaintained, no upstream issue
   dataenc = doJailbreak super.dataenc;
@@ -1120,10 +1084,6 @@ self: super: {
 
   # No upstream issue tracker
   hspec-expectations-pretty-diff = dontCheck super.hspec-expectations-pretty-diff;
-
-  # Don't depend on chell-quickcheck, which doesn't compile due to restricting
-  # QuickCheck to versions ">=2.3 && <2.9".
-  system-filepath = dontCheck super.system-filepath;
 
   # The tests spuriously fail
   libmpd = dontCheck super.libmpd;
@@ -1205,12 +1165,6 @@ self: super: {
   # Needs QuickCheck <2.10, which we don't have.
   edit-distance = doJailbreak super.edit-distance;
 
-  # Test suite fails due to trying to create directories
-  path-io = dontCheck super.path-io;
-
-  # Duplicate instance with smallcheck.
-  store = dontCheck super.store;
-
   # With ghc-8.2.x haddock would time out for unknown reason
   # See https://github.com/haskell/haddock/issues/679
   language-puppet = dontHaddock super.language-puppet;
@@ -1227,9 +1181,6 @@ self: super: {
   # Compiles some C or C++ source which requires these headers
   VulkanMemoryAllocator = addExtraLibrary pkgs.vulkan-headers super.VulkanMemoryAllocator;
   vulkan-utils = addExtraLibrary pkgs.vulkan-headers super.vulkan-utils;
-
-  # dontCheck: https://github.com/haskell-servant/servant-auth/issues/113
-  servant-auth-client = dontCheck super.servant-auth-client;
 
   # Generate cli completions for dhall.
   dhall = self.generateOptparseApplicativeCompletions [ "dhall" ] super.dhall;
@@ -1643,12 +1594,6 @@ self: super: {
   # So let's not go there and just disable the tests altogether.
   hspec-core = dontCheck super.hspec-core;
 
-  # tests seem to require a different version of hspec-core
-  hspec-contrib = dontCheck super.hspec-contrib;
-
-  # The test suite attempts to read `/etc/resolv.conf`, which doesn't work in the sandbox.
-  domain-auth = dontCheck super.domain-auth;
-
   # - Deps are required during the build for testing and also during execution,
   #   so add them to build input and also wrap the resulting binary so they're in
   #   PATH.
@@ -1788,9 +1733,6 @@ self: super: {
     "--ghc-option=-fno-safe-haskell"
     "--haddock-option=--optghc=-fno-safe-haskell"
   ] super.alg;
-
-  # Missing test files in 1.8.1.0, fixed in 1.8.1.1
-  sequence-formats = dontCheck super.sequence-formats;
 
   # 2025-02-11: Too strict bounds on hedgehog < 1.5
   nothunks = doJailbreak super.nothunks;
@@ -2155,10 +2097,6 @@ self: super: {
   sdp4unordered = disableLibraryProfiling super.sdp4unordered;
   sdp4vector = disableLibraryProfiling super.sdp4vector;
 
-  # Test suite fails to compile
-  # https://github.com/kuribas/mfsolve/issues/8
-  mfsolve = dontCheck super.mfsolve;
-
   # Fixes compilation with GHC 9.0 and above
   # https://hub.darcs.net/shelarcy/regex-compat-tdfa/issue/3
   regex-compat-tdfa = appendPatches [
@@ -2222,9 +2160,6 @@ self: super: {
   # 2025-01-07: unreleased upstream supports hedgehog 1.5 but drifted quite a bit from hackage revisions so hard to patch
   hw-hspec-hedgehog = doJailbreak super.hw-hspec-hedgehog;
 
-  # dontCheck:   tests don't typecheck after ghc 8.4 (possibly introduced by api change of unix library)
-  system-fileio = dontCheck super.system-fileio;
-
   # Test suite doesn't support hspec 2.8
   # https://github.com/zellige/hs-geojson/issues/29
   geojson = dontCheck super.geojson;
@@ -2263,10 +2198,6 @@ self: super: {
   })
   super.polynomial);
 
-  # Tests likely broke because of https://github.com/nick8325/quickcheck/issues/359,
-  # but fft is not on GitHub, so no issue reported.
-  fft = dontCheck super.fft;
-
   # lucid-htmx has restrictive upper bounds on lucid and servant:
   #
   #   Setup: Encountered missing or private dependencies:
@@ -2279,9 +2210,6 @@ self: super: {
   # has been resolved.
   lucid-htmx = doJailbreak super.lucid-htmx;
 
-  # doctest-parallel is broken with v1-style cabal-install / Setup.hs
-  # https://github.com/martijnbastiaan/doctest-parallel/issues/22
-  doctest-parallel = dontCheck super.doctest-parallel;
   clash-prelude = dontCheck super.clash-prelude;
 
   krank = appendPatches [
@@ -2589,18 +2517,8 @@ self: super: {
     hash = "sha256-4osUMo0cvTvyDTXF8lY9tQbFqLywRwsc3RkHIhqSriQ=";
   }) super.gauge;
 
-  # Flaky QuickCheck tests
-  # https://github.com/Haskell-Things/ImplicitCAD/issues/441
-  implicit = dontCheck super.implicit;
-
   # The hackage source is somehow missing a file present in the repo (tests/ListStat.hs).
   sym = dontCheck super.sym;
-
-  # 2024-01-23: https://github.com/composewell/unicode-data/issues/118
-  unicode-data = dontCheck super.unicode-data;
-
-  # 2024-01-24: https://github.com/haskellari/tree-diff/issues/79
-  tree-diff = dontCheck super.tree-diff;
 
   # base <4.19
   # https://github.com/well-typed/large-records/issues/168

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -101,7 +101,9 @@ self: super: {
   # Test suite issues
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
+  fsnotify = dontCheck super.fsnotify; # https://github.com/haskell-fswatch/hfsnotify/issues/115
   hinotify = pkgs.haskell.lib.dontCheck super.hinotify; # https://github.com/kolmodin/hinotify/issues/38
+  monad-dijkstra = dontCheck super.monad-dijkstra; # needs hlint 3.10
 
   haskell-language-server = disableCabalFlag "retrie" (disableCabalFlag "hlint" (disableCabalFlag "stylishhaskel" (super.haskell-language-server.override {stylish-haskell = null;retrie = null;apply-refact=null;hlint = null;})));
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -75,7 +75,6 @@ self: super: {
   #
   # Test suite issues
   #
-  unordered-containers = dontCheck super.unordered-containers; # ChasingBottoms doesn't support base 4.20
   pcre-heavy = dontCheck super.pcre-heavy; # GHC warnings cause the tests to fail
 
   #

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -606,9 +606,6 @@ self: super: builtins.intersectAttrs super {
     testHaskellDepends = (drv.testHaskellDepends or []) ++ [ self.test-framework self.test-framework-hunit ];
   }) super.either-unwrap;
 
-  # https://github.com/haskell-fswatch/hfsnotify/issues/62
-  fsnotify = dontCheck super.fsnotify;
-
   hs-GeoIP = super.hs-GeoIP.override { GeoIP = pkgs.geoipWithDatabase; };
 
   discount = super.discount.override { markdown = pkgs.discount; };

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -89,8 +89,6 @@ self: super: builtins.intersectAttrs super {
   ghcide = overrideCabal (drv: {
     # tests depend on executable
     preCheck = ''export PATH="$PWD/dist/build/ghcide:$PATH"'';
-    # tests disabled because they require network
-    doCheck = false;
   }) super.ghcide;
 
   hiedb = overrideCabal (drv: {
@@ -337,24 +335,20 @@ self: super: builtins.intersectAttrs super {
   hjsonschema = overrideCabal (drv: { testTargets = [ "local" ]; }) super.hjsonschema;
   marmalade-upload = dontCheck super.marmalade-upload;  # http://hydra.cryp.to/build/501904/nixlog/1/raw
   mongoDB = dontCheck super.mongoDB;
-  network-transport-tcp = dontCheck super.network-transport-tcp;
   network-transport-zeromq = dontCheck super.network-transport-zeromq; # https://github.com/tweag/network-transport-zeromq/issues/30
   oidc-client = dontCheck super.oidc-client;            # the spec runs openid against google.com
   persistent-migration = dontCheck super.persistent-migration; # spec requires pg_ctl binary
   pipes-mongodb = dontCheck super.pipes-mongodb;        # http://hydra.cryp.to/build/926195/log/raw
   pixiv = dontCheck super.pixiv;
-  raven-haskell = dontCheck super.raven-haskell;        # http://hydra.cryp.to/build/502053/log/raw
   riak = dontCheck super.riak;                          # http://hydra.cryp.to/build/498763/log/raw
   scotty-binding-play = dontCheck super.scotty-binding-play;
   servant-router = dontCheck super.servant-router;
   serversession-backend-redis = dontCheck super.serversession-backend-redis;
   slack-api = dontCheck super.slack-api;                # https://github.com/mpickering/slack-api/issues/5
-  socket = dontCheck super.socket;
   stackage = dontCheck super.stackage;                  # http://hydra.cryp.to/build/501867/nixlog/1/raw
   textocat-api = dontCheck super.textocat-api;          # http://hydra.cryp.to/build/887011/log/raw
   wreq = dontCheck super.wreq;                          # http://hydra.cryp.to/build/501895/nixlog/1/raw
   wreq-sb = dontCheck super.wreq-sb;                    # http://hydra.cryp.to/build/783948/log/raw
-  wuss = dontCheck super.wuss;                          # http://hydra.cryp.to/build/875964/nixlog/2/raw
   download = dontCheck super.download;
   http-client = dontCheck super.http-client;
   http-client-openssl = dontCheck super.http-client-openssl;
@@ -362,10 +356,8 @@ self: super: builtins.intersectAttrs super {
   http-conduit = dontCheck super.http-conduit;
   transient-universe = dontCheck super.transient-universe;
   telegraph = dontCheck super.telegraph;
-  typed-process = dontCheck super.typed-process;
   js-jquery = dontCheck super.js-jquery;
   hPDB-examples = dontCheck super.hPDB-examples;
-  configuration-tools = dontCheck super.configuration-tools; # https://github.com/alephcloud/hs-configuration-tools/issues/40
   tcp-streams = dontCheck super.tcp-streams;
   holy-project = dontCheck super.holy-project;
   mustache = dontCheck super.mustache;
@@ -1213,9 +1205,6 @@ self: super: builtins.intersectAttrs super {
     )
   );
 
-  # Test suite is just the default example executable which doesn't work if not
-  # executed by Setup.hs, but works if started on a proper TTY
-  isocline = dontCheck super.isocline;
 
   # Some hash implementations are x86 only, but part of the test suite.
   # So executing and building it on non-x86 platforms will always fail.


### PR DESCRIPTION
I've been prototyping a snippet that returns all derivations for which `doCheck = false`, but with the flag set to true instead. Then I build the whole bunch against `haskellPackages` and see which ones succeed. Out of ~300 ones, close to 100 built.

I didn't remove a good chunk of them that had scary comments, e.g.
- 32 bit only behavior (not sure how we want to test that)
- mutual cycles between test packages
- non determinism in tests

These ones also built but they have `doCheck = false` right in `hackage-packages.nix`. Not sure why
- Cabal-3.10
- Cabal-3.12
- Cabal-3.14
- haskell-src-exts
- mwc-random
- req
- websockets





Before and after this PR there's no failures when running
```
nix-build -E 'with (import ./. {}).haskell.packages.ghc98; [ HList Random123 configuration-tools css-text data-hash direct-sqlite dlist docopt doctest-parallel domain-auth fft fsnotify ghcide haeredes hath hedn hindent hspec-contrib implicit isocline memcache metrics mfsolve monad-dijkstra mysql-haskell netpbm network network-transport-tcp path-io pipes-websockets raven-haskell safecopy sequence-formats servant-auth-client socket store snap-core strive system-fileio system-filepath systemd th-printf token-bucket tree-diff typed-process unagi-chan unicode-data unordered-containers xml-picklers wai-logger webdriver wuss yi-keymap-vim zip-archive ]'
```

and there are exactly these failures when using `ghc910`: `HList`, `hindent` `ghcide`

Given the large volume, I wouldn't be surprised if we eventually end up having to add a few back, but hard to tell the reasons for a `doCheck` when there's no comment. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
