### PR TITLE
dbus: 1.14.10 → 1.16.2

### DIFF
--- a/pkgs/by-name/db/dbus/meson-install-dirs.patch
+++ b/pkgs/by-name/db/dbus/meson-install-dirs.patch
@@ -1,0 +1,190 @@
+diff --git a/bus/legacy-config/meson.build b/bus/legacy-config/meson.build
+index 1e635713..4be240e9 100644
+--- a/bus/legacy-config/meson.build
++++ b/bus/legacy-config/meson.build
+@@ -24,7 +24,7 @@ if platform_unix
+         input: 'system.conf.in',
+         output: 'system.conf',
+         configuration: data_config,
+-        install_dir: get_option('sysconfdir') / 'dbus-1',
++        install_dir: install_sysconfdir / 'dbus-1',
+     )
+ endif
+ 
+@@ -32,5 +32,5 @@ configure_file(
+     input: 'session.conf.in',
+     output: 'session.conf',
+     configuration: data_config,
+-    install_dir: get_option('sysconfdir') / 'dbus-1',
++    install_dir: install_sysconfdir / 'dbus-1',
+ )
+diff --git a/bus/meson.build b/bus/meson.build
+index 058e3b25..0a5de112 100644
+--- a/bus/meson.build
++++ b/bus/meson.build
+@@ -23,7 +23,7 @@ session_conf = configure_file(
+     input: 'session.conf.in',
+     output: 'session.conf',
+     configuration: data_config,
+-    install_dir: get_option('datadir') / 'dbus-1',
++    install_dir: install_datadir / 'dbus-1',
+ )
+ 
+ if platform_unix
+@@ -31,7 +31,7 @@ if platform_unix
+         input: 'system.conf.in',
+         output: 'system.conf',
+         configuration: data_config,
+-        install_dir: get_option('datadir') / 'dbus-1',
++        install_dir: install_datadir / 'dbus-1',
+     )
+ endif
+ 
+@@ -39,19 +39,19 @@ configure_file(
+     input: 'example-system-enable-stats.conf.in',
+     output: 'example-system-enable-stats.conf',
+     configuration: data_config,
+-    install_dir: get_option('datadir') / 'doc' / 'dbus' / 'examples',
++    install_dir: install_datadir / 'doc' / 'dbus' / 'examples',
+ )
+ 
+ configure_file(
+     input: 'example-session-disable-stats.conf.in',
+     output: 'example-session-disable-stats.conf',
+     configuration: data_config,
+-    install_dir: get_option('datadir') / 'doc' / 'dbus' / 'examples',
++    install_dir: install_datadir / 'doc' / 'dbus' / 'examples',
+ )
+ 
+ install_data(
+     'example-system-hardening-without-traditional-activation.conf',
+-    install_dir: get_option('datadir') / 'doc' / 'dbus' / 'examples',
++    install_dir: install_datadir / 'doc' / 'dbus' / 'examples',
+ )
+ 
+ if use_launchd
+@@ -185,15 +185,14 @@ if platform_unix and use_traditional_activation
+ endif
+ 
+ install_emptydirs += [
+-    get_option('datadir') / 'dbus-1' / 'session.d',
+-    get_option('datadir') / 'dbus-1' / 'services',
++    install_datadir / 'dbus-1' / 'session.d',
++    install_datadir / 'dbus-1' / 'services',
+ ]
+ 
+ if platform_unix
+     install_emptydirs += [
+-        runstatedir / 'dbus',
+-        get_option('datadir') / 'dbus-1' / 'system.d',
+-        get_option('datadir') / 'dbus-1' / 'system-services',
++        install_datadir / 'dbus-1' / 'system.d',
++        install_datadir / 'dbus-1' / 'system-services',
+     ]
+ endif
+ 
+diff --git a/doc/meson.build b/doc/meson.build
+index adc6f17d..1f2c5dce 100644
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -142,7 +142,7 @@ configure_file(
+ # Install dtd files
+ 
+ 
+-xml_dir = get_option('datadir') / 'xml' / 'dbus-1'
++xml_dir = install_datadir / 'xml' / 'dbus-1'
+ dtd_files = [
+     'busconfig.dtd',
+     'introspect.dtd',
+diff --git a/meson.build b/meson.build
+index 3f4ad316..6cee2c6b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -918,7 +918,17 @@ dbus_enable_modular_tests = (
+ ###############################################################################
+ # Paths and directories
+ 
+-docs_dir = get_option('datadir') / 'doc' / 'dbus'
++install_datadir = get_option('install_datadir')
++if install_datadir == ''
++  install_datadir = get_option('prefix') / get_option('datadir')
++endif
++
++install_sysconfdir = get_option('install_sysconfdir')
++if install_sysconfdir == ''
++  install_sysconfdir = get_option('prefix') / get_option('sysconfdir')
++endif
++
++docs_dir = install_datadir / 'doc' / 'dbus'
+ 
+ # TODO: If a future Meson version gets a runstatedir option, try both.
+ # https://github.com/mesonbuild/meson/issues/4141
+diff --git a/meson_options.txt b/meson_options.txt
+index 1bd00579..1dfb3c15 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -109,6 +109,20 @@ option(
+   description: 'Inotify support on Linux'
+ )
+ 
++option(
++  'install_datadir',
++  type: 'string',
++  value: '',
++  description: 'datadir for installation, so that we can set --datadir=/etc and have dbus load files from there but still install them to $out/share'
++)
++
++option(
++  'install_sysconfdir',
++  type: 'string',
++  value: '',
++  description: 'sysconfdir for installation, so that we can set --sysconfdir=/etc and have dbus load files from there but still install them to $out/etc'
++)
++
+ option(
+   'installed_tests',
+   type: 'boolean',
+diff --git a/test/data/meson.build b/test/data/meson.build
+index ef570492..713396b7 100644
+--- a/test/data/meson.build
++++ b/test/data/meson.build
+@@ -224,14 +224,14 @@ if install_tests
+                 'link_name': 'session.conf',
+                 'install_dir': test_exec_dir / 'data' / 'valid-config-files',
+                 'pointing_to':
+-                    get_option('prefix') / get_option('datadir') /
++                    install_datadir /
+                     'dbus-1' / 'session.conf',
+             },
+             {
+                 'link_name': 'system.conf',
+                 'install_dir': test_exec_dir / 'data' / 'valid-config-files-system',
+                 'pointing_to':
+-                    get_option('prefix') / get_option('datadir') /
++                    install_datadir /
+                     'dbus-1' / 'system.conf',
+             },
+         ]
+diff --git a/test/meson.build b/test/meson.build
+index a60afac6..be7bd935 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -25,7 +25,7 @@
+ install_tests = get_option('installed_tests')
+ 
+ test_exec_dir = get_option('libexecdir') / 'installed-tests' / 'dbus'
+-test_meta_dir = get_option('datadir') / 'installed-tests' / 'dbus'
++test_meta_dir = install_datadir / 'installed-tests' / 'dbus'
+ 
+ ###############################################################################
+ # Test configuration needs some specific keys
+diff --git a/tools/meson.build b/tools/meson.build
+index 5d78d93a..7d094364 100644
+--- a/tools/meson.build
++++ b/tools/meson.build
+@@ -112,5 +112,4 @@ install_data('GetAllMatchRules.py',
+ 
+ # Create the empty directory to hold the machine ID
+ install_emptydirs += [
+-    get_option('localstatedir') / 'lib' / 'dbus',
+ ]

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -64,24 +64,22 @@ stdenv.mkDerivation rec {
     xmlto
   ];
 
-  propagatedBuildInputs = [
+  buildInputs = [
     expat
+  ]
+  ++ lib.optionals x11Support (
+    with xorg;
+    [
+      libX11
+      libICE
+      libSM
+    ]
+  )
+  ++ lib.optional enableSystemd systemdMinimal
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    audit
+    libapparmor
   ];
-
-  buildInputs =
-    lib.optionals x11Support (
-      with xorg;
-      [
-        libX11
-        libICE
-        libSM
-      ]
-    )
-    ++ lib.optional enableSystemd systemdMinimal
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      audit
-      libapparmor
-    ];
   # ToDo: optional selinux?
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -7,20 +7,23 @@
   enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
   systemdMinimal,
   audit,
+  libcap_ng,
   libapparmor,
   dbus,
   docbook_xml_dtd_44,
   docbook-xsl-nons,
-  xmlto,
-  autoreconfHook,
-  autoconf-archive,
+  libxslt,
+  meson,
+  ninja,
+  python3,
   x11Support ? (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin),
   xorg,
+  writeText,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dbus";
-  version = "1.14.10";
+  version = "1.16.2";
 
   outputs = [
     "out"
@@ -33,21 +36,36 @@ stdenv.mkDerivation rec {
   separateDebugInfo = true;
 
   src = fetchurl {
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${version}.tar.xz";
-    sha256 = "sha256-uh8h0r2dM52i1KqHgMCd8y/qh5mLc9ok9Jq53x42pQ8=";
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-C6KhpLFq/nvOssB+nOmajCw1COXewpDbtkM4S9a+t+I=";
   };
 
-  patches = lib.optional stdenv.hostPlatform.isSunOS ./implement-getgrouplist.patch;
+  patches = [
+    # Implement getgrouplist for platforms where it is not available (e.g. Illumos/Solaris)
+    ./implement-getgrouplist.patch
+
+    # Add a Meson configuration option that will allow us to use a different
+    # `datadir` for installation from the one that will be compiled into dbus.
+    # This is necessary to allow NixOS to manage dbus service definitions,
+    # since the `datadir` in the package will be immutable. But we still want
+    # to install the files to the latter, since there is no other suitable
+    # place for the project to install them.
+    #
+    # We will also just remove installation of empty `${runstatedir}/dbus`
+    # and `${localstatedir}/lib/dbus` since these are useless in the package.
+    ./meson-install-dirs.patch
+  ];
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    autoreconfHook
-    autoconf-archive
+    meson
+    ninja
     pkg-config
     docbook_xml_dtd_44
     docbook-xsl-nons
-    xmlto
+    libxslt # for xsltproc
+    python3
   ];
 
   buildInputs = [
@@ -64,67 +82,58 @@ stdenv.mkDerivation rec {
   ++ lib.optional enableSystemd systemdMinimal
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     audit
+    libcap_ng
     libapparmor
   ];
-  # ToDo: optional selinux?
 
   __darwinAllowLocalNetworking = true;
 
-  configureFlags = [
-    "--enable-user-session"
-    "--enable-xml-docs"
+  mesonFlags = [
     "--libexecdir=${placeholder "out"}/libexec"
+    # datadir from which dbus will load files will be managed by the NixOS module:
     "--datadir=/etc"
+    # But we still want to install stuff to the package:
+    "-Dinstall_datadir=${placeholder "out"}/share"
     "--localstatedir=/var"
-    "--runstatedir=/run"
+    "-Druntime_dir=/run"
     "--sysconfdir=/etc"
-    "--with-session-socket-dir=/tmp"
-    "--with-system-pid-file=/run/dbus/pid"
-    "--with-system-socket=/run/dbus/system_bus_socket"
-    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
-    "--with-systemduserunitdir=${placeholder "out"}/etc/systemd/user"
-  ]
-  ++ lib.optional (!x11Support) "--without-x"
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    "--enable-apparmor"
-    "--enable-libaudit"
-  ]
-  ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
-
-  NIX_CFLAGS_LINK = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-Wl,--as-needed";
-
-  enableParallelBuilding = true;
+    "-Dinstall_sysconfdir=${placeholder "out"}/etc"
+    "-Ddoxygen_docs=disabled"
+    "-Dducktype_docs=disabled"
+    "-Dqt_help=disabled"
+    "-Drelocation=disabled" # Conflicts with multiple outputs
+    "-Dmodular_tests=disabled" # Requires glib
+    "-Dsession_socket_dir=/tmp"
+    "-Dsystemd_system_unitdir=${placeholder "out"}/etc/systemd/system"
+    "-Dsystemd_user_unitdir=${placeholder "out"}/etc/systemd/user"
+    (lib.mesonEnable "x11_autolaunch" x11Support)
+    (lib.mesonEnable "apparmor" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "libaudit" stdenv.hostPlatform.isLinux)
+    (lib.mesonEnable "kqueue" (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isBSD))
+    (lib.mesonEnable "launchd" stdenv.hostPlatform.isDarwin)
+    "-Dselinux=disabled"
+    "--cross-file=${writeText "crossfile.ini" ''
+      [binaries]
+      systemctl = '${systemdMinimal}/bin/systemctl'
+    ''}"
+  ];
 
   doCheck = true;
 
-  makeFlags = [
-    # Fix paths in XML catalog broken by mismatching build/install datadir.
-    "dtddir=${placeholder "out"}/share/xml/dbus-1"
-  ];
-
-  installFlags = [
-    "sysconfdir=${placeholder "out"}/etc"
-    "datadir=${placeholder "out"}/share"
-  ];
-
   postPatch = ''
-    substituteInPlace bus/Makefile.am \
-      --replace 'install-data-hook:' 'disabled:' \
-      --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
-    substituteInPlace tools/Makefile.am \
-      --replace 'install-data-local:' 'disabled:' \
-      --replace 'installcheck-local:' 'disabled:'
-  ''
-  # cleanup of runtime references
-  + ''
+    patchShebangs \
+      test/data/copy_data_for_tests.py \
+      meson_post_install.py
+
+    # Cleanup of runtime references
     substituteInPlace ./dbus/dbus-sysdeps-unix.c \
-      --replace 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
+      --replace-fail 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
     substituteInPlace ./tools/dbus-launch.c \
-      --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
+      --replace-fail 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
   '';
 
-  # it's executed from $lib by absolute path
   postFixup = ''
+    # It's executed from $lib by absolute path
     moveToOutput bin/dbus-launch "$lib"
     ln -s "$lib/bin/dbus-launch" "$out/bin/"
   '';
@@ -136,9 +145,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Simple interprocess messaging system";
     homepage = "https://www.freedesktop.org/wiki/Software/dbus/";
-    changelog = "https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-${version}/NEWS";
+    changelog = "https://gitlab.freedesktop.org/dbus/dbus/-/blob/dbus-${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus; # most is also under AFL-2.1
     teams = [ lib.teams.freedesktop ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -22,29 +22,6 @@ stdenv.mkDerivation rec {
   pname = "dbus";
   version = "1.14.10";
 
-  src = fetchurl {
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${version}.tar.xz";
-    sha256 = "sha256-uh8h0r2dM52i1KqHgMCd8y/qh5mLc9ok9Jq53x42pQ8=";
-  };
-
-  patches = lib.optional stdenv.hostPlatform.isSunOS ./implement-getgrouplist.patch;
-
-  postPatch = ''
-    substituteInPlace bus/Makefile.am \
-      --replace 'install-data-hook:' 'disabled:' \
-      --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
-    substituteInPlace tools/Makefile.am \
-      --replace 'install-data-local:' 'disabled:' \
-      --replace 'installcheck-local:' 'disabled:'
-  ''
-  # cleanup of runtime references
-  + ''
-    substituteInPlace ./dbus/dbus-sysdeps-unix.c \
-      --replace 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
-    substituteInPlace ./tools/dbus-launch.c \
-      --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
-  '';
-
   outputs = [
     "out"
     "dev"
@@ -52,9 +29,18 @@ stdenv.mkDerivation rec {
     "doc"
     "man"
   ];
+
   separateDebugInfo = true;
 
+  src = fetchurl {
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-${version}.tar.xz";
+    sha256 = "sha256-uh8h0r2dM52i1KqHgMCd8y/qh5mLc9ok9Jq53x42pQ8=";
+  };
+
+  patches = lib.optional stdenv.hostPlatform.isSunOS ./implement-getgrouplist.patch;
+
   strictDeps = true;
+
   nativeBuildInputs = [
     autoreconfHook
     autoconf-archive
@@ -120,6 +106,22 @@ stdenv.mkDerivation rec {
     "sysconfdir=${placeholder "out"}/etc"
     "datadir=${placeholder "out"}/share"
   ];
+
+  postPatch = ''
+    substituteInPlace bus/Makefile.am \
+      --replace 'install-data-hook:' 'disabled:' \
+      --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/run/dbus' ':'
+    substituteInPlace tools/Makefile.am \
+      --replace 'install-data-local:' 'disabled:' \
+      --replace 'installcheck-local:' 'disabled:'
+  ''
+  # cleanup of runtime references
+  + ''
+    substituteInPlace ./dbus/dbus-sysdeps-unix.c \
+      --replace 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
+    substituteInPlace ./tools/dbus-launch.c \
+      --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
+  '';
 
   # it's executed from $lib by absolute path
   postFixup = ''

--- a/pkgs/by-name/ja/jack2/package.nix
+++ b/pkgs/by-name/ja/jack2/package.nix
@@ -16,6 +16,7 @@
 
   # Optional Dependencies
   dbus ? null,
+  expat, # for dbus
   libffado ? null,
   alsa-lib ? null,
 
@@ -66,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     optLibffado
     optAlsaLib
   ]
+  ++ lib.optionals (optDbus != null) [ expat ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     aften
   ]


### PR DESCRIPTION
https://gitlab.freedesktop.org/dbus/dbus/-/compare/dbus-1.14.10...dbus-1.16.2


This includes:

- Switch from Autotools to Meson
  - Since Meson does not support separate `installFlags`, we would either need to use `DESTDIR`, or patch the build system. I chose the latter since we want to keep the `$out` as close to FHS as possible to avoid confusion, and moving a subset of content of `$out/etc` back to `$out/share` would be annoying.
  - `libaudit` started to require `libcap-ng`.
  - `xmlto` was replaced by `xsltproc`.
  - Extra docs builds, disabled for now due to dependency requirements.

In the package definition:

- Use `finalAttrs`.
- Move `postPatch` to the bottom and `outputs` to the top.
- Use `--replace-fail` with `substitute`.
- Make `getgrouplist` unconditional.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Skimmed through [upstream diff](https://gitlab.freedesktop.org/dbus/dbus/-/compare/dbus-1.14.10...dbus-1.16.2)
- [x] Read upstream [NEWS](https://gitlab.freedesktop.org/dbus/dbus/-/blob/958bf9db2100553bcd2fe2a854e1ebb42e886054/NEWS#L1-823)
  - [x] If `meson install` is run as root, and traditional (non-systemd)
    activation is enabled, the ownership and setuid permission of
    dbus-daemon-launch-helper are not set automatically.
    This is not the same as the historical behaviour of the Autotools build
    system, which would set the ownership and permissions automatically if
    run as uid 0.
    The ownership and permissions must now be set by OS distribution packaging,
    or as a manual post-installation step if dbus is installed directly
    without going via a packaging system (which is not recommended).
   **We do this in NixOS module**
  - [x] On Unix, the well-known system bus socket is in the runtime state
    directory by default (normally /run)
    (see 1.15.4 for more details)
   **We symlink /var/run to /run**
  - [x] On Linux with systemd, dbus-daemon starts as the target user/group
    (retaining CAP_AUDIT_WRITE) instead of starting as root and
    dropping privileges
    **Looks fine, do not see anything that could cause issues**
- [x] Skimmed through diffs of package outputs
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
