### PR TITLE
starpu: init at 1.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19690,6 +19690,12 @@
     githubId = 2997905;
     name = "Petr Hodina";
   };
+  PhoqueEberlue = {
+    email = "andrewmhdb@gmail.com";
+    github = "PhoqueEberlue";
+    githubId = 58080347;
+    name = "Andrew Mary Huet de Barochez";
+  };
   photex = {
     email = "photex@gmail.com";
     github = "photex";

--- a/pkgs/by-name/st/starpu/package.nix
+++ b/pkgs/by-name/st/starpu/package.nix
@@ -1,0 +1,106 @@
+{
+  # derivation dependencies
+  lib,
+  fetchurl,
+  stdenv,
+  writableTmpDirAsHomeHook,
+  autoreconfHook,
+
+  # starpu dependencies
+  hwloc,
+  libuuid,
+  libX11,
+  fftw,
+  fftwFloat, # Same than previous but with float precision
+  pkg-config,
+  libtool,
+  simgrid,
+  mpi,
+  cudaPackages,
+
+  # Options
+  enableSimgrid ? false,
+  enableMPI ? false,
+  enableCUDA ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "starpu";
+  version = "1.4.7";
+
+  inherit enableSimgrid;
+  inherit enableMPI;
+  inherit enableCUDA;
+
+  src = fetchurl {
+    url = "https://files.inria.fr/starpu/starpu-${finalAttrs.version}/starpu-${finalAttrs.version}.tar.gz";
+    hash = "sha256-HrPfVRCJFT/m4LFyrZURhDS0qB6p6qWiw4cl0NtTsT4=";
+  };
+
+  nativeBuildInputs =
+    [
+      pkg-config
+      hwloc
+      libtool
+      writableTmpDirAsHomeHook
+      autoreconfHook
+    ]
+    ++ lib.optional finalAttrs.enableSimgrid simgrid
+    ++ lib.optional finalAttrs.enableMPI mpi
+    ++ lib.optional finalAttrs.enableCUDA cudaPackages.cudatoolkit;
+
+  buildInputs =
+    [
+      libuuid
+      libX11
+      fftw
+      fftwFloat
+      hwloc
+    ]
+    ++ lib.optional finalAttrs.enableSimgrid simgrid
+    ++ lib.optional finalAttrs.enableMPI mpi
+    ++ lib.optional finalAttrs.enableCUDA cudaPackages.cudatoolkit;
+
+  configureFlags = [
+    (lib.enableFeature true "quick-check")
+    (lib.enableFeature false "build-examples")
+    (lib.enableFeature finalAttrs.enableSimgrid "simgrid")
+    (lib.enableFeature finalAttrs.enableMPI "mpi")
+    (lib.enableFeature finalAttrs.enableMPI "mpi-check")
+    (lib.enableFeature (!finalAttrs.enableMPI) "shared") # Static linking is mandatory for smpi
+    (lib.optional stdenv.hostPlatform.isDarwin (lib.enableFeature true "maxcpus=4"))
+  ];
+  # No need to add flags for CUDA, it should be detected by ./configure
+
+  postConfigure = ''
+    # Patch shebangs recursively because a lot of scripts are used
+    shopt -s globstar
+    patchShebangs --build **/*.sh
+  '';
+
+  enableParallelBuilding = true;
+  doCheck = true;
+
+  meta = {
+    homepage = "https://starpu.gitlabpages.inria.fr/index.html";
+    changelog = "https://files.inria.fr/starpu/starpu-${finalAttrs.version}/log.txt";
+    description = "Task programming library for hybrid architectures";
+    longDescription = ''
+      StarPU is a task programming library for hybrid architectures
+
+      - The application provides algorithms and constraints
+        - CPU/GPU implementations of tasks
+        - A graph of tasks, using either StarPU’s rich C/C++/Fortran/Python API, or OpenMP pragmas.
+      - StarPU internally deals with the following aspects:
+        - Task dependencies
+        - Optimized heterogeneous scheduling
+        - Optimized data transfers and replication between main memory and discrete memories
+        - Optimized cluster communications
+        - Fully asynchronous execution without spurious waits
+
+      Rather than handling low-level issues, programmers can concentrate on algorithmic aspects!
+    '';
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.PhoqueEberlue ];
+  };
+})


### PR DESCRIPTION
Adds StarPU: A Unified Runtime System for Heterogeneous Multicore Architectures, see: https://starpu.gitlabpages.inria.fr/

## Things done

- Added myself as a new maintainer
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
