### PR TITLE
vegur: fix URLs

### DIFF
--- a/pkgs/by-name/ve/vegur/package.nix
+++ b/pkgs/by-name/ve/vegur/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/download/fonts/vegur_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/vegur_${majorVersion}${minorVersion}.zip";
     hash = "sha256-sGb3mEb3g15ZiVCxEfAanly8zMUopLOOjw8W4qbXLPA=";
     stripRoot = false;
   };
@@ -27,10 +27,10 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/vegur/";
+    homepage = "http://dotcolon.net/fonts/vegur/";
     description = "Humanist sans serif font";
     platforms = platforms.all;
     maintainers = with maintainers; [ minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/by-name/ve/vegur/package.nix
+++ b/pkgs/by-name/ve/vegur/package.nix
@@ -28,7 +28,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "http://dotcolon.net/fonts/vegur/";
     description = "Humanist sans serif font";
     platforms = platforms.all;
-    maintainers = with maintainers; [ minijackson ];
+    maintainers = with maintainers; [
+      djacu
+      minijackson
+    ];
     license = licenses.cc0;
   };
 })

--- a/pkgs/by-name/ve/vegur/package.nix
+++ b/pkgs/by-name/ve/vegur/package.nix
@@ -4,16 +4,14 @@
   fetchzip,
 }:
 
-let
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vegur";
+  version = "${finalAttrs.majorVersion}.${finalAttrs.minorVersion}";
   majorVersion = "0";
   minorVersion = "701";
-in
-stdenvNoCC.mkDerivation {
-  pname = "vegur";
-  version = "${majorVersion}.${minorVersion}";
 
   src = fetchzip {
-    url = "https://dotcolon.net/files/fonts/vegur_${majorVersion}${minorVersion}.zip";
+    url = "https://dotcolon.net/files/fonts/vegur_${finalAttrs.majorVersion}${finalAttrs.minorVersion}.zip";
     hash = "sha256-sGb3mEb3g15ZiVCxEfAanly8zMUopLOOjw8W4qbXLPA=";
     stripRoot = false;
   };


### PR DESCRIPTION
- Fixed the `src.url` and `meta.homepage` URLs.
- Implemented using `finalAttrs` so the derivation is more easily overridden.
- Added myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
