### PR TITLE
tytools: 0.9.8 -> 0.9.9

### DIFF
--- a/pkgs/development/embedded/tytools/default.nix
+++ b/pkgs/development/embedded/tytools/default.nix
@@ -5,34 +5,58 @@
   cmake,
   pkg-config,
   wrapQtAppsHook,
-  qtbase,
+  qt6,
 }:
 
 stdenv.mkDerivation rec {
   pname = "tytools";
-  version = "0.9.8";
+  version = "0.9.9";
 
   src = fetchFromGitHub {
     owner = "Koromix";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-MKhh0ooDZI1Ks8vVuPRiHhpOqStetGaAhE2ulvBstxA=";
+    repo = "rygel";
+    tag = "tytools/${version}";
+    hash = "sha256-nQZaNYOTkx79UC0RHencKIQFSYUnQ9resdmmWTmgQxA=";
   };
 
   nativeBuildInputs = [
-    cmake
     pkg-config
-    wrapQtAppsHook
-  ];
-  buildInputs = [
-    qtbase
+    qt6.wrapQtAppsHook
   ];
 
-  meta = with lib; {
+  buildInputs = [
+    qt6.qtbase
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./bootstrap.sh
+    ./felix -p Fast tyuploader
+    ./felix -p Fast tycmd
+    ./felix -p Fast tycommander
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/applications
+    cp bin/Fast/tyuploader $out/bin/
+    cp bin/Fast/tycmd $out/bin/
+    cp bin/Fast/tycommander $out/bin/
+    cp src/tytools/tycommander/tycommander_linux.desktop $out/share/applications/tycommander.desktop
+    cp src/tytools/tyuploader/tyuploader_linux.desktop $out/share/applications/tyuploader.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
     description = "Collection of tools to manage Teensy boards";
     homepage = "https://koromix.dev/tytools";
-    license = licenses.unlicense;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ahuzik ];
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ ahuzik ];
   };
 }


### PR DESCRIPTION
Release notes: https://github.com/Koromix/tytools/releases/tag/v0.9.9

This patch-level version bump in upstream includes:
  - change to a new [mono]repo,
  - change dep from qt5 to qt6,
  - change from cmake to a custom build system.

Tytools is a bit annoying to test because of qt.  Basically, the current tytools in nixpkgs 24.11 don't work for me.  Starting `tyuploader` works, but when I plug in a board and click the "Upload" button, the app crashes with `Cannot mix incompatible Qt library (5.15.15) with this library (5.15.16)`.

The same thing happens to me if I try to run this patch based on master.  The error is `Cannot mix incompatible Qt library (6.8.1) with this library (6.8.2)`.

However, if I run [this patch applied to 24.11](https://github.com/scvalex/nixpkgs/tree/tytools-099-2), then everything works as expected and I successfully flashed a board.  So, I assume it would work on nixos-unstable as well, but I don't have a system running that version to test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
