### PR TITLE
python312Packages.nifty8: 8.5.4 -> 8.5.6

### DIFF
--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -70,6 +70,19 @@ buildPythonPackage rec {
     openssh
   ];
 
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Fatal Python error: Aborted
+    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
+    "test_optimize_kl_domain_expansion"
+    "test_plot_priorsamples"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Fatal Python error: Aborted
+    # matplotlib/backend_bases.py", line 2654 in create_with_canvas
+    "test/test_plot.py"
+  ];
+
   __darwinAllowLocalNetworking = true;
   postCheck =
     lib.optionalString

--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -38,6 +38,15 @@ buildPythonPackage rec {
     hash = "sha256-Q42ZhQ/T8JmkG75BexevbvVKQqfDmMG6+oTYR0Ze718=";
   };
 
+  # nifty8.re is the jax-backed version of nifty8 (the regular one uses numpy).
+  # It is not compatible with the latest jax update:
+  # https://gitlab.mpcdf.mpg.de/ift/nifty/-/issues/414
+  # While the issue is being fixed by upstream, we completely remove this package from the source and the tests.
+  postPatch = ''
+    rm -r src/re
+    rm -r test/test_re
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "nifty8";
-  version = "8.5.4";
+  version = "8.5.6";
   pyproject = true;
 
   src = fetchFromGitLab {
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "ift";
     repo = "nifty";
     tag = "v${version}";
-    hash = "sha256-Q42ZhQ/T8JmkG75BexevbvVKQqfDmMG6+oTYR0Ze718=";
+    hash = "sha256-DQPCLRVl/UE1zv7nUZtPJa/sRwmAkHgrcDsxRa/ndX4=";
   };
 
   # nifty8.re is the jax-backed version of nifty8 (the regular one uses numpy).
@@ -87,7 +87,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://gitlab.mpcdf.mpg.de/ift/nifty";
-    changelog = "https://gitlab.mpcdf.mpg.de/ift/nifty/-/blob/${src.tag}/ChangeLog.md";
+    changelog = "https://gitlab.mpcdf.mpg.de/ift/nifty/-/blob/v${version}/ChangeLog.md";
     description = "Bayesian Imaging library for high-dimensional posteriors";
     longDescription = ''
       NIFTy, "Numerical Information Field Theory", is a Bayesian imaging library.

--- a/pkgs/development/python-modules/nifty8/default.nix
+++ b/pkgs/development/python-modules/nifty8/default.nix
@@ -21,6 +21,7 @@
 
   # test
   pytestCheckHook,
+  pytest-xdist,
   mpiCheckPhaseHook,
   openssh,
 }:
@@ -64,6 +65,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-xdist
     mpiCheckPhaseHook
     openssh
   ];


### PR DESCRIPTION
## Things done

- **python312Packages.nifty8: remove nifty8.re as it is incompatible with the latest jax version**
- **python312Packages.nifty8: add pytest-xdist to speed up the tests**
- **python312Packages.nifty8: 8.5.4 -> 8.5.6**
- **python312Packages.nifty8: refactor checkPhase**
- **python312Packages.nifty8: disable crashing tests on darwin**

Changelog: https://gitlab.mpcdf.mpg.de/ift/nifty/-/blob/v8.5.6/ChangeLog.md

The package is currently failing on `master`.

cc @phiadaarr

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
