### PR TITLE
jsonschema: 5.3.1 -> 0.7.0 with fixed update script

### DIFF
--- a/pkgs/by-name/js/jsonschema/package.nix
+++ b/pkgs/by-name/js/jsonschema/package.nix
@@ -7,19 +7,22 @@
 
 buildGoModule rec {
   pname = "jsonschema";
-  version = "5.3.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "santhosh-tekuri";
     repo = "jsonschema";
-    tag = "v${version}";
-    hash = "sha256-ANo9OkdNVCjV5uEqr9lNNbStquNb/3oxuTfMqE2nUzo=";
+    tag = "cmd/jv/v${version}";
+    hash = "sha256-bMDDji5daBmjSeGxeS4PZfmTg+b8OVHsP8+m3jtpQJc=";
   };
 
   sourceRoot = "${src.name}/cmd/jv";
-  passthru.updateScript = nix-update-script { };
+  env.GOWORK = "off";
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=cmd/jv/v([\\d\\.]+)" ];
+  };
 
-  vendorHash = "sha256-FuUkC7iwn/jO3fHjT9nGUXc2X1QuuxPc8DAzVpzhANk=";
+  vendorHash = "sha256-s7kEdA4yuExuzwN3hHgeZmtkES3Zw1SALoEHSNtdAww=";
 
   ldflags = [
     "-s"
@@ -29,7 +32,7 @@ buildGoModule rec {
   meta = {
     description = "JSON schema compilation and validation";
     homepage = "https://github.com/santhosh-tekuri/jsonschema";
-    changelog = "https://github.com/santhosh-tekuri/jsonschema/releases/tag/v${version}";
+    changelog = "https://github.com/santhosh-tekuri/jsonschema/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "jv";
     maintainers = with lib.maintainers; [ ibizaman ];


### PR DESCRIPTION
- [They have different tags for CLI(jv) and jsonschema](https://github.com/santhosh-tekuri/jsonschema/blob/83a4c8009c0e7855accffc926454a37a51d895ad/README.md?plain=1#L63). 
- [jv 0.7.0 is higher version than jsonschema 6.0.1.](https://github.com/santhosh-tekuri/jsonschema/tags)
- [Update script is failing](https://nixpkgs-update-logs.nix-community.org/jsonschema/2025-02-20.log)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @ibizaman

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
