### PR TITLE
feedbackd: 0.4.1 -> 0.7.0

### DIFF
--- a/nixos/modules/programs/feedbackd.nix
+++ b/nixos/modules/programs/feedbackd.nix
@@ -25,6 +25,8 @@ in
     services.dbus.packages = [ cfg.package ];
     services.udev.packages = [ cfg.package ];
 
+    # TODO: also enable systemd unit fbd-alert-slider for OnePlus 6/6T devices, see release notes of feedbackd v0.5.0
+
     users.groups.feedbackd = { };
   };
 }

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -110,7 +110,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Daemon to provide haptic (and later more) feedback on events";
     homepage = "https://source.puri.sm/Librem5/feedbackd";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ pacman99 ];
+    maintainers = with maintainers; [
+      pacman99
+      Luflosi
+    ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -34,7 +34,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "feedbackd";
-  version = "0.4.1";
+  version = "0.7.0";
 
   outputs = [
     "out"
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Librem5";
     repo = "feedbackd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ta14DYqkid8Cp8fx9ZMGOOJroCBszN9/VrTN6mrpTZg=";
+    hash = "sha256-qwyq1v+20Gotpk0CbUe6MdDJ5bmKmTHOen+rxWljjeA=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -20,6 +20,7 @@
   dbus,
   gmobile,
   umockdev,
+  nix-update-script,
 }:
 
 let
@@ -105,6 +106,10 @@ stdenv.mkDerivation (finalAttrs: {
         done
     fi
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Daemon to provide haptic (and later more) feedback on events";


### PR DESCRIPTION
https://source.puri.sm/Librem5/feedbackd/-/releases/v0.5.0
https://source.puri.sm/Librem5/feedbackd/-/releases/v0.6.0
https://source.puri.sm/Librem5/feedbackd/-/releases/v0.7.0

Also add an update script and add myself as a maintainer.

Release v0.5.0 mentions a new systemd unit "fbd-alert-slider" but I did not attempt to make it work as I don't have such a device.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
