### PR TITLE
tmuxPlugins.catppuccin: use correct hash for v2.1.2

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -96,7 +96,7 @@ in rec {
       owner = "catppuccin";
       repo = "tmux";
       rev = "v${version}";
-      hash = "sha256-EHinWa6Zbpumu+ciwcMo6JIIvYFfWWEKH1lwfyZUNTo=";
+      hash = "sha256-vBYBvZrMGLpMU059a+Z4SEekWdQD0GrDqBQyqfkEHPg=";
     };
     postInstall = ''
       sed -i -e 's|''${PLUGIN_DIR}/catppuccin-selected-theme.tmuxtheme|''${TMUX_TMPDIR}/catppuccin-selected-theme.tmuxtheme|g' $target/catppuccin.tmux


### PR DESCRIPTION
## Things done

Somehow, the hash for the upstream source was not correct for this package. This was reported in #385119.

This PR corrects the hash, and the resulting derivation contains the *correct* files for this release:

```
❯ ls result/share/tmux-plugins/catppuccin/status/
.r--r--r-- 297 root root  1 Jan  1970 application.conf
.r--r--r-- 852 root root  1 Jan  1970 battery.conf
.r--r--r-- 335 root root  1 Jan  1970 clima.conf
.r--r--r-- 758 root root  1 Jan  1970 cpu.conf
.r--r--r-- 289 root root  1 Jan  1970 date_time.conf
.r--r--r-- 297 root root  1 Jan  1970 directory.conf
.r--r--r-- 364 root root  1 Jan  1970 gitmux.conf
.r--r--r-- 269 root root  1 Jan  1970 host.conf
.r--r--r-- 565 root root  1 Jan  1970 kube.conf
.r--r--r-- 278 root root  1 Jan  1970 load.conf
.r--r--r-- 358 root root  1 Jan  1970 pomodoro_plus.conf
.r--r--r-- 302 root root  1 Jan  1970 session.conf
.r--r--r-- 438 root root  1 Jan  1970 uptime.conf
.r--r--r-- 237 root root  1 Jan  1970 user.conf
.r--r--r-- 309 root root  1 Jan  1970 weather.conf
```

Looks like the version was bumped 3 weeks ago (https://github.com/NixOS/nixpkgs/commit/fabd610051afc1c14becb5aa49f2648376b95ddd), but the hash wasn't bumped for 9 months (https://github.com/NixOS/nixpkgs/commit/59b372621c7ec994de5ad6a2fa29292366610145), and I mistakenly merged a patch to bump the version without the hash changing 🤦‍♂️

Fixes #385119
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
