### PR TITLE
python312Packages.audiotools: 3.1.1 -> 3.1.1-unstable-2020-07-29

### DIFF
--- a/pkgs/development/python-modules/audiotools/default.nix
+++ b/pkgs/development/python-modules/audiotools/default.nix
@@ -7,26 +7,61 @@
   AudioToolbox,
   AudioUnit,
   CoreServices,
+  pkg-config,
+  libmpg123,
+  lame,
+  twolame,
+  libopus,
+  opusfile,
+  libvorbis,
+  libcdio,
+  libcdio-paranoia,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "audiotools";
-  version = "3.1.1";
+  version = "3.1.1-unstable-2020-07-29";
   pyproject = true;
 
-  build-system = [ setuptools ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    AudioToolbox
-    AudioUnit
-    CoreServices
+  build-system = [
+    setuptools
   ];
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      libmpg123 # MP2/MP3 decoding
+      lame # MP3 encoding
+      twolame # MP2 encoding
+      opusfile # opus decoding
+      libopus # opus encoding
+      libvorbis # ogg encoding/decoding
+      libcdio # CD reading
+      libcdio-paranoia # CD reading
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      AudioToolbox
+      AudioUnit
+      CoreServices
+    ];
+
+  preConfigure = ''
+    # need to change probe to yes because mp3lame is not reported in pkg-config
+    substituteInPlace setup.cfg \
+      --replace-fail "mp3lame:           probe" "mp3lame:           yes"
+  '';
+
+  # the python code contains #variant formats, PY_SSIZE_T_CLEAN must be defined
+  # before including Python.h for 3.10 or newer
+  # the last released version does not contain the required fix for python 3.10
   src = fetchFromGitHub {
     owner = "tuffy";
     repo = "python-audio-tools";
-    rev = "v${version}";
-    hash = "sha256-y+EiK9BktyTWowOiJvOb2YjtbPa7R62Wb5zinkyt1OM=";
+    rev = "de55488dc982e3f6375cde2d0c2ea6aad1b1c31c";
+    hash = "sha256-iRakeV4Sg4oU0JtiA0O3jnmLJt99d89Hg6v9onUaSnw=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Updated to the head to fix some runtime error, and enabled most of the optional features.

Previously:

```
extraction arguments
  Format Readable Writable Default Quality
  ────── ──────── ──────── ───────────────
    aiff      yes      yes
    alac      yes      yes
      au      yes      yes
    flac      yes      yes               8
     m4a       no       no             100
     mp2       no       no             192
     mp3       no       no               2
     ogg       no       no               3
    opus       no       no              10
     tta      yes      yes
     wav      yes      yes
      wv       no       no        standard
```

Now:

```
extraction arguments
  Format Readable Writable Default Quality
  ────── ──────── ──────── ───────────────
    aiff      yes      yes
    alac      yes      yes
      au      yes      yes
    flac      yes      yes               8
     m4a       no       no             100
     mp2      yes      yes             192
     mp3      yes      yes               2
     mpc      yes      yes               5
     ogg      yes      yes               3
    opus      yes      yes              10
     spx       no       no
     tta      yes      yes
     wav      yes      yes
      wv       no       no        standard
```

Utilities like `cdda2track` for ripping CDs is also provided.

Note that I did not test all the formats and CD ripping. I only tested mp3 <-> flac for now.

The version update is needed so that python will not complain about missing `PY_SSIZE_T_CLEAN` when using Python 3.12.

For M4A support, it seems that it require unfree packages, so I did not enable it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
