### PR TITLE
Revert "nixos/grub: generate BLS entries"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -519,10 +519,6 @@
 
 - `services.gitea` now supports CAPTCHA usage through the `services.gitea.captcha` variable.
 
-- The GRUB bootloader (`boot.loader.grub`) now generates [boot loader entries](https://uapi-group.org/specifications/specs/boot_loader_specification/).
-  These files are used by userspace tools (for example, `bootctl`) to inspect the bootloader status, getting the default boot entry, the path of the kernel binary, etc.
-  As a consequence, `systemctl kexec` now works automatically: specifying the kernel and its arguments with `kexec --load` is no longer required.
-
 - `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
 - [`services.mongodb.enableAuth`](#opt-services.mongodb.enableAuth) now uses the newer [mongosh](https://github.com/mongodb-js/mongosh) shell instead of the legacy shell to configure the initial superuser. You can configure the mongosh package to use through the [`services.mongodb.mongoshPackage`](#opt-services.mongodb.mongoshPackage) option.

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -50,10 +50,6 @@ let
     then realGrub.override { efiSupport = cfg.efiSupport; }
     else null;
 
-  bootPath = if cfg.mirroredBoots != [ ]
-    then (builtins.head cfg.mirroredBoots).path
-    else "/boot";
-
   f = x: optionalString (x != null) ("" + x);
 
   grubConfig = args:
@@ -759,16 +755,6 @@ in
       system.boot.loader.id = "grub";
 
       environment.systemPackages = mkIf (grub != null) [ grub ];
-
-      # Link /boot under /run/boot-loder-entries to make
-      # systemd happy even on non-EFI system
-      systemd.mounts = lib.optional (!cfg.efiSupport) {
-        what  = bootPath;
-        where = "/run/boot-loader-entries";
-        type  = "none";
-        options = "bind";
-        requiredBy = [ "local-fs.target" ];
-      };
 
       boot.loader.grub.extraPrepareConfig =
         concatStrings (mapAttrsToList (n: v: ''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -463,7 +463,7 @@ in {
   greetd-no-shadow = handleTest ./greetd-no-shadow.nix {};
   grocy = handleTest ./grocy.nix {};
   grow-partition = runTest ./grow-partition.nix;
-  grub = import ./grub.nix { inherit pkgs runTest; };
+  grub = handleTest ./grub.nix {};
   guacamole-server = handleTest ./guacamole-server.nix {};
   guix = handleTest ./guix {};
   gvisor = handleTest ./gvisor.nix {};

--- a/nixos/tests/grub.nix
+++ b/nixos/tests/grub.nix
@@ -1,123 +1,60 @@
-{ pkgs, runTest }:
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "grub";
 
-{
-  # Basic GRUB setup with BIOS and a password
-  basic = runTest {
-    name = "grub-basic";
-    meta.maintainers = with pkgs.lib.maintainers; [ rnhmjoj ];
-
-    nodes.machine = { ... }: {
-      virtualisation.useBootLoader = true;
-      boot.loader.timeout = null;
-      boot.loader.grub = {
-        enable = true;
-        users.alice.password = "supersecret";
-        # OCR is not accurate enough
-        extraConfig = "serial; terminal_output serial";
-      };
-    };
-
-    testScript = ''
-      def grub_login_as(user, password):
-          """
-          Enters user and password to log into GRUB
-          """
-          machine.wait_for_console_text("Enter username:")
-          machine.send_chars(user + "\n")
-          machine.wait_for_console_text("Enter password:")
-          machine.send_chars(password + "\n")
-
-
-      def grub_select_all_configurations():
-          """
-          Selects "All configurations" from the GRUB menu
-          to trigger a login request.
-          """
-          machine.send_monitor_command("sendkey down")
-          machine.send_monitor_command("sendkey ret")
-
-
-      machine.start()
-
-      # wait for grub screen
-      machine.wait_for_console_text("GNU GRUB")
-
-      grub_select_all_configurations()
-      with subtest("Invalid credentials are rejected"):
-          grub_login_as("wronguser", "wrongsecret")
-          machine.wait_for_console_text("error: access denied.")
-
-      grub_select_all_configurations()
-      with subtest("Valid credentials are accepted"):
-          grub_login_as("alice", "supersecret")
-          machine.send_chars("\n")  # press enter to boot
-          machine.wait_for_console_text("Linux version")
-
-      with subtest("Machine boots correctly"):
-          machine.wait_for_unit("multi-user.target")
-    '';
-    };
-
-  # Test boot loader entries on EFI
-  bls-efi = runTest {
-    name = "grub-bls-efi";
-    meta.maintainers = with pkgs.lib.maintainers; [ rnhmjoj ];
-
-    nodes.machine = { pkgs, ... }: {
-      virtualisation.useBootLoader = true;
-      virtualisation.useEFIBoot = true;
-      boot.loader.efi.canTouchEfiVariables = true;
-      boot.loader.grub.enable = true;
-      boot.loader.grub.efiSupport = true;
-    };
-
-    testScript = ''
-      with subtest("Machine boots correctly"):
-          machine.wait_for_unit("multi-user.target")
-
-      with subtest("Boot entries are installed"):
-          entries = machine.succeed("bootctl list")
-          print(entries)
-          error = "NixOS boot entry not found in bootctl list."
-          assert "version: Generation 1" in entries, error
-
-      with subtest("systemctl kexec can detect the kernel"):
-          machine.succeed("systemctl kexec --dry-run")
-
-      with subtest("systemctl kexec really works"):
-          machine.execute("systemctl kexec", check_return=False)
-          machine.connected = False
-          machine.connect()
-          machine.wait_for_unit("multi-user.target")
-    '';
+  meta = with lib.maintainers; {
+    maintainers = [ rnhmjoj ];
   };
 
-  # Test boot loader entries on BIOS
-  bls-bios = runTest {
-    name = "grub-bls-bios";
-    meta.maintainers = with pkgs.lib.maintainers; [ rnhmjoj ];
+  nodes.machine = { ... }: {
+    virtualisation.useBootLoader = true;
 
-    nodes.machine = { pkgs, ... }: {
-      virtualisation.useBootLoader = true;
-      boot.loader.grub.enable = true;
+    boot.loader.timeout = null;
+    boot.loader.grub = {
+      enable = true;
+      users.alice.password = "supersecret";
+
+      # OCR is not accurate enough
+      extraConfig = "serial; terminal_output serial";
     };
-
-    testScript = ''
-      with subtest("Machine boots correctly"):
-          machine.wait_for_unit("multi-user.target")
-
-      with subtest("Boot entries are installed"):
-          machine.succeed("test -f /boot/loader/entries/nixos-generation-1.conf")
-
-      with subtest("systemctl kexec can detect the kernel"):
-          machine.succeed("systemctl kexec --dry-run")
-
-      with subtest("systemctl kexec really works"):
-          machine.execute("systemctl kexec", check_return=False)
-          machine.connected = False
-          machine.connect()
-          machine.wait_for_unit("multi-user.target")
-    '';
   };
 
-}
+  testScript = ''
+    def grub_login_as(user, password):
+        """
+        Enters user and password to log into GRUB
+        """
+        machine.wait_for_console_text("Enter username:")
+        machine.send_chars(user + "\n")
+        machine.wait_for_console_text("Enter password:")
+        machine.send_chars(password + "\n")
+
+
+    def grub_select_all_configurations():
+        """
+        Selects "All configurations" from the GRUB menu
+        to trigger a login request.
+        """
+        machine.send_monitor_command("sendkey down")
+        machine.send_monitor_command("sendkey ret")
+
+
+    machine.start()
+
+    # wait for grub screen
+    machine.wait_for_console_text("GNU GRUB")
+
+    grub_select_all_configurations()
+    with subtest("Invalid credentials are rejected"):
+        grub_login_as("wronguser", "wrongsecret")
+        machine.wait_for_console_text("error: access denied.")
+
+    grub_select_all_configurations()
+    with subtest("Valid credentials are accepted"):
+        grub_login_as("alice", "supersecret")
+        machine.send_chars("\n")  # press enter to boot
+        machine.wait_for_console_text("Linux version")
+
+    with subtest("Machine boots correctly"):
+        machine.wait_for_unit("multi-user.target")
+  '';
+})

--- a/nixos/tests/nixos-rebuild-install-bootloader.nix
+++ b/nixos/tests/nixos-rebuild-install-bootloader.nix
@@ -71,8 +71,5 @@ import ./make-test-python.nix ({ pkgs, lib, withNg ? false, ... }: {
           # at this point we've tested regression #262724, but haven't tested the bootloader itself
           # TODO: figure out how to how to tell the test driver to start the bootloader instead of
           # booting into the kernel directly.
-
-      with subtest("New boot entry has been added"):
-          machine.succeed("test -f /boot/loader/entries/nixos-generation-2.conf")
     '';
 })


### PR DESCRIPTION
Reverts NixOS/nixpkgs#95901

See: https://github.com/NixOS/nixpkgs/pull/95901#issuecomment-2691206119

If this commit is in Hydra evals, they should be canceled so that no channel bumps contains it, ***as it can lead to breakage on user's systems***. [At the time of writing, it is not in any channel bump](https://nixpk.gs/pr-tracker.html?pr=95901).

Test available here, please cherry-pick into the fixing PR:

 - https://github.com/samueldr/nixpkgs/commit/47450fa49ec3e2ac9351788e4edf5921b3cd565b

cc @rnhmjoj

cc *”all grub maintainers”* `ENOTFOUND`

* * *

This new behaviour is breaking assumptions under the BLS:

> # The Boot Loader Specification
>
> This document defines a set of file formats and naming conventions that
> allow the boot loader menu entries to be shared **between multiple
> operating systems** and boot loaders installed on one device.

(Emphasis my own.)

The changes here are currently breaking multi-boot setups where a BLS-aware bootloader is handling some boot options, and a NixOS is booted with GRUB.

It will remove the whole `loader/entries` folder, which may have included entries from another operating system.

Note that this also differs in behaviour compared to:

 - [nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py](https://github.com/NixOS/nixpkgs/blob/5954d3359cc7178623da6c7fd23dc7f7504d7187/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix)

Not re-using the same generator for all BLS entries generation has led to accidentally having diverging implementations.

***Additionally***, this behaviour should be behind an option, so it can be disabled. It probably should be a default-false option, too. The added BLS entries will be shown in the BLS entries menu, which may not be desirable when specifically configuring NixOS for GRUB usage.