### PR TITLE
wayvr-dashboard: init at 0.3.5

### DIFF
--- a/pkgs/by-name/wa/wayvr-dashboard/package.nix
+++ b/pkgs/by-name/wa/wayvr-dashboard/package.nix
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 Hana Kretzer <hanakretzer@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+{
+  alsa-lib,
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  gdk-pixbuf,
+  glib,
+  lib,
+  librsvg,
+  nodejs,
+  npmHooks,
+  openssl,
+  pkg-config,
+  pulseaudio,
+  rustPlatform,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "wayvr-dashboard";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "olekolek1000";
+    repo = "wayvr-dashboard";
+    tag = version;
+    hash = "sha256-C23O9EFOpGwamJuKjluBAMFF7YaNDqd61JVDkWyoy+E=";
+  };
+
+  cargoHash = "sha256-aljJ+N47rFSMAxdW4plqhHggLYHD+sJNUCcG/tWzUxU=";
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-kyb4xzBkNTCIzOEUTuPeESDOAqfWseoouUkZjqI/NhQ=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    alsa-lib
+    gdk-pixbuf
+    glib
+    librsvg
+    openssl
+    webkitgtk_4_1
+  ];
+
+  preBuild = ''
+    # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart
+    rm -r node_modules/sass-embedded*
+  '';
+
+  postInstall = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ pulseaudio ]}}"
+    )
+    install -Dm644 wayvr-dashboard.svg $out/share/icons/hicolor/scalable/apps/wayvr-dashboard.svg
+  '';
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = cargoRoot;
+
+  meta = {
+    description = "Work-in-progress overlay application for launching various applications and games directly into a VR desktop environment";
+    homepage = "https://github.com/olekolek1000/wayvr-dashboard";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      nanoyaki
+      Scrumplex
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "wayvr-dashboard";
+  };
+}


### PR DESCRIPTION
@nanoyaki: I hope it's okay that I have pulled you into the maintainer list here. If you don't wish to be maintainer here, I can drop the relevant commit.

Upstreamed from https://github.com/nix-community/nixpkgs-xr/pull/308

https://github.com/olekolek1000/wayvr-dashboard

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
