### PR TITLE
vigra: Fix compiling on LLVM 19

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZmHj1BSyoMBCuxI5hrRiBEb5pDUsGzis+T5FSX27UN8=";
   };
 
+  patches = [
+    # Pathes to fix compiling on LLVM 19 from https://github.com/ukoethe/vigra/pull/592
+    ./fix-llvm-19-1.patch
+    ./fix-llvm-19-2.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     boost

--- a/pkgs/development/libraries/vigra/fix-llvm-19-1.patch
+++ b/pkgs/development/libraries/vigra/fix-llvm-19-1.patch
@@ -1,0 +1,22 @@
+From c04362c082f35e87afbc9441dd2b3821de179055 Mon Sep 17 00:00:00 2001
+From: Lukas N Wirz <lnwirz@chem.helsinki.fi>
+Date: Sat, 9 Nov 2024 23:15:40 +0200
+Subject: [PATCH] fix --this typo
+
+---
+ include/vigra/multi_iterator_coupled.hxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/vigra/multi_iterator_coupled.hxx b/include/vigra/multi_iterator_coupled.hxx
+index 6831dad5d..9e6ca3c62 100644
+--- a/include/vigra/multi_iterator_coupled.hxx
++++ b/include/vigra/multi_iterator_coupled.hxx
+@@ -490,7 +490,7 @@ class CoupledScanOrderIterator<N, HANDLES, 0>
+     CoupledScanOrderIterator operator--(int)
+     {
+         CoupledScanOrderIterator res(*this);
+-        --this;
++        std::advance(this, -1);
+         return res;
+     }
+ 

--- a/pkgs/development/libraries/vigra/fix-llvm-19-2.patch
+++ b/pkgs/development/libraries/vigra/fix-llvm-19-2.patch
@@ -1,0 +1,22 @@
+From 191c09c2b086e1b0ab0ca1088e48e35fe492c620 Mon Sep 17 00:00:00 2001
+From: Lukas N Wirz <lnwirz@chem.helsinki.fi>
+Date: Sun, 10 Nov 2024 16:01:46 +0200
+Subject: [PATCH] typo
+
+---
+ include/vigra/multi_iterator_coupled.hxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/vigra/multi_iterator_coupled.hxx b/include/vigra/multi_iterator_coupled.hxx
+index 9e6ca3c62..1cb401897 100644
+--- a/include/vigra/multi_iterator_coupled.hxx
++++ b/include/vigra/multi_iterator_coupled.hxx
+@@ -490,7 +490,7 @@ class CoupledScanOrderIterator<N, HANDLES, 0>
+     CoupledScanOrderIterator operator--(int)
+     {
+         CoupledScanOrderIterator res(*this);
+-        std::advance(this, -1);
++        std::advance(*this, -1);
+         return res;
+     }
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Having to apply a non-accepted patch is unfortunate. The alternative seems to be to mark the package as broken on Darwin. Or, I guess force using LLVM 18, but I'm not sure if that's acceptable.