### PR TITLE
nixos/incus: add AppArmor rules

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -335,7 +335,40 @@ in
         "lxc-containers".profile = ''
           include ${cfg.lxcPackage}/etc/apparmor.d/lxc-containers
         '';
+        "incusd".profile = ''
+          # This profile allows everything and only exists to give the
+          # application a name instead of having the label "unconfined"
+
+          abi <abi/4.0>,
+          include <tunables/global>
+
+          profile incusd ${lib.getExe' config.virtualisation.incus.package "incusd"} flags=(unconfined) {
+            userns,
+            </var/lib/incus/security/apparmor/cache>
+            </var/lib/incus/security/apparmor/profiles>
+
+            # Site-specific additions and overrides. See local/README for details.
+            include if exists <local/incusd>
+          }
+        '';
       };
+      includes."abstractions/base" =
+        ''
+          # Allow incusd's various AA profiles to load dynamic libraries from Nix store
+          # https://discuss.linuxcontainers.org/t/creating-new-containers-vms-blocked-by-apparmor-on-nixos/21908/6
+          mr /nix/store/*/lib/*.so*,
+          r ${pkgs.stdenv.cc.libc}/lib/gconv/gconv-modules,
+          r ${pkgs.stdenv.cc.libc}/lib/gconv/gconv-modules.d/,
+          r ${pkgs.stdenv.cc.libc}/lib/gconv/gconv-modules.d/gconv-modules-extra.conf,
+
+          # Support use of VM instance
+          mrix ${pkgs.qemu_kvm}/bin/*,
+          k ${OVMF2MB.fd}/FV/*.fd,
+          k ${pkgs.OVMFFull.fd}/FV/*.fd,
+        ''
+        + lib.optionalString pkgs.stdenv.hostPlatform.isx86_64 ''
+          k ${pkgs.seabios-qemu}/share/seabios/bios.bin,
+        '';
     };
 
     systemd.services.incus = {

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -44,6 +44,6 @@ in
 
   zfs = incusTest {
     inherit lts pkgs system;
-    storageLvm = true;
+    storageZfs = true;
   };
 }

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -46,4 +46,10 @@ in
     inherit lts pkgs system;
     storageZfs = true;
   };
+
+  appArmor = incusTest {
+    inherit lts pkgs system;
+    appArmor = true;
+    allTests = true;
+  };
 }

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -7,6 +7,7 @@ import ../make-test-python.nix (
 
     allTests ? false,
 
+    appArmor ? false,
     featureUser ? allTests,
     initLegacy ? true,
     initSystemd ? true,
@@ -138,6 +139,9 @@ import ../make-test-python.nix (
 
       networking.hostId = "01234567";
       networking.firewall.trustedInterfaces = [ "incusbr0" ];
+
+      security.apparmor.enable = appArmor;
+      services.dbus.apparmor = (if appArmor then "enabled" else "disabled");
 
       services.lvm = {
         boot.thin.enable = storageLvm;


### PR DESCRIPTION
Add the necessary AppArmor rules when `incusd` tries to extract an image to create a new instance.

Fix #350012

Details can be found [here](https://discuss.linuxcontainers.org/t/creating-new-containers-vms-blocked-by-apparmor-on-nixos/21908/10?u=makisekurisu).

CC @NixOS/lxc @umbra @broizter since I can't select them as reviewers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
