### PR TITLE
cudaPackages.tensorrt: 10.3.0.26 -> 10.8.0.43

### DIFF
--- a/pkgs/by-name/ka/katago/package.nix
+++ b/pkgs/by-name/ka/katago/package.nix
@@ -34,8 +34,18 @@ assert lib.assertOneOf "backend" backend [
 let
   githash = "cd0ed6c0712088ddb901be68189ba7fa1439a9e7";
   fakegit = writeShellScriptBin "git" "echo ${githash}";
+  stdenv' =
+    if
+      builtins.elem backend [
+        "cuda"
+        "tensorrt"
+      ]
+    then
+      cudaPackages.backendStdenv
+    else
+      stdenv;
 in
-stdenv.mkDerivation rec {
+stdenv'.mkDerivation rec {
   pname = "katago";
   version = "1.15.3";
 
@@ -58,10 +68,12 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (backend == "eigen") [ eigen ]
     ++ lib.optionals (backend == "cuda") [
+      cudaPackages.cuda_cudart
       cudaPackages.cudnn
       cudaPackages.cudatoolkit
     ]
     ++ lib.optionals (backend == "tensorrt") [
+      cudaPackages.cuda_cudart
       cudaPackages.cudatoolkit
       cudaPackages.tensorrt
     ]

--- a/pkgs/development/cuda-modules/tensorrt/fixup.nix
+++ b/pkgs/development/cuda-modules/tensorrt/fixup.nix
@@ -75,6 +75,11 @@ finalAttrs: prevAttrs: {
         rm "$dir"
         mv "targets/${targetArch}/$dir" "$dir"
       done
+
+      # Remove broken symlinks
+      for dir in include samples; do
+        rm "targets/${targetArch}/$dir" || :
+      done
     '';
 
   # Tell autoPatchelf about runtime dependencies.

--- a/pkgs/development/cuda-modules/tensorrt/releases.nix
+++ b/pkgs/development/cuda-modules/tensorrt/releases.nix
@@ -1,4 +1,6 @@
-# NOTE: Check https://developer.nvidia.com/nvidia-tensorrt-8x-download.
+# NOTE: Check https://developer.nvidia.com/nvidia-tensorrt-8x-download
+#             https://developer.nvidia.com/nvidia-tensorrt-10x-download
+
 # Version policy is to keep the latest minor release for each major release.
 {
   tensorrt.releases = {
@@ -108,6 +110,22 @@
         cudnnVersion = "9.3";
         filename = "TensorRT-10.3.0.26.Linux.x86_64-gnu.cuda-12.5.tar.gz";
         hash = "sha256-rf8c1avl2HATgGFyNR5Y/QJOW/D8YdSe9LhM047ZkIE=";
+      }
+      {
+        version = "10.8.0.43";
+        minCudaVersion = "11.0";
+        maxCudaVersion = "11.8";
+        cudnnVersion = "8.9";
+        filename = "TensorRT-10.8.0.43.Linux.x86_64-gnu.cuda-11.8.tar.gz";
+        hash = "sha256-ZhdJ9ZUanOSQ3TbKNEIvS+fHLQ+TXZ+SdrUL4UiER+k=";
+      }
+      {
+        version = "10.8.0.43";
+        minCudaVersion = "12.0";
+        maxCudaVersion = "12.8";
+        cudnnVersion = "9.7";
+        filename = "TensorRT-10.8.0.43.Linux.x86_64-gnu.cuda-12.8.tar.gz";
+        hash = "sha256-V31tivU4FTQUuYZ8ZmtPZYUvwusefA6jogbl+vvH1J4=";
       }
     ];
   };


### PR DESCRIPTION
+ version update
+ fix build failure because of the broken symlinks (applies for both 10.3 and 10.8)
+ katago: fix cuda and tensorrt builds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
