### PR TITLE
semgrep-search: init at 1.1.0

### DIFF
--- a/pkgs/by-name/se/semgrep-search/package.nix
+++ b/pkgs/by-name/se/semgrep-search/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "semgrep-search";
+  version = "1.1.0";
+  pyproject = true;
+  pythonRelaxDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "hnzlmnn";
+    repo = "semgrep-search";
+    tag = "v${version}";
+    hash = "sha256-Rhz7bd5YdR2l03Z9naj1ozj7HbpvEk6gd1YAJiGFL/U=";
+  };
+
+  dependencies = with python3Packages; [
+    babel
+    oras
+    poetry-core
+    pyyaml
+    requests
+    rich
+    ruamel-yaml
+    semver
+    tinydb
+    tomli
+  ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  meta = {
+    changelog = "https://github.com/hnzlmnn/semgrep-search/releases/v${version}";
+    description = "CLI tool generating semgrep rulesets using an external semgrep rules database";
+    homepage = "https://github.com/hnzlmnn/semgrep-search";
+    license = lib.licenses.gpl3;
+    longDescription = "semgrep-search generates custom YAML rulesets using an external rules database published at ghcr.io/hnzlmnn/semgrep-search-db.";
+    mainProgram = "sgs";
+    maintainers = with lib.maintainers; [ cryptoluks ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
semgrep-search generates custom YAML rulesets for Semgrep using an external rules database published at ghcr.io/hnzlmnn/semgrep-search-db.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
