### PR TITLE
linux_latest-libre: 19712 -> 19729, fixes failing build on nixos-24.11

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -5,8 +5,8 @@
   linux,
   scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-    rev = "19712";
-    sha256 = "0km2iaicrz17ahklcjcmbjq87bfrcjj0ynsyi7jnwp0l9n95i8jc";
+    rev = "19729";
+    sha256 = "0w7bhb0ybvvx28gqrhk81wzhqxkrfbhzwr3hv1mpr3cjgldfppr9";
   },
   ...
 }@args:


### PR DESCRIPTION
The Linux-libre kernel on `nixos-24.11` and `release-24.11` (tested at 3c68be9b127f6f318ab246837ac32a3ccc7aae68) currently does not compile due to a syntax error, which [Hydra has already reproduced](https://hydra.nixos.org/build/291247319/nixlog/1):

```
../drivers/bluetooth/btqca.c: In function 'qca_get_alt_nvm_file':
../drivers/bluetooth/btqca.c:314:77: error: expected expression before ')' token
  314 |                        sizeof(fwname) - (suffix - filename), /*(DEBLOBBED)*/);
```

This is because revision 19712 does not contain patches for mainline kernel version 6.6.80, which was introduced in nixpkgs in commit 31de0a64ea5f6b02321684e9ef4e552c2051905e.

Luckily, the maintainers fixed this today in revision 19729. The latest revision is 19730, but it doesn't affect the subtree we are checking out, and therefore produces the exact same derivation output, down to the hash. I chose to bump to version 19729 by fair dice roll.

I am running tests locally right now, I will undraft the PR once finished. Since this is my first nixpkgs PR, please let me know if I've missed anything!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~~x86_64-darwin~~ (not applicable)
  - [ ] ~~aarch64-darwin~~ (not applicable)
- ~~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~ (not applicable)
  - [ ] ~~`sandbox = relaxed`~~
  - [ ] ~~`sandbox = true`~~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)), using `nixosTests.kernel-generic.linux_libre`:
    - [x] PR branch on x86_64 (kernel 6.12.17)
    - [x] PR branch backported to `staging-24.11` (at 2370a862b3cf41e286c73080b05a50b5fa4f9ab5, kernel 6.6.80)
  - ~~and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~ (not applicable)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
