### PR TITLE
librep: fix build on gcc-14 & modernize

### DIFF
--- a/pkgs/by-name/re/rep-gtk/package.nix
+++ b/pkgs/by-name/re/rep-gtk/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   gtk2-x11,
   librep,
@@ -12,9 +12,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "rep-gtk";
   version = "0.90.8.3";
 
-  src = fetchurl {
-    url = "https://download.tuxfamily.org/librep/rep-gtk/rep-gtk_${finalAttrs.version}.tar.xz";
-    hash = "sha256-qWV120V5Tu/QVkFylno47y1/7DriZExHjp99VLmf80E=";
+  src = fetchFromGitHub {
+    owner = "SawfishWM";
+    repo = "rep-gtk";
+    tag = "rep-gtk-${finalAttrs.version}";
+    hash = "sha256-vEhs7QsQUdeEiHZ6AOri6+SLz3Lq/s6j8rALhY0Xqsc=";
   };
 
   nativeBuildInputs = [
@@ -29,13 +31,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  enableParallelBuilding = true;
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.cc.isClang [
-      "-Wno-error=implicit-function-declaration"
-      "-Wno-error=int-conversion"
-    ]
-  );
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-function-declaration"
+    "-Wno-error=int-conversion"
+    "-Wno-error=incompatible-pointer-types"
+  ];
 
   patchPhase = ''
     sed -e 's|installdir=$(repexecdir)|installdir=$(libdir)/rep|g' -i Makefile.in
@@ -49,4 +51,3 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
   };
 })
-# TODO: investigate fetchFromGithub

--- a/pkgs/by-name/sa/sawfish/package.nix
+++ b/pkgs/by-name/sa/sawfish/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   gdk-pixbuf-xlib,
   gettext,
@@ -19,15 +19,18 @@
   rep-gtk,
   texinfo,
   which,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sawfish";
   version = "1.13.0";
 
-  src = fetchurl {
-    url = "https://download.tuxfamily.org/sawfish/sawfish_${finalAttrs.version}.tar.xz";
-    hash = "sha256-gWs8W/pMtQjbH8FEifzNAj3siZzxPd6xm8PmXXhyr10=";
+  src = fetchFromGitHub {
+    owner = "SawfishWM";
+    repo = "sawfish";
+    tag = "sawfish-${finalAttrs.version}";
+    hash = "sha256-4hxws3afDN9RjO9JCEjEgG4/g6bSycrmiJzRoyNnl3s=";
   };
 
   nativeBuildInputs = [
@@ -60,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   strictDeps = true;
+  enableParallelBuilding = true;
 
   postInstall = ''
     for file in $out/lib/sawfish/sawfish-menu \
@@ -72,6 +76,13 @@ stdenv.mkDerivation (finalAttrs: {
         --set REP_LOAD_PATH "$out/share/sawfish/lisp"
     done
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "--version" ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
 
   meta = {
     homepage = "http://sawfish.tuxfamily.org/";
@@ -86,5 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
+    mainProgram = "sawfish";
   };
 })


### PR DESCRIPTION
Fetching a patch to fix autoconf script build on newer C compilers.

Also, switch to [GitHub](https://github.com/SawfishWM/librep) fetch and cleanup the script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
