### PR TITLE
python312Packages.ipylab: fix broken 'ipylab._version' import

### DIFF
--- a/pkgs/development/python-modules/ipylab/default.nix
+++ b/pkgs/development/python-modules/ipylab/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   hatchling,
+  hatch-jupyter-builder,
   hatch-nodejs-version,
   ipywidgets,
   jupyterlab,
@@ -13,6 +14,8 @@ buildPythonPackage rec {
   version = "1.0.0";
   pyproject = true;
 
+  # This needs to be fetched from Pypi, as we rely on the nodejs build to be skipped,
+  # which only happens if ipylab/labextension/style.js is present.
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-xPB0Sx+W1sRgW5hqpZ68zWRFG/cclIOgGat6UsVlYXA=";
@@ -20,11 +23,10 @@ buildPythonPackage rec {
 
   build-system = [
     hatchling
+    hatch-jupyter-builder
     hatch-nodejs-version
     jupyterlab
   ];
-
-  env.HATCH_BUILD_NO_HOOKS = true;
 
   dependencies = [
     ipywidgets
@@ -41,10 +43,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/jtpio/ipylab/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ flokli ];
-    badPlatforms = [
-      # Unclear why it breaks on darwin only
-      # ModuleNotFoundError: No module named 'ipylab._version'
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }


### PR DESCRIPTION
Running hatchling without the version hook prevents this file from being created, which causes an import error on Darwin.
It's not clear why it still did work on Linux, howerver running the hook is cleaner.

The second hook, one that normally compiles javascript is skipped, as our sources already contain it, yet the declared dependency, hatch-jupyter-builder still needs to be provided.

With this I was able to successfully build it on Darwin as well.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
