### PR TITLE
jetbrains.plugins: fix darwin builds

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -569,6 +569,7 @@ with lib.maintainers;
       edwtjo
       leona
       theCapypara
+      thiagokokada
     ];
     shortName = "Jetbrains";
     scope = "Maintainers of the Jetbrains IDEs in nixpkgs";

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -1,17 +1,19 @@
-{ fetchurl
-, fetchzip
-, lib
-, stdenv
-, callPackage
-, autoPatchelfHook
-, glib
-, darwin
+{
+  fetchurl,
+  fetchzip,
+  lib,
+  stdenv,
+  callPackage,
+  autoPatchelfHook,
+  glib,
+  darwin,
 }:
 
 let
   pluginsJson = builtins.fromJSON (builtins.readFile ./plugins.json);
   specialPluginsInfo = callPackage ./specialPlugins.nix { };
-  fetchPluginSrc = url: hash:
+  fetchPluginSrc =
+    url: hash:
     let
       isJar = lib.hasSuffix ".jar" url;
       fetcher = if isJar then fetchurl else fetchzip;
@@ -23,21 +25,26 @@ let
   files = builtins.mapAttrs (key: value: fetchPluginSrc key value) pluginsJson.files;
   ids = builtins.attrNames pluginsJson.plugins;
 
-  mkPlugin = id: file:
-    if !specialPluginsInfo ? "${id}"
-    then files."${file}"
+  mkPlugin =
+    id: file:
+    if !specialPluginsInfo ? "${id}" then
+      files."${file}"
     else
-      stdenv.mkDerivation ({
-        name = "jetbrains-plugin-${id}";
-        installPhase = ''
-          runHook preInstall
-          mkdir -p $out && cp -r . $out
-          runHook postInstall
-        '';
-        src = files."${file}";
-      } // specialPluginsInfo."${id}");
+      stdenv.mkDerivation (
+        {
+          name = "jetbrains-plugin-${id}";
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out && cp -r . $out
+            runHook postInstall
+          '';
+          src = files."${file}";
+        }
+        // specialPluginsInfo."${id}"
+      );
 
-  selectFile = id: ide: build:
+  selectFile =
+    id: ide: build:
     if !builtins.elem ide pluginsJson.plugins."${id}".compatible then
       throw "Plugin with id ${id} does not support IDE ${ide}"
     else if !pluginsJson.plugins."${id}".builds ? "${build}" then
@@ -47,40 +54,41 @@ let
     else
       pluginsJson.plugins."${id}".builds."${build}";
 
-  byId = builtins.listToAttrs
-    (map
-      (id: {
-        name = id;
-        value = ide: build: mkPlugin id (selectFile id ide build);
-      })
-      ids);
+  byId = builtins.listToAttrs (
+    map (id: {
+      name = id;
+      value = ide: build: mkPlugin id (selectFile id ide build);
+    }) ids
+  );
 
-  byName = builtins.listToAttrs
-    (map
-      (id: {
-        name = pluginsJson.plugins."${id}".name;
-        value = byId."${id}";
-      })
-      ids);
-
-
-in {
+  byName = builtins.listToAttrs (
+    map (id: {
+      name = pluginsJson.plugins."${id}".name;
+      value = byId."${id}";
+    }) ids
+  );
+in
+{
   # Only use if you know what youre doing
   raw = { inherit files byId byName; };
 
-  tests = callPackage ./tests.nix {};
+  tests = callPackage ./tests.nix { };
 
-  addPlugins = ide: unprocessedPlugins:
+  addPlugins =
+    ide: unprocessedPlugins:
     let
-
-      processPlugin = plugin:
-        if lib.isDerivation plugin then plugin else
-        if byId ? "${plugin}" then byId."${plugin}" ide.pname ide.buildNumber else
-        if byName ? "${plugin}" then byName."${plugin}" ide.pname ide.buildNumber else
-        throw "Could not resolve plugin ${plugin}";
+      processPlugin =
+        plugin:
+        if lib.isDerivation plugin then
+          plugin
+        else if byId ? "${plugin}" then
+          byId."${plugin}" ide.pname ide.buildNumber
+        else if byName ? "${plugin}" then
+          byName."${plugin}" ide.pname ide.buildNumber
+        else
+          throw "Could not resolve plugin ${plugin}";
 
       plugins = map processPlugin unprocessedPlugins;
-
     in
     stdenv.mkDerivation rec {
       pname = meta.mainProgram + "-with-plugins";
@@ -102,35 +110,36 @@ in {
       inherit (ide) meta;
 
       buildPhase =
-      let
-        appDir = lib.optionalString stdenv.hostPlatform.isDarwin "Applications/${lib.escapeShellArg ide.product}.app";
-        rootDir = if stdenv.hostPlatform.isDarwin then "${appDir}/Contents" else meta.mainProgram;
-      in
-      ''
-        cp -r ${ide} $out
-        chmod +w -R $out
-        rm -f $out/${rootDir}/plugins/plugin-classpath.txt
+        let
+          appDir = lib.optionalString stdenv.hostPlatform.isDarwin "Applications/${lib.escapeShellArg ide.product}.app";
+          rootDir = if stdenv.hostPlatform.isDarwin then "${appDir}/Contents" else meta.mainProgram;
+        in
+        ''
+          cp -r ${ide} $out
+          chmod +w -R $out
+          rm -f $out/${rootDir}/plugins/plugin-classpath.txt
 
-        (
-          shopt -s nullglob
+          (
+            shopt -s nullglob
 
-          IFS=' ' read -ra pluginArray <<< "$newPlugins"
-          for plugin in "''${pluginArray[@]}"; do
-            if [[ "$plugin" == *.jar ]]; then
-              # if the plugin contains a single jar file, link it directly into the plugins folder
-              ln -s "$plugin" $out/${rootDir}/plugins/
-            else
-              # otherwise link the plugin directory itself
-              ln -s "$plugin" -t $out/${rootDir}/plugins/
-            fi
-          done
+            IFS=' ' read -ra pluginArray <<< "$newPlugins"
+            for plugin in "''${pluginArray[@]}"; do
+              pluginfiles=($plugin)
+              if [[ "$plugin" == *.jar ]]; then
+                # if the plugin contains a single jar file, link it directly into the plugins folder
+                ln -s "$plugin" $out/${rootDir}/plugins/
+              else
+                # otherwise link the plugin directory itself
+                ln -s "$plugin" -t $out/${rootDir}/plugins/
+              fi
+            done
 
-          for exe in $out/bin/${meta.mainProgram}*; do
-            if [[ -x "$exe" ]]; then
-              substituteInPlace $(realpath "$exe") --replace-warn '${ide.outPath}' $out
-            fi
-          done
-        )
-      '';
+            for exe in $out/bin/${meta.mainProgram}*; do
+              if [[ -x "$exe" ]]; then
+                substituteInPlace $(realpath "$exe") --replace-warn '${ide.outPath}' $out
+              fi
+            done
+          )
+        '';
     };
 }

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -110,26 +110,40 @@ in {
         cp -r ${ide} $out
         chmod +w -R $out
         rm -f $out/${rootDir}/plugins/plugin-classpath.txt
-        IFS=' ' read -ra pluginArray <<< "$newPlugins"
-        for plugin in "''${pluginArray[@]}"
-        do
-          pluginfiles=$(ls $plugin);
-          if [ $(echo $pluginfiles | wc -l) -eq 1 ] && echo $pluginfiles | grep -E "\.jar" 1> /dev/null; then
-            # if the plugin contains a single jar file, link it directly into the plugins folder
-            ln -s "$plugin/$(echo $pluginfiles | head -1)" $out/${rootDir}/plugins/
-          else
-            # otherwise link the plugin directory itself
-            ln -s "$plugin" -t $out/${rootDir}/plugins/
-          fi
-        done
-        sed "s|${ide.outPath}|$out|" \
-          -i $(realpath $out/bin/${meta.mainProgram})
 
-        if test -f "$out/bin/${meta.mainProgram}-remote-dev-server"; then
-          sed "s|${ide.outPath}|$out|" \
-            -i $(realpath $out/bin/${meta.mainProgram}-remote-dev-server)
+        (
+          IFS=' ' read -ra pluginArray <<< "$newPlugins"
+          shopt -s nullglob
+          for plugin in "''${pluginArray[@]}"; do
+            pluginfiles=($plugin)
+            if [[ ''${#pluginfiles[@]} -eq 1 ]] && [[ "$pluginfiles" == *.jar ]]; then
+              # if the plugin contains a single jar file, link it directly into the plugins folder
+              ln -s "$pluginfiles" $out/${rootDir}/plugins/
+            else
+              # otherwise link the plugin directory itself
+              ln -s "$plugin" -t $out/${rootDir}/plugins/
+            fi
+          done
+        )
+
+        substituteInPlace $(realpath "$out/bin/${meta.mainProgram}") \
+          --replace-warn '${ide.outPath}' $out
+            IFS=' ' read -ra pluginArray <<< "$newPlugins"
+            for plugin in "''${pluginArray[@]}"; do
+              if [[ "$plugin" == *.jar ]]; then
+                # if the plugin contains a single jar file, link it directly into the plugins folder
+                ln -s "$plugin" $out/${rootDir}/plugins/
+              else
+                # otherwise link the plugin directory itself
+                ln -s "$plugin" -t $out/${rootDir}/plugins/
+              fi
+            done
+
+        remote_dev="$out/bin/${meta.mainProgram}-remote-dev-server"
+        if [[ -f "$remote_dev" ]]; then
+          substituteInPlace $(realpath "$remote_dev") \
+            --replace-warn '${ide.outPath}' $out
         fi
-
       '' + lib.optionalString stdenv.hostPlatform.isLinux ''
         autoPatchelf $out
       '';

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -27,8 +27,9 @@
     in
     writeText "jb-ides" paths;
 
-  clion-with-vim = jetbrains.plugins.addPlugins jetbrains.clion [
+  idea-ce-with-plugins = jetbrains.plugins.addPlugins jetbrains.idea-community [
     "ideavim"
+    "nixidea"
     # test JAR plugins
     "wakatime"
   ];

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -27,9 +27,9 @@
     in
     writeText "jb-ides" paths;
 
-    clion-with-vim = jetbrains.plugins.addPlugins jetbrains.clion [
-      "ideavim"
-      # test JAR plugins
-      "wakatime"
-    ];
+  clion-with-vim = jetbrains.plugins.addPlugins jetbrains.clion [
+    "ideavim"
+    # test JAR plugins
+    "wakatime"
+  ];
 }

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -27,5 +27,9 @@
     in
     writeText "jb-ides" paths;
 
-  clion-with-vim = jetbrains.plugins.addPlugins jetbrains.clion [ "ideavim" ];
+    clion-with-vim = jetbrains.plugins.addPlugins jetbrains.clion [
+      "ideavim"
+      # test JAR plugins
+      "wakatime"
+    ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There were 2 issues for usage of `jetbrains.plugins.addPlugins` in darwin:

- Some IDE products have spaces in name (e.g.: "IntelliJ IDEA CE"). The current code didn't escape or quoted the strings together, so it failed during build
- After fixing the issue above, opening the resulting app bundle (e.g.: `open result/Applications/IntelliJ IDEA CE`) would result in an error because we modified the bundle but kept the old signature

This PR fixes both those issues, the first one by quoting the IDE name using `lib.escapeShellArg` and the second one by using `darwin.autoSignDarwinBinariesHook`.

Also it formats the code using the `nixfmt-rfc-style` and does some general clean-up in the plugin derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
