### PR TITLE
services/journald: Fix regression with containers, as well as associated tests

### DIFF
--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -12,11 +12,17 @@ import ./make-test-python.nix (
     };
     nodes.auditd = {
       security.auditd.enable = true;
+      security.audit.enable = true;
       environment.systemPackages = [ pkgs.audit ];
+      boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
+      boot.kernelParams = [ "audit_backlog_limit=8192" ];
     };
     nodes.journaldAudit = {
       services.journald.audit = true;
+      security.audit.enable = true;
       environment.systemPackages = [ pkgs.audit ];
+      boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
+      boot.kernelParams = [ "audit_backlog_limit=8192" ];
     };
 
     testScript = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix a regression introduced in https://github.com/NixOS/nixpkgs/pull/379629 where a systemd-journald-audit.socket is created in containers. This results in spurious messages to the journal of the form:

     systemd[1]: systemd-journald-audit.socket: Unit has no Listen setting (ListenStream=, ListenDatagram=, ListenFIFO=, ...). Refusing.
     systemd[1]: systemd-journald-audit.socket: Cannot add dependency job, ignoring: Unit systemd-journald-audit.socket has a bad unit file setting.

It also displays as having a bad unit file setting in systemctl status:

    $ systemctl status systemd-journald-audit.socket
    o systemd-journald-audit.socket
         Loaded: bad-setting (Reason: Unit systemd-journald-audit.socket has a bad unit file setting.)
         Active: inactive (dead)

This PR includes an update to the NixOS test (nixos/tests/systemd-journal.nix) to help verify that the above update works as expected.

This PR also includes a commit to fix existing issues with nixos/tests/systemd-journal.nix that are causing it to fail currently, due to a regression in  https://github.com/NixOS/nixpkgs/pull/379629.

To reproduce and test:

1. Checkout master (currently at f869e8f)
2. nix-build -A nixosTests.systemd-journal  _[this should fail due to pre-existing bug]_
3. Apply commit 1 [nixos/tests/systemd-journal: Fix failing tests]
4. nix-build -A nixosTests.systemd-journal _[this should succeed]_
5. Apply commit 2 [nixos/tests/systemd-journal: Check container for systemd-journald-audit]
6. nix-build -A nixosTests.systemd-journal _[this should fail due to systemd-journald-audit.socket in container]_
7. Apply commit 3 [services/journald: do not create systemd-journald-audit.socket in container]
8. nix-build -A nixosTests.systemd-journal _[this should succeed]_

@arianvp @SuperSandro2000 @ElvishJerricco @flokli @aanderse 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
