### PR TITLE
nixos/rsyncd: fix ini format

### DIFF
--- a/nixos/modules/services/network-filesystems/rsyncd.nix
+++ b/nixos/modules/services/network-filesystems/rsyncd.nix
@@ -6,10 +6,11 @@
 }:
 let
   cfg = config.services.rsyncd;
-  settingsFormat = pkgs.formats.ini { };
+  settingsFormat = pkgs.formats.iniWithGlobalSection { };
   configFile = settingsFormat.generate "rsyncd.conf" cfg.settings;
 in
 {
+
   options = {
     services.rsyncd = {
 
@@ -25,24 +26,27 @@ in
         inherit (settingsFormat) type;
         default = { };
         example = {
-          global = {
+          globalSection = {
             uid = "nobody";
             gid = "nobody";
             "use chroot" = true;
             "max connections" = 4;
+            address = "0.0.0.0";
           };
-          ftp = {
-            path = "/var/ftp/./pub";
-            comment = "whole ftp area";
-          };
-          cvs = {
-            path = "/data/cvs";
-            comment = "CVS repository (requires authentication)";
-            "auth users" = [
-              "tridge"
-              "susan"
-            ];
-            "secrets file" = "/etc/rsyncd.secrets";
+          sections = {
+            ftp = {
+              path = "/var/ftp/./pub";
+              comment = "whole ftp area";
+            };
+            cvs = {
+              path = "/data/cvs";
+              comment = "CVS repository (requires authentication)";
+              "auth users" = [
+                "tridge"
+                "susan"
+              ];
+              "secrets file" = "/etc/rsyncd.secrets";
+            };
           };
         };
         description = ''
@@ -81,7 +85,7 @@ in
 
   config = lib.mkIf cfg.enable {
 
-    services.rsyncd.settings.global.port = toString cfg.port;
+    services.rsyncd.settings.globalSection.port = toString cfg.port;
 
     systemd =
       let


### PR DESCRIPTION
According to the manpage the `rsyncd.conf` has a global section without a module header. Settings for listening port or bind address must be put there and will not work if defined in a global submodule (i.e. below a `[global]` header).

This PR changes the ini format generator for the rsyncd service to create a global section in the config file without a submodule header. This also fixes #304293.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
