### PR TITLE
nicegui: patch version in pyproject.toml

### DIFF
--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -60,6 +60,15 @@ buildPythonPackage rec {
     hash = "sha256-U7S4JQ92H0SYEpMsMw5inioO6ayQ1/NDA7vnvR4i7Mk=";
   };
 
+  # the version in the pyproject.toml file is always the version (+ "-dev")
+  # before the version in the git tag
+  # this is also fixed in the github publish workflow in the project itself
+  postPatch = ''
+    sed --in-place \
+    's#^version = "[0-9]*\.[0-9]*\.[0-9]*-dev"$#version = "${version}"#' \
+    pyproject.toml
+  '';
+
   build-system = [
     poetry-core
     setuptools

--- a/pkgs/development/python-modules/nicegui/default.nix
+++ b/pkgs/development/python-modules/nicegui/default.nix
@@ -65,8 +65,8 @@ buildPythonPackage rec {
   # this is also fixed in the github publish workflow in the project itself
   postPatch = ''
     sed --in-place \
-    's#^version = "[0-9]*\.[0-9]*\.[0-9]*-dev"$#version = "${version}"#' \
-    pyproject.toml
+      's#^version = "[0-9]*\.[0-9]*\.[0-9]*-dev"$#version = "${version}"#' \
+      pyproject.toml
   '';
 
   build-system = [


### PR DESCRIPTION
The version in the pyproject.toml file does not match the version in the git tag in the nicegui repository.

Therefore the pyproject.toml file is patched in the github workflow for publishing nicegui on pypy.
Failing to patch it results in wrong directory names for static files.

This is based on the problems encountered in #383920 but since this MR is outdated due to recent changes on master, a new MR is created. As I described there, changing the version fixes the version you get via `nicegui.__version__` but does not fix the missing static files.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
