### PR TITLE
vimix-icon-theme: lowercase `colorVariants` when passed to install.sh

### DIFF
--- a/pkgs/by-name/vi/vimix-icon-theme/package.nix
+++ b/pkgs/by-name/vi/vimix-icon-theme/package.nix
@@ -61,7 +61,7 @@ lib.checkListOfEnum "${pname}: color variants"
       runHook preInstall
 
       ./install.sh \
-        ${if colorVariants != [ ] then builtins.toString colorVariants else "-a"} \
+        ${if colorVariants != [ ] then builtins.toString (map lib.strings.toLower colorVariants) else "-a"} \
         -d $out/share/icons
 
       # replace duplicate files with symlinks


### PR DESCRIPTION
When attempting to overlay this package and customize the `colorVariants`, the build fails. For example, this overlay:


```nix
vimix-icon-theme-beryl = prev.vimix-icon-theme.override { colorVariants = ["Beryl"]; };

```

Results in:

```
error: builder for '/nix/store/6kvvwn2yhmbqgvm66jgr684sc34jbf7q-vimix-icon-theme-2025.02.10.drv' failed with exit code 1;
       last 15 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/fj2xx34nlbq6g5sbnbxvkjiajp78aa30-source
       > source root is source
       > Running phase: patchPhase
       > patching script interpreter paths in install.sh
       > install.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/11ciq72n4fdv8rw6wgjgasfv4mjs1jrw-bash-5.2p37/bin/bash"
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > no Makefile or custom buildPhase, doing nothing
       > Running phase: glibPreInstallPhase
       > Running phase: installPhase
       > ERROR: Unrecognized installation option 'Beryl'.
       > Try './install.sh -h' for more information.
```


This seems to be due to https://github.com/vinceliuice/Vimix-icon-theme/commit/4dae8dfe14b41a1313a9fdc4c72c3a2b4950e173.

I opted to address this by lowercasing the arguments to the installer, rather than requiring that all `colorVariants` be lowercased, to improve backwards-compat. 

TODO: may have to pascal case the output folder after installation to prevent config breakages

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
