### PR TITLE
thorium(browser): init at 130.0.6723.174

### DIFF
--- a/pkgs/applications/networking/browsers/thorium/default.nix
+++ b/pkgs/applications/networking/browsers/thorium/default.nix
@@ -1,0 +1,3 @@
+{ callPackage }:
+
+callPackage ./thorium.nix { }

--- a/pkgs/applications/networking/browsers/thorium/src.json
+++ b/pkgs/applications/networking/browsers/thorium/src.json
@@ -1,0 +1,6 @@
+{
+    "version": "130.0.6723.174",
+    "url": "https://github.com/Alex313031/thorium/releases/download/M130.0.6723.174/thorium-browser_130.0.6723.174_AVX.deb",
+    "sha256": "sha256-TBPWsMKulaNaUHO+F98y/e7W/AqciMt1ekf/bcl2RvY="
+  }
+  

--- a/pkgs/applications/networking/browsers/thorium/src.nix
+++ b/pkgs/applications/networking/browsers/thorium/src.nix
@@ -1,0 +1,7 @@
+let
+  data = builtins.fromJSON (builtins.readFile ./src.json);
+in
+{
+  url = data.url;
+  sha256 = data.sha256;
+}

--- a/pkgs/applications/networking/browsers/thorium/thorium.nix
+++ b/pkgs/applications/networking/browsers/thorium/thorium.nix
@@ -1,0 +1,188 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  wrapGAppsHook,
+  dpkg,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libX11,
+  libXScrnSaver,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libdrm,
+  libnotify,
+  libpulseaudio,
+  libuuid,
+  libxcb,
+  libxshmfence,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  udev,
+  xdg-utils,
+  libxkbcommon,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "thorium";
+  version = "130.0.6723.174";
+
+  src = fetchurl (import ./src.nix);
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libdrm
+    libnotify
+    libpulseaudio
+    libuuid
+    libxcb
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    udev
+    libxkbcommon
+  ];
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  # No need to patch files that don't exist yet
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt/chromium.org/thorium
+
+    if [ -d ./opt/chromium.org/thorium ]; then
+      cp -a ./opt/chromium.org/thorium/* $out/opt/chromium.org/thorium/
+    elif [ -d ./opt/thorium ]; then
+      cp -a ./opt/thorium/* $out/opt/chromium.org/thorium/
+    fi
+
+    makeWrapper "$out/opt/chromium.org/thorium/thorium" "$out/bin/thorium" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      --prefix PATH : "${xdg-utils}/bin" \
+      --add-flags "--no-sandbox"
+
+    if [ -f $out/opt/chromium.org/thorium/chromedriver ]; then
+      makeWrapper "$out/opt/chromium.org/thorium/chromedriver" "$out/bin/chromedriver" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}"
+    fi
+
+    if [ -f $out/opt/chromium.org/thorium/thorium-shell ]; then
+      makeWrapper "$out/opt/chromium.org/thorium/thorium-shell" "$out/bin/thorium-shell" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+        --add-flags "--no-sandbox"
+    fi
+
+    if [ -d ./usr/share/applications ]; then
+      mkdir -p $out/share/applications
+      cp ./usr/share/applications/thorium*.desktop $out/share/applications/ || true
+      
+      for file in $out/share/applications/*.desktop; do
+        if [ -f "$file" ]; then
+          substituteInPlace $file \
+            --replace "/opt/chromium.org/thorium/thorium" "$out/bin/thorium" \
+            --replace "/opt/chromium.org/thorium/" "$out/opt/chromium.org/thorium/" \
+            --replace "/opt/thorium/thorium" "$out/bin/thorium" \
+            --replace "/opt/thorium/" "$out/opt/chromium.org/thorium/"
+        fi
+      done
+    fi
+
+    if [ -d ./usr/share/icons ]; then
+      mkdir -p $out/share/icons
+      cp -r ./usr/share/icons/* $out/share/icons/ || true
+    fi
+
+    # If no desktop file was found, create one
+    if [ ! -f $out/share/applications/thorium.desktop ] && [ -f $out/opt/chromium.org/thorium/product_logo_256.png ]; then
+      mkdir -p $out/share/applications
+      cat > $out/share/applications/thorium.desktop << EOF
+    [Desktop Entry]
+    Type=Application
+    Name=Thorium Browser
+    Exec=$out/bin/thorium %U
+    Icon=$out/opt/chromium.org/thorium/product_logo_256.png
+    Comment=Chromium fork with various patches and optimizations
+    Categories=Network;WebBrowser;
+    MimeType=x-scheme-handler/http;x-scheme-handler/https;
+    StartupNotify=true
+    EOF
+    fi
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for file in $(find $out/opt/chromium.org/thorium -type f -executable); do
+      if [ -f "$file" ]; then
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      fi
+    done
+  '';
+
+  meta = with lib; {
+    description = "Chromium fork with JPEG XL support, performance and privacy patches";
+    homepage = "https://thorium.rocks/";
+    license = licenses.bsd3;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ qxrein ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "thorium";
+  };
+}

--- a/pkgs/applications/networking/browsers/thorium/update.nix
+++ b/pkgs/applications/networking/browsers/thorium/update.nix
@@ -1,0 +1,27 @@
+{ lib, writeScript, common-updater-scripts, bash, coreutils, curl, gnused, jq }:
+
+let
+  src = ./src.json;
+in writeScript "update-thorium" ''
+  #!${bash}/bin/bash
+  set -eu -o pipefail
+  
+  PATH=${lib.makeBinPath [ common-updater-scripts coreutils curl gnused jq ]}
+  
+  latest_tag=$(curl -s https://api.github.com/repos/Alex313031/thorium/releases/latest | jq -r '.tag_name')
+  version=$(echo $latest_tag | sed 's/^M//')  # Remove leading 'M' if present
+  
+  # Check if we already have the latest version
+  current_version=$(jq -r '.version' < ${src})
+  if [[ "$version" == "$current_version" ]]; then
+    echo "Thorium is already at the latest version: $version"
+    exit 0
+  fi
+  
+  asset_url="https://github.com/Alex313031/thorium/releases/download/M$version/thorium-browser_$'''{version}_AVX.deb"
+  
+  # Download the file and compute its hash
+  tmp_file=$(mktemp)
+  curl -L -o "$tmp_file" "$asset_url"
+  sha
+''


### PR DESCRIPTION
changelog: https://github.com/Alex313031/thorium/releases/tag/M130.0.6723.174

thorium repo: https://github.com/Alex313031/thorium
this was needed after firefox bullshit
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
