### PR TITLE
python313Packages.scrapy-splash: 0.9.0 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/scrapy-deltafetch/default.nix
+++ b/pkgs/development/python-modules/scrapy-deltafetch/default.nix
@@ -25,6 +25,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "scrapy_deltafetch" ];
 
   meta = {
+    # https://github.com/scrapy-plugins/scrapy-deltafetch/pull/50
+    broken = lib.versionAtLeast scrapy.version "2.12";
     description = "Scrapy spider middleware to ignore requests to pages containing items seen in previous crawls";
     homepage = "https://github.com/scrapy-plugins/scrapy-deltafetch";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/scrapy-splash/default.nix
+++ b/pkgs/development/python-modules/scrapy-splash/default.nix
@@ -1,34 +1,47 @@
 {
   lib,
-  fetchPypi,
   buildPythonPackage,
+  fetchFromGitHub,
+  hypothesis,
+  pytest-twisted,
+  pytestCheckHook,
   scrapy,
+  setuptools,
   six,
 }:
 
 buildPythonPackage rec {
   pname = "scrapy-splash";
-  version = "0.9.0";
-  format = "setuptools";
+  version = "0.11.1";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-7PEwJk3AjgxGHIYH7K13dGimStAd7bJinA+BvV/NcpU=";
+  src = fetchFromGitHub {
+    owner = "scrapy-plugins";
+    repo = "scrapy-splash";
+    tag = version;
+    hash = "sha256-eOWqSCuuZtUtaEuAew4g0P67N0zClaguHn2u4ZMT3FU=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     scrapy
     six
   ];
 
-  # no tests
-  doCheck = false;
   pythonImportsCheck = [ "scrapy_splash" ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    hypothesis
+    pytest-twisted
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/scrapy-plugins/scrapy-splash/blob/${src.tag}/CHANGES.rst";
     description = "Scrapy+Splash for JavaScript integration";
     homepage = "https://github.com/scrapy-plugins/scrapy-splash";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ evanjs ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ evanjs ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/scrapy-plugins/scrapy-splash/compare/refs/tags/0.9.0...0.11.1

Changelog: https://github.com/scrapy-plugins/scrapy-splash/blob/0.11.1/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
