### PR TITLE
bento: 1.5.0 -> 1.5.1

### DIFF
--- a/pkgs/by-name/be/bento/package.nix
+++ b/pkgs/by-name/be/bento/package.nix
@@ -8,16 +8,17 @@
 
 buildGoModule rec {
   pname = "bento";
-  version = "1.5.0";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "warpstreamlabs";
     repo = "bento";
     tag = "v${version}";
-    hash = "sha256-/8d2q810IMajBTTWPzIq/EDx4SRIfuYSzS4JfWs2vgE=";
+    hash = "sha256-l+XQAcLIL37UBvV++0U3vlPZaz53K+/grRBOZqCcbPM=";
   };
 
-  vendorHash = "sha256-oh2kI8HnVI76kAERRFJLUtSJoc9w9dZWjCnf+sHKIDI=";
+  proxyVendor = true;
+  vendorHash = "sha256-lWg3wX+iS+RXH00kngNGGb7/93iAHiFzGjuyp+KSfco=";
 
   subPackages = [
     "cmd/bento"
@@ -44,9 +45,5 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ genga898 ];
     mainProgram = "bento";
-    badPlatforms = [
-      # cannot find module providing package github.com/microsoft/gocosmos
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }


### PR DESCRIPTION
Enable darwin platform

This commit also enables the darwin platform back. It builds just fine.

The comment on previous failure was very likely due to some networking problems as the github repo is accessible.

## build log and bin test log
```
uname -a
Darwin Yvans-MacBook-Pro 24.3.0 Darwin Kernel Version 24.3.0: Thu Jan  2 20:24:24 PST 2025; root:xnu-11215.81.4~3/RELEASE_ARM64_T6030 arm64
```

```
nix-build $NIXPKGS -A bento
this derivation will be built:
  /nix/store/m3gp2n46a7fpdmw2wf5pqdsp2ravgmsg-bento-1.5.1.drv
building '/nix/store/m3gp2n46a7fpdmw2wf5pqdsp2ravgmsg-bento-1.5.1.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/3r9p4wwnjnmis63vbngyz2nabfk69gb4-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Building subPackage ./cmd/bento
Building subPackage ./cmd/serverless/bento-lambda
buildPhase completed in 59 seconds
Running phase: checkPhase
?       github.com/warpstreamlabs/bento/cmd/bento       [no test files]
?       github.com/warpstreamlabs/bento/cmd/serverless/bento-lambda     [no test files]
checkPhase completed in 41 seconds
Running phase: installPhase
Running phase: fixupPhase
checking for references to /private/tmp/nix-build-bento-1.5.1.drv-0/ in /nix/store/v5r4211lc0k4bzmpf0byp2jnvshk3wli-bento-1.5.1...
patching script interpreter paths in /nix/store/v5r4211lc0k4bzmpf0byp2jnvshk3wli-bento-1.5.1
stripping (with command strip and flags -S) in  /nix/store/v5r4211lc0k4bzmpf0byp2jnvshk3wli-bento-1.5.1/bin
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 1.5.1 in the output of the command /nix/store/v5r4211lc0k4bzmpf0byp2jnvshk3wli-bento-1.5.1/bin/bento --version
Version: 1.5.1
Date:
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing
/nix/store/v5r4211lc0k4bzmpf0byp2jnvshk3wli-bento-1.5.1
```
```
./result/bin/bento --version
Version: 1.5.1
Date:
./result/bin/bento-lambda --version
2025/02/25 13:42:15 expected AWS Lambda environment variables [_LAMBDA_SERVER_PORT AWS_LAMBDA_RUNTIME_API] are not defined
```
```
 ./result/bin/bento create -s
input:
  stdin: {}
buffer:
  none: {}
pipeline:
  threads: -1
  processors: []
output:
  stdout: {}
```
## Description of changes

Chanelog of [bento 1.5.1](https://github.com/warpstreamlabs/bento/releases/tag/v1.5.1)

## Things done

( Will do linux x86 asap )

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
