### PR TITLE
gnat: enable aarch64-darwin build

### DIFF
--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -85,6 +85,11 @@ stdenv.mkDerivation (
               hash = "sha256-DC95udGSzRDE22ON4UpekxTYWOSBeUdJvILbSFj6MFQ=";
               upstreamTriplet = "x86_64-pc-linux-gnu";
             };
+            aarch64-darwin = {
+              inherit url;
+              hash = "sha256-Bjl6iuM2xLknezR92j/kpDYpxqTcxK1v8rffmivOAVw=";
+              upstreamTriplet = "aarch64-apple-darwin23.2.0";
+            };
           }
           .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
         "14" =
@@ -107,6 +112,11 @@ stdenv.mkDerivation (
               inherit url;
               hash = "sha256-SVW/0yyj6ZH1GAjvD+unII+zSLGd3KGFt1bjjQ3SEFU=";
               upstreamTriplet = "aarch64-linux-gnu";
+            };
+            aarch64-darwin = {
+              inherit url;
+              hash = "sha256-/nARwdQzAMd41fslUbrgloxn0hVZp9PokfQ9yPmL1g8=";
+              upstreamTriplet = "aarch64-apple-darwin23.6.0";
             };
           }
           .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
@@ -214,7 +224,7 @@ stdenv.mkDerivation (
       # [2]: https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Fixed-Headers.html
 
       + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
-        upstreamBuildPrefix="/Users/runner/work/GNAT-FSF-builds/GNAT-FSF-builds/sbx/x86_64-darwin/gcc/install"
+        upstreamBuildPrefix="/Users/runner/work/GNAT-FSF-builds/GNAT-FSF-builds/sbx/${stdenv.hostPlatform.system}/gcc/install"
         for i in "$out"/lib/*.dylib "$out"/lib/gcc/*/*/adalib/*.dylib; do
           if [[ -f "$i" && ! -h "$i" ]]; then
             install_name_tool -id "$i" "$i" || true
@@ -246,10 +256,13 @@ stdenv.mkDerivation (
       homepage = "https://www.gnu.org/software/gnat";
       license = licenses.gpl3;
       maintainers = with maintainers; [ ethindp ];
-      platforms = [
-        "x86_64-linux"
-        "x86_64-darwin"
-      ] ++ lib.optionals (lib.versionAtLeast majorVersion "14") [ "aarch64-linux" ];
+      platforms =
+        [
+          "x86_64-linux"
+          "x86_64-darwin"
+        ]
+        ++ lib.optionals (lib.versionAtLeast majorVersion "14") [ "aarch64-linux" ]
+        ++ lib.optionals (lib.versionAtLeast majorVersion "13") [ "aarch64-darwin" ];
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6252,7 +6252,6 @@ with pkgs;
           stdenv.hostPlatform == stdenv.targetPlatform
           && stdenv.buildPlatform == stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
-          && stdenv.buildPlatform.isx86_64
         then
           overrideCC stdenv gnat-bootstrap13
         else
@@ -6280,7 +6279,6 @@ with pkgs;
           stdenv.hostPlatform == stdenv.targetPlatform
           && stdenv.buildPlatform == stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
-          && stdenv.buildPlatform.isx86_64
         then
           overrideCC stdenv gnat-bootstrap14
         else


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Resolves #385174

The upstream [GNAT-FSF-builds](https://github.com/alire-project/GNAT-FSF-builds) provides pre-built binaries for `aarch64-darwin`. This PR adds `gnat-bootstrap13` and `gnat-bootstrap14` using these prebuilt packages for `aarch64-darwin` and uses `gnat-bootstrap13` to build `gnat13` and `gnat14`.

## TODO:
 - [ ] hashes for `x86-64-linux`
 - [ ] Figure out the why there are missing symbols on aarch64-darwin build
```shell
$ nix log /nix/store/kif93dlgf3in47bn51l9c6cfrlrlhqni-gnat-14-20241116.drv
...
     ld: warning: object file (/nix/store/hmzvc39ni2v0s3frgspqwfvrv8npx3n4-gnat-bootstrap-13.2.0-2/lib/gcc/aarch64-apple-darwin23.2.0/13.2.0/adalib/libgnat.a(raise-gcc.o)) was built for newer macOS version (14.0) than being linked (11.3)
# Ignore errors to work around finalization issues in older compilers
cd ada/gen_il; ./gen_il-main
dyld[15710]: missing symbol called

raised PROGRAM_ERROR : unhandled signal
make[3]: [../../gcc-14-20241116/gcc/ada/Make-generated.in:23: ada/stamp-gen_il] Error 1 (ignored)
/private/tmp/nix-build-gnat-14-20241116.drv-1/gcc-14-20241116/gcc/../move-if-change ada/gen_il/seinfo_tables.ads ada/seinfo_tables.ads
mv: cannot stat 'ada/gen_il/seinfo_tables.ads': No such file or directory
make[3]: *** [../../gcc-14-20241116/gcc/ada/Make-generated.in:24: ada/stamp-gen_il] Error 1
make[3]: *** Waiting for unfinished jobs....
rm gfdl.pod gcc.pod gcov-dump.pod gcov-tool.pod fsf-funding.pod gpl.pod cpp.pod gcov.pod lto-dump.pod
make[3]: Leaving directory '/private/tmp/nix-build-gnat-14-20241116.drv-1/build/gcc'
make[2]: *** [Makefile:5091: all-stage2-gcc] Error 2
make[2]: Leaving directory '/private/tmp/nix-build-gnat-14-20241116.drv-1/build'
make[1]: *** [Makefile:23885: stage2-bubble] Error 2
make[1]: Leaving directory '/private/tmp/nix-build-gnat-14-20241116.drv-1/build'
make: *** [Makefile:24081: bootstrap] Error 2
```



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux (currently failing)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
