### PR TITLE
qtorganizer-mkcal: 0-unstable-2025-02-14 -> 0-unstable-2025-02-19

### DIFF
--- a/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
+++ b/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  # Flaky: https://github.com/dcaliste/qtorganizer-mkcal/issues/9
+  doCheck = false;
 
   preCheck =
     let

--- a/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
+++ b/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qtorganizer-mkcal";
-  version = "0-unstable-2025-02-14";
+  version = "0-unstable-2025-02-19";
 
   src = fetchFromGitHub {
     owner = "dcaliste";
     repo = "qtorganizer-mkcal";
-    rev = "3090565d70ecdfaad2cba57d5a895fa69afd024a";
-    hash = "sha256-ZNAcqjkVf9efP+WWTDr2YFZT+eZdIJAfX45Gm0+Y81A=";
+    rev = "312412de3f810fbedc7c4f27bd33adb2c3fbe967";
+    hash = "sha256-uv2cEs84bM614vg5K+t4vyXas+1b5Jm39tfGSwWj6n0=";
   };
 
   postPatch = ''
@@ -50,10 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   dontWrapQtApps = true;
-
-  cmakeFlags = [
-    (lib.cmakeBool "INSTALL_TESTS" false)
-  ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 


### PR DESCRIPTION
https://github.com/dcaliste/qtorganizer-mkcal/commit/312412de3f810fbedc7c4f27bd33adb2c3fbe967 drops the test installation entirely, so we can get rid of that CMake option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
