### PR TITLE
ocamlPackages.posix-math2: init at 2.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/posix/base.nix
+++ b/pkgs/development/ocaml-modules/posix/base.nix
@@ -13,11 +13,10 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-posix";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-JKJIiuo4lW8DmcK1mJlT22784J1NS2ig860jDbRIjIo=";
   };
 
-  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/posix/math2.nix
+++ b/pkgs/development/ocaml-modules/posix/math2.nix
@@ -1,0 +1,19 @@
+{
+  buildDunePackage,
+  posix-base,
+  unix-errno,
+}:
+
+buildDunePackage {
+  pname = "posix-math2";
+  inherit (posix-base) src version;
+
+  propagatedBuildInputs = [
+    posix-base
+    unix-errno
+  ];
+
+  meta = posix-base.meta // {
+    description = "Bindings for posix math";
+  };
+}

--- a/pkgs/development/ocaml-modules/posix/socket.nix
+++ b/pkgs/development/ocaml-modules/posix/socket.nix
@@ -5,7 +5,7 @@ buildDunePackage {
 
   inherit (posix-base) version src;
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.12";
 
   propagatedBuildInputs = [ posix-base ];
 

--- a/pkgs/development/ocaml-modules/posix/time2.nix
+++ b/pkgs/development/ocaml-modules/posix/time2.nix
@@ -11,8 +11,6 @@ buildDunePackage {
 
   inherit (posix-base) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     posix-base
     posix-types

--- a/pkgs/development/ocaml-modules/posix/types.nix
+++ b/pkgs/development/ocaml-modules/posix/types.nix
@@ -5,9 +5,6 @@ buildDunePackage {
 
   inherit (posix-base) version src;
 
-  minimalOCamlVersion = "4.03";
-  duneVersion = "3";
-
   propagatedBuildInputs = [ posix-base ];
 
   meta = posix-base.meta // {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1570,6 +1570,8 @@ let
 
     posix-base = callPackage ../development/ocaml-modules/posix/base.nix { };
 
+    posix-math2 = callPackage ../development/ocaml-modules/posix/math2.nix { };
+
     posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };
 
     posix-time2 = callPackage ../development/ocaml-modules/posix/time2.nix { };


### PR DESCRIPTION
Also clean-up and fix `ocamlPackages.posix-*` after #374424.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
