### PR TITLE
positron-bin: 2025.02.0-171 -> 2025.04.0-64

### DIFF
--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2025.02.0-171";
+  version = "2025.04.0-64";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -30,13 +30,13 @@ stdenv.mkDerivation {
   src =
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
-        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.dmg";
-        hash = "sha256-b5o1+UXt5JAuHkm1K1jrMLV+7PHfKJTOff4aTk8xm2I=";
+        url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
+        hash = "sha256-MmLc2YFmWIcmsRp4swKYJdQHAWfSIsW23D5ZLfyb4b4=";
       }
     else
       fetchurl {
-        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}-x64.deb";
-        hash = "sha256-TjQc/Y4Sa2MlLslbygYVFbIk3raArMvYstSiSEYzfo0=";
+        url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
+        hash = "sha256-d1HjnMGpKg68EW0wXWvgXL0VEepn1vFJWuAN0HD2IPs=";
       };
 
   buildInputs =

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -85,7 +85,8 @@ stdenv.mkDerivation {
 
         # Positron will use the system version of BLAS if we don't provide the nix version.
         wrapProgram "$out/Applications/Positron.app/Contents/Resources/app/bin/code" \
-          --prefix DYLD_INSERT_LIBRARIES : "${lib.makeLibraryPath [ blas ]}/libblas.dylib"
+          --prefix DYLD_INSERT_LIBRARIES : "${lib.makeLibraryPath [ blas ]}/libblas.dylib" \
+          --add-flags "--disable-updates"
 
         ln -s "$out/Applications/Positron.app/Contents/Resources/app/bin/code" "$out/bin/positron"
         runHook postInstall
@@ -112,7 +113,9 @@ stdenv.mkDerivation {
 
         # Fix libGL.so not found errors.
         wrapProgram "$out/share/positron/positron" \
-          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}"
+          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libglvnd ]}" \
+          --add-flags "--disable-updates"
+
 
         mkdir -p "$out/bin"
         ln -s "$out/share/positron/positron" "$out/bin/positron"

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -18,22 +18,22 @@ fi
 
 # Update Darwin hash.
 current_hash=$(nix store prefetch-file --json --hash-type sha256 \
-    "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}.dmg" \
+    "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${current_version}.dmg" \
     | jq -r .hash)
 
 new_hash=$(nix store prefetch-file --json --hash-type sha256 \
-    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}.dmg" \
+    "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${new_version}.dmg" \
     | jq -r .hash)
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
 # Update Linux hash.
 current_hash=$(nix store prefetch-file --json --hash-type sha256 \
-    "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}-x64.deb" \
+    "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${current_version}-x64.deb" \
     | jq -r .hash)
 
 new_hash=$(nix store prefetch-file --json --hash-type sha256 \
-    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}-x64.deb" \
+    "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${new_version}-x64.deb" \
     | jq -r .hash)
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix


### PR DESCRIPTION
updated to latest version, tested on non-nixos linux and aarch64-darwin


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
