### PR TITLE
buildPython*: unify the use of standard library function

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -443,13 +443,13 @@ let
         disabledTests = attrs.disabledTests;
       }
       // optionalAttrs (attrs ? pytestFlags) {
-          pytestFlags = attrs.pytestFlags;
+        pytestFlags = attrs.pytestFlags;
       }
       // optionalAttrs (attrs ? pytestFlagsArray) {
         pytestFlagsArray = attrs.pytestFlagsArray;
       }
       // optionalAttrs (attrs ? unittestFlags) {
-          unittestFlags = attrs.unittestFlags;
+        unittestFlags = attrs.unittestFlags;
       }
       // optionalAttrs (attrs ? unittestFlagsArray) {
         unittestFlagsArray = attrs.unittestFlagsArray;

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -35,6 +35,7 @@ let
     elem
     extendDerivation
     fixedWidthString
+    flip
     getName
     hasSuffix
     head
@@ -44,6 +45,7 @@ let
     optionalAttrs
     optionals
     optionalString
+    removePrefix
     splitString
     stringLength
     ;
@@ -64,18 +66,18 @@ let
 
   isMismatchedPython = drv: drv.pythonModule != python;
 
-  withDistOutput' = lib.flip elem [
+  withDistOutput' = flip elem [
     "pyproject"
     "setuptools"
     "wheel"
   ];
 
-  isBootstrapInstallPackage' = lib.flip elem [
+  isBootstrapInstallPackage' = flip elem [
     "flit-core"
     "installer"
   ];
 
-  isBootstrapPackage' = lib.flip elem (
+  isBootstrapPackage' = flip elem (
     [
       "build"
       "packaging"
@@ -87,12 +89,12 @@ let
     ]
   );
 
-  isSetuptoolsDependency' = lib.flip elem [
+  isSetuptoolsDependency' = flip elem [
     "setuptools"
     "wheel"
   ];
 
-  cleanAttrs = lib.flip removeAttrs [
+  cleanAttrs = flip removeAttrs [
     "disabled"
     "checkPhase"
     "checkInputs"
@@ -462,7 +464,7 @@ let
     drv:
     extendDerivation (
       drv.disabled
-      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
+      -> throw "${removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
     ) { } (toPythonModule drv);
 
 in

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -42,7 +42,6 @@ let
     optionals
     optionalAttrs
     hasSuffix
-    escapeShellArgs
     extendDerivation
     head
     splitString

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -33,19 +33,19 @@ let
   inherit (builtins) unsafeGetAttrPos;
   inherit (lib)
     elem
-    optionalString
-    max
-    stringLength
+    extendDerivation
     fixedWidthString
     getName
-    optional
-    optionals
-    optionalAttrs
     hasSuffix
-    extendDerivation
     head
-    splitString
     isBool
+    max
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    splitString
+    stringLength
     ;
 
   leftPadName =


### PR DESCRIPTION
This chore PR updates the `lib` function inheritance and sort them alphabetically. It also formats the file and fixes the mis-indentation after a hard staging merge.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
