### PR TITLE
peergos: 0.22.0 -> 1.0.0, build from source

### DIFF
--- a/pkgs/by-name/pe/peergos/package.nix
+++ b/pkgs/by-name/pe/peergos/package.nix
@@ -1,55 +1,103 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  ant,
+  jdk,
+  openjdk8-bootstrap,
   jre,
+  stripJavaArchivesHook,
   makeWrapper,
   nix-update-script,
 }:
 
+let
+  tweetnacl = stdenv.mkDerivation {
+    pname = "tweetnacl";
+    version = "0-unstable-12-02-2020";
+
+    src = fetchFromGitHub {
+      owner = "ianopolous";
+      repo = "tweetnacl-java";
+      rev = "6d1bde81ea63051750cda40422b62e478b85d2b0";
+      hash = "sha256-BDWzDpUBi4UuvxFwA9ton+RtHOzDcWql1ti+cdvhzks=";
+    };
+
+    postPatch = ''
+      substituteInPlace Makefile \
+        --replace-fail gcc cc
+    '';
+
+    makeFlags = [ "jni" ];
+
+    nativeBuildInputs = [
+      openjdk8-bootstrap # javah
+    ];
+
+    installPhase = ''
+      install -Dvm644 libtweetnacl.so $out/lib/libtweetnacl.so
+    '';
+  };
+in
 stdenv.mkDerivation rec {
   pname = "peergos";
-  version = "0.22.0";
-  src = fetchurl {
-    url = "https://github.com/Peergos/web-ui/releases/download/v${version}/Peergos.jar";
-    hash = "sha256-JjJBHL2wdAt+V9wAujvBIdAw/OAe89sHsYsv+cXEjTY=";
+  version = "1.0.0";
+  src = fetchFromGitHub {
+    owner = "Peergos";
+    repo = "web-ui";
+    rev = "v${version}";
+    hash = "sha256-TSvhp/9nneXGADiDPgGvA78emVcQG0UzHsFfVS9k7mo=";
+    fetchSubmodules = true;
   };
 
-  dontUnpack = true;
-  dontBuild = true;
+  nativeBuildInputs = [
+    ant
+    jdk
+    stripJavaArchivesHook
+    makeWrapper
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  postPatch = ''
+    substituteInPlace build.xml \
+      --replace-fail '${"\${repository.version}"}' '${version}'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    ant dist
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    install -D ${src} $out/share/java/peergos.jar
+    install -Dvm644 server/Peergos.jar $out/share/java/peergos.jar
+    install -Dvm644 ${tweetnacl}/lib/libtweetnacl.so $out/native-lib/libtweetnacl.so
+
+    # --chdir as peergos expects to find `libtweetnacl.so` in `native-lib/`
     makeWrapper ${lib.getExe jre} $out/bin/peergos \
-      --add-flags "-jar -Djava.library.path=native-lib $out/share/java/peergos.jar"
+      --chdir $out \
+      --add-flags "-Djava.library.path=native-lib -jar $out/share/java/peergos.jar"
 
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "^(v[0-9.]+)$"
-    ];
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/Peergos/web-ui/releases/tag/v${version}";
-    description = "P2p, secure file storage, social network and application protocol";
+    description = "P2P, secure file storage, social network and application protocol";
     downloadPage = "https://github.com/Peergos/web-ui";
     homepage = "https://peergos.org/";
-    # peergos have agpt3 license, peergos-web-ui have gpl3, both are used
     license = [
-      lib.licenses.agpl3Only
-      lib.licenses.gpl3Only
+      lib.licenses.agpl3Only # server
+      lib.licenses.gpl3Only # web-ui
     ];
     mainProgram = "peergos";
-    maintainers = with lib.maintainers; [ raspher ];
+    maintainers = with lib.maintainers; [
+      raspher
+      christoph-heiss
+    ];
     platforms = lib.platforms.all;
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This firstly updates peergos from 0.22.0 to 1.0.0. Closes #383441.

It also converts it to build entirely from source, instead of downloading pre-built releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
