### PR TITLE
eliza: init at 0-unstable-2025-02-21

### DIFF
--- a/pkgs/by-name/el/eliza/package.nix
+++ b/pkgs/by-name/el/eliza/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  clang,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eliza";
+  version = "0-unstable-2025-02-21";
+  src = fetchFromGitHub {
+    owner = "anthay";
+    repo = "ELIZA";
+    rev = "27bcf6e5fb1d32812cc0aab8133fa5e395d41773";
+    hash = "sha256-/i8mckRQWTK1yI/MNaieSuE+dx94DMdrABkqf/bXQbM=";
+  };
+
+  nativeBuildInputs = [
+    clang
+  ];
+
+  doCheck = true;
+
+  # Unit tests are executed automatically on execution
+  checkPhase = ''
+    runHook preCheck
+    ./eliza --help
+    runHook postCheck
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    clang++ -std=c++20 -pedantic -o eliza ./src/eliza.cpp
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m555 ./eliza $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A Simulation in C++ of Joseph Weizenbaum’s 1966 ELIZA";
+    longDescription = ''
+      This is an implementation in C++ of ELIZA that attempts to be as close
+      to the original as possible.
+      It was made to closely follow Joseph Weizenbaum’s description of his program
+      given in his January 1966 Communications of the ACM paper, and later changed
+      to follow the ELIZA source code found on 2021 and the SLIP programming
+      function HASH(D,N) found on 2022.
+      It is controlled by a script identical to the one given in the appendix of
+      the 1966 paper.
+    '';
+    license = lib.licenses.cc0;
+    mainProgram = "eliza";
+    homepage = "https://github.com/anthay/ELIZA";
+    maintainers = with lib.maintainers; [ EmanuelM153 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This is an implementation in C++ of [ELIZA](https://en.wikipedia.org/wiki/ELIZA) that attempts to be as close to the original as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
