### PR TITLE
ddm: init at 3.0.2

### DIFF
--- a/pkgs/by-name/dd/ddm/package.nix
+++ b/pkgs/by-name/dd/ddm/package.nix
@@ -1,0 +1,82 @@
+{
+  stdenvNoCC,
+  lib,
+  requireFile,
+  copyDesktopItems,
+  electron,
+  makeDesktopItem,
+  makeWrapper,
+  unzip,
+
+  campaigns ? [ ],
+  cubes ? [ ],
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ddm";
+  version = "3.0.2";
+
+  src = requireFile {
+    name = "DungeonDuelMonsters-linux-x64.zip";
+    hash = "sha256-APIFQC5k6J0K5Q/e5poW8wKGL67NUbqKTJL4Ohd1K18=";
+    url = "https://mikaygo.itch.io/ddm";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+    unzip
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase =
+    ''
+      runHook preInstall
+
+      mkdir -p $out/{bin,share/icons/hicolor/512x512/apps,share/ddm}
+
+      mv -t $out/share/ddm/ ./resources/app/*
+      ln -s $out/share/ddm/icon.png $out/share/icons/hicolor/512x512/apps/ddm.png
+
+      makeWrapper ${lib.getExe electron} $out/bin/ddm \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+        --add-flags "$out/share/ddm"
+
+      # Install externally-downloaded campaign packs & cube lists
+    ''
+    + lib.concatMapStringsSep "\n" (campaignZip: ''
+      unzip "${campaignZip}" -d $out/share/ddm/campaigns/
+    '') campaigns
+    + lib.concatMapStringsSep "\n" (cubeFile: ''
+      cp "${cubeFile}" $out/share/ddm/cubes/
+    '') cubes
+    + ''
+
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ddm";
+      desktopName = "Dungeon Duel Monsters";
+      comment = "A Tabletop Yugioh Experience";
+      exec = "ddm";
+      terminal = false;
+      icon = "ddm";
+    })
+  ];
+
+  meta = {
+    description = "Tabletop Yugioh Experience";
+    homepage = "https://dungeonduelmonsters.com";
+    changelog = "https://mikaygo.itch.io/ddm/devlog";
+    license = lib.licenses.unfree;
+    mainProgram = "ddm";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Provides wrapping for [Dungeon Duel Monsters](https://mikaygo.itch.io/ddm), to make it playable without `appimage-run` & declaratively configurable, on any Linux platform that our `electron` supports (includes aarch64-linux, which upstream normally doesn't support via their download).

![image](https://github.com/user-attachments/assets/59af0e50-1cef-4dce-bd31-26974e19f831)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
