### PR TITLE
chore: remove unused fetchpatch import in kvazaar

### DIFF
--- a/pkgs/by-name/kv/kvazaar/package.nix
+++ b/pkgs/by-name/kv/kvazaar/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchpatch,
   fetchFromGitHub,
   gitUpdater,
   testers,


### PR DESCRIPTION
no-op change fixup from https://github.com/NixOS/nixpkgs/pull/384458#pullrequestreview-2635855651