### PR TITLE
picolisp: fix darwin build

### DIFF
--- a/pkgs/by-name/pi/picolisp/package.nix
+++ b/pkgs/by-name/pi/picolisp/package.nix
@@ -29,10 +29,16 @@ stdenv.mkDerivation {
     readline
   ];
   sourceRoot = ''pil21'';
-  buildPhase = ''
-    cd src
-    make
-  '';
+  preBuild =
+    ''
+      cd src
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # Flags taken from instructions at: https://picolisp.com/wiki/?alternativeMacOSRepository
+      makeFlagsArray+=(
+        SHARED='-dynamiclib -undefined dynamic_lookup'
+      )
+    '';
 
   installPhase = ''
     cd ..
@@ -42,7 +48,7 @@ stdenv.mkDerivation {
     ln -s "$out/lib/picolisp/bin/pil" "$out/bin/pil"
     ln -s "$out/lib/picolisp/man/man1/pil.1" "$out/man/pil.1"
     ln -s "$out/lib/picolisp/man/man1/picolisp.1" "$out/man/picolisp.1"
-    substituteInPlace $out/bin/pil --replace /usr $out
+    substituteInPlace $out/bin/pil --replace-fail /usr $out
   '';
 
   meta = with lib; {


### PR DESCRIPTION
`picolisp` currently fails to build on Darwin/macOS - it uses the wrong flag to try and build a shared/dynamic library, and also doesn't tell the linker to allow that library to have undefined symbols that will be provided by the main program.

Based on the instructions at <https://picolisp.com/wiki/?alternativeMacOSRepository>, this PR tells `make` to set the `SHARED` variable to the correct flags when building for Darwin. I also modified the derivation to use the default `buildPhase` instead of a custom `make` command, so that `makeFlagsArray` works properly, and changed the deprecated `substituteInPlace --replace` to `--replace-fail`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - **Note:** Only tried under [nix-user-chroot](https://github.com/nix-community/nix-user-chroot), not a normal install.
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - **Note:** Not applicable as far as I can tell - nothing else seems to depend on this package.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - **Note:** Did some very minimal testing of `result/bin/{pil,picolisp}`, but I'm not familiar enough with the system to know what all to try. There are more binaries under `result/lib/picolisp/` which I have not tested yet.
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc