### PR TITLE
linuxPackages.nvidiaPackages.production: 550.142 -> 570.124.04

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -64,16 +64,12 @@ rec {
   stable = if stdenv.hostPlatform.system == "i686-linux" then legacy_390 else production;
 
   production = generic {
-    version = "550.142";
-    sha256_64bit = "sha256-bdVJivBLQtlSU7Zre9oVCeAbAk0s10WYPU3Sn+sXkqE=";
-    sha256_aarch64 = "sha256-sBp5fcCPMrfrTZTF1FqKo9g0wOWP+5+wOwQ7PLWI6wA=";
-    openSha256 = "sha256-hjpwTR4I0MM5dEjQn7MKM3RY1a4Mt6a61Ii9KW2KbiY=";
-    settingsSha256 = "sha256-Wk6IlVvs23cB4s0aMeZzSvbOQqB1RnxGMv3HkKBoIgY=";
-    persistencedSha256 = "sha256-yQFrVk4i2dwReN0XoplkJ++iA1WFhnIkP7ns4ORmkFA=";
-    patchesOpen = [
-      ./nvidia-nv-Convert-symbol-namespace-to-string-literal.patch
-      ./crypto-Add-fix-for-6.13-Module-compilation.patch
-    ];
+    version = "570.124.04";
+    sha256_64bit = "sha256-G3hqS3Ei18QhbFiuQAdoik93jBlsFI2RkWOBXuENU8Q=";
+    sha256_aarch64 = "sha256-HN58N00SNEwMQKSKuOMAXVW6J2VI/2YyDulQNJHuVeM=";
+    openSha256 = "sha256-KCGUyu/XtmgcBqJ8NLw/iXlaqB9/exg51KFx0Ta5ip0=";
+    settingsSha256 = "sha256-LNL0J/sYHD8vagkV1w8tb52gMtzj/F0QmJTV1cMaso8=";
+    persistencedSha256 = "sha256-SHSdnGyAiRH6e0gYMYKvlpRSH5KYlJSA1AJXPm7MDRk=";
   };
 
   latest = selectHighestVersion production (generic {


### PR DESCRIPTION
- Highlights since R570 Beta Release, 570.86.16
  - Fixed a bug that could prevent displays from being restored correctly when resuming from suspend on some systems with multiple displays.
  - Fixed a regression which stopped VRR from working on HDMI displays.
  - Fixed an issue which caused stuttering and performance issues when scrolling windows in Wayland with GSP firmware enabled.
  - Fixed a bug that resulted in corruption or application crashes when using PRIME render offloading between two NVIDIA GPUs with modeset=1 enabled in nvidia-drm.
  - Added a new kernel module parameter, 'conceal_vrr_caps', to the nvidia-modeset kernel module. This parameter may be used to enable usage of features on some displays such as ULMB (Ultra Low Motion Blur) which are incompatible with VRR. See the "Direct Rendering Manager Kernel Modesetting" (DRM KMS) chapter of the README for further information.
- Highlights from R570 Beta Release, 570.86.16
  - Fixed a bug that caused the nvidia-settings control panel to crash when querying VRR attributes on some monitors.
  - Updated the nvidia-settings control panel to use NVML rather than NV-CONTROL to control GPU clocks and fan speed. This allows related functionality to work when using Wayland, where the NV-CONTROL X extension is not available. Note that as a result, some operations which were previously available to unprivileged users, due to the privileges of the X server, may now require elevated privileges.
  - Added support for VRR on systems with multiple displays.
  - Added an application profile to improve performance on Indiana Jones and the Great Circle.
  - Added an application profile to resolve a corruption issue on Assassin's Creed Valhalla and Assassin's Creed Mirage.
  - Implemented support for the VK_KHR_incremental_present extension.
  - Fixed a bug that could cause some Vulkan applications to crash when responding to window resize events.
  - Updated GPU overclocking control to be available by default in nvidia-settings, for GPU boards that support programmable clock control. Previously, this was only available when bit 3 was set in the "Coolbits" X config option.
  - Disabled a power saving feature on Ada and above generation GPUs for surfaces allocated with the DRM Dumb-Buffers API, for example, when using a DRM fbdev. The power saving feature could cause black screens for DRM Dumb-Buffers which use front buffer rendering instead of KMS flips.
  - Fixed a bug that could cause some multi-threaded OpenGL applications, for example Civilization 6, to crash when running on Xwayland.
  - Added support for querying Dynamic Boost status via the 'power' file in /proc/driver/nvidia/gpus/*.
  - Enabled 32 bit compatibility support for the NVIDIA GBM backend.
  - Added a new kernel module parameter, 'conceal_vrr_caps', to the nvidia-modeset kernel module. This parameter may be used to enable usage of features on some displays such as ULMB (Ultra Low Motion Blur) which are incompatible with VRR. See the "Direct Rendering Manager Kernel Modesetting" (DRM KMS) chapter of the README for further information.
  - Fixed a bug that could cause games to crash when the "PROTON_ENABLE_NGX_UPDATER" environment variable was set to a value of "1".
  - Added /usr/share/nvidia/files.d/sandboxutils-filelist.json which lists all the driver files used by container runtime environments such as nvidia-container-toolkit and enroot.
  - Added support for the systemd suspend-then-hibernate method of system sleep. This feature requires systemd version 248 or newer.
  - Enabled the nvidia-drm fbdev=1 option by default. When supported by the kernel and the nvidia-drm modeset=1 option is enabled, nvidia-drm will replace the system's framebuffer console with one driven by DRM.
    - This feature can be disabled by setting fbdev=0.
  - Implemented a feature that allows low latency display interrupts to be serviced even when the system is under heavy contention. This is especially useful for reducing stutter when using virtual reality.
    - This feature is experimental and disabled by default.
    - This feature can be enabled by loading nvidia.ko with the `NVreg_RegistryDwords=RMIntrLockingMode=1` kernel module parameter.
  - Fixed a bug, introduced in 555.58, where some DVI outputs would not work with HDMI monitors.
  - In Linux kernel 6.11, drm_fbdev_generic was renamed to drm_fbdev_ttm. Use drm_fbdev_ttm when present to keep supporting direct framebuffer access needed for Wayland compositors to present content on newer kernels.
  - In linux-next commit 446d0f4849b1, output_poll_changed is removed from struct drm_mode_config_funcs. Do not implement the function pointer member when not present to ensure the driver can compile with newer kernels. The driver now supports enumerating modes on hotplug events through the DRM fbdev API.
  - In linux-next commit 446d0f4849b1, intended to be included in Linux kernel 6.12, output_poll_changed is removed from struct drm_mode_config_funcs. Do not implement the function pointer member when not present to ensure the driver can compile with newer kernels. Populating modes for DRM connectors during hotplug events will not be supported with r535 and kernels containing the relevant commit.
  - Fixed a bug that could cause external displays to become frozen until the next modeset when using PRIME Display Offloading with the NVIDIA dGPU acting as the display offload sink.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
