### PR TITLE
kew: 1.5.2->3.0.3, darwin support, add darwin maintainer, derivation cleanup

### DIFF
--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -1,27 +1,31 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, ffmpeg
 , fftwFloat
 , chafa
-, freeimage
 , glib
+, libopus
+, opusfile
+, libvorbis
+, taglib
+, faad2
+, libogg
 , pkg-config
 }:
 
 stdenv.mkDerivation rec {
   pname = "kew";
-  version = "1.5.2";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "ravachol";
     repo = "kew";
-    rev = "v${version}";
-    hash = "sha256-Om7v8eTlYxXQYf1MG+L0I5ICQ2LS7onouhPGosuK8NM=";
+    tag = "v${version}";
+    hash = "sha256-DzJ+7PanA15A9nIbFPWZ/tdxq4aDyParJORcuqHV7jc=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ffmpeg freeimage fftwFloat chafa glib ];
+  buildInputs = [ fftwFloat.dev chafa glib.dev libopus opusfile libvorbis taglib faad2 libogg ];
 
   installFlags = [
     "MAN_DIR=${placeholder "out"}/share/man"
@@ -31,7 +35,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command-line music player for Linux";
     homepage = "https://github.com/ravachol/kew";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ demine ];
     mainProgram = "kew";

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -1,21 +1,22 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fftwFloat
-, chafa
-, glib
-, libopus
-, opusfile
-, libvorbis
-, taglib
-, faad2
-, libogg
-, pkg-config
-, versionCheckHook
-, gitUpdater
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fftwFloat,
+  chafa,
+  glib,
+  libopus,
+  opusfile,
+  libvorbis,
+  taglib,
+  faad2,
+  libogg,
+  pkg-config,
+  versionCheckHook,
+  gitUpdater,
 }:
 
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kew";
   version = "3.0.3";
 
@@ -27,7 +28,17 @@ stdenv.mkDerivation(finalAttrs: {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ fftwFloat.dev chafa glib.dev libopus opusfile libvorbis taglib faad2 libogg ];
+  buildInputs = [
+    fftwFloat.dev
+    chafa
+    glib.dev
+    libopus
+    opusfile
+    libvorbis
+    taglib
+    faad2
+    libogg
+  ];
 
   installFlags = [
     "MAN_DIR=${placeholder "out"}/share/man"
@@ -48,7 +59,10 @@ stdenv.mkDerivation(finalAttrs: {
     homepage = "https://github.com/ravachol/kew";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ demine matteopacini ];
+    maintainers = with lib.maintainers; [
+      demine
+      matteopacini
+    ];
     mainProgram = "kew";
   };
 })

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ravachol/kew";
     platforms = platforms.unix;
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ demine ];
+    maintainers = with maintainers; [ demine matteopacini ];
     mainProgram = "kew";
   };
 }

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -11,6 +11,8 @@
 , faad2
 , libogg
 , pkg-config
+, versionCheckHook
+, gitUpdater
 }:
 
 stdenv.mkDerivation(finalAttrs: {
@@ -31,6 +33,15 @@ stdenv.mkDerivation(finalAttrs: {
     "MAN_DIR=${placeholder "out"}/share/man"
     "PREFIX=${placeholder "out"}"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = gitUpdater { };
+  };
 
   meta = {
     description = "Command-line music player for Linux";

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -13,14 +13,14 @@
 , pkg-config
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation(finalAttrs: {
   pname = "kew";
   version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "ravachol";
     repo = "kew";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DzJ+7PanA15A9nIbFPWZ/tdxq4aDyParJORcuqHV7jc=";
   };
 
@@ -32,12 +32,12 @@ stdenv.mkDerivation rec {
     "PREFIX=${placeholder "out"}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Command-line music player for Linux";
     homepage = "https://github.com/ravachol/kew";
-    platforms = platforms.unix;
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ demine matteopacini ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ demine matteopacini ];
     mainProgram = "kew";
   };
-}
+})


### PR DESCRIPTION
- Upgrade Kew to the latest available version - 3.0.3 (new deps and plenty of new features since 1.5.2): https://github.com/ravachol/kew/releases/tag/v3.0.3
- Added Darwin support and added myself as a maintainer
- Cleaned up derivation:
    - `rec` -> `finalAttrs`
    - `rev` -> `tag`
    - `with lib;` cleanup
    
    
![Screenshot 2025-03-01 at 22 52 35](https://github.com/user-attachments/assets/242e6933-48df-4af9-a8ac-004e7b74ea7b)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
