### PR TITLE
Git: 2.48.1 -> 2.49.0

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -30,7 +30,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.48.1";
+  version = "2.49.0";
   svn = subversionClient.override { perlBindings = perlSupport; };
   gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
 in
@@ -42,8 +42,11 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version;
 
   src = fetchurl {
-    url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    hash = "sha256-HF1UX13B61HpXSxQ2Y/fiLGja6H6MOmuXVOFxgJPgq0=";
+    url =
+      if lib.strings.hasInfix "-rc" version
+      then "https://www.kernel.org/pub/software/scm/git/testing/git-${builtins.replaceStrings ["-"] ["."] version}.tar.xz"
+      else "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+    hash = "sha256-YYGQz1kLfp9sEfkfI7HSZ82Yw6szuFBBbYdY+LWoVig=";
   };
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, lib, stdenv, buildPackages
-, curl, openssl, zlib, expat, perlPackages, python3, gettext, cpio
+, curl, openssl, zlib-ng, expat, perlPackages, python3, gettext, cpio
 , gnugrep, gnused, gawk, coreutils # needed at runtime by git-filter-branch etc
 , openssh, pcre2, bash
 , asciidoc, texinfo, xmlto, docbook2x, docbook_xsl, docbook_xml_dtd_45
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ deterministic-host-uname gettext perlPackages.perl makeWrapper pkg-config ]
     ++ lib.optionals withManual [ asciidoc texinfo xmlto docbook2x
          docbook_xsl docbook_xml_dtd_45 libxslt ];
-  buildInputs = [ curl openssl zlib expat cpio (if stdenv.hostPlatform.isFreeBSD then libiconvReal else libiconv) bash ]
+  buildInputs = [ curl openssl zlib-ng expat cpio (if stdenv.hostPlatform.isFreeBSD then libiconvReal else libiconv) bash ]
     ++ lib.optionals perlSupport [ perlPackages.perl ]
     ++ lib.optionals guiSupport [tcl tk]
     ++ lib.optionals withpcre2 [ pcre2 ]
@@ -108,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "prefix=\${out}"
+    "ZLIB_NG=1"
   ]
   # Git does not allow setting a shell separately for building and run-time.
   # Therefore lets leave it at the default /bin/sh when cross-compiling

--- a/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
@@ -1,7 +1,7 @@
 diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
 index 3db4eab4ba..39bc0e77c9 100644
---- a/Documentation/git-send-email.txt
-+++ b/Documentation/git-send-email.txt
+--- a/Documentation/git-send-email.adoc
++++ b/Documentation/git-send-email.adoc
 @@ -220,9 +220,9 @@ a password is obtained using 'git-credential'.
  --smtp-server=<host>::
  	If set, specifies the outgoing SMTP server to use (e.g.

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -33,7 +33,7 @@
     name = "leave-git-nix-source";
     url = "https://github.com/NixOS/nix";
     rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-    sha256 = "sha256-3YYVIeaeu6zO7bBkZxF+1d5VS0K2GHYEZwChB3tPJ4s=";
+    sha256 = "sha256-VmQ38+lr+rNPaTnjjV41uC2XSN4fkfZAfytE2uKyLfo=";
     leaveDotGit = true;
   };
 
@@ -49,7 +49,7 @@
     name = "submodule-leave-git-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-0pwleO/m4Iws3BF9ewyWbYMcGfEJLS3BYzWfDSYtXs8=";
+    sha256 = "sha256-EC2PMEEtA7f5OFdsluHn7pi4QXhCZuFML8tib4pV7Ek=";
     leaveDotGit = true;
     fetchSubmodules = true;
   };
@@ -70,7 +70,7 @@
     name = "submodule-leave-git-deep-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-eRHOwolRZDJS/5zk88e7SdoO7nKKtjDXMLVsyFPFgk8=";
+    sha256 = "sha256-ieYn9I/0RgeSwQkSqwKaU3RgjKFlRqMg7zw0Nvu3azA=";
     deepClone = true;
     leaveDotGit = true;
     fetchSubmodules = true;

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -58,9 +58,12 @@
     name = "submodule-deep-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-eRHOwolRZDJS/5zk88e7SdoO7nKKtjDXMLVsyFPFgk8=";
+    sha256 = "sha256-3zWogs6EZBnzUfz6gBnigETTKGYl9KFKFgsy6Bl4DME=";
     deepClone = true;
     fetchSubmodules = true;
+    # deepClone implies leaveDotGit, so delete the .git directory after
+    # fetching to distinguish from the submodule-leave-git-deep test.
+    postFetch = "rm -r $out/.git";
   };
 
   submodule-leave-git-deep = testers.invalidateFetcherByDrvHash fetchgit {


### PR DESCRIPTION
A few changes in addition to the straightforward version bump:

- Update the src url handling to cope with release candidate version strings. This makes no difference for the actual releases, but made testing the release candidates as they came out easier.
- Fix git-send-email-honor-PATH.patch to work after the upstream change in <https://github.com/gitster/git/commit/1f010d6bdf756129db13d1367c888aa4153f6d87>.
- Use make flags in the `postBuild` and `postInstall` hooks in a way that's consistent with how the flags are handled in the main stdenv build phase. This is necessary because the inconsistent handling of `PERL_PATH` flags was causing build failures in this release.
- Swap out zlib for the newly supported and faster zlib-ng. This adds about 176kiB to the closure size. 

Release notes: https://github.com/git/git/blob/v2.49.0/Documentation/RelNotes/2.49.0.adoc

## Things done

- Built:
  - x86_64-linux
    - [x] `git`
    - [x] `git.passthru.tests`
    - [x] `gitMinimal`
    - [x] `gitMinimal.passthru.tests`
    - [x] `gitFull`
    - [x] `gitFull.passthru.tests`
    - [x] `gitSVN`
    - [x] `gitSVN.passthru.tests`
    - [x] `nixosTests.gitdaemon`
    - [x] `tests.fetchgit`
  - aarch64-linux
    - [x] `git`
    - [ ] `git.passthru.tests`
    - [x] `gitMinimal`
    - [ ] `gitMinimal.passthru.tests`
    - [ ] `gitFull`
    - [ ] `gitFull.passthru.tests`
    - [x] `gitSVN`
    - [ ] `gitSVN.passthru.tests`
    - [ ] `nixosTests.gitdaemon`
    - [x] `tests.fetchgit`
  - [ ] x86_64-darwin (I don't have access to a test system)
  - [ ] aarch64-darwin (I don't have access to a test system)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] ~(Package updates) Added a release notes entry if the change is major or breaking~ _no major or breaking changes_
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
