### PR TITLE
atkinson-hyperlegible-next: init at 2.001-unstable-2025-02-21, atkinson-hyperlegible-mono: init at 2.001-unstable-2024-11-20

### DIFF
--- a/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "atkinson-hyperlegible-mono";
+  version = "2.001-unstable-2024-11-20";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "atkinson-hyperlegible-next-mono";
+    rev = "154d50362016cc3e873eb21d242cd0772384c8f9";
+    hash = "sha256-V0zWbNYT3RGO9vjX+GHfO38ywMozcZVJkBZH+8G5sC0=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/opentype fonts/otf/*
+    install -Dm644 -t $out/share/fonts/variable fonts/variable/*
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "New (2024) monospace sibling family to Atkinson Hyperlegible Next";
+    homepage = "https://www.brailleinstitute.org/freefont/";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "atkinson-hyperlegible-next";
+  version = "2.001-unstable-2025-02-21";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "atkinson-hyperlegible-next";
+    rev = "7925f50f649b3813257faf2f4c0b381011f434f1";
+    hash = "sha256-LhwfYI5Z6BhO7OaY/RwXT7r3WYiUY9AO2HL3MmhPpQY=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/opentype fonts/otf/*
+    install -Dm644 -t $out/share/fonts/variable fonts/variable/*
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "New (2024) second version of the Atkinson Hyperlegible fonts";
+    homepage = "https://www.brailleinstitute.org/freefont/";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ pancaek ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
2024 update of the Atkinson Hyperlegible fonts for low vision users. 

Resolves #381689 
Resolves #381691
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
