### PR TITLE
Add `buildArch` flag to translateLocally for controlling AVX512

### DIFF
--- a/pkgs/by-name/tr/translatelocally/package.nix
+++ b/pkgs/by-name/tr/translatelocally/package.nix
@@ -12,6 +12,7 @@
   runCommand,
   translatelocally,
   translatelocally-models,
+  buildArch ? "x86-64",
 }:
 
 let
@@ -65,6 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DBLAS_LIBRARIES=-lblas"
     "-DCBLAS_LIBRARIES=-lcblas"
+
+    # See the following for context:
+    # https://github.com/NixOS/nixpkgs/pull/385549
+    (lib.optionalString stdenv.hostPlatform.isx86_64 "-DBUILD_ARCH=${buildArch}")
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Per #379579, the `translateLocally` binaries built by hydra don't work on CPUs without [AVX-512](https://en.wikipedia.org/wiki/AVX-512#CPUs_with_AVX-512).  This happens because the build detects AVX-512 support at build time and the hydra builders have it (but my laptop doesn't).

The CPU detection happens in [CMakeLists.txt:41](https://github.com/XapaJIaMnu/translateLocally/blob/8e31cffc9a58372e4262332d8d0ffbc3201b711f/CMakeLists.txt#L41).

This patch adds an `buildArch` flag to the `translateLocally` derivation.  It defaults to `x86-64` (and not `x86-64-v2`, v3, or v4).  This sets the `BUILD_ARCH` flag for clang on x86-64 machines and will make hydra build the packages without AVX-512, so they should be usable by all nixos users.

If a user wants AVX-512, they can opt-in with an override like `pkgs.translatelocally.override { buildArch = "x86-64-v4"; }`.  If they want AVX2, then can use `x86-64-v3` instead.

I tested this by running the build with the flag enabled and checking that the CPU detection log messages don't happen.  I also tested the resulting binary, but that doesn't prove anything because the binaries built on my laptop always work on my laptop.

Fixes #379579 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
