### PR TITLE
ente-desktop: init at 1.7.10

### DIFF
--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -1,0 +1,147 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  nodejs,
+  electron_34,
+  yarnConfigHook,
+  copyDesktopItems,
+  vips,
+  ffmpeg,
+  makeWrapper,
+  autoPatchelfHook,
+  makeDesktopItem,
+  imagemagick,
+}:
+let
+  electron = electron_34;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ente-desktop";
+  version = "1.7.10";
+
+  src = fetchFromGitHub {
+    owner = "ente-io";
+    repo = "ente";
+    fetchSubmodules = true;
+    sparseCheckout = [
+      "desktop"
+      "web"
+    ];
+    tag = "photosd-v${finalAttrs.version}";
+    hash = "sha256-iH9fbeUOd/8oVVQbMCSlWyruQZKgSjexNrOuS7szJ9w=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/desktop";
+
+  offlineCache = fetchYarnDeps {
+    name = "ente-desktop-${finalAttrs.version}-offline-cache";
+    inherit (finalAttrs) src sourceRoot;
+    hash = "sha256-kiL2XQPPN9VkDa3rzO1rLwUZVTbwEz0zeqpgpWOSy7Y=";
+  };
+  webOfflineCache = fetchYarnDeps {
+    name = "ente-desktop-${finalAttrs.version}-web-offline-cache";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/web";
+    hash = "sha256-7epwOEWi5lZNo6Z7Rf+QZtGvVCZxk5bXU2aN+9KDYCc=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    yarnConfigHook
+    makeWrapper
+    autoPatchelfHook # for onnxruntime
+    copyDesktopItems
+    imagemagick
+  ];
+
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc) # for onnxruntime
+  ];
+
+  # Path to vips (otherwise it looks within the electron derivation)
+  postPatch = ''
+    substituteInPlace src/main/services/image.ts --replace-fail "process.resourcesPath" "\"$out/share/ente-desktop/resources\""
+  '';
+
+  postConfigure = ''
+    chmod u+w -R ..
+
+    pushd ../web
+    offlineCache=$webOfflineCache yarnConfigHook
+    popd
+
+    cp -r ${electron.dist} ./electron_dist
+    chmod u+w -R ./electron_dist
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd ../web
+    _ENTE_IS_DESKTOP=1 yarn build
+    popd
+    cp -r ../web/apps/photos/out out
+
+    yarn run tsc
+    yarn run electron-builder --dir -c.electronDist=./electron_dist -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for size in 16 32 48 64 72 96 128 192 256 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      convert -resize "$size"x"$size" build/icon.png $out/share/icons/hicolor/"$size"x"$size"/apps/ente-desktop.png
+    done
+
+    mkdir -p $out/share/ente-desktop
+    cp -r dist/*/resources $out/share/ente-desktop
+    ln -s ${vips}/bin/vips $out/share/ente-desktop/resources/vips
+    ln -s ${ffmpeg}/bin/ffmpeg $out/share/ente-desktop/resources/app.asar.unpacked/node_modules/ffmpeg-static/ffmpeg
+
+    # executable wrapper
+    makeWrapper '${electron}/bin/electron' "$out/bin/ente-desktop" \
+      --set ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set ELECTRON_IS_DEV 0 \
+      --add-flags "$out/share/ente-desktop/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+    runHook postInstall
+  '';
+
+  # The desktop item properties should be kept in sync with data from upstream:
+  # https://github.com/ente-io/ente/blob/main/desktop/electron-builder.yml
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ente-desktop";
+      desktopName = "Ente";
+      exec = "ente-desktop %U";
+      terminal = false;
+      type = "Application";
+      icon = "ente-desktop";
+      mimeTypes = [
+        "x-scheme-handler/ente"
+      ];
+      categories = [
+        "Photography"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Desktop (Electron) client for Ente Photos";
+    homepage = "https://ente.io/";
+    changelog = "https://github.com/ente-io/photos-desktop/releases";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      pinpox
+      yuka
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Building from source, because the AppImage keeps crashing on my machine.

Added vips binary to fix the thumbnail generation on image upload.
Added autoPatchelfHook to fix ML feature.

@pinpox  @surfaceflinger do you want to be maintainers of this app too?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
