### PR TITLE
make{Script; Binary}Wrapper: log if target file does not exist

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -3,6 +3,8 @@
 # assertExecutable FILE
 assertExecutable() {
     local file="$1"
+    [[ -e "$file" ]] || \
+        die "Cannot wrap '$file' because it does not exist"
     [[ -f "$file" && -x "$file" ]] || \
         die "Cannot wrap '$file' because it is not an executable file"
 }

--- a/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
+++ b/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # assertExecutable FILE
 assertExecutable() {
     local file="$1"
+    [[ -e "$file" ]] || \
+        die "Cannot wrap '$file' because it does not exist"
     [[ -f "$file" && -x "$file" ]] || \
         die "Cannot wrap '$file' because it is not an executable file"
 }


### PR DESCRIPTION
log if target file does not exist. useful if there is a typo when developing a package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested:
  - `makeScriptWrapper.tests`
  - `makeBinaryWrapper.tests`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
