### PR TITLE
hareThirdParty.hare-ssh: enable auto-update

### DIFF
--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -2,32 +2,40 @@
   fetchFromSourcehut,
   hareHook,
   lib,
+  nix-update-script,
   stdenv,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  inherit (lib) licenses;
+  inherit (lib.maintainers) patwid;
+
+  version = "0.24.0";
+in
+stdenv.mkDerivation {
   pname = "hare-ssh";
-  version = "0-unstable-2023-11-16";
+  inherit version;
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-ssh";
-    rev = "c6a39e37ba4a42721594e0a907fe016f8e2198a8";
+    rev = version;
     hash = "sha256-I43TLPoImBsvkgV3hDy9dw0pXVt4ezINnxFtEV9P2/M=";
   };
 
   nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
   doCheck = true;
 
-  meta = with lib; {
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     homepage = "https://git.sr.ht/~sircmpwn/hare-ssh/";
     description = "SSH client & server protocol implementation for Hare";
-    license = with licenses; [ mpl20 ];
-    maintainers = with maintainers; [ patwid ];
-
+    license = licenses.mpl20;
+    maintainers = [ patwid ];
     inherit (hareHook.meta) platforms badPlatforms;
   };
-})
+}

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -10,7 +10,7 @@ let
   inherit (lib) licenses;
   inherit (lib.maintainers) patwid;
 
-  version = "0.24.0";
+  version = "0.24.2";
 in
 stdenv.mkDerivation {
   pname = "hare-ssh";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     owner = "~sircmpwn";
     repo = "hare-ssh";
     rev = version;
-    hash = "sha256-I43TLPoImBsvkgV3hDy9dw0pXVt4ezINnxFtEV9P2/M=";
+    hash = "sha256-koH/M3Izyjz09SO29TF3+zWIgCxwZn024FDQPSLn1FY=";
   };
 
   nativeBuildInputs = [ hareHook ];


### PR DESCRIPTION
Enable automatic updates for hare-ssh.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
