### PR TITLE
edk2: 202411 -> 202502

### DIFF
--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -34,14 +34,14 @@ let
 
   edk2 = stdenv.mkDerivation {
     pname = "edk2";
-    version = "202411";
+    version = "202502";
 
     srcWithVendoring = fetchFromGitHub {
       owner = "tianocore";
       repo = "edk2";
       rev = "edk2-stable${edk2.version}";
       fetchSubmodules = true;
-      hash = "sha256-KYaTGJ3DHtWbPEbP+n8MTk/WwzLv5Vugty/tvzuEUf0=";
+      hash = "sha256-iobC0CeWSylS9sLuXOqAmL36hl/tY+IedT/I3xQ80Ag=";
     };
 
     src = applyPatches {
@@ -62,18 +62,16 @@ let
         })
       ];
 
-      # EDK2 is currently working on OpenSSL 3.3.x support. Use buildpackages.openssl again,
-      # when "https://github.com/tianocore/edk2/pull/6167" is merged.
       postPatch = ''
-        # We don't want EDK2 to keep track of OpenSSL, they're frankly bad at it.
+        # de-vendor OpenSSL
         rm -r CryptoPkg/Library/OpensslLib/openssl
         mkdir -p CryptoPkg/Library/OpensslLib/openssl
         (
         cd CryptoPkg/Library/OpensslLib/openssl
-        tar --strip-components=1 -xf ${buildPackages.openssl_3.src}
+        tar --strip-components=1 -xf ${buildPackages.openssl.src}
 
         # Apply OpenSSL patches.
-        ${lib.pipe buildPackages.openssl_3.patches [
+        ${lib.pipe buildPackages.openssl.patches [
           (builtins.filter (
             patch:
             !builtins.elem (baseNameOf patch) [


### PR DESCRIPTION
https://github.com/tianocore/edk2/releases/tag/edk2-stable202502

```
➜ nom-build -A edk2.passthru.tests -A nixosTests.incus.virtual-machine --argstr system aarch64-linux
/nix/store/yh5iwqks587vqr43g07sarcb2wly106l-vm-test-run-boot-uefi-cdrom
/nix/store/gajyls89g2zjax3xg2izaqnk8w0fal1j-vm-test-run-incus
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
