### PR TITLE
nixos/cross-seed: create outputDir on start and re-enable test

### DIFF
--- a/nixos/modules/services/torrent/cross-seed.nix
+++ b/nixos/modules/services/torrent/cross-seed.nix
@@ -154,9 +154,16 @@ in
         }
       ];
 
-      systemd.tmpfiles.settings."10-cross-seed"."${cfg.configDir}".d = {
-        inherit (cfg) group user;
-        mode = "700";
+      systemd.tmpfiles.settings."10-cross-seed" = {
+        ${cfg.configDir}.d = {
+          inherit (cfg) group user;
+          mode = "700";
+        };
+
+        ${cfg.settings.outputDir}.d = {
+          inherit (cfg) group user;
+          mode = "750";
+        };
       };
 
       systemd.services.cross-seed = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -294,6 +294,7 @@ in {
   curl-impersonate = handleTest ./curl-impersonate.nix {};
   custom-ca = handleTest ./custom-ca.nix {};
   croc = handleTest ./croc.nix {};
+  cross-seed = runTest ./cross-seed.nix;
   cyrus-imap = runTest ./cyrus-imap.nix;
   darling = handleTest ./darling.nix {};
   darling-dmg = runTest ./darling-dmg.nix;

--- a/nixos/tests/cross-seed.nix
+++ b/nixos/tests/cross-seed.nix
@@ -1,0 +1,43 @@
+{ lib, ... }:
+let
+  apiKey = "twentyfourcharacterskey!";
+in
+{
+  name = "cross-seed";
+  meta.maintainers = with lib.maintainers; [ pta2002 ];
+
+  nodes.machine =
+    { pkgs, config, ... }:
+    let
+      cfg = config.services.cross-seed;
+    in
+    {
+      systemd.tmpfiles.settings."0-cross-seed-test"."${cfg.settings.torrentDir}".d = {
+        inherit (cfg) user group;
+        mode = "700";
+      };
+
+      services.cross-seed = {
+        enable = true;
+        settings = {
+          torrentDir = "/var/lib/torrents";
+          torznab = [ ];
+          useClientTorrents = false;
+        };
+        # # We create this secret in the Nix store (making it readable by everyone).
+        # # DO NOT DO THIS OUTSIDE OF TESTS!!
+        settingsFile = (pkgs.formats.json { }).generate "secrets.json" {
+          inherit apiKey;
+        };
+      };
+    };
+
+  testScript = # python
+    ''
+      start_all()
+      machine.wait_for_unit("cross-seed.service")
+      machine.wait_for_open_port(2468)
+      # Check that the API is running
+      machine.succeed("curl --fail http://localhost:2468/api/ping?apiKey=${apiKey}")
+    '';
+}

--- a/pkgs/by-name/cr/cross-seed/package.nix
+++ b/pkgs/by-name/cr/cross-seed/package.nix
@@ -2,20 +2,23 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage rec {
   pname = "cross-seed";
-  version = "6.9.1";
+  version = "6.11.1";
 
   src = fetchFromGitHub {
     owner = "cross-seed";
     repo = "cross-seed";
     tag = "v${version}";
-    hash = "sha256-BZ4uLPKSLtkERNUJ6PY2+djU8r8xM8vaXerfdGmYQq0=";
+    hash = "sha256-ZyagXbbYUZA2CfoqVh0pmKt91kTLUGB8hUItgHbPb2w=";
   };
 
-  npmDepsHash = "sha256-hqQi0kSPm9SKEoLu6InvRMPxbQ+CBpKVPJhhOdo2ZII=";
+  npmDepsHash = "sha256-hSiGnw3Fo//oTONBmtuv0sDvldCzs1PsdImxdGWEpMo=";
+
+  passthru.updateScript = nix-update-script;
 
   meta = {
     description = "Fully-automatic torrent cross-seeding with Torznab";

--- a/pkgs/by-name/cr/cross-seed/package.nix
+++ b/pkgs/by-name/cr/cross-seed/package.nix
@@ -3,6 +3,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
 }:
 
 buildNpmPackage rec {
@@ -18,7 +19,10 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-hSiGnw3Fo//oTONBmtuv0sDvldCzs1PsdImxdGWEpMo=";
 
-  passthru.updateScript = nix-update-script;
+  passthru = {
+    updateScript = nix-update-script;
+    tests.cross-seed = nixosTests.cross-seed;
+  };
 
   meta = {
     description = "Fully-automatic torrent cross-seeding with Torznab";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Re-enables the test removed in #384279.

The issue with the broken test was multi-faceted:
- There was a bug in cross-seed 6.9.1 when no client was set up where it would fail to start. The version was bumped to 6.11.1 which fixes this.
- The outputDir was not being created. Added a tmpfiles rule that properly creates it.

I also changed the API endpoint to the `/ping` endpoint, and added an update script to the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
