### PR TITLE
mumble: Enable build on Darwin

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -116,7 +116,6 @@ let
 
       cmakeFlags = [
         "-D server=OFF"
-        "-D bundled-celt=ON"
         "-D bundled-speex=OFF"
         "-D bundle-qt-translations=OFF"
         "-D update=OFF"

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -33,6 +33,7 @@
   speechdSupport ? false,
   speechd-minimal,
   microsoft-gsl,
+  nlohmann_json,
 }:
 
 let
@@ -59,6 +60,7 @@ let
           poco
           protobuf
           microsoft-gsl
+          nlohmann_json
         ] ++ (overrides.buildInputs or [ ]);
 
         cmakeFlags = [
@@ -66,6 +68,7 @@ let
           "-D CMAKE_CXX_STANDARD=17" # protobuf >22 requires C++ 17
           "-D BUILD_NUMBER=${lib.versions.patch source.version}"
           "-D bundled-gsl=OFF"
+          "-D bundled-json=OFF"
         ] ++ (overrides.cmakeFlags or [ ]);
 
         preConfigure = ''
@@ -102,7 +105,6 @@ let
           libvorbis
           qt5.qtsvg
           rnnoise
-          speex
         ]
         ++ lib.optional (!jackSupport) alsa-lib
         ++ lib.optional jackSupport libjack2

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -148,7 +148,6 @@ let
         ]
         ++ lib.optionals iceSupport [
           "-D Ice_HOME=${lib.getDev zeroc-ice};${lib.getLib zeroc-ice}"
-          "-D CMAKE_PREFIX_PATH=${lib.getDev zeroc-ice};${lib.getLib zeroc-ice}"
           "-D Ice_SLICE_DIR=${lib.getDev zeroc-ice}/share/ice/slice"
         ];
 

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -113,10 +113,10 @@ let
         ++ lib.optional pulseSupport libpulseaudio
         ++ lib.optional pipewireSupport pipewire;
 
+
       cmakeFlags = [
         "-D server=OFF"
         "-D bundled-celt=ON"
-        "-D bundled-opus=OFF"
         "-D bundled-speex=OFF"
         "-D bundle-qt-translations=OFF"
         "-D update=OFF"

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -107,22 +107,22 @@ let
         ++ lib.optional pulseSupport libpulseaudio
         ++ lib.optional pipewireSupport pipewire;
 
-      cmakeFlags =
-        [
-          "-D server=OFF"
-          "-D bundled-celt=ON"
-          "-D bundled-opus=OFF"
-          "-D bundled-speex=OFF"
-          "-D bundle-qt-translations=OFF"
-          "-D update=OFF"
-          "-D overlay-xcompile=OFF"
-          "-D oss=OFF"
-          "-D warnings-as-errors=OFF" # conversion error workaround
-        ]
-        ++ lib.optional (!speechdSupport) "-D speechd=OFF"
-        ++ lib.optional (!pulseSupport) "-D pulseaudio=OFF"
-        ++ lib.optional (!pipewireSupport) "-D pipewire=OFF"
-        ++ lib.optional jackSupport "-D alsa=OFF -D jackaudio=ON";
+      cmakeFlags = [
+        "-D server=OFF"
+        "-D bundled-celt=ON"
+        "-D bundled-opus=OFF"
+        "-D bundled-speex=OFF"
+        "-D bundle-qt-translations=OFF"
+        "-D update=OFF"
+        "-D overlay-xcompile=OFF"
+        "-D oss=OFF"
+        "-D warnings-as-errors=OFF" # conversion error workaround
+        (lib.cmakeBool "speechd" speechdSupport)
+        (lib.cmakeBool "pulseaudio" pulseSupport)
+        (lib.cmakeBool "pipewire" pipewireSupport)
+        (lib.cmakeBool "jackaudio" jackSupport)
+        (lib.cmakeBool "alsa" (!jackSupport))
+      ];
 
       env.NIX_CFLAGS_COMPILE = lib.optionalString speechdSupport "-I${speechd-minimal}/include/speech-dispatcher";
 
@@ -144,8 +144,8 @@ let
       cmakeFlags =
         [
           "-D client=OFF"
+          (lib.cmakeBool "ice" iceSupport)
         ]
-        ++ lib.optional (!iceSupport) "-D ice=OFF"
         ++ lib.optionals iceSupport [
           "-D Ice_HOME=${lib.getDev zeroc-ice};${lib.getLib zeroc-ice}"
           "-D CMAKE_PREFIX_PATH=${lib.getDev zeroc-ice};${lib.getLib zeroc-ice}"

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -63,7 +63,7 @@ let
           "-D g15=OFF"
           "-D CMAKE_CXX_STANDARD=17" # protobuf >22 requires C++ 17
           "-D BUILD_NUMBER=${lib.versions.patch source.version}"
-        ] ++ (overrides.configureFlags or [ ]);
+        ] ++ (overrides.cmakeFlags or [ ]);
 
         preConfigure = ''
           patchShebangs scripts
@@ -107,7 +107,7 @@ let
         ++ lib.optional pulseSupport libpulseaudio
         ++ lib.optional pipewireSupport pipewire;
 
-      configureFlags =
+      cmakeFlags =
         [
           "-D server=OFF"
           "-D bundled-celt=ON"
@@ -141,7 +141,7 @@ let
     generic {
       type = "murmur";
 
-      configureFlags =
+      cmakeFlags =
         [
           "-D client=OFF"
         ]
@@ -161,7 +161,7 @@ let
       stdenv = stdenv_32bit;
       type = "mumble-overlay";
 
-      configureFlags = [
+      cmakeFlags = [
         "-D server=OFF"
         "-D client=OFF"
         "-D overlay=ON"

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   qt5,
   cmake,
@@ -150,6 +151,12 @@ let
       patches = [
         ./disable-overlay-build.patch
         ./fix-plugin-copy.patch
+        # Can be removed before the next update of Mumble, as that fix was upstreamed
+        # fix version display in MacOS Finder
+        (fetchpatch {
+          url = "https://github.com/mumble-voip/mumble/commit/fbd21bd422367bed19f801bf278562f567cbb8b7.patch";
+          sha256 = "sha256-qFhC2j/cOWzAhs+KTccDIdcgFqfr4y4VLjHiK458Ucs=";
+        })
       ];
 
       postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -32,6 +32,7 @@
   libpulseaudio,
   speechdSupport ? false,
   speechd-minimal,
+  microsoft-gsl,
 }:
 
 let
@@ -57,12 +58,14 @@ let
           boost
           poco
           protobuf
+          microsoft-gsl
         ] ++ (overrides.buildInputs or [ ]);
 
         cmakeFlags = [
           "-D g15=OFF"
           "-D CMAKE_CXX_STANDARD=17" # protobuf >22 requires C++ 17
           "-D BUILD_NUMBER=${lib.versions.patch source.version}"
+          "-D bundled-gsl=OFF"
         ] ++ (overrides.cmakeFlags or [ ]);
 
         preConfigure = ''

--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -10,8 +10,8 @@
   boost,
   libopus,
   libsndfile,
+  speexdsp,
   protobuf,
-  speex,
   libcap,
   alsa-lib,
   python3,
@@ -103,6 +103,7 @@ let
           libopus
           libsndfile
           libvorbis
+          speexdsp
           qt5.qtsvg
           rnnoise
         ]

--- a/pkgs/applications/networking/mumble/disable-overlay-build.patch
+++ b/pkgs/applications/networking/mumble/disable-overlay-build.patch
@@ -1,0 +1,21 @@
+diff --git a/macx/scripts/osxdist.py b/macx/scripts/osxdist.py
+index bdc7fcbd2..2114caf37 100755
+--- a/macx/scripts/osxdist.py
++++ b/macx/scripts/osxdist.py
+@@ -128,7 +128,7 @@ class AppBundle(object):
+ 				shutil.copy(rsrc, os.path.join(rsrcpath, b))
+
+ 		# Extras
+-		shutil.copy(os.path.join(options.binary_dir, 'MumbleOverlay.pkg'), os.path.join(rsrcpath, 'MumbleOverlay.pkg'))
++		# shutil.copy(os.path.join(options.binary_dir, 'MumbleOverlay.pkg'), os.path.join(rsrcpath, 'MumbleOverlay.pkg'))
+
+ 	def copy_codecs(self):
+ 		'''
+@@ -275,7 +276,7 @@ def package_client():
+ 		title = 'Mumble %s' % ver
+
+ 	# Fix overlay installer package
+-	create_overlay_package()
++	# create_overlay_package()
+ 	if options.only_overlay:
+ 		sys.exit(0)

--- a/pkgs/applications/networking/mumble/fix-plugin-copy.patch
+++ b/pkgs/applications/networking/mumble/fix-plugin-copy.patch
@@ -1,0 +1,13 @@
+diff --git a/macx/scripts/osxdist.py b/macx/scripts/osxdist.py
+index bdc7fcbd2..2114caf37 100755
+--- a/macx/scripts/osxdist.py
++++ b/macx/scripts/osxdist.py
+@@ -151,7 +151,7 @@ class AppBundle(object):
+ 		dst = os.path.join(self.bundle, 'Contents', 'Plugins')
+ 		if not os.path.exists(dst):
+ 			os.makedirs(dst)
+-		for plugin in glob.glob(os.path.join(options.binary_dir, 'plugins') + '/*.dylib'):
++		for plugin in glob.glob(os.path.join(options.binary_dir, 'lib/mumble/plugins') + '/*.dylib'):
+ 			shutil.copy(plugin, dst)
+
+ 	def update_plist(self):


### PR DESCRIPTION
## Things done

- Modernize mumble build, to use lib.cmake* functions to specify the cmake options
- Rename configureFlags to cmakeFlags, as the build had both, but it is actually a cmake build
- Add Install-Phase to copy the built Application and create a wrapper to start mumble from the shell.

There is more work to be done, and I'd appreciate some guidance:
- The app is missing it's icon, no idea why
- There should be some libraries built, and I seem to be missing them? Other builds depend on mumble to get their libraries. This might be a mistake, it might be that the overlay build target is actually the one that builds should depend on, but I don't understand this yet.
- …

This is based on my poco pull request, as poco is a dependency that didn't build on Darwin before, so that update is required. This is also one of the reasons I'm marking this as draft, to get early feedback.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
