### PR TITLE
arsenik: init at 0.2.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -637,6 +637,7 @@
   ./services/hardware/actkbd.nix
   ./services/hardware/amdgpu.nix
   ./services/hardware/argonone.nix
+  ./services/hardware/arsenik.nix
   ./services/hardware/asusd.nix
   ./services/hardware/auto-cpufreq.nix
   ./services/hardware/auto-epp.nix

--- a/nixos/modules/services/hardware/arsenik.nix
+++ b/nixos/modules/services/hardware/arsenik.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.arsenik;
+in
+{
+  options.services.arsenik = {
+    enable = lib.mkEnableOption "A 33-key layout that works with all keyboards.";
+    package = lib.mkPackageOption pkgs "arsenik" { };
+    tap_timeout = lib.mkOption {
+      default = 200;
+      description = "The key must be pressed twice in XX ms to enable repetitions.";
+      type = lib.types.int;
+    };
+    hold_timeout = lib.mkOption {
+      default = 200;
+      description = "The key must be held XX ms to become a layer shift.";
+      type = lib.types.int;
+    };
+    long_hold_timeout = lib.mkOption {
+      default = 300;
+      description = "Slightly higher value for typing keys, to prevent unexpected hold effect.";
+      type = lib.types.int;
+    };
+    mac = lib.mkOption {
+      default = false;
+      description = "Original key arrangement on your keyboard: Mac or PC.";
+      type = lib.types.bool;
+    };
+    anglemod = lib.mkOption {
+      default = false;
+      description = ''
+        Choose here if you want to add an angle mod: ZXCVB are shifted to the left.
+        See https://colemakmods.github.io/ergonomic-mods/angle.html for more details.
+      '';
+      type = lib.types.bool;
+    };
+    wide = lib.mkOption {
+      default = false;
+      description = "The right hand is moved one key to the right.";
+      type = lib.types.bool;
+    };
+    lt = lib.mkOption {
+      default = false;
+      description = "Enable layer-taps.";
+      type = lib.types.bool;
+    };
+    hrm = lib.mkOption {
+      default = false;
+      description = "Enable homerow.";
+      type = lib.types.bool;
+    };
+    lafayette = lib.mkOption {
+      default = false;
+      description = "Add AltGr programmation layer like Ergo‑L";
+      type = lib.types.bool;
+    };
+    num = lib.mkOption {
+      default = false;
+      description = "Add NumRow layer";
+      type = lib.types.bool;
+    };
+    vim = lib.mkOption {
+      default = false;
+      description = "Navigation layer: ESDF or HJKL?";
+      type = lib.types.bool;
+    };
+    run = lib.mkOption {
+      default = "M-p";
+      description = "The keyboard shortcut of your application launcher.";
+      type = lib.types.str;
+    };
+    layout = lib.mkOption {
+      default = "ergol";
+      description = ''
+        Your keyboard layout. Possible values are:
+        ergol qwerty-lafayette qwerty azerty qwertz bepo optimot
+      '';
+      type = lib.types.str;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.wide -> cfg.anglemod;
+        message = "service.arsenik.wide requires service.arsenik.anglemod";
+      }
+      {
+        assertion = cfg.hrm -> cfg.lt;
+        message = "service.arsenik.hrm requires service.arsenik.lt";
+      }
+    ];
+
+    services.kanata =
+      let
+        src = "${cfg.package}/share/arsenik";
+        defsrc = "${if cfg.mac then "mac" else "pc"}${if cfg.wide then "_wide" else ""}${
+          if cfg.anglemod then "_anglemod" else ""
+        }";
+        base = "base${if cfg.lt then "_lt" else ""}${if cfg.hrm then "_hrm" else ""}";
+        symbols = "symbols_${if cfg.lafayette then "lafayette" else "noop"}${
+          if cfg.num then "_num" else ""
+        }";
+        navigation = "navigation${if cfg.vim then "_vim" else ""}";
+        alias = "${cfg.layout}_${if cfg.mac then "mac" else "pc"}";
+      in
+      {
+        enable = true;
+        keyboards.arsenik.config = ''
+          (defvar
+            tap_timeout ${builtins.toString cfg.tap_timeout}
+            hold_timeout ${builtins.toString cfg.hold_timeout}
+            long_hold_timeout ${builtins.toString cfg.long_hold_timeout}
+          )
+          (include ${src}/defsrc/${defsrc}.kbd)
+          (include ${src}/deflayer/${base}.kbd)
+          (include ${src}/deflayer/${symbols}.kbd)
+          (include ${src}/deflayer/${navigation}.kbd)
+          (defalias run ${cfg.run})
+          (include ${src}/defalias/${alias}.kbd)
+        '';
+      };
+  };
+}

--- a/pkgs/by-name/ar/arsenik/package.nix
+++ b/pkgs/by-name/ar/arsenik/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "arsenik";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "OneDeadKey";
+    repo = "arsenik";
+    tag = finalAttrs.version;
+    hash = "sha256-qY+SRWvZoy3iwsoZbzN5+TVWNIe3WWXkUGu/9MT20AU=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -r kanata $out/share/arsenik
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "33-key layout that works with all keyboards";
+    homepage = "https://github.com/OneDeadKey/arsenik";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add https://github.com/OneDeadKey/arsenik, a configurable kanata layout, especially useful for french bépo / ergo-L users.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
