### PR TITLE
nixos/postgresql: allow customisations of SystemCallFilter

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -14,8 +14,11 @@ let
     const
     elem
     escapeShellArgs
+    filter
     filterAttrs
+    getAttr
     getName
+    hasPrefix
     isString
     literalExpression
     mapAttrs
@@ -31,6 +34,8 @@ let
     mkRemovedOptionModule
     mkRenamedOptionModule
     optionalString
+    pipe
+    sortProperties
     types
     versionAtLeast
     warn
@@ -121,6 +126,100 @@ in
         description = ''
           The postgresql package that will effectively be used in the system.
           It consists of the base package with plugins applied to it.
+        '';
+      };
+
+      systemCallFilter = mkOption {
+        type = types.attrsOf (
+          types.coercedTo types.bool (enable: { inherit enable; }) (
+            types.submodule (
+              { name, ... }:
+              {
+                options = {
+                  enable = mkEnableOption "${name} in postgresql's syscall filter";
+                  priority = mkOption {
+                    default =
+                      if hasPrefix "@" name then
+                        500
+                      else if hasPrefix "~@" name then
+                        1000
+                      else
+                        1500;
+                    defaultText = literalExpression ''
+                      if hasPrefix "@" name then 500 else if hasPrefix "~@" name then 1000 else 1500
+                    '';
+                    type = types.int;
+                    description = ''
+                      Set the priority of the system call filter setting. Later declarations
+                      override earlier ones, e.g.
+
+                      ```ini
+                      [Service]
+                      SystemCallFilter=~read write
+                      SystemCallFilter=write
+                      ```
+
+                      results in a service where _only_ `read` is not allowed.
+
+                      The ordering in the unit file is controlled by this option: the higher
+                      the number, the later it will be added to the filterset.
+
+                      By default, depending on the prefix a priority is assigned: usually, call-groups
+                      (starting with `@`) are used to allow/deny a larger set of syscalls and later
+                      on single syscalls are configured for exceptions. Hence, syscall groups
+                      and negative groups are placed before individual syscalls by default.
+                    '';
+                  };
+                };
+              }
+            )
+          )
+        );
+        defaultText = literalExpression ''
+          {
+            "@system-service" = true;
+            "~@privileged" = true;
+            "~@resources" = true;
+          }
+        '';
+        description = ''
+          Configures the syscall filter for `postgresql.service`. The keys are
+          declarations for `SystemCallFilter` as described in {manpage}`systemd.exec(5)`.
+
+          The value is a boolean: `true` adds the attribute name to the syscall filter-set,
+          `false` doesn't. This is done to allow downstream configurations to turn off
+          restrictions made here. E.g. with
+
+          ```nix
+          {
+            services.postgresql.systemCallFilter."~@resources" = false;
+          }
+          ```
+
+          it's possible to remove the restriction on `@resources` (keep in mind that
+          `@system-service` implies `@resources`).
+
+          As described in the section for [](#opt-services.postgresql.systemCallFilter._name_.priority),
+          the ordering matters. Hence, it's also possible to specify customizations with
+
+          ```nix
+          {
+            services.postgresql.systemCallFilter = {
+              "foobar" = { enable = true; priority = 23; };
+            };
+          }
+          ```
+
+          [](#opt-services.postgresql.systemCallFilter._name_.enable) is the flag whether
+          or not it will be added to the `SystemCallFilter` of `postgresql.service`.
+
+          Settings with a higher priority are added after filter settings with a lower
+          priority. Hence, syscall groups with a higher priority can discard declarations
+          with a lower priority.
+
+          By default, syscall groups (i.e. attribute names starting with `@`) are added
+          _before_ negated groups (i.e. `~@` as prefix) _before_ syscall names
+          and negations.
         '';
       };
 
@@ -583,6 +682,21 @@ in
       '')
     ];
 
+    services.postgresql.systemCallFilter = mkMerge [
+      (mapAttrs (const mkDefault) {
+        "@system-service" = true;
+        "~@privileged" = true;
+        "~@resources" = true;
+      })
+      (mkIf (any extensionInstalled [ "plv8" ]) {
+        "@pkey" = true;
+      })
+      (mkIf (any extensionInstalled [ "citus" ]) {
+        "getpriority" = true;
+        "setpriority" = true;
+      })
+    ];
+
     users.users.postgres = {
       name = "postgres";
       uid = config.ids.uids.postgres;
@@ -727,16 +841,12 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           SystemCallArchitectures = "native";
-          SystemCallFilter =
-            [
-              "@system-service"
-              "~@privileged @resources"
-            ]
-            ++ lib.optionals (any extensionInstalled [ "plv8" ]) [ "@pkey" ]
-            ++ lib.optionals (any extensionInstalled [ "citus" ]) [
-              "getpriority"
-              "setpriority"
-            ];
+          SystemCallFilter = pipe cfg.systemCallFilter [
+            (mapAttrsToList (name: v: v // { inherit name; }))
+            (filter (getAttr "enable"))
+            sortProperties
+            (map (getAttr "name"))
+          ];
           UMask = if groupAccessAvailable then "0027" else "0077";
         }
         (mkIf (cfg.dataDir != "/var/lib/postgresql/${cfg.package.psqlSchema}") {


### PR DESCRIPTION
Closes #385603

The problem described is that `wal-g` requires syscalls from `@resources`. However, we don't have support for it in the module now and I don't think it's reasonable to only support hardening adjustments for things support by this module. Also, list is a bad datatype here since it doesn't allow the level of customizations we need.

This is only for the syscall filterset since it's the option that's hard to customize otherwise. For downstream configs, it's recommended to adjust the hardening as needed in other cases.

Hence I decided to implement `services.postgresql.systemCallFilter` with the following semantics:

* `systemCallFilter."~@resources" = true` adds `~@resources` to the filterset.

* Setting this to `false` (e.g. in a downstream configuration using `wal-g`) removes the entry `~@resources` from the filterset. In this case it's sufficient since `@system-service` implies `@resources` and the `~@resources` declaration after that discards that.

  I decided to not implement logic about negations in here, but to keep it rather simple by only allowing to set/unset entries.

As described in `systemd.exec(5)`, the ordering matters: e.g. `@system-service` implies `@resources`, but `~@resources` _after_ that reverts that. By default, the ordering of the keys is as follows:

* syscall groups (starting with `@`) come at first.
* negations of syscall groups (starting with `~@`) come after that.
* anything else at the end.

If further ordering is needed, it can be done like this:

```
{
  services.postgresql.systemCallFilter."~@resources" = {
    enable = true; # whether or not it's part of the final SystemCallFilter
    priority = 23; # ordering priority in the filterset.
  };
}
```

The lower the priority, the higher up the entry will be in the final filterset.

---

cc @wolfgangwalther @mweinelt 
cc @kr-nn as reporter


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
