### PR TITLE
linuxPackages.r8125: 9.014.01 -> 9.015.00

### DIFF
--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -5,7 +5,7 @@
   kernel,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "r8125";
   version = "9.015.00";
 
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "r8125";
-    rev = "upstream/${version}";
-    sha256 = "sha256-RA7rvvF2Ngeu+hSACBbKfAJgLbPqhaXG14DH2NmztTE=";
+    tag = "upstream/${finalAttrs.version}";
+    hash = "sha256-RA7rvvF2Ngeu+hSACBbKfAJgLbPqhaXG14DH2NmztTE=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   preBuild = ''
-    substituteInPlace src/Makefile --replace "BASEDIR :=" "BASEDIR ?="
-    substituteInPlace src/Makefile --replace "modules_install" "INSTALL_MOD_PATH=$out modules_install"
+    substituteInPlace src/Makefile --replace-fail "BASEDIR :=" "BASEDIR ?="
+    substituteInPlace src/Makefile --replace-fail "modules_install" "INSTALL_MOD_PATH=$out modules_install"
   '';
 
   makeFlags = [
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.peelz ];
   };
-}
+})

--- a/pkgs/os-specific/linux/r8125/default.nix
+++ b/pkgs/os-specific/linux/r8125/default.nix
@@ -1,24 +1,20 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGitLab,
   kernel,
 }:
 
 stdenv.mkDerivation rec {
   pname = "r8125";
-  # On update please verify (using `diff -r`) that the source matches the
-  # realtek version.
-  version = "9.014.01";
+  version = "9.015.00";
 
-  # This is a mirror. The original website[1] doesn't allow non-interactive
-  # downloads, instead emailing you a download link.
-  # [1] https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software
-  src = fetchFromGitHub {
-    owner = "louistakepillz";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
     repo = "r8125";
-    rev = version;
-    sha256 = "sha256-vYgAOmKFQZDKrZsS3ynXB0DrT3wU0JWzNTYO6FyMG9M=";
+    rev = "upstream/${version}";
+    sha256 = "sha256-RA7rvvF2Ngeu+hSACBbKfAJgLbPqhaXG14DH2NmztTE=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -36,17 +32,16 @@ stdenv.mkDerivation rec {
 
   buildFlags = [ "modules" ];
 
-  meta = with lib; {
-    homepage = "https://github.com/louistakepillz/r8125";
-    downloadPage = "https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software";
-    description = "Realtek r8125 driver";
-    longDescription = ''
-      A kernel module for Realtek 8125 2.5G network cards.
-    '';
-    # r8125 has been integrated into the kernel as of v5.9.1
-    broken = lib.versionAtLeast kernel.version "5.9.1";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ peelz ];
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/realtek
+    cp src/r8125.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/ethernet/realtek/
+  '';
+
+  meta = {
+    homepage = "https://salsa.debian.org/debian/r8125";
+    description = "Realtek r8125 2.5G Ethernet driver";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.peelz ];
   };
 }


### PR DESCRIPTION
This drive is no longer broken.
This update is necessary because some kernel versions do not include the new driver.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have to use this driver on my ASUS X870 motherboard.
That's why I keep track of version updates and the status of the driver.
I have not encountered any problems at the moment.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
