### PR TITLE
beeref: init at 2024-06-02; rectangle-packer: init at 2024-10-26

### DIFF
--- a/pkgs/by-name/be/beeref/package.nix
+++ b/pkgs/by-name/be/beeref/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "beeref";
+  version = "2024-06-02";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rbreu";
+    repo = "beeref";
+    rev = "caed5c38016c9efea05f78d3f60178e0ba878cd4";
+    hash = "sha256-wA0cqJgyirAqpZYoWjzSTiGX4FraTHXLCLWm2kALWn4=";
+  };
+
+  patches = [
+    ./pyproject.toml.patch
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    exif
+    lxml
+    pyqt6
+    rectangle-packer
+  ];
+
+  meta = with lib; {
+    description = "A Simple Reference Image Viewer";
+    homepage = "https://beeref.org/";
+    changelog = "https://github.com/rbreu/beeref/blob/main/CHANGELOG.rst";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ wchresta ];
+  };
+}

--- a/pkgs/by-name/be/beeref/pyproject.toml.patch
+++ b/pkgs/by-name/be/beeref/pyproject.toml.patch
@@ -1,0 +1,15 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -20,9 +20,8 @@ authors = [
+ requires-python = ">=3.9,<3.13"
+ dependencies = [
+     "exif>=1.3.5,<=1.6.0",
+-    "lxml==5.1.0",
+-    "pyQt6-Qt6>=6.7.0,<=6.7.0",
+-    "pyQt6>=6.7.0,<=6.7.0",
++    "lxml",
++    "pyQt6",
+     "rectangle-packer>=2.0.1,<=2.0.2",
+ ]
+ 

--- a/pkgs/development/python-modules/rectangle-packer/default.nix
+++ b/pkgs/development/python-modules/rectangle-packer/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build system
+  cython,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "rectangle-packer";
+  version = "2024-10-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Penlect";
+    repo = "rectangle-packer";
+    rev = "46fa636fc8637081845151b4a0b16e8f60a57638";
+    sha256 = "sha256-9mXfa9tDB2QE6hHxOxk9XvUjiov0dUBX54X4uRxwSvQ=";
+  };
+
+  build-system = [ cython setuptools ];
+
+  dependencies = [ ];
+
+  nativeCheckInputs = [ ];
+
+  pythonImportsCheck = [ "rpack" ];
+
+  meta = with lib; {
+    description = "A Python module for rectangle packing utilities.";
+    homepage = "https://github.com/Penlect/rectangle-packer";
+    license = licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7936,6 +7936,8 @@ self: super: with self; {
 
   rtmixer = callPackage ../development/python-modules/rtmixer { };
 
+  rectangle-packer = callPackage ../development/python-modules/rectangle-packer { };
+
   regress = callPackage ../development/python-modules/regress { };
 
   macaroonbakery = callPackage ../development/python-modules/macaroonbakery { };


### PR DESCRIPTION
## Things done

Added two new packages

- application beeref: https://beeref.org/ - BeeRef lets you quickly arrange your reference images and view them while you create. Its minimal interface is designed not to get in the way of your creative process.
- python module [rectangle-packer](https://github.com/Penlect/rectangle-packer): Given a set of rectangles with fixed orientations, find a bounding box of minimum area that contains them all with no overlap.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
