### PR TITLE
git-revise: macOS: Skip failing GPG test

### DIFF
--- a/pkgs/development/python-modules/git-revise/default.nix
+++ b/pkgs/development/python-modules/git-revise/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   pythonOlder,
   git,
@@ -23,10 +24,18 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  nativeCheckInputs = [
-    git
-    gnupg
-    pytestCheckHook
+  nativeCheckInputs =
+    [
+      git
+      pytestCheckHook
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      gnupg
+    ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # `gpg: agent_genkey failed: No agent running`
+    "test_gpgsign"
   ];
 
   meta = with lib; {
@@ -35,6 +44,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/mystor/git-revise/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     mainProgram = "git-revise";
-    maintainers = with maintainers; [ emily ];
+    maintainers = with maintainers; [ _9999years ];
   };
 }


### PR DESCRIPTION
Fixes a macOS failure due to no GPG agent being run for the test suite (https://hydra.nixos.org/build/290744321):

```
E               subprocess.CalledProcessError: Command '['gpg', '--batch', '--passphrase', '', '--quick-gen-key', b'Test User <test@example.com>']' returned non-zero exit status 2.

/nix/store/wwqdmdr2f5wrjnsjs64bny8df471rh9b-python3-3.12.9/lib/python3.12/subprocess.py:573: CalledProcessError
----------------------------- Captured stdout call -----------------------------
[master (root-commit) 5aa2dc9] commit 1
 Author: Bash Author <bash_author@example.com>
----------------------------- Captured stderr call -----------------------------
gpg: keybox '/private/tmp/nix-build-python3.12-git-revise-0.7.0-unstable-2025-01-28.drv-0/tmpfmshzluc/pubring.kbx' created
gpg: error running '/nix/store/69pwwprid9rhgkz9ip9nq71p0r2b73b7-gnupg-2.4.7/bin/gpg-agent': exit status 2
gpg: failed to start gpg-agent '/nix/store/69pwwprid9rhgkz9ip9nq71p0r2b73b7-gnupg-2.4.7/bin/gpg-agent': General error
gpg: can't connect to the gpg-agent: General error
gpg: agent_genkey failed: No agent running
gpg: key generation failed: No agent running
=========================== short test summary info ============================
FAILED tests/test_gpgsign.py::test_gpgsign - subprocess.CalledProcessError: Command '['gpg', '--batch', '--passphrase', ...
======================== 1 failed, 37 passed in 20.81s =========================
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
