### PR TITLE
auto-editor: 24w29a -> 26.2.0

### DIFF
--- a/pkgs/by-name/au/auto-editor/package.nix
+++ b/pkgs/by-name/au/auto-editor/package.nix
@@ -3,25 +3,23 @@
   python3Packages,
   fetchFromGitHub,
   replaceVars,
-  ffmpeg,
   yt-dlp,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "auto-editor";
-  version = "24w29a";
+  version = "26.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "WyattBlue";
     repo = "auto-editor";
     tag = version;
-    hash = "sha256-2/6IqwMlaWobOlDr/h2WV2OqkxqVmUI65XsyBphTbpA=";
+    hash = "sha256-BYpt/EelCChhphfuTcqI/VIVis6dnt0J4FcNhWeiiyY=";
   };
 
   patches = [
     (replaceVars ./set-exe-paths.patch {
-      ffmpeg = lib.getExe ffmpeg;
       yt_dlp = lib.getExe yt-dlp;
     })
   ];
@@ -29,11 +27,8 @@ python3Packages.buildPythonApplication rec {
   postPatch = ''
     # pyav is a fork of av, but has since mostly been un-forked
     substituteInPlace pyproject.toml \
-        --replace-fail '"pyav==12.2.*"' '"av"'
+        --replace-fail '"pyav==14.*"' '"av"'
   '';
-
-  # our patch file also removes the dependency on ae-ffmpeg
-  pythonRemoveDeps = [ "ae-ffmpeg" ];
 
   build-system = with python3Packages; [
     setuptools

--- a/pkgs/by-name/au/auto-editor/set-exe-paths.patch
+++ b/pkgs/by-name/au/auto-editor/set-exe-paths.patch
@@ -1,29 +1,10 @@
-diff --git a/auto_editor/ffwrapper.py b/auto_editor/ffwrapper.py
-index b6df2d4..8409032 100644
---- a/auto_editor/ffwrapper.py
-+++ b/auto_editor/ffwrapper.py
-@@ -30,13 +30,7 @@ class FFmpeg:
-                 return ff_location
-             if my_ffmpeg:
-                 return "ffmpeg"
--
--            try:
--                import ae_ffmpeg
--
--                return ae_ffmpeg.get_path()
--            except ImportError:
--                return "ffmpeg"
-+            return "@ffmpeg@"
- 
-         self.debug = debug
-         self.show_cmd = show_cmd
 diff --git a/auto_editor/utils/types.py b/auto_editor/utils/types.py
-index ccd6581..a66e5e3 100644
+index 931cc33..b0aecbc 100644
 --- a/auto_editor/utils/types.py
 +++ b/auto_editor/utils/types.py
-@@ -218,7 +218,7 @@ def resolution(val: str | None) -> tuple[int, int] | None:
+@@ -191,7 +191,7 @@ def resolution(val: str | None) -> tuple[int, int] | None:
  
- @dataclass
+ @dataclass(slots=True)
  class Args:
 -    yt_dlp_location: str = "yt-dlp"
 +    yt_dlp_location: str = "@yt_dlp@"


### PR DESCRIPTION
Changelogs: https://github.com/WyattBlue/auto-editor/releases

I could remove the `ffmpeg` related patches, since `av` completely takes care of the `ffmpeg` side of things now.

Note: this is not the latest version, because `av` hasn't been updated to the version that's required by `auto-editor`



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
