### PR TITLE
holos: init at 0.104.1

### DIFF
--- a/pkgs/by-name/ho/holos/package.nix
+++ b/pkgs/by-name/ho/holos/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  holos,
+  kubectl,
+  kustomize,
+  kubernetes-helm,
+}:
+buildGoModule rec {
+  pname = "holos";
+  version = "0.104.1";
+
+  src = fetchFromGitHub {
+    owner = "holos-run";
+    repo = "holos";
+    rev = "v${version}";
+    hash = "sha256-4LCNKPf+b7O9DHCmOzaI8clCbmikyAAG+6C3I0aQdMg=";
+  };
+
+  vendorHash = "sha256-FR3H2NS4sEYjGmzIyaUglby98AgDAgbIzl9de8h/cj8=";
+
+  ldflags = [
+    "-w"
+    "-X github.com/holos-run/holos/version.GitDescribe=v${version}"
+    "-X github.com/holos-run/holos/version.GitCommit=${src.rev}"
+    "-X github.com/holos-run/holos/version.GitTreeState=clean"
+    # fix time for deterministic builds
+    "-X github.com/holos-run/holos/version.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  subPackages = [ "cmd/holos" ];
+
+  nativeCheckInputs = [
+    kubernetes-helm
+    kubectl
+    kustomize
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = holos;
+    command = "holos --version || true";
+    version = "${version}";
+  };
+
+  meta = with lib; {
+    description = "Holos CLI tool";
+    homepage = "https://github.com/holos-run/holos";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cameronraysmith ];
+    mainProgram = "holos";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves #384417

> [Holos](https://holos.run/docs/overview/) is a configuration management tool for Kubernetes implementing the [rendered manifests pattern](https://akuity.io/blog/the-rendered-manifests-pattern). It handles configurations ranging from single resources to multi-cluster platforms across regions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
