### PR TITLE
localstack: fix build, move to toplevel, 4.0.3 -> 4.1.1

### DIFF
--- a/pkgs/by-name/lo/localstack/package.nix
+++ b/pkgs/by-name/lo/localstack/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "localstack";
-  version = "4.0.3";
+  version = "4.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "localstack";
     repo = "localstack";
     tag = "v${version}";
-    hash = "sha256-BsmXhTJVvRKEubDQwehsrY2jRSfvDBSH5S35CNg8vrQ=";
+    hash = "sha256-hITo6BAsFNGFG5N0b2N9nydGCsG7ged8/3g0sWovNYw=";
   };
 
   build-system = with python3.pkgs; [

--- a/pkgs/by-name/lo/localstack/package.nix
+++ b/pkgs/by-name/lo/localstack/package.nix
@@ -1,29 +1,10 @@
 {
   lib,
-  buildPythonPackage,
+  python3,
   fetchFromGitHub,
-  apispec,
-  boto3,
-  build,
-  cachetools,
-  click,
-  cryptography,
-  localstack-client,
-  localstack-ext,
-  plux,
-  psutil,
-  python-dotenv,
-  pyyaml,
-  packaging,
-  requests,
-  rich,
-  semver,
-  setuptools,
-  setuptools-scm,
-  tailer,
 }:
 
-buildPythonPackage rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "localstack";
   version = "4.0.3";
   pyproject = true;
@@ -35,12 +16,12 @@ buildPythonPackage rec {
     hash = "sha256-BsmXhTJVvRKEubDQwehsrY2jRSfvDBSH5S35CNg8vrQ=";
   };
 
-  build-system = [
+  build-system = with python3.pkgs; [
     setuptools
     setuptools-scm
   ];
 
-  dependencies = [
+  propagatedBuildInputs = with python3.pkgs; [
     apispec
     boto3
     build
@@ -60,7 +41,9 @@ buildPythonPackage rec {
     tailer
   ];
 
-  pythonRelaxDeps = [ "dill" ];
+  pythonRelaxDeps = [
+    "dill"
+  ];
 
   pythonImportsCheck = [ "localstack" ];
 
@@ -74,6 +57,12 @@ buildPythonPackage rec {
     $out/bin/localstack --version
 
     runHook postCheck
+  '';
+
+  # Propagating dependencies leaks them through $PYTHONPATH which causes issues
+  # when used in nix-shell.
+  postFixup = ''
+    rm $out/nix-support/propagated-build-inputs
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/localstack-client/default.nix
+++ b/pkgs/development/python-modules/localstack-client/default.nix
@@ -5,8 +5,8 @@
   boto3,
   pytestCheckHook,
 
-  # downstream dependencies
-  localstack,
+  # use for promoted localstack
+  pkgs,
 }:
 
 buildPythonPackage rec {
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   passthru.tests = {
-    inherit localstack;
+    inherit (pkgs) localstack;
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/localstack-client/default.nix
+++ b/pkgs/development/python-modules/localstack-client/default.nix
@@ -1,25 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   boto3,
   pytestCheckHook,
 
-  # use for promoted localstack
+  # use for testing promoted localstack
   pkgs,
 }:
 
 buildPythonPackage rec {
   pname = "localstack-client";
-  version = "1.39";
+  version = "2.7";
   format = "setuptools";
 
-  src = fetchFromGitHub {
-    owner = "localstack";
-    repo = "localstack-python-client";
-    # Request for proper tags: https://github.com/localstack/localstack-python-client/issues/38
-    rev = "f1e538ad23700e5b1afe98720404f4801475e470";
-    hash = "sha256-MBXTiTzCwkduJPPRN7OKaWy2q9J8xCX/GGu09tyac3A=";
+  src = fetchPypi {
+    pname = "localstack_client";
+    inherit version;
+    hash = "sha256-FJkxGZAaS8vvfDLYmbJPSliodaZ2VpPt8QZNZrimhAg=";
   };
 
   propagatedBuildInputs = [ boto3 ];

--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -15,8 +15,8 @@
   python-dateutil,
   tabulate,
 
-  # Sensitive downstream dependencies
-  localstack,
+  # use for testing promoted localstack
+  pkgs,
 }:
 
 buildPythonPackage rec {
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   passthru.tests = {
-    inherit localstack;
+    inherit (pkgs) localstack;
   };
 
   meta = {

--- a/pkgs/development/python-modules/localstack-ext/default.nix
+++ b/pkgs/development/python-modules/localstack-ext/default.nix
@@ -21,13 +21,13 @@
 
 buildPythonPackage rec {
   pname = "localstack-ext";
-  version = "4.0.3";
+  version = "4.1.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "localstack_ext";
     inherit version;
-    hash = "sha256-vivEdEk32wJln8jfhrAtygO5CEvtsdXI7sxrj0dqIdA=";
+    hash = "sha256-Fgblk8eL5JnF4yLeH73yGuOeH9anSu1o9H1UxcjTyco=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/plux/default.nix
+++ b/pkgs/development/python-modules/plux/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "plux";
-  version = "1.11.0";
+  version = "1.12.0";
   pyproject = true;
 
   # Tests are not available from PyPi
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "localstack";
     repo = "plux";
     tag = "v${version}";
-    hash = "sha256-M4N3Ccuw95OcLsWQVtITv4QShBJKliTh5QIoqji8x9o=";
+    hash = "sha256-2Sxn/LuiwTzByAAz7VlNLsxEiPIyJWXr86/76Anx+EU=";
   };
 
   build-system = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4137,8 +4137,6 @@ with pkgs;
 
   liquidctl = with python3Packages; toPythonApplication liquidctl;
 
-  localstack = with python3Packages; toPythonApplication localstack;
-
   xz = callPackage ../tools/compression/xz { };
 
   lzwolf = callPackage ../games/lzwolf { SDL2_mixer = SDL2_mixer_2_0; };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -354,6 +354,7 @@ mapAliases ({
   livestreamer = throw "'livestreamer' has been removed, as it unmaintained. A currently maintained fork is 'streamlink'."; # added 2023-11-14
   livestreamer-curses = throw "'livestreamer-curses' has been removed as it, and livestreamer itself are unmaintained."; # added 2023-11-14
   lmcloud = pylamarzocco; # added 2024-11-26
+  localstack = throw "localstack was promoted to a top-level attribute"; # added 2025-02-21
   logilab_astng = throw "logilab-astng has not been released since 2013 and is unmaintained"; # added 2022-11-29
   logilab_common = logilab-common; # added 2022-11-21
   loo-py = loopy; # added 2022-05-03

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7736,8 +7736,6 @@ self: super: with self; {
 
   localimport = callPackage ../development/python-modules/localimport { };
 
-  localstack = callPackage ../development/python-modules/localstack { };
-
   localstack-client = callPackage ../development/python-modules/localstack-client { };
 
   localstack-ext = callPackage ../development/python-modules/localstack-ext { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes a broke build due to plux out of date.
localstack is an application not a module, so relocate to toplevel.
Update all the things.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
