### PR TITLE
chromaprint: modernize derivation

### DIFF
--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -9,6 +9,8 @@
   ffmpeg-headless,
   darwin,
   zlib,
+  withExamples ? true,
+  withTools ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,15 +63,18 @@ stdenv.mkDerivation (finalAttrs: {
     );
 
   cmakeFlags = [
-    "-DBUILD_EXAMPLES=ON"
-    "-DBUILD_TOOLS=ON"
+    (lib.cmakeBool "BUILD_EXAMPLES" withExamples)
+    (lib.cmakeBool "BUILD_TOOLS" withTools)
   ];
 
-  meta = {
-    homepage = "https://acoustid.org/chromaprint";
-    description = "AcoustID audio fingerprinting library";
-    mainProgram = "fpcalc";
-    license = lib.licenses.lgpl21Plus;
-    platforms = lib.platforms.unix;
-  };
+  meta =
+    {
+      homepage = "https://acoustid.org/chromaprint";
+      description = "AcoustID audio fingerprinting library";
+      license = lib.licenses.lgpl21Plus;
+      platforms = lib.platforms.unix;
+    }
+    // lib.attrsets.optionalAttrs withTools {
+      mainProgram = "fpcalc";
+    };
 })

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -9,6 +9,8 @@
   ffmpeg-headless,
   darwin,
   zlib,
+  testers,
+  validatePkgConfig,
   withExamples ? true,
   withTools ? true,
 }:
@@ -48,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
+    validatePkgConfig
   ];
 
   buildInputs =
@@ -67,12 +70,15 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TOOLS" withTools)
   ];
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta =
     {
       homepage = "https://acoustid.org/chromaprint";
       description = "AcoustID audio fingerprinting library";
       license = lib.licenses.lgpl21Plus;
       platforms = lib.platforms.unix;
+      pkgConfigModules = [ "libchromaprint" ];
     }
     // lib.attrsets.optionalAttrs withTools {
       mainProgram = "fpcalc";

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -1,21 +1,22 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchpatch
-, fetchpatch2
-, cmake
-, ninja
-, ffmpeg
-, darwin
-, zlib
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  fetchpatch2,
+  cmake,
+  ninja,
+  ffmpeg,
+  darwin,
+  zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chromaprint";
   version = "1.5.1";
 
   src = fetchurl {
-    url = "https://github.com/acoustid/chromaprint/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/acoustid/chromaprint/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-oarY+juLGLeNN1Wzdn+v+au2ckLgG0eOyaZOGQ8zXhw=";
   };
 
@@ -40,18 +41,33 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake ninja ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
 
-  buildInputs = [ ffmpeg ] ++ lib.optionals stdenv.hostPlatform.isDarwin
-    (with darwin.apple_sdk.frameworks; [ Accelerate CoreGraphics CoreVideo zlib ]);
+  buildInputs =
+    [ ffmpeg ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        Accelerate
+        CoreGraphics
+        CoreVideo
+        zlib
+      ]
+    );
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=ON"
+    "-DBUILD_TOOLS=ON"
+  ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://acoustid.org/chromaprint";
     description = "AcoustID audio fingerprinting library";
     mainProgram = "fpcalc";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -6,7 +6,7 @@
   fetchpatch2,
   cmake,
   ninja,
-  ffmpeg,
+  ffmpeg-headless,
   darwin,
   zlib,
 }:
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs =
-    [ ffmpeg ]
+    [ ffmpeg-headless ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk.frameworks;
       [

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
   fetchpatch2,
   cmake,
@@ -15,9 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "chromaprint";
   version = "1.5.1";
 
-  src = fetchurl {
-    url = "https://github.com/acoustid/chromaprint/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-oarY+juLGLeNN1Wzdn+v+au2ckLgG0eOyaZOGQ8zXhw=";
+  src = fetchFromGitHub {
+    owner = "acoustid";
+    repo = "chromaprint";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bFplHaqXYvGbl8E8b/HUNFO4X+B/HPZjGTmuVFPjS3g=";
   };
 
   patches = [

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -11,6 +11,7 @@
   zlib,
   testers,
   validatePkgConfig,
+  nix-update-script,
   withExamples ? true,
   withTools ? true,
 }:
@@ -70,7 +71,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TOOLS" withTools)
   ];
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta =
     {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Refactors the package and adds `validatePkgConfig` test. Reduces closure size by switching from `ffmpeg` to `ffmpeg-headless` since it's only used as a library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
