### PR TITLE
python313Packages.reflex: 0.6.8 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -47,7 +47,7 @@
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.6.8";
+  version = "0.7.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${version}";
-    hash = "sha256-fpFjVX48+FOnC3x7LT5DSXiUHpFLkD4gm/HGHZpS2ZY=";
+    hash = "sha256-KPReHngB2qop+rar2hHFVAwnB5W2/GQi3kAP2kQolL8=";
   };
 
   pythonRelaxDeps = [
@@ -133,10 +133,12 @@ buildPythonPackage rec {
     # flaky
     "test_preprocess" # KeyError: 'reflex___state____state'
     "test_send" # AssertionError: Expected 'post' to have been called once. Called 0 times.
+    # tries to pin the string of a traceback, doesn't account for ansi colors
+    "test_state_with_invalid_yield"
   ];
 
   disabledTestPaths = [
-    "benchmarks/"
+    "tests/benchmarks/"
     "tests/integration/"
   ];
 

--- a/pkgs/development/python-modules/starlette-admin/default.nix
+++ b/pkgs/development/python-modules/starlette-admin/default.nix
@@ -42,6 +42,32 @@ buildPythonPackage rec {
     hash = "sha256-DoYD8Hc5pd68+BhASw3mwwCdhu0vYHiELjVmVwU8FHs=";
   };
 
+  # recreates https://github.com/jowilf/starlette-admin/pull/630 which cannot be cherry-picked
+  postPatch = ''
+    test_files_to_fix=(
+      tests/mongoengine/test_auth.py
+      tests/odmantic/test_async_engine.py
+      tests/odmantic/test_auth.py
+      tests/odmantic/test_sync_engine.py
+      tests/sqla/test_async_engine.py
+      tests/sqla/test_auth.py
+      tests/sqla/test_multiple_pks.py
+      tests/sqla/test_sqla_and_pydantic.py
+      tests/sqla/test_sqla_utils.py
+      tests/sqla/test_sqlmodel.py
+      tests/sqla/test_sync_engine.py
+      tests/sqla/test_view_serialization.py
+      tests/test_auth.py
+    )
+    substituteInPlace "''${test_files_to_fix[@]}" \
+      --replace-fail  \
+        'from httpx import AsyncClient'  \
+        'from httpx import AsyncClient, ASGITransport' \
+      --replace-fail \
+        'AsyncClient(app=app,'  \
+        'AsyncClient(transport=ASGITransport(app=app),'
+  '';
+
   build-system = [ hatchling ];
 
   dependencies = [


### PR DESCRIPTION
Changelog: https://github.com/reflex-dev/reflex/releases/tag/v0.7.0
Changelog: https://github.com/reflex-dev/reflex/releases/tag/v0.7.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
