### PR TITLE
lemurs: 0.3.2-unstable-2024-07-24 -> 0.4.0; use versionCheckHook

### DIFF
--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -2,11 +2,10 @@
   fetchFromGitHub,
   lib,
   bash,
-  lemurs,
   linux-pam,
   rustPlatform,
   systemdMinimal,
-  testers,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "lemurs";
@@ -28,9 +27,8 @@ rustPlatform.buildRustPackage rec {
     systemdMinimal
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = lemurs;
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Customizable TUI display/login manager written in Rust";

--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -8,19 +8,19 @@
   systemdMinimal,
   testers,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "lemurs";
-  version = "0.3.2-unstable-2024-07-24";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "coastalwhite";
     repo = "lemurs";
-    rev = "1d4be7d0c3f528a0c1e9326ac77f1e8a17161c83";
-    hash = "sha256-t/riJpgy0bD5CU8Zkzket4Gks2JXXSLRreMlrxlok0c=";
+    tag = "v${version}";
+    hash = "sha256-dtAmgzsUhn3AfafWbCaaog0S1teIy+8eYtaHBhvLfLI=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-Cwgu30rGe1/Mm4FEEH11OTtTHUlBNwl5jVzmJg5qQe8=";
+  cargoHash = "sha256-XoGtIHYCGXNuwnpDTU7NbZAs6rCO+69CAG89VCv9aAc=";
 
   buildInputs = [
     bash
@@ -30,8 +30,6 @@ rustPlatform.buildRustPackage {
 
   passthru.tests.version = testers.testVersion {
     package = lemurs;
-    # Package version is now different from the version that lemurs reports itself as.
-    version = "0.3.2";
   };
 
   meta = {


### PR DESCRIPTION
I'm having some [deja vu...](https://github.com/NixOS/nixpkgs/pull/384051)

Updated lemurs to version 0.4.0, which includes many fixes for nixos.

Replaced testers.testVersion with versionCheckHook:
https://github.com/NixOS/nixpkgs/pull/384243#discussion_r1966650601

Changelog:
https://github.com/coastalwhite/lemurs/releases/tag/v0.4.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
