### PR TITLE
liquid-dsp: don't leak impure builder cpu extensions into the build

### DIFF
--- a/pkgs/development/libraries/liquid-dsp/default.nix
+++ b/pkgs/development/libraries/liquid-dsp/default.nix
@@ -19,7 +19,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3UKAwhYaYZ42+d+wiW/AB6x5TSOel8d++d3HeZqAg/8=";
   };
 
-  configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [ "LIBTOOL=${cctools}/bin/libtool" ];
+  configureFlags =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      "LIBTOOL=${cctools}/bin/libtool"
+    ]
+    ++ [
+      # Prevent native cpu arch from leaking into binaries. This might lead to
+      # poor performance, but having portable and working executables is more
+      # important.
+      (lib.enableFeature true "simdoverride")
+    ];
 
   nativeBuildInputs =
     [ autoreconfHook ]


### PR DESCRIPTION
By default the project builds with automatic vector extension detection for the cpu. This leaks impure state into the executable and depending on the builder results in executables that require AVX extensions.

Resolves #384082.

I've manually verified that the build log contains portable c code:

```
gcc -g -O2    -Wall -fPIC -Wno-deprecated -Wno-deprecated-declarations -I. -Iinclude  -c -o src/dotprod/src/dotprod_cccf.o src/dotprod/src/dotprod_cccf.c
gcc -g -O2    -Wall -fPIC -Wno-deprecated -Wno-deprecated-declarations -I. -Iinclude  -c -o src/dotprod/src/dotprod_crcf.o src/dotprod/src/dotprod_crcf.c
gcc -g -O2    -Wall -fPIC -Wno-deprecated -Wno-deprecated-declarations -I. -Iinclude  -c -o src/dotprod/src/dotprod_rrrf.o src/dotprod/src/dotprod_rrrf.c
```

This corresponds to [these](https://github.com/jgaeddert/liquid-dsp/blob/9ab893349aa8c7261ff508ba28244ec4a1f6e274/configure.ac#L154-L184) compiler checks.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
