### PR TITLE
chromium,chromedriver: 133.0.6943.126 -> 133.0.6943.141

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "133.0.6943.126",
+    "version": "133.0.6943.141",
     "chromedriver": {
-      "hash_darwin": "sha256-UeRQgrMG89DHywbvWUnjjlhkkyKR9eFE1i3ESPAElls=",
-      "hash_darwin_aarch64": "sha256-cpJOw+f+AybAtLu7w+g+Vojmjkl+r3sHzt4x6TjbBJI="
+      "hash_darwin": "sha256-ko7IT0yCfrz1Mdaen8FYsNBWMM6s7bzjZey4cG+QIIs=",
+      "hash_darwin_aarch64": "sha256-4wiQUAesLgPJLWKFl8pAiB6QsReB3RAiPR5yw0F4/Vs="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "cffa127ce7b6be72885391527c15b452056a2e81",
-        "hash": "sha256-WOd3FsqaZlKEroWg763LQhQS5S1964vAoZWxstxGS3U=",
+        "rev": "2a5d6da0d6165d7b107502095a937fe7704fcef6",
+        "hash": "sha256-MJlCEe1WBh+7Pl3H4jnkMuSykTBSgh5x/ZPnNwYM4DE=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -785,8 +785,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4e04a09a1a0ef90841656e210e976bfc2a81ed57",
-        "hash": "sha256-XbeU9L2IRHMP5pTzM3MPW1L2PMHViNRP/6u/HcBq96M="
+        "rev": "93c6f1082c25ef7fdf60ee2e4a029d65808d9343",
+        "hash": "sha256-OV1WncJaYvx1bB5najkKDNC2iMTU+m2vDAi9S/AjCyw="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_25.html

This update includes 3 security fixes.

CVEs:
CVE-2025-0999 CVE-2025-1426 CVE-2025-1006

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).