### PR TITLE
doc: add COSMIC section

### DIFF
--- a/doc/languages-frameworks/cosmic.section.md
+++ b/doc/languages-frameworks/cosmic.section.md
@@ -1,0 +1,152 @@
+# COSMIC {#sec-language-cosmic}
+
+## Packaging COSMIC applications {#ssec-cosmic-packaging}
+
+COSMIC (Computer Operating System Main Interface Components) is a desktop environment developed by
+System76, primarily for the Pop!_OS Linux distribution. Applications in the COSMIC ecosystem are
+written in Rust and use libcosmic, which builds on the Iced GUI framework. This section explains
+how to properly package and integrate COSMIC applications within Nix.
+
+### libcosmicAppHook {#ssec-cosmic-libcosmic-app-hook}
+
+The `libcosmicAppHook` is a setup hook that helps with this by automatically configuring
+and wrapping applications based on libcosmic. It handles many common requirements like:
+
+- Setting up proper linking for libraries that may be dlopen'd by libcosmic/iced apps
+- Configuring XDG paths for settings schemas, icons, and other resources
+- Managing Vergen environment variables for build-time information
+- Setting up Rust linker flags for specific libraries
+
+To use the hook, simply add it to your package's `nativeBuildInputs`:
+
+```nix
+{
+  lib,
+  rustPlatform,
+  libcosmicAppHook,
+}:
+rustPlatform.buildRustPackage {
+  # ...
+  nativeBuildInputs = [ libcosmicAppHook ];
+  # ...
+}
+```
+
+### Settings fallback {#ssec-cosmic-settings-fallback}
+
+COSMIC applications use libcosmic's UI components, which may need access to theme settings. The
+`cosmic-settings` package provides default theme settings as a fallback in its `share` directory.
+By default, `libcosmicAppHook` includes this fallback path in `XDG_DATA_DIRS`, ensuring that COSMIC
+applications will have access to theme settings even if they aren't available elsewhere in the
+system.
+
+This fallback behavior can be disabled by setting `includeSettings = false` when including the hook:
+
+```nix
+{
+  lib,
+  rustPlatform,
+  libcosmicAppHook,
+}:
+let
+  # Get build-time version of libcosmicAppHook
+  libcosmicAppHook' = (libcosmicAppHook.__spliced.buildHost or libcosmicAppHook).override {
+    includeSettings = false;
+  };
+in
+rustPlatform.buildRustPackage {
+  # ...
+  nativeBuildInputs = [ libcosmicAppHook' ];
+  # ...
+}
+```
+
+Note that `cosmic-settings` is a separate application and not a part of the libcosmic settings
+system itself. It's included by default in `libcosmicAppHook` only to provide these fallback theme
+settings.
+
+### Icons {#ssec-cosmic-icons}
+
+COSMIC applications can use icons from the COSMIC icon theme. While COSMIC applications can build
+and run without these icons, they would be missing visual elements. The `libcosmicAppHook`
+automatically includes `cosmic-icons` in the wrapped application's `XDG_DATA_DIRS` as a fallback,
+ensuring that the application has access to its required icons even if the system doesn't have the
+COSMIC icon theme installed globally.
+
+Unlike the `cosmic-settings` fallback, the `cosmic-icons` fallback cannot be removed or disabled, as
+it is essential for COSMIC applications to have access to these icons for proper visual rendering.
+
+### Runtime Libraries {#ssec-cosmic-runtime-libraries}
+
+COSMIC applications built on libcosmic and Iced require several runtime libraries that are dlopen'd
+rather than linked directly. The `libcosmicAppHook` ensures that these libraries are correctly
+linked by setting appropriate Rust linker flags. The libraries handled include:
+
+- Graphics libraries (EGL, Vulkan)
+- Input libraries (xkbcommon)
+- Display server protocols (Wayland, X11)
+
+This ensures that the applications will work correctly at runtime, even though they use dynamic
+loading for these dependencies.
+
+### Adding custom wrapper arguments {#ssec-cosmic-custom-wrapper-args}
+
+You can pass additional arguments to the wrapper using `libcosmicAppWrapperArgs` in the `preFixup` hook:
+
+```nix
+{
+  lib,
+  rustPlatform,
+  libcosmicAppHook,
+}:
+rustPlatform.buildRustPackage {
+  # ...
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(--set-default ENVIRONMENT_VARIABLE VALUE)
+  '';
+  # ...
+}
+```
+
+## Frequently encountered issues {#ssec-cosmic-common-issues}
+
+### Setting up Vergen environment variables {#ssec-cosmic-common-issues-vergen}
+
+Many COSMIC applications use the Vergen Rust crate for build-time information. The `libcosmicAppHook`
+automatically sets up the `VERGEN_GIT_COMMIT_DATE` environment variable based on `SOURCE_DATE_EPOCH`
+to ensure reproducible builds.
+
+However, some applications may explicitly require additional Vergen environment variables.
+Without these properly set, you may encounter build failures with errors like:
+
+```
+>   cargo:rerun-if-env-changed=VERGEN_GIT_COMMIT_DATE
+>   cargo:rerun-if-env-changed=VERGEN_GIT_SHA
+>
+>   --- stderr
+>   Error: no suitable 'git' command found!
+> warning: build failed, waiting for other jobs to finish...
+```
+
+While `libcosmicAppHook` handles `VERGEN_GIT_COMMIT_DATE`, you may need to explicitly set other
+variables. For applications that require these variables, you should set them directly in the
+package definition:
+
+```nix
+{
+  lib,
+  rustPlatform,
+  libcosmicAppHook,
+}:
+rustPlatform.buildRustPackage {
+  # ...
+  env = {
+    VERGEN_GIT_COMMIT_DATE = "2025-01-01";
+    VERGEN_GIT_SHA = "0000000000000000000000000000000000000000"; # SHA-1 hash of the commit
+  };
+  # ...
+}
+```
+
+Not all COSMIC applications require these variables, but for those that do, setting them explicitly
+will prevent build failures.

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -58,6 +58,7 @@ beam.section.md
 bower.section.md
 chicken.section.md
 coq.section.md
+cosmic.section.md
 crystal.section.md
 cuda.section.md
 cuelang.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -62,6 +62,9 @@
   "sec-build-helper-extendMkDerivation": [
     "index.html#sec-build-helper-extendMkDerivation"
   ],
+  "sec-language-cosmic": [
+    "index.html#sec-language-cosmic"
+  ],
   "sec-modify-via-packageOverrides": [
     "index.html#sec-modify-via-packageOverrides"
   ],
@@ -316,6 +319,30 @@
   ],
   "sec-tools-of-stdenv": [
     "index.html#sec-tools-of-stdenv"
+  ],
+  "ssec-cosmic-common-issues": [
+    "index.html#ssec-cosmic-common-issues"
+  ],
+  "ssec-cosmic-common-issues-vergen": [
+    "index.html#ssec-cosmic-common-issues-vergen"
+  ],
+  "ssec-cosmic-custom-wrapper-args": [
+    "index.html#ssec-cosmic-custom-wrapper-args"
+  ],
+  "ssec-cosmic-icons": [
+    "index.html#ssec-cosmic-icons"
+  ],
+  "ssec-cosmic-libcosmic-app-hook": [
+    "index.html#ssec-cosmic-libcosmic-app-hook"
+  ],
+  "ssec-cosmic-packaging": [
+    "index.html#ssec-cosmic-packaging"
+  ],
+  "ssec-cosmic-runtime-libraries": [
+    "index.html#ssec-cosmic-runtime-libraries"
+  ],
+  "ssec-cosmic-settings-fallback": [
+    "index.html#ssec-cosmic-settings-fallback"
   ],
   "ssec-stdenv-dependencies": [
     "index.html#ssec-stdenv-dependencies"


### PR DESCRIPTION
Adds a section for packaging COSMIC applications in the nixpkgs documentation

cc @a-kenji

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
