### PR TITLE
cosmic-settings: 1.0.0-alpha.1 -> 1.0.0-alpha.6

### DIFF
--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -29,14 +29,14 @@ let
 in
 rustPlatform.buildRustPackage.override
   { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  rec {
+  (finalAttrs: {
     pname = "cosmic-settings";
     version = "1.0.0-alpha.6";
 
     src = fetchFromGitHub {
       owner = "pop-os";
       repo = "cosmic-settings";
-      tag = "epoch-${version}";
+      tag = "epoch-${finalAttrs.version}";
       hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
     };
 
@@ -105,4 +105,4 @@ rustPlatform.buildRustPackage.override
       ];
       platforms = lib.platforms.linux;
     };
-  }
+  })

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   cmake,
@@ -18,83 +19,90 @@
   cosmic-randr,
   xkeyboard_config,
   nix-update-script,
+
+  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 let
   libcosmicAppHook' = (libcosmicAppHook.__spliced.buildHost or libcosmicAppHook).override {
     includeSettings = false;
   };
 in
-rustPlatform.buildRustPackage rec {
-  pname = "cosmic-settings";
-  version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage.override
+  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
+  rec {
+    pname = "cosmic-settings";
+    version = "1.0.0-alpha.6";
 
-  src = fetchFromGitHub {
-    owner = "pop-os";
-    repo = "cosmic-settings";
-    tag = "epoch-${version}";
-    hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
-  };
+    src = fetchFromGitHub {
+      owner = "pop-os";
+      repo = "cosmic-settings";
+      tag = "epoch-${version}";
+      hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
+    };
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
 
-  nativeBuildInputs = [
-    cmake
-    just
-    libcosmicAppHook'
-    pkg-config
-    rustPlatform.bindgenHook
-    util-linux
-  ];
-
-  buildInputs = [
-    expat
-    fontconfig
-    freetype
-    libinput
-    pipewire
-    pulseaudio
-    udev
-  ];
-
-  dontUseJustBuild = true;
-  dontUseJustCheck = true;
-
-  justFlags = [
-    "--set"
-    "prefix"
-    (placeholder "out")
-    "--set"
-    "bin-src"
-    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-settings"
-  ];
-
-  preFixup = ''
-    libcosmicAppWrapperArgs+=(
-      --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
-      --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
-      --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
-    )
-  '';
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version"
-      "unstable"
-      "--version-regex"
-      "epoch-(.*)"
+    nativeBuildInputs = [
+      cmake
+      just
+      libcosmicAppHook'
+      pkg-config
+      rustPlatform.bindgenHook
+      util-linux
     ];
-  };
 
-  meta = {
-    description = "Settings for the COSMIC Desktop Environment";
-    homepage = "https://github.com/pop-os/cosmic-settings";
-    license = lib.licenses.gpl3Only;
-    mainProgram = "cosmic-settings";
-    maintainers = with lib.maintainers; [
-      nyabinary
-      HeitorAugustoLN
+    buildInputs = [
+      expat
+      fontconfig
+      freetype
+      libinput
+      pipewire
+      pulseaudio
+      udev
     ];
-    platforms = lib.platforms.linux;
-  };
-}
+
+    dontUseJustBuild = true;
+    dontUseJustCheck = true;
+
+    justFlags = [
+      "--set"
+      "prefix"
+      (placeholder "out")
+      "--set"
+      "bin-src"
+      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-settings"
+    ];
+
+    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
+      lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
+
+    preFixup = ''
+      libcosmicAppWrapperArgs+=(
+        --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
+        --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
+        --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
+      )
+    '';
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--version"
+        "unstable"
+        "--version-regex"
+        "epoch-(.*)"
+      ];
+    };
+
+    meta = {
+      description = "Settings for the COSMIC Desktop Environment";
+      homepage = "https://github.com/pop-os/cosmic-settings";
+      license = lib.licenses.gpl3Only;
+      mainProgram = "cosmic-settings";
+      maintainers = with lib.maintainers; [
+        nyabinary
+        HeitorAugustoLN
+      ];
+      platforms = lib.platforms.linux;
+    };
+  }

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -17,6 +17,7 @@
   expat,
   udev,
   util-linux,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -70,6 +71,15 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]} \
       --suffix XDG_DATA_DIRS : "$out/share:${cosmic-icons}/share"
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "unstable"
+      "--version-regex"
+      "epoch-(.*)"
+    ];
+  };
 
   meta = with lib; {
     homepage = "https://github.com/pop-os/cosmic-settings";

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -30,16 +30,12 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-settings";
-    rev = "epoch-${version}";
+    tag = "epoch-${version}";
     hash = "sha256-gTzZvhj7oBuL23dtedqfxUCT413eMoDc0rlNeqCeZ6E=";
   };
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-zMHJc6ytbOoi9E47Zsg6zhbQKObsaOtVHuPnLAu36I4=";
-
-  postPatch = ''
-    substituteInPlace justfile --replace '#!/usr/bin/env' "#!$(command -v env)"
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -61,6 +57,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   dontUseJustBuild = true;
+  dontUseJustCheck = true;
 
   justFlags = [
     "--set"
@@ -84,12 +81,12 @@ rustPlatform.buildRustPackage rec {
     ];
   };
 
-  meta = with lib; {
-    homepage = "https://github.com/pop-os/cosmic-settings";
+  meta = {
     description = "Settings for the COSMIC Desktop Environment";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ nyabinary ];
-    platforms = platforms.linux;
+    homepage = "https://github.com/pop-os/cosmic-settings";
+    license = lib.licenses.gpl3Only;
     mainProgram = "cosmic-settings";
+    maintainers = with lib.maintainers; [ nyabinary ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -91,7 +91,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/pop-os/cosmic-settings";
     license = lib.licenses.gpl3Only;
     mainProgram = "cosmic-settings";
-    maintainers = with lib.maintainers; [ nyabinary ];
+    maintainers = with lib.maintainers; [
+      nyabinary
+      HeitorAugustoLN
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -16,6 +16,7 @@
   udev,
   util-linux,
   cosmic-randr,
+  xkeyboard_config,
   nix-update-script,
 }:
 let
@@ -69,7 +70,11 @@ rustPlatform.buildRustPackage rec {
   ];
 
   preFixup = ''
-    libcosmicAppWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ cosmic-randr ]})
+    libcosmicAppWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
+      --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
+      --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
+    )
   '';
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -26,17 +26,17 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "cosmic-settings";
-  version = "1.0.0-alpha.1";
+  version = "1.0.0-alpha.6";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-settings";
     tag = "epoch-${version}";
-    hash = "sha256-gTzZvhj7oBuL23dtedqfxUCT413eMoDc0rlNeqCeZ6E=";
+    hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-zMHJc6ytbOoi9E47Zsg6zhbQKObsaOtVHuPnLAu36I4=";
+  cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -11,6 +11,8 @@
   libinput,
   fontconfig,
   freetype,
+  pipewire,
+  pulseaudio,
   udev,
   util-linux,
   cosmic-randr,
@@ -44,6 +46,8 @@ rustPlatform.buildRustPackage rec {
     just
     libcosmicAppHook'
     pkg-config
+    rustPlatform.bindgenHook
+    util-linux
   ];
 
   buildInputs = [
@@ -51,8 +55,9 @@ rustPlatform.buildRustPackage rec {
     fontconfig
     freetype
     libinput
+    pipewire
+    pulseaudio
     udev
-    util-linux
   ];
 
   dontUseJustBuild = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add updateScript
- Use libcosmicAppHook
- Add some missing audio dependencies, and move `util-linux` to `nativeBuildInputs` since it is only needed when building
- Refactor package
- Add X11 xkb rules paths to wrapper, because the default paths used by xkb-data crate are not compatible with Nix.
- Add myself as a maintainer
- Bump `cosmic-settings` to `1.0.0-alpha.6`
- Use mold linker as it is used by justfiles in cosmic-settings (https://github.com/pop-os/cosmic-settings/blob/95e77491c5b713bbef20e2ae1b52b7d20399e90b/scripts/cargo.just#L5-L19)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
