### PR TITLE
teleport_17: 17.2.9 -> 17.3.3; teleport_16: 16.4.16 -> 16.4.17; teleport_15: 15.4.29 -> 15.4.30

### DIFF
--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -2,9 +2,9 @@ args:
 import ../generic.nix (
   args
   // {
-    version = "15.4.29";
-    hash = "sha256-FL7u7icwTS8V7ZodKjN/9vRTzXgJ0MCRgAz23eA+kfA=";
-    vendorHash = "sha256-LL18GI5w9kJdBJf2al9rK3dBwib2mLG/deZgSsmZv0U=";
+    version = "15.4.30";
+    hash = "sha256-qLGlhCDfIPVJfKI37Wv2XNl5tdloq48wJu8V/ww0yHc=";
+    vendorHash = "sha256-aM7VYauCC6zytFELKNyUa30H17ErFmBkyEr+eDoF92g=";
     yarnHash = "sha256-63JX0rAMyZA58CdaqHlTXlL7npvKcYnhVIh1NaJEmBk=";
     cargoHash = "sha256-2lIhtIWl26xoH7XxhPEmG/2FpfwgTC7kmahCim1W4To=";
   }

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,9 +2,9 @@ args:
 import ../generic.nix (
   args
   // {
-    version = "16.4.16";
-    hash = "sha256-0nag5T+qv00uA//N9ZDuCqarCfXYn76Ycxd97FfILpE=";
-    vendorHash = "sha256-5fSMbmvnbJ4zQuTBsmN/Ym3syn819hRmxv0aRzDnRFU=";
+    version = "16.4.17";
+    hash = "sha256-NLWISsh0zoTn849VK5YL2zxp7zuu7xFqLdbP/cPeNFc=";
+    vendorHash = "sha256-OoGx3ae69NCY6OFs/Ez4Lc8NVcgxl4bRoicFAVHicdQ=";
     pnpmHash = "sha256-OpCUYn69UNs6cplM74oNO4hQ5wiYBbjqGN3bJfbrsqk=";
     cargoHash = "sha256-oavJSszi6uWfUIzD+wRZL3wAFgmPvFwGeNHZexOlup4=";
   }

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "17.2.9";
-    hash = "sha256-4NOPNw5Hpb2V/M7y+tycCAdNPa/iKKoRdDO1kB3kkjo=";
-    vendorHash = "sha256-+nmkpUz1gT6qWNz9t2H1Txx1hl+37zXve9G45hEZMDU=";
-    pnpmHash = "sha256-6ziUPx5sNoMUe3fmzsPwddzNdL9Up6JlBkvq2lE6o5I=";
+    version = "17.3.3";
+    hash = "sha256-COvVkZN0ekuFEeCmFChHRiGS6ILtYAG4VM98DOKnnFc=";
+    vendorHash = "sha256-JO7wDDQLK9NE8OZla0VT/EKMV6YvdImoJWZPten42Z8=";
+    pnpmHash = "sha256-74hX508HQDEx6iWe1LHALBL8xwwgeDXGHog5RHFBud8=";
     cargoHash = "sha256-FiPfeDnb/FTemE1ZO2Ydg2KUjNmw7U3SCNu6cOqalOM=";
   }
 )


### PR DESCRIPTION
This update in teleport_17 includes a new functionality with new binary `teleport-update` which is supposed to be an alternative to package-managers' update mechanism.
It downloads binary releases directly from upstream without control for the package manager.
From my point of view this does not make sense for nixpkgs, which is why I decided to ignore this new binary.

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.3.0 https://github.com/gravitational/teleport/releases/tag/v17.3.0
Diff: https://github.com/gravitational/teleport/compare/v17.2.9..v17.3.3

Changelog: https://github.com/gravitational/teleport/releases/tag/v16.4.17
Diff: https://github.com/gravitational/teleport/compare/v16.2.16..v16.4.17

Changelog: https://github.com/gravitational/teleport/releases/tag/v15.4.30
Diff: https://github.com/gravitational/teleport/compare/v15.4.29..v15.4.30

The latest version bump per major includes an update of /x/crypto and /x/oauth2 (addresses CVE-2025-22869 and CVE-2025-22868).

cc @techknowlogick 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
