### PR TITLE
cargo: avoid using system curl on darwin (again)

### DIFF
--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -53,16 +53,21 @@ rec {
       patchShebangs .
     '';
 
-    installPhase = ''
-      ./install.sh --prefix=$out \
-        --components=${installComponents}
+    installPhase =
+      ''
+        ./install.sh --prefix=$out \
+          --components=${installComponents}
 
-      # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
-      # (or similar) here. It causes strange effects where rustc loads
-      # the wrong libraries in a bootstrap-build causing failures that
-      # are very hard to track down. For details, see
-      # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
-    '';
+        # Do NOT, I repeat, DO NOT use `wrapProgram` on $out/bin/rustc
+        # (or similar) here. It causes strange effects where rustc loads
+        # the wrong libraries in a bootstrap-build causing failures that
+        # are very hard to track down. For details, see
+        # https://github.com/rust-lang/rust/issues/34722#issuecomment-232164943
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        install_name_tool -change "/usr/lib/libcurl.4.dylib" \
+        "${lib.getLib curl}/lib/libcurl.4.dylib" "$out/bin/cargo"
+      '';
 
     # The strip tool in cctools 973.0.1 and up appears to break rlibs in the
     # binaries. The lib.rmeta object inside the ar archive should contain an
@@ -166,7 +171,7 @@ rec {
       ''
       + lib.optionalString stdenv.hostPlatform.isDarwin ''
         install_name_tool -change "/usr/lib/libcurl.4.dylib" \
-          "${curl.out}/lib/libcurl.4.dylib" "$out/bin/cargo"
+          "${lib.getLib curl}/lib/libcurl.4.dylib" "$out/bin/cargo"
       ''
       + ''
         wrapProgram "$out/bin/cargo" \


### PR DESCRIPTION
Modern versions of macOS link the system-provided curl library against the system-provided libressl library. On recent versions of macOS, the system libressl library reads from /private/etc/ssl/openssl.cnf. [As this path is not included in the default Nix sandbox profile, applications that use the system curl library will report a permission error][1].

PR #300521 previously addressed this for the prebuilt cargo binary used by the bootstrap version of cargo. [It appears that rustc-unwrapped, which includes its own cargo binary, has the same issue][2]. Similarly patch it with `install_name_tool` to replace use of the system curl library with one from nixpkgs.

[1]: https://github.com/NixOS/nix/issues/9625
[2]: https://gist.github.com/al3xtjames/645c8be2c23021aadfe062cfc319c8c4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
