### PR TITLE
nixos/light: add minBrightness option

### DIFF
--- a/nixos/modules/programs/light.nix
+++ b/nixos/modules/programs/light.nix
@@ -49,6 +49,15 @@ in
           '';
         };
 
+        minBrightness = lib.mkOption {
+          type = lib.types.numbers.between 0 100;
+          default = 0.1;
+          description = ''
+            The minimum authorized brightness value, e.g. to avoid the
+            display going dark.
+          '';
+        };
+
       };
 
     };
@@ -63,13 +72,14 @@ in
         let
           light = "${pkgs.light}/bin/light";
           step = builtins.toString cfg.brightnessKeys.step;
+          minBrightness = builtins.toString cfg.brightnessKeys.minBrightness;
         in
         [
           {
             keys = [ 224 ];
             events = [ "key" ];
-            # Use minimum brightness 0.1 so the display won't go totally black.
-            command = "${light} -N 0.1 && ${light} -U ${step}";
+            # -N is used to ensure that value >= minBrightness
+            command = "${light} -N ${minBrightness} && ${light} -U ${step}";
           }
           {
             keys = [ 225 ];


### PR DESCRIPTION
Hi everyone!
This is my first contribution to Nixpkgs, and more generally to the Nix world! 🤩

Until now the minimum brightness level was always 0.1, which is too low for some computers (including mine 😜),
so I added an option to allow customizing it, while maintaining the same behavior for existing users.

Since it is my first contribution please tell me what I can improve 😉

Like is there anything to add to release notes/docs? If yes, where?

Tested with the unstable branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
