### PR TITLE
nixos/gitea: drop mailerUseSendmail option and use PROTOCOL as an indication instead

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -27,6 +27,9 @@ let
 
     ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
   '';
+
+  inherit (cfg.settings) mailer;
+  useSendmail = mailer.ENABLED && mailer.PROTOCOL == "sendmail";
 in
 
 {
@@ -366,15 +369,6 @@ in
         description = "Path to a file containing the SMTP password.";
       };
 
-      mailerUseSendmail = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Use the operating system's sendmail command instead of SMTP.
-          Note: some sandbox settings will be disabled.
-        '';
-      };
-
       metricsTokenFile = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -422,120 +416,157 @@ in
             };
           }
         '';
-        type = types.submodule {
-          freeformType = format.type;
-          options = {
-            log = {
-              ROOT_PATH = mkOption {
-                default = "${cfg.stateDir}/log";
-                defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
-                type = types.str;
-                description = "Root path for log files.";
+        type = types.submodule (
+          { config, options, ... }:
+          {
+            freeformType = format.type;
+            options = {
+              log = {
+                ROOT_PATH = mkOption {
+                  default = "${cfg.stateDir}/log";
+                  defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
+                  type = types.str;
+                  description = "Root path for log files.";
+                };
+                LEVEL = mkOption {
+                  default = "Info";
+                  type = types.enum [
+                    "Trace"
+                    "Debug"
+                    "Info"
+                    "Warn"
+                    "Error"
+                    "Critical"
+                  ];
+                  description = "General log level.";
+                };
               };
-              LEVEL = mkOption {
-                default = "Info";
-                type = types.enum [
-                  "Trace"
-                  "Debug"
-                  "Info"
-                  "Warn"
-                  "Error"
-                  "Critical"
-                ];
-                description = "General log level.";
+
+              mailer = {
+                ENABLED = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = "Whether to use an email service to send notifications.";
+                };
+
+                PROTOCOL = lib.mkOption {
+                  type = lib.types.enum [
+                    null
+                    "smtp"
+                    "smtps"
+                    "smtp+starttls"
+                    "smtp+unix"
+                    "sendmail"
+                    "dummy"
+                  ];
+                  default = null;
+                  description = "Which mail server protocol to use.";
+                };
+
+                SENDMAIL_PATH = lib.mkOption {
+                  type = lib.types.path;
+                  # somewhat duplicated with useSendmail but cannot be deduped because of infinite recursion
+                  default =
+                    if config.mailer.ENABLED && config.mailer.PROTOCOL == "sendmail" then
+                      "/run/wrappers/bin/sendmail"
+                    else
+                      "sendmail";
+                  defaultText = lib.literalExpression ''if config.${options.mailer.ENABLED} && config.${options.mailer.PROTOCOL} == "sendmail" then "/run/wrappers/bin/sendmail" else "sendmail"'';
+                  description = "Path to sendmail binary or script.";
+                };
+              };
+
+              server = {
+                PROTOCOL = mkOption {
+                  type = types.enum [
+                    "http"
+                    "https"
+                    "fcgi"
+                    "http+unix"
+                    "fcgi+unix"
+                  ];
+                  default = "http";
+                  description = ''Listen protocol. `+unix` means "over unix", not "in addition to."'';
+                };
+
+                HTTP_ADDR = mkOption {
+                  type = types.either types.str types.path;
+                  default =
+                    if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0";
+                  defaultText = literalExpression ''if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0"'';
+                  description = "Listen address. Must be a path when using a unix socket.";
+                };
+
+                HTTP_PORT = mkOption {
+                  type = types.port;
+                  default = 3000;
+                  description = "Listen port. Ignored when using a unix socket.";
+                };
+
+                DOMAIN = mkOption {
+                  type = types.str;
+                  default = "localhost";
+                  description = "Domain name of your server.";
+                };
+
+                ROOT_URL = mkOption {
+                  type = types.str;
+                  default = "http://${cfg.settings.server.DOMAIN}:${toString cfg.settings.server.HTTP_PORT}/";
+                  defaultText = literalExpression ''"http://''${config.services.gitea.settings.server.DOMAIN}:''${toString config.services.gitea.settings.server.HTTP_PORT}/"'';
+                  description = "Full public URL of gitea server.";
+                };
+
+                STATIC_ROOT_PATH = mkOption {
+                  type = types.either types.str types.path;
+                  default = cfg.package.data;
+                  defaultText = literalExpression "config.${opt.package}.data";
+                  example = "/var/lib/gitea/data";
+                  description = "Upper level of template and static files path.";
+                };
+
+                DISABLE_SSH = mkOption {
+                  type = types.bool;
+                  default = false;
+                  description = "Disable external SSH feature.";
+                };
+
+                SSH_PORT = mkOption {
+                  type = types.port;
+                  default = 22;
+                  example = 2222;
+                  description = ''
+                    SSH port displayed in clone URL.
+                    The option is required to configure a service when the external visible port
+                    differs from the local listening port i.e. if port forwarding is used.
+                  '';
+                };
+              };
+
+              service = {
+                DISABLE_REGISTRATION = mkEnableOption "the registration lock" // {
+                  description = ''
+                    By default any user can create an account on this `gitea` instance.
+                    This can be disabled by using this option.
+
+                    *Note:* please keep in mind that this should be added after the initial
+                    deploy as the first registered user will be the administrator.
+                  '';
+                };
+              };
+
+              session = {
+                COOKIE_SECURE = mkOption {
+                  type = types.bool;
+                  default = false;
+                  description = ''
+                    Marks session cookies as "secure" as a hint for browsers to only send
+                    them via HTTPS. This option is recommend, if gitea is being served over HTTPS.
+                  '';
+                };
               };
             };
-
-            server = {
-              PROTOCOL = mkOption {
-                type = types.enum [
-                  "http"
-                  "https"
-                  "fcgi"
-                  "http+unix"
-                  "fcgi+unix"
-                ];
-                default = "http";
-                description = ''Listen protocol. `+unix` means "over unix", not "in addition to."'';
-              };
-
-              HTTP_ADDR = mkOption {
-                type = types.either types.str types.path;
-                default =
-                  if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0";
-                defaultText = literalExpression ''if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0"'';
-                description = "Listen address. Must be a path when using a unix socket.";
-              };
-
-              HTTP_PORT = mkOption {
-                type = types.port;
-                default = 3000;
-                description = "Listen port. Ignored when using a unix socket.";
-              };
-
-              DOMAIN = mkOption {
-                type = types.str;
-                default = "localhost";
-                description = "Domain name of your server.";
-              };
-
-              ROOT_URL = mkOption {
-                type = types.str;
-                default = "http://${cfg.settings.server.DOMAIN}:${toString cfg.settings.server.HTTP_PORT}/";
-                defaultText = literalExpression ''"http://''${config.services.gitea.settings.server.DOMAIN}:''${toString config.services.gitea.settings.server.HTTP_PORT}/"'';
-                description = "Full public URL of gitea server.";
-              };
-
-              STATIC_ROOT_PATH = mkOption {
-                type = types.either types.str types.path;
-                default = cfg.package.data;
-                defaultText = literalExpression "config.${opt.package}.data";
-                example = "/var/lib/gitea/data";
-                description = "Upper level of template and static files path.";
-              };
-
-              DISABLE_SSH = mkOption {
-                type = types.bool;
-                default = false;
-                description = "Disable external SSH feature.";
-              };
-
-              SSH_PORT = mkOption {
-                type = types.port;
-                default = 22;
-                example = 2222;
-                description = ''
-                  SSH port displayed in clone URL.
-                  The option is required to configure a service when the external visible port
-                  differs from the local listening port i.e. if port forwarding is used.
-                '';
-              };
-            };
-
-            service = {
-              DISABLE_REGISTRATION = mkEnableOption "the registration lock" // {
-                description = ''
-                  By default any user can create an account on this `gitea` instance.
-                  This can be disabled by using this option.
-
-                  *Note:* please keep in mind that this should be added after the initial
-                  deploy as the first registered user will be the administrator.
-                '';
-              };
-            };
-
-            session = {
-              COOKIE_SECURE = mkOption {
-                type = types.bool;
-                default = false;
-                description = ''
-                  Marks session cookies as "secure" as a hint for browsers to only send
-                  them via HTTPS. This option is recommend, if gitea is being served over HTTPS.
-                '';
-              };
-            };
-          };
-        };
+          }
+        );
       };
 
       extraConfig = mkOption {
@@ -663,15 +694,9 @@ in
           })
         ]);
 
-        mailer = mkMerge [
-          (mkIf (cfg.mailerPasswordFile != null) {
-            PASSWD = "#mailerpass#";
-          })
-          (mkIf cfg.mailerUseSendmail {
-            PROTOCOL = "sendmail";
-            SENDMAIL_PATH = "/run/wrappers/bin/sendmail";
-          })
-        ];
+        mailer = mkIf (cfg.mailerPasswordFile != null) {
+          PASSWD = "#mailerpass#";
+        };
 
         metrics = mkIf (cfg.metricsTokenFile != null) {
           TOKEN = "#metricstoken#";
@@ -884,18 +909,18 @@ in
           cfg.repositoryRoot
           cfg.stateDir
           cfg.lfs.contentDir
-        ] ++ optional cfg.mailerUseSendmail "/var/lib/postfix/queue/maildrop";
+        ] ++ lib.optional (useSendmail && config.services.postfix.enable) "/var/lib/postfix/queue/maildrop";
         UMask = "0027";
         # Capabilities
         CapabilityBoundingSet = "";
         # Security
-        NoNewPrivileges = optional (!cfg.mailerUseSendmail) true;
+        NoNewPrivileges = !useSendmail;
         # Sandboxing
         ProtectSystem = "strict";
         ProtectHome = true;
         PrivateTmp = true;
         PrivateDevices = true;
-        PrivateUsers = optional (!cfg.mailerUseSendmail) true;
+        PrivateUsers = !useSendmail;
         ProtectHostname = true;
         ProtectClock = true;
         ProtectKernelTunables = true;
@@ -906,7 +931,7 @@ in
           "AF_UNIX"
           "AF_INET"
           "AF_INET6"
-        ] ++ optional cfg.mailerUseSendmail "AF_NETLINK";
+        ] ++ lib.optional (useSendmail && config.services.postfix.enable) "AF_NETLINK";
         RestrictNamespaces = true;
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
@@ -916,10 +941,14 @@ in
         PrivateMounts = true;
         # System Call Filtering
         SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "~@cpu-emulation @debug @keyring @mount @obsolete @setuid"
-          "setrlimit"
-        ] ++ optional (!cfg.mailerUseSendmail) "~@privileged";
+        SystemCallFilter =
+          [
+            "~@cpu-emulation @debug @keyring @mount @obsolete @setuid"
+            "setrlimit"
+          ]
+          ++ lib.optionals (!useSendmail) [
+            "~@privileged"
+          ];
       };
 
       environment = {

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -997,7 +997,6 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
-    ma27
     techknowlogick
     SuperSandro2000
   ];


### PR DESCRIPTION
see #384535 , similar to #384580

The option was just introduced a few days back, so we don't need a removal notice.

This way is superior over the other PR as we do not have an option users need to turn which can be fully avoided. See commits for more details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
