### PR TITLE
video2x: init at 6.4.0

### DIFF
--- a/pkgs/by-name/vi/video2x/package.nix
+++ b/pkgs/by-name/vi/video2x/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  pkg-config,
+  versionCheckHook,
+  nix-update-script,
+  boost,
+  ffmpeg,
+  glslang,
+  llvmPackages,
+  ncnn,
+  spdlog,
+  vulkan-headers,
+  vulkan-loader,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "video2x";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "k4yt3x";
+    repo = "video2x";
+    tag = finalAttrs.version;
+    hash = "sha256-DSsfGAkPOtqqj0FA1N33O+OYmv+CMUsrvmh5SrnF7eA=";
+    fetchSubmodules = false;
+    leaveDotGit = true;
+    postFetch = ''
+      pushd $out
+      git reset --hard HEAD
+
+      # Fetch the dependencies that nixpkgs cannot provide (non-recursive)
+      git submodule update --init third_party/librealesrgan_ncnn_vulkan
+      git submodule update --init third_party/librealcugan_ncnn_vulkan
+      git submodule update --init third_party/librife_ncnn_vulkan
+
+      # Cleanup
+      rm -rf .git
+
+      popd
+    '';
+  };
+
+  postPatch = ''
+    substituteInPlace src/fsutils.cpp \
+      --replace-fail '/usr/share/video2x' '${placeholder "out"}/share/video2x'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    glslang
+  ];
+
+  buildInputs =
+    [
+      boost
+      ffmpeg
+      ncnn
+      spdlog
+      vulkan-headers
+      vulkan-loader
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      llvmPackages.openmp
+    ];
+
+  cmakeFlags = [
+    # Don't build the libvideo2x shared library, we only need the CLI tool
+    (lib.cmakeBool "BUILD_SHARED_LIBS" false)
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "AI-powered video upscaling tool";
+    changelog = "https://github.com/k4yt3x/video2x/releases/tag/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/k4yt3x/video2x";
+    license = lib.licenses.agpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "video2x";
+    maintainers = [ lib.maintainers.matteopacini ];
+  };
+})


### PR DESCRIPTION
This add a new AI video upscaling tool based on FFMPEG  and Vulkan/NCNN.

https://github.com/k4yt3x/video2x

Derivation based  on the following PKGBUILD: https://github.com/k4yt3x/video2x/blob/master/packaging/arch/PKGBUILD

Notes:
- Requires Clang and OpenMP
- Though it compiles on Darwin with a few adjustments, it fails to find a Vulkan device through MoltenVK (Darwin is not officially supported, so no point in trying to make it work there)
- The patch fixes the executable not being able to find model parameters (it expects either an AppImage env or a FHS one)
- Fixes #378239 , replaces the original PR #384665 .


Slow as hell on my server, but it was encoding fine with my old GPU - Nvidia Quadro P2000.

![Screenshot 2025-02-27 at 21 20 30](https://github.com/user-attachments/assets/977e66a6-b90c-4f4c-a965-130d734fbc26)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
