### PR TITLE
tectonic: 0.15.0 -> 0.15.0-unstable-2025-02-21

### DIFF
--- a/pkgs/by-name/te/tectonic-unwrapped/package.nix
+++ b/pkgs/by-name/te/tectonic-unwrapped/package.nix
@@ -11,7 +11,6 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
-  darwin,
   fontconfig,
   harfbuzzFull,
   openssl,
@@ -56,21 +55,12 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "external-harfbuzz" ];
 
-  buildInputs =
-    [
-      icu
-      fontconfig
-      harfbuzzFull
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk.frameworks;
-      [
-        ApplicationServices
-        Cocoa
-        Foundation
-      ]
-    );
+  buildInputs = [
+    icu
+    fontconfig
+    harfbuzzFull
+    openssl
+  ];
 
   postInstall =
     ''

--- a/pkgs/by-name/te/tectonic-unwrapped/package.nix
+++ b/pkgs/by-name/te/tectonic-unwrapped/package.nix
@@ -16,40 +16,22 @@
   openssl,
   pkg-config,
   icu,
-  fetchpatch2,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tectonic";
-  version = "0.15.0";
+  # https://github.com/tectonic-typesetting/tectonic/issues/1263
+  version = "0.15.0-unstable-2025-02-21";
 
   src = fetchFromGitHub {
     owner = "tectonic-typesetting";
     repo = "tectonic";
-    rev = "tectonic@${version}";
-    sha256 = "sha256-dZnUu0g86WJIIvwMgdmwb6oYqItxoYrGQTFNX7I61Bs=";
+    rev = "c2ae25ff1facd9e9cce31b48944b867773f709ec";
+    sha256 = "sha256-cDCJ1Tu2lA4KvN2EBUtT0MvMtkejd8YAoNRkNeoreEc=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      # https://github.com/tectonic-typesetting/tectonic/pull/1155
-      name = "1155-fix-endless-reruns-when-generating-bbl";
-      url = "https://github.com/tectonic-typesetting/tectonic/commit/fbb145cd079497b8c88197276f92cb89685b4d54.patch";
-      hash = "sha256-6FW5MFkOWnqzYX8Eg5DfmLaEhVWKYVZwodE4SGXHKV0=";
-    })
-  ];
-
-  cargoPatches = [
-    (fetchpatch2 {
-      # cherry-picked from https://github.com/tectonic-typesetting/tectonic/pull/1202
-      name = "1202-fix-build-with-rust-1_80";
-      url = "https://github.com/tectonic-typesetting/tectonic/commit/6b49ca8db40aaca29cb375ce75add3e575558375.patch";
-      hash = "sha256-i1L3XaSuBbsmgOSXIWVqr6EHlHGs8A+6v06kJ3C50sk=";
-    })
-  ];
-
   useFetchCargoVendor = true;
-  cargoHash = "sha256-OMa89riyopKMQf9E9Fr7Qs4hFfEfjnDFzaSWFtkYUXE=";
+  cargoHash = "sha256-dBthzRS+9wqKCwmo5cY/ynTdfIPK3QCsbZ2vAQ8q7aM=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -75,6 +57,13 @@ rustPlatform.buildRustPackage rec {
     '';
 
   doCheck = true;
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
+  checkFlags = [
+    # https://github.com/tectonic-typesetting/tectonic/issues/1263
+    "--skip=tests::no_segfault_after_failed_compilation"
+  ];
 
   meta = {
     description = "Modernized, complete, self-contained TeX/LaTeX engine, powered by XeTeX and TeXLive";


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
