### PR TITLE
lerc: fix build on FreeBSD

### DIFF
--- a/pkgs/by-name/le/lerc/package.nix
+++ b/pkgs/by-name/le/lerc/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
   fetchpatch,
   cmake,
@@ -23,14 +24,28 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IHY9QtNYsxPz/ksxRMZGHleT+/bawfTYNVRSTAuYQ7Y=";
   };
 
-  patches = [
-    # https://github.com/Esri/lerc/pull/227
-    (fetchpatch {
-      name = "use-cmake-install-full-dir.patch";
-      url = "https://github.com/Esri/lerc/commit/5462ca7f7dfb38c65e16f5abfd96873af177a0f8.patch";
-      hash = "sha256-qaNR3QwLe0AB6vu1nXOh9KhlPdWM3DmgCJj4d0VdOUk=";
-    })
-  ];
+  # Required to get the freebsd-ports patch to apply.
+  # There seem to be inconsistent line endings in this project - just converting the patch doesn't work
+  prePatch = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
+    ${buildPackages.dos2unix}/bin/dos2unix src/LercLib/fpl_EsriHuffman.cpp src/LercLib/fpl_Lerc2Ext.cpp
+  '';
+
+  patches =
+    [
+      # https://github.com/Esri/lerc/pull/227
+      (fetchpatch {
+        name = "use-cmake-install-full-dir.patch";
+        url = "https://github.com/Esri/lerc/commit/5462ca7f7dfb38c65e16f5abfd96873af177a0f8.patch";
+        hash = "sha256-qaNR3QwLe0AB6vu1nXOh9KhlPdWM3DmgCJj4d0VdOUk=";
+      })
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/ee9e39ceb1af729ac33854b5f3de652cb5ce0eca/graphics/lerc/files/patch-_assert";
+        hash = "sha256-agvGqgIsKS8v43UZdTVxDRDGbZdj2+AzKoQONvQumB4=";
+        extraPrefix = "";
+      })
+    ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Just applying this patch from freebsd-ports was harder than I thought...

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
