### PR TITLE
jasmin-compiler: 2024.07.2 → 2024.07.3

### DIFF
--- a/pkgs/by-name/ja/jasmin-compiler/package.nix
+++ b/pkgs/by-name/ja/jasmin-compiler/package.nix
@@ -9,14 +9,12 @@
 
 stdenv.mkDerivation rec {
   pname = "jasmin-compiler";
-  version = "2024.07.2";
+  version = "2024.07.3";
 
   src = fetchurl {
     url = "https://github.com/jasmin-lang/jasmin/releases/download/v${version}/jasmin-compiler-v${version}.tar.bz2";
-    hash = "sha256-I8z5/Ggj5GSyvD7b9YYMh3My4vXAYVcP53BCFwCNxwQ=";
+    hash = "sha256-z5J4zxnsykNWXeAfS0GhU4oK0GJFa5qca9HhgzWx/34=";
   };
-
-  sourceRoot = "jasmin-compiler-v${version}/compiler";
 
   nativeBuildInputs = with ocamlPackages; [
     ocaml
@@ -52,10 +50,12 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+    pushd compiler
     dune build @install
     dune install --prefix=$bin --libdir=$out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib
+    popd
     mkdir -p $lib/lib/jasmin/easycrypt
-    cp ../eclib/*.ec $lib/lib/jasmin/easycrypt
+    cp eclib/*.ec $lib/lib/jasmin/easycrypt
     runHook postInstall
   '';
 


### PR DESCRIPTION
https://github.com/jasmin-lang/jasmin/releases/tag/v2024.07.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
