### PR TITLE
prover9: fix build on GCC 14

### DIFF
--- a/pkgs/by-name/pr/prover9/package.nix
+++ b/pkgs/by-name/pr/prover9/package.nix
@@ -2,15 +2,16 @@
   lib,
   stdenv,
   fetchurl,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation {
   pname = "prover9";
-  version = "2009-11a";
+  version = "2009-11A";
 
   src = fetchurl {
     url = "https://www.cs.unm.edu/~mccune/mace4/download/LADR-2009-11A.tar.gz";
-    sha256 = "1l2i3d3h5z7nnbzilb6z92r0rbx0kh6yaxn2c5qhn3000xcfsay3";
+    hash = "sha256-wyvtWAcADAtxYcJ25Q2coK8MskjfLBr/svb8AkcbUdA=";
   };
 
   hardeningDisable = [ "format" ];
@@ -20,31 +21,54 @@ stdenv.mkDerivation {
     MV=$(type -tp mv)
     CP=$(type -tp cp)
     for f in Makefile */Makefile; do
-      substituteInPlace $f --replace "/bin/rm" "$RM" \
-        --replace "/bin/mv" "$MV" \
-        --replace "/bin/cp" "$CP";
+      substituteInPlace $f --replace-quiet "/bin/rm" "$RM" \
+        --replace-quiet "/bin/mv" "$MV" \
+        --replace-quiet "/bin/cp" "$CP";
     done
   '';
 
   buildFlags = [ "all" ];
 
-  checkPhase = "make test1";
+  # Fails the build on clang-16 and gcc-14.
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-int";
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp bin/* $out/bin
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    make test1
+    make test2
+    make test3
+
+    runHook postCheck
   '';
 
-  meta = with lib; {
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    for f in mace4 prover9 fof-prover9 autosketches4 newauto newsax ladr_to_tptp tptp_to_ladr; do
+      install -Dm555 bin/$f $out/bin/$f;
+    done
+    install -Dm644 -t $out/share/man/man1 manpages/*.1
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
     homepage = "https://www.cs.unm.edu/~mccune/mace4/";
-    license = licenses.gpl2Only;
+    license = lib.licenses.gpl2Only;
     description = "Automated theorem prover for first-order and equational logic";
     longDescription = ''
       Prover9 is a resolution/paramodulation automated theorem prover
       for first-order and equational logic. Prover9 is a successor of
       the Otter Prover. This is the LADR command-line version.
     '';
-    platforms = platforms.linux;
+    mainProgram = "prover9";
+    platforms = lib.platforms.linux;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Fix build on GCC 14, since implicit parameter type is now an error:

```c
select.c: In function 'select_concentric_band':
select.c:236:5: error: type of 'min_id' defaults to 'int' []
  236 | int select_concentric_band(min_id, max_id, max_constrained)
      |     ^~~~~~~~~~~~~~~~~~~~~~
```

Also, I modernized the build file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
