### PR TITLE
nixos/tests/clatd: fix and migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -250,7 +250,7 @@ in {
   cinnamon = handleTest ./cinnamon.nix {};
   cinnamon-wayland = handleTest ./cinnamon-wayland.nix {};
   cjdns = handleTest ./cjdns.nix {};
-  clatd = handleTest ./clatd.nix {};
+  clatd = runTest ./clatd.nix;
   clickhouse = handleTest ./clickhouse.nix {};
   cloud-init = handleTest ./cloud-init.nix {};
   cloud-init-hostname = handleTest ./cloud-init-hostname.nix {};

--- a/nixos/tests/clatd.nix
+++ b/nixos/tests/clatd.nix
@@ -26,230 +26,228 @@
 #        |         Route:   192.0.2.0/24 via 100.64.0.1
 #        +------
 
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+{ lib, pkgs, ... }:
 
-  {
-    name = "clatd";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        hax404
-        jmbaur
+{
+  name = "clatd";
+  meta = {
+    maintainers = with lib.maintainers; [
+      hax404
+      jmbaur
+    ];
+  };
+
+  nodes = {
+    # The server is configured with static IPv4 addresses. RFC 6052 Section 3.1
+    # disallows the mapping of non-global IPv4 addresses like RFC 1918 into the
+    # Well-Known Prefix 64:ff9b::/96. TAYGA also does not allow the mapping of
+    # documentation space (RFC 5737). To circumvent this, 100.64.0.2/24 from
+    # RFC 6589 (Carrier Grade NAT) is used here.
+    # To reach the IPv4 address pool of the NAT64 gateway, there is a static
+    # route configured. In normal cases, where the router would also source NAT
+    # the pool addresses to one IPv4 addresses, this would not be needed.
+    server = {
+      virtualisation.vlans = [
+        2 # towards router
       ];
+      networking = {
+        useDHCP = false;
+        interfaces.eth1 = lib.mkForce { };
+      };
+      systemd.network = {
+        enable = true;
+        networks."vlan1" = {
+          matchConfig.Name = "eth1";
+          address = [
+            "100.64.0.2/24"
+          ];
+          routes = [
+            {
+              Destination = "192.0.2.0/24";
+              Gateway = "100.64.0.1";
+            }
+          ];
+        };
+      };
     };
 
-    nodes = {
-      # The server is configured with static IPv4 addresses. RFC 6052 Section 3.1
-      # disallows the mapping of non-global IPv4 addresses like RFC 1918 into the
-      # Well-Known Prefix 64:ff9b::/96. TAYGA also does not allow the mapping of
-      # documentation space (RFC 5737). To circumvent this, 100.64.0.2/24 from
-      # RFC 6589 (Carrier Grade NAT) is used here.
-      # To reach the IPv4 address pool of the NAT64 gateway, there is a static
-      # route configured. In normal cases, where the router would also source NAT
-      # the pool addresses to one IPv4 addresses, this would not be needed.
-      server = {
-        virtualisation.vlans = [
-          2 # towards router
-        ];
-        networking = {
-          useDHCP = false;
-          interfaces.eth1 = lib.mkForce { };
-        };
-        systemd.network = {
-          enable = true;
-          networks."vlan1" = {
-            matchConfig.Name = "eth1";
-            address = [
-              "100.64.0.2/24"
-            ];
-            routes = [
+    # The router is configured with static IPv4 addresses towards the server
+    # and IPv6 addresses towards the client. DNS64 is exposed towards the
+    # client so clatd is able to auto-discover the PLAT prefix. For NAT64, the
+    # Well-Known prefix 64:ff9b::/96 is used. NAT64 is done with TAYGA which
+    # provides the tun-interface nat64 and does the translation over it. The
+    # IPv6 packets are sent to this interfaces and received as IPv4 packets and
+    # vice versa. As TAYGA only translates IPv6 addresses to dedicated IPv4
+    # addresses, it needs a pool of IPv4 addresses which must be at least as
+    # big as the expected amount of clients. In this test, the packets from the
+    # pool are directly routed towards the client. In normal cases, there would
+    # be a second source NAT44 to map all clients behind one IPv4 address.
+    router = {
+      boot.kernel.sysctl = {
+        "net.ipv4.conf.all.forwarding" = 1;
+        "net.ipv6.conf.all.forwarding" = 1;
+      };
+
+      virtualisation.vlans = [
+        2 # towards server
+        3 # towards client
+      ];
+
+      networking = {
+        useDHCP = false;
+        useNetworkd = true;
+        firewall.enable = false;
+        interfaces.eth1 = lib.mkForce {
+          ipv4 = {
+            addresses = [
               {
-                Destination = "192.0.2.0/24";
-                Gateway = "100.64.0.1";
+                address = "100.64.0.1";
+                prefixLength = 24;
+              }
+            ];
+          };
+        };
+        interfaces.eth2 = lib.mkForce {
+          ipv6 = {
+            addresses = [
+              {
+                address = "2001:db8::1";
+                prefixLength = 64;
               }
             ];
           };
         };
       };
 
-      # The router is configured with static IPv4 addresses towards the server
-      # and IPv6 addresses towards the client. DNS64 is exposed towards the
-      # client so clatd is able to auto-discover the PLAT prefix. For NAT64, the
-      # Well-Known prefix 64:ff9b::/96 is used. NAT64 is done with TAYGA which
-      # provides the tun-interface nat64 and does the translation over it. The
-      # IPv6 packets are sent to this interfaces and received as IPv4 packets and
-      # vice versa. As TAYGA only translates IPv6 addresses to dedicated IPv4
-      # addresses, it needs a pool of IPv4 addresses which must be at least as
-      # big as the expected amount of clients. In this test, the packets from the
-      # pool are directly routed towards the client. In normal cases, there would
-      # be a second source NAT44 to map all clients behind one IPv4 address.
-      router = {
-        boot.kernel.sysctl = {
-          "net.ipv4.conf.all.forwarding" = 1;
-          "net.ipv6.conf.all.forwarding" = 1;
-        };
-
-        virtualisation.vlans = [
-          2 # towards server
-          3 # towards client
-        ];
-
-        networking = {
-          useDHCP = false;
-          useNetworkd = true;
-          firewall.enable = false;
-          interfaces.eth1 = lib.mkForce {
-            ipv4 = {
-              addresses = [
-                {
-                  address = "100.64.0.1";
-                  prefixLength = 24;
-                }
-              ];
-            };
-          };
-          interfaces.eth2 = lib.mkForce {
-            ipv6 = {
-              addresses = [
-                {
-                  address = "2001:db8::1";
-                  prefixLength = 64;
-                }
-              ];
-            };
-          };
-        };
-
-        systemd.network.networks."40-eth2" = {
-          networkConfig.IPv6SendRA = true;
-          ipv6Prefixes = [ { Prefix = "2001:db8::/64"; } ];
-          ipv6PREF64Prefixes = [ { Prefix = "64:ff9b::/96"; } ];
-          ipv6SendRAConfig = {
-            EmitDNS = true;
-            DNS = "_link_local";
-          };
-        };
-
-        services.resolved.extraConfig = ''
-          DNSStubListener=no
-        '';
-
-        networking.extraHosts = ''
-          192.0.0.171 ipv4only.arpa
-          192.0.0.170 ipv4only.arpa
-        '';
-
-        services.coredns = {
-          enable = true;
-          config = ''
-            .:53 {
-              bind ::
-              hosts /etc/hosts
-              dns64 64:ff9b::/96
-            }
-          '';
-        };
-
-        services.tayga = {
-          enable = true;
-          ipv4 = {
-            address = "192.0.2.0";
-            router = {
-              address = "192.0.2.1";
-            };
-            pool = {
-              address = "192.0.2.0";
-              prefixLength = 24;
-            };
-          };
-          ipv6 = {
-            address = "2001:db8::1";
-            router = {
-              address = "64:ff9b::1";
-            };
-            pool = {
-              address = "64:ff9b::";
-              prefixLength = 96;
-            };
-          };
+      systemd.network.networks."40-eth2" = {
+        networkConfig.IPv6SendRA = true;
+        ipv6Prefixes = [ { Prefix = "2001:db8::/64"; } ];
+        ipv6PREF64Prefixes = [ { Prefix = "64:ff9b::/96"; } ];
+        ipv6SendRAConfig = {
+          EmitDNS = true;
+          DNS = "_link_local";
         };
       };
 
-      # The client uses SLAAC to assign IPv6 addresses. To reach the IPv4-only
-      # server, the client starts the clat daemon which starts and configures the
-      # local IPv4 -> IPv6 translation via Tayga after discovering the PLAT
-      # prefix via DNS64.
-      client = {
-        virtualisation.vlans = [
-          3 # towards router
-        ];
+      services.resolved.extraConfig = ''
+        DNSStubListener=no
+      '';
 
-        networking = {
-          useDHCP = false;
-          interfaces.eth1 = lib.mkForce { };
-        };
+      networking.extraHosts = ''
+        192.0.0.171 ipv4only.arpa
+        192.0.0.170 ipv4only.arpa
+      '';
 
-        systemd.network = {
-          enable = true;
-          networks."vlan1" = {
-            matchConfig.Name = "eth1";
+      services.coredns = {
+        enable = true;
+        config = ''
+          .:53 {
+            bind ::
+            hosts /etc/hosts
+            dns64 64:ff9b::/96
+          }
+        '';
+      };
 
-            # NOTE: clatd does not actually use the PREF64 prefix discovered by
-            # systemd-networkd (nor does systemd-networkd do anything with it,
-            # yet), but we set this to confirm it works. See the test script
-            # below.
-            ipv6AcceptRAConfig.UsePREF64 = true;
+      services.tayga = {
+        enable = true;
+        ipv4 = {
+          address = "192.0.2.0";
+          router = {
+            address = "192.0.2.1";
+          };
+          pool = {
+            address = "192.0.2.0";
+            prefixLength = 24;
           };
         };
-
-        services.clatd = {
-          enable = true;
-          # NOTE: Perl's Net::DNS resolver does not seem to work well querying
-          # for AAAA records to systemd-resolved's default IPv4 bind address
-          # (127.0.0.53), so we add an IPv6 listener address to systemd-resolved
-          # and tell clatd to use that instead.
-          settings.dns64-servers = "::1";
+        ipv6 = {
+          address = "2001:db8::1";
+          router = {
+            address = "64:ff9b::1";
+          };
+          pool = {
+            address = "64:ff9b::";
+            prefixLength = 96;
+          };
         };
-
-        # Allow clatd to find dns server. See comment above.
-        services.resolved.extraConfig = ''
-          DNSStubListenerExtra=::1
-        '';
-
-        environment.systemPackages = [ pkgs.mtr ];
       };
     };
 
-    testScript = ''
-      import json
+    # The client uses SLAAC to assign IPv6 addresses. To reach the IPv4-only
+    # server, the client starts the clat daemon which starts and configures the
+    # local IPv4 -> IPv6 translation via Tayga after discovering the PLAT
+    # prefix via DNS64.
+    client = {
+      virtualisation.vlans = [
+        3 # towards router
+      ];
 
-      start_all()
+      networking = {
+        useDHCP = false;
+        interfaces.eth1 = lib.mkForce { };
+      };
 
-      # wait for all machines to start up
-      for machine in client, router, server:
-        machine.start_job("network-online.target")
-        machine.wait_for_unit("network-online.target")
+      systemd.network = {
+        enable = true;
+        networks."vlan1" = {
+          matchConfig.Name = "eth1";
 
-      with subtest("Wait for tayga and clatd"):
-        router.wait_for_unit("tayga.service")
-        client.wait_for_unit("clatd.service")
-        # clatd checks if this system has IPv4 connectivity for 10 seconds
-        client.wait_until_succeeds(
-          'journalctl -u clatd -e | grep -q "Starting up TAYGA, using config file"'
-        )
+          # NOTE: clatd does not actually use the PREF64 prefix discovered by
+          # systemd-networkd (nor does systemd-networkd do anything with it,
+          # yet), but we set this to confirm it works. See the test script
+          # below.
+          ipv6AcceptRAConfig.UsePREF64 = true;
+        };
+      };
 
-      with subtest("networkd exports PREF64 prefix"):
-        assert json.loads(client.succeed("networkctl status eth1 --json=short"))[
-            "NDisc"
-        ]["PREF64"][0]["Prefix"] == [0x0, 0x64, 0xFF, 0x9B] + ([0] * 12)
+      services.clatd = {
+        enable = true;
+        # NOTE: Perl's Net::DNS resolver does not seem to work well querying
+        # for AAAA records to systemd-resolved's default IPv4 bind address
+        # (127.0.0.53), so we add an IPv6 listener address to systemd-resolved
+        # and tell clatd to use that instead.
+        settings.dns64-servers = "::1";
+      };
 
-      with subtest("Test ICMP"):
-        client.wait_until_succeeds("ping -c 3 100.64.0.2 >&2")
+      # Allow clatd to find dns server. See comment above.
+      services.resolved.extraConfig = ''
+        DNSStubListenerExtra=::1
+      '';
 
-      with subtest("Test ICMP and show a traceroute"):
-        client.wait_until_succeeds("mtr --show-ips --report-wide 100.64.0.2 >&2")
+      environment.systemPackages = [ pkgs.mtr ];
+    };
+  };
 
-      client.log(client.execute("systemd-analyze security clatd.service")[1])
-    '';
-  }
-)
+  testScript = ''
+    import json
+
+    start_all()
+
+    # wait for all machines to start up
+    for machine in client, router, server:
+      machine.start_job("network-online.target")
+      machine.wait_for_unit("network-online.target")
+
+    with subtest("Wait for tayga and clatd"):
+      router.wait_for_unit("tayga.service")
+      client.wait_for_unit("clatd.service")
+      # clatd checks if this system has IPv4 connectivity for 10 seconds
+      client.wait_until_succeeds(
+        'journalctl -u clatd -e | grep -q "Starting up TAYGA, using config file"'
+      )
+
+    with subtest("networkd exports PREF64 prefix"):
+      assert json.loads(client.succeed("networkctl status eth1 --json=short"))[
+          "NDisc"
+      ]["PREF64"][0]["Prefix"] == [0x0, 0x64, 0xFF, 0x9B] + ([0] * 12)
+
+    with subtest("Test ICMP"):
+      client.wait_until_succeeds("ping -c 3 100.64.0.2 >&2")
+
+    with subtest("Test ICMP and show a traceroute"):
+      client.wait_until_succeeds("mtr --show-ips --report-wide 100.64.0.2 >&2")
+
+    client.log(client.execute("systemd-analyze security clatd.service")[1])
+  '';
+}

--- a/nixos/tests/clatd.nix
+++ b/nixos/tests/clatd.nix
@@ -227,6 +227,7 @@ import ./make-test-python.nix (
 
       # wait for all machines to start up
       for machine in client, router, server:
+        machine.start_job("network-online.target")
         machine.wait_for_unit("network-online.target")
 
       with subtest("Wait for tayga and clatd"):


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes `nixosTests.clatd`.
Failing test on hydra: https://hydra.nixos.org/build/290852600/log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
