### PR TITLE
arcanechat-tui: init at 0.11.1

### DIFF
--- a/pkgs/by-name/ar/arcanechat-tui/package.nix
+++ b/pkgs/by-name/ar/arcanechat-tui/package.nix
@@ -3,20 +3,19 @@
   python3,
   fetchFromGitHub,
   testers,
-  deltachat-cursed,
+  arcanechat-tui,
 }:
 
 python3.pkgs.buildPythonApplication rec {
-  pname = "deltachat-cursed";
-  version = "0.10.0";
-
+  pname = "arcanechat-tui";
+  version = "0.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "adbenitez";
-    repo = "deltachat-cursed";
-    rev = "v${version}";
-    hash = "sha256-KCPIZf/8Acp9syFN1IHbf8hQrjk0yzniff+dVSSM/Ro=";
+    owner = "ArcaneChat";
+    repo = "arcanechat-tui";
+    tag = "v${version}";
+    hash = "sha256-ARk0WkpJ2VhIdOHQzYmmsuherABNgqwjwnPWk92y9yA=";
   };
 
   build-system = with python3.pythonOnBuildForHost.pkgs; [
@@ -35,18 +34,18 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru.tests = {
     version = testers.testVersion rec {
-      package = deltachat-cursed;
+      package = arcanechat-tui;
       command = ''
         HOME="$TEMP" ${lib.getExe package} --version
       '';
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Lightweight Delta Chat client";
-    homepage = "https://github.com/adbenitez/deltachat-cursed";
-    license = licenses.gpl3Plus;
-    mainProgram = "curseddelta";
-    maintainers = with maintainers; [ dotlambda ];
+    homepage = "https://github.com/ArcaneChat/arcanechat-tui";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "arcanechat-tui";
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -361,6 +361,7 @@ mapAliases {
   deadpixi-sam = deadpixi-sam-unstable;
 
   debugedit-unstable = throw "'debugedit-unstable' has been renamed to/replaced by 'debugedit'"; # Converted to throw 2024-10-17
+  deltachat-cursed = arcanechat-tui; # added 2025-02-25
   deltachat-electron = throw "'deltachat-electron' has been renamed to/replaced by 'deltachat-desktop'"; # Converted to throw 2024-10-17
 
   demjson = with python3Packages; toPythonApplication demjson; # Added 2022-01-18


### PR DESCRIPTION
deltachat-cursed was renamed to arcanechat-tui


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
