### PR TITLE
python312Packages.flax: 0.10.3 -> 0.10.4

### DIFF
--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -39,14 +39,14 @@
 
 buildPythonPackage rec {
   pname = "flax";
-  version = "0.10.3";
+  version = "0.10.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "flax";
     tag = "v${version}";
-    hash = "sha256-PRKdtltiBVX9p6Sjw4sCDghqxYRxq4L9TLle1vy5dkk=";
+    hash = "sha256-+3PQPRVju9kw/4KWeifD8LhY4t6EzakhYISubMxrMw4=";
   };
 
   build-system = [
@@ -100,11 +100,55 @@ buildPythonPackage rec {
     "tests/jax_utils_test.py"
   ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # SystemError: nanobind::detail::nb_func_error_except(): exception could not be translated!
-    "test_ref_changed"
-    "test_structure_changed"
-  ];
+  disabledTests =
+    [
+      # AttributeError: module 'jax.api_util' has no attribute 'debug_info'
+      # https://github.com/google/flax/issues/4585
+      "test_basic_seq_lengths"
+      "test_bidirectional"
+      "test_big_resnet"
+      "test_custom_merge_fn"
+      "test_jit_scan_retracing_retracing"
+      "test_lazy_init"
+      "test_lazy_init"
+      "test_lazy_init_fails_on_data_dependence"
+      "test_lazy_init_fails_on_data_dependence"
+      "test_lifted_transform"
+      "test_lifted_transform_no_rename"
+      "test_multi_method_class_transform"
+      "test_numerical_equivalence"
+      "test_numerical_equivalence_single_batch"
+      "test_numerical_equivalence_single_batch_nn_scan"
+      "test_numerical_equivalence_with_mask"
+      "test_pjit_scan_over_layers"
+      "test_remat_scan"
+      "test_return_carry"
+      "test_reverse"
+      "test_reverse_but_keep_order"
+      "test_rnn_basic_forward"
+      "test_rnn_equivalence_with_flax_linen"
+      "test_rnn_multiple_batch_dims"
+      "test_rnn_time_major"
+      "test_rnn_unroll"
+      "test_rnn_with_spatial_dimensions"
+      "test_same_key"
+      "test_scan"
+      "test_scan_compact_count"
+      "test_scan_decorated"
+      "test_scan_negative_axes"
+      "test_scan_of_setup_parameter"
+      "test_scan_over_layers"
+      "test_scan_shared_params"
+      "test_scan_unshared_params"
+      "test_scan_with_axes"
+      "test_shared_cell"
+      "test_toplevel_submodule_adoption_pytree_transform"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # SystemError: nanobind::detail::nb_func_error_except(): exception could not be translated!
+      "test_ref_changed"
+      "test_structure_changed"
+    ];
 
   passthru = {
     updateScript = writeScript "update.sh" ''

--- a/pkgs/development/python-modules/flaxlib/default.nix
+++ b/pkgs/development/python-modules/flaxlib/default.nix
@@ -1,40 +1,23 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   flax,
   tomlq,
   python,
 
   # build-system
-  meson-python,
   nanobind,
   ninja,
+  scikit-build-core,
 
   # nativeBuildInputs
   cmake,
   pkg-config,
 }:
 
-let
-  nanobind-wrapper = stdenv.mkDerivation {
-    pname = "nanobind-wrapper";
-    inherit (nanobind) version;
-
-    src = ./nanobind-wrapper;
-
-    nativeBuildInputs = [
-      cmake
-    ];
-
-    buildFlags = [ "nanobind-static" ];
-
-    env.CMAKE_PREFIX_PATH = "${nanobind}/${python.sitePackages}/nanobind";
-  };
-in
 buildPythonPackage rec {
   pname = "flaxlib";
-  version = "0.0.1-a1";
+  version = "0.0.1";
   pyproject = true;
 
   inherit (flax) src;
@@ -43,11 +26,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     expected_version="$version"
-    actual_version=$(${lib.getExe tomlq} --file Cargo.toml "package.version")
+    actual_version=$(${lib.getExe tomlq} --file pyproject.toml "project.version")
 
     if [ "$actual_version" != "$expected_version" ]; then
       echo -e "\n\tERROR:"
-      echo -e "\tThe version of the flaxlib python package ($expected_version) does not match the one in its Cargo.toml file ($actual_version)"
+      echo -e "\tThe version of the flaxlib python package ($expected_version) does not match the one in its pyproject.toml file ($actual_version)"
       echo -e "\tPlease update the version attribute of the nix python3Packages.flaxlib package."
       exit 1
     fi
@@ -56,15 +39,16 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
 
   build-system = [
-    meson-python
     nanobind
     ninja
+    scikit-build-core
   ];
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
-  buildInputs = [ nanobind-wrapper ];
+
+  env.CMAKE_PREFIX_PATH = "${nanobind}/${python.sitePackages}/nanobind";
 
   pythonImportsCheck = [ "flaxlib" ];
 

--- a/pkgs/development/python-modules/flaxlib/nanobind-wrapper/CMakeLists.txt
+++ b/pkgs/development/python-modules/flaxlib/nanobind-wrapper/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.31)
-project(nanobind-wrapper)
-
-find_package(Python COMPONENTS Interpreter Development REQUIRED)
-find_package(nanobind CONFIG REQUIRED)
-nanobind_build_library(nanobind-static)
-set_property(TARGET nanobind-static PROPERTY EXPORT_NAME nanobind)
-install(TARGETS nanobind-static EXPORT nanobind-static)
-install(EXPORT nanobind-static FILE nanobindConfig.cmake DESTINATION lib/nanobind/cmake)


### PR DESCRIPTION
## Things done

Changelog: https://github.com/google/flax/releases/tag/v0.10.4

cc @ndl

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
