### PR TITLE
dedup-darwin: init at 0.0.6

### DIFF
--- a/pkgs/by-name/de/dedup-darwin/build-date-fix.patch
+++ b/pkgs/by-name/de/dedup-darwin/build-date-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index c9c56ec..75654f7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,7 @@ CFLAGS += \
+     -mtune=generic \
+     -O \
+     '-DVERSION="$(VERSION)"' \
+-    '-DBUILD_DATE="$(shell date '+%Y%m%d')"'
++    '-DBUILD_DATE="19700101"'
+ 
+ ENTITLEMENT_FLAGS =
+ 

--- a/pkgs/by-name/de/dedup-darwin/no-codesign.patch
+++ b/pkgs/by-name/de/dedup-darwin/no-codesign.patch
@@ -1,0 +1,18 @@
+Entitlements & code signature are only needed 
+for ASAN and other debugging tools.
+See official README for more details.
+
+diff --git a/Makefile b/Makefile
+index c9c56ec..36b81e0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -63,9 +63,6 @@ dedup.x86_64: CFLAGS += -target x86_64-apple-macos11
+ 
+ dedup dedup.arm dedup.x86_64: $(OBJECTS)
+ 	$(CC) $(CFLAGS) -o $@ $^
+-	mv $@ $@.unsigned
+-	codesign -s - -v -f $(ENTITLEMENT_FLAGS) $@.unsigned
+-	mv $@.unsigned $@
+ 
+ dedup.universal:
+ 	rm -f *.o

--- a/pkgs/by-name/de/dedup-darwin/package.nix
+++ b/pkgs/by-name/de/dedup-darwin/package.nix
@@ -1,0 +1,42 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dedup-darwin";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    owner = "ttkb-oss";
+    repo = "dedup";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-/qVrZVSVJPANMuKphbekB4p4ehjrOg6097yvjdIdl7I=";
+  };
+
+  patches = [
+    ./build-date-fix.patch
+    ./no-codesign.patch
+  ];
+
+  postPatch = ''
+    # Fix the prefix
+    substituteInPlace Makefile --replace-fail \
+      "PREFIX ?= /usr/local" "PREFIX ?= ${placeholder "out"}"
+  '';
+
+  preInstall = ''
+    # Install complains of missing directories, hence this fix.
+    mkdir -p $out/{bin,share/man/man1}
+  '';
+
+  meta = {
+    description = "Darwin utility to replace duplicate file data with a copy-on-write clone";
+    homepage = "https://github.com/ttkb-oss/dedup";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.matteopacini ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "dedup";
+  };
+})


### PR DESCRIPTION
Adds a new package, `dedup`, a duplicate data handler tool for Darwin only.

I chose the name `dedup-darwin` because of the high number of packages named (or containing the word) "dedup":
https://search.nixos.org/packages?type=packages&query=dedup 

Fixes #385229.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
