### PR TITLE
frigate: 0.14.1 -> 0.15.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -410,7 +410,7 @@ in {
   freeswitch = handleTest ./freeswitch.nix {};
   freetube = discoverTests (import ./freetube.nix);
   freshrss = handleTest ./freshrss {};
-  frigate = handleTest ./frigate.nix {};
+  frigate = runTest ./frigate.nix;
   frp = handleTest ./frp.nix {};
   frr = handleTest ./frr.nix {};
   fsck = handleTest ./fsck.nix {};

--- a/nixos/tests/frigate.nix
+++ b/nixos/tests/frigate.nix
@@ -1,79 +1,81 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  ...
+}:
 
-  {
-    name = "frigate";
-    meta.maintainers = with lib.maintainers; [ hexa ];
+{
+  name = "frigate";
+  meta = { inherit (pkgs.frigate.meta) maintainers; };
 
-    nodes = {
-      machine = {
-        services.frigate = {
-          enable = true;
+  nodes = {
+    machine = {
+      services.frigate = {
+        enable = true;
 
-          hostname = "localhost";
+        hostname = "localhost";
 
-          settings = {
-            mqtt.enabled = false;
+        settings = {
+          mqtt.enabled = false;
 
-            cameras.test = {
-              ffmpeg = {
-                input_args = "-fflags nobuffer -strict experimental -fflags +genpts+discardcorrupt -r 10 -use_wallclock_as_timestamps 1";
-                inputs = [
-                  {
-                    path = "http://127.0.0.1:8080";
-                    roles = [
-                      "record"
-                    ];
-                  }
-                ];
-              };
+          cameras.test = {
+            ffmpeg = {
+              input_args = "-fflags nobuffer -strict experimental -fflags +genpts+discardcorrupt -r 10 -use_wallclock_as_timestamps 1";
+              inputs = [
+                {
+                  path = "http://127.0.0.1:8080";
+                  roles = [
+                    "record"
+                  ];
+                }
+              ];
             };
-
-            record.enabled = true;
           };
-        };
 
-        systemd.services.video-stream = {
-          description = "Start a test stream that frigate can capture";
-          before = [
-            "frigate.service"
-          ];
-          wantedBy = [
-            "multi-user.target"
-          ];
-          serviceConfig = {
-            DynamicUser = true;
-            ExecStart = "${lib.getExe pkgs.ffmpeg-headless} -re -f lavfi -i smptebars=size=1280x720:rate=5 -f mpegts -listen 1 http://0.0.0.0:8080";
-            Restart = "always";
-          };
+          record.enabled = true;
         };
-
-        environment.systemPackages = with pkgs; [ httpie ];
       };
+
+      systemd.services.video-stream = {
+        description = "Start a test stream that frigate can capture";
+        before = [
+          "frigate.service"
+        ];
+        wantedBy = [
+          "multi-user.target"
+        ];
+        serviceConfig = {
+          DynamicUser = true;
+          ExecStart = "${lib.getExe pkgs.ffmpeg-headless} -re -f lavfi -i smptebars=size=1280x720:rate=5 -f mpegts -listen 1 http://0.0.0.0:8080";
+          Restart = "always";
+        };
+      };
+
+      environment.systemPackages = with pkgs; [ httpie ];
     };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      # wait until frigate is up
-      machine.wait_for_unit("frigate.service")
-      machine.wait_for_open_port(5001)
+    # wait until frigate is up
+    machine.wait_for_unit("frigate.service")
+    machine.wait_for_open_port(5001)
 
-      # extract admin password from logs
-      machine.wait_until_succeeds("journalctl -u frigate.service -o cat | grep -q 'Password: '")
-      password = machine.execute("journalctl -u frigate.service -o cat | grep -oP '([a-f0-9]{32})'")[1]
+    # extract admin password from logs
+    machine.wait_until_succeeds("journalctl -u frigate.service -o cat | grep -q 'Password: '")
+    password = machine.execute("journalctl -u frigate.service -o cat | grep -oP '([a-f0-9]{32})'")[1]
 
-      # login and store session
-      machine.log(machine.succeed(f"http --check-status --session=frigate post http://localhost/api/login user=admin password={password}"))
+    # login and store session
+    machine.log(machine.succeed(f"http --check-status --session=frigate post http://localhost/api/login user=admin password={password}"))
 
-      # make authenticated api request
-      machine.log(machine.succeed("http --check-status --session=frigate get http://localhost/api/version"))
+    # make authenticated api request
+    machine.log(machine.succeed("http --check-status --session=frigate get http://localhost/api/version"))
 
-      # make unauthenticated api request
-      machine.log(machine.succeed("http --check-status get http://localhost:5000/api/version"))
+    # make unauthenticated api request
+    machine.log(machine.succeed("http --check-status get http://localhost:5000/api/version"))
 
-      # wait for a recording to appear
-      machine.wait_for_file("/var/cache/frigate/test@*.mp4")
-    '';
-  }
-)
+    # wait for a recording to appear
+    machine.wait_for_file("/var/cache/frigate/test@*.mp4")
+  '';
+}

--- a/pkgs/by-name/fr/frigate/constants.patch
+++ b/pkgs/by-name/fr/frigate/constants.patch
@@ -1,0 +1,380 @@
+diff --git a/frigate/api/media.py b/frigate/api/media.py
+index b5f3ba70..09a09c13 100644
+--- a/frigate/api/media.py
++++ b/frigate/api/media.py
+@@ -31,6 +31,7 @@ from frigate.config import FrigateConfig
+ from frigate.const import (
+     CACHE_DIR,
+     CLIPS_DIR,
++    INSTALL_DIR,
+     MAX_SEGMENT_DURATION,
+     PREVIEW_FRAME_TYPE,
+     RECORD_DIR,
+@@ -154,7 +155,9 @@ def latest_frame(
+             frame_processor.get_current_frame_time(camera_name) + retry_interval
+         ):
+             if request.app.camera_error_image is None:
+-                error_image = glob.glob("/opt/frigate/frigate/images/camera-error.jpg")
++                error_image = glob.glob(
++                    os.path.join(INSTALL_DIR, "frigate/images/camera-error.jpg")
++                )
+ 
+                 if len(error_image) > 0:
+                     request.app.camera_error_image = cv2.imread(
+@@ -497,7 +500,7 @@ def recording_clip(
+     )
+ 
+     file_name = sanitize_filename(f"playlist_{camera_name}_{start_ts}-{end_ts}.txt")
+-    file_path = f"/tmp/cache/{file_name}"
++    file_path = os.path.join(CACHE_DIR, file_name)
+     with open(file_path, "w") as file:
+         clip: Recordings
+         for clip in recordings:
+diff --git a/frigate/api/preview.py b/frigate/api/preview.py
+index d14a15ff..2db2326a 100644
+--- a/frigate/api/preview.py
++++ b/frigate/api/preview.py
+@@ -9,7 +9,7 @@ from fastapi import APIRouter
+ from fastapi.responses import JSONResponse
+ 
+ from frigate.api.defs.tags import Tags
+-from frigate.const import CACHE_DIR, PREVIEW_FRAME_TYPE
++from frigate.const import BASE_DIR, CACHE_DIR, PREVIEW_FRAME_TYPE
+ from frigate.models import Previews
+ 
+ logger = logging.getLogger(__name__)
+@@ -52,7 +52,7 @@ def preview_ts(camera_name: str, start_ts: float, end_ts: float):
+         clips.append(
+             {
+                 "camera": preview["camera"],
+-                "src": preview["path"].replace("/media/frigate", ""),
++                "src": preview["path"].replace(BASE_DIR, ""),
+                 "type": "video/mp4",
+                 "start": preview["start_time"],
+                 "end": preview["end_time"],
+diff --git a/frigate/comms/webpush.py b/frigate/comms/webpush.py
+index abfd52d1..ab4cf3c5 100644
+--- a/frigate/comms/webpush.py
++++ b/frigate/comms/webpush.py
+@@ -12,7 +12,7 @@ from pywebpush import WebPusher
+ from frigate.comms.config_updater import ConfigSubscriber
+ from frigate.comms.dispatcher import Communicator
+ from frigate.config import FrigateConfig
+-from frigate.const import CONFIG_DIR
++from frigate.const import BASE_DIR, CONFIG_DIR
+ from frigate.models import User
+ 
+ logger = logging.getLogger(__name__)
+@@ -151,7 +151,7 @@ class WebPushClient(Communicator):  # type: ignore[misc]
+         camera: str = payload["after"]["camera"]
+         title = f"{', '.join(sorted_objects).replace('_', ' ').title()}{' was' if state == 'end' else ''} detected in {', '.join(payload['after']['data']['zones']).replace('_', ' ').title()}"
+         message = f"Detected on {camera.replace('_', ' ').title()}"
+-        image = f"{payload['after']['thumb_path'].replace('/media/frigate', '')}"
++        image = f"{payload['after']['thumb_path'].replace(BASE_DIR, '')}"
+ 
+         # if event is ongoing open to live view otherwise open to recordings view
+         direct_url = f"/review?id={reviewId}" if state == "end" else f"/#{camera}"
+diff --git a/frigate/const.py b/frigate/const.py
+index 5976f47b..dc710467 100644
+--- a/frigate/const.py
++++ b/frigate/const.py
+@@ -1,5 +1,6 @@
+ import re
+ 
++INSTALL_DIR = "/opt/frigate"
+ CONFIG_DIR = "/config"
+ DEFAULT_DB_PATH = f"{CONFIG_DIR}/frigate.db"
+ MODEL_CACHE_DIR = f"{CONFIG_DIR}/model_cache"
+diff --git a/frigate/detectors/detector_config.py b/frigate/detectors/detector_config.py
+index 452f1fee..13535a62 100644
+--- a/frigate/detectors/detector_config.py
++++ b/frigate/detectors/detector_config.py
+@@ -9,7 +9,7 @@ import requests
+ from pydantic import BaseModel, ConfigDict, Field
+ from pydantic.fields import PrivateAttr
+ 
+-from frigate.const import DEFAULT_ATTRIBUTE_LABEL_MAP
++from frigate.const import DEFAULT_ATTRIBUTE_LABEL_MAP, MODEL_CACHE_DIR
+ from frigate.plus import PlusApi
+ from frigate.util.builtin import generate_color_palette, load_labels
+ 
+@@ -117,7 +117,7 @@ class ModelConfig(BaseModel):
+             return
+ 
+         model_id = self.path[7:]
+-        self.path = f"/config/model_cache/{model_id}"
++        self.path = os.path.join(MODEL_CACHE_DIR, model_id)
+         model_info_path = f"{self.path}.json"
+ 
+         # download the model if it doesn't exist
+diff --git a/frigate/detectors/plugins/hailo8l.py b/frigate/detectors/plugins/hailo8l.py
+index b66d78bd..69e86bc5 100644
+--- a/frigate/detectors/plugins/hailo8l.py
++++ b/frigate/detectors/plugins/hailo8l.py
+@@ -22,6 +22,7 @@ except ModuleNotFoundError:
+ from pydantic import BaseModel, Field
+ from typing_extensions import Literal
+ 
++from frigate.const import MODEL_CACHE_DIR
+ from frigate.detectors.detection_api import DetectionApi
+ from frigate.detectors.detector_config import BaseDetectorConfig
+ 
+@@ -57,7 +58,7 @@ class HailoDetector(DetectionApi):
+         self.h8l_tensor_format = detector_config.model.input_tensor
+         self.h8l_pixel_format = detector_config.model.input_pixel_format
+         self.model_url = "https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v2.11.0/hailo8l/ssd_mobilenet_v1.hef"
+-        self.cache_dir = "/config/model_cache/h8l_cache"
++        self.cache_dir = os.path.join(MODEL_CACHE_DIR, "h8l_cache")
+         self.expected_model_filename = "ssd_mobilenet_v1.hef"
+         output_type = "FLOAT32"
+ 
+diff --git a/frigate/detectors/plugins/openvino.py b/frigate/detectors/plugins/openvino.py
+index 51e48530..d199317b 100644
+--- a/frigate/detectors/plugins/openvino.py
++++ b/frigate/detectors/plugins/openvino.py
+@@ -7,6 +7,7 @@ import openvino.properties as props
+ from pydantic import Field
+ from typing_extensions import Literal
+ 
++from frigate.const import MODEL_CACHE_DIR
+ from frigate.detectors.detection_api import DetectionApi
+ from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
+ 
+@@ -35,8 +36,10 @@ class OvDetector(DetectionApi):
+             logger.error(f"OpenVino model file {detector_config.model.path} not found.")
+             raise FileNotFoundError
+ 
+-        os.makedirs("/config/model_cache/openvino", exist_ok=True)
+-        self.ov_core.set_property({props.cache_dir: "/config/model_cache/openvino"})
++        os.makedirs(os.path.join(MODEL_CACHE_DIR, "openvino"), exist_ok=True)
++        self.ov_core.set_property(
++            {props.cache_dir: os.path.join(MODEL_CACHE_DIR, "openvino")}
++        )
+         self.interpreter = self.ov_core.compile_model(
+             model=detector_config.model.path, device_name=detector_config.device
+         )
+diff --git a/frigate/detectors/plugins/rknn.py b/frigate/detectors/plugins/rknn.py
+index df94d7b6..bc3d9ae0 100644
+--- a/frigate/detectors/plugins/rknn.py
++++ b/frigate/detectors/plugins/rknn.py
+@@ -6,6 +6,7 @@ from typing import Literal
+ 
+ from pydantic import Field
+ 
++from frigate.const import MODEL_CACHE_DIR
+ from frigate.detectors.detection_api import DetectionApi
+ from frigate.detectors.detector_config import BaseDetectorConfig, ModelTypeEnum
+ 
+@@ -17,7 +18,7 @@ supported_socs = ["rk3562", "rk3566", "rk3568", "rk3576", "rk3588"]
+ 
+ supported_models = {ModelTypeEnum.yolonas: "^deci-fp16-yolonas_[sml]$"}
+ 
+-model_cache_dir = "/config/model_cache/rknn_cache/"
++model_cache_dir = os.path.join(MODEL_CACHE_DIR, "rknn_cache/")
+ 
+ 
+ class RknnDetectorConfig(BaseDetectorConfig):
+diff --git a/frigate/detectors/plugins/rocm.py b/frigate/detectors/plugins/rocm.py
+index 60118d12..7c87edb5 100644
+--- a/frigate/detectors/plugins/rocm.py
++++ b/frigate/detectors/plugins/rocm.py
+@@ -9,6 +9,7 @@ import numpy as np
+ from pydantic import Field
+ from typing_extensions import Literal
+ 
++from frigate.const import MODEL_CACHE_DIR
+ from frigate.detectors.detection_api import DetectionApi
+ from frigate.detectors.detector_config import (
+     BaseDetectorConfig,
+@@ -116,7 +117,7 @@ class ROCmDetector(DetectionApi):
+ 
+             logger.info(f"AMD/ROCm: saving parsed model into {mxr_path}")
+ 
+-            os.makedirs("/config/model_cache/rocm", exist_ok=True)
++            os.makedirs(os.path.join(MODEL_CACHE_DIR, "rocm"), exist_ok=True)
+             migraphx.save(self.model, mxr_path)
+ 
+         logger.info("AMD/ROCm: model loaded")
+diff --git a/frigate/output/birdseye.py b/frigate/output/birdseye.py
+index 00f17c8f..8331eb64 100644
+--- a/frigate/output/birdseye.py
++++ b/frigate/output/birdseye.py
+@@ -16,7 +16,7 @@ import numpy as np
+ 
+ from frigate.comms.config_updater import ConfigSubscriber
+ from frigate.config import BirdseyeModeEnum, FfmpegConfig, FrigateConfig
+-from frigate.const import BASE_DIR, BIRDSEYE_PIPE
++from frigate.const import BASE_DIR, BIRDSEYE_PIPE, INSTALL_DIR
+ from frigate.util.image import (
+     SharedMemoryFrameManager,
+     copy_yuv_to_position,
+@@ -297,7 +297,9 @@ class BirdsEyeFrameManager:
+             birdseye_logo = cv2.imread(custom_logo_files[0], cv2.IMREAD_UNCHANGED)
+ 
+         if birdseye_logo is None:
+-            logo_files = glob.glob("/opt/frigate/frigate/images/birdseye.png")
++            logo_files = glob.glob(
++                os.path.join(INSTALL_DIR, "frigate/images/birdseye.png")
++            )
+ 
+             if len(logo_files) > 0:
+                 birdseye_logo = cv2.imread(logo_files[0], cv2.IMREAD_UNCHANGED)
+diff --git a/frigate/test/http_api/base_http_test.py b/frigate/test/http_api/base_http_test.py
+index e7a1d03e..4fa4a5b5 100644
+--- a/frigate/test/http_api/base_http_test.py
++++ b/frigate/test/http_api/base_http_test.py
+@@ -9,6 +9,7 @@ from playhouse.sqliteq import SqliteQueueDatabase
+ 
+ from frigate.api.fastapi_app import create_fastapi_app
+ from frigate.config import FrigateConfig
++from frigate.const import BASE_DIR, CACHE_DIR
+ from frigate.models import Event, Recordings, ReviewSegment
+ from frigate.review.types import SeverityEnum
+ from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
+@@ -72,19 +73,19 @@ class BaseTestHttp(unittest.TestCase):
+                         "total": 67.1,
+                         "used": 16.6,
+                     },
+-                    "/media/frigate/clips": {
++                    os.path.join(BASE_DIR, "clips"): {
+                         "free": 42429.9,
+                         "mount_type": "ext4",
+                         "total": 244529.7,
+                         "used": 189607.0,
+                     },
+-                    "/media/frigate/recordings": {
++                    os.path.join(BASE_DIR, "recordings"): {
+                         "free": 0.2,
+                         "mount_type": "ext4",
+                         "total": 8.0,
+                         "used": 7.8,
+                     },
+-                    "/tmp/cache": {
++                    CACHE_DIR: {
+                         "free": 976.8,
+                         "mount_type": "tmpfs",
+                         "total": 1000.0,
+diff --git a/frigate/test/test_config.py b/frigate/test/test_config.py
+index e6cb1274..5a3deefd 100644
+--- a/frigate/test/test_config.py
++++ b/frigate/test/test_config.py
+@@ -854,9 +854,9 @@ class TestConfig(unittest.TestCase):
+         assert frigate_config.model.merged_labelmap[0] == "person"
+ 
+     def test_plus_labelmap(self):
+-        with open("/config/model_cache/test", "w") as f:
++        with open(os.path.join(MODEL_CACHE_DIR, "test"), "w") as f:
+             json.dump(self.plus_model_info, f)
+-        with open("/config/model_cache/test.json", "w") as f:
++        with open(os.path.join(MODEL_CACHE_DIR, "test.json"), "w") as f:
+             json.dump(self.plus_model_info, f)
+ 
+         config = {
+diff --git a/frigate/test/test_http.py b/frigate/test/test_http.py
+index 21379425..66f9d22a 100644
+--- a/frigate/test/test_http.py
++++ b/frigate/test/test_http.py
+@@ -12,6 +12,7 @@ from playhouse.sqliteq import SqliteQueueDatabase
+ 
+ from frigate.api.fastapi_app import create_fastapi_app
+ from frigate.config import FrigateConfig
++from frigate.const import BASE_DIR, CACHE_DIR
+ from frigate.models import Event, Recordings, Timeline
+ from frigate.stats.emitter import StatsEmitter
+ from frigate.test.const import TEST_DB, TEST_DB_CLEANUPS
+@@ -76,19 +77,19 @@ class TestHttp(unittest.TestCase):
+                         "total": 67.1,
+                         "used": 16.6,
+                     },
+-                    "/media/frigate/clips": {
++                    os.path.join(BASE_DIR, "clips"): {
+                         "free": 42429.9,
+                         "mount_type": "ext4",
+                         "total": 244529.7,
+                         "used": 189607.0,
+                     },
+-                    "/media/frigate/recordings": {
++                    os.path.join(BASE_DIR, "recordings"): {
+                         "free": 0.2,
+                         "mount_type": "ext4",
+                         "total": 8.0,
+                         "used": 7.8,
+                     },
+-                    "/tmp/cache": {
++                    CACHE_DIR: {
+                         "free": 976.8,
+                         "mount_type": "tmpfs",
+                         "total": 1000.0,
+diff --git a/frigate/util/config.py b/frigate/util/config.py
+index d456c755..b6b270c9 100644
+--- a/frigate/util/config.py
++++ b/frigate/util/config.py
+@@ -14,7 +14,7 @@ from frigate.util.services import get_video_properties
+ logger = logging.getLogger(__name__)
+ 
+ CURRENT_CONFIG_VERSION = "0.15-1"
+-DEFAULT_CONFIG_FILE = "/config/config.yml"
++DEFAULT_CONFIG_FILE = os.path.join(CONFIG_DIR, "config.yml")
+ 
+ 
+ def find_config_file() -> str:
+diff --git a/frigate/util/model.py b/frigate/util/model.py
+index ce2c9538..6e93cb38 100644
+--- a/frigate/util/model.py
++++ b/frigate/util/model.py
+@@ -12,6 +12,8 @@ except ImportError:
+     # openvino is not included
+     pass
+ 
++from frigate.const import MODEL_CACHE_DIR
++
+ logger = logging.getLogger(__name__)
+ 
+ 
+@@ -46,7 +48,8 @@ def get_ort_providers(
+             # so it is not enabled by default
+             if device == "Tensorrt":
+                 os.makedirs(
+-                    "/config/model_cache/tensorrt/ort/trt-engines", exist_ok=True
++                    os.path.join(MODEL_CACHE_DIR, "tensorrt/ort/trt-engines"),
++                    exist_ok=True,
+                 )
+                 device_id = 0 if not device.isdigit() else int(device)
+                 providers.append(provider)
+@@ -57,19 +60,23 @@ def get_ort_providers(
+                         and os.environ.get("USE_FP_16", "True") != "False",
+                         "trt_timing_cache_enable": True,
+                         "trt_engine_cache_enable": True,
+-                        "trt_timing_cache_path": "/config/model_cache/tensorrt/ort",
+-                        "trt_engine_cache_path": "/config/model_cache/tensorrt/ort/trt-engines",
++                        "trt_timing_cache_path": os.path.join(
++                            MODEL_CACHE_DIR, "tensorrt/ort"
++                        ),
++                        "trt_engine_cache_path": os.path.join(
++                            MODEL_CACHE_DIR, "tensorrt/ort/trt-engines"
++                        ),
+                     }
+                 )
+             else:
+                 continue
+         elif provider == "OpenVINOExecutionProvider":
+-            os.makedirs("/config/model_cache/openvino/ort", exist_ok=True)
++            os.makedirs(os.path.join(MODEL_CACHE_DIR, "openvino/ort"), exist_ok=True)
+             providers.append(provider)
+             options.append(
+                 {
+                     "arena_extend_strategy": "kSameAsRequested",
+-                    "cache_dir": "/config/model_cache/openvino/ort",
++                    "cache_dir": os.path.join(MODEL_CACHE_DIR, "openvino/ort"),
+                     "device_type": device,
+                 }
+             )
+@@ -103,7 +110,7 @@ class ONNXModelRunner:
+                 self.type = "ov"
+                 self.ov = ov.Core()
+                 self.ov.set_property(
+-                    {ov.properties.cache_dir: "/config/model_cache/openvino"}
++                    {ov.properties.cache_dir: os.path.join(MODEL_CACHE_DIR, "openvino")}
+                 )
+                 self.interpreter = self.ov.compile_model(
+                     model=model_path, device_name=device

--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -1,42 +1,42 @@
 {
   lib,
+  stdenv,
   callPackage,
   python312,
   fetchFromGitHub,
   fetchurl,
+  rocmPackages,
+  sqlite-vec,
   frigate,
   nixosTests,
 }:
 
 let
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     name = "frigate-${version}-source";
     owner = "blakeblackshear";
     repo = "frigate";
     tag = "v${version}";
-    hash = "sha256-PfUlo9ua4SVcQJTfmSVoEXHH1MUJ8A/w3kJHFpEzll8=";
+    hash = "sha256-qgiVE5UUjxRLya0mD2vfKdzdTdy5ThYOrHAGoFQ9PWA=";
   };
 
   frigate-web = callPackage ./web.nix {
     inherit version src;
   };
 
-  python = python312.override {
-    self = python;
-    packageOverrides = self: super: {
-    };
-  };
+  python = python312;
 
   # Tensorflow audio model
+  # https://github.com/blakeblackshear/frigate/blob/v0.15.0/docker/main/Dockerfile#L125
   tflite_audio_model = fetchurl {
     url = "https://www.kaggle.com/api/v1/models/google/yamnet/tfLite/classification-tflite/1/download";
     hash = "sha256-G5cbITJ2AnOl+49dxQToZ4OyeFO7MTXVVa4G8eHjZfM=";
   };
 
   # Tensorflow Lite models
-  # https://github.com/blakeblackshear/frigate/blob/v0.13.0/docker/main/Dockerfile#L96-L97
+  # https://github.com/blakeblackshear/frigate/blob/v0.15.0/docker/main/Dockerfile#L115-L117
   tflite_cpu_model = fetchurl {
     url = "https://github.com/google-coral/test_data/raw/release-frogfish/ssdlite_mobiledet_coco_qat_postprocess.tflite";
     hash = "sha256-kLszpjTgQZFMwYGapd+ZgY5sOWxNLblSwP16nP/Eck8=";
@@ -46,9 +46,11 @@ let
     hash = "sha256-Siviu7YU5XbVbcuRT6UnUr8PE0EVEnENNV2X+qGzVkE=";
   };
 
-  # OpenVino models
-  # https://github.com/blakeblackshear/frigate/blob/v0.13.0/docker/main/Dockerfile#L101
-  openvino_model = fetchurl {
+  # TODO: OpenVino model
+  # https://github.com/blakeblackshear/frigate/blob/v0.15.0/docker/main/Dockerfile#L64-L77
+  # https://github.com/blakeblackshear/frigate/blob/v0.15.0/docker/main/Dockerfile#L120-L123
+  # Convert https://www.kaggle.com/models/tensorflow/ssdlite-mobilenet-v2 with https://github.com/blakeblackshear/frigate/blob/v0.15.0/docker/main/build_ov_model.py into OpenVino IR format
+  coco_91cl_bkgr = fetchurl {
     url = "https://github.com/openvinotoolkit/open_model_zoo/raw/master/data/dataset_classes/coco_91cl_bkgr.txt";
     hash = "sha256-5Cj2vEiWR8Z9d2xBmVoLZuNRv4UOuxHSGZQWTJorXUQ=";
   };
@@ -60,84 +62,101 @@ python.pkgs.buildPythonApplication rec {
 
   inherit src;
 
-  postPatch = ''
-    echo 'VERSION = "${version}"' > frigate/version.py
+  patches = [ ./constants.patch ];
 
-    substituteInPlace frigate/app.py \
-      --replace-fail "Router(migrate_db)" 'Router(migrate_db, "${placeholder "out"}/share/frigate/migrations")'
+  postPatch =
+    ''
+      echo 'VERSION = "${version}"' > frigate/version.py
 
-    substituteInPlace frigate/const.py \
-      --replace-fail "/media/frigate" "/var/lib/frigate" \
-      --replace-fail "/tmp/cache" "/var/cache/frigate" \
-      --replace-fail "/config" "/var/lib/frigate" \
-      --replace-fail "{CONFIG_DIR}/model_cache" "/var/cache/frigate/model_cache"
+      substituteInPlace \
+        frigate/app.py \
+        frigate/test/test_{http,storage}.py \
+        frigate/test/http_api/base_http_test.py \
+        --replace-fail "Router(migrate_db)" 'Router(migrate_db, "${placeholder "out"}/share/frigate/migrations")'
 
-    substituteInPlace frigate/comms/{config,detections,events}_updater.py frigate/comms/inter_process.py \
-      --replace-fail "ipc:///tmp/cache" "ipc:///run/frigate"
+      substituteInPlace frigate/const.py \
+        --replace-fail "/opt/frigate" "${placeholder "out"}/${python.sitePackages}" \
+        --replace-fail "/media/frigate" "/var/lib/frigate" \
+        --replace-fail "/tmp/cache" "/var/cache/frigate" \
+        --replace-fail "/config" "/var/lib/frigate" \
+        --replace-fail "{CONFIG_DIR}/model_cache" "/var/cache/frigate/model_cache"
 
-    substituteInPlace frigate/detectors/detector_config.py \
-      --replace-fail "/labelmap.txt" "${placeholder "out"}/share/frigate/labelmap.txt"
+      substituteInPlace frigate/comms/{config,embeddings}_updater.py frigate/comms/{zmq_proxy,inter_process}.py \
+        --replace-fail "ipc:///tmp/cache" "ipc:///run/frigate"
 
-    substituteInPlace frigate/output/birdseye.py frigate/api/media.py \
-      --replace-fail "/opt/frigate/" "${placeholder "out"}/${python.sitePackages}/"
+      substituteInPlace frigate/db/sqlitevecq.py \
+        --replace-fail "/usr/local/lib/vec0" "${lib.getLib sqlite-vec}/lib/vec0${stdenv.hostPlatform.extensions.sharedLibrary}"
 
-    # work around onvif-zeep idiosyncrasy
-    substituteInPlace frigate/ptz/onvif.py \
-      --replace-fail dist-packages site-packages
+    ''
+    + lib.optionalString (stdenv.hostPlatform == "x86_64-linux") ''
+      substituteInPlace frigate/detectors/plugins/rocm.py \
+        --replace-fail "/opt/rocm/bin/rocminfo" "rocminfo" \
+        --replace-fail "/opt/rocm/lib" "${rocmPackages.clr}/lib"
 
-    # provide default paths for models and maps that are shipped with frigate
-    substituteInPlace frigate/config.py \
-      --replace-fail "/cpu_model.tflite" "${tflite_cpu_model}" \
-      --replace-fail "/edgetpu_model.tflite" "${tflite_edgetpu_model}"
+    ''
+    + ''
+      # provide default paths for models and maps that are shipped with frigate
+      substituteInPlace frigate/config/config.py \
+        --replace-fail "/cpu_model.tflite" "${tflite_cpu_model}" \
+        --replace-fail "/edgetpu_model.tflite" "${tflite_edgetpu_model}"
 
-    substituteInPlace frigate/events/audio.py \
-      --replace-fail "/cpu_audio_model.tflite" "${placeholder "out"}/share/frigate/cpu_audio_model.tflite" \
-      --replace-fail "/audio-labelmap.txt" "${placeholder "out"}/share/frigate/audio-labelmap.txt"
+      substituteInPlace frigate/detectors/detector_config.py \
+        --replace-fail "/labelmap.txt" "${placeholder "out"}/share/frigate/labelmap.txt"
 
-    substituteInPlace frigate/test/test_config.py \
-      --replace-fail "(MODEL_CACHE_DIR" "('/build/model_cache'" \
-      --replace-fail "/config/model_cache" "/build/model_cache"
+      substituteInPlace frigate/events/audio.py \
+        --replace-fail "/cpu_audio_model.tflite" "${placeholder "out"}/share/frigate/cpu_audio_model.tflite" \
+        --replace-fail "/audio-labelmap.txt" "${placeholder "out"}/share/frigate/audio-labelmap.txt"
 
-    substituteInPlace frigate/api/preview.py \
-      --replace-fail "/media/frigate" "/var/lib/frigate"
-  '';
+      # work around onvif-zeep idiosyncrasy
+      substituteInPlace frigate/ptz/onvif.py \
+        --replace-fail dist-packages site-packages
+    '';
 
   dontBuild = true;
 
-  propagatedBuildInputs = with python.pkgs; [
+  dependencies = with python.pkgs; [
     # docker/main/requirements.txt
     scikit-build
     # docker/main/requirements-wheel.txt
+    aiohttp
     click
-    distutils
-    flask
-    flask-limiter
+    fastapi
+    google-generativeai
     imutils
     joserfc
     markupsafe
-    matplotlib
     norfair
     numpy
+    ollama
+    onnxruntime
     onvif-zeep
+    openai
     opencv4
     openvino
-    pandas
     paho-mqtt
+    pandas
+    pathvalidate
     peewee
     peewee-migrate
     psutil
     py3nvml
     pydantic
     pytz
-    pyyaml
+    py-vapid
+    pywebpush
     pyzmq
     requests
     ruamel-yaml
     scipy
     setproctitle
+    slowapi
+    starlette
+    starlette-context
     tensorflow-bin
+    transformers
     tzlocal
     unidecode
+    uvicorn
     ws4py
   ];
 
@@ -153,7 +172,7 @@ python.pkgs.buildPythonApplication rec {
     tar --extract --gzip --file ${tflite_audio_model}
     cp --no-preserve=mode ./1.tflite $out/share/frigate/cpu_audio_model.tflite
 
-    cp --no-preserve=mode ${openvino_model} $out/share/frigate/coco_91cl_bkgr.txt
+    cp --no-preserve=mode ${coco_91cl_bkgr} $out/share/frigate/coco_91cl_bkgr.txt
     sed -i 's/truck/car/g' $out/share/frigate/coco_91cl_bkgr.txt
 
     runHook postInstall
@@ -163,6 +182,16 @@ python.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
+  # interpreter crash in onnxruntime on aarch64-linux
+  doCheck = !(stdenv.hostPlatform.system == "aarch64-linux");
+
+  preCheck = ''
+    # Unavailable in the build sandbox
+    substituteInPlace frigate/const.py \
+      --replace-fail "/var/lib/frigate" "$TMPDIR/" \
+      --replace-fail "/var/cache/frigate" "$TMPDIR"
+  '';
+
   disabledTests = [
     # Test needs network access
     "test_plus_labelmap"
@@ -171,8 +200,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     web = frigate-web;
     inherit python;
-    pythonPath =
-      (python.pkgs.makePythonPath propagatedBuildInputs) + ":${frigate}/${python.sitePackages}";
+    pythonPath = (python.pkgs.makePythonPath dependencies) + ":${frigate}/${python.sitePackages}";
     tests = {
       inherit (nixosTests) frigate;
     };

--- a/pkgs/by-name/fr/frigate/web.nix
+++ b/pkgs/by-name/fr/frigate/web.nix
@@ -16,20 +16,21 @@ buildNpmPackage {
       --replace-fail "--base=/BASE_PATH/" ""
 
     substituteInPlace \
-      src/views/system/StorageMetrics.tsx \
-      src/components/card/{AnimatedEvent,Export,Review}Card.tsx \
-      src/components/timeline/EventSegment.tsx \
       src/pages/Exports.tsx \
+      src/components/preview/ScrubbablePreview.tsx \
+      src/components/card/ExportCard.tsx \
+      src/components/card/ReviewCard.tsx \
+      src/components/card/AnimatedEventCard.tsx \
       src/components/player/PreviewThumbnailPlayer.tsx \
+      src/views/system/StorageMetrics.tsx \
+      src/components/timeline/EventSegment.tsx \
       --replace-fail "/media/frigate" "/var/lib/frigate" \
 
     substituteInPlace src/views/system/StorageMetrics.tsx \
       --replace-fail "/tmp/cache" "/var/cache/frigate"
   '';
 
-  npmDepsHash = "sha256-PLs3oCWQjK38eHgdQt2Qkj7YqkfanC8JnLMpzMjNfxU=";
-
-  env.NODE_OPTIONS = "--no-experimental-require-module";
+  npmDepsHash = "sha256-tPwydUJtFDJs17q0haJaUVEkxua+nHfmwQ9Z9Y24ca8=";
 
   installPhase = ''
     cp -rv dist/ $out


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/releases/tag/v0.15.0

The config is now copied to `/run/frigate/config` and writable to the frigate user, so it can do migrations and so you can change settings in the web frontend. They will however not be persisted and you need to sync them back or they will be lost on restart.

Testing:
- [x] Dummy camera capture
- [x] Coral Detector
- [x] OpenVINO detector (converted models are here: https://shells.darmstadt.ccc.de/~hexa/omz/) <details><summary>config</summary>
  <pre>
  detectors.ov = {
    type = "openvino";
    device = "AUTO";
  };
  model = {
    width = 300;
    height = 300;
    input_tensor = "nhwc";
    input_pixel_format = "bgr";
    path = "/var/lib/frigate/openvino-model/ssdlite_mobilenet_v2.xml";
    labelmap_path = "${config.services.frigate.package}/share/frigate/coco_91cl_bkgr.txt";
  };
  </pre>
- [x] System metrics (General/Storage/Camera)
- [x] Anonymous Usage
- [x] Semantic Search (model download succeeds, runs with whatever backend onnxruntime provides)
- [x] User management

Things that do not work:
- Restarting from the webui (would require a patch to exit from the MainPID with a custom exit code)
- Logs (would require journal permissions)
- ROCM Detector (x86_64-linux only, missing migraphx python bindings)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (tests are crashing :eyes:)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
