### PR TITLE
runInLinuxVM: apply Qemu's vCPU limit

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -247,11 +247,17 @@ rec {
     eval "$preVM"
 
     if [ "$enableParallelBuilding" = 1 ]; then
+      QEMU_NR_VCPUS=0
       if [ ''${NIX_BUILD_CORES:-0} = 0 ]; then
-        QEMU_OPTS+=" -smp cpus=$(nproc)"
+        QEMU_NR_VCPUS="$(nproc)"
       else
-        QEMU_OPTS+=" -smp cpus=$NIX_BUILD_CORES"
+        QEMU_NR_VCPUS="$NIX_BUILD_CORES"
       fi
+      # qemu only supports 255 vCPUs (see error from `qemu-system-x86_64 -smp 256`)
+      if [ "$QEMU_NR_VCPUS" -gt 255 ]; then
+        QEMU_NR_VCPUS=255
+      fi
+      QEMU_OPTS+=" -smp cpus=$QEMU_NR_VCPUS"
     fi
 
     # Write the command to start the VM to a file so that the user can


### PR DESCRIPTION
Problem: 

`pkgs.vmTools.runInLinuxVM` is used, e.g. by `make-disk-image.nix` and some tests. Its starts a Qemu instance but may fail on systems with >= 256 CPU cores because Qemu for now only supports 255 cores. 

Solution: 

Limit number of virtual CPUs created by Qemu to 255. 

Tested on a 256 core system. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: `nix-build ./pkgs/build-support/vm/test.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@Mic92 @lheckemann @wolfgangwalther 