### PR TITLE
{makeSetupHook',sourceGuard}: init

### DIFF
--- a/doc/build-helpers/special.md
+++ b/doc/build-helpers/special.md
@@ -6,6 +6,7 @@ This chapter describes several special build helpers.
 special/fakenss.section.md
 special/fhs-environments.section.md
 special/makesetuphook.section.md
+special/makeSetupHookPrime.section.md
 special/mkshell.section.md
 special/vm-tools.section.md
 special/checkpoint-build.section.md

--- a/doc/build-helpers/special/makeSetupHookPrime.section.md
+++ b/doc/build-helpers/special/makeSetupHookPrime.section.md
@@ -1,0 +1,91 @@
+# makeSetupHook' {#build-helpers-special-makeSetupHookPrime}
+
+`makeSetupHook'` is a build helper which produces hooks which may be added to a derivation's `nativeBuildInputs`.
+
+This helper differs from `makeSetupHook`[#sec-pkgs.makesetuphook] in several ways:
+
+- it uses `pkgs.replaceVars` instead of the bash function `substituteAll`
+- it uses `sourceGuard`[#setup-hook-sourceGuard] to source the script
+- `strictDeps` is set to `true`
+- script dependencies are provided using the `nativeBuildInputs` and `buildInputs` arguments rather than `propagatedBuildInputs` and `depsTargetTargetPropagated`
+- the script argument must be a path and is interpolated into a string, causing Nix to create a store path for only it, enforcing isolation
+
+
+:::{.example #ex-makeSetupHookPrime-doc-example}
+
+# Usage example of makeSetupHook'
+
+Re-using the example from [`makeSetupHook`](#sec-pkgs.makeSetupHook-usage-example):
+
+```nix
+pkgs.makeSetupHook' {
+  name = "run-hello-hook";
+  guardName = "runHelloHook";
+  script = writeScript "run-hello-hook.sh" ''
+    #!@shell@
+    # the direct path to the executable has to be here because
+    # this will be run when the file is sourced
+    # at which point '$PATH' has not yet been populated with inputs
+    @cowsay@ cow
+
+    _printHelloHook() {
+      hello
+    }
+    preConfigureHooks+=(_printHelloHook)
+  '';
+  nativeBuildInputs = [
+    pkgs.cowsay
+    pkgs.hello
+  ];
+  replacements = {
+    cowsay = lib.getExe pkgs.cowsay;
+    shell = lib.getExe pkgs.bash;
+  };
+}
+```
+
+Note that we must specify `guardName`, since `name` is not a valid bash identifier.
+
+:::
+
+## Inputs {#build-helpers-special-makeSetupHookPrime-inputs}
+
+`name` (string)
+
+: The name of the hook.
+
+`guardName` (string, optional)
+
+: The name of the guard.
+  `guardName` must be a valid bash identifier.
+  When `useSourceGuard` is enabled, `guardName` defaults to the value of `name`.
+
+`script` (path-like)
+
+: The derivation or store path to make into a hook.
+  The script path is interpolated into a string, causing Nix to create a store path for only it, enforcing isolation.
+  Values in the script may be replaced using the `replacements` argument.
+
+`nativeBuildInputs` (array of path-like values, optional)
+: A list of derivations or store paths which should be added to the `nativeBuildInputs` of derivations which include this hook in their `nativeBuildInputs`.
+  When not provided, this value defaults to `[ ]`.
+
+`buildInputs` (array of path-like values, optional)
+: A list of derivations or store paths which should be added to the `buildInputs` of derivations which include this hook in their `nativeBuildInputs`.
+  When not provided, this value defaults to `[ ]`.
+
+`useSourceGuard` (boolean, optional)
+: Whether to use `sourceGuard`[#setup-hook-sourceGuard] to source the hook.
+  When not provided, this value defaults to `true`.
+
+`replacements` (attribute set of string-like values, optional)
+: A map of string-like values which are used to replace variables in `script`.
+  When not provided, this value defaults to `{ }`.
+
+`passthru` (attribute set, optional)
+: A map of values which are passed to the `passthru` attribute of the hook derivation.
+  When not provided, this value defaults to `{ }`.
+
+`meta` (attribute set, optional)
+: A map of values which are passed to the `meta` attribute of the hook derivation.
+  When not provided, this value defaults to `{ }`.

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -32,6 +32,7 @@ postgresql-test-hook.section.md
 premake.section.md
 python.section.md
 scons.section.md
+sourceGuard.section.md
 tauri.section.md
 tetex-tex-live.section.md
 unzip.section.md

--- a/doc/hooks/sourceGuard.section.md
+++ b/doc/hooks/sourceGuard.section.md
@@ -1,0 +1,8 @@
+# sourceGuard {#setup-hook-sourceGuard}
+
+This hook provides the `sourceGuard` bash function.
+
+Using `sourceGuard` to source scripts ensures two things:
+
+- the script is only sourced if it is a build-time dependency (which is to say it has a `hostOffset` of `-1`)
+- the script is only sourced once, even if `sourceGuard` is called multiple times

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1,4 +1,10 @@
 {
+  "build-helpers-special-makeSetupHookPrime": [
+    "index.html#build-helpers-special-makeSetupHookPrime"
+  ],
+  "build-helpers-special-makeSetupHookPrime-inputs": [
+    "index.html#build-helpers-special-makeSetupHookPrime-inputs"
+  ],
   "chap-build-helpers-finalAttrs": [
     "index.html#chap-build-helpers-finalAttrs"
   ],
@@ -10,6 +16,9 @@
   ],
   "ex-shfmt": [
     "index.html#ex-shfmt"
+  ],
+  "ex-makeSetupHookPrime-doc-example": [
+    "index.html#ex-makeSetupHookPrime-doc-example"
   ],
   "ex-testBuildFailurePrime-doc-example": [
     "index.html#ex-testBuildFailurePrime-doc-example"
@@ -349,6 +358,9 @@
   ],
   "ssec-cosmic-settings-fallback": [
     "index.html#ssec-cosmic-settings-fallback"
+  ],
+  "setup-hook-sourceGuard": [
+    "index.html#setup-hook-sourceGuard"
   ],
   "ssec-stdenv-dependencies": [
     "index.html#ssec-stdenv-dependencies"

--- a/pkgs/by-name/so/sourceGuard/package.nix
+++ b/pkgs/by-name/so/sourceGuard/package.nix
@@ -1,0 +1,17 @@
+# Docs in doc/hooks/sourceGuard.section.md
+# See https://nixos.org/manual/nixpkgs/unstable/#setup-hook-sourceGuard
+{
+  callPackages,
+  lib,
+  makeSetupHook',
+}:
+makeSetupHook' {
+  name = "source-guard";
+  script = ./source-guard.bash;
+  useSourceGuard = false; # Avoid self-reference
+  passthru.tests = callPackages ./tests.nix { };
+  meta = {
+    description = "Ensure files are sourced at most once and are build-time dependencies";
+    maintainers = [ lib.maintainers.connorbaker ];
+  };
+}

--- a/pkgs/by-name/so/sourceGuard/source-guard.bash
+++ b/pkgs/by-name/so/sourceGuard/source-guard.bash
@@ -1,0 +1,151 @@
+# shellcheck shell=bash
+
+# Early return without logging attempting to source this file if we've already sourced it because this
+# script is used in a number of places and we don't want to spam the log.
+((${sourceGuardSourced:-0} == 1)) && return 0
+
+# sourceGuardArgumentCheck checks the arguments accepted by the sourceGuard family of functions.
+sourceGuardArgumentCheck() {
+  local -ir numArgsExpected=$1
+  shift
+  if ((numArgsExpected < 1 || 2 < numArgsExpected)); then
+    nixErrorLog "numArgsExpected must be 1 or 2, but got $numArgsExpected"
+    exit 1
+  fi
+
+  if (($# != numArgsExpected)); then
+    nixErrorLog "${FUNCNAME[1]} expected $numArgsExpected arguments, but got $#!"
+    if ((numArgsExpected == 1)); then
+      nixErrorLog "usage: ${FUNCNAME[1]} guardName"
+    elif ((numArgsExpected == 2)); then
+      nixErrorLog "usage: ${FUNCNAME[1]} guardName script"
+    fi
+    exit 1
+  fi
+
+  local -r guardName="$1"
+  if [[ -z $guardName ]]; then
+    nixErrorLog "${FUNCNAME[1]}: guardName argument for script $script must not be empty"
+    exit 1
+  fi
+  ((numArgsExpected == 1)) && return 0
+
+  local -r script="$2"
+  if [[ ! -f $script || ! -r $script ]]; then
+    nixErrorLog "${FUNCNAME[1]}: guardName $guardName supplied script $script which is not a readable file"
+    exit 1
+  fi
+
+  return 0
+}
+
+# Returns zero if the guard has been sourced, one otherwise.
+sourceGuardHasSourced() {
+  sourceGuardArgumentCheck 1 "$@"
+  local -r guardName="$1"
+  local -nr guardNameSourcedRef="${guardName}Sourced"
+  return $((1 - ${guardNameSourcedRef:-0}))
+}
+
+# sourceGuardPrintCurrent prints the current guard name and script.
+sourceGuardPrintCurrent() {
+  sourceGuardArgumentCheck 2 "$@"
+  local -r guardName="$1"
+  local -r script="$2"
+  echo -n \
+    "guardName=$guardName" \
+    "script=$script" \
+    "hostOffset=${hostOffset:-0}" \
+    "targetOffset=${targetOffset:-0}"
+  return 0
+}
+
+# sourceGuardPrintSourced prints the sourced guard name and script.
+# It is an error to call this function if the script has not been sourced.
+sourceGuardPrintSourced() {
+  sourceGuardArgumentCheck 1 "$@"
+  local -r guardName="$1"
+  local -nr guardNameSourcedRef="${guardName}Sourced"
+
+  if ((${guardNameSourcedRef:-0} == 0)); then
+    nixErrorLog "guardName $guardName has not been sourced"
+    exit 1
+  fi
+
+  local -nr guardNameSourcedScriptRef="${!guardNameSourcedRef}Script"
+  local -nr guardNameSourcedHostOffsetRef="${!guardNameSourcedRef}HostOffset"
+  local -nr guardNameSourcedTargetOffsetRef="${!guardNameSourcedRef}TargetOffset"
+
+  echo -n \
+    "guardName=$guardName" \
+    "script=${guardNameSourcedScriptRef:?}" \
+    "hostOffset=${guardNameSourcedHostOffsetRef:?}" \
+    "targetOffset=${guardNameSourcedTargetOffsetRef:?}"
+
+  return 0
+}
+
+# sourceGuardSetSourced sets the sourced guard name and script.
+# It is an error to call this function if the script has already been sourced.
+sourceGuardSetSourced() {
+  sourceGuardArgumentCheck 2 "$@"
+  local -r guardName="$1"
+  local -r script="$2"
+
+  if sourceGuardHasSourced "$guardName"; then
+    nixErrorLog "guardName $guardName has already been sourced"
+    exit 1
+  fi
+
+  declare -gir "${guardName}Sourced"=1
+  declare -gr "${guardName}SourcedScript"="$script"
+  declare -gir "${guardName}SourcedHostOffset"="${hostOffset:-0}"
+  declare -gir "${guardName}SourcedTargetOffset"="${targetOffset:-0}"
+
+  return 0
+}
+
+# sourceGuard ensures:
+#
+# - the script is sourced at most once per build
+# - the script must be in a dependency array such that the script is a build-time dependency
+# - the script exists and is readable
+sourceGuard() {
+  sourceGuardArgumentCheck 2 "$@"
+  local -r guardName="$1"
+  local -r script="$2"
+
+  # Check if we have already sourced the script
+  if sourceGuardHasSourced "$guardName"; then
+    nixInfoLog "skipping sourcing $(sourceGuardPrintCurrent "$guardName" "$script")" \
+      "because we have already sourced $(sourceGuardPrintSourced "$guardName")"
+  elif [[ -n ${strictDeps:-} && ${hostOffset:?} -ge 0 ]]; then
+    nixInfoLog "skipping sourcing $(sourceGuardPrintCurrent "$guardName" "$script")" \
+      "because it is not a build-time dependency"
+  else
+    sourceGuardSetSourced "$guardName" "$script"
+    nixInfoLog "sourcing $(sourceGuardPrintSourced "$guardName")"
+    # shellcheck disable=SC1090
+    source "$script" || {
+      nixErrorLog "failed to source $(sourceGuardPrintSourced "$guardName")"
+      exit 1
+    }
+  fi
+
+  return 0
+}
+
+# If we've not already sourced this file, try to source it, and make sourceGuard readonly if we were successfull.
+if ! sourceGuardHasSourced "sourceGuard"; then
+  sourceGuardSetSourced "sourceGuard" "${BASH_SOURCE[0]}"
+  if sourceGuardHasSourced "sourceGuard"; then
+    readonly -f sourceGuardArgumentCheck
+    readonly -f sourceGuardHasSourced
+    readonly -f sourceGuardPrintCurrent
+    readonly -f sourceGuardPrintSourced
+    readonly -f sourceGuardSetSourced
+    readonly -f sourceGuard
+  fi
+fi
+
+return 0

--- a/pkgs/by-name/so/sourceGuard/tests.nix
+++ b/pkgs/by-name/so/sourceGuard/tests.nix
@@ -1,0 +1,11 @@
+{ lib, testers }:
+lib.recurseIntoAttrs {
+  shellcheck = testers.shellcheck {
+    name = "sourceGuard";
+    src = ./source-guard.bash;
+  };
+  shfmt = testers.shfmt {
+    name = "sourceGuard";
+    src = ./source-guard.bash;
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -201,6 +201,10 @@ with pkgs;
 
   auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
 
+  makeSetupHook' = callPackages ./make-setup-hook-prime { };
+
+  sourceGuard = pkgs.sourceGuard.passthru.tests;
+
   srcOnly = callPackage ../build-support/src-only/tests.nix { };
 
   systemd = callPackage ./systemd { };

--- a/pkgs/test/make-setup-hook-prime/default.nix
+++ b/pkgs/test/make-setup-hook-prime/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  makeSetupHook',
+  testers,
+}:
+let
+  exampleHook = makeSetupHook' {
+    name = "exampleHook";
+    script = ./example-hook.bash;
+  };
+
+  mkExampleArrayTest =
+    name:
+    testers.testEqualArrayOrMap {
+      inherit name;
+      valuesArray = [
+        1
+        2
+        3
+        4
+        5
+      ];
+      expectedArray = [
+        2
+        3
+        4
+        5
+        6
+      ];
+      script = null; # The hook uses scriptHooks, but the script argument must be present.
+    };
+in
+lib.recurseIntoAttrs {
+  # Test that the hook executes successfully when included once.
+  testHookRunWhenIncludedOnce =
+    (mkExampleArrayTest "testHookRunWhenIncludedOnce").overrideAttrs
+      (prevAttrs: {
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
+          exampleHook
+        ];
+      });
+
+  # Test that the hook executes successfully even when included twice.
+  testHookRunWhenIncludedTwice =
+    (mkExampleArrayTest "testHookRunWhenIncludedTwice").overrideAttrs
+      (prevAttrs: {
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
+          exampleHook
+          exampleHook
+        ];
+      });
+
+  # Test that the hook doesn't get sourced twice when included twice by verifying `scriptHooks` is contains only one
+  # copy of the hooks our setup hook adds when sourced.
+  testScriptHooksWhenIncludedTwice =
+    ((mkExampleArrayTest "testScriptHooksWhenIncludedTwice").override {
+      script = ''
+        nixLog "checking that scriptHooks contains only two entires..."
+        if ((''${#scriptHooks[@]} != 2)); then
+          nixErrorLog "scriptHooks contains ''${#scriptHooks[@]} entries, but it should contain only 2"
+          exit 1
+        fi
+
+        nixLog "checking that scriptHooks contains the expected entries..."
+        if [[ ''${scriptHooks[0]} != "copyValuesArrayToActualArray" ]]; then
+          nixErrorLog "scriptHooks[0] contains ''${scriptHooks[0]}', but it should contain 'copyValuesArrayToActualArray'"
+          exit 1
+        fi
+        if [[ ''${scriptHooks[1]} != "addOneToActualArrayMembers" ]]; then
+          nixErrorLog "scriptHooks[1] contains ''${scriptHooks[1]}', but it should contain 'addOneToActualArrayMembers'"
+          exit 1
+        fi
+      '';
+    }).overrideAttrs
+      (prevAttrs: {
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
+          exampleHook
+          exampleHook
+        ];
+      });
+}

--- a/pkgs/test/make-setup-hook-prime/example-hook.bash
+++ b/pkgs/test/make-setup-hook-prime/example-hook.bash
@@ -1,0 +1,22 @@
+# shellcheck shell=bash
+
+# Add the hooks we want to run to scriptHooks, which are defined as part of testers.testEqualArrayOrMap.
+scriptHooks+=(
+  copyValuesArrayToActualArray
+  addOneToActualArrayMembers
+)
+
+copyValuesArrayToActualArray() {
+  # NOTE: Concatenation is important here, because we want to be able to detect if the hooks was run twice (resulting
+  # actualArray being twice the size of valuesArray).
+  nixLog "concatenating valuesArray to actualArray"
+  actualArray+=("${valuesArray[@]}")
+}
+
+addOneToActualArrayMembers() {
+  nixLog "adding one to each member of actualArray"
+  local -i i
+  for ((i = 0; i < ${#actualArray[@]}; i++)); do
+    actualArray[i]=$((actualArray[i] + 1))
+  done
+}


### PR DESCRIPTION
> [!IMPORTANT]
>
> This PR is largely made obsolete by #363191; I made this prior to upgrading to a version of Nixpkgs with this fix. However, there might be something worthwhile in the implementation of `sourceGuard` which includes logging the offsets with which a hook was sourced.

This PR introduces two new packages with the aim of easing writing (more) idempotent setup hooks.

Since setup hooks typically modify global state (e.g., registering hooks for different phases or modifying environment variables) and rarely guard against being sourced multiple times, the utmost care must be taken to ensure they are sourced at most once.

### `sourceGuard`

This hook provides a bash function of the same name which ensures scripts are sourced at most once.

### `makeSetupHook'`

Using `sourceGuard`, this variant of `makeSetupHook` prevents multiple-sourcing of setup hooks and frames dependencies to be provided to the setup hook in terms of the setup hook's offsets.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]: https://nixos.org/manual/nixpkgs/stable/#ssec-setup-hooks