### PR TITLE
xpra-html5: init at v17

### DIFF
--- a/pkgs/by-name/xp/xpra-html5/package.nix
+++ b/pkgs/by-name/xp/xpra-html5/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  python3,
+  uglify-js,
+}:
+let
+  version = "17";
+in
+stdenvNoCC.mkDerivation {
+  name = "xpra-html5";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Xpra-org";
+    repo = "xpra-html5";
+    rev = "v${version}";
+    hash = "sha256-SwP7NazsiUyDD4LUziCwN0X9GTQVq0lYM2jXqNaXLEA=";
+  };
+  buildInputs = [
+    python3
+    uglify-js
+  ];
+  installPhase = "python $src/setup.py install $out /share/xpra/www /share/xpra/www";
+
+  meta = with lib; {
+    homepage = "https://xpra.org/";
+    downloadPage = "https://xpra.org/src/";
+    description = "HTML5 client for Xpra";
+    changelog = "https://github.com/Xpra-org/xpra-html5/releases/tag/v${version}";
+    platforms = platforms.linux;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [
+      catern
+    ];
+  };
+}

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -41,6 +41,8 @@
   xorgserver,
   xxHash,
   clang,
+  withHtml ? true,
+  xpra-html5,
 }@args:
 
 let
@@ -240,16 +242,20 @@ buildPythonApplication rec {
       )
     '';
 
-  postInstall = ''
-    # append module paths to xorg.conf
-    cat ${xorgModulePaths} >> $out/etc/xpra/xorg.conf
-    cat ${xorgModulePaths} >> $out/etc/xpra/xorg-uinput.conf
+  postInstall =
+    ''
+      # append module paths to xorg.conf
+      cat ${xorgModulePaths} >> $out/etc/xpra/xorg.conf
+      cat ${xorgModulePaths} >> $out/etc/xpra/xorg-uinput.conf
 
-    # make application icon visible to desktop environemnts
-    icon_dir="$out/share/icons/hicolor/64x64/apps"
-    mkdir -p "$icon_dir"
-    ln -sr "$out/share/icons/xpra.png" "$icon_dir"
-  '';
+      # make application icon visible to desktop environemnts
+      icon_dir="$out/share/icons/hicolor/64x64/apps"
+      mkdir -p "$icon_dir"
+      ln -sr "$out/share/icons/xpra.png" "$icon_dir"
+    ''
+    + lib.optionalString withHtml ''
+      ln -s ${xpra-html5}/share/xpra/www $out/share/xpra/www;
+    '';
 
   doCheck = false;
 


### PR DESCRIPTION
Also add as an optional dependency of xpra, enabled by default.

Closes #384368

Cc xpra maintainers @offline @numinit @mvnetbiz

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
