### PR TITLE
theforceengine: 1.10.000 -> 1.15.000

### DIFF
--- a/pkgs/by-name/th/theforceengine/package.nix
+++ b/pkgs/by-name/th/theforceengine/package.nix
@@ -2,12 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   SDL2,
   SDL2_image,
   rtaudio,
   rtmidi,
   glew,
   alsa-lib,
+  angelscript,
   cmake,
   pkg-config,
   zenity,
@@ -20,14 +22,22 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "theforceengine";
-  version = "1.10.000";
+  version = "1.15.000";
 
   src = fetchFromGitHub {
     owner = "luciusDXL";
     repo = "TheForceEngine";
     rev = "v${version}";
-    hash = "sha256-oEcjHb6HY5qxKuPoNBuobPbdi39hUUWtKSb7FbAfEpc=";
+    hash = "sha256-pcPR2KCGbyL1JABF30yJrlcLPGU2h0//Ghf7e7zYO0s=";
   };
+
+  patches = [
+    # https://github.com/luciusDXL/TheForceEngine/pull/493 -- fixes finding data files outside program directory
+    (fetchpatch {
+      url = "https://github.com/luciusDXL/TheForceEngine/commit/476a5277666bfdffb33ed10bdd1177bfe8ec3a70.diff";
+      hash = "sha256-ZcfKIXQMcWMmnM4xfQRd/Ozl09vkQr3jUxZ5e4Mw5CU=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -41,6 +51,14 @@ stdenv.mkDerivation rec {
     rtmidi
     glew
     alsa-lib
+    angelscript
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_EDITOR" true)
+    (lib.cmakeBool "ENABLE_FORCE_SCRIPT" true)
   ];
 
   prePatch = ''


### PR DESCRIPTION
https://github.com/luciusDXL/TheForceEngine/compare/v1.10.000...v1.15.000
- add patch for https://github.com/luciusDXL/TheForceEngine/pull/493 to fix data outside program directory

Note: in-application version is incorrect due to upstream not bumping the version string until after they tagged the release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
