### PR TITLE
linux-rpi & raspberrypifw: stable_20241008 -> stable_20250127, raspberrypiWirelessFirmware: unstable-2024-02-26 -> unstable-2024-12-23 

### DIFF
--- a/pkgs/by-name/ra/raspberrypiWirelessFirmware/package.nix
+++ b/pkgs/by-name/ra/raspberrypiWirelessFirmware/package.nix
@@ -6,7 +6,7 @@
 
 stdenvNoCC.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "unstable-2024-02-26";
+  version = "unstable-2024-12-23";
 
   srcs = [
     (fetchFromGitHub {
@@ -20,8 +20,8 @@ stdenvNoCC.mkDerivation {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "223ccf3a3ddb11b3ea829749fbbba4d65b380897";
-      hash = "sha256-BGq0+cr+xBRwQM/LqiQuRWuZpQsKM5jfcrNCqWMuVzM=";
+      rev = "a6ed59a078d52ad72f0f2b99e68f324e7411afa1";
+      hash = "sha256-Yu9hoy4lWQlkjq9LTTmXaLpUKzaEkJaMz9oYmOfbDos=";
     })
   ];
 

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,13 +3,13 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20241008";
+  version = "1.20250127";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    hash = "sha256-4gnK0KbqFnjBmWia9Jt2gveVWftmHrprpwBqYVqE/k0=";
+    hash = "sha256-gdZt9xS3X1Prh+TU0DLy6treFoJjiUUUiZ3IoDbopzI=";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -12,8 +12,8 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.6.51";
-  tag = "stable_20241008";
+  modDirVersion = "6.6.74";
+  tag = "stable_20250127";
 in
 lib.overrideDerivation
   (buildLinux (
@@ -27,7 +27,7 @@ lib.overrideDerivation
         owner = "raspberrypi";
         repo = "linux";
         rev = tag;
-        hash = "sha256-phCxkuO+jUGZkfzSrBq6yErQeO2Td+inIGHxctXbD5U=";
+        hash = "sha256-17PrkPUGBKU+nO40OP+O9dzZeCfRPlKnnk/PJOGamU8=";
       };
 
       defconfig =


### PR DESCRIPTION
- linux-rpi contains change between upstream 6.6.51 and 6.6.74 + RPi-specific changes. [This compare] might paint some picture on what additional commits are made on top of 6.6.74, but I'm not sure if I specify the compare arguments correctly.
- [raspberrypifw changes] contain 1 actual firmware upgrade and 2 kernel binary upgrades.
- Change of raspberrypiWirelessFirmware comes from firmware-nonfree. [Changes] include new Wi-Fi firmware for WPA3 offload and new symlinks for CM5 and Raspberry  Pi 500.

[This compare]: https://github.com/raspberrypi/linux/compare/4407146cf3fcfe8883f6123b89f861a11cc4e4df...stable_20250127 
[raspberrypifw changes]: https://github.com/raspberrypi/firmware/compare/1.20241008...1.20250127
[Changes]: https://github.com/RPi-Distro/firmware-nonfree/compare/223ccf3a3ddb11b3ea829749fbbba4d65b380897...a6ed59a078d52ad72f0f2b99e68f324e7411afa1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux (N/A)
  - [x] aarch64-linux (For linux_rpi4)
  - [ ] x86_64-darwin (N/A)
  - [ ] aarch64-darwin (N/A)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
