### PR TITLE
testers.shfmt: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -165,6 +165,64 @@ testers.shellcheck {
 A derivation that runs `shellcheck` on the given script(s).
 The build will fail if `shellcheck` finds any issues.
 
+## `shfmt` {#tester-shfmt}
+
+Run files through `shfmt`, a shell script formatter, failing if any files are reformatted.
+
+:::{.example #ex-shfmt}
+# Run `testers.shfmt`
+
+A single script
+
+```nix
+testers.shfmt {
+  name = "script";
+  src = ./script.sh;
+}
+```
+
+Multiple files
+
+```nix
+let
+  inherit (lib) fileset;
+in
+testers.shfmt {
+  name = "nixbsd";
+  src = fileset.toSource {
+    root = ./.;
+    fileset = fileset.unions [
+      ./lib.sh
+      ./nixbsd-activate
+    ];
+  };
+}
+```
+
+:::
+
+### Inputs {#tester-shfmt-inputs}
+
+`name` (string)
+: The name of the test.
+  `name` is required because it massively improves traceability of test failures.
+  The name of the derivation produced by the tester is `shfmt-${name}`.
+
+`src` (path-like)
+: The path to the shell script(s) to check.
+  This can be a single file or a directory containing shell files.
+  All files in `src` will be checked, so you may want to provide `fileset`-based source instead of a whole directory.
+
+`indent` (integer, optional)
+: The number of spaces to use for indentation.
+  Defaults to `2`.
+  A value of `0` indents with tabs.
+
+### Return value {#tester-shfmt-return}
+
+A derivation that runs `shfmt` on the given script(s), producing an empty output upon success.
+The build will fail if `shfmt` reformats anything.
+
 ## `testVersion` {#tester-testVersion}
 
 Checks that the output from running a command contains the specified version string in it as a whole word.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -8,6 +8,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-shfmt": [
+    "index.html#ex-shfmt"
+  ],
   "ex-testBuildFailurePrime-doc-example": [
     "index.html#ex-testBuildFailurePrime-doc-example"
   ],
@@ -334,6 +337,15 @@
   ],
   "footnote-stdenv-find-inputs-location.__back.0": [
     "index.html#footnote-stdenv-find-inputs-location.__back.0"
+  ],
+  "tester-shfmt": [
+    "index.html#tester-shfmt"
+  ],
+  "tester-shfmt-inputs": [
+    "index.html#tester-shfmt-inputs"
+  ],
+  "tester-shfmt-return": [
+    "index.html#tester-shfmt-return"
   ],
   "tester-testBuildFailurePrime": [
     "index.html#tester-testBuildFailurePrime"

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -190,4 +190,6 @@
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
 
   shellcheck = callPackage ./shellcheck/tester.nix { };
+
+  shfmt = callPackage ./shfmt { };
 }

--- a/pkgs/build-support/testers/shfmt/default.nix
+++ b/pkgs/build-support/testers/shfmt/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  shfmt,
+  stdenvNoCC,
+}:
+# See https://nixos.org/manual/nixpkgs/unstable/#tester-shfmt
+# or doc/build-helpers/testers.chapter.md
+{
+  name,
+  src,
+  indent ? 2,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+  inherit src indent;
+  name = "shfmt-${name}";
+  dontUnpack = true; # Unpack phase tries to extract archive
+  nativeBuildInputs = [ shfmt ];
+  doCheck = true;
+  dontConfigure = true;
+  dontBuild = true;
+  checkPhase = ''
+    shfmt --diff --indent $indent --simplify "$src"
+  '';
+  installPhase = ''
+    touch "$out"
+  '';
+})

--- a/pkgs/build-support/testers/shfmt/src/indent2.sh
+++ b/pkgs/build-support/testers/shfmt/src/indent2.sh
@@ -1,0 +1,3 @@
+hello() {
+  echo "hello"
+}

--- a/pkgs/build-support/testers/shfmt/tests.nix
+++ b/pkgs/build-support/testers/shfmt/tests.nix
@@ -1,0 +1,43 @@
+{ lib, testers }:
+lib.recurseIntoAttrs {
+  # Positive tests
+  indent2 = testers.shfmt {
+    name = "indent2";
+    indent = 2;
+    src = ./src/indent2.sh;
+  };
+  indent2Bin = testers.shfmt {
+    name = "indent2Bin";
+    indent = 2;
+    src = ./src;
+  };
+  # Negative tests
+  indent2With0 = testers.testBuildFailure' {
+    drv = testers.shfmt {
+      name = "indent2";
+      indent = 0;
+      src = ./src/indent2.sh;
+    };
+  };
+  indent2BinWith0 = testers.testBuildFailure' {
+    drv = testers.shfmt {
+      name = "indent2Bin";
+      indent = 0;
+      src = ./src;
+    };
+  };
+  indent2With4 = testers.testBuildFailure' {
+    drv = testers.shfmt {
+      name = "indent2";
+      indent = 4;
+      src = ./src/indent2.sh;
+    };
+  };
+  indent2BinWith4 = testers.testBuildFailure' {
+    drv = testers.shfmt {
+      name = "indent2Bin";
+      indent = 4;
+      src = ./src;
+    };
+  };
+}

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -39,6 +39,8 @@ lib.recurseIntoAttrs {
 
   shellcheck = pkgs.callPackage ../shellcheck/tests.nix { };
 
+  shfmt = pkgs.callPackages ../shfmt/tests.nix { };
+
   runCommand = lib.recurseIntoAttrs {
     bork = pkgs.python3Packages.bork.tests.pytest-network;
 


### PR DESCRIPTION
Adds `testers.shfmt`, much like `testers.shellcheck`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
