### PR TITLE
nix-playground: init at 1.0.1

### DIFF
--- a/pkgs/by-name/ni/nix-playground/package.nix
+++ b/pkgs/by-name/ni/nix-playground/package.nix
@@ -1,0 +1,53 @@
+{
+  cacert,
+  fetchFromGitHub,
+  lib,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nix-playground";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LaunchPlatform";
+    repo = "nix-playground";
+    tag = version;
+    hash = "sha256-uAQoJmhsTJZ4IW8Zzamq4zW+MT6k5ZrB7g+YsWFpKVs=";
+  };
+
+  build-system = with python3.pkgs; [
+    hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    click
+    pygit2
+    rich
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Disable tests that require nix store
+    "tests/acceptance/"
+  ];
+
+  # Tests require certificates
+  # https://github.com/NixOS/nixpkgs/pull/72544#issuecomment-582674047
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  pythonImportsCheck = [ "nix_playground" ];
+
+  meta = {
+    description = "Command line tools for patching nixpkgs package source code easily";
+    mainProgram = "np";
+    homepage = "https://github.com/LaunchPlatform/nix-playground";
+    changelog = "https://github.com/LaunchPlatform/nix-playground/releases/tag/${src.tag}";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ fangpen ];
+  };
+}


### PR DESCRIPTION
The nix-playground is a command line tool that makes applying patches to the nixpkgs packages much easier.

Repo: https://github.com/LaunchPlatform/nix-playground

Example:

```bash
# checkout libnvidia-container package source code locally
np checkout nixpkgs#libnvidia-container

# modify the code
vim checkout/src/cli/main.c

# build the package with changes you made in the checkout folder and try it out
np build

# output the patch for applying on the production environments
np patch > bugfix.patch

# clean up the generated files
np clean
```

Why:

Too often, we are afraid of digging into the upstream code, modifying and patching it because it's a very tedious process. Just getting the project to build could take hours. Thanks to [nixpkgs](https://nixos.org/), building open-source software is much easier with a single source tree capable of building from the Linux kernel all the way to a simple utils command-line tool. With nix-playground, now you can easily check out source code from a package, modify it, test it out, and then create patches effortlessly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
