### PR TITLE
openrct2: 0.4.19.1 -> 0.4.20, asset fixes and overall cleanup

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -147,6 +147,9 @@ stdenv.mkDerivation {
     downloadPage = "https://github.com/OpenRCT2/OpenRCT2/releases";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ oxzi ];
+    maintainers = with maintainers; [
+      oxzi
+      keenanweaver
+    ];
   };
 }

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchurl,
+  unzip,
 
   SDL2,
   cmake,
@@ -14,6 +16,7 @@
   freetype,
   gbenchmark,
   icu,
+  innoextract,
   jansson,
   libGLU,
   libiconv,
@@ -46,32 +49,21 @@ let
     hash = "sha256-sg09JmoWF9utPG7PakKpgLgX64FAc2x8ILX3lVHkRi0=";
   };
 
-  objects-src = fetchFromGitHub {
-    owner = "OpenRCT2";
-    repo = "objects";
-    rev = "v${objects-version}";
-    hash = "sha256-mxlabWuh8TTJs74yXdiv7XtdeGmCWQ5N1JoY7Xo0itQ=";
+  objects = fetchurl {
+    url = "https://github.com/OpenRCT2/objects/releases/download/v${objects-version}/objects.zip";
+    hash = "sha256-xrgAy817G5xwfzZX+8Xy2508/Zwq32aKzMndus14Qd8=";
   };
-
-  openmsx-src = fetchFromGitHub {
-    owner = "OpenRCT2";
-    repo = "OpenMusic";
-    rev = "v${openmsx-version}";
-    hash = "sha256-KjWJSB2tdE0ExswVlz0dLXNPhLJ1kI6VZb3vqXQfx8w=";
+  openmsx = fetchurl {
+    url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${openmsx-version}/openmusic.zip";
+    hash = "sha256-8JfTpMzTn3VG+X2z7LG4vnNkj1O3p1lbhszL3Bp1V+Q=";
   };
-
-  opensfx-src = fetchFromGitHub {
-    owner = "OpenRCT2";
-    repo = "OpenSoundEffects";
-    rev = "v${opensfx-version}";
-    hash = "sha256-ucADnMLGm36eAo+NiioxEzeMqtu7YbGF9wsydK1mmoE=";
+  opensfx = fetchurl {
+    url = "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${opensfx-version}/opensound.zip";
+    hash = "sha256-qVIUi+FkwSjk/TrqloIuXwUe3ZoLHyyE3n92KM47Lhg=";
   };
-
-  title-sequences-src = fetchFromGitHub {
-    owner = "OpenRCT2";
-    repo = "title-sequences";
-    rev = "v${title-sequences-version}";
-    hash = "sha256-ier7sBYJjBIvKVxfaCelJPZ+oF9NEshvR2k/X9JpP+0=";
+  title-sequences = fetchurl {
+    url = "https://github.com/OpenRCT2/title-sequences/releases/download/v${title-sequences-version}/title-sequences.zip";
+    hash = "sha256-FA33FOgG/tQRzEl2Pn8WsPzypIelcAHR5Q/Oj5FIqfM=";
   };
 in
 stdenv.mkDerivation {
@@ -83,6 +75,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    unzip
   ];
 
   buildInputs = [
@@ -96,6 +89,7 @@ stdenv.mkDerivation {
     freetype
     gbenchmark
     icu
+    innoextract
     jansson
     libGLU
     libiconv
@@ -118,12 +112,11 @@ stdenv.mkDerivation {
   ];
 
   postUnpack = ''
-    mkdir -p $sourceRoot/data/assetpack
-
-    cp -r ${objects-src}         $sourceRoot/data/object
-    cp -r ${openmsx-src}         $sourceRoot/data/assetpack/openrct2.music.alternative.parkap
-    cp -r ${opensfx-src}         $sourceRoot/data/assetpack/openrct2.sound.parkap
-    cp -r ${title-sequences-src} $sourceRoot/data/sequence
+    mkdir -p $sourceRoot/data/{object,sequence}
+    unzip -o ${objects} -d $sourceRoot/data/object
+    unzip -o ${openmsx} -d $sourceRoot/data
+    unzip -o ${opensfx} -d $sourceRoot/data
+    unzip -o ${title-sequences} -d $sourceRoot/data/sequence
   '';
 
   # Fix blank changelog & contributors screen. See https://github.com/OpenRCT2/OpenRCT2/issues/16988

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -33,7 +33,7 @@
 }:
 
 let
-  openrct2-version = "0.4.19.1";
+  openrct2-version = "0.4.20";
 
   # Those versions MUST match the pinned versions within the CMakeLists.txt
   # file. The REPLAYS repository from the CMakeLists.txt is not necessary.
@@ -41,13 +41,6 @@ let
   openmsx-version = "1.6";
   opensfx-version = "1.0.5";
   title-sequences-version = "0.4.14";
-
-  openrct2-src = fetchFromGitHub {
-    owner = "OpenRCT2";
-    repo = "OpenRCT2";
-    rev = "v${openrct2-version}";
-    hash = "sha256-sg09JmoWF9utPG7PakKpgLgX64FAc2x8ILX3lVHkRi0=";
-  };
 
   objects = fetchurl {
     url = "https://github.com/OpenRCT2/objects/releases/download/v${objects-version}/objects.zip";
@@ -66,11 +59,16 @@ let
     hash = "sha256-FA33FOgG/tQRzEl2Pn8WsPzypIelcAHR5Q/Oj5FIqfM=";
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openrct2";
   version = openrct2-version;
 
-  src = openrct2-src;
+  src = fetchFromGitHub {
+    owner = "OpenRCT2";
+    repo = "OpenRCT2";
+    rev = "v${openrct2-version}";
+    hash = "sha256-G/uD3t8m7C74pjSA6dbz4gzu9CwEpmyFwtYpoFIiRjM=";
+  };
 
   nativeBuildInputs = [
     cmake
@@ -140,15 +138,15 @@ stdenv.mkDerivation {
       + (versionCheck "TITLE_SEQUENCE" title-sequences-version)
     );
 
-  meta = with lib; {
+  meta = {
     description = "Open source re-implementation of RollerCoaster Tycoon 2 (original game required)";
     homepage = "https://openrct2.io/";
     downloadPage = "https://github.com/OpenRCT2/OpenRCT2/releases";
-    license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       oxzi
       keenanweaver
     ];
   };
-}
+})

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -126,6 +126,12 @@ stdenv.mkDerivation {
     cp -r ${title-sequences-src} $sourceRoot/data/sequence
   '';
 
+  # Fix blank changelog & contributors screen. See https://github.com/OpenRCT2/OpenRCT2/issues/16988
+  postPatch = ''
+    substituteInPlace src/openrct2/platform/Platform.Linux.cpp \
+      --replace-fail "/usr/share/doc/openrct2" "$out/share/doc/openrct2"
+  '';
+
   preConfigure =
     # Verify that the correct version of each third party repository is used.
     (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.20
Compare: https://github.com/OpenRCT2/OpenRCT2/compare/v0.4.19.1...v0.4.20

## Things done

- Bumped to 0.4.20
- Changed assets to download via `fetchurl` instead of `fetchFomGitHub`. Close https://github.com/NixOS/nixpkgs/issues/315875
- Added `innoextract` for GOG installer extraction
- Added `substituteInPlace` to close https://github.com/NixOS/nixpkgs/issues/315871
- Added me as a maintainer and meta cleanup
- ~Changed to all platforms. **Did not test this!**~
- finalAttrs pattern

Supersedes https://github.com/NixOS/nixpkgs/pull/385184.
Did not factor in changes from https://github.com/NixOS/nixpkgs/pull/225894. (Should it?)

Willing to squash, drop, or rebase!

@oxzi

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
