### PR TITLE
nixos/users-groups: Enforce ASCII usernames and fix repeated doubling of activation script runtime

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -376,4 +376,4 @@ foreach my $u (values %usersOut) {
 
 updateFile("/etc/subuid", join("\n", @subUids) . "\n");
 updateFile("/etc/subgid", join("\n", @subGids) . "\n");
-updateFile($subUidMapFile, encode_json($subUidMap) . "\n");
+updateFile($subUidMapFile, to_json($subUidMap) . "\n");

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -931,6 +931,21 @@ in {
       }
     ] ++ flatten (flip mapAttrsToList cfg.users (name: user:
       [
+        (
+          let
+            # Things fail in various ways with especially non-ascii usernames.
+            # This regex mirrors the one from shadow's is_valid_name:
+            # https://github.com/shadow-maint/shadow/blob/bee77ffc291dfed2a133496db465eaa55e2b0fec/lib/chkname.c#L68
+            # though without the trailing $, because Samba 3 got its last release
+            # over 10 years ago and is not in Nixpkgs anymore,
+            # while later versions don't appear to require anything like that.
+            nameRegex = "[a-zA-Z0-9_.][a-zA-Z0-9_.-]*";
+          in
+          {
+            assertion = builtins.match nameRegex user.name != null;
+            message = "The username \"${user.name}\" is not valid, it does not match the regex \"${nameRegex}\".";
+          }
+        )
         {
         assertion = (user.hashedPassword != null)
         -> (match ".*:.*" user.hashedPassword == null);


### PR DESCRIPTION
I unsuccessfully tried to specify a non-ascii username, all kinds of things broke, so I undid that. Only a bit later I'm running into a very weird problem: The NixOS activation script is taking ~twice as long to finish every time its run, now up to ~10 minutes!

After debugging, I figured out that it's taking so long to decode the `/var/lib/nixos/auto-subuid-map`, which has grown to 24MB! Turns out, the users-groups script has been _doubly-encoding_ that file as UTF-8, while only singly-decoding it. While this works fine if it's just ASCII, this leads to an exponential explosion for anything else. Here's a demo of this:

```perl
#!/usr/bin/env perl

use utf8;
use File::Slurp;
use JSON;

my $file = "/tmp/perl-encoding-test";
my $content = "猫\n";

sub run {
    print $content;
    # Both write_file and encode_json take care of encoding to UTF-8,
    # so this doubly-encodes as UTF-8!
    # Should be without the binmode, or to_json alternatively
    write_file($file, { binmode => ':utf8' }, encode_json($content));
    $content = decode_json(read_file($file));
}

run();
run();
run();
run();
```

```
$ nix-shell -p 'perl.withPackages (p: [ p.FileSlurp p.JSON ])' --run 'perl -CS ./test.pl'
猫
ç«
Ã§ÂÂ«
ÃÂ§ÃÂÃÂ«
```

In addition to avoiding this double encoding, this PR also adds an assertion to ensure that `users.users.*.name` only matches what [shadow considers valid](https://github.com/shadow-maint/shadow/blob/bee77ffc291dfed2a133496db465eaa55e2b0fec/lib/chkname.c#L68), to save the trouble of users running into other issues with weird usernames.

Note that Ubuntu by default limits usernames to the more strict `[a-z][-a-z0-9_]*`, but that would break some configs.[^1]

[^1]: [1](https://github.com/tolgaerok/nixos-kde/blob/aabf266efb4a7671e94384b72ceb9a0c491ee573/user/SOS/SOS.nix#L40) [2](https://github.com/Pablo1107/dotfiles/blob/7b997eb555421799d30e173e0f4311a9c6e90b8a/hosts/darwin/nix-darwin.nix#L36) [3](https://github.com/mightyiam/infra/blob/93b57e3cfa767154151f579756adacde3e50e5f8/nixos-modules/bow.nix#L3)

Ping @adisbladis who originally [introduced](https://github.com/NixOS/nixpkgs/pull/86278) the code and @Mic92 who did some [other UTF-8 fixes](https://github.com/NixOS/nixpkgs/pull/98544) in the script.

## Things done

- [x] Ran the patched activation script on my system and checked that non-ascii characters in `/var/lib/nixos/auto-subuid-map` don't get elongated anymore.
- [x] Set `users.users."猫"` and ensured that an assertion is thrown:
  ```
  Failed assertions:
  - The username "猫" is not valid, it does not match the regex "[a-zA-Z0-9_.][a-zA-Z0-9_.-]*".
  ```

---

This work is funded by [Antithesis](https://antithesis.com/) and [Tweag](https://tweag.io) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
