### PR TITLE
flite: fix building with clang + glibc

### DIFF
--- a/pkgs/by-name/fl/flite/0001-Remove-defining-const-as-nothing.patch
+++ b/pkgs/by-name/fl/flite/0001-Remove-defining-const-as-nothing.patch
@@ -1,0 +1,79 @@
+From c71d844f5639ea447b9f795a4db5b5d43f0de814 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 2 Jul 2024 21:41:24 -0700
+Subject: [PATCH] Remove defining 'const' as nothing
+
+This is a hack to override constness of struct members
+however, with modern compiler like clang with fortified
+glibc ( 2.40+ ) headers this runs into compiler errors
+
+| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/flite/2.2/recipe-sysroot/usr/include/bits/stdlib.h:38:54: error: pass_object_size attribute only applies to constant pointer arguments
+|    38 |                  __fortify_clang_overload_arg (char *, __restrict, __resolved)))
+|       |                                                                    ^
+| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/flite/2.2/recipe-sysroot/usr/include/bits/stdlib.h:73:43: error: pass_object_size attribute only applies to constant pointer arguments
+|    73 |                  __fortify_clang_overload_arg (char *, ,__buf),
+|       |                                                         ^
+| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/flite/2.2/recipe-sysroot/usr/include/bits/stdlib.h:91:55: error: pass_object_size attribute only applies to constant pointer arguments
+|    91 | __NTH (wctomb (__fortify_clang_overload_arg (char *, ,__s), wchar_t __wchar))
+|       |                                                       ^
+| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/flite/2.2/recipe-sysroot/usr/include/bits/stdlib.h:129:71: error: pass_object_size attribute only applies to constant pointer arguments
+|   129 | __NTH (mbstowcs (__fortify_clang_overload_arg (wchar_t *, __restrict, __dst),
+|       |                                                                       ^
+| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/flite/2.2/recipe-sysroot/usr/include/bits/stdlib.h:159:68: error: pass_object_size attribute only applies to constant pointer arguments
+|   159 | __NTH (wcstombs (__fortify_clang_overload_arg (char *, __restrict, __dst),
+|       |                                                                    ^
+| 5 errors generated.
+|
+
+Therefore take this out, instead cast away the 'const' qualifier where needed ( equilly dangerous )
+however limited to just this file instead of apply to all headers including system headers
+
+Upstream-Status: Submitted [https://github.com/festvox/flite/pull/112]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tools/find_sts_main.c | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/tools/find_sts_main.c b/tools/find_sts_main.c
+index 3c94449..a5bf8ef 100644
+--- a/tools/find_sts_main.c
++++ b/tools/find_sts_main.c
+@@ -41,9 +41,6 @@
+ #include <math.h>
+ #include <string.h>
+ 
+-/* To allow some normally const fields to manipulated during building */
+-#define const
+-
+ #include "cst_args.h"
+ #include "cst_wave.h"
+ #include "cst_track.h"
+@@ -132,16 +129,16 @@ cst_sts *find_sts(cst_wave *sig, cst_track *lpc)
+ 			lpc->frames[i],lpc->num_channels,
+ 			resd,
+ 			size);
+-	sts[i].size = size;
++	*(int *)(&sts[i].size) = size;
+ 	sts[i].frame = cst_alloc(unsigned short,lpc->num_channels-1);
+ 	for (j=1; j < lpc->num_channels; j++)
+-	    sts[i].frame[j-1] = (unsigned short)
++	    *(unsigned short *)(&sts[i].frame[j-1]) = (unsigned short)
+ 		(((lpc->frames[i][j]-lpc_min)/lpc_range)*65535);
+         if (cst_streq(residual_codec,"ulaw"))
+         {
+             sts[i].residual = cst_alloc(unsigned char,size);
+             for (j=0; j < size; j++)
+-                sts[i].residual[j] = cst_short_to_ulaw((short)resd[j]);
++                *(unsigned char *)(&sts[i].residual[j]) = cst_short_to_ulaw((short)resd[j]);
+         }
+         else if (cst_streq(residual_codec,"g721"))
+         {
+@@ -189,7 +186,7 @@ cst_sts *find_sts(cst_wave *sig, cst_track *lpc)
+             {
+                 sts[i].residual = cst_alloc(unsigned char,size);
+                 for (j=0; j < size; j++)
+-                    sts[i].residual[j] = cst_short_to_ulaw((short)resd[j]);
++                    *(unsigned char *)(&sts[i].residual[j]) = cst_short_to_ulaw((short)resd[j]);
+             } 
+             else /* Unvoiced frame */
+             {

--- a/pkgs/by-name/fl/flite/package.nix
+++ b/pkgs/by-name/fl/flite/package.nix
@@ -27,19 +27,26 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "festvox";
     repo = "flite";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Tq5pyg3TiQt8CPqGXTyLOaGgaeLTmPp+Duw3+2VAF9g=";
   };
 
-  # https://github.com/festvox/flite/pull/60.
-  # Replaces `ar` with `$(AR)` in config/common_make_rules.
-  # Improves cross-compilation compatibility.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/festvox/flite/commit/54c65164840777326bbb83517568e38a128122ef.patch";
-      hash = "sha256-hvKzdX7adiqd9D+9DbnfNdqEULg1Hhqe1xElYxNM1B8=";
-    })
-  ];
+  patches =
+    [
+      # https://github.com/festvox/flite/pull/60.
+      # Replaces `ar` with `$(AR)` in config/common_make_rules.
+      # Improves cross-compilation compatibility.
+      (fetchpatch {
+        url = "https://github.com/festvox/flite/commit/54c65164840777326bbb83517568e38a128122ef.patch";
+        hash = "sha256-hvKzdX7adiqd9D+9DbnfNdqEULg1Hhqe1xElYxNM1B8=";
+      })
+    ]
+    # Fixes (fortified) builds with clang against glibc >= 2.40
+    # https://lists.openembedded.org/g/openembedded-devel/message/111217
+    # https://github.com/NixOS/nixpkgs/issues/384409
+    ++ lib.optional (
+      stdenv.cc.isClang && stdenv.hostPlatform.libc == "glibc"
+    ) ./0001-Remove-defining-const-as-nothing.patch;
 
   buildInputs = lib.optional stdenv.hostPlatform.isLinux (
     {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/384409

See also:

- https://bugs.gentoo.org/938721
- https://lists.openembedded.org/g/openembedded-devel/message/111217


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
