### PR TITLE
lenovo-legion-app: 0.0.18 -> unstable-2025-02-20

### DIFF
--- a/pkgs/os-specific/linux/lenovo-legion/app.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/app.nix
@@ -8,13 +8,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "lenovo-legion-app";
-  version = "0.0.18";
+  version = "0.0.19-unstable-2025-02-20";
 
   src = fetchFromGitHub {
     owner = "johnfanv2";
     repo = "LenovoLegionLinux";
-    rev = "e9c1d8157a7b25e4334d0b1d887338c670e39f6a";
-    hash = "sha256-6JYOTDzz9/flyEDQo1UPjWT5+Cuea5fsdbdc6AooDxU=";
+    rev = "43f2ad0ea67b69f509a0c5f0254272fe85f3b070";
+    hash = "sha256-k7CHL59tRjfly1xV+TXjNitkhV7q6qtMhuc+QO5ASkI=";
   };
 
   sourceRoot = "${src.name}/python/legion_linux";
@@ -33,7 +33,7 @@ python3.pkgs.buildPythonApplication rec {
     # only fixup application (legion-linux-gui), service (legiond) currently not installed so do not fixup
     # version
     substituteInPlace ./setup.cfg \
-      --replace-fail "_VERSION" "${version}"
+      --replace-fail "_VERSION" "${builtins.head (lib.splitString "-" version)}"
 
     # /etc
     substituteInPlace ./legion_linux/legion.py \


### PR DESCRIPTION
## Things done
- Updated to latest commit to fix 6.13 kernel builds.

---

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
