### PR TITLE
Revert "python3Packages.pytensor: 2.26.4 -> 2.28.0"

### DIFF
--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -32,14 +32,14 @@
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.28.0";
+  version = "2.26.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
     repo = "pytensor";
     tag = "rel-${version}";
-    hash = "sha256-jwx7fcMiFNvnwP746nM2rqo2BD6PEbKkfEwIz8MenN4=";
+    hash = "sha256-pREyBedkF9MW7g3Bctnk8C9vVbRTsLLreldxlqDdHVI=";
   };
 
   pythonRelaxDeps = [
@@ -88,9 +88,6 @@ buildPythonPackage rec {
       "test_minimal_random_function_call_benchmark"
       "test_scan_multiple_output"
       "test_vector_taps_benchmark"
-
-      # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
-      "test_jax_pad"
 
       # Failure reported upstream: https://github.com/pymc-devs/pytensor/issues/980
       "test_choose_signature"
@@ -163,9 +160,6 @@ buildPythonPackage rec {
       "test_unbroadcast"
       "test_update_equiv"
       "test_update_same"
-      "test_solve_triangular_grad"
-      "test_numba_Cholesky_grad"
-      "test_alloc"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
       # Fatal Python error: Segmentation fault
@@ -202,11 +196,14 @@ buildPythonPackage rec {
     description = "Python library to define, optimize, and efficiently evaluate mathematical expressions involving multi-dimensional arrays";
     mainProgram = "pytensor-cache";
     homepage = "https://github.com/pymc-devs/pytensor";
-    changelog = "https://github.com/pymc-devs/pytensor/releases/tag/${src.tag}";
+    changelog = "https://github.com/pymc-devs/pytensor/releases/tag/rel-${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       bcdarwin
       ferrine
     ];
+    # Not yet compatible with numpy >= 2.0
+    # https://github.com/pymc-devs/pytensor/issues/688
+    broken = true;
   };
 }


### PR DESCRIPTION
This reverts commit 17a5d4a73d48166f3482900a2238f3a45199c7ae.

#384618 was rebased and merged on top of #383783 which largely subsumed it. The disabled tests were placed in different locations in the file which avoided a merge conflict but cause them to be duplicated, so revert.

@GaetanLepage @prusnak 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
