### PR TITLE
mdq: init at 0.3.1

### DIFF
--- a/pkgs/by-name/md/mdq/package.nix
+++ b/pkgs/by-name/md/mdq/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mdq";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "yshavit";
+    repo = "mdq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IMDyPIuG5Zyp323XYsFcFo0yNimCm2DV9rY+Ac0DiZo=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GxQ9YyofalnIP3EtGVpIpg7s8QW2d1Z/gFF2CUBg1P0=";
+
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Like jq but for Markdown: find specific elements in a md doc";
+    homepage = "https://github.com/yshavit/mdq";
+    changelog = "https://github.com/yshavit/mdq/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    mainProgram = "mdq";
+  };
+})


### PR DESCRIPTION
## Things done

Add https://github.com/yshavit/mdq

Tested basic functionality with:
```sh
$ nix-build --option sandbox relaxed -A mdq
/nix/store/wd22vqhirx3fibxdkw1j00sq7g9n5ji1-mdq-0.3.1
$ curl -O https://raw.githubusercontent.com/yshavit/mdq/refs/heads/main/examples/hello.md
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1730  100  1730    0     0  85702      0 --:--:-- --:--:-- --:--:-- 86500
$ cat hello.md | ./result/bin/mdq '# Hello there'
## Hello there

In fact, I'm doing very well!
This line isn't a new paragraph, just some
wrapping that mdq should unwrap.

### Sub-section with link

This is [my referenced link][a1].

[a1]: https://example.com/reference
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
