### PR TITLE
[Backport release-24.11] mdevctl: fix script dir location

### DIFF
--- a/nixos/modules/programs/mdevctl.nix
+++ b/nixos/modules/programs/mdevctl.nix
@@ -16,8 +16,9 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ mdevctl ];
 
-    environment.etc."mdevctl.d/scripts.d/notifiers/.keep".text = "";
-    environment.etc."mdevctl.d/scripts.d/callouts/.keep".text = "";
+    environment.etc."mdevctl.d/.keep".text = "";
+    environment.etc."mdevctl/scripts.d/notifiers/.keep".text = "";
+    environment.etc."mdevctl/scripts.d/callouts/.keep".text = "";
 
   };
 }

--- a/pkgs/by-name/md/mdevctl/package.nix
+++ b/pkgs/by-name/md/mdevctl/package.nix
@@ -15,7 +15,13 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-4K4NW3DOTtzZJ7Gg0mnRPr88YeqEjTtKX+C4P8i923E=";
   };
 
-  cargoHash = "sha256-hCqNy32uPLsKfUJqiG2DRcXfqdvlp4bCutQmt+FieXc=";
+  # https://github.com/mdevctl/mdevctl/issues/111
+  patches = [
+    ./script-dir.patch
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xfrW7WiKBM9Hz49he/42z9gBrwZ3sKGH/u105hcyln0=";
 
   nativeBuildInputs = [
     docutils

--- a/pkgs/by-name/md/mdevctl/script-dir.patch
+++ b/pkgs/by-name/md/mdevctl/script-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/src/environment.rs b/src/environment.rs
+index 3db5933..f6da56c 100644
+--- a/src/environment.rs
++++ b/src/environment.rs
+@@ -35,7 +35,7 @@ pub trait Environment {
+     }
+ 
+     fn scripts_base(&self) -> PathBuf {
+-        self.root().join("usr/lib/mdevctl/scripts.d")
++        self.root().join("etc/mdevctl/scripts.d")
+     }
+ 
+     fn callout_dir(&self) -> PathBuf {


### PR DESCRIPTION
Bot-based backport to `release-24.11`, triggered by a label in #383111.

* [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.