### PR TITLE
[Backport release-24.11] nixos/victorialogs: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -129,6 +129,8 @@
 
 - [Dashy](https://dashy.to), an open source, highly customizable, easy to use, privacy-respecting dashboard app. Available as [services.dashy](options.html#opt-services.dashy).
 
+- [victorialogs][https://docs.victoriametrics.com/victorialogs/], log database from VictoriaMetrics. Available as [services.victorialogs](options.html#opt-services.victorialogs.enable)
+
 - [QGroundControl], a ground station support and configuration manager for the PX4 and APM Flight Stacks. Available as [programs.qgroundcontrol](options.html#opt-programs.qgroundcontrol.enable).
 
 - [Eintopf](https://eintopf.info), a community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -498,6 +498,7 @@
   ./services/databases/redis.nix
   ./services/databases/surrealdb.nix
   ./services/databases/tigerbeetle.nix
+  ./services/databases/victorialogs.nix
   ./services/databases/victoriametrics.nix
   ./services/desktops/accountsservice.nix
   ./services/desktops/ayatana-indicators.nix

--- a/nixos/modules/services/databases/victorialogs.nix
+++ b/nixos/modules/services/databases/victorialogs.nix
@@ -1,0 +1,125 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    escapeShellArgs
+    getBin
+    hasPrefix
+    literalExpression
+    mkBefore
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionalString
+    types
+    ;
+  cfg = config.services.victorialogs;
+  startCLIList = [
+    "${cfg.package}/bin/victoria-logs"
+    "-storageDataPath=/var/lib/${cfg.stateDir}"
+    "-httpListenAddr=${cfg.listenAddress}"
+  ] ++ cfg.extraOptions;
+in
+{
+  options.services.victorialogs = {
+    enable = mkEnableOption "VictoriaLogs is an open source user-friendly database for logs from VictoriaMetrics";
+    package = mkPackageOption pkgs "victoriametrics" { };
+    listenAddress = mkOption {
+      default = ":9428";
+      type = types.str;
+      description = ''
+        TCP address to listen for incoming http requests.
+      '';
+    };
+    stateDir = mkOption {
+      type = types.str;
+      default = "victorialogs";
+      description = ''
+        Directory below `/var/lib` to store VictoriaLogs data.
+        This directory will be created automatically using systemd's StateDirectory mechanism.
+      '';
+    };
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExpression ''
+        [
+          "-httpAuth.username=username"
+          "-httpAuth.password=file:///abs/path/to/file"
+          "-loggerLevel=WARN"
+        ]
+      '';
+      description = ''
+        Extra options to pass to VictoriaLogs. See {command}`victoria-logs -help` for
+        possible options.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    systemd.services.victorialogs = {
+      description = "VictoriaLogs logs database";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      startLimitBurst = 5;
+
+      serviceConfig = {
+        ExecStart = escapeShellArgs startCLIList;
+        DynamicUser = true;
+        RestartSec = 1;
+        Restart = "on-failure";
+        RuntimeDirectory = "victorialogs";
+        RuntimeDirectoryMode = "0700";
+        StateDirectory = cfg.stateDir;
+        StateDirectoryMode = "0700";
+
+        # Hardening
+        DeviceAllow = [ "/dev/null rw" ];
+        DevicePolicy = "strict";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+      };
+
+      postStart =
+        let
+          bindAddr = (optionalString (hasPrefix ":" cfg.listenAddress) "127.0.0.1") + cfg.listenAddress;
+        in
+        mkBefore ''
+          until ${getBin pkgs.curl}/bin/curl -s -o /dev/null http://${bindAddr}/ping; do
+            sleep 1;
+          done
+        '';
+    };
+  };
+}


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/376834, conflict was `nixos/doc/manual/release-notes/rl-2505.section.md`

Should I also update the 24.11 release notes?

cc @getchoo