### PR TITLE
n-m3u8dl-re: init at 0.3.0-beta

### DIFF
--- a/pkgs/by-name/n-/n-m3u8dl-re/deps.json
+++ b/pkgs/by-name/n-/n-m3u8dl-re/deps.json
@@ -1,0 +1,17 @@
+[
+  {
+    "pname": "NiL.JS",
+    "version": "2.5.1684",
+    "hash": "sha256-lxFTYyuj0SuNzIQGq+rK9s0tAqxqQg8PBj/YdktJunw="
+  },
+  {
+    "pname": "Spectre.Console",
+    "version": "0.49.2-preview.0.50",
+    "hash": "sha256-ivFyHTfQxPf/RIin+aftmd+G4PcrqmJXmdu0u/RU6YA="
+  },
+  {
+    "pname": "System.CommandLine",
+    "version": "2.0.0-beta4.22272.1",
+    "hash": "sha256-zSO+CYnMH8deBHDI9DHhCPj79Ce3GOzHCyH1/TiHxcc="
+  }
+]

--- a/pkgs/by-name/n-/n-m3u8dl-re/package.nix
+++ b/pkgs/by-name/n-/n-m3u8dl-re/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildDotnetModule,
+  fetchFromGitHub,
+  dotnetCorePackages,
+}:
+buildDotnetModule rec {
+  pname = "n-m3u8dl-re";
+  version = "0.3.0-beta";
+  src = fetchFromGitHub {
+    owner = "nilaoda";
+    repo = "N_m3u8DL-RE";
+    tag = "v${version}";
+    sha256 = "sha256-AVLO7pxD1LCoogsJPPN5aoOmVBIm3Y/EVsiQWdYI6QU=";
+  };
+  patches = [
+    ./publish-fix.patch
+    ./reverse-arr.patch
+  ];
+
+  # from openutau/default.nix
+  # [...]/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(248,5): error MSB4018: The "GenerateDepsFile" task failed unexpectedly. [[...]/N_m3u8DL-RE.Common.csproj]
+  # [...]/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(248,5): error MSB4018: System.IO.IOException: The process cannot access the file '[...]/N_m3u8DL-RE.Common.deps.json' because it is being used by another process. [[...]/N_m3u8DL-RE.Common.csproj]
+  enableParallelBuilding = false;
+
+  projectFile = "src/N_m3u8DL-RE.sln";
+  nugetDeps = ./deps.json;
+
+  executables = [ "N_m3u8DL-RE" ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.runtime_9_0;
+
+  postFixup = ''
+    ln -s $out/bin/N_m3u8DL-RE $out/bin/n-m3u8dl-re
+  '';
+
+  meta = {
+    description = "Cross-Platform, modern and powerful stream downloader for MPD/M3U8/ISM";
+    homepage = "https://github.com/nilaoda/N_m3u8DL-RE";
+    license = lib.licenses.mit;
+    mainProgram = "n-m3u8dl-re";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    platforms = lib.platforms.linux ++ lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/n-/n-m3u8dl-re/publish-fix.patch
+++ b/pkgs/by-name/n-/n-m3u8dl-re/publish-fix.patch
@@ -1,0 +1,10 @@
+--- a/src/N_m3u8DL-RE/Directory.Build.props
++++ b/src/N_m3u8DL-RE/Directory.Build.props
+@@ -9,7 +9,6 @@
+     <IlcTrimMetadata>true</IlcTrimMetadata>
+     <IlcGenerateStackTraceData>true</IlcGenerateStackTraceData>
+     <SatelliteResourceLanguages>zh-CN;zh-TW;en-US</SatelliteResourceLanguages>
+-    <PublishAot>true</PublishAot>
+     <StripSymbols>true</StripSymbols>
+     <ObjCopyName Condition="'$(RuntimeIdentifier)' == 'linux-arm64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">aarch64-linux-gnu-objcopy</ObjCopyName>
+   </PropertyGroup>

--- a/pkgs/by-name/n-/n-m3u8dl-re/reverse-arr.patch
+++ b/pkgs/by-name/n-/n-m3u8dl-re/reverse-arr.patch
@@ -1,0 +1,42 @@
+diff --git a/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs b/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs
+index 6b6d284..b57fc24 100644
+--- a/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs
++++ b/src/N_m3u8DL-RE.Common/Entity/WebVttSub.cs
+@@ -201,7 +201,8 @@ public partial class WebVttSub
+             time += Convert.ToInt32(parts.Last().PadRight(3, '0'));
+             str = parts.First();
+         }
+-        var t = str.Split(':').Reverse().ToList();
++        var t = str.Split(':').ToList();
++        t.Reverse();
+         for (int i = 0; i < t.Count; i++)
+         {
+             time += (long)Math.Pow(60, i) * Convert.ToInt32(t[i]) * 1000;
+@@ -265,4 +266,4 @@ public partial class WebVttSub
+ 
+         return srt;
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/src/N_m3u8DL-RE/Util/OtherUtil.cs b/src/N_m3u8DL-RE/Util/OtherUtil.cs
+index b2487f3..4eab23f 100644
+--- a/src/N_m3u8DL-RE/Util/OtherUtil.cs
++++ b/src/N_m3u8DL-RE/Util/OtherUtil.cs
+@@ -70,7 +70,8 @@ internal static partial class OtherUtil
+         var hours = -1;
+         var mins = -1;
+         var secs = -1;
+-        arr.Reverse().Select(i => Convert.ToInt32(i)).ToList().ForEach(item =>
++        arr.Reverse();
++        arr.Select(i => Convert.ToInt32(i)).ToList().ForEach(item =>
+         {
+             if (secs == -1) secs = item;
+             else if (mins == -1) mins = item;
+@@ -170,4 +171,4 @@ internal static partial class OtherUtil
+ 
+     [GeneratedRegex(@"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")]
+     private static partial Regex TimeStrRegex();
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
closes #347115

adapted from https://github.com/luis-caldas/nix/blob/517ebc1bbfdfed4ac2d4dca4a5873505889f379d/pkgs/stable/n-m3u8dl-re/default.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @luis-caldas @Lusephur @TheTechRun

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
