### PR TITLE
[Backport release-24.11] grafanaPlugins.victoriametrics-logs-datasource: init at 0.14.3

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -28,6 +28,7 @@
   redis-datasource = callPackage ./redis-datasource { };
   redis-explorer-app = callPackage ./redis-explorer-app { };
   ventura-psychrometric-panel = callPackage ./ventura-psychrometric-panel { };
+  victoriametrics-logs-datasource = callPackage ./victoriametrics-logs-datasource { };
   victoriametrics-metrics-datasource = callPackage ./victoriametrics-metrics-datasource { };
   volkovlabs-echarts-panel = callPackage ./volkovlabs-echarts-panel { };
   volkovlabs-form-panel = callPackage ./volkovlabs-form-panel { };

--- a/pkgs/servers/monitoring/grafana/plugins/victoriametrics-logs-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/victoriametrics-logs-datasource/default.nix
@@ -1,0 +1,13 @@
+{ grafanaPlugin, lib }:
+
+grafanaPlugin {
+  pname = "victoriametrics-logs-datasource";
+  version = "0.14.3";
+  zipHash = "sha256-g/ntmNyWJ9h/eYpZ0gqiESvVfm2fU6/Ci8R7FHIV7AQ=";
+  meta = {
+    description = "Grafana datasource for VictoriaLogs";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ samw ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
see #376400 