### PR TITLE
erofs-utils: enable lzma by default and enable zstd by default

### DIFF
--- a/pkgs/by-name/er/erofs-utils/package.nix
+++ b/pkgs/by-name/er/erofs-utils/package.nix
@@ -9,6 +9,7 @@
   lz4,
   xz,
   zlib,
+  zstd,
   libselinux,
   fuseSupport ? stdenv.hostPlatform.isLinux,
   selinuxSupport ? false,
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       lz4
       zlib
       xz
+      zstd
     ]
     ++ lib.optionals fuseSupport [ fuse ]
     ++ lib.optionals selinuxSupport [ libselinux ];

--- a/pkgs/by-name/er/erofs-utils/package.nix
+++ b/pkgs/by-name/er/erofs-utils/package.nix
@@ -12,7 +12,6 @@
   libselinux,
   fuseSupport ? stdenv.hostPlatform.isLinux,
   selinuxSupport ? false,
-  lzmaSupport ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,16 +36,15 @@ stdenv.mkDerivation (finalAttrs: {
       util-linux
       lz4
       zlib
+      xz
     ]
     ++ lib.optionals fuseSupport [ fuse ]
-    ++ lib.optionals selinuxSupport [ libselinux ]
-    ++ lib.optionals lzmaSupport [ xz ];
+    ++ lib.optionals selinuxSupport [ libselinux ];
 
   configureFlags =
     [ "MAX_BLOCK_SIZE=4096" ]
     ++ lib.optional fuseSupport "--enable-fuse"
-    ++ lib.optional selinuxSupport "--with-selinux"
-    ++ lib.optional lzmaSupport "--enable-lzma";
+    ++ lib.optional selinuxSupport "--with-selinux";
 
   meta = with lib; {
     homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/about/";


### PR DESCRIPTION
aligns with upstream since 1.8 https://github.com/erofs/erofs-utils/commit/37ada1b449ae823ca6d596059e5fbe78c4b6cc63

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
