### PR TITLE
home-assistant: 2025.2.4 -> 2025.2.5

### DIFF
--- a/pkgs/development/python-modules/airgradient/default.nix
+++ b/pkgs/development/python-modules/airgradient/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "airgradient";
-  version = "0.9.1";
+  version = "0.9.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "airgradienthq";
     repo = "python-airgradient";
     tag = "v${version}";
-    hash = "sha256-al0DLsub3xLU1BWLNn0cMI87O0mcQJ0Y4Boj2Xwk1r0=";
+    hash = "sha256-llhdLqVueATKCb4wyPYjnsdOpbbE2BnUU0PH0jwHPMU=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/pyhive-integration/default.nix
+++ b/pkgs/development/python-modules/pyhive-integration/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pyhive-integration";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "Pyhass";
     repo = "Pyhiveapi";
     tag = "v${version}";
-    hash = "sha256-/Q6nQb6JyjjWJv7Yj+EJdqOMy+j3cYPIkRpXa3Q48Oo=";
+    hash = "sha256-lfBr889s6NHcos/kdzQa9HJEcQ4dfCEMjuLYiLzesfE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyhive-integration/default.nix
+++ b/pkgs/development/python-modules/pyhive-integration/default.nix
@@ -14,7 +14,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "pyhiveapi";
+  pname = "pyhive-integration";
   version = "1.0.1";
   pyproject = true;
 

--- a/pkgs/development/python-modules/pyprosegur/default.nix
+++ b/pkgs/development/python-modules/pyprosegur/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pyprosegur";
-  version = "0.0.12";
+  version = "0.0.14";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "dgomes";
     repo = "pyprosegur";
     tag = version;
-    hash = "sha256-A223aafa0eXNBVd2cVVV7p2wXg4Z2rcoggM3czmRsOE=";
+    hash = "sha256-FMkz5zZ5+607gfmw4KRmCgfR+TJF2JGLRVEUzZAjTrc=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyrympro/default.nix
+++ b/pkgs/development/python-modules/pyrympro/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "pyrympro";
-  version = "0.0.8";
+  version = "0.0.9";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "OnFreund";
     repo = "pyrympro";
     tag = "v${version}";
-    hash = "sha256-mRvKLPgtBgmFDTHqra7GslxsgsJpQ2w/DE0Zgz5jujk=";
+    hash = "sha256-+KgYdiVuX8Ycw0Odte/EXsoWiMaLmTU6zTeJCw9jwvs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyvesync/default.nix
+++ b/pkgs/development/python-modules/pyvesync/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "pyvesync";
-  version = "2.1.17";
+  version = "2.1.18";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "webdjoe";
     repo = "pyvesync";
     tag = version;
-    hash = "sha256-h5pxoPtIZVfhSHyvCkde2uVMzNjqXEYaMM8+gsNMd/k=";
+    hash = "sha256-p46QVjJ8MzvsAu9JAQo4XN+z96arWLoJakdT81ITasU=";
   };
 
   build-system = [ setuptools ];
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python library to manage Etekcity Devices and Levoit Air Purifier";
     homepage = "https://github.com/webdjoe/pyvesync";
-    changelog = "https://github.com/webdjoe/pyvesync/releases/tag/${version}";
+    changelog = "https://github.com/webdjoe/pyvesync/releases/tag/${src.tag}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "reolink-aio";
-  version = "0.11.10";
+  version = "0.12.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "starkillerOG";
     repo = "reolink_aio";
     tag = version;
-    hash = "sha256-qEcu+jdzPSNzgT5aK1nZxT6EAlH1ady5Vyx11PTsTic=";
+    hash = "sha256-HIBNmn8qGTOV6eP7pX0EGgenYoNXuXPu9o2Uf8VFaUw=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2225,7 +2225,7 @@
       ];
     "hive" =
       ps: with ps; [
-        pyhiveapi
+        pyhive-integration
       ];
     "hko" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.2.4";
+  version = "2025.2.5";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/adaptive_lighting/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/adaptive_lighting/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "basnijholt";
   domain = "adaptive_lighting";
-  version = "1.23.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "basnijholt";
     repo = "adaptive-lighting";
-    tag = version;
-    hash = "sha256-Yq8mKk2j2CHyHvwyej0GeFQhuy1MFXwt0o+lDOGwrBU=";
+    tag = "v${version}";
+    hash = "sha256-ykliUi/gnJB9hMNI72RCofcGzS7799lVTAXZyrho/Ng=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/auth-header/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/auth-header/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "BeryJu";
   domain = "auth_header";
-  version = "1.11";
+  version = "1.12";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hass-auth-header";
     tag = "v${version}";
-    hash = "sha256-N2jEFyb/OWsO48rAuQBDHtQ5yKfIrGTcwlEb2P3LyVc=";
+    hash = "sha256-BPG/G6IM95g9ip2OsPmcAebi2ZvKHUpFzV4oquOFLPM=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/custom-components/auth_oidc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/auth_oidc/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "christaangoossens";
   domain = "auth_oidc";
-  version = "0.5.1-alpha";
+  version = "0.6.2-alpha";
 
   src = fetchFromGitHub {
     owner = "christiaangoossens";
     repo = "hass-oidc-auth";
     tag = "v${version}";
-    hash = "sha256-GT82LWzfZzmCACS51mJctT/NeCTckJsJGl3x+wCQGjs=";
+    hash = "sha256-C/Nui0frlcRLaOqsfFH72QNo756karLq/UUcvs2LgE0=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/emporia_vue/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/emporia_vue/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "magico13";
   domain = "emporia_vue";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "magico13";
     repo = "ha-emporia-vue";
     rev = "v${version}";
-    hash = "sha256-bUfFRcVu/i6yp9BbfM3d6J8TBT3X35HNk0tr00JIwC8=";
+    hash = "sha256-OfJvln80ek/+4PURk23REhIyUckAEZ+Ybb5rZyKs6h4=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/garmin_connect/package.nix
@@ -6,16 +6,16 @@
   tzlocal,
 }:
 
-buildHomeAssistantComponent {
+buildHomeAssistantComponent rec {
   owner = "cyberjunky";
   domain = "garmin_connect";
-  version = "0.2.22";
+  version = "0.2.30";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "home-assistant-garmin_connect";
-    rev = "d42edcabc67ba6a7f960e849c8aaec1aabef87c0";
-    hash = "sha256-KqbP6TpH9B0/AjtsW5TcWSNgUhND+w8rO6X8fHqtsDI=";
+    tag = version;
+    hash = "sha256-Gxz0mKVgs2o7IlhGJkz4JlKRb448IRFqK87Kn+Gebkk=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "mill1000";
   domain = "midea_ac";
-  version = "2025.1.1";
+  version = "2025.1.4";
 
   src = fetchFromGitHub {
     owner = "mill1000";
     repo = "midea-ac-py";
     tag = version;
-    hash = "sha256-dQcSXV7UlcSNjad5IkqoBXyJO3GRKzgPGpydnWHYxxE=";
+    hash = "sha256-xKoZFcvfVF6x3PM1lNZ+/1hPIAcIQoDNSs9jUJU90p4=";
   };
 
   dependencies = [ msmart-ng ];

--- a/pkgs/servers/home-assistant/custom-components/miele/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/miele/package.nix
@@ -9,13 +9,13 @@
 buildHomeAssistantComponent rec {
   owner = "astrandb";
   domain = "miele";
-  version = "2024.11.1";
+  version = "2025.1.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-fM/ARQ4wJt2/vIVsdWpAur/YWPvBH5fOPYqiaz4DxzU=";
+    hash = "sha256-TShy2q3gKqTgRU3u4Wp7zQjzhEogqUVip8EkH8XIYw8=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/nest_protect/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/nest_protect/package.nix
@@ -6,13 +6,13 @@
 buildHomeAssistantComponent rec {
   owner = "iMicknl";
   domain = "nest_protect";
-  version = "0.3.12";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "ha-nest-protect";
     tag = "v${version}";
-    hash = "sha256-IiHndx+mQVfpMLisiRwSEhrFJ3mJ4qaWTxZrubowkQs=";
+    hash = "sha256-UAVyfI+cHYx0va2P14moyy6BbhNegsdLWtiex5QeFrs=";
   };
 
   dontBuild = true;

--- a/pkgs/servers/home-assistant/custom-components/ntfy/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ntfy/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "hbrennhaeuser";
   domain = "ntfy";
-  version = "1.1.0-pre.2";
+  version = "1.2.0-pre.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "homeassistant_integration_ntfy";
     rev = "v${version}";
-    hash = "sha256-OGCAJsAsnUjwaLR8lCBdU+ghVOGFF0mT73t5JtcngUA=";
+    hash = "sha256-cdqO8fwaEZzAEa7aVjV00OQYnmx0vJZqz7Nd9+MUHN8=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/sensi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/sensi/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "iprak";
   domain = "sensi";
-  version = "1.3.14";
+  version = "1.3.15";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-kskffpfxpUjNUgsGc/sSkCbGdjt47KfPpH6KBFDLsHw=";
+    hash = "sha256-t6SOjjoMQ2V+KcqFx03PJPrbviDmidi+XbQGlQ5ghuc=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "wills106";
   domain = "solax_modbus";
-  version = "2025.01.8";
+  version = "2025.01.9";
 
   src = fetchFromGitHub {
     owner = "wills106";
     repo = "homeassistant-solax-modbus";
     tag = version;
-    hash = "sha256-jvz9CtVCuNu3w/1ebXcI8GNRAWajm51F9SMf13cBhlw=";
+    hash = "sha256-x9dlqc2kckrd0C5W7VfNQGhuSODxopzwO4gOSeSOl1E=";
   };
 
   dependencies = [ pymodbus ];

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "make-all";
   domain = "tuya_local";
-  version = "2025.2.0";
+  version = "2025.2.2";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "tuya-local";
     tag = version;
-    hash = "sha256-G/+mAq++bJ2Z41B6gi/izBLvuZwew3Tx/0mGZm4g6TE=";
+    hash = "sha256-RwPbFIDXSXFzR2sck1EUvQL+1o8Ppb5clsIAHhYxX5o=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "jmcollin78";
   domain = "versatile_thermostat";
-  version = "7.2.1";
+  version = "7.2.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     rev = "refs/tags/${version}";
-    hash = "sha256-KdDeY1hTCWEy5l9mq2HdCrmVfLV6NkO43lC2QigOXeo=";
+    hash = "sha256-OYqN8xdNl7A5pxSKR8PeKRQ54RARo8JKILlv+cqSYpE=";
   };
 
   passthru.updateScript = gitUpdater { ignoredVersions = "(Alpha|Beta|alpha|beta).*"; };

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "al-one";
   domain = "xiaomi_miot";
-  version = "1.0.9";
+  version = "1.0.12";
 
   src = fetchFromGitHub {
     owner = "al-one";
     repo = "hass-xiaomi-miot";
     rev = "v${version}";
-    hash = "sha256-2XCm7XEKQgoe8myAgPnYCOO+XdLTAl8NtAVCBMJGqDc=";
+    hash = "sha256-WU512UnKRHVoflerXK4vs/wJXxaerC1XVhfLN1YPh84=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "cdnninja";
   domain = "yoto";
-  version = "1.22.6";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "cdnninja";
     repo = "yoto_ha";
     tag = "v${version}";
-    hash = "sha256-6igIcDGPYUOz5dWZr9TKFmoYoUCsZOpfpESTxYRR67w=";
+    hash = "sha256-FB711ofk5BV/U0ZWfa6Q2aheZkzbwxDUfqNDu9wj2aQ=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
@@ -9,18 +9,18 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "clock-weather-card";
-  version = "2.8.7";
+  version = "2.8.9";
 
   src = fetchFromGitHub {
     owner = "pkissling";
     repo = "clock-weather-card";
     tag = "v${version}";
-    hash = "sha256-ylJNI0DE+3j8EZFpUmuuBnII8nBMrJ5bhlGVh3M25eo=";
+    hash = "sha256-7b0U6HelWLoCvkJrqzRbRyDnl0odi6OYYEp0sUOYnoU=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-EUuPF2kS6CaJ2MUYoBocLOQyOgkhRHd34ul+efJua7Q=";
+    hash = "sha256-9MFEJQ9JYUjded6sdDcF/kB+ZdGE6z4MZOzFk1Qb3vo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/package.nix
@@ -6,18 +6,18 @@
 
 buildNpmPackage rec {
   pname = "universal-remote-card";
-  version = "4.3.9";
+  version = "4.3.10";
 
   src = fetchFromGitHub {
     owner = "Nerwyn";
     repo = "android-tv-card";
     rev = version;
-    hash = "sha256-7Eoa1CVruVDuNHvvcdxMERWtq1S+HIFPXMFc+GZu4ns=";
+    hash = "sha256-z34zdkfDnMlfmCpJYclxvuXK8Vaji0FoTCPjRoe5joA=";
   };
 
   patches = [ ./dont-call-git.patch ];
 
-  npmDepsHash = "sha256-jjN8VFVw4wFAArUzdxjmH6w9M9WUtpKUgjPqfE3jTOw=";
+  npmDepsHash = "sha256-5sOUuES/rbXmqdd8vFqGy5Wa3ZvI3B/KJhg7WtaQjPA=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/versatile-thermostat-ui-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/versatile-thermostat-ui-card/package.nix
@@ -6,13 +6,13 @@
 
 buildNpmPackage rec {
   pname = "versatile-thermostat-ui-card";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "jmcollin78";
     repo = "versatile-thermostat-ui-card";
     rev = "${version}";
-    hash = "sha256-JOm0jQysBtKHjAXtWnjbEn7UPSNLHd95TGfP13WH0Ww=";
+    hash = "sha256-yPp478uXiRWDH4DP/d0Mloie7nPY1hWLt8X1vLhysvA=";
   };
 
   npmFlags = [ "--legacy-peer-deps" ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -379,7 +379,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.2.4";
+  hassVersion = "2025.2.5";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -400,13 +400,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-Zrr4keJwY1q/PrHZEVUphxhA3dAOkyE5vCEa3Msr9Yk=";
+    hash = "sha256-8adHpOiuWddgqQjInc92FjEwVyg2Rvgx7wNOj3+Kxsk=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-24AOIyC00U6J1Abg1zj4BbSLsRik2tQZSFaoAu7w85M=";
+    hash = "sha256-JD2xus356qNzT5jqZOHr5gn4WGeC189rM83D81xVtWo=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250214.0";
+  version = "20250221.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-dIV0P/9GsHV4xN84+HGe/I7ay1FM3jLw9F60WpxaEIM=";
+    hash = "sha256-SgNtsXtg/i9AO+xu5O0loDbAifO4rn1GRFE1LmeJLfU=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.213";
+  version = "0.13.214";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-mYdG3LFjkm7vkQTLW/5kRe/Yrflq1jZGgQRiIuIqJYg=";
+    hash = "sha256-AbqDLFC/U+zJJF4pc1ovuzwmXLv37ojCpQQIzWUc/70=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.2.3";
+  version = "2025.2.5";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     rev = "refs/tags/${version}";
-    hash = "sha256-bb9LAgra8AVqoNsyL95wrOt9JXMPnT7FxwU1+JLKw5c=";
+    hash = "sha256-tqg7NHvtKrXJ8+czcWqoaPMLYfskjuoFmSOkhjmnr3g=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -45,7 +45,6 @@ PKG_PREFERENCES = {
     "numpy": "numpy",
     "ollama-hass": "ollama",
     "paho-mqtt": "paho-mqtt",
-    "pyhive-integration": "pyhiveapi", # https://github.com/home-assistant/core/pull/135482
     "pysuezV2": "pysuez",
     "sentry-sdk": "sentry-sdk",
     "slackclient": "slack-sdk",

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -500,6 +500,7 @@ mapAliases ({
   pyialarmxr = pyialarmxr-homeassistant; # added 2022-06-07
   pyialarmxr-homeassistant = throw "The package was removed together with the component support in home-assistant 2022.7.0"; # added 2022-07-07
   PyICU = pyicu; # Added 2022-12-22
+  pyhiveapi = pyhive-integration; # Added 2025-02-22
   pyhs100 = throw "pyhs100 has been removed in favor of python-kasa."; # added 2024-01-05
   pylibgen = throw "pylibgen is unmaintained upstreamed, and removed from nixpkgs"; # added 2020-06-20
   PyLD = pyld; # added 2022-06-22

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10763,7 +10763,7 @@ self: super: with self; {
 
   pyhepmc = callPackage ../development/python-modules/pyhepmc { };
 
-  pyhiveapi = callPackage ../development/python-modules/pyhiveapi { };
+  pyhive-integration = callPackage ../development/python-modules/pyhive-integration { };
 
   pyhumps = callPackage ../development/python-modules/pyhumps { };
 


### PR DESCRIPTION
    https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/refs/tags/0.13.214/CHANGELOG.md
    https://github.com/KapJI/homeassistant-stubs/releases/tag/2025.2.5
    https://github.com/home-assistant/core/releases/tag/2025.2.5
    https://github.com/starkillerOG/reolink_aio/releases/tag/0.12.0
    https://github.com/webdjoe/pyvesync/releases/tag/2.18
    https://github.com/OnFreund/pyrympro/compare/refs/tags/v0.0.8...v0.0.9
    https://github.com/dgomes/pyprosegur/releases/tag/0.0.13
    https://github.com/dgomes/pyprosegur/releases/tag/0.0.14
    https://github.com/Pyhass/Pyhiveapi/releases/tag/v1.0.2
    https://github.com/airgradienthq/python-airgradient/releases/tag/v0.9.2


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
