### PR TITLE
libdragon-docker: init at 12.0.4

### DIFF
--- a/pkgs/by-name/li/libdragon-docker/allow-write.patch
+++ b/pkgs/by-name/li/libdragon-docker/allow-write.patch
@@ -1,0 +1,13 @@
+diff --git a/pack.mjs b/pack.mjs
+index 9aed1c2..3dc3255 100644
+--- a/pack.mjs
++++ b/pack.mjs
+@@ -63,6 +63,8 @@ if (process.platform === 'win32') {
+   await $`codesign --remove-signature ${executablePath}`.nothrow();
+ }
+ 
++await $`chmod +w ${executablePath}`;
++
+ await $([
+   `npx postject ${executablePath} NODE_SEA_BLOB ${path.join(
+     'build',

--- a/pkgs/by-name/li/libdragon-docker/package.nix
+++ b/pkgs/by-name/li/libdragon-docker/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs_22,
+  npmHooks,
+  stdenv,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdragon-docker";
+  version = "12.0.4";
+
+  src = fetchFromGitHub {
+    owner = "anacierdem";
+    repo = "libdragon-docker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sSibqWh60d0LhuCkAnLwkitFD5XgRejyS3ptbacYjkk=";
+  };
+  patches = [ ./allow-write.patch ];
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps-${finalAttrs.version}";
+    inherit (finalAttrs) src;
+    hash = "sha256-N/p5uexuGoNryx27+nNyDU4z3VkDT2x1FRis2OdA9Js=";
+  };
+
+  nativeBuildInputs = [
+    nodejs_22
+    npmHooks.npmConfigHook
+  ];
+
+  dontFixup = true;
+
+  buildPhase = ''
+    runHook preBuild
+    npm run pack ${finalAttrs.version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv build/libdragon-linux $out/bin/libdragon
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Docker container for easy development with DragonMinded libdragon";
+    homepage = "https://github.com/anacierdem/libdragon-docker";
+    license = lib.licenses.mit;
+    mainProgram = "libdragon";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc: @mackereldev for testing

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
