### PR TITLE
rabbitmqadmin-ng: init at 0.24.0

### DIFF
--- a/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
+++ b/pkgs/by-name/ra/rabbitmqadmin-ng/package.nix
@@ -1,0 +1,43 @@
+{
+  rustPlatform,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rabbitmqadmin-ng";
+  version = "0.24.0";
+
+  src = fetchFromGitHub {
+    owner = "rabbitmq";
+    repo = "rabbitmqadmin-ng";
+    tag = "v${version}";
+    hash = "sha256-P6/M90LvvK4NQ7jiT84rROrzgQukJ8V+24naRBehhHQ";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-SODm95UOvsRIMI4WgV0Nk5UBtQU0lmcENoOcyhuGU9s=";
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
+
+  strictDeps = true;
+
+  # This requires a running rabbitmq instance to communicate with that needs
+  # to be set up by hand. It should be possible to run tests in the future
+  # if we ever add a `rabbitmqTestHook`, similar to the `postgresqlTestHook`.
+  doCheck = false;
+
+  meta = {
+    description = "Command line tool for RabbitMQ that uses the HTTP API";
+    maintainers = lib.teams.flyingcircus.members;
+    homepage = "https://www.rabbitmq.com/docs/management-cli";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "rabbitmqadmin";
+  };
+}


### PR DESCRIPTION
See https://www.rabbitmq.com/docs/management-cli

This is the CLI upstream recommends to run management commands such as declaring/viewing/deleting queues/users/etc..

cc @frlan 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
