### PR TITLE
util-linux: add cryptsetup support

### DIFF
--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -106,7 +106,10 @@ stdenv.mkDerivation rec {
     changelog = "https://gitlab.com/cryptsetup/cryptsetup/-/raw/v${version}/docs/v${version}-ReleaseNotes";
     license = lib.licenses.gpl2Plus;
     mainProgram = "cryptsetup";
-    maintainers = with lib.maintainers; [ raitobezarius ];
+    maintainers = with lib.maintainers; [
+      numinit
+      raitobezarius
+    ];
     platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     ++ (lib.mapAttrsToList (lib.flip lib.enableFeature)) programs;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals rebuildMan [ asciidoctor ];
-  buildInputs = [
+  propagatedBuildInputs = [
     lvm2
     json_c
     openssl

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -8,6 +8,11 @@
   capabilitiesSupport ? stdenv.hostPlatform.isLinux,
   libcap_ng,
   libxcrypt,
+  # Disable this by default because `mount` is setuid. However, we also support
+  # "dlopen" as a value here. Note that the nixpkgs setuid wrapper and ld-linux.so will filter out LD_LIBRARY_PATH
+  # if you set this to dlopen, so ensure you're accessing it without the wrapper if you depend on that.
+  cryptsetupSupport ? false,
+  cryptsetup,
   ncursesSupport ? true,
   ncurses,
   pamSupport ? true,
@@ -24,9 +29,11 @@
   gitUpdater,
 }:
 
+let
+  isMinimal = cryptsetupSupport == false && !nlsSupport && !ncursesSupport && !systemdSupport;
+in
 stdenv.mkDerivation rec {
-  pname =
-    "util-linux" + lib.optionalString (!nlsSupport && !ncursesSupport && !systemdSupport) "-minimal";
+  pname = "util-linux" + lib.optionalString isMinimal "-minimal";
   version = "2.40.4";
 
   src = fetchurl {
@@ -88,6 +95,14 @@ stdenv.mkDerivation rec {
       "--disable-su" # provided by shadow
       (lib.enableFeature writeSupport "write")
       (lib.enableFeature nlsSupport "nls")
+      (lib.withFeatureAs (cryptsetupSupport != false) "cryptsetup" (
+        if cryptsetupSupport == true then
+          "yes"
+        else if cryptsetupSupport == "dlopen" then
+          "dlopen"
+        else
+          throw "invalid cryptsetupSupport value: ${toString cryptsetupSupport}"
+      ))
       (lib.withFeature ncursesSupport "ncursesw")
       (lib.withFeature systemdSupport "systemd")
       (lib.withFeatureAs systemdSupport "systemdsystemunitdir" "${placeholder "bin"}/lib/systemd/system/")
@@ -113,10 +128,13 @@ stdenv.mkDerivation rec {
     "usrsbin_execdir=${placeholder "bin"}/sbin"
   ];
 
-  nativeBuildInputs = [
-    pkg-config
-    installShellFiles
-  ] ++ lib.optionals translateManpages [ po4a ];
+  nativeBuildInputs =
+    [
+      pkg-config
+      installShellFiles
+    ]
+    ++ lib.optionals translateManpages [ po4a ]
+    ++ lib.optionals (cryptsetupSupport == "dlopen") [ cryptsetup ];
 
   buildInputs =
     [
@@ -124,6 +142,7 @@ stdenv.mkDerivation rec {
       libxcrypt
       sqlite
     ]
+    ++ lib.optionals (cryptsetupSupport == true) [ cryptsetup ]
     ++ lib.optionals pamSupport [ pam ]
     ++ lib.optionals capabilitiesSupport [ libcap_ng ]
     ++ lib.optionals ncursesSupport [ ncurses ]

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -193,12 +193,12 @@ stdenv.mkDerivation rec {
     hasCol = stdenv.hostPlatform.libc == "glibc";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.kernel.org/pub/linux/utils/util-linux/";
     description = "Set of system utilities for Linux";
     changelog = "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${lib.versions.majorMinor version}/v${version}-ReleaseNotes";
     # https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/README.licensing
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl2Only
       gpl2Plus
       gpl3Plus
@@ -207,7 +207,8 @@ stdenv.mkDerivation rec {
       bsdOriginalUC
       publicDomain
     ];
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ numinit ];
+    platforms = lib.platforms.unix;
     pkgConfigModules = [
       "blkid"
       "fdisk"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12421,6 +12421,7 @@ with pkgs;
   usbrelayd = callPackage ../os-specific/linux/usbrelay/daemon.nix { };
 
   util-linuxMinimal = util-linux.override {
+    cryptsetupSupport = false;
     nlsSupport = false;
     ncursesSupport = false;
     pamSupport = false;


### PR DESCRIPTION
Various tools (see mount.8) have extra features that only work if util-linux is linked with cryptsetup. Allow enabling it so things like this work:
    
https://man7.org/linux/man-pages/man8/mount.8.html#DM-VERITY_SUPPORT
    
Do not enable it by default since `mount` is setuid, and pulling all of OpenSSL into a setuid context seems like a quite easy way to cause a privesc vulnerability.

----

Testing linking:

```
nix-shell -E 'with import ./. {}; mkShell { buildInputs = [ (util-linux.override { cryptsetupSupport = true; }) cryptsetup squashfsTools ]; }'
mkdir -p test
dd if=/dev/urandom of=test/random.bin bs=1M count=1
mksquashfs test test.squashfs
veritysetup format --root-hash-file=test.hash test.squashfs test.verity
sudo sh -c "$(which mount) -t squashfs -o verity.hashdevice=$(realpath test.verity),verity.roothash=$(<test.hash) ./test.squashfs test; mount | tail -n1; umount test"
# /dev/mapper/63d26b05305b1fd3063f66edcf213b74cf33b422708856b63bfb0162f03c09a1-verity on /home/numinit/projects/nix/nixpkgs/test type squashfs (ro,relatime,errors=continue,threads=single)
```

Testing dlopen:

```
nix-shell -E 'with import ./. {}; mkShell { buildInputs = [ (util-linux.override { cryptsetupSupport = "dlopen"; }) cryptsetup squashfsTools ]; shellHook = "export LD_LIBRARY_PATH=${lib.makeLibraryPath [ cryptsetup ]}"; }'
mkdir -p test
dd if=/dev/urandom of=test/random.bin bs=1M count=1
mksquashfs test test.squashfs
veritysetup format --root-hash-file=test.hash test.squashfs test.verity
sudo sh -c "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH; $(which mount) -t squashfs -o verity.hashdevice=$(realpath test.verity),verity.roothash=$(<test.hash) ./test.squashfs test; mount | tail -n1; umount test"
# /dev/mapper/63d26b05305b1fd3063f66edcf213b74cf33b422708856b63bfb0162f03c09a1-verity on /home/numinit/projects/nix/nixpkgs/test type squashfs (ro,relatime,errors=continue,threads=single)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
