### PR TITLE
drawio: 26.0.4 -> 26.0.16

### DIFF
--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -15,14 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "drawio";
-  version = "26.0.4";
+  version = "26.0.16";
 
   src = fetchFromGitHub {
     owner = "jgraph";
     repo = "drawio-desktop";
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-3tEWLRen8lRQEDFlfTWT9+L15k+7z/7To6p7SkmdJhU=";
+    hash = "sha256-se3yxIzxeinOnfltv+fSflypwxRHvW/wxKJ43LPsiho=";
   };
 
   # `@electron/fuses` tries to run `codesign` and fails. Disable and use autoSignDarwinBinariesHook instead
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-DElSCZwVGZF/sjec0SFi7iIe/2Ern85oT5rp6bQl5wg=";
+    hash = "sha256-AtrBaN6Pvi5rvncHN64RCHS/fLA0u9WTC+hXsMQe7tU=";
   };
 
   nativeBuildInputs =


### PR DESCRIPTION
Update security patch level on drawio, changelog from 26.0.4 to 26.0.16:

21-FEB-2025: 26.0.16

- Fixes colors in vsdx export [DID-14515]
- Fixes background color option for selection text

19-FEB-2025: 26.0.15

- Adds default dark mode support for SVG images
- Shows word wrap option for non-resizable cells [jgraph/drawio-desktop#1994]
- Adds word wrapping to attributes section of entity shape [jgraph/drawio-desktop#1994]
- [conf cloud] Fixes Aura compatibility [DID-14484]

14-FEB-2025: 26.0.14

- Fixes change of line height for wrapped text [jgraph/drawio#4902]
- Adds support for older browsers with no light-dark colors
- Improves compatibility of exported SVG
- Improves handling of ignored stroke-widths in clipSvgDataUri
- Fixes handling of single color values in SVG with editable CSS rules

12-FEB-2025: 26.0.13

- Adds appearance option in publish and embed dialogs
- Forces light export of diagrams with no adaptive colors
- Skips light-dark function for same light and dark color
- [conf cloud] Adds support for pagePin in Gliffy import
- Adds enableLightDarkColors configuration

07-FEB-2025: 26.0.12

- [conf cloud] Fixes simple view of imported Gliffy diagrams [DID-14343]
- [conf cloud] Disable direct editing if a page has unpublished changes [DID-14257]
- Fixes handling of Ctrl+Enter on Windows [jgraph/drawio#4883]
- Adds transparent background option in iframe embed dialog [jgraph/drawio#4884]
- Handles Ctrl+S while editing labels [jgraph/drawio#4885]
- Fixes editing toolbar alignment in embed mode [jgraph/drawio#4874]
- Updates DOMPurify from 3.2.3 to 3.2.4
- Handles subgroups in GitLab paths [jgraph/drawio#4870]

04-FEB-2025: 26.0.11

- [conf cloud] Show error when embed diagram page not found (deleted or restricted) [DID-14304]
- [conf cloud] Fixed realtime collaboration [DID-12871]

28-JAN-2025: 26.0.10

- [conf cloud] Fixes Gliffy mass import of linked diagrams when done in separate runs [DID-14151]
- Enhanced page links in vsdx import [DID-14276]

27-JAN-2025: 26.0.9

- Fixes possible split is not a function in StyleFormatPanel
- Uses light custom background with simple adaptive colors [jgraph/drawio-desktop#1978]

24-JAN-2025: 26.0.8

- Improves VSDX Import [DID-14176]
- [conf cloud]] Fixes Gliffy diagrams with core ui icons [DID-14260]

22-JAN-2025: 26.0.7

- Fixes for Atlas theme dark mode
- Dark mode fixes
- Changes raster images to SVG
- Stroke width fix for some BPMN2 shapes. Ticket [jgraph/drawio#4861]
- [conf cloud] Adds disableGithubEmbedding config to hide Github tab from embed editor [DID-14232]

15-JAN-2025: 26.0.6

- Various dark mode improvements

10-JAN-2025: 26.0.5

- Fixes Ctrl+Shift+G to enable grid [jgraph/drawio#4825]
- Replaces three dots with layers icon [jgraph/drawio-desktop#1953]
- Mermaid2drawio: Added support for new flowchart shapes and fixed [jgraph/drawio-#4832]
- Adds editableCssRules=.* for imported SVG images [jgraph/drawio#4721]
- Adds default and font keyword for stencil colors [jgraph/drawio#4723]

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
