### PR TITLE
testers.shellcheck: refactor, update docs, and simplify tests

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -118,7 +118,7 @@ It has two modes:
 
 ## `shellcheck` {#tester-shellcheck}
 
-Runs files through `shellcheck`, a static analysis tool for shell scripts.
+Run files through `shellcheck`, a static analysis tool for shell scripts, failing if there are any issues.
 
 :::{.example #ex-shellcheck}
 # Run `testers.shellcheck`
@@ -127,7 +127,7 @@ A single script
 
 ```nix
 testers.shellcheck {
-  name = "shellcheck";
+  name = "script";
   src = ./script.sh;
 }
 ```
@@ -139,7 +139,7 @@ let
   inherit (lib) fileset;
 in
 testers.shellcheck {
-  name = "shellcheck";
+  name = "nixbsd-activate";
   src = fileset.toSource {
     root = ./.;
     fileset = fileset.unions [
@@ -154,15 +154,20 @@ testers.shellcheck {
 
 ### Inputs {#tester-shellcheck-inputs}
 
-[`src` (path or string)]{#tester-shellcheck-param-src}
+`name` (string, optional)
+: The name of the test.
+  `name` will be required at a future point because it massively improves traceability of test failures, but is kept optional for now to avoid breaking existing usages.
+  Defaults to `run-shellcheck`.
+  The name of the derivation produced by the tester is `shellcheck-${name}` when `name` is supplied.
 
+`src` (path-like)
 : The path to the shell script(s) to check.
   This can be a single file or a directory containing shell files.
   All files in `src` will be checked, so you may want to provide `fileset`-based source instead of a whole directory.
 
 ### Return value {#tester-shellcheck-return}
 
-A derivation that runs `shellcheck` on the given script(s).
+A derivation that runs `shellcheck` on the given script(s), producing an empty output if no issues are found.
 The build will fail if `shellcheck` finds any issues.
 
 ## `testVersion` {#tester-testVersion}

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1533,9 +1533,6 @@
   "tester-shellcheck-inputs": [
     "index.html#tester-shellcheck-inputs"
   ],
-  "tester-shellcheck-param-src": [
-    "index.html#tester-shellcheck-param-src"
-  ],
   "tester-shellcheck-return": [
     "index.html#tester-shellcheck-return"
   ],

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -11,6 +11,9 @@
 - The hand written `perlPackages.SearchXapian` bindings have been dropped in favor of the (mostly compatible)
   `perlPackages.Xapian`.
 
+- [testers.shellcheck](https://nixos.org/manual/nixpkgs/unstable/#tester-shellcheck) now warns when `name` is not provided.
+  The `name` argument will become mandatory in a future release.
+
 - The `nixLog*` family of functions made available through the standard environment have been rewritten to prefix messages with both the debug level and the function name of the caller.
   The `nixLog` function, which logs unconditionally, was also re-introduced and modified to prefix messages with the function name of the caller.
   For more information, [see this PR](https://github.com/NixOS/nixpkgs/pull/370742).

--- a/nixos/modules/config/nix-channel/test.nix
+++ b/nixos/modules/config/nix-channel/test.nix
@@ -5,6 +5,7 @@ let
   inherit (lib) fileset;
 
   runShellcheck = testers.shellcheck {
+    name = "activation-check";
     src = fileset.toSource {
       root = ./.;
       fileset = fileset.unions [

--- a/nixos/modules/system/activation/lib/test.nix
+++ b/nixos/modules/system/activation/lib/test.nix
@@ -31,6 +31,7 @@ let
   };
 
   runShellcheck = testers.shellcheck {
+    name = "activation-lib";
     src = runTests.src;
   };
 

--- a/pkgs/build-support/testers/shellcheck/tester.nix
+++ b/pkgs/build-support/testers/shellcheck/tester.nix
@@ -1,39 +1,35 @@
 # Dependencies (callPackage)
 {
   lib,
-  stdenv,
-  runCommand,
+  stdenvNoCC,
   shellcheck,
 }:
 
 # testers.shellcheck function
 # Docs: doc/build-helpers/testers.chapter.md
 # Tests: ./tests.nix
-{ src }:
-let
-  inherit (lib) pathType isPath;
-in
-stdenv.mkDerivation {
-  name = "run-shellcheck";
-  src =
-    if
-      isPath src && pathType src == "regular" # note that for strings this would have been IFD, which we prefer to avoid
-    then
-      runCommand "testers-shellcheck-src" { } ''
-        mkdir $out
-        cp ${src} $out
-      ''
+{
+  name ? null,
+  src,
+}:
+stdenvNoCC.mkDerivation {
+  __structuredAttrs = true;
+  strictDeps = true;
+  name =
+    if name == null then
+      lib.warn "testers.shellcheck: name will be required in a future release, defaulting to run-shellcheck" "run-shellcheck"
     else
-      src;
+      "shellcheck-${name}";
+  inherit src;
+  dontUnpack = true; # Unpack phase tries to extract an archive, which we don't want to do with source trees
   nativeBuildInputs = [ shellcheck ];
   doCheck = true;
   dontConfigure = true;
   dontBuild = true;
   checkPhase = ''
-    find . -type f -print0 \
-      | xargs -0 shellcheck
+    find "$src" -type f -print0 | xargs -0 shellcheck
   '';
   installPhase = ''
-    touch $out
+    touch "$out"
   '';
 }

--- a/pkgs/build-support/testers/shellcheck/tests.nix
+++ b/pkgs/build-support/testers/shellcheck/tests.nix
@@ -13,6 +13,7 @@ lib.recurseIntoAttrs {
       {
         failure = testers.testBuildFailure (
           testers.shellcheck {
+            name = "shellcheck-example-dir";
             src = ./src;
           }
         );
@@ -29,6 +30,7 @@ lib.recurseIntoAttrs {
       {
         failure = testers.testBuildFailure (
           testers.shellcheck {
+            name = "shellcheck-example-file";
             src = ./src/example.sh;
           }
         );

--- a/pkgs/build-support/testers/shellcheck/tests.nix
+++ b/pkgs/build-support/testers/shellcheck/tests.nix
@@ -4,41 +4,33 @@
 {
   lib,
   testers,
-  runCommand,
 }:
 lib.recurseIntoAttrs {
-
-  example-dir =
-    runCommand "test-testers-shellcheck-example-dir"
-      {
-        failure = testers.testBuildFailure (
-          testers.shellcheck {
-            name = "shellcheck-example-dir";
-            src = ./src;
-          }
-        );
-      }
+  example-dir = testers.testBuildFailure' {
+    drv = testers.shellcheck {
+      name = "example-dir";
+      src = ./src;
+    };
+    expectedBuilderExitCode = 123;
+    expectedBuilderLogEntries = [
       ''
-        log="$failure/testBuildFailure.log"
-        echo "Checking $log"
-        grep SC2068 "$log"
-        touch $out
-      '';
-
-  example-file =
-    runCommand "test-testers-shellcheck-example-file"
-      {
-        failure = testers.testBuildFailure (
-          testers.shellcheck {
-            name = "shellcheck-example-file";
-            src = ./src/example.sh;
-          }
-        );
-      }
+        echo $@
+             ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.
       ''
-        log="$failure/testBuildFailure.log"
-        echo "Checking $log"
-        grep SC2068 "$log"
-        touch $out
-      '';
+    ];
+  };
+
+  example-file = testers.testBuildFailure' {
+    drv = testers.shellcheck {
+      name = "example-file";
+      src = ./src/example.sh;
+    };
+    expectedBuilderExitCode = 123;
+    expectedBuilderLogEntries = [
+      ''
+        echo $@
+             ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.
+      ''
+    ];
+  };
 }


### PR DESCRIPTION
- refactors `testers.shellcheck` to be more inline with the interface provided by `testers.shfmt` in #385939
- switches to `testers.testBuildFailure'`
- setting `dontUnpack = true` fixed an issue I was seeing in https://github.com/connorbaker/cuda-packages where providing a single in-tree file would cause the tester to use the default unpack phase and fail to extract an archive from a shell script

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
