### PR TITLE
actual-server: 25.1.0 -> 25.3.1

### DIFF
--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -12,12 +12,12 @@
   nix-update-script,
 }:
 let
-  version = "25.1.0";
+  version = "25.3.1";
   src = fetchFromGitHub {
     owner = "actualbudget";
-    repo = "actual-server";
+    repo = "actual";
     tag = "v${version}";
-    hash = "sha256-zpZNITXd9QOJNRz8RbAuHH1hrrWPEGsrROGWJuYXqrc=";
+    hash = "sha256-UZ2Z1tkMbGJwka//cIC0aG1KCcTSxUPLzctEaOhnKQA=";
   };
 
   yarn_20 = yarn.override { nodejs = nodejs_20; };
@@ -58,7 +58,8 @@ let
       yarn config set enableTelemetry 0
       yarn config set cacheFolder $out
       yarn config set --json supportedArchitectures "$SUPPORTED_ARCHITECTURES"
-      yarn
+
+      yarn workspaces focus @actual-app/sync-server --production
 
       runHook postBuild
     '';
@@ -77,10 +78,10 @@ let
     outputHashMode = "recursive";
     outputHash =
       {
-        x86_64-linux = "sha256-N31aAAkznncKlygyeH5A3TrnOinXVz7CTQ8/G4QX6hY=";
-        aarch64-linux = "sha256-j7BFAKXi+TKIlmHBjbx6rwaKuAo6gnOlv6FV8rnlld0=";
-        aarch64-darwin = "sha256-YpUQYOLJHYxWuE6ToLFkXWEloAau9bLBvdbpNh8jRZQ=";
-        x86_64-darwin = "sha256-AioO82Y6mK0blSQRhhZZtWmduUcYwyVAewcXEVClJUg=";
+        aarch64-darwin = "sha256-IJBfBA71PZeE/Zlu2kzQw8l/D4lVAV5I5loRyRfncKA=";
+        aarch64-linux = "sha256-djE2lt/o/7kd7ci2TW3mhjSptD3etChbvtdbiWqp/wo=";
+        x86_64-darwin = "sha256-AShd87VFwqDbJZoFJPg6HsdhTx7XMVdZ5sRWLXU8ldM=";
+        x86_64-linux = "sha256-me0v+RuoleOKFRyJ7iyLTKRnV2Cz2Q1MLc/SE2sSSH8=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
@@ -97,13 +98,13 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,lib,lib/actual}
+    mkdir -p $out/{bin,lib,lib/actual/packages/sync-server}
     cp -r ${offlineCache}/node_modules/ $out/lib/actual
-    cp -r ./ $out/lib/actual
+    cp -r ./packages/sync-server/{app.js,src,migrations,package.json} $out/lib/actual/packages/sync-server
 
     makeWrapper ${lib.getExe nodejs_20} "$out/bin/actual-server" \
-      --add-flags "$out/lib/actual/app.js" \
-      --set NODE_PATH "$out/node_modules"
+      --add-flags "$out/lib/actual/packages/sync-server/app.js" \
+      --set NODE_PATH "$out/actual/lib/node_modules"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The code for `actual-server` was moved to a new repo (https://www.actualbudget.com/docs/releases#2530).

~~I don't know how to calculate the output hash of the dependencies for the remaining platforms, so any help would be appreciated (maybe @PatrickDaG or @oddlama can help?)~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
