### PR TITLE
py7zr: init at 0.22.0; pyppmd: init at 1.1.1; pybcj: init at 1.0.3; multivolumefile: init at 0.2.3; inflate64: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "inflate64";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "inflate64";
+    tag = "v${version}";
+    hash = "sha256-deFx8NMbGLP51CdNvmZ25LQ5FLPBb1PB3QhGhIfTMfc=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "inflate64"
+  ];
+
+  meta = {
+    description = "Compress and decompress with Enhanced Deflate compression algorithm";
+    homepage = "https://codeberg.org/miurahr/inflate64";
+    changelog = "https://codeberg.org/miurahr/inflate64/src/tag/v${version}/docs/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+
+}

--- a/pkgs/development/python-modules/multivolumefile/default.nix
+++ b/pkgs/development/python-modules/multivolumefile/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "multivolumefile";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "multivolume";
+    tag = "v${version}";
+    hash = "sha256-7gjfF7biQZOcph2dfwi2ouDn/uIYik/KBQ0k6u5Ne+Q=";
+  };
+
+  postPatch =
+    # Fix typo: `tools` -> `tool`
+    # upstream PR: https://codeberg.org/miurahr/multivolume/pulls/9
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'tools.setuptools_scm' 'tool.setuptools_scm'
+    '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "multivolumefile"
+  ];
+
+  meta = {
+    description = "Library to provide a file-object wrapping multiple files as virtually like as a single file";
+    homepage = "https://codeberg.org/miurahr/multivolume";
+    changelog = "https://codeberg.org/miurahr/multivolume/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/py7zr/default.nix
+++ b/pkgs/development/python-modules/py7zr/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  brotli,
+  inflate64,
+  multivolumefile,
+  psutil,
+  pybcj,
+  pycryptodomex,
+  pyppmd,
+  pyzstd,
+  texttable,
+  py-cpuinfo,
+  pytest-benchmark,
+  pytest-remotedata,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "py7zr";
+  version = "0.22.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "miurahr";
+    repo = "py7zr";
+    tag = "v${version}";
+    hash = "sha256-YR2cuHZWwqrytidAMbNvRV1/N4UZG8AMMmzcTcG9FvY=";
+  };
+
+  postPatch =
+    # Replace inaccessible mirror (qt.mirrors.tds.net):
+    # upstream PR: https://github.com/miurahr/py7zr/pull/637
+    ''
+      substituteInPlace tests/test_concurrent.py \
+        --replace-fail 'http://qt.mirrors.tds.net/qt/' 'https://download.qt.io/'
+    '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    brotli
+    inflate64
+    multivolumefile
+    psutil
+    pybcj
+    pycryptodomex
+    pyppmd
+    pyzstd
+    texttable
+  ];
+
+  nativeCheckInputs = [
+    py-cpuinfo
+    pytest-benchmark
+    pytest-remotedata
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "py7zr"
+  ];
+
+  meta = {
+    description = "7zip in Python 3 with ZStandard, PPMd, LZMA2, LZMA1, Delta, BCJ, BZip2";
+    homepage = "https://github.com/miurahr/py7zr";
+    changelog = "https://github.com/miurahr/py7zr/blob/v${version}/docs/Changelog.rst#v${
+      builtins.replaceStrings [ "." ] [ "" ] version
+    }";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pybcj/default.nix
+++ b/pkgs/development/python-modules/pybcj/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pybcj";
+  version = "1.0.3";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "pybcj";
+    tag = "v${version}";
+    hash = "sha256-ExSt7E7ZaVEa0NwAQHU0fOaXJW9jYmEUUy/1iUilGz8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "bcj"
+  ];
+
+  meta = {
+    description = "BCJ (Branch-Call-Jump) filter for Python";
+    homepage = "https://codeberg.org/miurahr/pybcj";
+    changelog = "https://codeberg.org/miurahr/pybcj/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytest-benchmark,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyppmd";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "pyppmd";
+    tag = "v${version}";
+    hash = "sha256-0t1vyVMtmhb38C2teJ/Lq7dx4usm4Bzx+k7Zalf/nXE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-benchmark
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyppmd"
+  ];
+
+  meta = {
+    description = "PPMd compression/decompression library";
+    homepage = "https://codeberg.org/miurahr/pyppmd";
+    changelog = "https://codeberg.org/miurahr/pyppmd/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       MattSturgeon
+      pitkling
       PopeRigby
     ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1058,6 +1058,8 @@ with pkgs;
 
   pricehist = python3Packages.callPackage ../tools/misc/pricehist { };
 
+  py7zr = with python3Packages; toPythonApplication py7zr;
+
   q = callPackage ../tools/networking/q { };
 
   qFlipper = libsForQt5.callPackage ../tools/misc/qflipper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10710,6 +10710,8 @@ self: super: with self; {
 
   pyatome = callPackage ../development/python-modules/pyatome { };
 
+  pybcj = callPackage ../development/python-modules/pybcj { };
+
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
   pycolorecho = callPackage ../development/python-modules/pycolorecho { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10695,6 +10695,8 @@ self: super: with self; {
 
   py65 = callPackage ../development/python-modules/py65 { };
 
+  py7zr = callPackage ../development/python-modules/py7zr { };
+
   pyabpoa = toPythonModule (pkgs.abpoa.override {
     enablePython = true;
     python3Packages = self;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10841,6 +10841,8 @@ self: super: with self; {
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };
 
+  pyppmd = callPackage ../development/python-modules/pyppmd { };
+
   pyrail = callPackage ../development/python-modules/pyrail { };
 
   pyrdfa3 = callPackage ../development/python-modules/pyrdfa3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6380,6 +6380,8 @@ self: super: with self; {
 
   infinity = callPackage ../development/python-modules/infinity { };
 
+  inflate64 = callPackage ../development/python-modules/inflate64 { };
+
   inflect = callPackage ../development/python-modules/inflect { };
 
   inflection = callPackage ../development/python-modules/inflection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8685,6 +8685,8 @@ self: super: with self; {
 
   multitasking = callPackage ../development/python-modules/multitasking { };
 
+  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
+
   munch = callPackage ../development/python-modules/munch { };
 
   mung = callPackage ../development/python-modules/mung { };


### PR DESCRIPTION
Continues the work done by @poperigby (in PR #365111) and @ByteSudoer (in PR #324293).

* closes #365111
* closes #324293
* closes #324207

## Commit Explanation:
* The first five commits are just a cleanup of the commit history of PR #365111. Otherwise **no** changes.
* Commit six adds me as a maintainer to the related `pyzstd`. It was originally part of PR #365111 but has been added in another PR #381975 by @MattSturgeon that has been merged.
* The remaining commits are new changes by me. The commits are temporary to ease reviews of anyone that previously reviewed PR #365111. I'll squash them into the corresponding package-related commits later on.
    * They mostly just activate standard python checks (as suggested by @MattSturgeon in [this comment](https://github.com/NixOS/nixpkgs/pull/365111#issuecomment-2674996025)).
    * There are also two substitutes to fix minor problems in the upstream packages:
        * an inaccessible mirror in test of `py7zr` (upstream PR: miurahr/py7zr#637)
        * typo in `pyproject.toml` of `multivolumefile` ([upstream PR](https://codeberg.org/miurahr/multivolume/pulls/9))

## Potential Reviewers
* @poperigby, @ByteSudoer: initiated previous PRs for these packages
* @MattSturgeon: cherry picked the related `pyzstd` from the original PRs
* @natsukium: gave a lot of helpful feedback on the cherry-picked `pyzstd` in PR #381975

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
