### PR TITLE
nodejs: fix cross compilation for non-emulatable platforms

### DIFF
--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, python3, enableNpm ? true }:
+{ lib, stdenv, buildPackages, callPackage, fetchpatch2, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -10,8 +10,24 @@ buildNodejs {
   inherit enableNpm;
   version = "22.14.0";
   sha256 = "c609946bf793b55c7954c26582760808d54c16185d79cb2fb88065e52de21914";
-  patches = [
+  patches = (if (stdenv.hostPlatform.emulatorAvailable buildPackages) then [
     ./configure-emulator.patch
+  ] else [
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/buildroot/buildroot/2f0c31bffdb59fb224387e35134a6d5e09a81d57/package/nodejs/nodejs-src/0003-include-obj-name-in-shared-intermediate.patch";
+      hash = "sha256-3g4aS+NmmUYNOYRNc6UMJKYoaTlpP5Knt9UHegx+o0Y=";
+    })
+  ]) ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
+    # This patch is concerning.
+    # https://github.com/nodejs/node/issues/54576
+    # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
+    # I'm keeping the predicate for this patch pretty strict out of caution,
+    # so if you see the error it's supposed to prevent, feel free to loosen it.
+    (fetchpatch2 {
+      url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
+      hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
+    })
+  ] ++ [
     ./configure-armv6-vfpv2.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch

--- a/pkgs/development/web/nodejs/v23.nix
+++ b/pkgs/development/web/nodejs/v23.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildPackages,
   callPackage,
   fetchpatch2,
   openssl,
@@ -19,8 +20,31 @@ buildNodejs {
   version = "23.10.0";
   sha256 = "b39e5fbd3debb8318ddea6af3e89b07dafb891421fb7ca99fbe19c99adabe5fd";
   patches =
-    [
-      ./configure-emulator.patch
+    (
+      if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
+        [
+          ./configure-emulator.patch
+        ]
+      else
+        [
+          (fetchpatch2 {
+            url = "https://raw.githubusercontent.com/buildroot/buildroot/2f0c31bffdb59fb224387e35134a6d5e09a81d57/package/nodejs/nodejs-src/0003-include-obj-name-in-shared-intermediate.patch";
+            hash = "sha256-3g4aS+NmmUYNOYRNc6UMJKYoaTlpP5Knt9UHegx+o0Y=";
+          })
+        ]
+    )
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
+      # This patch is concerning.
+      # https://github.com/nodejs/node/issues/54576
+      # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
+      # I'm keeping the predicate for this patch pretty strict out of caution,
+      # so if you see the error it's supposed to prevent, feel free to loosen it.
+      (fetchpatch2 {
+        url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
+        hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
+      })
+    ]
+    ++ [
       ./configure-armv6-vfpv2.patch
       ./disable-darwin-v8-system-instrumentation-node19.patch
       ./bypass-darwin-xcrun-node16.patch


### PR DESCRIPTION
This was tested x86_64-linux -> x86_64-freebsd. It works by injecting the tools that would otherwise be run at build time for the same executables extracted from a native build.

Without this, there are multiple issues:
a) It will fail to start building since there are naming conflicts
   between the "host" (build system) and "normal" (host system) object
   files. This is resolved with a patch from buildroot.
b) It will then still fail to build since it will still try to build the
   "host" objects, with a host compiler, but it will use the
   configuration flags for the "target" OS. This is resolved by
   importing the executables that would otherwise be run on the build
   system from the intermediate stage of a native build, saved in a new
   "dev" output. We also fake the "host" compiler as a tool which simply
   touches its outputs.
c) Finally, there is a clang bug which causes a static assert that
   something is trivially copyable to fire as a false positive. We
   remove this check with a patch from rubyjs.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
