### PR TITLE
buildPython*: simplify check-related attribute inheritance

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -50,6 +50,9 @@ let
     stringLength
     ;
 
+  getOptionalAttrs =
+    names: attrs: lib.getAttrs (lib.intersectLists names (lib.attrNames attrs)) attrs;
+
   leftPadName =
     name: against:
     let
@@ -195,8 +198,6 @@ in
   meta ? { },
 
   doCheck ? true,
-
-  disabledTestPaths ? [ ],
 
   # Allow passing in a custom stdenv to buildPython*
   stdenv ? python.stdenv,
@@ -437,24 +438,14 @@ let
       installCheckPhase = attrs.checkPhase;
     }
     // optionalAttrs (attrs.doCheck or true) (
-      optionalAttrs (disabledTestPaths != [ ]) {
-        disabledTestPaths = disabledTestPaths;
-      }
-      // optionalAttrs (attrs ? disabledTests) {
-        disabledTests = attrs.disabledTests;
-      }
-      // optionalAttrs (attrs ? pytestFlags) {
-        pytestFlags = attrs.pytestFlags;
-      }
-      // optionalAttrs (attrs ? pytestFlagsArray) {
-        pytestFlagsArray = attrs.pytestFlagsArray;
-      }
-      // optionalAttrs (attrs ? unittestFlags) {
-        unittestFlags = attrs.unittestFlags;
-      }
-      // optionalAttrs (attrs ? unittestFlagsArray) {
-        unittestFlagsArray = attrs.unittestFlagsArray;
-      }
+      getOptionalAttrs [
+        "disabledTestPaths"
+        "disabledTests"
+        "pytestFlags"
+        "pytestFlagsArray"
+        "unittestFlags"
+        "unittestFlagsArray"
+      ] attrs
     )
   );
 


### PR DESCRIPTION
This PR simplifies the inheritance of check-related attributes. It essentially pass these arguments directly whenever `attrs.doCheck` is true or unspecified.

This PR is implemented with a local helper function `getExistingAttrs`, which is like `getAttrs` but ignores non-existing attributes. This helps reduce boilerplate codes, and subsequent PRs will also utilize such helper function.

This can be seen as the non-controvertial, backward-compatible part of #376060.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
