### PR TITLE
virtualgl: fix library paths that were preventing it from working

### DIFF
--- a/pkgs/tools/X11/virtualgl/default.nix
+++ b/pkgs/tools/X11/virtualgl/default.nix
@@ -3,6 +3,9 @@
   lib,
   virtualglLib,
   virtualglLib_i686 ? null,
+  makeWrapper,
+  vulkan-loader,
+  addDriverRunpath,
 }:
 
 stdenv.mkDerivation {
@@ -10,6 +13,7 @@ stdenv.mkDerivation {
   version = lib.getVersion virtualglLib;
 
   paths = [ virtualglLib ];
+  nativeBuildInputs = [ makeWrapper ];
 
   buildCommand =
     ''
@@ -17,6 +21,19 @@ stdenv.mkDerivation {
       for i in ${virtualglLib}/bin/* ${virtualglLib}/bin/.vglrun*; do
         ln -s "$i" $out/bin
       done
+
+      wrapProgram $out/bin/vglrun \
+        --prefix LD_LIBRARY_PATH : "${
+          lib.makeLibraryPath [
+            virtualglLib
+            virtualglLib_i686
+
+            addDriverRunpath.driverLink
+
+            # Needed for vulkaninfo to work
+            vulkan-loader
+          ]
+        }"
     ''
     + lib.optionalString (virtualglLib_i686 != null) ''
       ln -sf ${virtualglLib_i686}/bin/.vglrun.vars32 $out/bin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wrapped the vglrun binary so it can actually work.

```bash
nix-shell -p virtualgl glxinfo --run "vglrun glxinfo -B"
...
name of display: :0
Error: couldn't find RGB GLX visual or fbconfig

---

./result/bin/vglrun glxinfo -B
...
output you'd expect

```

One more thing:
I think the virtualGL package(s) need to undergo many changes. The virtualgl package is using buildCommand instead of phases, and the entire command copies files from ${virtualglLib}/bin to $out/bin. I think virtualglLib should just be renamed to virtualgl, with the current virtualgl package being deleted. It should also be moved from the tools/X11 directory to by-name I can make a PR for that if it is good.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

