### PR TITLE
nickel: enable `nix-experimental` feature flag

### DIFF
--- a/pkgs/by-name/ni/nickel/package.nix
+++ b/pkgs/by-name/ni/nickel/package.nix
@@ -1,10 +1,14 @@
 {
   lib,
+  boost,
   rustPlatform,
   fetchFromGitHub,
   python3,
   versionCheckHook,
+  pkg-config,
+  nix,
   nix-update-script,
+  enableNixImport ? true,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -26,16 +30,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "-p nickel-lang-lsp"
   ];
 
-  nativeBuildInputs = [
-    python3
+  nativeBuildInputs =
+    [
+      python3
+    ]
+    ++ lib.optionals enableNixImport [
+      pkg-config
+    ];
+
+  buildInputs = lib.optionals enableNixImport [
+    nix
+    boost
   ];
+
+  buildFeatures = lib.optionals enableNixImport [ "nix-experimental" ];
 
   outputs = [
     "out"
     "nls"
   ];
 
-  # This fixes the way comrak is defined as a dependency, without the sed the build fails:
+  # This fixes the way comrak is defined as a dependency, without it the build fails:
   #
   # cargo metadata failure: error: Package `nickel-lang-core v0.10.0
   # (/build/source/core)` does not have feature `comrak`. It has an optional


### PR DESCRIPTION
add nickel's [`nix-experimental`](https://github.com/tweag/nickel/commit/91d63ed611f2f86e245b696b34b4cf09f637ee91) feature flag

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
