### PR TITLE
nixos/dhcpcd: fix hostname via DHCP

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -284,7 +284,8 @@ in
           [
             dhcpcd
             config.networking.resolvconf.package
-          ] ++ lib.optional cfg.setHostname (
+          ]
+          ++ lib.optional cfg.setHostname (
             pkgs.writeShellScriptBin "hostname" ''
               ${lib.getExe' pkgs.systemd "hostnamectl"} set-hostname --transient $1
             ''

--- a/pkgs/by-name/dh/dhcpcd/package.nix
+++ b/pkgs/by-name/dh/dhcpcd/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--disable-privsep"
     "--dbdir=/var/lib/dhcpcd"
+    "--with-default-hostname=nixos"
     (lib.enableFeature enablePrivSep "privsep")
   ] ++ lib.optional enablePrivSep "--privsepuser=dhcpcd";
 

--- a/pkgs/by-name/dh/dhcpcd/package.nix
+++ b/pkgs/by-name/dh/dhcpcd/package.nix
@@ -63,7 +63,12 @@ stdenv.mkDerivation rec {
   ) "[ -e ${placeholder "out"}/lib/dhcpcd/dev/udev.so ]";
 
   passthru.tests = {
-    inherit (nixosTests.networking.scripted) macvlan dhcpSimple dhcpOneIf;
+    inherit (nixosTests.networking.scripted)
+      macvlan
+      dhcpSimple
+      dhcpHostname
+      dhcpOneIf
+      ;
   };
 
   meta = with lib; {


### PR DESCRIPTION
Fix support for setting the hostname from DHCP in dhcpcd
(see https://github.com/NixOS/nixpkgs/pull/336988#issuecomment-2628192341)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested via `dhcpcd.tests`
- [x] Tested `dhcpcd.allowSetuid` with hooks relying on `sudo`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @nfroger 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
