### PR TITLE
deno: enable tests

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -14,6 +14,13 @@
   libffi,
   sqlite,
   lld,
+  writableTmpDirAsHomeHook,
+
+  # Test deps
+  curl,
+  nodejs,
+  git,
+  python3,
 }:
 
 let
@@ -27,16 +34,27 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "denoland";
     repo = "deno";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ASP+1EuGLU9BBY7iBer92AbnVEeQc4nwtOEyULlvc2w=";
+    fetchSubmodules = true; # required for tests
+    hash = "sha256-lu3r1v3iB9NIruooRrV9NawUnKqufqlYJQe+Aumgn8E=";
   };
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-XJy7+cARYEX8tAPXLHJnEwXyZIwPaqhM7ZUzoem1Wo0=";
 
+  patches = [
+    ./tests-replace-hardcoded-paths.patch
+    ./tests-darwin-differences.patch
+    ./tests-no-chown.patch
+  ];
   postPatch = ''
     # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857
     tomlq -ti '.workspace.dependencies.libffi = { "version": .workspace.dependencies.libffi, "features": ["system"] }' Cargo.toml
   '';
+
+  buildInputs = [
+    libffi
+    sqlite
+  ];
 
   # uses zlib-ng but can't dynamically link yet
   # https://github.com/rust-lang/libz-sys/issues/158
@@ -56,12 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--disable-multi-os-directory"
   ];
 
-  buildInputs = [
-    libffi
-    # required by libsqlite3-sys
-    sqlite.dev
-  ];
-  buildAndTestSubdir = "cli";
+  buildFlags = [ "--package=cli" ];
 
   # work around "error: unknown warning group '-Wunused-but-set-parameter'"
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unknown-warning-option";
@@ -69,19 +82,86 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
-  # Tests have some inconsistencies between runs with output integration tests
-  # Skipping until resolved
-  doCheck = false;
-
-  preInstall = ''
-    find ./target -name libswc_common${stdenv.hostPlatform.extensions.sharedLibrary} -delete
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Unset the env var defined by bintools-wrapper because it triggers Deno's sandbox protection in some tests.
+    # ref: https://github.com/denoland/deno/pull/25271
+    unset LD_DYLD_PATH
   '';
 
-  postInstall = lib.optionalString canExecute ''
-    installShellCompletion --cmd deno \
-      --bash <($out/bin/deno completions bash) \
-      --fish <($out/bin/deno completions fish) \
-      --zsh <($out/bin/deno completions zsh)
+  cargoTestFlags = [
+    "--lib" # unit tests
+    "--test integration_tests"
+    # Test targets not included here:
+    # - node_compat: there are tons of network access in them and it's not trivial to skip test cases.
+    # - specs: this target uses a custom test harness that doesn't implement the --skip flag.
+    #   refs:
+    #   - https://github.com/denoland/deno/blob/2212d7d814914e43f43dfd945ee24197f50fa6fa/tests/Cargo.toml#L25
+    #   - https://github.com/denoland/file_test_runner/blob/9c78319a4e4c6180dde0e9e6c2751017176e65c9/src/collection/mod.rs#L49
+  ];
+  checkFlags =
+    [
+      # Internet access
+      "--skip=check::ts_no_recheck_on_redirect"
+      "--skip=js_unit_tests::quic_test"
+      "--skip=js_unit_tests::net_test"
+      "--skip=node_unit_tests::http_test"
+      "--skip=node_unit_tests::http2_test"
+      "--skip=node_unit_tests::net_test"
+      "--skip=node_unit_tests::tls_test"
+      "--skip=npm::lock_file_lock_write"
+
+      # GPU access
+      "--skip=js_unit_tests::webgpu_test"
+      "--skip=js_unit_tests::jupyter_test"
+
+      # Use of /usr/bin
+      "--skip=specs::permission::proc_self_fd"
+
+      # Flaky
+      "--skip=init::init_subcommand_serve"
+
+      # Test hangs, needs investigation
+      "--skip=repl::pty_complete_imports_no_panic_empty_specifier"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Expects specific shared libraries from macOS to be linked
+      "--skip=shared_library_tests::macos_shared_libraries"
+
+      # Darwin sandbox issues
+      "--skip=watcher"
+      "--skip=node_unit_tests::_fs_watch_test"
+      "--skip=js_unit_tests::fs_events_test"
+    ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    curl
+    nodejs
+    git
+    python3
+  ];
+
+  preInstall = ''
+    # Delete generated shared libraries that aren't needed in the final package
+    find ./target \
+      -name "libswc_common${stdenv.hostPlatform.extensions.sharedLibrary}" -o \
+      -name "libtest_ffi${stdenv.hostPlatform.extensions.sharedLibrary}" -o \
+      -name "libtest_napi${stdenv.hostPlatform.extensions.sharedLibrary}" \
+      -delete
+  '';
+
+  postInstall = ''
+    # Remove non-essential binaries like denort and test_server
+    find $out/bin/* -not -name "deno" -delete
+
+    ${lib.optionalString canExecute ''
+      installShellCompletion --cmd deno \
+        --bash <($out/bin/deno completions bash) \
+        --fish <($out/bin/deno completions fish) \
+        --zsh <($out/bin/deno completions zsh)
+    ''}
   '';
 
   doInstallCheck = canExecute;

--- a/pkgs/by-name/de/deno/tests-darwin-differences.patch
+++ b/pkgs/by-name/de/deno/tests-darwin-differences.patch
@@ -1,0 +1,43 @@
+Disable codesign check and a Darwin-specific temp dir workaround.
+
+Note: the darwin.sigtool package includes a codesign utility, but it doesn't support the -v flag used in this test.
+
+diff --git a/tests/integration/compile_tests.rs b/tests/integration/compile_tests.rs
+index 503538d24..ca89e3133 100644
+--- a/tests/integration/compile_tests.rs
++++ b/tests/integration/compile_tests.rs
+@@ -32,17 +32,6 @@ fn compile_basic() {
+     output.assert_matches_text("Welcome to Deno!\n");
+   }
+ 
+-  // On arm64 macOS, check if `codesign -v` passes
+-  #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+-  {
+-    let output = std::process::Command::new("codesign")
+-      .arg("-v")
+-      .arg(&exe)
+-      .output()
+-      .unwrap();
+-    assert!(output.status.success());
+-  }
+-
+   // now ensure this works when the deno_dir is readonly
+   let readonly_dir = dir.path().join("readonly");
+   readonly_dir.make_dir_readonly();
+diff --git a/tests/unit/dir_test.ts b/tests/unit/dir_test.ts
+index 757c8fec3..22b999820 100644
+--- a/tests/unit/dir_test.ts
++++ b/tests/unit/dir_test.ts
+@@ -12,11 +12,7 @@ Deno.test(
+     const path = Deno.makeTempDirSync();
+     Deno.chdir(path);
+     const current = Deno.cwd();
+-    if (Deno.build.os === "darwin") {
+-      assertEquals(current, "/private" + path);
+-    } else {
+-      assertEquals(current, path);
+-    }
++    assertEquals(current, path);
+     Deno.chdir(initialdir);
+   },
+ );

--- a/pkgs/by-name/de/deno/tests-no-chown.patch
+++ b/pkgs/by-name/de/deno/tests-no-chown.patch
@@ -1,0 +1,77 @@
+Disable chown, uid and gid tests on Linux. These fail in the Nix sandbox.
+
+diff --git a/tests/unit/chown_test.ts b/tests/unit/chown_test.ts
+index 99e7dd4..a343122 100644
+--- a/tests/unit/chown_test.ts
++++ b/tests/unit/chown_test.ts
+@@ -69,7 +69,7 @@ Deno.test(
+ );
+ 
+ Deno.test(
+-  { permissions: { write: true }, ignore: Deno.build.os == "windows" },
++  { permissions: { write: true }, ignore: Deno.build.os == "windows" || Deno.build.os === "linux" },
+   function chownSyncPermissionDenied() {
+     const dirPath = Deno.makeTempDirSync();
+     const filePath = dirPath + "/chown_test_file.txt";
+@@ -84,7 +84,7 @@ Deno.test(
+ );
+ 
+ Deno.test(
+-  { permissions: { write: true }, ignore: Deno.build.os == "windows" },
++  { permissions: { write: true }, ignore: Deno.build.os == "windows" || Deno.build.os === "linux" },
+   async function chownPermissionDenied() {
+     const dirPath = await Deno.makeTempDir();
+     const filePath = dirPath + "/chown_test_file.txt";
+diff --git a/tests/unit/command_test.ts b/tests/unit/command_test.ts
+index fa941df..9292864 100644
+--- a/tests/unit/command_test.ts
++++ b/tests/unit/command_test.ts
+@@ -755,7 +755,7 @@ Deno.test(
+ Deno.test(
+   {
+     permissions: { run: true, read: true },
+-    ignore: Deno.build.os === "windows",
++    ignore: Deno.build.os === "windows" || Deno.build.os === "linux",
+   },
+   async function commandUid() {
+     const { stdout } = await new Deno.Command("id", {
+@@ -778,7 +778,7 @@ Deno.test(
+ Deno.test(
+   {
+     permissions: { run: true, read: true },
+-    ignore: Deno.build.os === "windows",
++    ignore: Deno.build.os === "windows" || Deno.build.os === "linux",
+   },
+   function commandSyncUid() {
+     const { stdout } = new Deno.Command("id", {
+@@ -801,7 +801,7 @@ Deno.test(
+ Deno.test(
+   {
+     permissions: { run: true, read: true },
+-    ignore: Deno.build.os === "windows",
++    ignore: Deno.build.os === "windows" || Deno.build.os === "linux",
+   },
+   async function commandGid() {
+     const { stdout } = await new Deno.Command("id", {
+@@ -824,7 +824,7 @@ Deno.test(
+ Deno.test(
+   {
+     permissions: { run: true, read: true },
+-    ignore: Deno.build.os === "windows",
++    ignore: Deno.build.os === "windows" || Deno.build.os === "linux",
+   },
+   function commandSyncGid() {
+     const { stdout } = new Deno.Command("id", {
+diff --git a/tests/unit_node/_fs/_fs_handle_test.ts b/tests/unit_node/_fs/_fs_handle_test.ts
+index 6bf37b6..3a4567f 100644
+--- a/tests/unit_node/_fs/_fs_handle_test.ts
++++ b/tests/unit_node/_fs/_fs_handle_test.ts
+@@ -276,7 +276,7 @@ Deno.test({
+ 
+ Deno.test({
+   name: "[node/fs filehandle.chown] Change owner of the file",
+-  ignore: Deno.build.os === "windows",
++  ignore: Deno.build.os === "windows" || Deno.build.os === "linux",
+   async fn() {
+     const fileHandle = await fs.open(testData);
+ 

--- a/pkgs/by-name/de/deno/tests-replace-hardcoded-paths.patch
+++ b/pkgs/by-name/de/deno/tests-replace-hardcoded-paths.patch
@@ -1,0 +1,44 @@
+diff --git a/tests/unit/serve_test.ts b/tests/unit/serve_test.ts
+index 6373fbb3a..2b43226f6 100644
+--- a/tests/unit/serve_test.ts
++++ b/tests/unit/serve_test.ts
+@@ -4218,7 +4218,7 @@ Deno.test(
+       },
+     );
+     await promise;
+-    const e = await execCode3("/usr/bin/sh", [
++    const e = await execCode3("sh", [
+       "-c",
+       `curl --stderr - -N --compressed --no-progress-meter http://localhost:${servePort}`,
+     ]);
+diff --git a/tests/unit_node/process_test.ts b/tests/unit_node/process_test.ts
+index fe6f43b3e..29916019a 100644
+--- a/tests/unit_node/process_test.ts
++++ b/tests/unit_node/process_test.ts
+@@ -509,7 +509,7 @@ Deno.test({
+     const scriptPath = "./testdata/process_stdin.ts";
+     const filePath = "./testdata/process_stdin_dummy.txt";
+ 
+-    const shell = Deno.build.os === "windows" ? "cmd.exe" : "/bin/sh";
++    const shell = Deno.build.os === "windows" ? "cmd.exe" : "sh";
+     const cmd = `"${Deno.execPath()}" run ${scriptPath} < ${filePath}`;
+     const args = Deno.build.os === "windows" ? ["/d", "/c", cmd] : ["-c", cmd];
+ 
+@@ -569,7 +569,7 @@ Deno.test({
+       listener.close();
+     });
+ 
+-    const shell = "/bin/bash";
++    const shell = "bash";
+     const cmd =
+       `"${Deno.execPath()}" run ${scriptPath} < /dev/tcp/127.0.0.1/9000`;
+     const args = ["-c", cmd];
+@@ -620,7 +620,7 @@ Deno.test({
+     const scriptPath = "./testdata/process_stdin.ts";
+     const directoryPath = "./testdata/";
+ 
+-    const shell = "/bin/bash";
++    const shell = "bash";
+     const cmd = `"${Deno.execPath()}" run ${scriptPath} < ${directoryPath}`;
+     const args = ["-c", cmd];
+ 


### PR DESCRIPTION
The project has an extensive tests suite in both Rust and Typescript, and while I couldn't enable all of them, this is one attempt to run at least a subset in the Nix build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
