### PR TITLE
open-web-calendar: 1.42 -> 1.48

### DIFF
--- a/pkgs/by-name/op/open-web-calendar/package.nix
+++ b/pkgs/by-name/op/open-web-calendar/package.nix
@@ -12,7 +12,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "open-web-calendar";
-  version = "1.42";
+  version = "1.48";
   pyproject = true;
 
   disabled = python.pythonOlder "3.9";
@@ -20,7 +20,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchPypi {
     inherit version;
     pname = "open_web_calendar";
-    hash = "sha256-w4XaT1+qIM80K6B+LIAeYdZzYIw4FYSd/nvWphOx460=";
+    hash = "sha256-SSe5vkrfTpUFdSLglBxo5//VZfuXYnWs5sUKJL2zWOw=";
   };
 
   # The Pypi tarball doesn't contain open_web_calendars/features
@@ -35,6 +35,7 @@ python.pkgs.buildPythonApplication rec {
   build-system = with python.pkgs; [
     hatchling
     hatch-vcs
+    hatch-requirements-txt
   ];
 
   dependencies =
@@ -44,6 +45,10 @@ python.pkgs.buildPythonApplication rec {
       flask-allowed-hosts
       flask
       icalendar
+      icalendar-compatibility
+      cryptography
+      bcrypt
+      caldav
       requests
       pyyaml
       recurring-ical-events
@@ -52,6 +57,7 @@ python.pkgs.buildPythonApplication rec {
       beautifulsoup4
       lxml-html-clean
       pytz
+      mergecal
     ]
     ++ requests.optional-dependencies.socks;
 

--- a/pkgs/development/python-modules/icalendar-compatibility/default.nix
+++ b/pkgs/development/python-modules/icalendar-compatibility/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  icalendar,
+  pytestCheckHook,
+  git,
+}:
+
+buildPythonPackage rec {
+  pname = "icalendar-compatibility";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "niccokunzmann";
+    repo = "icalendar_compatibility";
+    tag = "v${version}";
+    hash = "sha256-h9rpbltNEPMteicPJ6oC32NsZS8QXQphLbC0Qiu7j5Q=";
+  };
+
+  # hatch-vcs tries to read the current git commit hash
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'dynamic = ["urls", "version"]' 'version = "${version}"'
+  '';
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [ icalendar ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    git
+  ];
+
+  pythonImportsCheck = [ "icalendar_compatibility" ];
+
+  # env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = {
+    homepage = "https://icalendar-compatibility.readthedocs.io/en/latest/";
+    changelog = "https://icalendar-compatibility.readthedocs.io/en/latest/changes.html";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ erictapen ];
+  };
+
+}

--- a/pkgs/development/python-modules/mergecal/default.nix
+++ b/pkgs/development/python-modules/mergecal/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  icalendar,
+  rich,
+  typer,
+  x-wr-timezone,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "mergecal";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mergecal";
+    repo = "python-mergecal";
+    tag = "v${version}";
+    hash = "sha256-Je3gFREu97Ycofszhr6pKOCiK76oBuzb3ji4LAf5aE8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    icalendar
+    rich
+    typer
+    x-wr-timezone
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportChecks = [ "mergecal" ];
+
+  meta = {
+    homepage = "https://mergecal.readthedocs.io/en/latest/";
+    changelog = "https://github.com/mergecal/python-mergecal/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ erictapen ];
+  };
+}

--- a/pkgs/development/python-modules/x-wr-timezone/default.nix
+++ b/pkgs/development/python-modules/x-wr-timezone/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "x-wr-timezone";
-  version = "2.0.0";
+  version = "2.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "niccokunzmann";
     repo = "x-wr-timezone";
     tag = "v${version}";
-    hash = "sha256-F/bNETgscbhEkpG/D1eSJaBNdpi0+xEYuNL4RURGST0=";
+    hash = "sha256-Llpe3Z0Yfd0vRgx95D4YVrnNJk0g/VqPuNvtUrUpFk0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6306,6 +6306,8 @@ self: super: with self; {
 
   icalendar = callPackage ../development/python-modules/icalendar { };
 
+  icalendar-compatibility = callPackage ../development/python-modules/icalendar-compatibility { };
+
   icalevents = callPackage ../development/python-modules/icalevents { };
 
   icecream = callPackage ../development/python-modules/icecream { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8288,6 +8288,8 @@ self: super: with self; {
 
   merge3 = callPackage ../development/python-modules/merge3 { };
 
+  mergecal = callPackage ../development/python-modules/mergecal { };
+
   mergedb = callPackage ../development/python-modules/mergedb { };
 
   mergedeep = callPackage ../development/python-modules/mergedeep { };


### PR DESCRIPTION
Closes #383089 

New packages:

- icalendar-compatibility
- mergecal

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
