### PR TITLE
screen: fix the use of strncpy when using -X

### DIFF
--- a/pkgs/tools/misc/screen/buffer-overflow-SendCmdMessage.patch
+++ b/pkgs/tools/misc/screen/buffer-overflow-SendCmdMessage.patch
@@ -1,0 +1,13 @@
+--- a/attacher.c	2025-02-24 20:15:31.701820351 +0100
++++ b/attacher.c	2025-02-24 20:17:05.893826559 +0100
+@@ -461,8 +461,8 @@
+ 		size_t len;
+ 		len = strlen(*av) + 1;
+ 		if (p + len >= m.m.command.cmd + ARRAY_SIZE(m.m.command.cmd) - 1)
+-			break;
++			Panic(0, "Total length of the command to send too large.\n");
+-		strncpy(p, *av, MAXPATHLEN);
++		memcpy(p, *av, len);
+ 		p += len;
+ 	}
+ 	*p = 0;

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -26,6 +26,13 @@ stdenv.mkDerivation rec {
   # We need _GNU_SOURCE so that mallocmock_reset() is defined: https://savannah.gnu.org/bugs/?66416
   NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isGNU) "-D_GNU_SOURCE=1 -Wno-int-conversion -Wno-incompatible-pointer-types";
 
+  patches = [
+    # GNU Screen 5.0 uses strncpy incorrectly in SendCmdMessage
+    # This causes issues detected when using -D_FORTIFY_SOURCE=3
+    # e.g. https://savannah.gnu.org/bugs/index.php?66215
+    ./buffer-overflow-SendCmdMessage.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
   ];


### PR DESCRIPTION
SendCmdMessage in attacher.c used strncpy with increasing pointers into the same buffer without reducing the available buffer size.

Fixes: #384835

Related to: https://savannah.gnu.org/bugs/index.php?66215

`nixosTests.rxe` uses `screen` and did not get broken.

Will probably self-merge if no reaction.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
