### PR TITLE
python3Packages.craft-parts: 2.6.1 -> 2.6.2

### DIFF
--- a/pkgs/development/python-modules/craft-parts/bash-path.patch
+++ b/pkgs/development/python-modules/craft-parts/bash-path.patch
@@ -29,14 +29,13 @@ index f2b4064..cb4e9e8 100644
      @override
      def get_build_environment(self) -> dict[str, str]:
 diff --git a/craft_parts/plugins/validator.py b/craft_parts/plugins/validator.py
-index 5b4c735..8ff30c2 100644
+index 5b4c735..d7a446e 100644
 --- a/craft_parts/plugins/validator.py
 +++ b/craft_parts/plugins/validator.py
-@@ -141,9 +141,9 @@ class PluginEnvironmentValidator:
-             print(self._env, file=env_file)
+@@ -142,8 +142,9 @@ class PluginEnvironmentValidator:
              print(cmd, file=env_file)
              env_file.flush()
--
+ 
 +            import shutil
              proc = subprocess.run(
 -                ["/bin/bash", env_file.name],
@@ -45,7 +44,7 @@ index 5b4c735..8ff30c2 100644
                  capture_output=True,
                  text=True,
 diff --git a/tests/unit/executor/test_step_handler.py b/tests/unit/executor/test_step_handler.py
-index 4e73c2b..b762fb8 100644
+index 4e73c2b..a5f9374 100644
 --- a/tests/unit/executor/test_step_handler.py
 +++ b/tests/unit/executor/test_step_handler.py
 @@ -209,9 +209,10 @@ class TestStepHandlerBuiltins:
@@ -56,21 +55,21 @@ index 4e73c2b..b762fb8 100644
              assert file.read() == dedent(
                  f"""\
 -                #!/bin/bash
-+                #!{shutil.which('bash')}
++                #!{shutil.which("bash")}
                  set -euo pipefail
                  source {environment_script_path}
                  set -x
 diff --git a/tests/unit/utils/test_process.py b/tests/unit/utils/test_process.py
-index 84b29ad..dc2d772 100644
+index a025494..a76cfa2 100644
 --- a/tests/unit/utils/test_process.py
 +++ b/tests/unit/utils/test_process.py
 @@ -33,7 +33,8 @@ _RUN_TEST_CASES = [
  
  @pytest.mark.parametrize(("out", "err"), _RUN_TEST_CASES)
  def test_run(out, err):
--    result = process.run(["/usr/bin/sh", "-c", f"echo {out};sleep 0;echo {err} >&2"])
+-    result = process.run(["/usr/bin/sh", "-c", f"echo {out};sleep 0.1;echo {err} >&2"])
 +    import shutil
-+    result = process.run([shutil.which("sh"), "-c", f"echo {out};sleep 0;echo {err} >&2"])
++    result = process.run([shutil.which("sh"), "-c", f"echo {out};sleep 0.1;echo {err} >&2"])
      assert result.returncode == 0
      assert result.stdout == (out + "\n").encode()
      assert result.stderr == (err + "\n").encode()
@@ -95,5 +94,5 @@ index 84b29ad..dc2d772 100644
 -            "/usr/bin/sh",
 +            shutil.which("sh"),
              "-c",
-             f"echo {out};sleep 0;echo {err} >&2; echo -n {out}|socat - UNIX-CONNECT:{new_dir}/test.socket",
+             f"echo {out};sleep 0.1;echo {err} >&2; echo -n {out}|socat - UNIX-CONNECT:{new_dir}/test.socket",
          ],

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "craft-parts";
-  version = "2.6.1";
+  version = "2.6.2";
 
   pyproject = true;
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-parts";
     tag = version;
-    hash = "sha256-KQS4jjA66rROglOrGR7UofJL+oYEEC2X+o6pROrR5r4=";
+    hash = "sha256-3NFbAxgY183RmZ+ats6M5WM07VO2amj7EdqMCLcKNvI=";
   };
 
   patches = [ ./bash-path.patch ];


### PR DESCRIPTION
## Things done

Bump to latest upstream release; resulted in a slight change to one of the patches which affects one of the unit tests: https://github.com/canonical/craft-parts/compare/2.6.1...2.6.2

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
