### PR TITLE
nixos/frp: support multiple instances

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -922,7 +922,7 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
 
 - [frp](https://github.com/fatedier/frp), a fast reverse proxy to help you
   expose a local server behind a NAT or firewall to the Internet. Available as
-  [services.frp](#opt-services.frp.enable).
+  `services.frp`.
 
 - [river](https://github.com/riverwm/river), A dynamic tiling wayland
   compositor. Available as `programs.river`.

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -26,4 +26,6 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `services.frp` now supports multiple instances through `services.frp.instances` to make it possible to run multiple frp clients or servers at the same time.
+
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.

--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -7,95 +7,121 @@
 let
   cfg = config.services.frp;
   settingsFormat = pkgs.formats.toml { };
-  configFile = settingsFormat.generate "frp.toml" cfg.settings;
-  isClient = (cfg.role == "client");
-  isServer = (cfg.role == "server");
+  enabledInstances = lib.filterAttrs (name: conf: conf.enable) cfg.instances;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "frp" "enable" ]
+      [ "services" "frp" "instances" "" "enable" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "frp" "role" ] [ "services" "frp" "instances" "" "role" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "frp" "settings" ]
+      [ "services" "frp" "instances" "" "settings" ]
+    )
+  ];
+
   options = {
     services.frp = {
-      enable = lib.mkEnableOption "frp";
+      instances = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              enable = lib.mkEnableOption "frp";
 
-      package = lib.mkPackageOption pkgs "frp" { };
+              role = lib.mkOption {
+                type = lib.types.enum [
+                  "server"
+                  "client"
+                ];
+                description = ''
+                  The frp consists of `client` and `server`. The server is usually
+                  deployed on the machine with a public IP address, and
+                  the client is usually deployed on the machine
+                  where the Intranet service to be penetrated resides.
+                '';
+              };
 
-      role = lib.mkOption {
-        type = lib.types.enum [
-          "server"
-          "client"
-        ];
-        description = ''
-          The frp consists of `client` and `server`. The server is usually
-          deployed on the machine with a public IP address, and
-          the client is usually deployed on the machine
-          where the Intranet service to be penetrated resides.
-        '';
-      };
-
-      settings = lib.mkOption {
-        type = settingsFormat.type;
+              settings = lib.mkOption {
+                type = settingsFormat.type;
+                default = { };
+                description = ''
+                  Frp configuration, for configuration options
+                  see the example of [client](https://github.com/fatedier/frp/blob/dev/conf/frpc_full_example.toml)
+                  or [server](https://github.com/fatedier/frp/blob/dev/conf/frps_full_example.toml) on github.
+                '';
+                example = {
+                  serverAddr = "x.x.x.x";
+                  serverPort = 7000;
+                };
+              };
+            };
+          }
+        );
         default = { };
         description = ''
-          Frp configuration, for configuration options
-          see the example of [client](https://github.com/fatedier/frp/blob/dev/conf/frpc_full_example.toml)
-          or [server](https://github.com/fatedier/frp/blob/dev/conf/frps_full_example.toml) on github.
+          Frp instances.
         '';
-        example = {
-          serverAddr = "x.x.x.x";
-          serverPort = 7000;
-        };
       };
+
+      package = lib.mkPackageOption pkgs "frp" { };
     };
   };
 
-  config =
-    let
-      serviceCapability = lib.optionals isServer [ "CAP_NET_BIND_SERVICE" ];
-      executableFile = if isClient then "frpc" else "frps";
-    in
-    lib.mkIf cfg.enable {
-      systemd.services = {
-        frp = {
-          wants = lib.optionals isClient [ "network-online.target" ];
-          after = if isClient then [ "network-online.target" ] else [ "network.target" ];
-          wantedBy = [ "multi-user.target" ];
-          description = "A fast reverse proxy frp ${cfg.role}";
-          serviceConfig = {
-            Type = "simple";
-            Restart = "on-failure";
-            RestartSec = 15;
-            ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
-            DynamicUser = true;
-            # Hardening
-            CapabilityBoundingSet = serviceCapability;
-            AmbientCapabilities = serviceCapability;
-            PrivateDevices = true;
-            ProtectHostname = true;
-            ProtectClock = true;
-            ProtectKernelTunables = true;
-            ProtectKernelModules = true;
-            ProtectKernelLogs = true;
-            ProtectControlGroups = true;
-            RestrictAddressFamilies = [
-              "AF_INET"
-              "AF_INET6"
-            ]
-            ++ lib.optionals isClient [ "AF_UNIX" ];
-            LockPersonality = true;
-            MemoryDenyWriteExecute = true;
-            RestrictRealtime = true;
-            RestrictSUIDSGID = true;
-            PrivateMounts = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = [ "@system-service" ];
-          }
-          // lib.optionalAttrs isServer {
-            StateDirectory = "frp";
-            StateDirectoryMode = "0700";
-            UMask = "0007";
-          };
+  config = lib.mkIf (enabledInstances != { }) {
+    systemd.services = lib.mapAttrs' (
+      instance: options:
+      let
+        serviceName = "frp" + lib.optionalString (instance != "") ("-" + instance);
+        configFile = settingsFormat.generate "${serviceName}.toml" options.settings;
+        isClient = (options.role == "client");
+        isServer = (options.role == "server");
+        serviceCapability = lib.optionals isServer [ "CAP_NET_BIND_SERVICE" ];
+        executableFile = if isClient then "frpc" else "frps";
+      in
+      lib.nameValuePair serviceName {
+        wants = lib.optionals isClient [ "network-online.target" ];
+        after = if isClient then [ "network-online.target" ] else [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        description = "A fast reverse proxy frp ${options.role} for instance ${instance}";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "on-failure";
+          RestartSec = 15;
+          ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
+          DynamicUser = true;
+          # Hardening
+          CapabilityBoundingSet = serviceCapability;
+          AmbientCapabilities = serviceCapability;
+          PrivateDevices = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ]
+          ++ lib.optionals isClient [ "AF_UNIX" ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          PrivateMounts = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" ];
+        }
+        // lib.optionalAttrs isServer {
+          StateDirectory = "frp";
+          StateDirectoryMode = "0700";
+          UMask = "0007";
         };
-      };
-    };
+      }
+    ) enabledInstances;
+  };
 
   meta.maintainers = with lib.maintainers; [ zaldnoay ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds support for running multiple frp instances. With this change, it is possible to run an frp client instance alongside a server instance or multiple client instances.

It renamed the old options to provide backward compatibility as well.

Closes #338277.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
