### PR TITLE
nginx: disable PCRE2 JIT SEAlloc to avoid crashes

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11396,6 +11396,9 @@ with pkgs;
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
     # Use latest boringssl to allow http3 support
     openssl = quictls;
+    pcre2 = pcre2.override {
+      withJitSealloc = false; # experimental allocator that may crash when forking
+    };
   };
 
   nginxStable = callPackage ../servers/http/nginx/stable.nix {
@@ -11403,6 +11406,9 @@ with pkgs;
     # We don't use `with` statement here on purpose!
     # See https://github.com/NixOS/nixpkgs/pull/10474#discussion_r42369334
     modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders ];
+    pcre2 = pcre2.override {
+      withJitSealloc = false; # experimental allocator that may crash when forking
+    };
   };
 
   nginxMainline = callPackage ../servers/http/nginx/mainline.nix {
@@ -11411,6 +11417,9 @@ with pkgs;
     # We don't use `with` statement here on purpose!
     # See https://github.com/NixOS/nixpkgs/pull/10474#discussion_r42369334
     modules = [ nginxModules.dav nginxModules.moreheaders ];
+    pcre2 = pcre2.override {
+      withJitSealloc = false; # experimental allocator that may crash when forking
+    };
   };
 
   nginxModules = recurseIntoAttrs (callPackage ../servers/http/nginx/modules.nix { });


### PR DESCRIPTION
Since nginx switched from pcre to pcre2, I have noticed many crashes on my nginx workers. Many of them don't have a stack trace, but when they do, I have:

```
0x00007ff314806526 sljit_free_exec (libpcre2-8.so.0 + 0x22526)
0x00007ff31483a2c3 _pcre2_jit_free_8 (libpcre2-8.so.0 + 0x562c3)
0x00007ff3147f10ea pcre2_code_free_8 (libpcre2-8.so.0 + 0xd0ea)
0x000055d042089266 ngx_regex_cleanup (nginx + 0x63266)
0x000055d042051e06 ngx_destroy_pool (nginx + 0x2be06)
0x000055d0420798c2 ngx_worker_process_exit (nginx + 0x538c2)
0x000055d04207a2c8 ngx_worker_process_cycle (nginx + 0x542c8)
0x000055d04207887b ngx_spawn_process (nginx + 0x5287b)
0x000055d04207ad26 ngx_master_process_cycle (nginx + 0x54d26)
0x000055d042050552 main (nginx + 0x2a552)
0x00007ff313cd527e __libc_start_call_main (libc.so.6 + 0x2a27e)
0x00007ff313cd5339 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a339)
0x000055d04204eaf5 _start (nginx + 0x28af5)
```

In nixpkgs, pcre2 uses an experimental allocator by default to workaround a possible crash for processes using
`MemoryDenyWriteExecute=true` [1].

It should also be noted that OpenSUSE did try to enable PCRE2 JIT SEAlloc by default in the past but reverted the change [2]. Maybe it is not a good idea to enable globally an experimental allocator with known limitations:

> If you are enabling JIT under SELinux environment you may also want to add
>  --enable-jit-sealloc, which enables the use of an executable memory allocator
>  that is compatible with SELinux. Warning: this allocator is experimental!
>  It does not support fork() operation and may crash when no disk space is
>  available. This option has no effect if JIT is disabled.

[1] https://github.com/NixOS/nixpkgs/commit/c990bd600791a4c7070aa377a93adcdc319c6cdb
[2] https://bugzilla.opensuse.org/show_bug.cgi?id=1182864


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
