### PR TITLE
python312Packages: langgraph* update (with langraph 0.3.x)

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "2.0.13";
+  version = "2.0.15";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointpostgres==${version}";
-    hash = "sha256-Vz2ZoikEZuMvt3j9tvBIcXCwWSrCV8MI7x9PIHodl8Y=";
+    hash = "sha256-8JNPKaaKDM7VROd1n9TDALN6yxKRz1CuAultBcqBMG0=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-sqlite";
-  version = "2.0.3";
+  version = "2.0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointsqlite==${version}";
-    hash = "sha256-u3tKh63bOu+Ko2YynEfxQ/nGElEfwwTQ6Z1RhqF51Qs=";
+    hash = "sha256-8JNPKaaKDM7VROd1n9TDALN6yxKRz1CuAultBcqBMG0=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint-sqlite";

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "2.0.10";
+  version = "2.0.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${version}";
-    hash = "sha256-Bs8XWSyI/6a756iWXT40vvNIe/XZ/vnMsZbXjTW3770=";
+    hash = "sha256-HieCzNM+z7d0UGL8QOyjNP5P2IbLf0x0xhaUCWM/c0k=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "langgraph-cli";
-  version = "0.1.71";
+  version = "0.1.74";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "cli==${version}";
-    hash = "sha256-bTW+je4wuoR0YX5T1wdAee4w/T2jMTQybLLpCxouJxA=";
+    hash = "sha256-9/lL2TyOPiRIy6PfWEcd2fBNjn3n3Rpg0/7DL/4+Qpc=";
   };
 
   sourceRoot = "${src.name}/libs/cli";

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.51";
+  version = "0.1.53";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "sdk==${version}";
-    hash = "sha256-BkwH9O59gG/OtnFWYEFe2WD0sIidptlkPACX9i7kCb8=";
+    hash = "sha256-Mx/36+FYZi/XNHJwlNRKE/lVo6nRTXUQwtYkq7HmBu0=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -22,6 +22,7 @@
   langgraph-checkpoint-sqlite,
   langsmith,
   psycopg,
+  psycopg-pool,
   pydantic,
   pytest-asyncio,
   pytest-mock,
@@ -32,17 +33,75 @@
   postgresql,
   postgresqlTestHook,
 }:
+let
+  # langgraph-prebuilt isn't meant to be a standalone package but is bundled into langgraph at build time.
+  # It exists so the langgraph team can iterate on it without having to rebuild langgraph.
+  langgraph-prebuilt = buildPythonPackage rec {
+    pname = "langgraph-prebuilt";
+    version = "0.1.1";
+    pyproject = true;
 
+    src = fetchFromGitHub {
+      owner = "langchain-ai";
+      repo = "langgraph";
+      tag = "prebuilt==${version}";
+      hash = "sha256-Kyyr4BSrUReC6jBp4LItuS/JNSzGK5IUaPl7UaLse78=";
+    };
+
+    sourceRoot = "${src.name}/libs/prebuilt";
+
+    build-system = [ poetry-core ];
+
+    dependencies = [
+      langchain-core
+      langgraph-checkpoint
+    ];
+
+    skipPythonImportsCheck = true; # This will be packaged with langgraph
+
+    # postgresql doesn't play nicely with the darwin sandbox:
+    # FATAL:  could not create shared memory segment: Operation not permitted
+    doCheck = !stdenv.hostPlatform.isDarwin;
+
+    nativeCheckInputs = [
+      pytestCheckHook
+      postgresql
+      postgresqlTestHook
+    ];
+
+    checkInputs = [
+      langgraph-checkpoint
+      langgraph-checkpoint-postgres
+      langgraph-checkpoint-sqlite
+      psycopg
+      psycopg-pool
+      pytest-asyncio
+      pytest-mock
+    ];
+
+    preCheck = ''
+      export PYTHONPATH=${src}/libs/langgraph:$PYTHONPATH
+    '';
+
+    pytestFlagsArray = [
+      "-W"
+      "ignore::pytest.PytestDeprecationWarning"
+      "-W"
+      "ignore::DeprecationWarning"
+    ];
+
+  };
+in
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.2.70";
+  version = "0.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "${version}";
-    hash = "sha256-Vz2ZoikEZuMvt3j9tvBIcXCwWSrCV8MI7x9PIHodl8Y=";
+    hash = "sha256-EawVIzG+db2k6/tQyUHCF6SzlO77QTXsYRUm3XpLu/c=";
   };
 
   postgresqlTestSetupPost = ''
@@ -57,6 +116,7 @@ buildPythonPackage rec {
   dependencies = [
     langchain-core
     langgraph-checkpoint
+    langgraph-prebuilt
     langgraph-sdk
   ];
 
@@ -67,6 +127,12 @@ buildPythonPackage rec {
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   nativeCheckInputs = [
+    pytestCheckHook
+    postgresql
+    postgresqlTestHook
+  ];
+
+  checkInputs = [
     aiosqlite
     dataclasses-json
     grandalf
@@ -82,10 +148,7 @@ buildPythonPackage rec {
     pytest-mock
     pytest-repeat
     pytest-xdist
-    pytestCheckHook
     syrupy
-    postgresql
-    postgresqlTestHook
   ];
 
   disabledTests = [


### PR DESCRIPTION
Bringing Langgraph up to date with 0.3.x 

* python312Packages.langgraph`: 0.2.70 -> 0.3.2 includes bundled `langgraph-prebuilt`
* python3Packages.langgraph-sdk: 0.1.51 -> 0.1.53
* python312Packages.langgraph-cli: 0.1.71 -> 0.1.74
* python312Packages.langgraph-checkpoint: 2.0.10 -> 2.0.16
* python312Packages.langgraph-checkpoint-postgres: 2.0.13 -> 2.0.15
* python312Packages.langgraph-checkpoint-sqlite: 2.0.2 -> 2.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
