### PR TITLE
go-mockery: 2.52.1 -> 2.52.4

### DIFF
--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -1,4 +1,4 @@
-{ lib, buildGo124Module, fetchFromGitHub, go-mockery, runCommand, go }:
+{ lib, buildGo124Module, fetchFromGitHub, go-mockery, runCommand, go_1_24 }:
 
 buildGo124Module rec {
   pname = "go-mockery";
@@ -31,7 +31,7 @@ buildGo124Module rec {
   passthru.tests = {
     generateMock = runCommand "${pname}-test" {
       nativeBuildInputs = [ go-mockery ];
-      buildInputs = [ go ];
+      buildInputs = [ go_1_24 ];
     } ''
       if [[ $(mockery --version) != *"${version}"* ]]; then
         echo "Error: program version does not match package version"

--- a/pkgs/by-name/go/go-mockery/package.nix
+++ b/pkgs/by-name/go/go-mockery/package.nix
@@ -1,14 +1,14 @@
-{ lib, buildGoModule, fetchFromGitHub, go-mockery, runCommand, go }:
+{ lib, buildGo124Module, fetchFromGitHub, go-mockery, runCommand, go }:
 
-buildGoModule rec {
+buildGo124Module rec {
   pname = "go-mockery";
-  version = "2.52.1";
+  version = "2.52.4";
 
   src = fetchFromGitHub {
     owner = "vektra";
     repo = "mockery";
     rev = "v${version}";
-    sha256 = "sha256-algCErKmB43r/t7wo8BJSM0MHRxvxVWZ2u0n1xuLLdw=";
+    sha256 = "sha256-5LGwBnUWO9iB8NVm0qxOChLri7lIQM9TYhIUTZeA1UI=";
   };
 
   preCheck = ''
@@ -24,7 +24,7 @@ buildGoModule rec {
   env.CGO_ENABLED = false;
 
   proxyVendor = true;
-  vendorHash = "sha256-nL6dDGifhtmDHfz1ae+wnmVPPQDLrRgI7v8c5cQzo8Q=";
+  vendorHash = "sha256-oNecP9ruwv/tD5Xf9zOhK6x8O2U4zHrgQJk29Ro1QGU=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
Updated mockery to [v2.52.4 from v2.52.1](https://github.com/vektra/mockery/releases).

Besides minor bug fixes, the most notable change is Go 1.24 support. This version requires a Go 1.24 toolchain, so we also switch from `buildGoModule` to `buildGo124Module` for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
