### PR TITLE
codec2: fix cross compilation

### DIFF
--- a/pkgs/by-name/co/codec2/package.nix
+++ b/pkgs/by-name/co/codec2/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
   cmake,
   freedvSupport ? false,
@@ -18,11 +19,22 @@ stdenv.mkDerivation rec {
     hash = "sha256-69Mp4o3MgV98Fqfai4txv5jQw2WpoPuoWcwHsNAFPQM=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    buildPackages.stdenv.cc # needs to build a C program to run at build time
+  ];
 
   buildInputs = lib.optionals freedvSupport [
     lpcnetfreedv
   ];
+
+  # we need to unset these variables from stdenv here and then set their equivalents in the cmake flags
+  # otherwise it will pass the same compiler to the native and cross phases and crash trying to execute
+  # host binaries (generate_codebook) on the build system.
+  preConfigure = ''
+    unset CC
+    unset CXX
+  '';
 
   postInstall = ''
     install -Dm0755 src/{c2enc,c2sim,freedv_rx,freedv_tx,cohpsk_*,fdmdv_*,fsk_*,ldpc_*,ofdm_*} -t $out/bin/
@@ -37,6 +49,8 @@ stdenv.mkDerivation rec {
     [
       # RPATH of binary /nix/store/.../bin/freedv_rx contains a forbidden reference to /build/
       "-DCMAKE_SKIP_BUILD_RPATH=ON"
+      "-DCMAKE_C_COMPILER=${stdenv.cc.targetPrefix}cc"
+      "-DCMAKE_CXX_COMPILER=${stdenv.cc.targetPrefix}c++"
     ]
     ++ lib.optionals freedvSupport [
       "-DLPCNET=ON"


### PR DESCRIPTION
It uses cmake flags and environment variables in a way that interacts poorly with stdenv's defaults. See code comments for details.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
