### PR TITLE
mochi: init at 1.18.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18731,6 +18731,12 @@
     githubId = 4201956;
     name = "pongo1231";
   };
+  poopsicles = {
+    name = "Fumnanya";
+    email = "fmowete@outlook.com";
+    github = "poopsicles";
+    githubId = 87488715;
+  };
   PopeRigby = {
     name = "PopeRigby";
     github = "poperigby";

--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -1,0 +1,65 @@
+{
+  _7zz,
+  appimageTools,
+  fetchurl,
+  fetchzip,
+  lib,
+  stdenvNoCC,
+  xorg,
+}:
+
+let
+  pname = "mochi";
+  version = "1.18.7";
+
+  linux = appimageTools.wrapType2 rec {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://mochi.cards/releases/Mochi-${version}.AppImage";
+      hash = "sha256-FCh8KLnvs26GKTVJY4Tqp+iA8sNlK7e0rv+oywBIF+U=";
+    };
+
+    appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+    extraPkgs = pkgs: [ xorg.libxshmfence ];
+
+    extraInstallCommands = ''
+      install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications/
+      install -Dm444 ${appimageContents}/${pname}.png -t $out/share/pixmaps/
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace-fail 'Exec=AppRun --no-sandbox' 'Exec=${pname}'
+    '';
+  };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchzip {
+      url = "https://mochi.cards/releases/Mochi-${version}.dmg";
+      hash = "sha256-W3JqEPF8iCiXlKqjPoFcm7lP+n3lN4XBeAQdBEWvy8s=";
+      stripRoot = false;
+      nativeBuildInputs = [ _7zz ];
+    };
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+
+      runHook postInstall
+    '';
+  };
+
+  meta = {
+    description = "Simple markdown-powered SRS app";
+    homepage = "https://mochi.cards/";
+    changelog = "https://mochi.cards/changelog.html";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ poopsicles ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+in
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Mochi is a spaced-repetition app, similar to Anki: https://mochi.cards. There's an AppImage and I made a [flake](https://codeberg.org/fumnanya/flakes/src/branch/main/mochi.nix) for it, but figured it'd be useful to add it here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
