### PR TITLE
nixos-container: Conform to ShellCheck

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -53,23 +53,23 @@ let
       trap "exit 0" SIGRTMIN+3
 
       # Initialise the container side of the veth pair.
-      if [ -n "$HOST_ADDRESS" ]   || [ -n "$HOST_ADDRESS6" ]  ||
-         [ -n "$LOCAL_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS6" ] ||
-         [ -n "$HOST_BRIDGE" ]; then
+      if [[ -n "''${HOST_ADDRESS-}" ]]   || [[ -n "''${HOST_ADDRESS6-}" ]]  ||
+         [[ -n "''${LOCAL_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS6-}" ]] ||
+         [[ -n "''${HOST_BRIDGE-}" ]]; then
         ip link set host0 name eth0
         ip link set dev eth0 up
 
-        if [ -n "$LOCAL_ADDRESS" ]; then
+        if [[ -n "''${LOCAL_ADDRESS-}" ]]; then
           ip addr add $LOCAL_ADDRESS dev eth0
         fi
-        if [ -n "$LOCAL_ADDRESS6" ]; then
+        if [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
           ip -6 addr add $LOCAL_ADDRESS6 dev eth0
         fi
-        if [ -n "$HOST_ADDRESS" ]; then
+        if [[ -n "''${HOST_ADDRESS-}" ]]; then
           ip route add $HOST_ADDRESS dev eth0
           ip route add default via $HOST_ADDRESS
         fi
-        if [ -n "$HOST_ADDRESS6" ]; then
+        if [[ -n "''${HOST_ADDRESS6-}" ]]; then
           ip -6 route add $HOST_ADDRESS6 dev eth0
           ip -6 route add default via $HOST_ADDRESS6
         fi
@@ -96,11 +96,11 @@ let
     chmod 0755 "$root/etc" "$root/var/lib"
     mkdir -p "$root/var/lib/private" "$root/root" /run/nixos-containers
     chmod 0700 "$root/var/lib/private" "$root/root" /run/nixos-containers
-    if ! [ -e "$root/etc/os-release" ] && ! [ -h "$root/etc/os-release" ]; then
+    if ! [[ -e "$root/etc/os-release" ]] && ! [[ -h "$root/etc/os-release" ]]; then
       touch "$root/etc/os-release"
     fi
 
-    if ! [ -e "$root/etc/machine-id" ]; then
+    if ! [[ -e "$root/etc/machine-id" ]]; then
       touch "$root/etc/machine-id"
     fi
 
@@ -113,19 +113,19 @@ let
 
     cp --remove-destination /etc/resolv.conf "$root/etc/resolv.conf"
 
-    if [ -n "$FLAKE" ] && [ ! -e "/nix/var/nix/profiles/per-container/$INSTANCE/system" ]; then
+    if [ -n "''${FLAKE-}" ] && [ ! -e "/nix/var/nix/profiles/per-container/$INSTANCE/system" ]; then
       # we create the etc/nixos-container config file, then if we utilize the update function, we can then build all the necessary system files for the container
       ${lib.getExe nixos-container} update "$INSTANCE"
     fi
 
     declare -a extraFlags
 
-    if [ "$PRIVATE_NETWORK" = 1 ]; then
+    if [[ "''${PRIVATE_NETWORK-}" = 1 ]]; then
       extraFlags+=("--private-network")
     fi
 
     NIX_BIND_OPT=""
-    if [ -n "$PRIVATE_USERS" ]; then
+    if [[ -n "''${PRIVATE_USERS-}" ]]; then
       extraFlags+=("--private-users=$PRIVATE_USERS")
       if [[
         "$PRIVATE_USERS" = "pick"
@@ -137,12 +137,12 @@ let
       fi
     fi
 
-    if [ -n "$HOST_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS" ] ||
-       [ -n "$HOST_ADDRESS6" ] || [ -n "$LOCAL_ADDRESS6" ]; then
+    if [[ -n "''${HOST_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS-}" ]] ||
+       [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
       extraFlags+=("--network-veth")
     fi
 
-    if [ -n "$HOST_PORT" ]; then
+    if [[ -n "''${HOST_PORT-}" ]]; then
       OIFS=$IFS
       IFS=","
       for i in $HOST_PORT
@@ -152,28 +152,28 @@ let
       IFS=$OIFS
     fi
 
-    if [ -n "$HOST_BRIDGE" ]; then
+    if [[ -n "''${HOST_BRIDGE-}" ]]; then
       extraFlags+=("--network-bridge=$HOST_BRIDGE")
     fi
 
-    if [ -n "$NETWORK_NAMESPACE_PATH" ]; then
+    if [[ -n "''${NETWORK_NAMESPACE_PATH-}" ]]; then
       extraFlags+=("--network-namespace-path=$NETWORK_NAMESPACE_PATH")
     fi
 
     extraFlags+=(${lib.escapeShellArgs (mapAttrsToList nspawnExtraVethArgs cfg.extraVeths)})
 
-    for iface in $INTERFACES; do
+    for iface in ''${INTERFACES-}; do
       extraFlags+=("--network-interface=$iface")
     done
 
-    for iface in $MACVLANS; do
+    for iface in ''${MACVLANS-}; do
       extraFlags+=("--network-macvlan=$iface")
     done
 
     # If the host is 64-bit and the container is 32-bit, add a
     # --personality flag.
     ${optionalString (pkgs.stdenv.hostPlatform.system == "x86_64-linux") ''
-      if [ "$(< "''${SYSTEM_PATH:-/nix/var/nix/profiles/per-container/$INSTANCE/system}/system")" = i686-linux ]; then
+      if [[ "$(< "''${SYSTEM_PATH:-/nix/var/nix/profiles/per-container/$INSTANCE/system}/system")" = i686-linux ]]; then
         extraFlags+=("--personality=x86")
       fi
     ''}
@@ -198,14 +198,14 @@ let
       --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles$NIX_BIND_OPT" \
       --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots$NIX_BIND_OPT" \
       ${optionalString (!cfg.ephemeral) "--link-journal=try-guest"} \
-      --setenv PRIVATE_NETWORK="$PRIVATE_NETWORK" \
-      --setenv PRIVATE_USERS="$PRIVATE_USERS" \
-      --setenv HOST_BRIDGE="$HOST_BRIDGE" \
-      --setenv HOST_ADDRESS="$HOST_ADDRESS" \
-      --setenv LOCAL_ADDRESS="$LOCAL_ADDRESS" \
-      --setenv HOST_ADDRESS6="$HOST_ADDRESS6" \
-      --setenv LOCAL_ADDRESS6="$LOCAL_ADDRESS6" \
-      --setenv HOST_PORT="$HOST_PORT" \
+      --setenv PRIVATE_NETWORK="''${PRIVATE_NETWORK-}" \
+      --setenv PRIVATE_USERS="''${PRIVATE_USERS-}" \
+      --setenv HOST_BRIDGE="''${HOST_BRIDGE-}" \
+      --setenv HOST_ADDRESS="''${HOST_ADDRESS-}" \
+      --setenv LOCAL_ADDRESS="''${LOCAL_ADDRESS-}" \
+      --setenv HOST_ADDRESS6="''${HOST_ADDRESS6-}" \
+      --setenv LOCAL_ADDRESS6="''${LOCAL_ADDRESS6-}" \
+      --setenv HOST_PORT="''${HOST_PORT-}" \
       --setenv PATH="$PATH" \
       ${optionalString cfg.ephemeral "--ephemeral"} \
       ${
@@ -218,7 +218,7 @@ let
           cfg.tmpfs != null && cfg.tmpfs != [ ]
         ) ''--tmpfs=${concatStringsSep " --tmpfs=" cfg.tmpfs}''
       } \
-      $EXTRA_NSPAWN_FLAGS \
+      ''${EXTRA_NSPAWN_FLAGS-} \
       ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
   '';
 
@@ -226,8 +226,8 @@ let
     # Clean up existing machined registration and interfaces.
     machinectl terminate "$INSTANCE" 2> /dev/null || true
 
-    if [ -n "$HOST_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS" ] ||
-       [ -n "$HOST_ADDRESS6" ] || [ -n "$LOCAL_ADDRESS6" ]; then
+    if [[ -n "''${HOST_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS-}" ]] ||
+       [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
       ip link del dev "ve-$INSTANCE" 2> /dev/null || true
       ip link del dev "vb-$INSTANCE" 2> /dev/null || true
     fi
@@ -244,8 +244,8 @@ let
         cfg: ipcmd: variable: attribute:
         if cfg.${attribute} == null then
           ''
-            if [ -n "${variable}" ]; then
-              ${ipcmd} add "${variable}" dev "$ifaceHost"
+            if [[ -n "''${${variable}-}" ]]; then
+              ${ipcmd} add "''${${variable}}" dev "$ifaceHost"
             fi
           ''
         else
@@ -277,16 +277,16 @@ let
           '';
     in
     ''
-      if [ -n "$HOST_ADDRESS" ]  || [ -n "$LOCAL_ADDRESS" ] ||
-         [ -n "$HOST_ADDRESS6" ] || [ -n "$LOCAL_ADDRESS6" ]; then
-        if [ -z "$HOST_BRIDGE" ]; then
+      if [[ -n "''${HOST_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS-}" ]] ||
+         [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
+        if [[ -z "''${HOST_BRIDGE-}" ]]; then
           ifaceHost=ve-$INSTANCE
           ip link set dev "$ifaceHost" up
 
-          ${ipcall cfg "ip addr" "$HOST_ADDRESS" "hostAddress"}
-          ${ipcall cfg "ip -6 addr" "$HOST_ADDRESS6" "hostAddress6"}
-          ${ipcall cfg "ip route" "$LOCAL_ADDRESS" "localAddress"}
-          ${ipcall cfg "ip -6 route" "$LOCAL_ADDRESS6" "localAddress6"}
+          ${ipcall cfg "ip addr" "HOST_ADDRESS" "hostAddress"}
+          ${ipcall cfg "ip -6 addr" "HOST_ADDRESS6" "hostAddress6"}
+          ${ipcall cfg "ip route" "LOCAL_ADDRESS" "localAddress"}
+          ${ipcall cfg "ip -6 route" "LOCAL_ADDRESS6" "localAddress6"}
         fi
       fi
       ${concatStringsSep "\n" (mapAttrsToList renderExtraVeth cfg.extraVeths)}
@@ -966,6 +966,8 @@ in
             pkgs.iproute2
             config.nix.package
           ];
+
+          enableStrictShellChecks = true;
 
           environment = {
             root = "${stateDirectory}/%i";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -374,7 +374,7 @@ in
   consul = runTest ./consul.nix;
   consul-template = runTest ./consul-template.nix;
   containers-bridge = runTest ./containers-bridge.nix;
-  containers-custom-pkgs.nix = runTest ./containers-custom-pkgs.nix;
+  containers-custom-pkgs = runTest ./containers-custom-pkgs.nix;
   containers-ephemeral = runTest ./containers-ephemeral.nix;
   containers-extra_veth = runTest ./containers-extra_veth.nix;
   containers-hosts = runTest ./containers-hosts.nix;


### PR DESCRIPTION
[Motivation](https://github.com/NixOS/nixpkgs/issues/349572)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
