### PR TITLE
Reapply "Fix Xf86videointel driver immediate crash on NixOS (Mesa Patch Backport)"

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -123,6 +123,24 @@ setting](https://en.wikipedia.org/wiki/Mode_setting) (KMS) mechanism, it
 supports Glamor (2D graphics acceleration via OpenGL) and is actively
 maintained, it may perform worse in some cases (like in old chipsets).
 
+There is a second driver, `intel` (provided by the xf86-video-intel package),
+specific to older Intel iGPUs from generation 2 to 9. It is not recommended by
+most distributions: it lacks several modern features (for example, it doesn't
+support Glamor) and the package hasn't been officially updated since 2015.
+
+Third generation and older iGPUs (15-20+ years old) are not supported by the
+`modesetting` driver (X will crash upon startup). Thus, the `intel` driver is
+required for these chipsets.
+Otherwise, the results vary depending on the hardware, so you may have to try
+both drivers. Use the option
+[](#opt-services.xserver.videoDrivers)
+to set one. The recommended configuration for modern systems is:
+
+```nix
+{
+  services.xserver.videoDrivers = [ "modesetting" ];
+}
+```
 ::: {.note}
 The `modesetting` driver doesn't currently provide a `TearFree` option (this
 will become available in an upcoming X.org release), So, without using a
@@ -130,19 +148,21 @@ compositor (for example, see [](#opt-services.picom.enable)) you will
 experience screen tearing.
 :::
 
-There also used to be a second driver, `intel` (provided by the
-xf86-video-intel package), specific to older Intel iGPUs from generation 2 to
-9.
-This driver hasn't been maintained in years and was removed in NixOS 24.11
-after it stopped working. If you chipset is too old to be supported by
-`modesetting` and have no other choice you may try an unsupported NixOS version
-(reportedly working up to NixOS 24.05) and set
+If you experience screen tearing no matter what, this configuration was
+reported to resolve the issue:
 
 ```nix
 {
   services.xserver.videoDrivers = [ "intel" ];
+  services.xserver.deviceSection = ''
+    Option "DRI" "2"
+    Option "TearFree" "true"
+  '';
 }
 ```
+
+Note that this will likely downgrade the performance compared to
+`modesetting` or `intel` with DRI 3 (default).
 
 ## Proprietary NVIDIA drivers {#sec-x11-graphics-cards-nvidia}
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -51,6 +51,8 @@
   - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
   - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
 
+- The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -6,6 +6,7 @@
 , expat
 , fetchCrate
 , fetchFromGitLab
+, fetchpatch
 , file
 , flex
 , glslang
@@ -141,6 +142,13 @@ in stdenv.mkDerivation {
     # cherry-picked from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32719
     # safe to remove for versions > 24.3.2
     ./cross_clc.patch
+
+    # dril fix for xf86videointel
+    # FIXME: remove when backported upstream
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/4ecd183c563670c5c3ab371d6b5596ecabbe6fad.diff";
+      hash = "sha256-AXXp1MHXEsvua1SyzQUbQLVqaA4Iw1yziqvAce+UkxQ=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1009,10 +1009,26 @@ self: super:
     meta = attrs.meta // { mainProgram = "xinit"; };
   });
 
-  xf86videointel = throw ''
-    xf86videointel has been removed as the package is unmaintained and the driver is no longer functional.
-    Please remove "intel" from `services.xserver.videoDrivers` and switch to the "modesetting" driver.
-  ''; # Added 2024-12-16;
+  xf86videointel = super.xf86videointel.overrideAttrs (attrs: {
+    # the update script only works with released tarballs :-/
+    name = "xf86-video-intel-2024-05-06";
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      group = "xorg";
+      owner = "driver";
+      repo = "xf86-video-intel";
+      rev = "ce811e78882d9f31636351dfe65351f4ded52c74";
+      sha256 = "sha256-PKCxFHMwxgbew0gkxNBKiezWuqlFG6bWLkmtUNyoF8Q=";
+    };
+    buildInputs = attrs.buildInputs ++ [ xorg.libXScrnSaver xorg.libXv xorg.pixman xorg.utilmacros ];
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [autoreconfHook ];
+    configureFlags = [ "--with-default-dri=3" "--enable-tools" ];
+    patches = [ ./use_crocus_and_iris.patch ];
+
+    meta = attrs.meta // {
+      platforms = ["i686-linux" "x86_64-linux"];
+    };
+  });
 
   xf86videoopenchrome = super.xf86videoopenchrome.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ xorg.libXv ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1020,8 +1020,8 @@ self: super:
       rev = "ce811e78882d9f31636351dfe65351f4ded52c74";
       sha256 = "sha256-PKCxFHMwxgbew0gkxNBKiezWuqlFG6bWLkmtUNyoF8Q=";
     };
-    buildInputs = attrs.buildInputs ++ [ xorg.libXScrnSaver xorg.libXv xorg.pixman xorg.utilmacros ];
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [autoreconfHook ];
+    buildInputs = attrs.buildInputs ++ [ xorg.libXScrnSaver xorg.libXv xorg.pixman ];
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [ autoreconfHook xorg.utilmacros xorg.xorgserver ];
     configureFlags = [ "--with-default-dri=3" "--enable-tools" ];
     patches = [ ./use_crocus_and_iris.patch ];
 

--- a/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
+++ b/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
@@ -1,0 +1,28 @@
+--- a/src/uxa/intel_dri.c
++++ b/src/uxa/intel_dri.c
+@@ -1540,8 +1540,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (INTEL_INFO(intel)->gen < 040)
+ 			return "i915";
++		else if (INTEL_INFO(intel)->gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;
+--- a/src/sna/sna_dri2.c
++++ b/src/sna/sna_dri2.c
+@@ -3707,8 +3707,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (sna->kgem.gen < 040)
+ 			return "i915";
++		else if (sna->kgem.gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#385486