### PR TITLE
fish-lsp: 1.0.8-1 -> 1.0.8-4

### DIFF
--- a/pkgs/by-name/fi/fish-lsp/package.nix
+++ b/pkgs/by-name/fi/fish-lsp/package.nix
@@ -15,18 +15,18 @@
 }:
 stdenv.mkDerivation rec {
   pname = "fish-lsp";
-  version = "1.0.8-1";
+  version = "1.0.8-4";
 
   src = fetchFromGitHub {
     owner = "ndonfris";
     repo = "fish-lsp";
     tag = "v${version}";
-    hash = "sha256-u125EZXQEouVbmJuoW3KNDNqLB5cS/TzblXraClcw6Q=";
+    hash = "sha256-rtogxbcnmOEFT1v7aK+pzt9Z4B2O4rFwH3pTNVLTxiA=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-hHw7DbeqaCapqx4dK5Y3sPut94ist9JOU8g9dd6gBdo=";
+    hash = "sha256-83QhVDG/zyMbHJbV48m84eimXejLKdeVrdk1uZjI8bk=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +43,11 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     yarn --offline compile
+  '';
+
+  # We do it in postPatch, since it needs to be fixed before buildPhase
+  postPatch = ''
+    patchShebangs bin/fish-lsp
   '';
 
   installPhase = ''


### PR DESCRIPTION
EDIT: Errors fixed, all good for review!

~Getting some errors when running - would appreciate some support on solving them. Relevant logs:~
```
finished yarnConfigHook
Running phase: buildPhase
Executing yarnBuildHook
yarn run v1.22.22
$ run-s sh:build-time sh:build-wasm compile sh:relink sh:build-completions
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ fish ./scripts/build-time.fish
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ fish ./scripts/build-fish-wasm.fish
SUCCESS: tree-sitter-fish.wasm copied from location 'node_modules/@esdmr/tree-sitter-fish/tree-sitter-fish.wasm'
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ tsc -b
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ fish ./scripts/relink-locally.fish
RELINKING 'fish-lsp' GLOBALLY...
SUCCESS! "fish-lsp" is now installed and linked
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ fish ./scripts/build-completions.fish
exec: Failed to execute process './bin/fish-lsp': The file specified the interpreter '/usr/bin/env node', which is not an executable command.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "sh:build-completions" exited with 127.
error Command failed with exit code 1.
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
