### PR TITLE
libcdio: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/libcdio/default.nix
+++ b/pkgs/development/libraries/libcdio/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   libcddb,
   pkg-config,
   ncurses,
@@ -14,28 +13,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libcdio";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "mirror://gnu/libcdio/libcdio-${version}.tar.bz2";
-    sha256 = "0avi6apv5ydjy6b9c3z9a46rvp5i57qyr09vr7x4nndxkmcfjl45";
+    url = "https://github.com/libcdio/libcdio/releases/download/${version}/${pname}-${version}.tar.bz2";
+    hash = "sha256-b4+99NGJz2Pyp6FUnFFs1yDHsiLHqq28kkom50WkhTk=";
   };
-
-  patches = [
-    # Fixes test failure of realpath test with glibc-2.36
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/libcdio/raw/d49ccdd9c8b4e9d57c01539f4c8948f28ce82bca/f/realpath-test-fix.patch";
-      sha256 = "sha256-ldAGlcf79uQ8QAt4Au8Iv6jsI6ICZXtXOKZBpyELtN8=";
-    })
-
-    # pull pending upstream patch to fix build on ncurses-6.3:
-    #  https://savannah.gnu.org/patch/index.php?10130
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://savannah.gnu.org/patch/download.php?file_id=52179";
-      sha256 = "1v15gxhpi4bgcr12pb3d9c3hiwj0drvc832vic7sham34lhjmcbb";
-    })
-  ];
 
   postPatch = ''
     patchShebangs .
@@ -57,10 +40,6 @@ stdenv.mkDerivation rec {
     ];
 
   enableParallelBuilding = true;
-
-  env = lib.optionalAttrs stdenv.cc.isGNU {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-  };
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
Supercedes https://github.com/NixOS/nixpkgs/pull/384469

Changelog 2.1.1: https://github.com/libcdio/libcdio/releases/tag/2.1.1
Changelog 2.2.0: https://github.com/libcdio/libcdio/releases/tag/2.2.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
