### PR TITLE
 newt, python3Packages.snack: fix darwin linking

### DIFF
--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -58,8 +58,12 @@ stdenv.mkDerivation rec {
   ];
 
   postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    set -xe
     install_name_tool -id $out/lib/libnewt.so.${version} $out/lib/libnewt.so.${version}
     install_name_tool -change libnewt.so.${version} $out/lib/libnewt.so.${version} $out/bin/whiptail
+    install_name_tool -change libnewt.so.${version} $out/lib/libnewt.so.${version} \
+      $out/lib/python*/site-packages/_snack* # glob for version & suffix
+    set +x
   '';
 
   passthru.tests.pythonModule = (python3.withPackages (ps: [ ps.snack ])).overrideAttrs (

--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -43,7 +43,9 @@ stdenv.mkDerivation rec {
       gettext # for darwin with clang
     ];
 
-  NIX_LDFLAGS = "-lncurses";
+  NIX_LDFLAGS =
+    "-lncurses"
+    + lib.optionalString stdenv.hostPlatform.isDarwin " -L${python3}/lib -lpython${python3.pythonVersion}";
 
   preConfigure = ''
     # If CPP is set explicitly, configure and make will not agree about which

--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -4,11 +4,11 @@
   stdenv,
   slang,
   popt,
-  python,
+  python3,
 }:
 
 let
-  pythonIncludePath = "${lib.getDev python}/include/python";
+  pythonIncludePath = "${lib.getDev python3}/include/python";
 in
 stdenv.mkDerivation rec {
   pname = "newt";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   strictDeps = true;
-  nativeBuildInputs = [ python ];
+  nativeBuildInputs = [ python3 ];
   buildInputs = [
     slang
     popt

--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -5,6 +5,7 @@
   slang,
   popt,
   python3,
+  gettext,
 }:
 
 let
@@ -33,10 +34,14 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ python3 ];
-  buildInputs = [
-    slang
-    popt
-  ];
+  buildInputs =
+    [
+      slang
+      popt
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      gettext # for darwin with clang
+    ];
 
   NIX_LDFLAGS = "-lncurses";
 
@@ -45,10 +50,6 @@ stdenv.mkDerivation rec {
     # programs to use at different stages.
     unset CPP
   '';
-
-  configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "--disable-nls"
-  ];
 
   makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
@@ -59,13 +60,13 @@ stdenv.mkDerivation rec {
     install_name_tool -change libnewt.so.${version} $out/lib/libnewt.so.${version} $out/bin/whiptail
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Library for color text mode, widget based user interfaces";
     mainProgram = "whiptail";
     homepage = "https://pagure.io/newt";
     changelog = "https://pagure.io/newt/blob/master/f/CHANGES";
-    license = licenses.lgpl2;
-    platforms = platforms.unix;
-    maintainers = [ ];
+    license = lib.licenses.lgpl2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ bryango ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9740,8 +9740,6 @@ with pkgs;
 
   nettle = import ../development/libraries/nettle { inherit callPackage fetchurl; };
 
-  newt = callPackage ../development/libraries/newt { python = python3; };
-
   libnghttp2 = nghttp2.lib;
 
   nghttp3 = callPackage ../development/libraries/nghttp3 { inherit (darwin.apple_sdk.frameworks) CoreServices; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16542,7 +16542,7 @@ self: super: with self; {
 
   smtpdfix = callPackage ../development/python-modules/smtpdfix { };
 
-  snack = toPythonModule (pkgs.newt.override { inherit (self) python; });
+  snack = toPythonModule (pkgs.newt.override { python3 = self.python; });
 
   snakebite = callPackage ../development/python-modules/snakebite { };
 


### PR DESCRIPTION
The python module "snack" (packaged along with "newt") has been [failing on darwin](https://hydra.nixos.org/build/289850022/nixlog/1) (the job succeeds but the python c extension fails to be built and is simply absent). This causes commands that relies on `python3Packages.snack` to fail, e.g. byobu-config from the byobu package.

This patch uses some linker magic borrowed from https://github.com/NixOS/nixpkgs/blob/f61bd35c9f3711d85a39a1acffb3f85d2f521e1d/pkgs/by-name/sp/spade/package.nix#L55 to fix the issue.

This patch only changes the derivation hash on darwin; it should cause zero rebuild on linux. There are 3 commits:
1. move to by-name and adopt the package
2. clean up and explicitly add gettext for clang on darwin
3. fix python module (c extensions) with some linker magic
4. **(new)** add a (nonblocking) pythonImportsCheck to passthru.tests
5. **(new)** fix up the dylib names in _snack (bug revealed by the previous test)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
