### PR TITLE
vpn-slice: fix script startup with python > 3.11 on darwin, modernize a little

### DIFF
--- a/pkgs/tools/networking/vpn-slice/default.nix
+++ b/pkgs/tools/networking/vpn-slice/default.nix
@@ -13,10 +13,11 @@
 buildPythonApplication rec {
   pname = "vpn-slice";
   version = "0.16.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dlenski";
-    repo = pname;
+    repo = "vpn-slice";
     rev = "v${version}";
     sha256 = "sha256-T6VULLNRLWO4OcAsuTmhty6H4EhinyxQSg0dfv2DUJs=";
   };
@@ -24,15 +25,20 @@ buildPythonApplication rec {
   postPatch =
     lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace vpn_slice/mac.py \
-        --replace "'/sbin/route'" "'${unixtools.route}/bin/route'"
+        --replace-fail "'/sbin/route'" "'${unixtools.route}/bin/route'"
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace vpn_slice/linux.py \
-        --replace "'/sbin/ip'" "'${iproute2}/bin/ip'" \
-        --replace "'/sbin/iptables'" "'${iptables}/bin/iptables'"
+        --replace-fail "'/sbin/ip'" "'${iproute2}/bin/ip'" \
+        --replace-fail "'/sbin/iptables'" "'${iptables}/bin/iptables'"
     '';
 
-  propagatedBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    setuptools # can be removed with next package update, upstream no longer has a dependency on distutils
     setproctitle
     dnspython
   ];


### PR DESCRIPTION
## Things done

Python 3.12 removed distutils from the standard library, on which vpn-slice depends as a fallback if setuptools is not available.

In testing I tried adding distutils to nativeBuildInputs of buildInputs, but neithe worked (not sure why, this should not be needed at runtime, but is probably an interaction with buildPythonApplication).

Closes #385323

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
