### PR TITLE
windsurf: 1.3.9 -> 1.3.10

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.3.9",
+    "version": "1.3.10",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/43976ecab7354ba352849517e15779fe8a4eff88/Windsurf-darwin-arm64-1.3.9.zip",
-    "sha256": "1f6c3b1f1fd1a634ad90b523a892989fe18b1b95aa7cea074070bff4b792c2e5"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/61d65579650f356494469f86c21fb953834289a0/Windsurf-darwin-arm64-1.3.10.zip",
+    "sha256": "d4308fef263dddb8ae931b5ed6a5c86da9650e63d9043153833082e3180823c5"
   },
   "x86_64-darwin": {
-    "version": "1.3.9",
+    "version": "1.3.10",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/43976ecab7354ba352849517e15779fe8a4eff88/Windsurf-darwin-x64-1.3.9.zip",
-    "sha256": "3388e05e2cf3835fe2a1c9442cb2cf7fa5c6abdbc4e36af9af56fa8a64132364"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/61d65579650f356494469f86c21fb953834289a0/Windsurf-darwin-x64-1.3.10.zip",
+    "sha256": "dee42a845ecd7b97c77daba109d5dd2392a28686fb75c63ea50f519b2a8b4da0"
   },
   "x86_64-linux": {
-    "version": "1.3.9",
+    "version": "1.3.10",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/43976ecab7354ba352849517e15779fe8a4eff88/Windsurf-linux-x64-1.3.9.tar.gz",
-    "sha256": "0228099a39128cb21b1cd87516d74ac1bfaa1dd801f47feb3a67b1dbef7365c7"
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/61d65579650f356494469f86c21fb953834289a0/Windsurf-linux-x64-1.3.10.tar.gz",
+    "sha256": "9a98223f0629b0e0219d82902b8c38d18dd08dd8b6700d2739419a385344d17f"
   }
 }


### PR DESCRIPTION
v. 1.3.10
February 28, 2025

**Patch Fixes**
* Improvements for Cascade credit usage for Claude 3.7 Sonnet
  * Once updating, try running Cascade in a new conversation with Claude 3.7 Sonnet
* Fixes for some App Icon issues for Mac users
* Option for Cascade to view / edit .gitignored files

P.S. Apologies to @SuperSandro2000 for two of these in short succession. As always, you took care of 1.3.9 efficiently just as I was trying to merge in today's update. 
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
