### PR TITLE
nixos/tandoor-recipes: fix database leak when serving media

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1191,6 +1191,7 @@ in {
   startx = import ./startx.nix { inherit pkgs runTest; };
   taler = handleTest ./taler {};
   tandoor-recipes = handleTest ./tandoor-recipes.nix {};
+  tandoor-recipes-media = handleTest ./tandoor-recipes-media.nix {};
   tandoor-recipes-script-name = handleTest ./tandoor-recipes-script-name.nix {};
   tang = handleTest ./tang.nix {};
   taskserver = handleTest ./taskserver.nix {};

--- a/nixos/tests/tandoor-recipes-media.nix
+++ b/nixos/tests/tandoor-recipes-media.nix
@@ -1,0 +1,85 @@
+import ./make-test-python.nix (
+  { ... }:
+  {
+    name = "tandoor-recipes";
+
+    nodes.machine = {
+      services.tandoor-recipes = {
+        enable = true;
+        # This setting is not recommended, but it's an easy way serve the media
+        # folder in this test.
+        extraConfig = {
+          GUNICORN_MEDIA = true;
+        };
+      };
+
+      specialisation.oldVersion.configuration = {
+        system.stateVersion = "24.11";
+      };
+
+      specialisation.oldVersionOverrideMedia.configuration = {
+        system.stateVersion = "24.11";
+        services.tandoor-recipes = {
+          enable = true;
+          extraConfig = {
+            GUNICORN_MEDIA = true;
+            MEDIA_ROOT = /var/lib/tandoor-recipes/media;
+          };
+        };
+      };
+    };
+
+    testScript =
+      { nodes, ... }:
+      let
+        specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+        oldVersion = "${specBase}/oldVersion";
+        oldVersionOverrideMedia = "${specBase}/oldVersionOverrideMedia";
+      in
+      # python
+      ''
+        def wait_for_tandoor():
+          machine.wait_for_unit("tandoor-recipes.service")
+          machine.wait_for_open_port(8080)
+
+
+        def stop_and_rm():
+          machine.systemctl("stop tandoor-recipes")
+          machine.succeed("rm -r /var/lib/tandoor-recipes")
+
+
+        db_path = "http://localhost:8080/media/db.sqlite3"
+
+
+        # The media folder shouldn't contain the database. Subsequently it
+        # should **not** get served, resulting in a 404. Previously the
+        # database was located in the media folder. Therefore serving the media
+        # folder would expose the database. See #338339.
+        wait_for_tandoor()
+        machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+
+
+        # Switch to NixOS 24.11 to check if the setup still functions the same
+        # as before.
+        stop_and_rm()
+        machine.succeed("${oldVersion}/bin/switch-to-configuration test")
+
+        # With the old setup the media folder should contain the database.
+        # Subsequently it should get served, resulting in a 200.
+        wait_for_tandoor()
+        machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 200 OK\"")
+
+
+        # Switch to NixOS 24.11 with the MEDIA_ROOT already set to
+        # /var/lib/tandoor-recipes/media.
+        stop_and_rm()
+        machine.succeed("${oldVersionOverrideMedia}/bin/switch-to-configuration test")
+
+        # With MEDIA_ROOT being set to /var/lib/tandoor-recipes/media the media
+        # folder shouldn't contain the database. Subsequently it should **not**
+        # get served, resulting in a 404.
+        wait_for_tandoor()
+        machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+      '';
+  }
+)

--- a/pkgs/applications/misc/tandoor-recipes/default.nix
+++ b/pkgs/applications/misc/tandoor-recipes/default.nix
@@ -143,7 +143,7 @@ python.pkgs.pythonPackages.buildPythonPackage {
     updateScript = ./update.sh;
 
     tests = {
-      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name;
+      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name tandoor-recipes-media;
     };
   };
 


### PR DESCRIPTION
As explained in https://github.com/NixOS/nixpkgs/issues/338339 the default storage setup is prone to database leaking. I tried to implement a solution where the media is served from a `/media` folder in the state directory. Additionally I added a test ensure accessing the database returns a 404.

This is a breaking change, because the `MEDIA_ROOT` variable is changed. Before merging this fix we could add a `builtins.warn` for a couple months so people on unstable become aware. After that we could add the breaking change to the 25.05 release notes so people upgrading from stable are informed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
