### PR TITLE
nixos/movim: H2O support, H2O + Ejabberd + `runTest`

### DIFF
--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -481,21 +481,22 @@ in
         );
         default = null;
         example =
-          lib.literalExpression # nginx
+          lib.literalExpression # nix
             ''
               {
                 serverAliases = [
-                  "pics.''${config.networking.domain}"
+                  "pics.''${config.movim.domain}"
                 ];
                 enableACME = true;
                 forceHttps = true;
               }
             '';
         description = ''
-          With this option, you can customize an nginx virtual host which already has sensible defaults for Movim.
-          Set to `{ }` if you do not need any customization to the virtual host.
-          If enabled, then by default, the {option}`serverName` is `''${domain}`,
-          If this is set to null (the default), no nginx virtualHost will be configured.
+          With this option, you can customize an Nginx virtual host which
+          already has sensible defaults for Movim. Set to `{ }` if you do not
+          need any customization to the virtual host. If enabled, then by
+          default, the {option}`serverName` is `''${domain}`, If this is set to
+          `null` (the default), no Nginx `virtualHost` will be configured.
         '';
       };
 
@@ -657,7 +658,7 @@ in
                     '';
                 };
               };
-              extraConfig = # ngnix
+              extraConfig = # nginx
                 ''
                   index index.php;
                 '';

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -209,19 +209,19 @@ in
       };
 
       dataDir = mkOption {
-        type = types.nonEmptyStr;
+        type = types.path;
         default = "/var/lib/movim";
         description = "State directory of the `movim` user which holds the application’s state & data.";
       };
 
       logDir = mkOption {
-        type = types.nonEmptyStr;
+        type = types.path;
         default = "/var/log/movim";
         description = "Log directory of the `movim` user which holds the application’s logs.";
       };
 
       runtimeDir = mkOption {
-        type = types.nonEmptyStr;
+        type = types.path;
         default = "/run/movim";
         description = "Runtime directory of the `movim` user which holds the application’s caches & temporary files.";
       };
@@ -319,30 +319,28 @@ in
       };
 
       precompressStaticFiles = mkOption {
-        type =
-          with types;
-          submodule {
-            options = {
-              brotli = {
-                enable = mkEnableOption "Brotli precompression";
-                package = mkPackageOption pkgs "brotli" { };
-                compressionLevel = mkOption {
-                  type = types.ints.between 0 11;
-                  default = 11;
-                  description = "Brotli compression level";
-                };
+        type = types.submodule {
+          options = {
+            brotli = {
+              enable = mkEnableOption "Brotli precompression";
+              package = mkPackageOption pkgs "brotli" { };
+              compressionLevel = mkOption {
+                type = types.ints.between 0 11;
+                default = 11;
+                description = "Brotli compression level";
               };
-              gzip = {
-                enable = mkEnableOption "Gzip precompression";
-                package = mkPackageOption pkgs "gzip" { };
-                compressionLevel = mkOption {
-                  type = types.ints.between 1 9;
-                  default = 9;
-                  description = "Gzip compression level";
-                };
+            };
+            gzip = {
+              enable = mkEnableOption "Gzip precompression";
+              package = mkPackageOption pkgs "gzip" { };
+              compressionLevel = mkOption {
+                type = types.ints.between 1 9;
+                default = 9;
+                description = "Gzip compression level";
               };
             };
           };
+        };
         default = {
           brotli.enable = true;
           gzip.enable = false;
@@ -354,67 +352,67 @@ in
         type = types.submodule {
           options = {
             info = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "Content of the info box on the login page";
             };
 
             description = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "General description of the instance";
             };
 
             timezone = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "The server timezone";
             };
 
             restrictsuggestions = mkOption {
-              type = with types; nullOr bool;
+              type = types.nullOr types.bool;
               default = null;
               description = "Only suggest chatrooms, Communities and other contents that are available on the user XMPP server and related services";
             };
 
             chatonly = mkOption {
-              type = with types; nullOr bool;
+              type = types.nullOr types.bool;
               default = null;
               description = "Disable all the social feature (Communities, Blog…) and keep only the chat ones";
             };
 
             disableregistration = mkOption {
-              type = with types; nullOr bool;
+              type = types.nullOr types.bool;
               default = null;
               description = "Remove the XMPP registration flow and buttons from the interface";
             };
 
             loglevel = mkOption {
-              type = with types; nullOr (ints.between 0 3);
+              type = types.nullOr (types.ints.between 0 3);
               default = null;
               description = "The server loglevel";
             };
 
             locale = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "The server main locale";
             };
 
             xmppdomain = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "The default XMPP server domain";
             };
 
             xmppdescription = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "The default XMPP server description";
             };
 
             xmppwhitelist = mkOption {
-              type = with types; nullOr str;
+              type = types.nullOr types.nonEmptyStr;
               default = null;
               description = "The allowlisted XMPP servers";
             };
@@ -442,7 +440,7 @@ in
       };
 
       secretFile = mkOption {
-        type = with types; nullOr path;
+        type = types.nullOr types.path;
         default = null;
         description = "The secret file to be sourced for the .env settings.";
       };
@@ -459,13 +457,13 @@ in
         };
 
         name = mkOption {
-          type = types.str;
+          type = types.nonEmptyStr;
           default = "movim";
           description = "Database name.";
         };
 
         user = mkOption {
-          type = types.str;
+          type = types.nonEmptyStr;
           default = "movim";
           description = "Database username.";
         };
@@ -478,15 +476,9 @@ in
       };
 
       nginx = mkOption {
-        type =
-          with types;
-          nullOr (
-            submodule (
-              import ../web-servers/nginx/vhost-options.nix {
-                inherit config lib;
-              }
-            )
-          );
+        type = types.nullOr (
+          types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; })
+        );
         default = null;
         example =
           lib.literalExpression # nginx

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -803,7 +803,7 @@ in
   morty = handleTest ./morty.nix { };
   mosquitto = handleTest ./mosquitto.nix { };
   moosefs = handleTest ./moosefs.nix { };
-  movim = discoverTests (import ./web-apps/movim { inherit handleTestOn; });
+  movim = import ./web-apps/movim { inherit recurseIntoAttrs runTest; };
   mpd = handleTest ./mpd.nix { };
   mpv = handleTest ./mpv.nix { };
   mtp = handleTest ./mtp.nix { };

--- a/nixos/tests/web-apps/movim/default.nix
+++ b/nixos/tests/web-apps/movim/default.nix
@@ -7,6 +7,7 @@ let
   supportedSystems = [
     "x86_64-linux"
     "i686-linux"
+    "aarch64-linux"
   ];
 in
 {

--- a/nixos/tests/web-apps/movim/default.nix
+++ b/nixos/tests/web-apps/movim/default.nix
@@ -1,5 +1,6 @@
 { recurseIntoAttrs, runTest }:
 
 recurseIntoAttrs {
+  ejabberd-h2o = runTest ./ejabberd-h2o.nix;
   prosody-nginx = runTest ./prosody-nginx.nix;
 }

--- a/nixos/tests/web-apps/movim/default.nix
+++ b/nixos/tests/web-apps/movim/default.nix
@@ -1,15 +1,5 @@
-{
-  system ? builtins.currentSystem,
-  handleTestOn,
-}:
+{ recurseIntoAttrs, runTest }:
 
-let
-  supportedSystems = [
-    "x86_64-linux"
-    "i686-linux"
-    "aarch64-linux"
-  ];
-in
-{
-  prosody-nginx = handleTestOn supportedSystems ./prosody-nginx.nix { inherit system; };
+recurseIntoAttrs {
+  prosody-nginx = runTest ./prosody-nginx.nix;
 }

--- a/nixos/tests/web-apps/movim/default.nix
+++ b/nixos/tests/web-apps/movim/default.nix
@@ -11,5 +11,5 @@ let
   ];
 in
 {
-  standard = handleTestOn supportedSystems ./standard.nix { inherit system; };
+  prosody-nginx = handleTestOn supportedSystems ./prosody-nginx.nix { inherit system; };
 }

--- a/nixos/tests/web-apps/movim/ejabberd-h2o.nix
+++ b/nixos/tests/web-apps/movim/ejabberd-h2o.nix
@@ -1,0 +1,274 @@
+{ hostPkgs, lib, ... }:
+
+let
+  movim = {
+    domain = "movim.local";
+    port = 8080;
+    info = "No ToS in tests";
+    description = "NixOS testing server";
+  };
+  ejabberd = {
+    domain = "ejabberd.local";
+    ports = {
+      c2s = 5222;
+      s2s = 5269;
+      http = 5280;
+    };
+    spoolDir = "/var/lib/ejabberd";
+    admin = rec {
+      JID = "${username}@${ejabberd.domain}";
+      username = "romeo";
+      password = "juliet";
+    };
+  };
+
+  # START OF EJABBERD CONFIG ##################################################
+  #
+  # Ejabberd has sparse defaults as it is a generic XMPP server. As such this
+  # config might be longer than expected for a test.
+  #
+  # Movim suggests: https://github.com/movim/movim/wiki/Configure ejabberd
+  #
+  # In the future this may be the default setup
+  # See: https://github.com/NixOS/nixpkgs/pull/312316
+  ejabberd_config_file =
+    let
+      settingsFormat = hostPkgs.formats.yaml { };
+    in
+    settingsFormat.generate "ejabberd.yml" {
+      loglevel = "info";
+      hide_sensitive_log_data = false;
+      hosts = [ ejabberd.domain ];
+      default_db = "mnesia";
+      acme.auto = false;
+      s2s_access = "s2s";
+      s2s_use_starttls = false;
+      new_sql_schema = true;
+      acl = {
+        admin = [
+          { user = ejabberd.admin.JID; }
+        ];
+        local.user_regexp = "";
+        loopback.ip = [
+          "127.0.0.1/8"
+          "::1/128"
+        ];
+      };
+      access_rules = {
+        c2s = {
+          deny = "blocked";
+          allow = "all";
+        };
+        s2s = {
+          allow = "all";
+        };
+        local.allow = "local";
+        announce.allow = "admin";
+        configure.allow = "admin";
+        pubsub_createnode.allow = "local";
+        trusted_network.allow = "loopback";
+      };
+      api_permissions = {
+        "console commands" = {
+          from = [ "ejabberd_ctl" ];
+          who = "all";
+          what = "*";
+        };
+      };
+      shaper = {
+        normal = {
+          rate = 3000;
+          burst_size = 20000;
+        };
+        fast = 100000;
+      };
+      modules = {
+        mod_caps = { };
+        mod_disco = { };
+        mod_mam = { };
+        mod_http_upload = {
+          docroot = "${ejabberd.spoolDir}/uploads";
+          dir_mode = "0755";
+          file_mode = "0644";
+          get_url = "http://@HOST@/upload";
+          put_url = "http://@HOST@/upload";
+          max_size = 65536;
+          custom_headers = {
+            Access-Control-Allow-Origin = "http://@HOST@,http://${movim.domain}";
+            Access-Control-Allow-Methods = "GET,HEAD,PUT,OPTIONS";
+            Access-Control-Allow-Headers = "Content-Type";
+          };
+        };
+        # This PubSub block is required for Movim to work.
+        #
+        # See: https://github.com/movim/movim/wiki/Configure ejabberd#pubsub
+        mod_pubsub = {
+          hosts = [ "pubsub.@HOST@" ];
+          access_createnode = "pubsub_createnode";
+          ignore_pep_from_offline = false;
+          last_item_cache = false;
+          max_items_node = 2048;
+          default_node_config = {
+            max_items = 2048;
+          };
+          plugins = [
+            "flat"
+            "pep"
+          ];
+          force_node_config = {
+            "storage:bookmarks".access_model = "whitelist";
+            "eu.siacs.conversations.axolotl.*".access_model = "open";
+            "urn:xmpp:bookmarks:0" = {
+              access_model = "whitelist";
+              send_last_published_item = "never";
+              max_items = "infinity";
+              persist_items = true;
+            };
+            "urn:xmpp:bookmarks:1" = {
+              access_model = "whitelist";
+              send_last_published_item = "never";
+              max_items = "infinity";
+              persist_items = true;
+            };
+            "urn:xmpp:pubsub:movim-public-subscription" = {
+              access_model = "whitelist";
+              max_items = "infinity";
+              persist_items = true;
+            };
+            "urn:xmpp:microblog:0" = {
+              notify_retract = true;
+              max_items = "infinity";
+              persist_items = true;
+            };
+            "urn:xmpp:microblog:0:comments*" = {
+              access_model = "open";
+              notify_retract = true;
+              max_items = "infinity";
+              persist_items = true;
+            };
+          };
+        };
+        mod_stream_mgmt = { };
+      };
+      listen = [
+        {
+          module = "ejabberd_c2s";
+          port = ejabberd.ports.c2s;
+          max_stanza_size = 262144;
+          access = "c2s";
+          starttls_required = false;
+        }
+        {
+          module = "ejabberd_s2s_in";
+          port = ejabberd.ports.s2s;
+          max_stanza_size = 524288;
+          shaper = "fast";
+        }
+        {
+          module = "ejabberd_http";
+          port = ejabberd.ports.http;
+          request_handlers = {
+            "/upload" = "mod_http_upload";
+          };
+        }
+      ];
+    };
+  # END OF EJABBERD CONFIG ##################################################
+in
+{
+  name = "movim-ejabberd-h2o";
+
+  meta = {
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          # For testing
+          pkgs.websocat
+        ];
+
+        services.movim = {
+          inherit (movim) domain port;
+          enable = true;
+          verbose = true;
+          podConfig = {
+            inherit (movim) description info;
+            xmppdomain = ejabberd.domain;
+          };
+          database = {
+            type = "postgresql";
+            createLocally = true;
+          };
+          h2o = { };
+        };
+
+        services.ejabberd = {
+          inherit (ejabberd) spoolDir;
+          enable = true;
+          configFile = ejabberd_config_file;
+          imagemagick = false;
+        };
+
+        services.h2o.settings = {
+          compress = "ON";
+        };
+
+        systemd.services.ejabberd = {
+          serviceConfig = {
+            # Certain misconfigurations can cause RAM usage to swell before
+            # crashing; fail sooner with more-than-liberal memory limits
+            StartupMemoryMax = "1G";
+            MemoryMax = "512M";
+          };
+        };
+
+        networking = {
+          firewall.allowedTCPPorts = with ejabberd.ports; [
+            c2s
+            s2s
+          ];
+          extraHosts = ''
+            127.0.0.1 ${movim.domain}
+            127.0.0.1 ${ejabberd.domain}
+          '';
+        };
+      };
+  };
+
+  testScript = # python
+    ''
+      ejabberdctl = "su ejabberd -s $(which ejabberdctl) "
+
+      server.wait_for_unit("phpfpm-movim.service")
+      server.wait_for_unit("h2o.service")
+      server.wait_for_open_port(${builtins.toString movim.port})
+      server.wait_for_open_port(80)
+
+      server.wait_for_unit("ejabberd.service")
+      ejabberd_status = server.succeed(ejabberdctl + "status")
+      assert "status: started" in ejabberd_status
+      server.succeed(ejabberdctl + "register ${ejabberd.admin.username} ${ejabberd.domain} ${ejabberd.admin.password}")
+
+      server.wait_for_unit("movim.service")
+
+      # Test unauthenticated
+      server.fail("curl -L --fail-with-body --max-redirs 0 http://${movim.domain}/chat")
+
+      # Test basic Websocket
+      server.succeed("echo | websocat --origin 'http://${movim.domain}' 'ws://${movim.domain}/ws/?path=login&offset=0'")
+
+      # Test login + create cookiejar
+      login_html = server.succeed("curl --fail-with-body -c /tmp/cookies http://${movim.domain}/login")
+      assert "${movim.description}" in login_html
+      assert "${movim.info}" in login_html
+
+      # Test authentication POST
+      server.succeed("curl --fail-with-body -b /tmp/cookies -X POST --data-urlencode 'username=${ejabberd.admin.JID}' --data-urlencode 'password=${ejabberd.admin.password}' http://${movim.domain}/login")
+
+      server.succeed("curl -L --fail-with-body --max-redirs 1 -b /tmp/cookies http://${movim.domain}/chat")
+    '';
+}

--- a/nixos/tests/web-apps/movim/prosody-nginx.nix
+++ b/nixos/tests/web-apps/movim/prosody-nginx.nix
@@ -1,110 +1,115 @@
-import ../../make-test-python.nix (
-  { lib, pkgs, ... }:
+{ lib, ... }:
 
-  let
-    movim = {
-      domain = "movim.local";
-      info = "No ToS in tests";
-      description = "NixOS testing server";
+let
+  movim = {
+    domain = "movim.local";
+    port = 8080;
+    info = "No ToS in tests";
+    description = "NixOS testing server";
+  };
+  prosody = {
+    domain = "prosody.local";
+    admin = rec {
+      JID = "${username}@${prosody.domain}";
+      username = "romeo";
+      password = "juliet";
     };
-    prosody = {
-      domain = "prosody.local";
-      admin = rec {
-        JID = "${username}@${prosody.domain}";
-        username = "romeo";
-        password = "juliet";
-      };
-    };
-  in
-  {
-    name = "movim-prosody-nginx";
+  };
+in
+{
+  name = "movim-prosody-nginx";
 
-    meta = {
-      maintainers = with pkgs.lib.maintainers; [ toastal ];
-    };
+  meta = {
+    maintainers = with lib.maintainers; [ toastal ];
+  };
 
-    nodes = {
-      server =
-        { pkgs, ... }:
-        {
-          services.movim = {
-            inherit (movim) domain;
-            enable = true;
-            verbose = true;
-            podConfig = {
-              inherit (movim) description info;
-              xmppdomain = prosody.domain;
-            };
-            nginx = { };
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          # For testing
+          pkgs.websocat
+        ];
+
+        services.movim = {
+          inherit (movim) domain port;
+          enable = true;
+          verbose = true;
+          podConfig = {
+            inherit (movim) description info;
+            xmppdomain = prosody.domain;
           };
+          nginx = { };
+        };
 
-          services.prosody = {
-            enable = true;
-            xmppComplianceSuite = false;
-            disco_items = [
-              {
-                url = "upload.${prosody.domain}";
-                description = "File Uploads";
-              }
-            ];
-            virtualHosts."${prosody.domain}" = {
-              inherit (prosody) domain;
-              enabled = true;
-              extraConfig = ''
-                Component "pubsub.${prosody.domain}" "pubsub"
-                    pubsub_max_items = 10000
-                    expose_publisher = true
-
-                Component "upload.${prosody.domain}" "http_file_share"
-                    http_external_url = "http://upload.${prosody.domain}"
-                    http_file_share_expires_after = 300 * 24 * 60 * 60
-                    http_file_share_size_limit = 1024 * 1024 * 1024
-                    http_file_share_daily_quota = 4 * 1024 * 1024 * 1024
-              '';
-            };
+        services.prosody = {
+          enable = true;
+          xmppComplianceSuite = false;
+          disco_items = [
+            {
+              url = "upload.${prosody.domain}";
+              description = "File Uploads";
+            }
+          ];
+          virtualHosts."${prosody.domain}" = {
+            inherit (prosody) domain;
+            enabled = true;
             extraConfig = ''
-              pep_max_items = 10000
+              Component "pubsub.${prosody.domain}" "pubsub"
+                  pubsub_max_items = 10000
+                  expose_publisher = true
 
-              http_paths = {
-                  file_share = "/";
-              }
+              Component "upload.${prosody.domain}" "http_file_share"
+                  http_external_url = "http://upload.${prosody.domain}"
+                  http_file_share_expires_after = 300 * 24 * 60 * 60
+                  http_file_share_size_limit = 1024 * 1024 * 1024
+                  http_file_share_daily_quota = 4 * 1024 * 1024 * 1024
             '';
           };
+          extraConfig = ''
+            pep_max_items = 10000
 
-          networking.extraHosts = ''
-            127.0.0.1 ${movim.domain}
-            127.0.0.1 ${prosody.domain}
+            http_paths = {
+                file_share = "/";
+            }
           '';
         };
-    };
 
-    testScript = # python
-      ''
-        server.wait_for_unit("phpfpm-movim.service")
-        server.wait_for_unit("nginx.service")
-        server.wait_for_open_port(80)
+        networking.extraHosts = ''
+          127.0.0.1 ${movim.domain}
+          127.0.0.1 ${prosody.domain}
+        '';
+      };
+  };
 
-        server.wait_for_unit("prosody.service")
-        server.succeed('prosodyctl status | grep "Prosody is running"')
-        server.succeed("prosodyctl register ${prosody.admin.username} ${prosody.domain} ${prosody.admin.password}")
+  testScript = # python
+    ''
+      server.wait_for_unit("phpfpm-movim.service")
+      server.wait_for_unit("nginx.service")
+      server.wait_for_open_port(${builtins.toString movim.port})
+      server.wait_for_open_port(80)
 
-        server.wait_for_unit("movim.service")
+      server.wait_for_unit("prosody.service")
+      server.succeed('prosodyctl status | grep "Prosody is running"')
+      server.succeed("prosodyctl register ${prosody.admin.username} ${prosody.domain} ${prosody.admin.password}")
 
-        # Test unauthenticated
-        server.fail("curl -L --fail-with-body --max-redirs 0 http://${movim.domain}/chat")
+      server.wait_for_unit("movim.service")
 
-        # Test basic Websocket
-        server.succeed("echo \"\" | ${lib.getExe pkgs.websocat} 'ws://${movim.domain}/ws/?path=login&offset=0' --origin 'http://${movim.domain}'")
+      # Test unauthenticated
+      server.fail("curl -L --fail-with-body --max-redirs 0 http://${movim.domain}/chat")
 
-        # Test login + create cookiejar
-        login_html = server.succeed("curl --fail-with-body -c /tmp/cookies http://${movim.domain}/login")
-        assert "${movim.description}" in login_html
-        assert "${movim.info}" in login_html
+      # Test basic Websocket
+      server.succeed("echo | websocat --origin 'http://${movim.domain}' 'ws://${movim.domain}/ws/?path=login&offset=0'")
 
-        # Test authentication POST
-        server.succeed("curl --fail-with-body -b /tmp/cookies -X POST --data-urlencode 'username=${prosody.admin.JID}' --data-urlencode 'password=${prosody.admin.password}' http://${movim.domain}/login")
+      # Test login + create cookiejar
+      login_html = server.succeed("curl --fail-with-body -c /tmp/cookies http://${movim.domain}/login")
+      assert "${movim.description}" in login_html
+      assert "${movim.info}" in login_html
 
-        server.succeed("curl -L --fail-with-body --max-redirs 1 -b /tmp/cookies http://${movim.domain}/chat")
-      '';
-  }
-)
+      # Test authentication POST
+      server.succeed("curl --fail-with-body -b /tmp/cookies -X POST --data-urlencode 'username=${prosody.admin.JID}' --data-urlencode 'password=${prosody.admin.password}' http://${movim.domain}/login")
+
+      server.succeed("curl -L --fail-with-body --max-redirs 1 -b /tmp/cookies http://${movim.domain}/chat")
+    '';
+}


### PR DESCRIPTION
H2O virtual host support added for easy enabling. Added a test that covers both H2O _and_ Ejabberd (other test is Prosody + Nginx)… which should cover a bigger gamut. As always, fixups were found along the way & documented in separate commits before the big addition.

~~*UNFORTUNATELY*, `nixfmt` had to be ran which adds a lot of noise to the review & makes the code so much more vertical & therefore harder to modify/read/review. Probably easier to review by commit.~~ Got that merged separately to reduce noise. Actually a lot of the commits were merge separately to increase the chance someone re-reviews it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
