### PR TITLE
Add gcc-arm-embedded-14

### DIFF
--- a/pkgs/by-name/gc/gcc-arm-embedded-14/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-14/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses6,
+  libxcrypt-legacy,
+  runtimeShell,
+  zstd,
+  xz,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-arm-embedded";
+  version = "14.2.rel1";
+
+  platform =
+    {
+      aarch64-darwin = "darwin-arm64";
+      aarch64-linux = "aarch64";
+      x86_64-darwin = "darwin-x86_64";
+      x86_64-linux = "x86_64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
+    # hashes obtained from location ${url}.sha256asc
+    sha256 =
+      {
+        aarch64-darwin = "c7c78ffab9bebfce91d99d3c24da6bf4b81c01e16cf551eb2ff9f25b9e0a3818";
+        aarch64-linux = "87330bab085dd8749d4ed0ad633674b9dc48b237b61069e3b481abd364d0a684";
+        x86_64-darwin = "2d9e717dd4f7751d18936ae1365d25916534105ebcb7583039eff1092b824505";
+        x86_64-linux = "62a63b981fe391a9cbad7ef51b17e49aeaa3e7b0d029b36ca1e9c3b2a9b78823";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+    # these binaries require ancient Python 3.8 not available in Nixpkgs
+    rm $out/bin/{arm-none-eabi-gdb-py,arm-none-eabi-gdb-add-index-py} || :
+  '';
+
+  preFixup = lib.optionalString stdenv.isLinux ''
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${
+        lib.makeLibraryPath [
+          "$out"
+          stdenv.cc.cc
+          ncurses6
+          libxcrypt-legacy
+          zstd
+          xz
+        ]
+      } "$f" || true
+    done
+  '';
+
+  meta = with lib; {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";
+    homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
+    license = with licenses; [
+      bsd2
+      gpl2
+      gpl3
+      lgpl21
+      lgpl3
+      mit
+    ];
+    maintainers = with maintainers; [
+      prusnak
+      prtzl
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Add newest arm-none-eabi version 14.2.rel1.

## Things done

The python wrapping of `arm-none-eabi-gdb` is now removed since the executable seems to work without it.

Issues with versions 11 to 13 regarding absence of python version 3.8 (seemingly only compatible version with gdb implementation) should be solved by switching to this (currently latest) version. (https://github.com/NixOS/nixpkgs/issues/303651)

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
