### PR TITLE
rebels-in-the-sky: init at 1.0.29

### DIFF
--- a/pkgs/by-name/re/rebels-in-the-sky/disable-radio.patch
+++ b/pkgs/by-name/re/rebels-in-the-sky/disable-radio.patch
@@ -1,0 +1,25 @@
+diff --git a/assets/data/stream_data.json b/assets/data/stream_data.json
+index c049ec7..fe51488 100644
+--- a/assets/data/stream_data.json
++++ b/assets/data/stream_data.json
+@@ -1,18 +1 @@
+-[
+-    {
+-        "name": "Radio Frittura",
+-        "url_string": "https://radio.frittura.org/frittura.ogg"
+-    },
+-    {
+-        "name": "Matt Johnson radio",
+-        "url_string": "https://us2.internet-radio.com/proxy/mattjohnsonradio?mp=/stream"
+-    },
+-    {
+-        "name" : "Lofi 24/7",
+-        "url_string": "http://usa9.fastcast4u.com/proxy/jamz?mp=/1"
+-    },
+-    {
+-        "name" : "Radio Sarajevo",
+-        "url_string": "https://cast2.asurahosting.com/proxy/balkanhi/stream"
+-    }
+-]
+\ No newline at end of file
++[]

--- a/pkgs/by-name/re/rebels-in-the-sky/package.nix
+++ b/pkgs/by-name/re/rebels-in-the-sky/package.nix
@@ -1,0 +1,88 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  withRadio ? false,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rebels-in-the-sky";
+  version = "1.0.29";
+
+  src = fetchFromGitHub {
+    owner = "ricott1";
+    repo = "rebels-in-the-sky";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rWBaD4nxSmr1RZRbc51Sz9Xl2Te2yv4HNuFqWj8KayM=";
+  };
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ZRxq6/mgXZ33o1AEHnSOt4HJAI1y+F+ysVNvvbb9M28=";
+
+  patches =
+    lib.optionals (!withRadio) [
+      ./disable-radio.patch
+    ]
+    ++ [
+      # https://github.com/ricott1/rebels-in-the-sky/pull/25
+      (fetchpatch {
+        url = "https://github.com/ricott1/rebels-in-the-sky/commit/31778fee783637fe8af09f71754f35c5d15b800a.patch";
+        hash = "sha256-PO/aY+fB72gQpxE5eaIP/s4xevfQ/Ac1TH5ZEKwpw1I=";
+      })
+    ];
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      rustPlatform.bindgenHook
+    ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
+
+  nativeCheckInputs = [
+    # Save system tests write to home dir
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/rebels";
+  versionCheckProgramArg = "--version";
+  # Darwin: "Error: Operation not permitted (os error 1)"
+  doInstallCheck = !stdenv.hostPlatform.isDarwin;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "P2P terminal game about spacepirates playing basketball across the galaxy";
+    longDescription = ''
+      It's the year 2101. Corporations have taken over the world. The only way to be free is
+      to join a pirate crew and start plundering the galaxy. The only means of survival is
+      to play basketball.
+
+      Now it's your turn to go out there and make a name for yourself. Create your crew and
+      start wandering the galaxy in search of worthy basketball opponents.
+    '';
+    homepage = "https://frittura.org/";
+    changelog = "https://github.com/ricott1/rebels-in-the-sky/releases/tag/v${finalAttrs.version}";
+    license =
+      with lib.licenses;
+      [ gpl3Only ]
+      # The original game soundtrack was generated using AI so its licensing is unclear.
+      # I couldn't find licensing information regarding other radio stations, so I'm
+      # assuming they're nonfree.
+      ++ lib.optionals withRadio [ unfree ];
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    mainProgram = "rebels";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/ricott1/rebels-in-the-sky

cc #380688 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
