### PR TITLE
androidndk-pkgs: do not force armv4t for armv7a

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -156,7 +156,11 @@ rec {
       echo "-D__ANDROID_API__=${stdenv.targetPlatform.androidSdkVersion}" >> $out/nix-support/cc-cflags
       # Android needs executables linked with -pie since version 5.0
       # Use -fPIC for compilation, and link with -pie if no -shared flag used in ldflags
-      echo "-target ${targetInfo.triple} -fPIC" >> $out/nix-support/cc-cflags
+      if [ ${targetInfo.triple} == arm-linux-androideabi ]; then
+        echo "-target armv7a-linux-androideabi -fPIC" >> $out/nix-support/cc-cflags
+      else
+        echo "-target ${targetInfo.triple} -fPIC" >> $out/nix-support/cc-cflags
+      fi
       echo "-z,noexecstack -z,relro -z,now -z,muldefs" >> $out/nix-support/cc-ldflags
       echo 'expandResponseParams "$@"' >> $out/nix-support/add-flags.sh
       echo 'if [[ ! (" ''${params[@]} " =~ " -shared ") && ! (" ''${params[@]} " =~ " -no-pie ") ]]; then NIX_LDFLAGS_${suffixSalt}+=" -pie"; fi' >> $out/nix-support/add-flags.sh


### PR DESCRIPTION
Passing `arm-linux-androideabi` as `-target` will cause clang to assume `armv4t` instead of `armv7a` and subsequently inject all kinds of builtins into the produced code. However the necessary polyfills for the builtins do not exist in any of the shipped libraries. E.g. `__sync_val_compare_and_swap_1`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
