### PR TITLE
rpiboot: fix broken symlink failure

### DIFF
--- a/pkgs/by-name/rp/rpiboot/package.nix
+++ b/pkgs/by-name/rp/rpiboot/package.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
     owner = "raspberrypi";
     repo = "usbboot";
     rev = version;
-    hash = "sha256-nUwero1BLSx+JORqJVWIXi2ElnN17al1jA+I4Cqe9hM=";
+    hash = "sha256-m11SX31GLmb/LGiO7X8P7eL88zvLfoJ/anAVEpg8WL4=";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ libusb1 ];
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mkdir -p $out/share/rpiboot
     cp rpiboot $out/bin
-    cp -r msd firmware eeprom-erase mass-storage-gadget* recovery* secure-boot* rpi-imager-embedded $out/share/rpiboot
+    cp -r msd firmware eeprom-erase mass-storage-gadget* recovery* secure-boot* rpi-eeprom rpi-imager-embedded $out/share/rpiboot
   '';
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Build had started failing on broken symlinks pointing to the `rpi-eeprom` submodule.

```
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/recovery5/bootcode5.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2712/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/recovery5/pieeprom.original.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2712/pieeprom.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2712/pieeprom.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/rpi-eeprom/firmware-2712/latest/pieeprom-2025-01-22.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2712/recovery.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/rpi-eeprom/firmware-2712/latest/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/pieeprom.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/rpi-eeprom/firmware-2711/latest/pieeprom-2024-07-30.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/recovery.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/rpi-eeprom/firmware-2711/latest/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/recovery/bootcode4.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/recovery/pieeprom.original.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/pieeprom.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/secure-boot-recovery/bootcode4.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/secure-boot-recovery/pieeprom.original.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2711/pieeprom.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/secure-boot-recovery5/recovery.original.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/firmware/2712/recovery.bin
ERROR: noBrokenSymlinks: the symlink /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/secure-boot-recovery5/pieeprom.original.bin points to a missing target: /nix/store/0wfl0zr406y0aqk10f7lrzr8s27zr3cn-rpiboot-20250129-123632/share/rpiboot/recovery5/pieeprom.original.bin
ERROR: noBrokenSymlinks: found 12 dangling symlinks and 0 reflexive symlinks
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
