### PR TITLE
ddev: install autocompletion scripts

### DIFF
--- a/pkgs/by-name/dd/ddev/package.nix
+++ b/pkgs/by-name/dd/ddev/package.nix
@@ -1,4 +1,12 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, ddev }:
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  ddev,
+}:
 
 buildGoModule rec {
   pname = "ddev";
@@ -11,6 +19,10 @@ buildGoModule rec {
     hash = "sha256-Bvp1mx07PXnLChmbaiBv2wnoN/oAZED5xQSoKMUo9tY=";
   };
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   vendorHash = null;
 
   ldflags = [
@@ -21,6 +33,17 @@ buildGoModule rec {
 
   # Tests need docker.
   doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # DDEV will try to create $HOME/.ddev, so we set $HOME to a temporary
+    # directory.
+    export HOME=$(mktemp -d)
+    $out/bin/ddev_gen_autocomplete
+    installShellCompletion --cmd ddev \
+      --bash .gotmp/bin/completions/ddev_bash_completion.sh \
+      --fish .gotmp/bin/completions/ddev_fish_completion.sh \
+      --zsh .gotmp/bin/completions/ddev_zsh_completion.sh
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = ddev;


### PR DESCRIPTION
Creates the auto-completion scripts in the `postInstall` hook by calling the `ddev_gen_autocomplete` command that's build by the package. This aligns with how it's done in the package's `Makefile`: https://github.com/ddev/ddev/blob/bc697f52e1494e028472c820d648587134ca0844/Makefile#L86-L88

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
