### PR TITLE
meshlab-unstable: init at 2023.12-unstable-2025-02-21

### DIFF
--- a/pkgs/applications/graphics/meshlab-unstable/default.nix
+++ b/pkgs/applications/graphics/meshlab-unstable/default.nix
@@ -1,0 +1,127 @@
+{
+  mkDerivation,
+  lib,
+  fetchFromGitHub,
+  libGLU,
+  qtbase,
+  qtscript,
+  qtxmlpatterns,
+  lib3ds,
+  bzip2,
+  muparser,
+  eigen,
+  glew,
+  gmp,
+  levmar,
+  qhull,
+  cmake,
+  cgal,
+  boost,
+  mpfr,
+  xercesc,
+  tbb,
+  embree,
+  libigl,
+  corto,
+  openctm,
+  structuresynth,
+}:
+
+let
+  tinygltf-src = fetchFromGitHub {
+    owner = "syoyo";
+    repo = "tinygltf";
+    rev = "v2.6.3";
+    hash = "sha256-IyezvHzgLRyc3z8HdNsQMqDEhP+Ytw0stFNak3C8lTo=";
+  };
+  # requires submodules to build
+  lib3mf-src = fetchFromGitHub {
+    owner = "3MFConsortium";
+    repo = "lib3mf";
+    rev = "v2.3.2";
+    fetchSubmodules = true;
+    hash = "sha256-pKjnN9H6/A2zPvzpFed65J+mnNwG/dkSE2/pW7IlN58=";
+  };
+in
+mkDerivation {
+  pname = "meshlab-unstable";
+  version = "2023.12-unstable-2025-02-21";
+
+  src = fetchFromGitHub {
+    owner = "cnr-isti-vclab";
+    repo = "meshlab";
+    # note that this is in branch devel
+    rev = "72142583980b6dbfc5b85c6cca226a72f48497a9";
+    sha256 = "1q7qga4d82pvpcbsp9pi2i7nzdbflhp6q0d3y31kpch9r3r9pzks";
+    # needed for an updated version of vcg in their submodule
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    libGLU
+    qtbase
+    qtscript
+    qtxmlpatterns
+    lib3ds
+    bzip2
+    muparser
+    eigen
+    glew
+    gmp
+    levmar
+    qhull
+    cgal
+    boost
+    mpfr
+    xercesc
+    tbb
+    embree
+    libigl
+    corto
+    openctm
+    structuresynth
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  preConfigure = ''
+    mkdir src/external/downloads
+    cp -r --no-preserve=mode,ownership ${lib3mf-src} src/external/downloads/lib3mf-2.3.2
+
+    substituteAll ${./meshlab.desktop} resources/linux/meshlab.desktop
+    substituteInPlace src/external/tinygltf.cmake \
+      --replace-fail '$'{MESHLAB_EXTERNAL_DOWNLOAD_DIR}/tinygltf-2.6.3 ${tinygltf-src}
+    substituteInPlace src/external/libigl.cmake \
+      --replace-fail '$'{MESHLAB_EXTERNAL_DOWNLOAD_DIR}/libigl-'$'{LIBIGL_VER} ${libigl}
+    substituteInPlace src/external/nexus.cmake \
+      --replace-fail '$'{NEXUS_DIR}/src/corto ${corto.src}
+    substituteInPlace src/external/levmar.cmake \
+      --replace-fail '$'{LEVMAR_LINK} ${levmar.src} \
+      --replace-warn "MD5 ''${LEVMAR_MD5}" ""
+    substituteInPlace src/external/ssynth.cmake \
+      --replace-fail '$'{SSYNTH_LINK} ${structuresynth.src} \
+      --replace-warn "MD5 ''${SSYNTH_MD5}" ""
+    substituteInPlace src/common_gui/CMakeLists.txt \
+      --replace-warn "MESHLAB_LIB_INSTALL_DIR" "CMAKE_INSTALL_LIBDIR"
+  '';
+
+  postFixup = ''
+    patchelf --add-needed $out/lib/meshlab/libmeshlab-common.so $out/bin/.meshlab-wrapped
+    patchelf --add-needed $out/lib/meshlab/lib3mf.so $out/lib/meshlab/plugins/libio_3mf.so
+  '';
+
+  # display a black screen on wayland, so force XWayland for now.
+  # Might be fixed when upstream will be ready for Qt6.
+  qtWrapperArgs = [
+    "--set QT_QPA_PLATFORM xcb"
+  ];
+
+  meta = {
+    description = "System for processing and editing 3D triangular meshes (unstable)";
+    mainProgram = "meshlab";
+    homepage = "https://www.meshlab.net/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pca006132 ];
+    platforms = with lib.platforms; linux;
+  };
+}

--- a/pkgs/applications/graphics/meshlab-unstable/meshlab.desktop
+++ b/pkgs/applications/graphics/meshlab-unstable/meshlab.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=MeshLab
+Version=@version@
+Name[en_GB]=MeshLab
+GenericName=Mesh processing
+GenericName[en_GB]=Mesh processing
+Comment=View and process meshes
+Type=Application
+Exec=@out@/bin/meshlab %U
+TryExec=@out@/bin/meshlab
+Icon=@out@/share/icons/hicolor/meshlab.png
+Terminal=false
+MimeType=model/mesh;application/x-3ds;image/x-3ds;model/x-ply;application/sla;model/x-quad-object;model/x-geomview-off;application/x-cyclone-ptx;application/x-vmi;application/x-bre;model/vnd.collada+xml;model/openctm;application/x-expe-binary;application/x-expe-ascii;application/x-xyz;application/x-gts;chemical/x-pdb;application/x-tri;application/x-asc;model/x3d+xml;model/x3d+vrml;model/vrml;model/u3d;model/idtf;
+Categories=Graphics;3DGraphics;Viewer;Qt;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14226,6 +14226,7 @@ with pkgs;
   meshcentral = callPackage ../tools/admin/meshcentral { };
 
   meshlab = libsForQt5.callPackage ../applications/graphics/meshlab { };
+  meshlab-unstable = libsForQt5.callPackage ../applications/graphics/meshlab-unstable { };
 
   michabo = libsForQt5.callPackage ../applications/misc/michabo { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added meshlab-unstable for the nightly version of meshlab, which supports 3mf files. This also includes the patch in #386130 that supports gltf file.

I tried finding a simpler way to add lib3mf, but it doesn't work. Using prebuilt 3MF with a custom `FindLib3MF.cmake` will not build `io_3mf.so` for some weird reason. Using the source from `lib3mf.src` will require setting cmake flags for the subdir. And finally, not patching the `io_3mf.so` file to find `lib3mf.so` will fail the dynamically loaded plugin.

Any help on this is appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
