### PR TITLE
apple-sdk: add multiple URLs for fetching SDK

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/common/fetch-sdk.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/fetch-sdk.nix
@@ -6,14 +6,14 @@
 }:
 
 {
-  url,
+  urls,
   version,
   hash,
 }:
 
 fetchurl {
   pname = "macOS-SDK";
-  inherit version url hash;
+  inherit version urls hash;
 
   recursiveHash = true;
 

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -1,26 +1,41 @@
 {
   "11": {
-    "url": "https://web.archive.org/web/20250210235110/https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg",
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250210235110/https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg"
+    ],
     "version": "11.3",
     "hash": "sha256-/go8utcx3jprf6c8V/DUbXwsmNYSFchOAai1OaJs3Bg="
   },
   "12": {
-    "url": "https://web.archive.org/web/20250210235341/https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg",
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250210235341/https://swcdn.apple.com/content/downloads/24/42/002-83793-A_74JRE8GVAT/rlnkct919wgc5c0pjq986z5bb9h62uvni2/CLTools_macOSNMOS_SDK.pkg"
+    ],
     "version": "12.3",
     "hash": "sha256-qG21ssNUmkqxPLTXALGP2N/RBHu8NMlI1dWvGlV+Wm8="
   },
   "13": {
-    "url": "https://web.archive.org/web/20250210235949/https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg",
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250210235949/https://swcdn.apple.com/content/downloads/15/62/032-84673-A_7A1TG1RF8Z/xpc8q44ggn2pkn82iwr0fi1zeb9cxi8ath/CLTools_macOSNMOS_SDK.pkg"
+    ],
     "version": "13.3",
     "hash": "sha256-zZ4pbgoXunLGwdYDemxOfyH4CE5WGfMy2s5jN+0q4B4="
   },
   "14": {
-    "url": "https://web.archive.org/web/20250211001355/https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250211001355/https://swcdn.apple.com/content/downloads/14/48/052-59890-A_I0F5YGAY0Y/p9n40hio7892gou31o1v031ng6fnm9sb3c/CLTools_macOSNMOS_SDK.pkg"
+    ],
     "version": "14.4",
     "hash": "sha256-QozDiwY0Czc0g45vPD7G4v4Ra+3DujCJbSads3fJjjM="
   },
   "15": {
-    "url": "https://web.archive.org/web/20250210234739/https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg",
+    "urls": [
+      "https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250210234739/https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg"
+    ],
     "version": "15.2",
     "hash": "sha256-OP5Ah/JnSZ6sD42BD5vGDmikgFzjsfFBmz1hvQD1dOI="
   }


### PR DESCRIPTION
The Internet Archive mirrors are unreliable for pulling SDKs, with 400 error pulling the .pkg currently when attempting to build macOS-SDK-11.3 (and some other versions, but this is the one I noted as it is how I encountered the issue):
```
curl: (22) The requested URL returned error: 400
error: cannot download macOS-SDK-11.3 from any mirror
error: builder for '/nix/store/1y35ds4bsp1mc87l7jms0lpd617wqy78-macOS-SDK-11.3.drv' failed with exit code 1;
       last 19 log lines:
       >
       > trying https://web.archive.org/web/20250210235110/https://swcdn.apple.com/content/downloads/02/62/071-54303-A_EU2CL1YVT7/943i95dpeyi2ghlnj2mgyq3t202t5gf18b/CLTools_macOSNMOS_SDK.pkg
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
       > curl: (22) The requested URL returned error: 400
(...)
error: 1 dependencies of derivation '/nix/store/fjhm3zwm1f0rrkkjshzmw09ygrymmb77-apple-sdk-11.3.drv' failed to build
```

I notice this change to using the archive links is [only about 2 weeks old](https://github.com/NixOS/nixpkgs/commit/8f6d2b14efe41b6bbed6be180d4487ace1c84bb5) due to Apple deprecating versions occasionally; to ensure we keep this insurance against Apple mirrors going down, both the Internet Archive URL and the Apple URL is included, and `fetchurl`'s inbuilt ability to take a list of URLs is leveraged. 

For testing, I don't see any test suite, but I did a local nix-build and can confirm for 11.3 it successfully uses direct Apple mirror after internet archive mirror fails, and in other cases it uses Internet Archive mirror.

No SHA checksums are changed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
