### PR TITLE
electron: simplify usage of headers

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -55,6 +55,8 @@
 - The hand written `perlPackages.SearchXapian` bindings have been dropped in favor of the (mostly compatible)
   `perlPackages.Xapian`.
 
+- The `electron` packages will now provide their headers (available via `electron.headers`) in extracted form instead of in a tarball.
+
 - [testers.shellcheck](https://nixos.org/manual/nixpkgs/unstable/#tester-shellcheck) now warns when `name` is not provided.
   The `name` argument will become mandatory in a future release.
 

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -44,12 +44,6 @@ let
   # need to be updated every time the latest electron gets a new abi version number
   electron = electron_33;
 
-  # unpack tarball containing electron's headers
-  electron-headers = runCommand "electron-headers" { } ''
-    mkdir -p $out
-    tar -C $out --strip-components=1 -xvf ${electron.headers}
-  '';
-
   mathJaxSrc = fetchzip {
     url = "https://s3.amazonaws.com/rstudio-buildtools/mathjax-27.zip";
     hash = "sha256-J7SZK/9q3HcXTD7WFHxvh++ttuCd89Vc4SEBrUEU0AI=";
@@ -241,7 +235,7 @@ stdenv.mkDerivation rec {
         --replace-fail "npm ci && " ""
 
       # use electron's headers to make node-gyp compile against the electron ABI
-      export npm_config_nodedir="${electron-headers}"
+      export npm_config_nodedir="${electron.headers}"
 
       ### override the detected electron version
       substituteInPlace node_modules/@electron-forge/core-utils/dist/electron-version.js \

--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -31,12 +31,6 @@ let
     rev = "687106c4e37297f86fab79f77ef83599b61ab65c";
     hash = "sha256-Y0irD0jzqYobnjtD2M1+hTDRUUYnuygUx9+tE1gUoTw=";
   };
-
-  electron-headers = runCommand "electron-headers" { } ''
-    mkdir -p $out
-    tar -C $out --strip-components=1 -xvf ${electron.headers}
-  '';
-
 in
 buildNpmPackage {
   inherit pname version src;
@@ -55,7 +49,7 @@ buildNpmPackage {
 
   npmFlags = [
     # keytar needs to be built against electron's ABI
-    "--nodedir=${electron-headers}"
+    "--nodedir=${electron.headers}"
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/el/element-desktop/keytar/default.nix
+++ b/pkgs/by-name/el/element-desktop/keytar/default.nix
@@ -11,17 +11,10 @@
   fetchNpmDeps,
   npmHooks,
   electron,
-  runCommand,
 }:
 
 let
   pinData = lib.importJSON ./pin.json;
-
-  electron-headers = runCommand "electron-headers" { } ''
-    mkdir -p $out
-    tar -C $out --strip-components=1 -xvf ${electron.headers}
-  '';
-
 in
 stdenv.mkDerivation rec {
   pname = "keytar-forked";
@@ -57,7 +50,7 @@ stdenv.mkDerivation rec {
 
   npmFlags = [
     # Make sure the native modules are built against electron's ABI
-    "--nodedir=${electron-headers}"
+    "--nodedir=${electron.headers}"
     # https://nodejs.org/api/os.html#osarch
     "--arch=${
       if stdenv.hostPlatform.parsed.cpu.name == "i686" then

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -24,14 +24,6 @@
   git,
 }:
 
-let
-  # unpack tarball containing electron's headers
-  electron-headers = runCommand "electron-headers" { } ''
-    mkdir -p $out
-    tar -C $out --strip-components=1 -xvf ${electron.headers}
-  '';
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "logseq";
   version = "0.10.9-unstable-2025-03-11";
@@ -202,7 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
     npm rebuild --verbose
     popd
 
-    export npm_config_nodedir=${electron-headers}
+    export npm_config_nodedir=${electron.headers}
 
     pushd static
 
@@ -210,13 +202,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace node_modules/dugite/package.json \
       --replace-fail '"postinstall"' '"_postinstall"'
 
-    # this doesn't seem to build with electron-headers
+    # this doesn't seem to build with electron.headers
     rm node_modules/macos-alias/binding.gyp
 
     # the electron-rebuild command deadlocks for some reason, let's just use normal npm rebuild (since we overrode the nodedir anyways)
     npm rebuild --verbose
 
-    # remove most references to electron-headers
+    # remove most references to electron.headers
     # TODO: track down the remaining references
     find node_modules -type f \( -name "*.target.mk" -o -name "config.gypi" -o -name "Makefile" \) -delete
 

--- a/pkgs/by-name/si/signal-desktop-source/package.nix
+++ b/pkgs/by-name/si/signal-desktop-source/package.nix
@@ -8,7 +8,6 @@
   makeWrapper,
   callPackage,
   fetchFromGitHub,
-  runCommand,
   jq,
   makeDesktopItem,
   copyDesktopItems,
@@ -38,11 +37,6 @@ let
     }
     .${stdenv.hostPlatform.parsed.cpu.name}
       or (throw "unsupported platform ${stdenv.hostPlatform.parsed.cpu.name}");
-
-  electron-headers = runCommand "electron-headers" { } ''
-    mkdir -p $out
-    tar -C $out --strip-components=1 -xvf ${electron.headers}
-  '';
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
 
@@ -179,7 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    export npm_config_nodedir=${electron-headers}
+    export npm_config_nodedir=${electron.headers}
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
     cp -r ${sticker-creator} sticker-creator/dist

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   fetchurl,
+  fetchzip,
   wrapGAppsHook3,
   glib,
   gtk3,
@@ -69,7 +70,8 @@ let
 
   headersFetcher =
     vers: hash:
-    fetchurl {
+    fetchzip {
+      name = "electron-${vers}-headers";
       url = "https://artifacts.electronjs.org/headers/dist/v${vers}/node-v${vers}-headers.tar.gz";
       sha256 = hash;
     };

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -4,7 +4,7 @@
             "aarch64-darwin": "67e5f8ce2c395b6b5a4c896ee1f2558b0003d0a54a7f4aef3b7760409ffc5825",
             "aarch64-linux": "6b18f435855284852be2b2c1b49e58df380a56784d78b358a13ea77bbace4a8a",
             "armv7l-linux": "a067329d55cc6648e9f783fd8b01b93da45ac21892b8096d758b30a87505c1a7",
-            "headers": "0pb06wlx5zz0asrh05c90q0np14c4swkvhzrcqmcyfz7ihczqh5a",
+            "headers": "13all8fl0zafswszd6lwlhd7bvflglawpglhwal68vliz5sz0p9a",
             "x86_64-darwin": "0499216feffc2ba56438d8c4ac89cf40117baee6335099f5b12457d339f465a6",
             "x86_64-linux": "0e1f1540492e48e3b8805f87c5096c3b99995c4c1b581ee57e9c836538bae813"
         },
@@ -15,7 +15,7 @@
             "aarch64-darwin": "b1425938a053b47bdf1c3c28abd146defb7372a8e645adb0a2f2a9650ca6a36d",
             "aarch64-linux": "0f7350d2aa0d03b4e57aced4cc921a71fa15a0a5528ee463651771cb415e0381",
             "armv7l-linux": "153938fe15bf90e2ff6429d1f7db19144b01b8ec12a00a351fdb9fee56c585c3",
-            "headers": "1ji9mxjh2pigx1ldvp6m9ydlkcyvl6mrrpqsbvzvxd2spppzih0d",
+            "headers": "0gwin292x5ryx41kw0c801b4ipin9q1agnigdv31vcd4y0na2p3s",
             "x86_64-darwin": "38d247a3540650e21ee8d99a8e07b3c9f40439ad09cc176628adb2af948070f6",
             "x86_64-linux": "ae5cb348d7697f4acfb6d19dddc4ffc9fae1a687be5bee66684279a82fd8621b"
         },
@@ -26,7 +26,7 @@
             "aarch64-darwin": "5a142772493b25ad22dda774a1d4da78887024adae8e83b0e74ad0ba64a7f55a",
             "aarch64-linux": "d22f1778894393414d7da01aa3f85d6f11f2cb5a5c7623d9d8339bcd824df4cb",
             "armv7l-linux": "29af72e24c74da70c85bfdce1ed6492b7efbe85f88cfb3da642844b51e5d7259",
-            "headers": "175n6wkz5gyj7plbjbcd6nkhbc108i2ng8ms2wvjya042mshzlqi",
+            "headers": "1jyc5riakfry5gmlcx7nmvl29iq6a01013k7zcfrcmijpkdw0p9z",
             "x86_64-darwin": "618156b4c923adcc2bf3d0a81d82dc874f27129893b7b3c349d0ca13651619e8",
             "x86_64-linux": "18ebcf0d2b681e273eb003ea0d77bb4fb91ed891f39778ad9c22b41972ed1975"
         },
@@ -37,7 +37,7 @@
             "aarch64-darwin": "ad701bedd2b969eddad8676c8dfa69a21d18896ae58fbd7310a358dd21c7d0eb",
             "aarch64-linux": "a1a71be2bb826b59a1da726a59895025481ee335896c175fcffdc2fcfc432675",
             "armv7l-linux": "28186a0edb4e83c9d7afeb32923f26794d26c39f28a3706462a060d4b0e3bc5f",
-            "headers": "1y6d1nygfg6hdcjlzzgdz12hvh8j3xihhg9sg7p6fkmqkll4fyyb",
+            "headers": "1la2xfr8lyvq7dc4mxllj3qksrrwxmz3nc2fnr2h0l08bfn2y1ay",
             "x86_64-darwin": "858f17d67ea811711802b209d041cfca8caa14e6c8f0960de48df14892a0c632",
             "x86_64-linux": "ab6d4bceff76a070ebf3264ee516a3f96a040947f462d26ba202aa754e54d852"
         },

--- a/pkgs/development/tools/electron/binary/update.py
+++ b/pkgs/development/tools/electron/binary/update.py
@@ -81,6 +81,7 @@ def get_headers(version: str) -> str:
         called_process: subprocess.CompletedProcess = subprocess.run(
             [
                 "nix-prefetch-url",
+                "--unpack",
                 f"https://artifacts.electronjs.org/headers/dist/v{version}/node-v{version}-headers.tar.gz",
             ],
             capture_output=True,

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -10,7 +10,6 @@
   yarn,
   libnotify,
   unzip,
-  pkgs,
   pkgsBuildHost,
   pipewire,
   libsecret,
@@ -36,6 +35,9 @@ in
     "out"
     "headers"
   ];
+
+  # don't automatically move the include directory from $headers back into $out
+  moveToDev = false;
 
   nativeBuildInputs = base.nativeBuildInputs ++ [
     nodejs
@@ -213,11 +215,8 @@ in
     mkdir -p $libExecPath
     unzip -d $libExecPath out/Release/dist.zip
 
-    # Create reproducible tarball, per instructions at https://reproducible-builds.org/docs/archives/
-    tar --sort=name \
-      --mtime="@$SOURCE_DATE_EPOCH" \
-      --owner=0 --group=0 --numeric-owner \
-      -czf $headers -C out/Release/gen node_headers
+    mkdir -p $headers
+    cp -r out/Release/gen/node_headers/* $headers/
 
     runHook postInstall
   '';


### PR DESCRIPTION
Lets avoid code duplication as in #384979 and #385029

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
