### PR TITLE
video2x: init at 6.4.0

### DIFF
--- a/pkgs/by-name/vi/video2x/package.nix
+++ b/pkgs/by-name/vi/video2x/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/k4yt3x/video2x/releases/tag/${finalAttrs.version}/CHANGELOG.md";
     homepage = "https://github.com/k4yt3x/video2x";
     license = lib.licenses.agpl3Plus;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
     mainProgram = "video2x";
   };
 })

--- a/pkgs/by-name/vi/video2x/package.nix
+++ b/pkgs/by-name/vi/video2x/package.nix
@@ -1,0 +1,84 @@
+{
+  stdenv,
+  lib,
+  moltenvk,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  ffmpeg,
+  ncnn,
+  spdlog,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-tools,
+  shaderc,
+  glslang,
+  boost,
+}:
+
+let
+  librealcugan_ncnn_vulkan = fetchFromGitHub {
+    owner = "k4yt3x";
+    repo = "librealcugan-ncnn-vulkan";
+    rev = "d9c5a7eb4c8475af6110496c27c3d1f702f9b96a";
+    hash = "sha256-PPoAAjtIbA16u0n2S0Bn6NBd4LYAovqFf5jDyuN6gsE=";
+  };
+  librealesrgan-ncnn-vulkan = fetchFromGitHub {
+    owner = "k4yt3x";
+    repo = "librealesrgan-ncnn-vulkan";
+    rev = "c1f255524f79566c40866b38e5e65b40adf77eee";
+    hash = "sha256-0+oudxABQxwLHZFueoPkYlofUOzMUSd0dOhRXOdxrcA=";
+  };
+  librife-ncnn-vulkan = fetchFromGitHub {
+    owner = "k4yt3x";
+    repo = "librife-ncnn-vulkan";
+    rev = "3f7bcb44f38b2acda6fa5e575a6d12517ac16b94";
+    hash = "sha256-tlRLUSmPz4H81TGkvcEUsJeQbxi+CRaQhCKmUl0JZi4=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "video2x";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "k4yt3x";
+    repo = "video2x";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-arl4+fr8CwSN/Frw1jYZpuNUAa7BfJ9ffopKdoUTRc4=";
+  };
+
+  postUnpack = ''
+    # Use Nix dependencies instead
+    rm -rf source/third_party/*
+    ln -s ${librealcugan_ncnn_vulkan} source/third_party/librealcugan_ncnn_vulkan
+    ln -s ${librealesrgan-ncnn-vulkan} source/third_party/librealesrgan_ncnn_vulkan
+    ln -s ${librife-ncnn-vulkan} source/third_party/librife_ncnn_vulkan
+  '';
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      ffmpeg.dev
+      ncnn
+      spdlog
+      boost
+      vulkan-headers
+      vulkan-loader
+      vulkan-tools
+      shaderc
+      glslang
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      moltenvk
+    ];
+
+  meta = {
+    description = "AI-powered video upscaling tool";
+    changelog = "https://github.com/k4yt3x/video2x/releases/tag/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/k4yt3x/video2x";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.unix;
+    mainProgram = "video2x";
+  };
+})


### PR DESCRIPTION
This software allows you to upscale different types of videos.
It has several different model files for anime or different types of videos.
This program allows you to upscale video files without having to split them into picture frames.

Graphical interface and flatpak support is not yet available.
Thank you @matteo-pacini for your help with the packaging.

https://github.com/k4yt3x/video2x

I did not add myself as a maintainer because I cannot follow the updates.

## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have tested several different videos with different combinations and have not encountered any problems.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
