### PR TITLE
buildkite-agent: override buildVersion sentinel value to fix crashes

### DIFF
--- a/pkgs/by-name/bu/buildkite-agent/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent/package.nix
@@ -33,6 +33,13 @@ buildGoModule rec {
 
   doCheck = false;
 
+  # buildkite-agent expects the `buildVersion` variable to be set to something
+  # other than its sentinel, otherwise the agent will not work correctly as of
+  # https://github.com/buildkite/agent/pull/3123
+  ldflags = [
+    "-X github.com/buildkite/agent/v3/version.buildNumber=nix"
+  ];
+
   postInstall = ''
     # Fix binary name
     mv $out/bin/{agent,buildkite-agent}


### PR DESCRIPTION
Buildkite introduced a weird check that determines whether the bootstrap agent path (?) matches the binary that the agent was started from:

https://github.com/buildkite/agent/pull/3123

They did this to work around some issues with the internal development flows. However, this check is toggled by whether or not the `buildNumber` compile-time variable is set to the special `x` sentinel value.

In their publicly released binaries (which we do not use, of course), this is set to some other value. In Nix builds they are at the default sentinel value, causing crashes at startup because of the wrapper script not matching the binary path:

```
buildkite-agent: fatal: check binary paths: mismatched buildkite-agent paths: host="/nix/store/rmp9g00bppi8yimr0ngnx6490w196in8-buildkite-agent-3.89.0/bin/.buildkite-agent-wrapped" bootstrap="/nix/store/rmp9g00bppi8yimr0ngnx6490w196in8-buildkite-agent-3.89.0/bin/buildkite-agent"
```

To work around this we just set the build "number" to `nix`.

Relates: TVL [b/439](https://b.tvl.fyi/issues/439)