### PR TITLE
xgboost: 2.0.3 -> 2.1.4

### DIFF
--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   gtest,
   doCheck ? true,
@@ -49,24 +48,15 @@ effectiveStdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "2.0.3";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-LWco3A6zwdnAf8blU4qjW7PFEeZaTcJlVTwVrs7nwWM=";
+    hash = "sha256-k1k6K11cWpG6PtzTt99q/rrkN3FyxCVEzfPI9fCTAjM=";
   };
-
-  patches = lib.optionals (cudaSupport && cudaPackages.cudaMajorMinorVersion == "12.4") [
-    (fetchpatch {
-      # https://github.com/dmlc/xgboost/pull/10123
-      name = "Fix compilation with the ctk 12.4.";
-      url = "https://github.com/dmlc/xgboost/commit/c760f85db0bc7bd6379901fbfb67ceccc2b37700.patch";
-      hash = "sha256-iP9mll9pg8T2ztCR7dBPnLP17/x3ImJFrr5G3e2dqHo=";
-    })
-  ];
 
   nativeBuildInputs =
     [ cmake ]
@@ -77,6 +67,7 @@ effectiveStdenv.mkDerivation rec {
   buildInputs =
     [ gtest ]
     ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+    ++ lib.optional cudaSupport cudaPackages.cuda_cudart
     ++ lib.optional ncclSupport cudaPackages.nccl;
 
   propagatedBuildInputs = lib.optionals rLibrary [
@@ -115,12 +106,61 @@ effectiveStdenv.mkDerivation rec {
   GTEST_FILTER =
     let
       # Upstream Issue: https://github.com/xtensor-stack/xsimd/issues/456
-      filteredTests = lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+      xsimdTests = lib.optionals effectiveStdenv.hostPlatform.isDarwin [
         "ThreadGroup.TimerThread"
         "ThreadGroup.TimerThreadSimple"
       ];
+      networkingTest = [
+        "AllgatherTest.Basic"
+        "AllgatherTest.VAlgo"
+        "AllgatherTest.VBasic"
+        "AllgatherTest.VRing"
+        "AllreduceGlobal.Basic"
+        "AllreduceGlobal.Small"
+        "AllreduceTest.Basic"
+        "AllreduceTest.BitOr"
+        "AllreduceTest.Restricted"
+        "AllreduceTest.Sum"
+        "Approx.PartitionerColumnSplit"
+        "BroadcastTest.Basic"
+        "CPUHistogram.BuildHistColSplit"
+        "CPUPredictor.CategoricalPredictLeafColumnSplit"
+        "CPUPredictor.CategoricalPredictionColumnSplit"
+        "ColumnSplit/ColumnSplitTrainingTest*"
+        "ColumnSplit/TestApproxColumnSplit*"
+        "ColumnSplit/TestHistColumnSplit*"
+        "ColumnSplitObjective/TestColumnSplit*"
+        "CommGroupTest.Basic"
+        "CommTest.Channel"
+        "CpuPredictor.BasicColumnSplit"
+        "CpuPredictor.IterationRangeColmnSplit"
+        "CpuPredictor.LesserFeaturesColumnSplit"
+        "CpuPredictor.SparseColumnSplit"
+        "DistributedMetric/TestDistributedMetric.BinaryAUCRowSplit/Dist_*"
+        "InitEstimation.FitStumpColumnSplit"
+        "MetaInfo.GetSetFeatureColumnSplit"
+        "Quantile.ColumnSplit"
+        "Quantile.ColumnSplitBasic"
+        "Quantile.ColumnSplitSorted"
+        "Quantile.ColumnSplitSortedBasic"
+        "Quantile.Distributed"
+        "Quantile.DistributedBasic"
+        "Quantile.SameOnAllWorkers"
+        "Quantile.SortedDistributed"
+        "Quantile.SortedDistributedBasic"
+        "QuantileHist.MultiPartitionerColumnSplit"
+        "QuantileHist.PartitionerColumnSplit"
+        "SimpleDMatrix.ColumnSplit"
+        "TrackerAPITest.CAPI"
+        "TrackerTest.AfterShutdown"
+        "TrackerTest.Bootstrap"
+        "TrackerTest.GetHostAddress"
+        "TrackerTest.Print"
+        "VectorAllgatherV.Basic"
+      ];
+      excludedTests = xsimdTests ++ networkingTest;
     in
-    "-${builtins.concatStringsSep ":" filteredTests}";
+    "-${builtins.concatStringsSep ":" excludedTests}";
 
   installPhase =
     ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This update picks up from where #334044 left off
 - Updated `xgboost` to 2.1.4
 - Excluded new tests that require network connection
 - Excluded nvidia-nccl-cu12 from the python package. As far as I understand, we already statically link NCCL when needed so this is not necessary.
 
I tested the python package without CUDA (I don't have an Nvidia GPU) and it works as expected. It'd be good if someone can check if CUDA support still works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
