### PR TITLE
ungoogled-chromium: 133.0.6943.126-1 -> 133.0.6943.141-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -791,7 +791,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "133.0.6943.126",
+    "version": "133.0.6943.141",
     "deps": {
       "depot_tools": {
         "rev": "423f1e1914ab4aa7b2bdf804e216d4c097853ba2",
@@ -802,16 +802,16 @@
         "hash": "sha256-T2dcISln9WCODoI/LsE2ldkRfFdMwVOmqqjQinAmZss="
       },
       "ungoogled-patches": {
-        "rev": "133.0.6943.126-1",
-        "hash": "sha256-bOtkMuGYu/iovgj0ZOecxQBmBvUhbF0px/M3Zp7ixKI="
+        "rev": "133.0.6943.141-1",
+        "hash": "sha256-FqpRx73axclW8bXmsRO845c3NB3ZBxE4fL4n7gU1P5A="
       },
       "npmHash": "sha256-oVoTruhxTymYiGkELd2Oa1wOfjGLtChQZozP4GzOO1A="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "cffa127ce7b6be72885391527c15b452056a2e81",
-        "hash": "sha256-WOd3FsqaZlKEroWg763LQhQS5S1964vAoZWxstxGS3U=",
+        "rev": "2a5d6da0d6165d7b107502095a937fe7704fcef6",
+        "hash": "sha256-MJlCEe1WBh+7Pl3H4jnkMuSykTBSgh5x/ZPnNwYM4DE=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1576,8 +1576,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "4e04a09a1a0ef90841656e210e976bfc2a81ed57",
-        "hash": "sha256-XbeU9L2IRHMP5pTzM3MPW1L2PMHViNRP/6u/HcBq96M="
+        "rev": "93c6f1082c25ef7fdf60ee2e4a029d65808d9343",
+        "hash": "sha256-OV1WncJaYvx1bB5najkKDNC2iMTU+m2vDAi9S/AjCyw="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #385085

https://chromereleases.googleblog.com/2025/02/stable-channel-update-for-desktop_25.html

This update includes 3 security fixes.

CVEs:
CVE-2025-0999 CVE-2025-1426 CVE-2025-1006

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
