### PR TITLE
linuxPackages.xone: 0.3-unstable-2024-04-25 -> 0.3-unstable-2024-12-23; switch to dlundqvist fork, drop patches for newer kernels, add 'fazzi' as maintainer

### DIFF
--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -3,36 +3,18 @@
   lib,
   fetchFromGitHub,
   kernel,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xone";
-  version = "0.3-unstable-2024-04-25";
+  version = "0.3-unstable-2024-12-23";
 
   src = fetchFromGitHub {
-    owner = "medusalix";
+    owner = "dlundqvist";
     repo = "xone";
-    rev = "29ec3577e52a50f876440c81267f609575c5161e";
-    hash = "sha256-ZKIV8KtrFEyabQYzWpxz2BvOAXKV36ufTI87VpIfkFs=";
+    rev = "6b9d59aed71f6de543c481c33df4705d4a590a31";
+    hash = "sha256-MpxP2cb0KEPKaarjfX/yCbkxIFTwwEwVpTMhFcis+A4=";
   };
-
-  patches = [
-    # Fix build on kernel 6.11
-    # https://github.com/medusalix/xone/pull/48
-    (fetchpatch {
-      name = "kernel-6.11.patch";
-      url = "https://github.com/medusalix/xone/commit/28df566c38e0ee500fd5f74643fc35f21a4ff696.patch";
-      hash = "sha256-X14oZmxqqZJoBZxPXGZ9R8BAugx/hkSOgXlGwR5QCm8=";
-    })
-    # Fix build on kernel 6.12
-    # https://github.com/medusalix/xone/pull/53
-    (fetchpatch {
-      name = "kernel-6.12.patch";
-      url = "https://github.com/medusalix/xone/commit/d88ea1e8b430d4b96134e43ca1892ac48334578e.patch";
-      hash = "sha256-zQK1tuxu2ZmKxPO0amkfcT/RFBSkU2pWD0qhGyCCHXI=";
-    })
-  ];
 
   setSourceRoot = ''
     export sourceRoot=$(pwd)/${finalAttrs.src.name}
@@ -54,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Linux kernel driver for Xbox One and Xbox Series X|S accessories";
-    homepage = "https://github.com/medusalix/xone";
+    homepage = "https://github.com/dlundqvist/xone";
     license = licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       rhysmdnz

--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -56,7 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Linux kernel driver for Xbox One and Xbox Series X|S accessories";
     homepage = "https://github.com/medusalix/xone";
     license = licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ rhysmdnz ];
+    maintainers = with lib.maintainers; [
+      rhysmdnz
+      fazzi
+    ];
     platforms = platforms.linux;
     broken = kernel.kernelOlder "5.11";
   };


### PR DESCRIPTION
Currently, we are using upstream https://github.com/medusalix/xone as the source for our xone nixpkg. This has caused a few issues, like the fact that we have to pull in some patches ourselves to make the module successfully build for newer kernels (6.11+).

We should follow what the official xone support server is suggesting, which is to use dlundqvist's fork of the project. 
![image](https://github.com/user-attachments/assets/cabfbed6-575d-4815-bf35-895ac8b6704b)

This allows us to remove the patches we were originally applying (they are upstream in this fork), and also puts us on a more up to date path for the package. It is clear that the original repo is no longer being worked on, considering it hasn't had an update in 10 months, the creator's (medusalix) last message on the support server was on 2024/05/13, and the AUR package maintainer (which was previously me when I was running arch), has now moved the base package over to this fork as well. https://aur.archlinux.org/packages/xone-dkms-git

The comment from the new maintainer states: 
![image](https://github.com/user-attachments/assets/19a9906b-b96f-4a48-a0a9-b2b6d04540c1)

This fork also contains a few minor changes including additional support for some devices, and some other minor fixes.

Finally, I have also added myself as a maintainer of this package, just in case the driver ever breaks again for a newer kernel release.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
