### PR TITLE
 python3Packages.hyperscan: 0.7.8 -> 0.7.9 

### DIFF
--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -58,6 +58,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace libhs.pc.in \
       --replace-fail "libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@" "libdir=@CMAKE_INSTALL_LIBDIR@" \
       --replace-fail "includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@" "includedir=@CMAKE_INSTALL_INCLUDEDIR@"
+
+    substituteInPlace cmake/pcre.cmake --replace-fail 'CHECK_C_SOURCE_COMPILES("#include <pcre.h.generic>
+        #if PCRE_MAJOR != ''${PCRE_REQUIRED_MAJOR_VERSION} || PCRE_MINOR < ''${PCRE_REQUIRED_MINOR_VERSION}
+        #error Incorrect pcre version
+        #endif
+        main() {}" CORRECT_PCRE_VERSION)' 'set(CORRECT_PCRE_VERSION TRUE)'
   '';
 
   doCheck = true;

--- a/pkgs/development/python-modules/hyperscan/default.nix
+++ b/pkgs/development/python-modules/hyperscan/default.nix
@@ -3,41 +3,50 @@
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
-  pdm-backend,
-  setuptools,
-  wheel,
+  symlinkJoin,
+  cmake,
+  ninja,
+  pathspec,
   pcre,
-  pkg-config,
+  scikit-build-core,
   pytestCheckHook,
   pytest-mock,
 }:
-
+let
+  lib-deps = symlinkJoin {
+    name = "hyperscan-static-deps";
+    paths = [
+      (pkgs.hyperscan.override { withStatic = true; })
+      (pcre.overrideAttrs { dontDisableStatic = 0; }).out
+    ];
+  };
+in
 buildPythonPackage rec {
   pname = "hyperscan";
-  version = "0.7.8";
+  version = "0.7.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "darvid";
     repo = "python-hyperscan";
     tag = "v${version}";
-    hash = "sha256-gNXE2VjHRTmIMyoLyTsmC9CuY3YT5ZsKfNZvMRthPn0=";
+    hash = "sha256-tf3dQgY0p+J6GIS8pB3+kvomNVYcbMJ+72T8IVbrnrU=";
   };
 
-  buildInputs = [
-    (pkgs.hyperscan.override { withStatic = true; })
-    # we need static pcre to be built, by default only shared library is built
-    (pcre.overrideAttrs { dontDisableStatic = 0; })
-  ];
+  env.CMAKE_ARGS = "-DHS_SRC_ROOT=${pkgs.hyperscan.src} -DHS_BUILD_LIB_ROOT=${lib-deps}/lib";
+
+  dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [
-    pkg-config
-    pdm-backend
-    setuptools
-    wheel
+    cmake
+    pathspec
+    ninja
+    scikit-build-core
   ];
 
   pythonImportsCheck = [ "hyperscan" ];
+
+  pytestFlagsArray = [ "tests" ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
https://github.com/darvid/python-hyperscan/releases/tag/v0.7.9

## Things done
Static build of hyperscan library was broken, because the check for correct pcre version doesn't work.
I wasn't able to fix the check, so I patched it out

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
