### PR TITLE
firefox-bin: update license

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -119,7 +119,27 @@ stdenv.mkDerivation {
     changelog = "https://www.mozilla.org/en-US/firefox/${version}/releasenotes/";
     description = "Mozilla Firefox, free web browser (binary package)";
     homepage = "https://www.mozilla.org/firefox/";
-    license = licenses.mpl20;
+    license = {
+      shortName = "firefox";
+      fullName = "Firefox Terms of Use";
+      url = "https://www.mozilla.org/about/legal/terms/firefox/";
+      # "You Are Responsible for the Consequences of Your Use of Firefox"
+      # (despite the heading, not an indemnity clause) states the following:
+      #
+      # > You agree that you will not use Firefox to infringe anyone’s rights
+      # > or violate any applicable laws or regulations.
+      # >
+      # > You will not do anything that interferes with or disrupts Mozilla’s
+      # > services or products (or the servers and networks which are connected
+      # > to Mozilla’s services).
+      #
+      # This conflicts with FSF freedom 0: "The freedom to run the program as
+      # you wish, for any purpose". (Why should Mozilla be involved in
+      # instances where you break your local laws just because you happen to
+      # use Firefox whilst doing it?)
+      free = false;
+      redistributable = true; # since MPL-2.0 still applies
+    };
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     platforms = builtins.attrNames mozillaPlatforms;
     hydraPlatforms = [];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

NB: this change does not affect the regular `firefox` derivation.

A couple of days ago, Mozilla added [Terms of Use](https://www.mozilla.org/about/legal/terms/firefox/) to the official Firefox binaries: https://blog.mozilla.org/en/products/firefox/firefox-terms-of-use/

From a freeness standpoint, the following phrase appears challenging:

> Your use of Firefox must follow Mozilla’s [Acceptable Use Policy](https://www.mozilla.org/about/legal/acceptable-use/)

This is a violation of freedom 0 ("The freedom to run the program as you wish, for any purpose"). Therefore, I have set `licenses.firefox.free = false`.

Further, I worry that the following phrase (particularly the limitation to installation/usage, and the lack of a verb like "distribute"):

> Mozilla grants you a personal, non-exclusive license to install and use the “Executable Code" version of the Firefox web browser

implies that it is not permissible to redistribute the official Firefox binaries. Therefore, I have set `licenses.firefox.redistributable = false`.

(I'm, hopefully obviously, not really expecting this to just get merged as-is – but I hope it will provoke some discussion.)

No idea if GHA will ping maintainers for a `meta`-only change, so: @taku0 @lovesegfault

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>all-the-package-names</li>
    <li>amnezia-vpn</li>
    <li>nixpkgs-manual</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
