### PR TITLE
python3Packages.psycopg2{,cffi}: use libpq instead of postgresql

### DIFF
--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -5,6 +5,7 @@
   pythonOlder,
   isPyPy,
   fetchPypi,
+  libpq,
   postgresql,
   postgresqlTestHook,
   openssl,
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     # some linker flags are added but the linker ignores them because they're incompatible
     # https://github.com/psycopg/psycopg2/blob/89005ac5b849c6428c05660b23c5a266c96e677d/setup.py
     substituteInPlace setup.py \
-      --replace-fail "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getDev buildPackages.postgresql}/bin/pg_config"'
+      --replace-fail "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getDev buildPackages.libpq}/bin/pg_config"'
   '';
 
   nativeBuildInputs = [
@@ -45,7 +46,7 @@ buildPythonPackage rec {
     sphinx-better-theme
   ];
 
-  buildInputs = [ postgresql ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ openssl ];
+  buildInputs = [ libpq ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ openssl ];
 
   sphinxRoot = "doc/src";
 
@@ -53,7 +54,10 @@ buildPythonPackage rec {
   #   current transaction is aborted, commands ignored until end of transaction block
   doCheck = false;
 
-  nativeCheckInputs = [ postgresqlTestHook ];
+  nativeCheckInputs = [
+    postgresql
+    postgresqlTestHook
+  ];
 
   env = {
     PGDATABASE = "psycopg2_test";
@@ -62,7 +66,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "psycopg2" ];
 
   disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-    buildPackages.postgresql
+    buildPackages.libpq
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -3,6 +3,7 @@
   cffi,
   fetchFromGitHub,
   lib,
+  libpq,
   postgresql,
   postgresqlTestHook,
   pytestCheckHook,
@@ -29,8 +30,11 @@ buildPythonPackage rec {
       --replace-fail "sysconfig.get_python_inc()" "sysconfig.get_path('include')"
   '';
 
+  buildInputs = [ libpq ];
+  # To find pg_config
+  nativeBuildInputs = [ libpq ];
+
   build-system = [
-    postgresql
     setuptools
   ];
 
@@ -43,6 +47,7 @@ buildPythonPackage rec {
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   nativeCheckInputs = [
+    postgresql
     postgresqlTestHook
     pytestCheckHook
   ];


### PR DESCRIPTION
We don't need the whole server to link against. We still use it in the checkPhase do run tests against, but this will later be replaced by a test-only derivation of the server.

The ultimate goal is to reduce the number of rebuilds required to update postgresql's major versions on master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Still going to run a few builds after Eval has finished.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
