### PR TITLE
orthanc: init at 1.12.6, nixos/orthanc: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -187,6 +187,8 @@
 
 - [Limine](https://github.com/limine-bootloader/limine) a modern, advanced, portable, multiprotocol bootloader and boot manager. Available as [boot.loader.limine](#opt-boot.loader.limine.enable)
 
+- [Orthanc](https://orthanc.uclouvain.be/) a lightweight, RESTful DICOM server for healthcare and medical research. Available as [services.orthanc](#opt-services.orthanc.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -848,6 +848,7 @@
   ./services/misc/ombi.nix
   ./services/misc/omnom.nix
   ./services/misc/open-webui.nix
+  ./services/misc/orthanc.nix
   ./services/misc/osrm.nix
   ./services/misc/owncast.nix
   ./services/misc/packagekit.nix

--- a/nixos/modules/services/misc/orthanc.nix
+++ b/nixos/modules/services/misc/orthanc.nix
@@ -1,0 +1,134 @@
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  cfg = config.services.orthanc;
+  opt = options.services.orthanc;
+
+  settingsFormat = pkgs.formats.json { };
+in
+{
+  options = {
+    services.orthanc = {
+      enable = lib.mkEnableOption "Orthanc server";
+      package = lib.mkPackageOption pkgs "orthanc" { };
+
+      stateDir = lib.mkOption {
+        type = types.path;
+        default = "/var/lib/orthanc";
+        example = "/home/foo";
+        description = "State directory of Orthanc.";
+      };
+
+      environment = lib.mkOption {
+        type = types.attrsOf types.str;
+        default = {
+        };
+        example = ''
+          {
+            ORTHANC_NAME = "Orthanc server";
+          }
+        '';
+        description = ''
+          Extra environment variables
+          For more details see <https://orthanc.uclouvain.be/book/users/configuration.html>
+        '';
+      };
+
+      environmentFile = lib.mkOption {
+        description = ''
+          Environment file to be passed to the systemd service.
+          Useful for passing secrets to the service to prevent them from being
+          world-readable in the Nix store.
+        '';
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/var/lib/secrets/orthancSecrets";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+        };
+        default = {
+          HttpPort = lib.mkDefault 8042;
+          IndexDirectory = lib.mkDefault "/var/lib/orthanc/";
+          StorageDirectory = lib.mkDefault "/var/lib/orthanc/";
+        };
+        example = {
+          Name = "My Orthanc Server";
+          HttpPort = 12345;
+        };
+        description = ''
+          Configuration written to a json file that is read by orthanc.
+          See <https://orthanc.uclouvain.be/book/index.html> for more.
+        '';
+      };
+
+      openFirewall = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open the firewall for Orthanc.
+          This adds `services.orthanc.settings.HttpPort` to `networking.firewall.allowedTCPPorts`.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.orthanc.settings = options.services.orthanc.settings.default;
+
+    systemd.services.orthanc = {
+      description = "Orthanc is a lightweight, RESTful DICOM server for healthcare and medical research";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = cfg.environment;
+
+      serviceConfig =
+        let
+          config-json = settingsFormat.generate "orthanc-config.json" (cfg.settings);
+        in
+        {
+          ExecStart = "${lib.getExe cfg.package} ${config-json}";
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+          WorkingDirectory = cfg.stateDir;
+          BindReadOnlyPaths = [
+            "-/etc/localtime"
+          ];
+          StateDirectory = "orthanc";
+          RuntimeDirectory = "orthanc";
+          RuntimeDirectoryMode = "0755";
+          PrivateTmp = true;
+          DynamicUser = true;
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          PrivateUsers = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+        };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.settings.HttpPort ]; };
+
+    # Orthanc requires /etc/localtime to be present
+    time.timeZone = lib.mkDefault "UTC";
+  };
+
+  meta.maintainers = with lib.maintainers; [ drupol ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -862,6 +862,7 @@ in {
   opentelemetry-collector = handleTest ./opentelemetry-collector.nix {};
   open-web-calendar = handleTest ./web-apps/open-web-calendar.nix {};
   ocsinventory-agent = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./ocsinventory-agent.nix {};
+  orthanc = runTest ./orthanc.nix;
   owncast = handleTest ./owncast.nix {};
   outline = handleTest ./outline.nix {};
   image-contents = handleTest ./image-contents.nix {};

--- a/nixos/tests/orthanc.nix
+++ b/nixos/tests/orthanc.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+
+{
+  name = "orthanc";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        services.orthanc = {
+          enable = true;
+          settings = {
+            HttpPort = 12345;
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("orthanc.service")
+    machine.wait_for_open_port(12345)
+    machine.wait_for_open_port(4242)
+  '';
+
+  meta.maintainers = [ lib.maintainers.drupol ];
+}

--- a/pkgs/by-name/or/orthanc/add-missing-include.patch
+++ b/pkgs/by-name/or/orthanc/add-missing-include.patch
@@ -1,0 +1,10 @@
+diff -r cba3e8ca3a87 OrthancServer/Sources/OrthancInitialization.cpp
+--- a/Sources/OrthancInitialization.cpp   Tue Mar 11 10:46:15 2025 +0100
++++ b/Sources/OrthancInitialization.cpp   Thu Mar 13 18:20:00 2025 +0100
+@@ -59,6 +59,7 @@
+ #    undef __FILE__
+ #    define __FILE__ __ORTHANC_FILE__
+ #  endif
++#  include <google/protobuf/stubs/common.h>
+ #  include <google/protobuf/any.h>
+ #endif

--- a/pkgs/by-name/or/orthanc/package.nix
+++ b/pkgs/by-name/or/orthanc/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  stdenv,
+  fetchhg,
+  boost,
+  charls,
+  civetweb,
+  cmake,
+  curl,
+  dcmtk,
+  gtest,
+  jsoncpp,
+  libjpeg,
+  libpng,
+  libuuid,
+  log4cplus,
+  lua,
+  openssl,
+  protobuf,
+  pugixml,
+  python3,
+  sqlite,
+  unzip,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "orthanc";
+  version = "1.12.6";
+
+  src = fetchhg {
+    url = "https://orthanc.uclouvain.be/hg/orthanc/";
+    rev = "Orthanc-${finalAttrs.version}";
+    hash = "sha256-1ztA95PiCGL1oD6zVfsEhwrwGNID13/NcyZDD3eHYv0=";
+  };
+
+  patches = [
+    # Without this patch, the build fails to find `GOOGLE_PROTOBUF_VERIFY_VERSION`
+    # The patch has been included upstream, it need to be removed in the next release.
+    ./add-missing-include.patch
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/OrthancServer";
+
+  nativeBuildInputs = [
+    cmake
+    protobuf
+    python3
+    unzip
+  ];
+
+  buildInputs = [
+    protobuf
+    boost
+    charls
+    civetweb
+    curl
+    dcmtk
+    gtest
+    jsoncpp
+    libjpeg
+    libpng
+    libuuid
+    log4cplus
+    lua
+    openssl
+    pugixml
+    sqlite
+  ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "DCMTK_DICTIONARY_DIR_AUTO" "${dcmtk}/share/dcmtk-${dcmtk.version}")
+    (lib.cmakeFeature "DCMTK_LIBRARIES" "dcmjpls;oflog;ofstd")
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+
+    (lib.cmakeBool "BUILD_CONNECTIVITY_CHECKS" false)
+    (lib.cmakeBool "UNIT_TESTS_WITH_HTTP_CONNEXIONS" false)
+    (lib.cmakeBool "STANDALONE_BUILD" true)
+    (lib.cmakeBool "USE_SYSTEM_BOOST" true)
+    (lib.cmakeBool "USE_SYSTEM_CIVETWEB" true)
+    (lib.cmakeBool "USE_SYSTEM_DCMTK" true)
+    (lib.cmakeBool "USE_SYSTEM_GOOGLE_TEST" true)
+    (lib.cmakeBool "USE_SYSTEM_JSONCPP" true)
+    (lib.cmakeBool "USE_SYSTEM_LIBICONV" true)
+    (lib.cmakeBool "USE_SYSTEM_LIBJPEG" true)
+    (lib.cmakeBool "USE_SYSTEM_LIBPNG" true)
+    (lib.cmakeBool "USE_SYSTEM_LUA" true)
+    (lib.cmakeBool "USE_SYSTEM_OPENSSL" true)
+    (lib.cmakeBool "USE_SYSTEM_PROTOBUF" true)
+    (lib.cmakeBool "USE_SYSTEM_PUGIXML" true)
+    (lib.cmakeBool "USE_SYSTEM_SQLITE" true)
+    (lib.cmakeBool "USE_SYSTEM_UUID" true)
+    (lib.cmakeBool "USE_SYSTEM_ZLIB" true)
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Orthanc is a lightweight, RESTful DICOM server for healthcare and medical research";
+    homepage = "https://www.orthanc-server.com/";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "Orthanc";
+    maintainers = with lib.maintainers; [ drupol ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/or/orthanc/package.nix
+++ b/pkgs/by-name/or/orthanc/package.nix
@@ -22,6 +22,7 @@
   sqlite,
   unzip,
   versionCheckHook,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -103,6 +104,10 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
+
+  passthru.tests = {
+    inherit (nixosTests) orthanc;
+  };
 
   meta = {
     description = "Orthanc is a lightweight, RESTful DICOM server for healthcare and medical research";


### PR DESCRIPTION
A local 1-line patch has been added to prevent a compilation issue.

Past compilation issues:
- https://gist.github.com/drupol/6ac3541b9845c5ea4609073be2ab044b (fixed by adding `-DDCMTK_LIBRARIES=oflog`)
- https://gist.github.com/drupol/c7013b74cc1267d8bc5f1ad0d763448c (fixed by adding `-DDCMTK_LIBRARIES=ofstd;oflog`)
- https://gist.github.com/drupol/5c2d9e24eac9c7867197757e5423a518 (fixed by adding `-DDCMTK_LIBRARIES=oflog;ofstd`) (mind the order!)

### Useful links
- FreeBSD port: https://cgit.freebsd.org/ports/tree/science/orthanc/Makefile?id=8098887d0c2d76b93b21ba0827fac96bb33a9667
- Debian repo: https://salsa.debian.org/med-team/orthanc
- Arch build: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=orthanc
- OpenSuse spec: https://build.opensuse.org/projects/openSUSE:Factory/packages/orthanc/files/orthanc.spec?expand=1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
