### PR TITLE
nixos/h2o: add simple listen.host setting, add example

### DIFF
--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -230,6 +230,9 @@ let
                     ssl = (lib.recursiveUpdate tlsRecAttrs value.tls.extraSettings) // {
                       inherit identity;
                     };
+                  }
+                  // lib.optionalAttrs (value.host != null) {
+                    host = value.host;
                   };
               };
           };

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -302,6 +302,22 @@ in
         type = settingsFormat.type;
         default = { };
         description = "Configuration for H2O (see <https://h2o.examp1e.net/configure.html>)";
+        example =
+          literalExpression
+            # nix
+            ''
+              {
+                compress = "ON";
+                ssl-offload = "kernel";
+                http2-reprioritize-blocking-assets = "ON";
+                "file.mime.addtypes" = {
+                  "text/x-rst" = {
+                    extensions = [ ".rst" ];
+                    is_compressible = "YES";
+                  };
+                };
+              }
+            '';
       };
 
       hosts = mkOption {

--- a/nixos/modules/services/web-servers/h2o/vhost-options.nix
+++ b/nixos/modules/services/web-servers/h2o/vhost-options.nix
@@ -37,6 +37,15 @@ in
       '';
     };
 
+    host = mkOption {
+      type = types.nullOr types.nonEmptyStr;
+      default = null;
+      example = "127.0.0.1";
+      description = ''
+        Set the host address for this virtual host.
+      '';
+    };
+
     http = mkOption {
       type = types.nullOr (
         types.submodule {

--- a/nixos/modules/services/web-servers/h2o/vhost-options.nix
+++ b/nixos/modules/services/web-servers/h2o/vhost-options.nix
@@ -33,7 +33,8 @@ in
         "example.org"
       ];
       description = ''
-        Additional names of virtual hosts served by this virtual host configuration.
+        Additional names of virtual hosts served by this virtual host
+        configuration.
       '';
     };
 
@@ -42,7 +43,8 @@ in
       default = null;
       example = "127.0.0.1";
       description = ''
-        Set the host address for this virtual host.
+        Set the host address for this virtual host. If unset, the default is to
+        listen on all network interfaces.
       '';
     };
 
@@ -79,7 +81,7 @@ in
                 config.services.h2o.defaultTLSListenPort
               '';
               description = ''
-                Override the default TLS port for this virtual host.";
+                Override the default TLS port for this virtual host.
               '';
               example = 8443;
             };
@@ -114,11 +116,17 @@ in
                   options = {
                     key-file = mkOption {
                       type = types.path;
-                      description = "Path to key file";
+                      description = ''
+                        Path to key file. See
+                        <https://h2o.examp1e.net/configure/base_directives.html#key-file>.
+                      '';
                     };
                     certificate-file = mkOption {
                       type = types.path;
-                      description = "Path to certificate file";
+                      description = ''
+                        Path to certificate file. See
+                        <https://h2o.examp1e.net/configure/base_directives.html#certificate-file>.
+                      '';
                     };
                   };
                 }
@@ -148,7 +156,8 @@ in
               type = types.attrs;
               default = { };
               description = ''
-                Additional TLS/SSL-related configuration options.
+                Additional TLS/SSL-related configuration options. See
+                <https://h2o.examp1e.net/configure/base_directives.html#listen-ssl>.
               '';
               example =
                 literalExpression
@@ -214,7 +223,8 @@ in
       default = { };
       description = ''
         Attrset to be transformed into YAML for host config. Note that the HTTP
-        / TLS configurations will override these config values.
+        / TLS configurations will override these config values. See
+        <https://h2o.examp1e.net/configure/base_directives.html#hosts>.
       '';
     };
   };


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixups to the module for usability / documentation. A user may want a way to be able to easily get a `host` name from `listen` without trying dig into the whole generated config. This is a convenience to be able to call `services.h2o.hosts.<name>.(http|tls).host`. The default setup, no host provided in `settings` or this `.host`, is `[::]` listening on all addresses for IPv4 & IP6. Multiple hosts would require either using a `proxy` or specifying multiple unique hosts (limitation of Nix vs YAML where YAML can have duplicate keys). However, there is a lot of basic cases where `.host` would more than suffice & be easier to pull from & reuse in other, non-H2O configurations. The alternative would be trying to dig thru `services.h2o.hosts.<name>.settings.listen.…` which has a couple of different valid YAML shapes, but I want to enforce the non-shorthand option where possible (this also more closely matches other web servers NixOS modules).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
