### PR TITLE
postgresql: provide PL/Perl, PL/Python and PL/Tcl as packages

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -25,7 +25,7 @@
   The `nixLog` function, which logs unconditionally, was also re-introduced and modified to prefix messages with the function name of the caller.
   For more information, [see this PR](https://github.com/NixOS/nixpkgs/pull/370742).
 
-- `postgresql`'s `pythonSupport` argument has been changed. It is now enabled by default, but to use PL/Python the extension needs to be added explicitly with `postgresql.withPackages`. If you were using `postgresql.override { pythonSupport = true; }` before, change it to `postgresql.withPackages (ps: [ ps.plpython3 ])`. The same applies to `perlSupport`/`plperl` respectively.
+- `postgresql`'s `pythonSupport` argument has been changed. It is now enabled by default, but to use PL/Python the extension needs to be added explicitly with `postgresql.withPackages`. If you were using `postgresql.override { pythonSupport = true; }` before, change it to `postgresql.withPackages (ps: [ ps.plpython3 ])`. The same applies to `perlSupport`/`plperl` and `tclSupport`/`pltcl` respectively.
 
 - The `rustPlatform.fetchCargoTarball` function is deprecated, because it relied on `cargo vendor` not changing its output format to keep fixed-output derivation hashes the same, which is a Nix invariant, and Cargo 1.84.0 changed `cargo vendor`'s output format.
   It should generally be replaced with `rustPlatform.fetchCargoVendor`, but `rustPlatform.importCargoLock` may also be appropriate in some circumstances.

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -25,6 +25,8 @@
   The `nixLog` function, which logs unconditionally, was also re-introduced and modified to prefix messages with the function name of the caller.
   For more information, [see this PR](https://github.com/NixOS/nixpkgs/pull/370742).
 
+- `postgresql`'s `pythonSupport` argument has been changed. It is now enabled by default, but to use PL/Python the extension needs to be added explicitly with `postgresql.withPackages`. If you were using `postgresql.override { pythonSupport = true; }` before, change it to `postgresql.withPackages (ps: [ ps.plpython3 ])`.
+
 - The `rustPlatform.fetchCargoTarball` function is deprecated, because it relied on `cargo vendor` not changing its output format to keep fixed-output derivation hashes the same, which is a Nix invariant, and Cargo 1.84.0 changed `cargo vendor`'s output format.
   It should generally be replaced with `rustPlatform.fetchCargoVendor`, but `rustPlatform.importCargoLock` may also be appropriate in some circumstances.
   `rustPlatform.buildRustPackage` users must set `useFetchCargoVendor` to `true` and regenerate the `cargoHash`.

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -25,7 +25,7 @@
   The `nixLog` function, which logs unconditionally, was also re-introduced and modified to prefix messages with the function name of the caller.
   For more information, [see this PR](https://github.com/NixOS/nixpkgs/pull/370742).
 
-- `postgresql`'s `pythonSupport` argument has been changed. It is now enabled by default, but to use PL/Python the extension needs to be added explicitly with `postgresql.withPackages`. If you were using `postgresql.override { pythonSupport = true; }` before, change it to `postgresql.withPackages (ps: [ ps.plpython3 ])`.
+- `postgresql`'s `pythonSupport` argument has been changed. It is now enabled by default, but to use PL/Python the extension needs to be added explicitly with `postgresql.withPackages`. If you were using `postgresql.override { pythonSupport = true; }` before, change it to `postgresql.withPackages (ps: [ ps.plpython3 ])`. The same applies to `perlSupport`/`plperl` respectively.
 
 - The `rustPlatform.fetchCargoTarball` function is deprecated, because it relied on `cargo vendor` not changing its output format to keep fixed-output derivation hashes the same, which is a Nix invariant, and Cargo 1.84.0 changed `cargo vendor`'s output format.
   It should generally be replaced with `rustPlatform.fetchCargoVendor`, but `rustPlatform.importCargoLock` may also be appropriate in some circumstances.

--- a/pkgs/servers/sql/postgresql/ext.nix
+++ b/pkgs/servers/sql/postgresql/ext.nix
@@ -9,6 +9,9 @@ in
 // {
   timescaledb-apache = super.callPackage ./ext/timescaledb.nix { enableUnfree = false; };
 }
+// lib.optionalAttrs (!self.perlSupport) {
+  plperl = throw "PostgreSQL extension `plperl` is not available, because `postgresql` was built without Perl support. Override with `perlSupport = true` to enable the extension.";
+}
 // lib.optionalAttrs (!self.pythonSupport) {
   plpython3 = throw "PostgreSQL extension `plpython3` is not available, because `postgresql` was built without Python support. Override with `pythonSupport = true` to enable the extension.";
 }

--- a/pkgs/servers/sql/postgresql/ext.nix
+++ b/pkgs/servers/sql/postgresql/ext.nix
@@ -15,6 +15,9 @@ in
 // lib.optionalAttrs (!self.pythonSupport) {
   plpython3 = throw "PostgreSQL extension `plpython3` is not available, because `postgresql` was built without Python support. Override with `pythonSupport = true` to enable the extension.";
 }
+// lib.optionalAttrs (!self.tclSupport) {
+  pltcl = throw "PostgreSQL extension `pltcl` is not available, because `postgresql` was built without Tcl support. Override with `tclSupport = true` to enable the extension.";
+}
 // lib.optionalAttrs config.allowAliases {
   pg_embedding = throw "PostgreSQL extension `pg_embedding` has been removed since the project has been abandoned. Upstream's recommendation is to use pgvector instead (https://neon.tech/docs/extensions/pg_embedding#migrate-from-pg_embedding-to-pgvector)";
 }

--- a/pkgs/servers/sql/postgresql/ext.nix
+++ b/pkgs/servers/sql/postgresql/ext.nix
@@ -9,6 +9,9 @@ in
 // {
   timescaledb-apache = super.callPackage ./ext/timescaledb.nix { enableUnfree = false; };
 }
+// lib.optionalAttrs (!self.pythonSupport) {
+  plpython3 = throw "PostgreSQL extension `plpython3` is not available, because `postgresql` was built without Python support. Override with `pythonSupport = true` to enable the extension.";
+}
 // lib.optionalAttrs config.allowAliases {
   pg_embedding = throw "PostgreSQL extension `pg_embedding` has been removed since the project has been abandoned. Upstream's recommendation is to use pgvector instead (https://neon.tech/docs/extensions/pg_embedding#migrate-from-pg_embedding-to-pgvector)";
 }

--- a/pkgs/servers/sql/postgresql/ext/plperl.nix
+++ b/pkgs/servers/sql/postgresql/ext/plperl.nix
@@ -1,0 +1,45 @@
+{
+  buildEnv,
+  perl,
+  postgresql,
+  postgresqlTestExtension,
+}:
+
+let
+  withPackages =
+    f:
+    let
+      perl' = perl.withPackages f;
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-plperl-${postgresql.version}";
+        paths = [ postgresql.plperl ];
+        passthru = {
+          inherit withPackages;
+          wrapperArgs = [
+            ''--set PERL5LIB "${perl'}/${perl'.libPrefix}"''
+          ];
+          tests.extension = postgresqlTestExtension {
+            finalPackage = finalPackage.withPackages (ps: [ ps.boolean ]);
+            sql = ''
+              CREATE EXTENSION plperlu;
+              DO LANGUAGE plperlu $$
+                use boolean;
+              $$;
+            '';
+          };
+        };
+        meta = {
+          inherit (postgresql.meta)
+            homepage
+            license
+            changelog
+            maintainers
+            platforms
+            ;
+          description = "PL/Perl - Perl Procedural Language";
+        };
+      };
+    in
+    finalPackage;
+in
+withPackages (_: [ ])

--- a/pkgs/servers/sql/postgresql/ext/plpython3.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpython3.nix
@@ -1,0 +1,45 @@
+{
+  buildEnv,
+  postgresql,
+  postgresqlTestExtension,
+  python3,
+}:
+
+let
+  withPackages =
+    f:
+    let
+      python = python3.withPackages f;
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-plpython3-${postgresql.version}";
+        paths = [ postgresql.plpython3 ];
+        passthru = {
+          inherit withPackages;
+          wrapperArgs = [
+            ''--set PYTHONPATH "${python}/${python.sitePackages}"''
+          ];
+          tests.extension = postgresqlTestExtension {
+            finalPackage = finalPackage.withPackages (ps: [ ps.base58 ]);
+            sql = ''
+              CREATE EXTENSION plpython3u;
+              DO LANGUAGE plpython3u $$
+                import base58
+              $$;
+            '';
+          };
+        };
+        meta = {
+          inherit (postgresql.meta)
+            homepage
+            license
+            changelog
+            maintainers
+            platforms
+            ;
+          description = "PL/Python - Python Procedural Language";
+        };
+      };
+    in
+    finalPackage;
+in
+withPackages (_: [ ])

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -1,16 +1,21 @@
 {
-  R,
+  buildEnv,
   fetchFromGitHub,
   lib,
   pkg-config,
   postgresql,
   postgresqlBuildExtension,
+  postgresqlTestExtension,
+  R,
+  rPackages,
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "plr";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (lib.strings.removePrefix "REL" src.rev)}";
+  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
+    lib.strings.removePrefix "REL" finalAttrs.src.rev
+  )}";
 
   src = fetchFromGitHub {
     owner = "postgres-plr";
@@ -24,12 +29,38 @@ postgresqlBuildExtension rec {
 
   makeFlags = [ "USE_PGXS=1" ];
 
+  passthru = {
+    withPackages =
+      f:
+      let
+        pkgs = f rPackages;
+        paths = lib.concatMapStringsSep ":" (pkg: "${pkg}/library") pkgs;
+      in
+      buildEnv {
+        name = "${finalAttrs.pname}-with-packages-${finalAttrs.version}";
+        paths = [ finalAttrs.finalPackage ];
+        passthru.wrapperArgs = [
+          ''--set R_LIBS_SITE "${paths}"''
+        ];
+      };
+    tests.extension = postgresqlTestExtension {
+      finalPackage = finalAttrs.finalPackage.withPackages (ps: [ ps.base64enc ]);
+      sql = ''
+        CREATE EXTENSION plr;
+        DO LANGUAGE plr $$
+          require('base64enc')
+          base64encode(1:100)
+        $$;
+      '';
+    };
+  };
+
   meta = {
     description = "PL/R - R Procedural Language for PostgreSQL";
     homepage = "https://github.com/postgres-plr/plr";
-    changelog = "https://github.com/postgres-plr/plr/blob/${src.rev}/changelog.md";
+    changelog = "https://github.com/postgres-plr/plr/blob/${finalAttrs.src.rev}/changelog.md";
     maintainers = with lib.maintainers; [ qoelet ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.gpl2Only;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pltcl.nix
+++ b/pkgs/servers/sql/postgresql/ext/pltcl.nix
@@ -1,0 +1,53 @@
+{
+  buildEnv,
+  lib,
+  postgresql,
+  postgresqlTestExtension,
+  tcl,
+  tclPackages,
+}:
+
+let
+  withPackages =
+    f:
+    let
+      pkgs = f tclPackages;
+      paths = lib.concatMapStringsSep " " (pkg: "${pkg}/lib") pkgs;
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-pltcl-${postgresql.version}";
+        paths = [ postgresql.pltcl ];
+        passthru = {
+          inherit withPackages;
+          wrapperArgs = [
+            ''--set TCLLIBPATH "${paths}"''
+          ];
+          tests.extension = postgresqlTestExtension {
+            finalPackage = finalPackage.withPackages (ps: [
+              ps.mustache-tcl
+              ps.tcllib
+            ]);
+            sql = ''
+              CREATE EXTENSION pltclu;
+              CREATE FUNCTION test() RETURNS VOID
+              LANGUAGE pltclu AS $$
+                package require mustache
+              $$;
+              SELECT test();
+            '';
+          };
+        };
+        meta = {
+          inherit (postgresql.meta)
+            homepage
+            license
+            changelog
+            maintainers
+            platforms
+            ;
+          description = "PL/Tcl - Tcl Procedural Language";
+        };
+      };
+    in
+    finalPackage;
+in
+withPackages (_: [ ])

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -79,11 +79,13 @@ let
       gettext,
 
       # PAM
-      # Building with linux-pam in pkgsStatic gives a few "undefined reference" errors like this:
-      #   /nix/store/3s55icpsbc36sgn7sa8q3qq4z6al6rlr-linux-pam-static-x86_64-unknown-linux-musl-1.6.1/lib/libpam.a(pam_audit.o):
-      #     in function `pam_modutil_audit_write':(.text+0x571):
-      #     undefined reference to `audit_close'
-      pamSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic,
+      pamSupport ?
+        lib.meta.availableOn stdenv.hostPlatform linux-pam
+        # Building with linux-pam in pkgsStatic gives a few "undefined reference" errors like this:
+        #   /nix/store/3s55icpsbc36sgn7sa8q3qq4z6al6rlr-linux-pam-static-x86_64-unknown-linux-musl-1.6.1/lib/libpam.a(pam_audit.o):
+        #     in function `pam_modutil_audit_write':(.text+0x571):
+        #     undefined reference to `audit_close'
+        && !stdenv.hostPlatform.isStatic,
       linux-pam,
 
       # PL/Perl

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -216,7 +216,6 @@ let
         ++ lib.optionals pamSupport [ linux-pam ]
         ++ lib.optionals perlSupport [ perl ]
         ++ lib.optionals ldapSupport [ openldap ]
-        ++ lib.optionals tclSupport [ tcl ]
         ++ lib.optionals selinuxSupport [ libselinux ]
         ++ lib.optionals nlsSupport [ gettext ];
 
@@ -256,7 +255,8 @@ let
             + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
         }
         // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
-        // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; };
+        // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
+        // lib.optionalAttrs tclSupport { TCLSH = "${lib.getBin tcl}/bin/tclsh"; };
 
       configureFlags =
         let

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -212,7 +212,6 @@ let
         ++ lib.optionals lz4Enabled [ lz4 ]
         ++ lib.optionals zstdEnabled [ zstd ]
         ++ lib.optionals systemdSupport [ systemdLibs ]
-        ++ lib.optionals pythonSupport [ python3 ]
         ++ lib.optionals gssSupport [ libkrb5 ]
         ++ lib.optionals pamSupport [ linux-pam ]
         ++ lib.optionals perlSupport [ perl ]

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -254,7 +254,7 @@ let
         CFLAGS =
           "-fdata-sections -ffunction-sections"
           + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
-      } // lib.optionalAttrs pythonSupport { PYTHON = "${python3}/bin/python"; };
+      } // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; };
 
       configureFlags =
         let

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -36,7 +36,7 @@ let
       docbook_xml_dtd_45,
       flex,
       libxslt,
-      makeWrapper,
+      makeBinaryWrapper,
       pkg-config,
       removeReferencesTo,
 
@@ -229,7 +229,7 @@ let
           flex
           libxml2
           libxslt
-          makeWrapper
+          makeBinaryWrapper
           perl
           pkg-config
           removeReferencesTo

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -243,12 +243,12 @@ let
 
       buildFlags = [ "world" ];
 
-      # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
-      # into all binaries. However, almost no binaries actually use those paths. The following
-      # flags will remove unused sections from all shared libraries and binaries - including
-      # those paths. This avoids a lot of circular dependency problems with different outputs,
-      # and allows splitting them cleanly.
       env = {
+        # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
+        # into all binaries. However, almost no binaries actually use those paths. The following
+        # flags will remove unused sections from all shared libraries and binaries - including
+        # those paths. This avoids a lot of circular dependency problems with different outputs,
+        # and allows splitting them cleanly.
         CFLAGS =
           "-fdata-sections -ffunction-sections"
           + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -269,6 +269,7 @@ let
           "--enable-debug"
           (lib.optionalString systemdSupport "--with-systemd")
           (if stdenv.hostPlatform.isFreeBSD then "--with-uuid=bsd" else "--with-uuid=e2fs")
+          (withFeature perlSupport "perl")
         ]
         ++ lib.optionals lz4Enabled [ "--with-lz4" ]
         ++ lib.optionals zstdEnabled [ "--with-zstd" ]
@@ -292,7 +293,6 @@ let
             [
               "LDFLAGS_EX_BE=-Wl,--export-dynamic"
             ]
-        ++ lib.optionals (atLeast "17" && !perlSupport) [ "--without-perl" ]
         ++ lib.optionals ldapSupport [ "--with-ldap" ]
         ++ lib.optionals tclSupport [ "--with-tcl" ]
         ++ lib.optionals selinuxSupport [ "--with-selinux" ]

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -244,16 +244,19 @@ let
 
       buildFlags = [ "world" ];
 
-      env = {
-        # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
-        # into all binaries. However, almost no binaries actually use those paths. The following
-        # flags will remove unused sections from all shared libraries and binaries - including
-        # those paths. This avoids a lot of circular dependency problems with different outputs,
-        # and allows splitting them cleanly.
-        CFLAGS =
-          "-fdata-sections -ffunction-sections"
-          + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
-      } // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; };
+      env =
+        {
+          # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
+          # into all binaries. However, almost no binaries actually use those paths. The following
+          # flags will remove unused sections from all shared libraries and binaries - including
+          # those paths. This avoids a lot of circular dependency problems with different outputs,
+          # and allows splitting them cleanly.
+          CFLAGS =
+            "-fdata-sections -ffunction-sections"
+            + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
+        }
+        // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
+        // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; };
 
       configureFlags =
         let


### PR DESCRIPTION
This follows up on https://github.com/NixOS/nixpkgs/pull/372655#issuecomment-2583632238 and allows this:

```
postgresql.withPackages (pgps: [ pgps.plpython3.withPackages (pyps: [ pyps.base58 ]) ])
```

The same is done for `plperl` and `pltcl`.

While the extensions are split at run-time, they are still built in the main `postgresql` build and only stored in separate outputs. This allowed me to enable them by default, which has the following benefits:
- Those code paths are tested, they were not before. Neither `tclSupport` nor `perlSupport` worked properly before.
- Users avoid rebuilds when actually using them.
- They are not provided out of the box, reducing the attack surface for stuff like https://www.postgresql.org/support/security/CVE-2024-10979 (and if only by being able to confidently say "nope, I don't have it installed").

This is a breaking change for users of `pythonSupport`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
