### PR TITLE
librsvg: generate loaders.cache even when cross compiling

### DIFF
--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -11,7 +11,6 @@
   installShellFiles,
   pango,
   freetype,
-  harfbuzz,
   cairo,
   libxml2,
   bzip2,
@@ -25,7 +24,6 @@
   python3Packages,
   gnome,
   vala,
-  writeShellScript,
   shared-mime-info,
   # Requires building a cdylib.
   withPixbufLoader ? !stdenv.hostPlatform.isStatic,
@@ -71,9 +69,27 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
+      # merged in 2.60.0-beta.0
       name = "cross-introspection.patch";
       url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/84f24b1f5767f807f8d0442bbf3f149a0defcf78.patch";
       hash = "sha256-FRyAYCCP3eu7YDUS6g7sKCdbq2nU8yQdbdVaQwLrlhE=";
+    })
+    (fetchpatch {
+      # merged in 2.60.0-beta.0; required for cross-gdk-pixbuf-loader.patch to apply
+      name = "Replace-CRLF-with-just-LF-in-a-few-remaining-files-that-had-them";
+      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/8c93369806283feafd060f4507111344e1110f79.patch";
+      hash = "sha256-FU6ZiWhXm8jPhGGuNKqlxDIEXu2bSfq1MWyQoADqLZA=";
+    })
+    (fetchpatch {
+      # merged in 2.60.0-beta.0; required for cross-gdk-pixbuf-loader.patch to apply
+      name = "do-not-look-for-gdk-pixbuf-query-loaders-in-cross-builds.patch";
+      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/ce2957acb7b0b5d7f75f47a3c503f5532aa698a6.patch";
+      hash = "sha256-f0Mdt4GjycIkM/k68KRsR0Hv2C+gaieQ4WnhjPbA5vs=";
+    })
+    (fetchpatch {
+      name = "cross-gdk-pixbuf-loader.patch";
+      url = "https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/1095.patch";
+      hash = "sha256-4R/DfDkNn7WhgBy526v309FzK6znCt2dV/ooz4LYrVU=";
     })
   ];
 
@@ -92,7 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs =
     [
-      gdk-pixbuf
       installShellFiles
       pkg-config
       meson
@@ -146,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = !stdenv.isDarwin && !stdenv.hostPlatform.isi686;
 
   env = {
-    PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_QUERY_LOADERS = writeShellScript "gdk-pixbuf-loader-loaders-wrapped" ''
+    PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_QUERY_LOADERS = buildPackages.writeShellScript "gdk-pixbuf-loader-loaders-wrapped" ''
       ${lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (stdenv.hostPlatform.emulator buildPackages)} ${lib.getDev gdk-pixbuf}/bin/gdk-pixbuf-query-loaders
     '';
   };
@@ -178,8 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       emulator = stdenv.hostPlatform.emulator buildPackages;
     in
-    # Not generated when cross compiling.
-    lib.optionalString (lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
+    lib.optionalString withPixbufLoader ''
       # Merge gdkpixbuf and librsvg loaders
       GDK_PIXBUF=$out/${gdk-pixbuf.binaryDir}
       cat ${lib.getLib gdk-pixbuf}/${gdk-pixbuf.binaryDir}/loaders.cache $GDK_PIXBUF/loaders.cache > $GDK_PIXBUF/loaders.cache.tmp


### PR DESCRIPTION
this fixes icons in several gtk applications, e.g. fractal, calls, etc.

- `nix-build -A librsvg`  -> unchanged.
- `nix-build -A pkgsCross.aarch64-multiplatform.librsvg`  -> now includes `$out/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache`, restoring the behavior from 2.58.3.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
