### PR TITLE
haskellPackages: remove jailbreak for many packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2017,8 +2017,6 @@ self: super: {
   # Too strict lower bounds on (test) deps
   # https://github.com/phadej/puresat/issues/6
   puresat = doJailbreak super.puresat;
-  # https://github.com/phadej/spdx/issues/62
-  spdx = doJailbreak super.spdx;
 
   # test suite requires stack to run, https://github.com/dino-/photoname/issues/24
   photoname = dontCheck super.photoname;
@@ -2125,10 +2123,6 @@ self: super: {
   sdp4text = disableLibraryProfiling super.sdp4text;
   sdp4unordered = disableLibraryProfiling super.sdp4unordered;
   sdp4vector = disableLibraryProfiling super.sdp4vector;
-
-  # Unnecessarily strict bound on template-haskell
-  # https://github.com/tree-sitter/haskell-tree-sitter/issues/298
-  tree-sitter = doJailbreak super.tree-sitter;
 
   # Test suite fails to compile
   # https://github.com/kuribas/mfsolve/issues/8

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -115,18 +115,16 @@ self: super: {
         ghc-paths = lsuper.ghc-paths.override { Cabal = null; };
       }))
       [
-        doJailbreak
         dontCheck
       ];
 
-  hls-plugin-api = doJailbreak super.hls-plugin-api;
-  ghcide = doJailbreak (appendPatch (pkgs.fetchpatch {
+  ghcide = appendPatch (pkgs.fetchpatch {
     name = "ghcide-ghc-9.8.3.patch";
     url = "https://github.com/haskell/haskell-language-server/commit/6d0a6f220226fe6c1cb5b6533177deb55e755b0b.patch";
     sha256 = "1jwxldar9qzkg2z6vsx8f2yih3vkf4yjk9p3mryv0azn929qn3h1";
     stripLen = 1;
     excludes = [ "cabal.project" ];
-  }) super.ghcide);
+  }) super.ghcide;
 
   # For -f-auto see cabal.project in haskell-language-server.
   ghc-lib-parser-ex = addBuildDepend self.ghc-lib-parser (disableCabalFlag "auto" super.ghc-lib-parser-ex);
@@ -251,9 +249,6 @@ self: super: {
 
   # There are numerical tests on random data, that may fail occasionally
   lapack = dontCheck super.lapack;
-
-  # currently, cabal-plan seems to get not much maintenance
-  cabal-plan = doJailbreak super.cabal-plan;
 
   # support for transformers >= 0.6
   lifted-base = appendPatch (fetchpatch {
@@ -771,8 +766,7 @@ self: super: {
   separated = dontCheck super.separated;
   shadowsocks = dontCheck super.shadowsocks;
   shake-language-c = dontCheck super.shake-language-c;
-  snap-core = doJailbreak (dontCheck super.snap-core); # attoparsec bound is too strict. This has been fixed on master
-  snap-server = doJailbreak super.snap-server; # attoparsec bound is too strict
+  snap-core = dontCheck super.snap-core;
   sourcemap = dontCheck super.sourcemap;
   static-resources = dontCheck super.static-resources;
   strive = dontCheck super.strive;                      # fails its own hlint test with tons of warnings
@@ -896,9 +890,6 @@ self: super: {
   # 2025-02-10: Too strict bounds on hedgehog < 1.5
   tasty-sugar = doJailbreak super.tasty-sugar;
 
-  # Allow bytestring-0.12.1.0, https://github.com/lpeterse/haskell-socket/issues/71
-  socket = doJailbreak super.socket;
-
   # Known issue with nondeterministic test suite failure
   # https://github.com/nomeata/tasty-expected-failure/issues/21
   tasty-expected-failure = dontCheck super.tasty-expected-failure;
@@ -937,9 +928,6 @@ self: super: {
 
   # https://github.com/kazu-yamamoto/logger/issues/42
   logger = dontCheck super.logger;
-
-  # https://github.com/Euterpea/Euterpea2/issues/40
-  Euterpea = doJailbreak super.Euterpea;
 
   # Byte-compile elisp code for Emacs.
   ghc-mod = overrideCabal (drv: {
@@ -1450,14 +1438,10 @@ self: super: {
   # lsp-1.4.0.0 which is hard to build with this LTS. However, the latest
   # git version of dhall-lsp-server works with lsp-2.1.0.0, and only
   # needs jailbreaking to build successfully.
-  dhall-lsp-server = lib.pipe
-    (super.dhall-lsp-server.overrideScope (lself: lsuper: {
-      lsp = doJailbreak lself.lsp_2_1_0_0;  # sorted-list <0.2.2
-      lsp-types = doJailbreak lself.lsp-types_2_1_1_0;  # lens <5.3
-    }))
-    [
-      doJailbreak
-    ];
+  dhall-lsp-server = super.dhall-lsp-server.overrideScope (lself: lsuper: {
+    lsp = doJailbreak lself.lsp_2_1_0_0;  # sorted-list <0.2.2
+    lsp-types = doJailbreak lself.lsp-types_2_1_1_0;  # lens <5.3
+  });
 
   ghcjs-dom-hello = appendPatches [
     (fetchpatch {
@@ -1862,7 +1846,6 @@ self: super: {
   # 2021-04-16: too strict bounds on QuickCheck and tasty
   # https://github.com/hasufell/lzma-static/issues/1
   lzma-static = doJailbreak super.lzma-static;
-  xz = doJailbreak super.xz;
 
   # Too strict version bounds on base:
   # https://github.com/obsidiansystems/database-id/issues/1
@@ -2032,7 +2015,7 @@ self: super: {
       "--skip" "/Data.List.UniqueUnsorted.repeatedBy,repeated,unique/unique: simple test/"
       "--skip" "/Data.List.UniqueUnsorted.repeatedBy,repeated,unique/repeatedBy: simple test/"
     ] ++ drv.testFlags or [];
-  }) (doJailbreak super.Unique);
+  }) super.Unique;
 
   # https://github.com/AndrewRademacher/aeson-casing/issues/8
   aeson-casing = assert super.aeson-casing.version == "0.2.0.0"; overrideCabal (drv: {
@@ -2393,8 +2376,6 @@ self: super: {
 
   # Overly strict bounds on tasty-quickcheck (test suite) (< 0.11)
   hashable = doJailbreak super.hashable;
-  # https://github.com/haskell/aeson/pull/1126
-  text-iso8601 = doJailbreak super.text-iso8601;
   # https://github.com/well-typed/cborg/issues/340
   cborg = doJailbreak super.cborg;
   # Doesn't compile with tasty-quickcheck == 0.11 (see issue above)
@@ -2803,7 +2784,7 @@ let
   setAmazonkaSourceRoot = dir: drv: (overrideSrc { version = "2.0"; src = amazonkaSrc + "/${dir}"; }) drv;
   isAmazonkaService = name: lib.hasPrefix "amazonka-" name && name != "amazonka-test";
   amazonkaServices = lib.filter isAmazonkaService (lib.attrNames super);
-  amazonkaServiceOverrides = (lib.genAttrs amazonkaServices (name: lib.pipe super.${name} [(setAmazonkaSourceRoot "lib/services/${name}") doJailbreak]));
+  amazonkaServiceOverrides = (lib.genAttrs amazonkaServices (name: lib.pipe super.${name} [(setAmazonkaSourceRoot "lib/services/${name}") (x: x)]));
 in
 amazonkaServiceOverrides // {
   amazonka-core = assert super.amazonka-core.version == "2.0"; lib.pipe

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -85,8 +85,10 @@ self: super: {
   #
   base64 = doJailbreak super.base64; # base <4.20
   floskell = doJailbreak super.floskell; # base <4.20
+  spdx = doJailbreak super.spdx; # Cabal-syntax < 3.13
   tasty-coverage = doJailbreak super.tasty-coverage; # base <4.20, filepath <1.5
   tree-diff = doJailbreak super.tree-diff; # base <4.20
+  tree-sitter = doJailbreak super.tree-sitter; # containers <0.7, filepath <1.5
   time-compat = doJailbreak super.time-compat; # base <4.20
 
   bitvec = doJailbreak super.bitvec; # primitive <0.9

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -60,32 +60,17 @@ self: super: {
   #
   # Jailbreaks
   #
-  blaze-svg = doJailbreak super.blaze-svg; # base <4.19
-  commutative-semigroups = doJailbreak super.commutative-semigroups; # base < 4.19
-  diagrams-lib = doJailbreak super.diagrams-lib; # base <4.19, text <2.1
-  diagrams-postscript = doJailbreak super.diagrams-postscript;  # base <4.19, bytestring <0.12
-  diagrams-svg = doJailbreak super.diagrams-svg;  # base <4.19, text <2.1
-  ghc-trace-events = doJailbreak super.ghc-trace-events; # text < 2.1, bytestring < 0.12, base < 4.19
   hashing = doJailbreak super.hashing; # bytestring <0.12
   hevm = appendPatch (pkgs.fetchpatch {
     url = "https://github.com/hellwolf/hevm/commit/338674d1fe22d46ea1e8582b24c224d76d47d0f3.patch";
     name = "release-0.54.2-ghc-9.8.4-patch";
     sha256 = "sha256-Mo65FfP1nh7QTY+oLia22hj4eV2v9hpXlYsrFKljA3E=";
   }) super.hevm;
-  json-sop = doJailbreak super.json-sop; # aeson <2.2, base <4.19, text <2.1
   primitive-unlifted = doJailbreak super.primitive-unlifted; # bytestring < 0.12
-  statestack = doJailbreak super.statestack; # base < 4.19
-  newtype-generics = doJailbreak super.newtype-generics; # base < 4.19
   hw-prim = doJailbreak super.hw-prim; # doctest < 0.22, ghc-prim < 0.11, hedgehog < 1.4
-  svg-builder = doJailbreak super.svg-builder; # base <4.19, bytestring <0.12, text <2.1
   HaskellNet-SSL = doJailbreak super.HaskellNet-SSL; # bytestring >=0.9 && <0.12
-  raven-haskell = doJailbreak super.raven-haskell; # aeson <2.2
   saltine = doJailbreak super.saltine; # bytestring  && <0.12, deepseq <1.5, text > 1.2 && <1.3 || >=2.0 && <2.1
-  stripe-concepts = doJailbreak super.stripe-concepts; # text >=1.2.5 && <1.3 || >=2.0 && <2.1
-  stripe-signature = doJailbreak super.stripe-signature; # text >=1.2.5 && <1.3 || >=2.0 && <2.1
-  string-random = doJailbreak super.string-random; # text >=1.2.2.1 && <2.1
   inflections = doJailbreak super.inflections; # text >=0.2 && <2.1
-  universe-some = doJailbreak super.universe-some; # th-abstraction < 0.7
   broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19  https://github.com/merijn/broadcast-chan/pull/19
 
   #

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -598,7 +598,7 @@ self: super: builtins.intersectAttrs super {
     '';
   }) super.GLUT;
 
-  libsystemd-journal = doJailbreak (addExtraLibrary pkgs.systemd super.libsystemd-journal);
+  libsystemd-journal = addExtraLibrary pkgs.systemd super.libsystemd-journal;
 
   # does not specify tests in cabal file, instead has custom runTest cabal hook,
   # so cabal2nix will not detect test dependencies.
@@ -952,8 +952,7 @@ self: super: builtins.intersectAttrs super {
     }) (addBuildTool pkgs.buildPackages.makeWrapper super.cut-the-crap);
 
   # Compiling the readme throws errors and has no purpose in nixpkgs
-  aeson-gadt-th =
-    disableCabalFlag "build-readme" (doJailbreak super.aeson-gadt-th);
+  aeson-gadt-th = disableCabalFlag "build-readme" super.aeson-gadt-th;
 
   # Fix compilation of Setup.hs by removing the module declaration.
   # See: https://github.com/tippenein/guid/issues/1
@@ -1065,7 +1064,7 @@ self: super: builtins.intersectAttrs super {
       substituteInPlace src/Nix/Diff/Types.hs \
         --replace "{-# OPTIONS_GHC -Wno-orphans #-}" "{-# OPTIONS_GHC -Wno-orphans -fconstraint-solver-iterations=0 #-}"
       '';
-  }) (doJailbreak (dontCheck super.nix-diff));
+  }) (dontCheck super.nix-diff);
 
   # mockery's tests depend on hspec-discover which dependso on mockery for its tests
   mockery = dontCheck super.mockery;

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -23,7 +23,7 @@ let
     });
 in
 {
-  tensorflow-proto = doJailbreak (setTensorflowSourceRoot "tensorflow-proto" super.tensorflow-proto);
+  tensorflow-proto = setTensorflowSourceRoot "tensorflow-proto" super.tensorflow-proto;
 
   tensorflow = overrideCabal (drv: {
     libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.vector-split ];


### PR DESCRIPTION
Similar to #384127

Before and after, there are no failures on ghc98, and no change in failures for ghc96, ghc910. 

Tested with
```
nix-build -E 'with (import ./. {}).haskell.packages.ghc98; [Euterpea Unique aeson-gadt-th amazonka blaze-svg cabal-plan commutative-semigroups dhall-lsp-server diagrams-lib diagrams-postscript diagrams-svg ghc-trace-events ghcide haskell-language-server hls-plugin-api json-sop libsystemd-journal newtype-generics nix-diff raven-haskell snap-core snap-server socket spdx statestack string-random stripe-concepts stripe-signature svg-builder tensorflow-proto text-iso8601 tree-sitter universe-some xz]'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
