### PR TITLE
graphql-language-service-cli: init at 3.5.0

### DIFF
--- a/pkgs/by-name/gr/graphql-language-service-cli/package.nix
+++ b/pkgs/by-name/gr/graphql-language-service-cli/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  makeWrapper,
+  nodejs,
+  stdenv,
+  yarnBuildHook,
+  yarnConfigHook,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "graphql-language-service-cli";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "graphql";
+    repo = "graphiql";
+    tag = "graphql-language-service-cli@${finalAttrs.version}";
+    hash = "sha256-NJTggaMNMjOP5oN+gHxFTwEdNipPNzTFfA6f975HDgM=";
+  };
+
+  patches = [
+    ./patches/0001-repurpose-vscode-graphql-build-script.patch
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-ae6KP2sFgw8/8YaTJSPscBlVQ5/bzbvHRZygcMgFAlU=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+
+    pushd packages/graphql-language-service-cli
+
+    node esbuild.js --minify
+
+    # copy package.json for --version command
+    mv {out/graphql.js,package.json} $out/lib
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/graphql-lsp \
+      --add-flags $out/lib/graphql.js \
+
+    popd
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+
+  passthru = {
+    updateScript = ./updater.sh;
+  };
+
+  meta = {
+    description = "Official, runtime independent Language Service for GraphQL";
+    homepage = "https://github.com/graphql/graphiql";
+    changelog = "https://github.com/graphql/graphiql/blob/${finalAttrs.src.tag}/packages/graphql-language-service-cli/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nathanregner ];
+    mainProgram = "graphql-lsp";
+  };
+})

--- a/pkgs/by-name/gr/graphql-language-service-cli/patches/0001-repurpose-vscode-graphql-build-script.patch
+++ b/pkgs/by-name/gr/graphql-language-service-cli/patches/0001-repurpose-vscode-graphql-build-script.patch
@@ -1,0 +1,63 @@
+From ceeca9463380ab11483ec22f9e46fdc3f83162b0 Mon Sep 17 00:00:00 2001
+From: Nathan Regner <nathanregner@gmail.com>
+Date: Sat, 15 Mar 2025 15:50:13 -0600
+Subject: [PATCH] Repurpose vscode-graphql build script
+
+Bundling the output script means we don't have to ship 1GB of
+`node_modules` (there are lots of unrelated dependencies used by other
+packages in the monorepo).
+---
+ .../esbuild.js                                | 28 ++-----------------
+ 1 file changed, 2 insertions(+), 26 deletions(-)
+ rename packages/{vscode-graphql => graphql-language-service-cli}/esbuild.js (59%)
+
+diff --git a/packages/vscode-graphql/esbuild.js b/packages/graphql-language-service-cli/esbuild.js
+similarity index 59%
+rename from packages/vscode-graphql/esbuild.js
+rename to packages/graphql-language-service-cli/esbuild.js
+index 744f4e60..4b9147fa 100644
+--- a/packages/vscode-graphql/esbuild.js
++++ b/packages/graphql-language-service-cli/esbuild.js
+@@ -1,12 +1,8 @@
+ const { build } = require('esbuild');
+ const [, , arg] = process.argv;
+ 
+-const logger = console;
+-
+-const isWatchMode = arg === '--watch';
+-
+ build({
+-  entryPoints: ['src/extension.ts', 'src/server/index.ts'],
++  entryPoints: ['bin/graphql.js'],
+   bundle: true,
+   minify: arg === '--minify',
+   platform: 'node',
+@@ -50,24 +46,4 @@ build({
+     'liquor',
+     'twig',
+   ],
+-})
+-  .then(({ errors, warnings }) => {
+-    if (warnings.length) {
+-      logger.warn(...warnings);
+-    }
+-    if (errors.length) {
+-      logger.error(...errors);
+-    }
+-
+-    logger.log('successfully bundled vscode-graphql 🚀');
+-
+-    if (isWatchMode) {
+-      logger.log('watching... 🕰');
+-    } else {
+-      process.exit();
+-    }
+-  })
+-  .catch(err => {
+-    logger.error(err);
+-    process.exit(1);
+-  });
++});
+-- 
+2.48.1
+

--- a/pkgs/by-name/gr/graphql-language-service-cli/updater.sh
+++ b/pkgs/by-name/gr/graphql-language-service-cli/updater.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl jq nix-update
+
+set -euo pipefail
+
+# this package is part of a monorepo with many tags; nix-update only seems to
+# fetch the 10 most recent
+# https://github.com/Mic92/nix-update/issues/231
+owner="graphql"
+repo="graphiql"
+version=$(
+    curl -s ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/graphql/graphiql/git/refs/tags/graphql-language-service-cli" |
+        jq 'map(.ref | capture("refs/tags/graphql-language-service-cli@(?<version>[0-9.]+)").version) | .[]' -r |
+        sort --reverse --version-sort | head -n1
+)
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+    echo "Already up to date!"
+    exit 0
+fi
+
+nix-update graphql-language-service-cli --version $version

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -115,6 +115,7 @@ mapAliases {
   inherit (pkgs) gramma; # added 2024-06-26
   grammarly-languageserver = throw "grammarly-languageserver was removed because it requires EOL Node.js 16"; # added 2024-07-15
   inherit (pkgs) graphite-cli; # added 2024-01-25
+  inherit (pkgs) graphql-language-service-cli; # added 2025-03-17
   inherit (pkgs) graphqurl; # added 2023-08-19
   gtop = pkgs.gtop; # added 2023-07-31
   hs-client = pkgs.hsd; # added 2023-08-20


### PR DESCRIPTION
Previously packaged by `node2nix`, removed in 776868ce712918511e17fe26abcf2a5254a4a3f9/#382557 due to build breakage

Fixes #390063

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
