### PR TITLE
deepin.deepin-system-monitor: fix build

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-system-monitor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-system-monitor/default.nix
@@ -80,7 +80,11 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DVERSION=${version}" ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  # To build with icu4c need at least c++17
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=incompatible-pointer-types"
+    "--std=c++17"
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
```
/build/source/deepin-system-monitor-main/common/han_latin.cpp:44:78: error: no matching function for call to 'icu_76::UnicodeString::UnicodeString(const UChar [16])'
   44 |                      .arg(QString::fromStdString(UnicodeString(pe.postContext).toUTF8String(post)));
      |                                                                              ^
/nix/store/x4mxg72g9k7srfvp7pndgn7r92savaf6-icu4c-76.1-dev/include/unicode/unistr.h:3101:29: note: candidate: 'icu_76::UnicodeString::UnicodeString(UChar32)' (near match)
 3101 |   UNISTR_FROM_CHAR_EXPLICIT UnicodeString(UChar32 ch);
      |                             ^~~~~~~~~~~~~
/nix/store/x4mxg72g9k7srfvp7pndgn7r92savaf6-icu4c-76.1-dev/include/unicode/unistr.h:3101:29: note:   conversion of argument 1 would be ill-formed:
/build/source/deepin-system-monitor-main/common/han_latin.cpp:44:67: error: invalid conversion from 'const UChar*' {aka 'const char16_t*'} to 'UChar32' {aka 'int'} []
   44 |                      .arg(QString::fromStdString(UnicodeString(pe.postContext).toUTF8String(post)));
      |                                                                ~~~^~~~~~~~~~~
      |                                                                   |
      |                                                                   const UChar* {aka const char16_t*}
/nix/store/x4mxg72g9k7srfvp7pndgn7r92savaf6-icu4c-76.1-dev/include/unicode/unistr.h:3090:29: note: candidate: 'icu_76::UnicodeString::UnicodeString(char16_t)' (near match)
 3090 |   UNISTR_FROM_CHAR_EXPLICIT UnicodeString(char16_t ch);
      |                             ^~~~~~~~~~~~~
/nix/store/x4mxg72g9k7srfvp7pndgn7r92savaf6-icu4c-76.1-dev/include/unicode/unistr.h:3090:29: note:   conversion of argument 1 would be ill-formed:
/build/source/deepin-system-monitor-main/common/han_latin.cpp:44:67: error: invalid conversion from 'const UChar*' {aka 'const char16_t*'} to 'char16_t' []
   44 |                      .arg(QString::fromStdString(UnicodeString(pe.postContext).toUTF8String(post)));
      |                                                                ~~~^~~~~~~~~~~
      |                                                                   |
      |                                                                   const UChar* {aka const char16_t*}

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
