### PR TITLE
applet-window-buttons6: fix build with plasma 6.3

### DIFF
--- a/pkgs/kde/third-party/applet-window-buttons6/default.nix
+++ b/pkgs/kde/third-party/applet-window-buttons6/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
+  fetchpatch,
   kcoreaddons,
   kdeclarative,
   kdecoration,
@@ -20,6 +21,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-S7JcDPo4QDqi/RtvreFNoPKwTg14bgaFGsuGSDxs5nM=";
   };
+
+  patches = [
+    # Needed for the new kdecorations3 (part of plasma 6.3) and should no longer be needed with next release.
+    (fetchpatch {
+      url = "https://github.com/moodyhunter/applet-window-buttons6/commit/326382805641d340c9902689b549e4488682f553.patch";
+      hash = "sha256-xlrmA/SSPH41VE7xjYJ8xQ1EVBnE8jMbwnuDSpKWQPM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/moodyhunter/applet-window-buttons6/commit/e27cd7559581e84b559a5da2c7bc6ea5a3f5bf15.patch";
+      hash = "sha256-1GwZh2ZR9+cB+4ggiwsNN1KT5m8tsi/AEGZK0Cx5sdw=";
+    })
+  ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
This fixes the build failure described in #382742.

This adds two pre-released patches that update the kdecorations dependency from v2 to v3, allowing it to be build against plasma v6.3 which was made the new default plasma version with #372458.