### PR TITLE
libguestfs: 1.54.0 -> 1.54.1

### DIFF
--- a/pkgs/by-name/li/libguestfs-with-appliance/package.nix
+++ b/pkgs/by-name/li/libguestfs-with-appliance/package.nix
@@ -4,9 +4,25 @@
   libguestfs-appliance,
 }:
 
+let
+  appliance = libguestfs-appliance;
+  # check explicit forward compatibility declaration:
+  # then do not warn if older appliance if known to work fine with newer libguestfs
+  libguestfsCompatible =
+    if lib.hasAttr "libguestfsCompatible" appliance then
+      appliance.libguestfsCompatible libguestfs
+    else
+      false;
+in
 # https://github.com/NixOS/nixpkgs/issues/280881
-lib.warnIf (builtins.compareVersions libguestfs.version libguestfs-appliance.version > 0)
-  "libguestfs has a higher version than libguestfs-appliance (${libguestfs.version} > ${libguestfs-appliance.version}), runtime errors may occur!"
+lib.warnIf
+  (
+    builtins.compareVersions (lib.versions.majorMinor libguestfs.version) (
+      lib.versions.majorMinor appliance.version
+    ) > 0
+    && !libguestfsCompatible
+  )
+  "libguestfs has a different version than ${appliance.pname} (${libguestfs.version} > ${appliance.version}), runtime errors may occur!"
 
   libguestfs.override
-  { appliance = libguestfs-appliance; }
+  { inherit appliance; }

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -48,11 +48,11 @@ assert appliance == null || lib.isDerivation appliance;
 stdenv.mkDerivation (finalAttrs: {
   pname = "libguestfs";
 
-  version = "1.54.0";
+  version = "1.54.1";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/${lib.versions.majorMinor finalAttrs.version}-stable/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-tK+g+P1YAgXqVUjUaLxuQ8O+y5leL2DmMmVSemMFQkY=";
+    sha256 = "sha256-bj/GrBkmdfe8KEClYbs2o209Wo36f4jqL1P4z2AqF34=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -47,11 +47,10 @@ assert appliance == null || lib.isDerivation appliance;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libguestfs";
-
   version = "1.54.1";
 
   src = fetchurl {
-    url = "https://libguestfs.org/download/${lib.versions.majorMinor finalAttrs.version}-stable/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://libguestfs.org/download/${lib.versions.majorMinor finalAttrs.version}-stable/libguestfs-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-bj/GrBkmdfe8KEClYbs2o209Wo36f4jqL1P4z2AqF34=";
   };
 


### PR DESCRIPTION
-  3rd commit tames the version mismatch warning to only check majorMinor.
   - also allows providing `libguestfsCompatible` to be used in #381224 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
