### PR TITLE
kdePackages.akonadi: enable support for SQLite and PostgreSQL backends

### DIFF
--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -7,7 +7,17 @@
   shared-mime-info,
   xz,
   mariadb,
+  postgresql,
+  sqlite,
+  backend ? "mysql",
 }:
+
+assert lib.assertOneOf "backend" backend [
+  "mysql"
+  "postgres"
+  "sqlite"
+];
+
 mkKdeDerivation {
   pname = "akonadi";
 
@@ -16,24 +26,40 @@ mkKdeDerivation {
     ./ignore-mysql-config-timestamp.patch
   ];
 
-  extraCmakeFlags = [
-    "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
-  ];
+  extraCmakeFlags =
+    [ "-DDATABASE_BACKEND=${lib.toUpper backend}" ]
+    ++ lib.optionals (backend == "mysql") [
+      "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
+    ]
+    ++ lib.optionals (backend == "postgres") [
+      "-DPOSTGRES_PATH=${lib.getBin postgresql}/bin"
+    ];
 
   extraNativeBuildInputs = [
     qttools
     shared-mime-info
   ];
-  extraBuildInputs = [
-    kaccounts-integration
-    accounts-qt
-    xz
-    mariadb
-  ];
+
+  extraBuildInputs =
+    [
+      kaccounts-integration
+      accounts-qt
+      xz
+    ]
+    ++ lib.optionals (backend == "mysql") [ mariadb ]
+    ++ lib.optionals (backend == "postgres") [ postgresql ]
+    ++ lib.optionals (backend == "sqlite") [ sqlite ];
 
   # Hardcoded as a QString, which is UTF-16 so Nix can't pick it up automatically
-  postFixup = ''
-    mkdir -p $out/nix-support
-    echo "${mariadb}" > $out/nix-support/depends
-  '';
+
+  postFixup =
+    ''
+      mkdir -p $out/nix-support
+    ''
+    ++ lib.optional (backend == "mysql") ''
+      echo "${mariadb}" > $out/nix-support/depends
+    ''
+    ++ lib.optional (backend == "postgres") ''
+      echo "${postgresql}" > $out/nix-support/depends
+    '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This patch adds options to enable other database backends aside mysql (current default on nixos).
It keeps the defaults as it is as there is atm no nice way available (for us) to migrate data from one backend to another backend.
I tried to play around with the provided tooling from akonadi upstream, but that just crashes for me.

Nevertheless it could be nice to provide experienced users and users who want to play around an easier access to the other akonadi backends.

I am running on sqlite backend on my main desktop machine since some time (it was a side quest in reducing my perl foodprint).
The postgresql backend is honestly untested from my end.

To enable the other backends one need to do the following:

```
nixpkgs.config.packageOverrides = pkgs: {
      kdePackages = pkgs.kdePackages.overrideScope (
        self: super: {
          akonadi = super.akonadi.override {
            withMariaDB = false;
            withSQLite = true;
            defaultBackend = "SQLITE";
          };
        }
      );
    };
```

Or similar way in overriding the original backend.


In addition one might want to check `~/.config/akonadi/akonadiserverrc` that should look like:

```
[%General]
Driver=QSQLITE

[QSQLITE]
Name=/home/<username>/.local/share/akonadi/akonadi.db
```

Otherwise it might still spin up the old mysql instance, if it was the previously used default backend.
The `akonadiserverrc` contains instructions how to start the mysql instance otherwise.


I am opening that as i was asked on matrix if i want to upstream that commit.
But there is be quite some more work to be done to make it available for a wide audience (esp. data migration).

ref: https://github.com/NixOS/nixpkgs/pull/292495 as it contains some initial conversation where i asked if a upstream patch might be welcome.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
