### PR TITLE
rocmPackages_5.clr: fix dangling symlink

### DIFF
--- a/pkgs/development/rocm-modules/5/clr/default.nix
+++ b/pkgs/development/rocm-modules/5/clr/default.nix
@@ -139,6 +139,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Replace rocm-opencl-icd functionality
     mkdir -p $icd/etc/OpenCL/vendors
     echo "$out/lib/libamdocl64.so" > $icd/etc/OpenCL/vendors/amdocl64.icd
+
+    # add version info to output (downstream rocmPackages look for this)
+    echo "HIP_VERSION_MAJOR=${builtins.elemAt (lib.splitVersion finalAttrs.version) 0}" > $out/bin/.hipVersion
+    echo "HIP_VERSION_MINOR=${builtins.elemAt (lib.splitVersion finalAttrs.version) 1}" >> $out/bin/.hipVersion
+    echo "HIP_VERSION_PATCH=${builtins.elemAt (lib.splitVersion finalAttrs.version) 2}" >> $out/bin/.hipVersion
   '';
 
   passthru = {


### PR DESCRIPTION
This is an attempt to fix ROCm clr package. The failure is 

```
ERROR: noBrokenSymlinks: the symlink /nix/store/ahkw37ag0q7kag89z51zjpn029l78lsg-clr-5.7.1/hip/bin/.hipVersion points to a missing target: /nix/store/ahkw37ag0q7kag89z51zjpn029l78lsg-clr-5.7.1/bin/.hipVersion
```

(see [Hybra](https://hydra.nixos.org/build/289929804))

From the ROCm [repo](https://github.com/search?q=repo%3AROCm%2Fclr+.hipversion&type=commits), I got the impression, that this file is probably a version and added a script similar to what is uses in `rocmPackages_6.clr`.

I am however not an expert in ROCm, please review this carefully.

Fixes #383730

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
