### PR TITLE
dvrescue: init at 24.07

### DIFF
--- a/pkgs/by-name/dv/dvrescue/package.nix
+++ b/pkgs/by-name/dv/dvrescue/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  pkgs,
+  lib,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "dvrescue";
+  version = "24.07";
+
+  src = fetchFromGitHub {
+    owner = "mipops";
+    repo = "dvrescue";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cR7az1F/K+/88oWKI0ns/jkOzIg6JGXzzO0IB6ZK5HM=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    autoreconfHook
+    pkg-config
+    libmediainfo
+    libavc1394
+    libiec61883
+    zlib
+    makeWrapper
+  ];
+
+  buildInputs = with pkgs; [
+    libzen
+  ];
+
+  postPatch = ''
+    # dvplay otherwise hardcodes a path to the liberation font on Linux
+    font_path="${pkgs.liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf"
+    if [ ! -e "$font_path" ]; then
+       echo >&2 "ERROR: A file was expected to exist at:"
+       echo >&2 "$font_path"
+       echo >&2 "On Linux, dvplay will fail at runtime if this file does not exist."
+       echo >&2 "If this file moves, the dvrescue package must be updated."
+       exit 1
+    fi
+    substituteInPlace "tools/dvplay" \
+      --replace-fail /usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf "$font_path"
+  '';
+
+  preAutoreconf = ''
+    cd "./Project/GNU/CLI"
+  '';
+
+  postFixup = ''
+    for program in dvplay; do
+      wrapProgram "$out/bin/$program" \
+        --set PATH ${
+          lib.makeBinPath [
+            pkgs.which
+            pkgs.coreutils
+            pkgs.mediainfo
+            pkgs.ffmpeg
+            pkgs.ncurses # tput
+            pkgs.gnugrep
+            pkgs.gnused
+          ]
+        }
+    done
+  '';
+
+  passthru = {
+    updateScript = nix-update-script;
+  };
+
+  meta = {
+    description = "Archivist-made software that supports data migration from DV tapes into digital files suitable for long-term preservation";
+    longDescription = ''
+      DVRescue is cross-platform archivist made and designed software for the
+      advanced support of data migration from DV tapes into digital files suitable
+      for long-term preservation. It facilitates both high-quality digital capture
+      via FireWire as well as provides deep levels of context and analysis of
+      embedded DV metadata that can be used, among other things, to create files with
+      highly reduced error rate via amalgamating across multiple captures.
+    '';
+    homepage = "https://mediaarea.net/DVRescue";
+    license = lib.licenses.bsd3;
+    changelog = "https://github.com/mipops/dvrescue/blob/v${finalAttrs.version}/History.txt";
+    maintainers = with lib.maintainers; [
+      acuteaangle
+    ];
+    mainProgram = "dvrescue";
+  };
+})


### PR DESCRIPTION
### This is a draft. While the package builds on my main system, I have not yet tested the functionality of all included programs.

***
This PR adds [dvrescue](https://www.mipops.org/dvrescue/), a tool for transferring videos from DV tapes to a computer, with the ability to check for errors and retry portions of the tape.

Homepage URL:
https://mediaarea.net/DVRescue

Source URL:
https://github.com/mipops/dvrescue

License:
[BSD-3-Clause](https://github.com/mipops/dvrescue/blob/main/LICENSE.txt)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [ ] `dvloupe`
  - [ ] `dvmap`
  - [ ] `dvpackager`
  - [ ] `dvplay`
  - [ ] `dvrescue`
  - [ ] `dvsampler`
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc