### PR TITLE
[upgrade] zoxide -> 0.9.7

### DIFF
--- a/pkgs/by-name/zo/zoxide/package.nix
+++ b/pkgs/by-name/zo/zoxide/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "zoxide";
-  version = "0.9.6";
+  version = "0.9.7";
 
   src = fetchFromGitHub {
     owner = "ajeetdsouza";
     repo = "zoxide";
     tag = "v${version}";
-    hash = "sha256-3XC5K4OlituoFMPN9yJkYi+tkH6M0KK5jVAGdr/GLd0=";
+    hash = "sha256-+QZpLMlHOZdbKLFYOUOIRZHvIsbMDdstj9oGzyEGVxk=";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
repairs an issue in code produced by `zoxide init nushell`. see https://github.com/ajeetdsouza/zoxide/releases/tag/v0.9.7

I'm unsure how rust packages usually go, I made no change to `cargoHash` regardless of a local build error using `.overrideAttrs`.

ping
- @ysndr
- @cole-h
- @SuperSandro2000