### PR TITLE
zlog: 1.2.17 → 1.2.18

### DIFF
--- a/pkgs/by-name/zl/zlog/package.nix
+++ b/pkgs/by-name/zl/zlog/package.nix
@@ -2,27 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.17";
+  version = "1.2.18";
   pname = "zlog";
 
   src = fetchFromGitHub {
     owner = "HardySimpson";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ckpDMRLxObpl8N539DC5u2bPpmD7jM+KugurUfta6tg=";
+    hash = "sha256-79yyOGKgqUR1KI2+ngZd7jfVcz4Dw1IxaYfBJyjsxYc=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2024-22857.patch";
-      url = "https://github.com/HardySimpson/zlog/commit/c47f781a9f1e9604f5201e27d046d925d0d48ac4.patch";
-      hash = "sha256-3FAAHJ2R/OpNpErWXptjEh0x370/jzvK2VhuUuyaOjE=";
-    })
-  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
@@ -33,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Reliable, high-performance, thread safe, flexible, clear-model, pure C logging library";
     homepage = "https://hardysimpson.github.io/zlog/";
-    license = licenses.lgpl21;
+    license = licenses.asl20;
     maintainers = [ maintainers.matthiasbeyer ];
     mainProgram = "zlog-chk-conf";
     platforms = platforms.unix;

--- a/pkgs/by-name/zl/zlog/package.nix
+++ b/pkgs/by-name/zl/zlog/package.nix
@@ -2,31 +2,28 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
 }:
 
-stdenv.mkDerivation rec {
-  version = "1.2.18";
+stdenv.mkDerivation (finalAttrs: {
   pname = "zlog";
+  version = "1.2.18";
 
   src = fetchFromGitHub {
     owner = "HardySimpson";
-    repo = pname;
-    rev = version;
+    repo = "zlog";
+    tag = finalAttrs.version;
     hash = "sha256-79yyOGKgqUR1KI2+ngZd7jfVcz4Dw1IxaYfBJyjsxYc=";
   };
 
-  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  nativeBuildInputs = [ cmake ];
 
-  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    makeFlagsArray+=(CFLAGS="-Wno-pointer-to-int-cast -Wno-newline-eof")
-  '';
-
-  meta = with lib; {
+  meta = {
     description = "Reliable, high-performance, thread safe, flexible, clear-model, pure C logging library";
     homepage = "https://hardysimpson.github.io/zlog/";
-    license = licenses.asl20;
-    maintainers = [ maintainers.matthiasbeyer ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "zlog-chk-conf";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
https://github.com/HardySimpson/zlog/releases/tag/1.2.18
> * patched severe vulnerability [CVE-2024-22857](https://github.com/advisories/GHSA-6q5p-rp5c-wmph)
> * restructured build system

Fixes cross compilation.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
