### PR TITLE
fetchFromBitbucket: url escape rev

### DIFF
--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -11,8 +11,7 @@ lib.makeOverridable (
   fetchzip (
     {
       inherit name;
-      url = "https://bitbucket.org/${owner}/${repo}/get/${rev}.tar.gz";
-      # url = "https://bitbucket.org/${owner}/${repo}/get/${lib.strings.escapeURL rev}.tar.gz";
+      url = "https://bitbucket.org/${owner}/${repo}/get/${lib.strings.escapeURL rev}.tar.gz";
       meta.homepage = "https://bitbucket.org/${owner}/${repo}/";
     }
     // removeAttrs args [

--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -12,6 +12,7 @@ lib.makeOverridable (
     {
       inherit name;
       url = "https://bitbucket.org/${owner}/${repo}/get/${rev}.tar.gz";
+      # url = "https://bitbucket.org/${owner}/${repo}/get/${lib.strings.escapeURL rev}.tar.gz";
       meta.homepage = "https://bitbucket.org/${owner}/${repo}/";
     }
     // removeAttrs args [

--- a/pkgs/build-support/fetchbitbucket/tests.nix
+++ b/pkgs/build-support/fetchbitbucket/tests.nix
@@ -1,0 +1,18 @@
+{ testers, fetchFromBitbucket, ... }:
+{
+  withEncodedWhitespace = testers.invalidateFetcherByDrvHash fetchFromBitbucket {
+    name = "withWhitespace";
+    owner = "tetov";
+    repo = "fetchbitbucket_tester";
+    rev = "tag%20with%20encoded%20spaces";
+    sha256 = "sha256-Nf1Cvbx7Sbab8EeSSBU5baLBiuFYiQtITED+f4tfjC0=";
+  };
+
+  withoutWhitespace = testers.invalidateFetcherByDrvHash fetchFromBitbucket {
+    name = "withoutWhitespace";
+    owner = "tetov";
+    repo = "fetchbitbucket_tester";
+    rev = "main";
+    sha256 = "sha256-eTd773gE1z4+Fl2YPBbbsrADD4Dr7sFGoOWgphXUhtE=";
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -129,6 +129,7 @@ with pkgs;
   fetchDebianPatch = recurseIntoAttrs (callPackages ../build-support/fetchdebianpatch/tests.nix { });
   fetchzip = recurseIntoAttrs (callPackages ../build-support/fetchzip/tests.nix { });
   fetchgit = recurseIntoAttrs (callPackages ../build-support/fetchgit/tests.nix { });
+  fetchFromBitbucket = recurseIntoAttrs (callPackages ../build-support/fetchbitbucket/tests.nix { });
   fetchFirefoxAddon = recurseIntoAttrs (
     callPackages ../build-support/fetchfirefoxaddon/tests.nix { }
   );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -701,9 +701,7 @@ with pkgs;
 
   fetchFromGitHub = callPackage ../build-support/fetchgithub { };
 
-  fetchFromBitbucket = callPackage ../build-support/fetchbitbucket { } // {
-    tests = pkgs.tests.fetchFromBitbucket;
-  };
+  fetchFromBitbucket = callPackage ../build-support/fetchbitbucket { };
 
   fetchFromSavannah = callPackage ../build-support/fetchsavannah { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -701,7 +701,9 @@ with pkgs;
 
   fetchFromGitHub = callPackage ../build-support/fetchgithub { };
 
-  fetchFromBitbucket = callPackage ../build-support/fetchbitbucket { };
+  fetchFromBitbucket = callPackage ../build-support/fetchbitbucket { } // {
+    tests = pkgs.tests.fetchFromBitbucket;
+  };
 
   fetchFromSavannah = callPackage ../build-support/fetchsavannah { };
 


### PR DESCRIPTION
As brought up in #29733. Closes #29733.

The original repo reported has moved so have no target to test against, since Bitbucket no longer allows spaces in rev. I did find one issue and that's if the user specifies a rev with "%20" in it (for a tag or branch with %20 in it). It's a bit convoluted but shows that fetchFromBitbucket currently does not support all revision names possible on the Bitbucket service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
