### PR TITLE
nixos/h2o: TLS recommendations

### DIFF
--- a/nixos/modules/services/web-servers/h2o/common.nix
+++ b/nixos/modules/services/web-servers/h2o/common.nix
@@ -1,0 +1,46 @@
+{ lib }:
+{
+  tlsRecommendationsOption = lib.mkOption {
+    type = lib.types.nullOr (
+      lib.types.enum [
+        "modern"
+        "intermediate"
+        "old"
+      ]
+    );
+    default = null;
+    example = "intermediate";
+    description = ''
+      By default, H2O, without prejudice, will use as many TLS versions &
+      cipher suites as it & the TLS library (OpenSSL) can support. The user is
+      expected to hone settings for the security of their server. Setting some
+      constraints is recommended, & if unsure about what TLS settings to use,
+      this option gives curated TLS settings recommendations from Mozilla’s
+      ‘SSL Configuration Generator’ project (see
+      <https://ssl-config.mozilla.org>) or read more at Mozilla’s Wiki (see
+      <https://wiki.mozilla.org/Security/Server_Side_TLS>).
+
+      modern
+      : Services with clients that support TLS 1.3 & don’t need backward
+        compatibility
+
+      intermediate
+      : General-purpose servers with a variety of clients, recommended for
+        almost all systems
+
+      old
+      : Compatible with a number of very old clients, & should be used only as
+        a last resort
+
+      The default for all virtual hosts can be set with
+      services.h2o.defaultTLSRecommendations, but this value can be overridden
+      on a per-host basis using services.h2o.hosts.<name>.tls.recommmendations.
+      The settings will also be overidden by manual values set with
+      services.settings.h2o.hosts.<name>.tls.extraSettings.
+
+      NOTE: older/weaker ciphers might require overriding the OpenSSL version
+      of H2O (such as `openssl_legacy`). This can be done with
+      sevices.settings.h2o.package.
+    '';
+  };
+}

--- a/nixos/modules/services/web-servers/h2o/vhost-options.nix
+++ b/nixos/modules/services/web-servers/h2o/vhost-options.nix
@@ -195,6 +195,7 @@ in
 
     settings = mkOption {
       type = types.attrs;
+      default = { };
       description = ''
         Attrset to be transformed into YAML for host config. Note that the HTTP
         / TLS configurations will override these config values.

--- a/nixos/modules/services/web-servers/h2o/vhost-options.nix
+++ b/nixos/modules/services/web-servers/h2o/vhost-options.nix
@@ -1,4 +1,8 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 
 let
   inherit (lib)
@@ -6,6 +10,8 @@ let
     mkOption
     types
     ;
+
+  inherit (import ./common.nix { inherit lib; }) tlsRecommendationsOption;
 in
 {
   options = {
@@ -128,6 +134,7 @@ in
                     ]
                   '';
             };
+            recommendations = tlsRecommendationsOption;
             extraSettings = mkOption {
               type = types.attrs;
               default = { };

--- a/nixos/tests/web-servers/h2o/default.nix
+++ b/nixos/tests/web-servers/h2o/default.nix
@@ -13,4 +13,5 @@ in
 {
   basic = handleTestOn supportedSystems ./basic.nix { inherit system; };
   mruby = handleTestOn supportedSystems ./mruby.nix { inherit system; };
+  tls-recommendations = handleTestOn supportedSystems ./tls-recommendations.nix { inherit system; };
 }

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -1,0 +1,115 @@
+import ../../make-test-python.nix (
+  { lib, pkgs, ... }:
+
+  let
+    domain = "acme.test";
+    port = 8443;
+
+    hello_txt =
+      name:
+      pkgs.writeTextFile {
+        name = "/hello_${name}.txt";
+        text = "Hello, ${name}!";
+      };
+
+    mkH2OServer =
+      recommendations:
+      { pkgs, lib, ... }:
+      {
+        services.h2o = {
+          enable = true;
+          package = pkgs.h2o.override (
+            lib.optionalAttrs
+              (builtins.elem recommendations [
+                "intermediate"
+                "old"
+              ])
+              {
+                openssl = pkgs.openssl_legacy;
+              }
+          );
+          defaultTLSRecommendations = "modern"; # prove overridden
+          hosts = {
+            "${domain}" = {
+              tls = {
+                inherit port recommendations;
+                policy = "force";
+                identity = [
+                  {
+                    key-file = ../../common/acme/server/acme.test.key.pem;
+                    certificate-file = ../../common/acme/server/acme.test.cert.pem;
+                  }
+                ];
+              };
+              settings = {
+                paths."/"."file.file" = "${hello_txt recommendations}";
+              };
+            };
+          };
+          settings = {
+            ssl-offload = "kernel";
+          };
+        };
+
+        security.pki.certificates = [
+          (builtins.readFile ../../common/acme/server/ca.cert.pem)
+        ];
+
+        networking = {
+          firewall.allowedTCPPorts = [ port ];
+          extraHosts = "127.0.0.1 ${domain}";
+        };
+      };
+  in
+  {
+    name = "h2o-tls-recommendations";
+
+    meta = {
+      maintainers = with lib.maintainers; [ toastal ];
+    };
+
+    nodes = {
+      server_modern = mkH2OServer "modern";
+      server_intermediate = mkH2OServer "intermediate";
+      server_old = mkH2OServer "old";
+    };
+
+    testScript =
+      let
+        portStr = builtins.toString port;
+      in
+      # python
+      ''
+        curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:${portStr}/'"
+        curl_head = "curl -v --head 'https://${domain}:${portStr}/'"
+        curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:${portStr}/'"
+        curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:${portStr}/'"
+        curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:${portStr}/'"
+
+        server_modern.wait_for_unit("h2o.service")
+        modern_response = server_modern.succeed(curl_basic)
+        assert "Hello, modern!" in modern_response
+        modern_head = server_modern.succeed(curl_head)
+        assert "strict-transport-security" in modern_head
+        server_modern.fail(curl_max_tls1_2)
+
+        server_intermediate.wait_for_unit("h2o.service")
+        intermediate_response = server_intermediate.succeed(curl_basic)
+        assert "Hello, intermediate!" in intermediate_response
+        intermediate_head = server_modern.succeed(curl_head)
+        assert "strict-transport-security" in intermediate_head
+        server_intermediate.succeed(curl_max_tls1_2)
+        server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher)
+        server_intermediate.fail(curl_max_tls1_2_old_cipher)
+
+        server_old.wait_for_unit("h2o.service")
+        old_response = server_old.succeed(curl_basic)
+        assert "Hello, old!" in old_response
+        old_head = server_modern.succeed(curl_head)
+        assert "strict-transport-security" in old_head
+        server_old.succeed(curl_max_tls1_2)
+        server_old.succeed(curl_max_tls1_2_intermediate_cipher)
+        server_old.succeed(curl_max_tls1_2_old_cipher)
+      '';
+  }
+)


### PR DESCRIPTION
From Mozilla’s ssl-config-generator project… adds cipher suites & HSTS header. It should be as easy as `services.h2o.tlsRecommendations = "modern"`.

<span id="before-anyone-asks">Before anyone asks</span>: I am not interested at this time in pulling out these Mozilla recommendations into some abstraction other modules could use.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.