### PR TITLE
air-formatter: init at 0.4.0

### DIFF
--- a/pkgs/by-name/ai/air-formatter/cargo-lock.patch
+++ b/pkgs/by-name/ai/air-formatter/cargo-lock.patch
@@ -1,0 +1,84 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index df5a6e9..0cf72e2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -382,7 +382,7 @@ dependencies = [
+  "anyhow",
+  "biome_rowan",
+  "rustc-hash",
+- "tower-lsp 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tower-lsp",
+ ]
+ 
+ [[package]]
+@@ -1369,7 +1369,7 @@ dependencies = [
+  "time",
+  "tokio",
+  "tokio-util",
+- "tower-lsp 0.20.0 (git+https://github.com/lionel-/tower-lsp?branch=bugfix%2Fpatches)",
++ "tower-lsp",
+  "tracing",
+  "tracing-subscriber",
+  "tree-sitter",
+@@ -1406,7 +1406,7 @@ dependencies = [
+  "serde_json",
+  "tokio",
+  "tokio-util",
+- "tower-lsp 0.20.0 (git+https://github.com/lionel-/tower-lsp?branch=bugfix%2Fpatches)",
++ "tower-lsp",
+  "tracing",
+  "url",
+ ]
+@@ -2311,29 +2311,6 @@ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+ 
+-[[package]]
+-name = "tower-lsp"
+-version = "0.20.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+-dependencies = [
+- "async-trait",
+- "auto_impl",
+- "bytes",
+- "dashmap 5.5.3",
+- "futures",
+- "httparse",
+- "lsp-types",
+- "memchr",
+- "serde",
+- "serde_json",
+- "tokio",
+- "tokio-util",
+- "tower",
+- "tower-lsp-macros 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "tracing",
+-]
+-
+ [[package]]
+ name = "tower-lsp"
+ version = "0.20.0"
+@@ -2352,21 +2329,10 @@ dependencies = [
+  "tokio",
+  "tokio-util",
+  "tower",
+- "tower-lsp-macros 0.9.0 (git+https://github.com/lionel-/tower-lsp?branch=bugfix%2Fpatches)",
++ "tower-lsp-macros",
+  "tracing",
+ ]
+ 
+-[[package]]
+-name = "tower-lsp-macros"
+-version = "0.9.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.90",
+-]
+-
+ [[package]]
+ name = "tower-lsp-macros"
+ version = "0.9.0"

--- a/pkgs/by-name/ai/air-formatter/package.nix
+++ b/pkgs/by-name/ai/air-formatter/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (attrs: {
+  pname = "air-formatter";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "posit-dev";
+    repo = "air";
+    rev = attrs.version;
+    hash = "sha256-BUbOG4D5UD+Z8Cpr4qodUrM3FFcMwjBd4M/YdPZPtpM=";
+  };
+
+  # Remove duplicate entries from cargo lock
+  cargoPatches = [ ./cargo-lock.patch ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-EnvhqAZK76O6g99OgLruQDBUe9m9bn5ier3bgHI/f+A=";
+
+  useNextest = true;
+
+  meta = {
+    description = "An extremely fast R code formatter";
+    homepage = "https://posit-dev.github.io/air";
+    changelog = "https://github.com/posit-dev/air/blob/" + attrs.version + "/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kupac ];
+    mainProgram = "air";
+  };
+})


### PR DESCRIPTION
**Package tests fail** at the moment, so they are disabled

Will fix https://github.com/NixOS/nixpkgs/issues/384760

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
