### PR TITLE
icewm: 3.7.0 -> 3.7.1 & fix icon-less start menu entries

### DIFF
--- a/pkgs/by-name/ic/icewm/package.nix
+++ b/pkgs/by-name/ic/icewm/package.nix
@@ -42,13 +42,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icewm";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "ice-wm";
     repo = "icewm";
     rev = finalAttrs.version;
-    hash = "sha256-RUT/zJcoDiNMit7XlxVb2lctta7NxcGAiFe3Mj7jUyM=";
+    hash = "sha256-4JF2ZAp8dx2fpSYRUz4I8US3oIZrSS90oljuxQDm38A=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ic/icewm/package.nix
+++ b/pkgs/by-name/ic/icewm/package.nix
@@ -37,6 +37,7 @@
   pcre2,
   perl,
   pkg-config,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -92,6 +93,17 @@ stdenv.mkDerivation (finalAttrs: {
     libxcb
     mkfontdir
     pcre2
+  ];
+
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/385959
+    # https://github.com/bbidulock/icewm/issues/794
+    # TODO: remove this patch when it is included in a release
+    (fetchpatch {
+      name = "fdomenu-icons-quoted";
+      url = "https://github.com/bbidulock/icewm/commit/74bb0a2989127a3ff87d2932ff547713bc710cfe.patch";
+      hash = "sha256-/rMSJYGAJs9cgNu5j4Mov/PfO7ocXQeNRq0vasfRcKA=";
+    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
* update icewm to [latest release](https://github.com/ice-wm/icewm/releases/tag/3.7.1)
* add a patch to fix https://github.com/NixOS/nixpkgs/issues/385959


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] `nixosTests.{lightdm,sddm,xrdp}` build/pass (these seem to use IceWM in one way or another)
- [x] looks OK in qemu
- [x] I can no longer reproduce the problem from https://github.com/NixOS/nixpkgs/issues/385959

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
