### PR TITLE
haskell/ghcup: init at v0.1.50.1

### DIFF
--- a/pkgs/development/tools/haskell/ghcup/default.nix
+++ b/pkgs/development/tools/haskell/ghcup/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  curl,
+  gmp,
+  gnupg,
+  libffi,
+  libiconv,
+  ncurses,
+  zlib,
+  openssl,
+  stdenvNoCC,
+  bash,
+  coreutils,
+  fetchurl,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ghcup";
+  version = "0.1.50.1";
+
+  src = fetchurl {
+    url = "https://downloads.haskell.org/~ghcup/${finalAttrs.version}/x86_64-linux-ghcup-${finalAttrs.version}";
+    hash = "sha256-s0hv7t5Xj+ywQnWkXYGHCIw/3Fltb0CqshTCFeq9siM=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    curl
+    gmp
+    libffi
+    ncurses
+    zlib
+    openssl
+  ] ++ lib.optional stdenv.isDarwin libiconv;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp $src $out/bin/ghcup
+    chmod +x $out/bin/ghcup
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+    wrapProgram $out/bin/ghcup \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          curl
+          gnupg
+          bash
+          coreutils
+        ]
+      }
+    runHook postFixup
+  '';
+
+  meta = {
+    description = "GHCup Haskell toolchain installer";
+    longDescription = ''
+      GHCup is an installer for the general purpose language Haskell.
+      It can install the Glasgow Haskell Compiler (GHC), the Haskell build tool
+      Cabal, the Haskell-centric IDE-compatible server HLS, and the
+      Haskell-centric build tool Stack.
+    '';
+    homepage = "https://www.haskell.org/ghcup/";
+    changelog = "https://github.com/haskell/ghcup-hs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = [ lib.maintainers.qxrein ];
+    platforms = lib.platforms.unix;
+    mainProgram = "ghcup";
+  };
+})


### PR DESCRIPTION
initializing this package even if it is there in search.nixos and it crashes(why is it there?), i just need this package for ghcup testing in my local machine and curl fails

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
