### PR TITLE
convmv: add dependencies to support additional encodings

### DIFF
--- a/pkgs/by-name/co/convmv/package.nix
+++ b/pkgs/by-name/co/convmv/package.nix
@@ -12,8 +12,9 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.06";
 
   outputs = [
-    "out"
+    "bin"
     "man"
+    "out"
   ];
 
   src = fetchzip {
@@ -36,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [
-    "PREFIX=${placeholder "out"}"
+    "PREFIX=${placeholder "bin"}"
     "MANDIR=${placeholder "man"}/share/man"
   ];
 
@@ -57,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontPatchShebangs = true;
 
   postFixup = ''
-    wrapProgram "$out/bin/convmv" --prefix PERL5LIB : "$PERL5LIB"
+    wrapProgram "$bin/bin/convmv" --prefix PERL5LIB : "$PERL5LIB"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/co/convmv/package.nix
+++ b/pkgs/by-name/co/convmv/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenv,
   fetchzip,
+  makeWrapper,
   perl,
+  perlPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,9 +23,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [
+    makeWrapper
+    perl
+  ];
 
-  buildInputs = [ perl ];
+  buildInputs = [
+    perl
+    perlPackages.EncodeHanExtra
+    perlPackages.EncodeIMAPUTF7
+    perlPackages.EncodeJIS2K
+  ];
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
@@ -45,6 +55,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   dontPatchShebangs = true;
+
+  postFixup = ''
+    wrapProgram "$out/bin/convmv" --prefix PERL5LIB : "$PERL5LIB"
+  '';
 
   meta = with lib; {
     description = "Converts filenames from one encoding to another";


### PR DESCRIPTION
This adds support for the following encodings:

```diff
diff --git a/a b/b
--- a/a
+++ b/b
@@ -4,8 +4,21 @@ AdobeSymbol
 AdobeZdingbat
 ascii
 ascii-ctrl
+big5-1984
+big5-2003
 big5-eten
 big5-hkscs
+big5ext
+big5plus
+cccii
+cns11643-1
+cns11643-2
+cns11643-3
+cns11643-4
+cns11643-5
+cns11643-6
+cns11643-7
+cns11643-f
 cp1006
 cp1026
 cp1047
@@ -46,15 +59,20 @@ cp949
 cp950
 dingbats
 euc-cn
+euc-jisx0213
 euc-jp
 euc-kr
+euc-tw
 gb12345-raw
+gb18030
 gb2312-raw
 gsm0338
 hp-roman8
 hz
+IMAP-UTF-7
 iso-2022-jp
 iso-2022-jp-1
+iso-2022-jp-3
 iso-2022-kr
 iso-8859-1
 iso-8859-10
@@ -75,6 +93,8 @@ iso-ir-165
 jis0201-raw
 jis0208-raw
 jis0212-raw
+jis0213-1-raw
+jis0213-2-raw
 johab
 koi8-f
 koi8-r
@@ -109,9 +129,11 @@ nextstep
 null
 posix-bc
 shiftjis
+shiftjisx0213
 symbol
 UCS-2BE
 UCS-2LE
+unisys
 UTF-16
 UTF-16BE
 UTF-16LE
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
