### PR TITLE
flightgear: 2020.3.19 -> 2024.1.1

### DIFF
--- a/pkgs/by-name/si/simgear/package.nix
+++ b/pkgs/by-name/si/simgear/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   plib,
   libglut,
   xorgproto,
@@ -27,16 +27,17 @@
   curl,
 }:
 let
-  version = "2020.3.19";
-  shortVersion = builtins.substring 0 6 version;
+  version = "2024.1.1";
 in
 stdenv.mkDerivation rec {
   pname = "simgear";
   inherit version;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/flightgear/release-${shortVersion}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-O5N8W5RCJHjl15EUvc1seOQ6Cm/7qXVEqG1EHD+ejDo=";
+  src = fetchFromGitLab {
+    owner = "flightgear";
+    repo = "simgear";
+    tag = "v${version}";
+    hash = "sha256-hOA/q/cTsqRy82rTAXRxyHBDdw93TW9UL+K5Jq5b/08=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   wrapQtAppsHook,
   libglut,
   freealut,
@@ -28,30 +28,31 @@
   udev,
   fltk13,
   apr,
-  makeDesktopItem,
   qtbase,
+  qtquickcontrols2,
   qtdeclarative,
   glew,
   curl,
 }:
 
 let
-  version = "2020.3.19";
-  shortVersion = builtins.substring 0 6 version;
+  version = "2024.1.1";
   data = stdenv.mkDerivation rec {
     pname = "flightgear-data";
     inherit version;
 
-    src = fetchurl {
-      url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.txz";
-      sha256 = "sha256-863EnNBU+rYTdxHwMV6HbBu99lO6H3mKGuyumm6YR5U=";
+    src = fetchFromGitLab {
+      owner = "flightgear";
+      repo = "fgdata";
+      tag = "v${version}";
+      hash = "sha256-PdqsIZw9mSrvnqqB/fVFjWPW9njhXLWR/2LQCMoBLQI=";
     };
 
     dontUnpack = true;
 
     installPhase = ''
       mkdir -p "$out/share/FlightGear"
-      tar xf "${src}" -C "$out/share/FlightGear/" --strip-components=1
+      cp ${src}/* -a "$out/share/FlightGear/"
     '';
   };
 in
@@ -60,9 +61,11 @@ stdenv.mkDerivation rec {
   # inheriting data for `nix-prefetch-url -A pkgs.flightgear.data.src`
   inherit version data;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/flightgear/release-${shortVersion}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-Fn0I3pzA9yIYs3myPNflbH9u4Y19VZUS2lGjvWfzjm4=";
+  src = fetchFromGitLab {
+    owner = "flightgear";
+    repo = "flightgear";
+    tag = "v${version}";
+    hash = "sha256-h4N18VAbJGQSBKA+eEQxej5e5MEwAcZpvH+dpTypM+k=";
   };
 
   nativeBuildInputs = [
@@ -95,6 +98,7 @@ stdenv.mkDerivation rec {
     fltk13
     apr
     qtbase
+    qtquickcontrols2
     glew
     qtdeclarative
     curl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://www.flightgear.org/download/releases/2024-1/

![image](https://github.com/user-attachments/assets/3c322f6d-c6bc-4ceb-9363-4a5d6b9af2b0)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
