### PR TITLE
xash3d-fwgs: init at 0-unstable-2026-02-25

### DIFF
--- a/pkgs/by-name/hl/hlsdk-portable/package.nix
+++ b/pkgs/by-name/hl/hlsdk-portable/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  wafHook,
+  python3,
+}:
+
+stdenv.mkDerivation {
+  pname = "hlsdk-portable";
+
+  # Taken from build script: https://github.com/FWGS/hlsdk-portable/blob/afe7d33e15c75fa61fc5a8e287bc484146e7c377/wscript#L10
+  version = "2.4";
+
+  src = fetchFromGitHub {
+    owner = "FWGS";
+    repo = "hlsdk-portable";
+    fetchSubmodules = true;
+    rev = "afe7d33e15c75fa61fc5a8e287bc484146e7c377";
+    hash = "sha256-lR5otfTur9yRcyAt/NkcCIYcqsMg2QQ+EdkA8o18vA0=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    wafHook
+  ];
+
+  dontAddPrefix = true;
+
+  wafConfigureFlags = [ "-T release" ] ++ lib.optionals stdenv.buildPlatform.is64bit [ "-8" ];
+
+  wafInstallFlags = [ "--destdir=${placeholder "out"}" ];
+
+  meta = {
+    homepage = "https://github.com/FWGS/hlsdk-portable";
+    description = "Portable crossplatform Half-Life SDK for GoldSource and Xash3D engines";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ r4v3n6101 ];
+  };
+}

--- a/pkgs/by-name/xa/xash3d-fwgs/package.nix
+++ b/pkgs/by-name/xa/xash3d-fwgs/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  ensureNewerSourcesForZipFilesHook,
+  python3,
+  pkg-config,
+  wafHook,
+  SDL2,
+  libx11,
+  freetype,
+  opusfile,
+  libopus,
+  libogg,
+  libvorbis,
+  bzip2,
+  hlsdk-portable,
+  makeWrapper,
+
+  # Options
+  buildSdk ? false,
+  buildServer ? false,
+}:
+let
+  exe = if buildServer then "xash" else "xash3d";
+in
+stdenv.mkDerivation {
+  pname = "xash3d-fwgs";
+  version = "0-unstable-2026-02-25";
+
+  src = fetchFromGitHub {
+    owner = "FWGS";
+    repo = "xash3d-fwgs";
+    rev = "2c004e6cb78f0b435f2923a5105c9df43130e337";
+    hash = "sha256-Bh0JaeDO/RrMSQKvqJGbmrQoG1aR7Q+5YnBEedARliU=";
+    postCheckout = ''
+      cd $out/3rdparty
+      git submodule update --init --recursive \
+        MultiEmulator extras/xash-extras gl-wes-v2 gl4es/gl4es \
+        libbacktrace/libbacktrace library_suffix maintui mainui nanogl \
+        vgui_support
+    '';
+  };
+
+  nativeBuildInputs = [
+    ensureNewerSourcesForZipFilesHook
+    python3
+    pkg-config
+    wafHook
+    makeWrapper
+  ];
+
+  buildInputs =
+    lib.optionals (!buildServer) [
+      freetype
+      opusfile
+      libopus
+      libogg
+      libvorbis
+      bzip2
+      SDL2
+    ]
+    ++ lib.optionals (!buildServer && stdenv.isLinux) [
+      libx11
+    ];
+
+  dontAddPrefix = true;
+
+  wafConfigureFlags = [
+    "-T release"
+  ]
+  ++ lib.optionals buildServer [
+    "-d"
+  ]
+  ++ lib.optionals (!buildServer) [
+    "--sdl-use-pkgconfig"
+  ]
+  ++ lib.optionals stdenv.buildPlatform.is64bit [ "-8" ];
+
+  wafInstallFlags = [ "--destdir=${placeholder "out"}/lib" ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    mv $out/lib/${exe} $out/bin/${exe}-unwrapped
+    makeWrapper $out/bin/${exe}-unwrapped $out/bin/${exe} \
+      --set XASH3D_RODIR $out/lib/valve \
+      --run "export XASH3D_BASEDIR=\$HOME/.xash3d/" \
+      --prefix ${
+        if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"
+      } : "$out/lib"
+  ''
+  + lib.optionalString buildSdk "cp -TR ${hlsdk-portable}/valve $out/lib/valve";
+
+  meta = {
+    homepage = "https://github.com/FWGS/xash3d-fwgs";
+    description = "Xash3D FWGS engine";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ r4v3n6101 ];
+    mainProgram = exe;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11445,6 +11445,8 @@ with pkgs;
     xonotic
     ;
 
+  xash-dedicated = callPackage ../by-name/xa/xash3d-fwgs/package.nix { buildServer = true; };
+
   xonotic-glx =
     (callPackage ../games/xonotic {
       withSDL = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description

This PR adds three new packages: xash, xash-sdk, and xash-dedicated. These provide the Xash3D engine, an open-source reimplementation of Half-Life's GoldSrc engine.

**xash3d-fwgs**: The main game engine.
**xash-sdk**: SDK for mod development (also required by the game, since the Steam version is only for 32 bits).
**xash-dedicated**: Dedicated server for hosting servers. 

## Motivation

Repositories do not contain xash (or other Half-Life engines), but they contain other games, such as Quake. I believe it would be beneficial to enhance this situation creating these packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
