### PR TITLE
libreoffice-collabora: move disabled test from generic to fresh,still patch file

### DIFF
--- a/pkgs/applications/office/libreoffice/skip-broken-tests-fresh.patch
+++ b/pkgs/applications/office/libreoffice/skip-broken-tests-fresh.patch
@@ -122,5 +122,15 @@
  {
 +    return; // fails on aarch64
      loadFromURL(u"private:factory/swriter"_ustr);
- 
+
      uno::Reference<rdf::XDocumentMetadataAccess> xDocumentMetadataAccess(mxComponent,
+--- a/sw/qa/extras/odfexport/odfexport2.cxx
++++ b/sw/qa/extras/odfexport/odfexport2.cxx
+@@ -1711,6 +1711,7 @@ CPPUNIT_TEST_FIXTURE(Test, testMidnightRedlineDatetime)
+     // - Error: "2001-01-01" does not satisfy the "dateTime" type
+     // because "2001-01-01T00:00:00" became "2001-01-01" on roundtrip.
+     loadAndReload("midnight_redline.fodt");
++    return; // fails on aarch64
+
+     xmlDocUniquePtr pXmlDoc = parseExport(u"content.xml"_ustr);
+     assertXPathContent(pXmlDoc,

--- a/pkgs/applications/office/libreoffice/skip-broken-tests-still.patch
+++ b/pkgs/applications/office/libreoffice/skip-broken-tests-still.patch
@@ -134,4 +134,13 @@
 +
      comphelper::LibreOfficeKit::setActive();
      SwXTextDocument* pXTextDocument = createDoc("shape.fodt");
- 
+--- a/sw/qa/extras/odfexport/odfexport2.cxx
++++ b/sw/qa/extras/odfexport/odfexport2.cxx
+@@ -1711,6 +1711,7 @@ CPPUNIT_TEST_FIXTURE(Test, testMidnightRedlineDatetime)
+     // - Error: "2001-01-01" does not satisfy the "dateTime" type
+     // because "2001-01-01T00:00:00" became "2001-01-01" on roundtrip.
+     loadAndReload("midnight_redline.fodt");
++    return; // fails on aarch64
+
+     xmlDocUniquePtr pXmlDoc = parseExport(u"content.xml"_ustr);
+     assertXPathContent(pXmlDoc,

--- a/pkgs/applications/office/libreoffice/skip-broken-tests.patch
+++ b/pkgs/applications/office/libreoffice/skip-broken-tests.patch
@@ -121,13 +121,3 @@
      createSwDoc();
      SwDoc* pDoc = getSwDoc();
      CPPUNIT_ASSERT(pDoc);
---- a/sw/qa/extras/odfexport/odfexport2.cxx
-+++ b/sw/qa/extras/odfexport/odfexport2.cxx
-@@ -1711,6 +1711,7 @@ CPPUNIT_TEST_FIXTURE(Test, testMidnightRedlineDatetime)
-     // - Error: "2001-01-01" does not satisfy the "dateTime" type
-     // because "2001-01-01T00:00:00" became "2001-01-01" on roundtrip.
-     loadAndReload("midnight_redline.fodt");
-+    return; // fails on aarch64
- 
-     xmlDocUniquePtr pXmlDoc = parseExport(u"content.xml"_ustr);
-     assertXPathContent(pXmlDoc,


### PR DESCRIPTION
The build of collabora-online was broken, because the old version of libreoffice that is used for libreoffice-collabora does not contain the moved test.

This does fix the build for me, as in, it does not fail immediately in the patch phase anymore. But unfortunately I do not have a build machine / vm  powerful enough to actually build libreoffice. For that I would need some help.

Perhaps something that one of the maintainers can help with?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
