### PR TITLE
prismlauncher-unwrapped: add patch to make MangoHud 0.8 work correctly

### DIFF
--- a/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
+++ b/pkgs/by-name/pr/prismlauncher-unwrapped/package.nix
@@ -5,6 +5,7 @@
   cmake,
   cmark,
   extra-cmake-modules,
+  fetchpatch,
   gamemode,
   ghc_filesystem,
   jdk17,
@@ -14,11 +15,9 @@
   stripJavaArchivesHook,
   tomlplusplus,
   zlib,
-
   msaClientID ? null,
   gamemodeSupport ? stdenv.hostPlatform.isLinux,
 }:
-
 let
   libnbtplusplus = fetchFromGitHub {
     owner = "PrismLauncher";
@@ -27,11 +26,9 @@ let
     hash = "sha256-yy0q+bky80LtK1GWzz7qpM+aAGrOqLuewbid8WT1ilk=";
   };
 in
-
 assert lib.assertMsg (
   gamemodeSupport -> stdenv.hostPlatform.isLinux
 ) "gamemodeSupport is only available on Linux.";
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "prismlauncher-unwrapped";
   version = "9.2";
@@ -86,6 +83,15 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
       (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
     ];
+
+  patches = [
+    # This patch allows Mangohud 0.8 to run correctly with Prism Launcher.
+    # This should be removed on the next Prism Launcher release.
+    (fetchpatch {
+      url = "https://github.com/PrismLauncher/PrismLauncher/commit/3295b0717a8c4805022eccb74fee2304361d8dab.patch";
+      hash = "sha256-A7DrmI00dFUNZLoMFDfym7e5rSFg6V4/MjVxAnQwT6E=";
+    })
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Following #381317, MangoHud stopped working correctly with PrismLauncher as shown with the comments between me and kira.

Upstream issue report was made: https://github.com/PrismLauncher/PrismLauncher/issues/3411
Upstream pushed an extremely simple fix to it too: https://github.com/PrismLauncher/PrismLauncher/pull/3413

This PR simply grabs this PR as a patch for prismlauncher-unwrapped. This patch should of course be dropped once a new prismlauncher version is released.

I also ran a nixfmt-rfc-style on the prismlauncher-unwrapped file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
