### PR TITLE
yazi-unwrapped: fix update script; use finalAttrs

### DIFF
--- a/pkgs/by-name/ya/yazi-unwrapped/package.nix
+++ b/pkgs/by-name/ya/yazi-unwrapped/package.nix
@@ -8,34 +8,13 @@
   Foundation,
   rust-jemalloc-sys,
 }:
-let
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yazi";
   version = "25.2.26";
 
-  code_src = fetchFromGitHub {
-    owner = "sxyazi";
-    repo = "yazi";
-    tag = "v${version}";
-    hash = "sha256-DqhqpQRCSBTGonL9+bP7pA3mO2CemlbhwzShVdrL1/0=";
-  };
+  srcs = builtins.attrValues finalAttrs.passthru.srcs;
 
-  man_src = fetchFromGitHub {
-    name = "manpages"; # needed to ensure name is unique
-    owner = "yazi-rs";
-    repo = "manpages";
-    rev = "8950e968f4a1ad0b83d5836ec54a070855068dbf";
-    hash = "sha256-kEVXejDg4ChFoMNBvKlwdFEyUuTcY2VuK9j0PdafKus=";
-  };
-in
-rustPlatform.buildRustPackage {
-  pname = "yazi";
-  inherit version;
-
-  srcs = [
-    code_src
-    man_src
-  ];
-
-  sourceRoot = code_src.name;
+  sourceRoot = finalAttrs.passthru.srcs.code_src.name;
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-xg37aypFKY0ZG9GOkygTHlOAjqkTuhLNKo8Fz6MF2ZY=";
@@ -53,14 +32,29 @@ rustPlatform.buildRustPackage {
       --fish ./yazi-boot/completions/yazi.fish \
       --zsh  ./yazi-boot/completions/_yazi
 
-    installManPage ../${man_src.name}/yazi{.1,-config.5}
+    installManPage ../${finalAttrs.passthru.srcs.man_src.name}/yazi{.1,-config.5}
 
     install -Dm444 assets/yazi.desktop -t $out/share/applications
     install -Dm444 assets/logo.png $out/share/pixmaps/yazi.png
   '';
 
   passthru.updateScript.command = [ ./update.sh ];
-  passthru.srcs = { inherit code_src man_src; }; # for updating sources
+  passthru.srcs = {
+    code_src = fetchFromGitHub {
+      owner = "sxyazi";
+      repo = "yazi";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-DqhqpQRCSBTGonL9+bP7pA3mO2CemlbhwzShVdrL1/0=";
+    };
+
+    man_src = fetchFromGitHub {
+      name = "manpages"; # needed to ensure name is unique
+      owner = "yazi-rs";
+      repo = "manpages";
+      rev = "8950e968f4a1ad0b83d5836ec54a070855068dbf";
+      hash = "sha256-kEVXejDg4ChFoMNBvKlwdFEyUuTcY2VuK9j0PdafKus=";
+    };
+  };
 
   meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";
@@ -76,4 +70,4 @@ rustPlatform.buildRustPackage {
     ];
     mainProgram = "yazi";
   };
-}
+})

--- a/pkgs/by-name/ya/yazi-unwrapped/package.nix
+++ b/pkgs/by-name/ya/yazi-unwrapped/package.nix
@@ -26,7 +26,7 @@ let
     hash = "sha256-kEVXejDg4ChFoMNBvKlwdFEyUuTcY2VuK9j0PdafKus=";
   };
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "yazi";
   inherit version;
 
@@ -34,6 +34,7 @@ rustPlatform.buildRustPackage rec {
     code_src
     man_src
   ];
+
   sourceRoot = code_src.name;
 
   useFetchCargoVendor = true;
@@ -59,6 +60,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru.updateScript.command = [ ./update.sh ];
+  passthru.srcs = { inherit code_src man_src; }; # for updating sources
 
   meta = {
     description = "Blazing fast terminal file manager written in Rust, based on async I/O";


### PR DESCRIPTION
The update script silently broke because of the changes to `srcs` and also because `nix-prefetch` is very outdated.

Got the code to update the cargoHash from the [scx update script](https://github.com/NixOS/nixpkgs/blob/0ca83b9d944ae12975bbef80077b7016460e7f27/pkgs/os-specific/linux/scx/update.sh#L47).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
