### PR TITLE
apache-directory-studio: fix startup

### DIFF
--- a/pkgs/by-name/ap/apache-directory-studio/package.nix
+++ b/pkgs/by-name/ap/apache-directory-studio/package.nix
@@ -64,10 +64,10 @@ stdenv.mkDerivation rec {
         "$out/bin/ApacheDirectoryStudio" \
         --prefix PATH : "${jdk}/bin" \
         --prefix LD_LIBRARY_PATH : ${
-          lib.makeLibraryPath ([
+          lib.makeLibraryPath [
             glib
             webkitgtk_4_0
-          ])
+          ]
         } \
         --run "mkdir -p /tmp/SWT-GDBusServer"
     install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"

--- a/pkgs/by-name/ap/apache-directory-studio/package.nix
+++ b/pkgs/by-name/ap/apache-directory-studio/package.nix
@@ -59,7 +59,12 @@ stdenv.mkDerivation rec {
     makeWrapper "$dest/ApacheDirectoryStudio" \
         "$out/bin/ApacheDirectoryStudio" \
         --prefix PATH : "${jdk}/bin" \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath ([ webkitgtk_4_0 ])}
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath ([
+            glib
+            webkitgtk_4_0
+          ])
+        }
     install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"
     install -D -t "$out/share/applications" ${desktopItem}/share/applications/*
   '';

--- a/pkgs/by-name/ap/apache-directory-studio/package.nix
+++ b/pkgs/by-name/ap/apache-directory-studio/package.nix
@@ -56,6 +56,10 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         "$dest/ApacheDirectoryStudio"
 
+    # About `/tmp/SWT-GDBusServer`, see
+    # https://github.com/adoptium/adoptium-support/issues/785#issuecomment-1866680133
+    # and
+    # https://github.com/adoptium/adoptium-support/issues/785#issuecomment-2387481967.
     makeWrapper "$dest/ApacheDirectoryStudio" \
         "$out/bin/ApacheDirectoryStudio" \
         --prefix PATH : "${jdk}/bin" \
@@ -64,7 +68,8 @@ stdenv.mkDerivation rec {
             glib
             webkitgtk_4_0
           ])
-        }
+        } \
+        --run "mkdir -p /tmp/SWT-GDBusServer"
     install -D icon.xpm "$out/share/pixmaps/apache-directory-studio.xpm"
     install -D -t "$out/share/applications" ${desktopItem}/share/applications/*
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **apache-directory-studio: add missing glib**
- **apache-directory-studio: fix startup by creating /tmp/SWT-GDBusServer**
- **apache-directory-studio: remove redundant parenthesis**

Fixes https://github.com/nixos/nixpkgs/issues/333377.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
