### PR TITLE
tdb, talloc, tevent, ldb: fix `pkgsLLVM` build (take 2)

### DIFF
--- a/pkgs/by-name/ld/ldb/package.nix
+++ b/pkgs/by-name/ld/ldb/package.nix
@@ -1,20 +1,22 @@
-{ lib, stdenv
-, fetchurl
-, python3
-, pkg-config
-, readline
-, tdb
-, talloc
-, tevent
-, popt
-, libxslt
-, docbook-xsl-nons
-, docbook_xml_dtd_42
-, cmocka
-, wafHook
-, buildPackages
-, libxcrypt
-, testers
+{
+  lib,
+  stdenv,
+  fetchurl,
+  python3,
+  pkg-config,
+  readline,
+  tdb,
+  talloc,
+  tevent,
+  popt,
+  libxslt,
+  docbook-xsl-nons,
+  docbook_xml_dtd_42,
+  cmocka,
+  wafHook,
+  buildPackages,
+  libxcrypt,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,7 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0VWIQALHnbscPYZC+LEBPy5SCzru/W6WQSrexbjWy8A=";
   };
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -59,21 +64,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   wafPath = "buildtools/bin/waf";
 
-  wafConfigureFlags = [
-    "--bundled-libraries=NONE"
-    "--builtin-libraries=replace"
-    "--without-ldb-lmdb"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--cross-compile"
-    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
-  ];
+  wafConfigureFlags =
+    [
+      "--bundled-libraries=NONE"
+      "--builtin-libraries=replace"
+      "--without-ldb-lmdb"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-compile"
+      "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
+    ];
 
   # python-config from build Python gives incorrect values when cross-compiling.
   # If python-config is not found, the build falls back to using the sysconfig
   # module, which works correctly in all cases.
   PYTHON_CONFIG = "/invalid";
 
-  stripDebugList = [ "bin" "lib" "modules" ];
+  # https://reviews.llvm.org/D135402
+  NIX_LDFLAGS = lib.optional (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
+
+  stripDebugList = [
+    "bin"
+    "lib"
+    "modules"
+  ];
 
   passthru.tests.pkg-config = testers.hasPkgConfigModules {
     package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ta/talloc/package.nix
+++ b/pkgs/by-name/ta/talloc/package.nix
@@ -67,6 +67,11 @@ stdenv.mkDerivation rec {
   # module, which works correctly in all cases.
   PYTHON_CONFIG = "/invalid";
 
+  # https://reviews.llvm.org/D135402
+  NIX_LDFLAGS = lib.optional (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
+
   # this must not be exported before the ConfigurePhase otherwise waf whines
   preBuild = lib.optionalString stdenv.hostPlatform.isMusl ''
     export NIX_CFLAGS_LINK="-no-pie -shared";

--- a/pkgs/by-name/td/tdb/package.nix
+++ b/pkgs/by-name/td/tdb/package.nix
@@ -1,14 +1,16 @@
-{ lib, stdenv
-, fetchurl
-, pkg-config
-, wafHook
-, buildPackages
-, python3
-, readline
-, libxslt
-, libxcrypt
-, docbook-xsl-nons
-, docbook_xml_dtd_45
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  wafHook,
+  buildPackages,
+  python3,
+  readline,
+  libxslt,
+  libxcrypt,
+  docbook-xsl-nons,
+  docbook_xml_dtd_45,
 }:
 
 stdenv.mkDerivation rec {
@@ -44,22 +46,31 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  wafConfigureFlags = [
-    "--bundled-libraries=NONE"
-    "--builtin-libraries=replace"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--cross-compile"
-    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
-  ];
+  wafConfigureFlags =
+    [
+      "--bundled-libraries=NONE"
+      "--builtin-libraries=replace"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-compile"
+      "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
+    ];
 
-  postFixup = if stdenv.hostPlatform.isDarwin
-    then ''install_name_tool -id $out/lib/libtdb.dylib $out/lib/libtdb.dylib''
-    else null;
+  postFixup =
+    if stdenv.hostPlatform.isDarwin then
+      ''install_name_tool -id $out/lib/libtdb.dylib $out/lib/libtdb.dylib''
+    else
+      null;
 
   # python-config from build Python gives incorrect values when cross-compiling.
   # If python-config is not found, the build falls back to using the sysconfig
   # module, which works correctly in all cases.
   PYTHON_CONFIG = "/invalid";
+
+  # https://reviews.llvm.org/D135402
+  NIX_LDFLAGS = lib.optional (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
 
   meta = with lib; {
     description = "Trivial database";

--- a/pkgs/by-name/te/tevent/package.nix
+++ b/pkgs/by-name/te/tevent/package.nix
@@ -67,6 +67,11 @@ stdenv.mkDerivation rec {
   # module, which works correctly in all cases.
   PYTHON_CONFIG = "/invalid";
 
+  # https://reviews.llvm.org/D135402
+  NIX_LDFLAGS = lib.optional (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
+
   meta = with lib; {
     description = "Event system based on the talloc memory management library";
     homepage = "https://tevent.samba.org/";


### PR DESCRIPTION
Applies the suggestions from https://github.com/NixOS/nixpkgs/pull/373264 and tested by building for FreeBSD

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
