### PR TITLE
ocamlPackages.tcpip: 8.2.0 → 9.0.0; ocamlPackages.arp: 3.1.1 → 4.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/arp/default.nix
+++ b/pkgs/development/ocaml-modules/arp/default.nix
@@ -10,31 +10,22 @@
   logs,
   lwt,
   macaddr,
-  mirage-time,
+  mirage-sleep,
   alcotest,
-  mirage-clock-unix,
-  mirage-flow,
-  mirage-random,
-  mirage-random-test,
-  mirage-time-unix,
+  bos,
   mirage-vnetif,
-  bisect_ppx,
 }:
 
 buildDunePackage rec {
   pname = "arp";
-  version = "3.1.1";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    hash = "sha256-6jPFiene6jAPtivCugtVfP3+6k9A5gBoWzpoxoaPBvE=";
+    hash = "sha256-C2Bh/2NwZqCJEidCnkhwRMoW3AsbQtvwdFh9IiJkDaU=";
   };
 
   minimalOCamlVersion = "4.08";
-
-  nativeBuildInputs = [
-    bisect_ppx
-  ];
 
   propagatedBuildInputs = [
     cstruct
@@ -44,18 +35,14 @@ buildDunePackage rec {
     logs
     lwt
     macaddr
-    mirage-time
+    mirage-sleep
   ];
 
   ## NOTE: As of 18 april 2023 and ARP version 3.0.0, tests fail on Darwin.
   doCheck = !stdenv.hostPlatform.isDarwin;
   checkInputs = [
     alcotest
-    mirage-clock-unix
-    mirage-flow
-    mirage-random
-    mirage-random-test
-    mirage-time-unix
+    bos
     mirage-vnetif
   ];
 

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -13,6 +13,7 @@
   tcpip,
   tls,
   tls-mirage,
+  mirage-crypto-rng-mirage,
   dnssec,
   alcotest,
 }:
@@ -37,6 +38,7 @@ buildDunePackage {
     tcpip
     tls
     tls-mirage
+    mirage-crypto-rng-mirage
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/mirage-mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-mtime/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  mtime,
+  version ? "5.0.0",
+}:
+
+buildDunePackage {
+  pname = "mirage-mtime";
+
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-mtime/releases/download/v${version}/mirage-mtime-${version}.tbz";
+    hash = "sha256-IwdaAyZyj8gfRPxQP9SOwb28AbtVy9PY7qcr0Pns9GU=";
+  };
+
+  propagatedBuildInputs = [
+    mtime
+  ];
+
+  meta = {
+    description = "Monotonic time for MirageOS";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+    homepage = "https://github.com/mirage/mirage-mtime";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-sleep/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-sleep/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  lwt,
+  duration,
+  version ? "4.0.0",
+}:
+
+buildDunePackage {
+  inherit version;
+  pname = "mirage-sleep";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/mirage-sleep/releases/download/v${version}/mirage-sleep-${version}.tbz";
+    hash = "sha256-J7cw7sE3EE3BIhSdwD1KV3VeXjEqviVmys3LgGhEE/A=";
+  };
+
+  propagatedBuildInputs = [
+    duration
+    lwt
+  ];
+
+  meta = {
+    description = "Sleep operations for MirageOS";
+    homepage = "https://github.com/mirage/mirage-sleep";
+    changelog = "https://raw.githubusercontent.com/mirage/mirage-sleep/refs/tags/v${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -6,9 +6,9 @@
   cstruct,
   cstruct-lwt,
   mirage-net,
-  mirage-clock,
-  mirage-crypto-rng-mirage,
-  mirage-time,
+  mirage-mtime,
+  mirage-crypto-rng,
+  mirage-sleep,
   macaddr,
   macaddr-cstruct,
   fmt,
@@ -22,10 +22,8 @@
   mirage-flow,
   mirage-vnetif,
   pcap-format,
-  mirage-clock-unix,
   arp,
   ipaddr-cstruct,
-  mirage-crypto-rng,
   lru,
   metrics,
   withFreestanding ? false,
@@ -34,11 +32,11 @@
 
 buildDunePackage rec {
   pname = "tcpip";
-  version = "8.2.0";
+  version = "9.0.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    hash = "sha256-kW5oirqJdnbERNuBKfSWOtc5+NG+Yx2eAJxiKLS31u0=";
+    hash = "sha256-WTd+01kIDY2pSuyRR0pTO62VXBK+eYJ77IU8y0ltZZo=";
   };
 
   nativeBuildInputs = [
@@ -50,9 +48,9 @@ buildDunePackage rec {
       cstruct
       cstruct-lwt
       mirage-net
-      mirage-clock
-      mirage-crypto-rng-mirage
-      mirage-time
+      mirage-mtime
+      mirage-crypto-rng
+      mirage-sleep
       ipaddr-cstruct
       macaddr
       macaddr-cstruct
@@ -75,11 +73,8 @@ buildDunePackage rec {
   doCheck = true;
   checkInputs = [
     alcotest
-    mirage-crypto-rng
-    mirage-flow
     mirage-vnetif
     pcap-format
-    mirage-clock-unix
   ];
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1224,6 +1224,8 @@ let
 
     mirage-runtime = callPackage ../development/ocaml-modules/mirage/runtime.nix { };
 
+    mirage-sleep = callPackage ../development/ocaml-modules/mirage-sleep { };
+
     mirage-time = callPackage ../development/ocaml-modules/mirage-time { };
 
     mirage-time-unix = callPackage ../development/ocaml-modules/mirage-time/unix.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1206,6 +1206,8 @@ let
 
     mirage-logs = callPackage ../development/ocaml-modules/mirage-logs { };
 
+    mirage-mtime = callPackage ../development/ocaml-modules/mirage-mtime { };
+
     mirage-nat = callPackage ../development/ocaml-modules/mirage-nat { };
 
     mirage-net = callPackage ../development/ocaml-modules/mirage-net { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
