### PR TITLE
ocamlPackages.tls: 1.0.4 → 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-ptime/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-ptime/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  ptime,
+  version ? "5.0.0",
+}:
+
+buildDunePackage {
+  inherit version;
+
+  pname = "mirage-ptime";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-ptime/releases/download/v${version}/mirage-ptime-${version}.tbz";
+    hash = "sha256-1VNWBGjVuU2yWwVzjCSZ8pDuZrFKwitDAuZn8fpENHE=";
+  };
+
+  propagatedBuildInputs = [ ptime ];
+
+  meta = {
+    description = "A POSIX clock for MirageOS";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+    changelog = "https://raw.githubusercontent.com/mirage/mirage-ptime/refs/tags/v${version}/CHANGES.md";
+    homepage = "https://github.com/mirage/mirage-ptime";
+  };
+}

--- a/pkgs/development/ocaml-modules/tls/async.nix
+++ b/pkgs/development/ocaml-modules/tls/async.nix
@@ -4,10 +4,10 @@
   async,
   cstruct-async,
   core,
-  mirage-crypto-rng-async,
+  mirage-crypto-rng,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "tls-async";
 
   inherit (tls) src version;
@@ -20,7 +20,7 @@ buildDunePackage rec {
     async
     core
     cstruct-async
-    mirage-crypto-rng-async
+    mirage-crypto-rng
     tls
   ];
 

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -18,11 +18,11 @@
 
 buildDunePackage rec {
   pname = "tls";
-  version = "1.0.4";
+  version = "2.0.0";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
-    hash = "sha256-yFt8Gh4ipseWEHsnJVld3iYElMDvBrYdn1O+IuHcQug=";
+    hash = "sha256-aEcNa6hIAHWQjAzGn/6Cq7y7g6t/mI0mYzWhnxLCamI=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/tls/eio.nix
+++ b/pkgs/development/ocaml-modules/tls/eio.nix
@@ -5,20 +5,19 @@
   eio_main,
   logs,
   mdx,
-  mirage-crypto-rng-eio,
+  mirage-crypto-rng,
   ptime,
   tls,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "tls-eio";
 
   inherit (tls) src meta version;
 
   minimalOCamlVersion = "5.0";
 
-  # Tests are not compatible with mirage-crypto-rng 1.2.0
-  doCheck = false;
+  doCheck = true;
   nativeCheckInputs = [
     mdx.bin
   ];
@@ -31,7 +30,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     ptime
     eio
-    mirage-crypto-rng-eio
+    mirage-crypto-rng
     tls
   ];
 }

--- a/pkgs/development/ocaml-modules/tls/lwt.nix
+++ b/pkgs/development/ocaml-modules/tls/lwt.nix
@@ -2,10 +2,10 @@
   buildDunePackage,
   tls,
   lwt,
-  mirage-crypto-rng-lwt,
+  mirage-crypto-rng,
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "tls-lwt";
 
   inherit (tls) src meta version;
@@ -16,7 +16,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     lwt
-    mirage-crypto-rng-lwt
+    mirage-crypto-rng
     tls
   ];
 }

--- a/pkgs/development/ocaml-modules/tls/mirage.nix
+++ b/pkgs/development/ocaml-modules/tls/mirage.nix
@@ -3,11 +3,11 @@
   tls,
   fmt,
   lwt,
-  mirage-clock,
   mirage-crypto,
   mirage-crypto-pk,
   mirage-flow,
   mirage-kv,
+  mirage-ptime,
   ptime,
 }:
 
@@ -18,11 +18,11 @@ buildDunePackage {
   propagatedBuildInputs = [
     fmt
     lwt
-    mirage-clock
     mirage-crypto
     mirage-crypto-pk
     mirage-flow
     mirage-kv
+    mirage-ptime
     ptime
     tls
   ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1216,6 +1216,8 @@ let
 
     mirage-protocols = callPackage ../development/ocaml-modules/mirage-protocols { };
 
+    mirage-ptime = callPackage ../development/ocaml-modules/mirage-ptime { };
+
     mirage-random = callPackage ../development/ocaml-modules/mirage-random { };
 
     mirage-random-test = callPackage ../development/ocaml-modules/mirage-random-test { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
