### PR TITLE
tinymist: 0.12.22 -> 0.13.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -11,7 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "tinymist";
     publisher = "myriad-dreamin";
     inherit (tinymist) version;
-    hash = "sha256-rsQlYzgOXN1avTRG8Z80+dMuaGJp2evnnflTPKgTyTI=";
+    hash = "sha256-AaH/G5Bv0rUa0t6m1iiNMkX3p+mEzwWaDqH9qZzAm+Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-  fetchpatch,
   installShellFiles,
   pkg-config,
   libgit2,
@@ -19,29 +18,17 @@ rustPlatform.buildRustPackage rec {
   pname = "tinymist";
   # Please update the corresponding vscode extension when updating
   # this derivation.
-  version = "0.12.22";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "Myriad-Dreamin";
     repo = "tinymist";
     tag = "v${version}";
-    hash = "sha256-fhM9IF+1iHfDcL+aI/31sqkyO5UmN+AwUUkKwyw+hWw=";
+    hash = "sha256-b2tU9weUKc0Y8LikSblfa3ifckp3u09M9Rhl+WujugI=";
   };
 
-  patches = [
-    # Fixes:
-    # cargo metadata failure: error: Package `tinymist-std v0.12.20 (/build/source/crates/tinymist-std)` does not have feature `wasm-bindgen`.
-    # It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
-    # https://github.com/Myriad-Dreamin/tinymist/pull/1363
-    (fetchpatch {
-      name = "fix-cargo-features";
-      url = "https://github.com/Myriad-Dreamin/tinymist/pull/1363/commits/96e0a15fa20f09734f2b8152977a1137f5469761.patch";
-      hash = "sha256-W3HzV0GGhGuX/V4rox32LSw6YJ2BLTAG16bF2pZ+xYs=";
-    })
-  ];
-
   useFetchCargoVendor = true;
-  cargoHash = "sha256-3nmGg0dF9GesbmJUQyvSHTg0KAj3FeyCxdK03q1BctM=";
+  cargoHash = "sha256-eKMkvRPVM6UjURQ8GCCYYU4gTaVi/dLWh/D/XQmM6mw=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Harmless package update.
Changelog: https://github.com/Myriad-Dreamin/tinymist/releases/tag/v0.13.0
Diff: https://github.com/Myriad-Dreamin/tinymist/compare/v0.12.22...v0.13.0

Depends on Typst 0.13.0 whose changelog is at https://typst.app/docs/changelog/0.13.0/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
