### PR TITLE
nixos/matter-server: fix permission denied error in 7.0.1

### DIFF
--- a/nixos/tests/matter-server.nix
+++ b/nixos/tests/matter-server.nix
@@ -8,6 +8,7 @@ import ./make-test-python.nix (
   {
     name = "matter-server";
     meta.maintainers = with lib.maintainers; [ leonm1 ];
+    meta.timeout = 120; # Timeout after two minutes
 
     nodes = {
       machine =
@@ -22,29 +23,30 @@ import ./make-test-python.nix (
 
     testScript = # python
       ''
+        @polling_condition
+        def matter_server_running():
+          machine.succeed("systemctl status matter-server")
+
         start_all()
 
-        machine.wait_for_unit("matter-server.service")
-        machine.wait_for_open_port(1234)
+        machine.wait_for_unit("matter-server.service", timeout=20)
+        machine.wait_for_open_port(1234, timeout=20)
 
-        with subtest("Check websocket server initialized"):
-            output = machine.succeed("echo \"\" | ${pkgs.websocat}/bin/websocat ws://localhost:1234/ws")
-            machine.log(output)
+        with matter_server_running: # type: ignore[union-attr]
+          with subtest("Check websocket server initialized"):
+              output = machine.succeed("echo \"\" | ${pkgs.websocat}/bin/websocat ws://localhost:1234/ws")
+              machine.log(output)
 
-        assert '"sdk_version": "${chipVersion}"' in output, (
-          'CHIP version \"${chipVersion}\" not present in websocket message'
-        )
+          assert '"fabric_id": 1' in output, (
+            "fabric_id not propagated to server"
+          )
 
-        assert '"fabric_id": 1' in output, (
-          "fabric_id not propagated to server"
-        )
+          with subtest("Check storage directory is created"):
+              machine.succeed("ls /var/lib/matter-server/chip.json")
 
-        with subtest("Check storage directory is created"):
-            machine.succeed("ls /var/lib/matter-server/chip.json")
-
-        with subtest("Check systemd hardening"):
-            _, output = machine.execute("systemd-analyze security matter-server.service | grep -v '✓'")
-            machine.log(output)
+          with subtest("Check systemd hardening"):
+              _, output = machine.execute("systemd-analyze security matter-server.service | grep -v '✓'")
+              machine.log(output)
       '';
   }
 )


### PR DESCRIPTION
Remove `DynamicUser=yes`, which causes a permission denied error when the matter SDK tries to write its config file.

The error looks like this:
```
[1740088364.983513][49694:49694] CHIP:DL: Failed to create temp file /data/chip_factory.ini-gR0axc: Permission denied
```

I can't quite figure out why there's an error, but it appears to be something involving the ordering of bind mounts and permissions. After this change, the error no longer triggers. Systemd should migrate the config from DynamicUser=yes to DynamicUser=no automatically, leaving a snarky message in the journal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
