### PR TITLE
pretix: 2025.1.0 -> 2025.2.0

### DIFF
--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -42,13 +42,13 @@ let
   };
 
   pname = "pretix";
-  version = "2025.1.0";
+  version = "2025.2.0";
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix";
     rev = "refs/tags/v${version}";
-    hash = "sha256-azJFXuoV+9qs5MJQTkc1+ZiJb6UKwEa0Ow0p31CkHqI=";
+    hash = "sha256-ZVrdkIeVUAKb4617BCcfvs0HqFmctPb7zriDJplyUns=";
   };
 
   npmDeps = buildNpmPackage {
@@ -56,7 +56,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/src/pretix/static/npm_dir";
-    npmDepsHash = "sha256-oo9fo3MjwKYA8gueJ5otIPawORaVNj/Js3y8ZuCZ4qQ=";
+    npmDepsHash = "sha256-MOxOzaP6p6Q61ZuDVzbYJvMXpCQ1pzQx86Yl24yt4SQ=";
 
     dontBuild = true;
 
@@ -81,6 +81,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   pythonRelaxDeps = [
+    "beautifulsoup4"
     "django-phonenumber-field"
     "dnspython"
     "drf_ujson2"
@@ -94,6 +95,7 @@ python.pkgs.buildPythonApplication rec {
     "python-bidi"
     "qrcode"
     "redis"
+    "reportlab"
     "requests"
     "sentry-sdk"
     "ua-parser"

--- a/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-mollie";
-  version = "2.2.2";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-mollie";
     tag = "v${version}";
-    hash = "sha256-yc4t+XtHk7u3KcfeS+0CSTrBJ6e6SyLRpaQBHAKYVvo=";
+    hash = "sha256-sI4uHMACCf9HmcJUxJlkGgT70ra/bRs6XorghX99iJo=";
   };
 
   build-system = [

--- a/pkgs/by-name/pr/pretix/plugins/passbook/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/passbook/package.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-passbook";
-  version = "1.13.2";
+  version = "1.13.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-passbook";
     rev = "v${version}";
-    hash = "sha256-rdX93AFoLLsA44a9sSgcQrCJiOlhe3j5WTBO+MHZ/X8=";
+    hash = "sha256-xN37nM2AQVxFg+TOZ3cEvEV4F115U9m6YVX12al4SIw=";
   };
 
   patches = [

--- a/pkgs/by-name/pr/pretix/plugins/zugferd/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/zugferd/package.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-zugferd";
-  version = "2.3.0";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-zugferd";
     rev = "v${version}";
-    hash = "sha256-/efhp9B/cw/C3Bok8/E93dOrP9FHfaVZNSwC/j2lNuA=";
+    hash = "sha256-VtmlgxqV34e3Yu9uTYwJAZoZQ/TQoEJgjHcpqUsxxq8=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/django-filter/default.nix
+++ b/pkgs/development/python-modules/django-filter/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "django-filter";
-  version = "24.3";
+  version = "25.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "carltongibson";
     repo = "django-filter";
     tag = version;
-    hash = "sha256-4q/x9FO9ErKnGeJDEXDMcvUKA4nlA7nkwwM2xj3WGWs=";
+    hash = "sha256-ODbBlaJo6sgXkFxLNhqwGTXSHs2d6R6wGKyDz5qA7bs=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "geoip2";
-  version = "4.8.1";
+  version = "5.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-muouq0s+YlL0dFZSiunDWxBMRSd2OcE/zhvofJL4Qlc=";
+    hash = "sha256-kK+LbTaH877yUfJwitAXsw1ifRFEwAQOq8TJAXqAfYY=";
   };
 
   build-system = [


### PR DESCRIPTION
    https://github.com/pretix/pretix-zugferd/compare/v2.3.0...v2.4.0
    https://github.com/pretix/pretix-passbook/compare/v1.13.2...v1.13.3
    https://github.com/pretix/pretix-mollie/compare/refs/tags/v2.2.2...v2.3.0
    https://pretix.eu/about/en/blog/20250225-release-2025-2/
    https://github.com/pretix/pretix/compare/refs/tags/v2025.1.0...v2025.2.0
    https://github.com/maxmind/GeoIP2-python/blob/v5.0.1/HISTORY.rst
    https://github.com/carltongibson/django-filter/blob/25.1/CHANGES.rst

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
