### PR TITLE
redis-dump-go: init at 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20064,6 +20064,12 @@
     githubId = 10631029;
     name = "Richard Ipsum";
   };
+  richiejp = {
+    email = "io@richiejp.com";
+    github = "richiejp";
+    githubId = 988098;
+    name = "Richard Palethorpe";
+  };
   rick68 = {
     email = "rick68@gmail.com";
     github = "rick68";

--- a/pkgs/by-name/re/redis-dump-go/package.nix
+++ b/pkgs/by-name/re/redis-dump-go/package.nix
@@ -9,14 +9,14 @@ buildGoModule rec {
   pname = "redis-dump-go";
   version = "0.8.2";
 
-  vendorHash = null;
-
   src = fetchFromGitHub {
     owner = "yannh";
     repo = "redis-dump-go";
     tag = "v${version}";
     hash = "sha256-+5iYigtMQvd6D90mpKyMa7ZKm2UDtCG91uFZ7dURBT4=";
   };
+
+  vendorHash = null;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/re/redis-dump-go/package.nix
+++ b/pkgs/by-name/re/redis-dump-go/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "redis-dump-go";
+  version = "0.8.2";
+
+  vendorHash = null;
+
+  src = fetchFromGitHub {
+    owner = "yannh";
+    repo = "redis-dump-go";
+    tag = "v${version}";
+    hash = "sha256-+5iYigtMQvd6D90mpKyMa7ZKm2UDtCG91uFZ7dURBT4=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/yannh/redis-dump-go";
+    description = "Dump Redis keys to a file in RESP format using multiple connections";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.richiejp ];
+    changelog = "https://github.com/yannh/redis-dump-go/releases/tag/v${version}";
+  };
+}


### PR DESCRIPTION
- **maintainers: add richiejp**
- **redis-dump-go: init at 0.8.2**

Simple Go package to dump a Redis DB to RESP with some performance enhancements over redis-dump.
https://github.com/yannh/redis-dump-go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

