### PR TITLE
maintainers/scripts/update: Allow updating in (reverse) topological order

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -16,6 +16,7 @@
   keep-going ? null,
   commit ? null,
   skip-prompt ? null,
+  order ? null,
 }:
 
 let
@@ -217,6 +218,18 @@ let
     to skip prompt:
 
         --argstr skip-prompt true
+
+    By default, the updater will update the packages in arbitrary order. Alternately, you can force a specific order based on the packages’ dependency relations:
+
+        - Reverse topological order (e.g. {"gnome-text-editor", "gimp"}, {"gtk3", "gtk4"}, {"glib"}) is useful when you want checkout each commit one by one to build each package individually but some of the packages to be updated would cause a mass rebuild for the others. Of course, this requires that none of the updated dependents require a new version of the dependency.
+
+            --argstr order reverse-topological
+
+        - Topological order (e.g. {"glib"}, {"gtk3", "gtk4"}, {"gnome-text-editor", "gimp"}) is useful when the updated dependents require a new version of updated dependency.
+
+            --argstr order topological
+
+    Note that sorting requires instantiating each package and then querying Nix store for requisites so it will be pretty slow with large number of packages.
   '';
 
   # Transform a matched package into an object for update.py.
@@ -241,7 +254,8 @@ let
     lib.optional (max-workers != null) "--max-workers=${max-workers}"
     ++ lib.optional (keep-going == "true") "--keep-going"
     ++ lib.optional (commit == "true") "--commit"
-    ++ lib.optional (skip-prompt == "true") "--skip-prompt";
+    ++ lib.optional (skip-prompt == "true") "--skip-prompt"
+    ++ lib.optional (order != null) "--order=${order}";
 
   args = [ packagesJson ] ++ optionalArgs;
 

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -242,6 +242,8 @@ async def updater(
 
         await run_update_script(nixpkgs_root, merge_lock, temp_dir, package, keep_going)
 
+        packages_to_update.task_done()
+
 
 async def start_updates(
     max_workers: int,

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -10,15 +10,19 @@ import subprocess
 import sys
 import tempfile
 
+
 class CalledProcessError(Exception):
     process: asyncio.subprocess.Process
     stderr: Optional[bytes]
 
+
 class UpdateFailedException(Exception):
     pass
 
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
+
 
 async def check_subprocess_output(*args, **kwargs):
     """
@@ -38,26 +42,43 @@ async def check_subprocess_output(*args, **kwargs):
 
     return stdout
 
-async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_dir: Optional[Tuple[str, str]], package: Dict, keep_going: bool):
+
+async def run_update_script(
+    nixpkgs_root: str,
+    merge_lock: asyncio.Lock,
+    temp_dir: Optional[Tuple[str, str]],
+    package: Dict,
+    keep_going: bool,
+):
     worktree: Optional[str] = None
 
-    update_script_command = package['updateScript']
+    update_script_command = package["updateScript"]
 
     if temp_dir is not None:
         worktree, _branch = temp_dir
 
         # Ensure the worktree is clean before update.
-        await check_subprocess_output('git', 'reset', '--hard', '--quiet', 'HEAD', cwd=worktree)
+        await check_subprocess_output(
+            "git",
+            "reset",
+            "--hard",
+            "--quiet",
+            "HEAD",
+            cwd=worktree,
+        )
 
         # Update scripts can use $(dirname $0) to get their location but we want to run
         # their clones in the git worktree, not in the main nixpkgs repo.
-        update_script_command = map(lambda arg: re.sub(r'^{0}'.format(re.escape(nixpkgs_root)), worktree, arg), update_script_command)
+        update_script_command = map(
+            lambda arg: re.sub(r"^{0}".format(re.escape(nixpkgs_root)), worktree, arg),
+            update_script_command,
+        )
 
     eprint(f" - {package['name']}: UPDATING ...")
 
     try:
         update_info = await check_subprocess_output(
-            'env',
+            "env",
             f"UPDATE_NIX_NAME={package['name']}",
             f"UPDATE_NIX_PNAME={package['pname']}",
             f"UPDATE_NIX_OLD_VERSION={package['oldVersion']}",
@@ -69,50 +90,72 @@ async def run_update_script(nixpkgs_root: str, merge_lock: asyncio.Lock, temp_di
         )
         await merge_changes(merge_lock, package, update_info, temp_dir)
     except KeyboardInterrupt as e:
-        eprint('Cancelling…')
+        eprint("Cancelling…")
         raise asyncio.exceptions.CancelledError()
     except CalledProcessError as e:
         eprint(f" - {package['name']}: ERROR")
         eprint()
         eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
         eprint()
-        eprint(e.stderr.decode('utf-8'))
-        with open(f"{package['pname']}.log", 'wb') as logfile:
+        eprint(e.stderr.decode("utf-8"))
+        with open(f"{package['pname']}.log", "wb") as logfile:
             logfile.write(e.stderr)
         eprint()
         eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
 
         if not keep_going:
-            raise UpdateFailedException(f"The update script for {package['name']} failed with exit code {e.process.returncode}")
+            raise UpdateFailedException(
+                f"The update script for {package['name']} failed with exit code {e.process.returncode}"
+            )
+
 
 @contextlib.contextmanager
 def make_worktree() -> Generator[Tuple[str, str], None, None]:
     with tempfile.TemporaryDirectory() as wt:
-        branch_name = f'update-{os.path.basename(wt)}'
-        target_directory = f'{wt}/nixpkgs'
+        branch_name = f"update-{os.path.basename(wt)}"
+        target_directory = f"{wt}/nixpkgs"
 
-        subprocess.run(['git', 'worktree', 'add', '-b', branch_name, target_directory])
+        subprocess.run(["git", "worktree", "add", "-b", branch_name, target_directory])
         try:
             yield (target_directory, branch_name)
         finally:
-            subprocess.run(['git', 'worktree', 'remove', '--force', target_directory])
-            subprocess.run(['git', 'branch', '-D', branch_name])
+            subprocess.run(["git", "worktree", "remove", "--force", target_directory])
+            subprocess.run(["git", "branch", "-D", branch_name])
 
-async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, branch: str, changes: List[Dict]) -> None:
+
+async def commit_changes(
+    name: str,
+    merge_lock: asyncio.Lock,
+    worktree: str,
+    branch: str,
+    changes: List[Dict],
+) -> None:
     for change in changes:
         # Git can only handle a single index operation at a time
         async with merge_lock:
-            await check_subprocess_output('git', 'add', *change['files'], cwd=worktree)
-            commit_message = '{attrPath}: {oldVersion} -> {newVersion}'.format(**change)
-            if 'commitMessage' in change:
-                commit_message = change['commitMessage']
-            elif 'commitBody' in change:
-                commit_message = commit_message + '\n\n' + change['commitBody']
-            await check_subprocess_output('git', 'commit', '--quiet', '-m', commit_message, cwd=worktree)
-            await check_subprocess_output('git', 'cherry-pick', branch)
+            await check_subprocess_output("git", "add", *change["files"], cwd=worktree)
+            commit_message = "{attrPath}: {oldVersion} -> {newVersion}".format(**change)
+            if "commitMessage" in change:
+                commit_message = change["commitMessage"]
+            elif "commitBody" in change:
+                commit_message = commit_message + "\n\n" + change["commitBody"]
+            await check_subprocess_output(
+                "git",
+                "commit",
+                "--quiet",
+                "-m",
+                commit_message,
+                cwd=worktree,
+            )
+            await check_subprocess_output("git", "cherry-pick", branch)
 
-async def check_changes(package: Dict, worktree: str, update_info: str):
-    if 'commit' in package['supportedFeatures']:
+
+async def check_changes(
+    package: Dict,
+    worktree: str,
+    update_info: str,
+):
+    if "commit" in package["supportedFeatures"]:
         changes = json.loads(update_info)
     else:
         changes = [{}]
@@ -120,54 +163,93 @@ async def check_changes(package: Dict, worktree: str, update_info: str):
     # Try to fill in missing attributes when there is just a single change.
     if len(changes) == 1:
         # Dynamic data from updater take precedence over static data from passthru.updateScript.
-        if 'attrPath' not in changes[0]:
+        if "attrPath" not in changes[0]:
             # update.nix is always passing attrPath
-            changes[0]['attrPath'] = package['attrPath']
+            changes[0]["attrPath"] = package["attrPath"]
 
-        if 'oldVersion' not in changes[0]:
+        if "oldVersion" not in changes[0]:
             # update.nix is always passing oldVersion
-            changes[0]['oldVersion'] = package['oldVersion']
+            changes[0]["oldVersion"] = package["oldVersion"]
 
-        if 'newVersion' not in changes[0]:
-            attr_path = changes[0]['attrPath']
-            obtain_new_version_output = await check_subprocess_output('nix-instantiate', '--expr', f'with import ./. {{}}; lib.getVersion {attr_path}', '--eval', '--strict', '--json', stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=worktree)
-            changes[0]['newVersion'] = json.loads(obtain_new_version_output.decode('utf-8'))
+        if "newVersion" not in changes[0]:
+            attr_path = changes[0]["attrPath"]
+            obtain_new_version_output = await check_subprocess_output(
+                "nix-instantiate",
+                "--expr",
+                f"with import ./. {{}}; lib.getVersion {attr_path}",
+                "--eval",
+                "--strict",
+                "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=worktree,
+            )
+            changes[0]["newVersion"] = json.loads(
+                obtain_new_version_output.decode("utf-8")
+            )
 
-        if 'files' not in changes[0]:
-            changed_files_output = await check_subprocess_output('git', 'diff', '--name-only', 'HEAD', stdout=asyncio.subprocess.PIPE, cwd=worktree)
+        if "files" not in changes[0]:
+            changed_files_output = await check_subprocess_output(
+                "git",
+                "diff",
+                "--name-only",
+                "HEAD",
+                stdout=asyncio.subprocess.PIPE,
+                cwd=worktree,
+            )
             changed_files = changed_files_output.splitlines()
-            changes[0]['files'] = changed_files
+            changes[0]["files"] = changed_files
 
             if len(changed_files) == 0:
                 return []
 
     return changes
 
-async def merge_changes(merge_lock: asyncio.Lock, package: Dict, update_info: str, temp_dir: Optional[Tuple[str, str]]) -> None:
+
+async def merge_changes(
+    merge_lock: asyncio.Lock,
+    package: Dict,
+    update_info: str,
+    temp_dir: Optional[Tuple[str, str]],
+) -> None:
     if temp_dir is not None:
         worktree, branch = temp_dir
         changes = await check_changes(package, worktree, update_info)
 
         if len(changes) > 0:
-            await commit_changes(package['name'], merge_lock, worktree, branch, changes)
+            await commit_changes(package["name"], merge_lock, worktree, branch, changes)
         else:
             eprint(f" - {package['name']}: DONE, no changes.")
     else:
         eprint(f" - {package['name']}: DONE.")
 
-async def updater(nixpkgs_root: str, temp_dir: Optional[Tuple[str, str]], merge_lock: asyncio.Lock, packages_to_update: asyncio.Queue[Optional[Dict]], keep_going: bool, commit: bool):
+
+async def updater(
+    nixpkgs_root: str,
+    temp_dir: Optional[Tuple[str, str]],
+    merge_lock: asyncio.Lock,
+    packages_to_update: asyncio.Queue[Optional[Dict]],
+    keep_going: bool,
+    commit: bool,
+):
     while True:
         package = await packages_to_update.get()
         if package is None:
             # A sentinel received, we are done.
             return
 
-        if not ('commit' in package['supportedFeatures'] or 'attrPath' in package):
+        if not ("commit" in package["supportedFeatures"] or "attrPath" in package):
             temp_dir = None
 
         await run_update_script(nixpkgs_root, merge_lock, temp_dir, package, keep_going)
 
-async def start_updates(max_workers: int, keep_going: bool, commit: bool, packages: List[Dict]):
+
+async def start_updates(
+    max_workers: int,
+    keep_going: bool,
+    commit: bool,
+    packages: List[Dict],
+):
     merge_lock = asyncio.Lock()
     packages_to_update: asyncio.Queue[Optional[Dict]] = asyncio.Queue()
 
@@ -177,8 +259,13 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
         # Do not create more workers than there are packages.
         num_workers = min(max_workers, len(packages))
 
-        nixpkgs_root_output = await check_subprocess_output('git', 'rev-parse', '--show-toplevel', stdout=asyncio.subprocess.PIPE)
-        nixpkgs_root = nixpkgs_root_output.decode('utf-8').strip()
+        nixpkgs_root_output = await check_subprocess_output(
+            "git",
+            "rev-parse",
+            "--show-toplevel",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        nixpkgs_root = nixpkgs_root_output.decode("utf-8").strip()
 
         # Set up temporary directories when using auto-commit.
         for i in range(num_workers):
@@ -196,7 +283,19 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
 
         # Prepare updater workers for each temp_dir directory.
         # At most `num_workers` instances of `run_update_script` will be running at one time.
-        updaters = asyncio.gather(*[updater(nixpkgs_root, temp_dir, merge_lock, packages_to_update, keep_going, commit) for temp_dir in temp_dirs])
+        updaters = asyncio.gather(
+            *[
+                updater(
+                    nixpkgs_root,
+                    temp_dir,
+                    merge_lock,
+                    packages_to_update,
+                    keep_going,
+                    commit,
+                )
+                for temp_dir in temp_dirs
+            ]
+        )
 
         try:
             # Start updater workers.
@@ -210,43 +309,86 @@ async def start_updates(max_workers: int, keep_going: bool, commit: bool, packag
             eprint(e)
             sys.exit(1)
 
-def main(max_workers: int, keep_going: bool, commit: bool, packages_path: str, skip_prompt: bool) -> None:
+
+def main(
+    max_workers: int,
+    keep_going: bool,
+    commit: bool,
+    packages_path: str,
+    skip_prompt: bool,
+) -> None:
     with open(packages_path) as f:
         packages = json.load(f)
 
     eprint()
-    eprint('Going to be running update for following packages:')
+    eprint("Going to be running update for following packages:")
     for package in packages:
         eprint(f" - {package['name']}")
     eprint()
 
-    confirm = '' if skip_prompt else input('Press Enter key to continue...')
+    confirm = "" if skip_prompt else input("Press Enter key to continue...")
 
-    if confirm == '':
+    if confirm == "":
         eprint()
-        eprint('Running update for:')
+        eprint("Running update for:")
 
         asyncio.run(start_updates(max_workers, keep_going, commit, packages))
 
         eprint()
-        eprint('Packages updated!')
+        eprint("Packages updated!")
         sys.exit()
     else:
-        eprint('Aborting!')
+        eprint("Aborting!")
         sys.exit(130)
 
-parser = argparse.ArgumentParser(description='Update packages')
-parser.add_argument('--max-workers', '-j', dest='max_workers', type=int, help='Number of updates to run concurrently', nargs='?', default=4)
-parser.add_argument('--keep-going', '-k', dest='keep_going', action='store_true', help='Do not stop after first failure')
-parser.add_argument('--commit', '-c', dest='commit', action='store_true', help='Commit the changes')
-parser.add_argument('packages', help='JSON file containing the list of package names and their update scripts')
-parser.add_argument('--skip-prompt', '-s', dest='skip_prompt', action='store_true', help='Do not stop for prompts')
 
-if __name__ == '__main__':
+parser = argparse.ArgumentParser(description="Update packages")
+parser.add_argument(
+    "--max-workers",
+    "-j",
+    dest="max_workers",
+    type=int,
+    help="Number of updates to run concurrently",
+    nargs="?",
+    default=4,
+)
+parser.add_argument(
+    "--keep-going",
+    "-k",
+    dest="keep_going",
+    action="store_true",
+    help="Do not stop after first failure",
+)
+parser.add_argument(
+    "--commit",
+    "-c",
+    dest="commit",
+    action="store_true",
+    help="Commit the changes",
+)
+parser.add_argument(
+    "packages",
+    help="JSON file containing the list of package names and their update scripts",
+)
+parser.add_argument(
+    "--skip-prompt",
+    "-s",
+    dest="skip_prompt",
+    action="store_true",
+    help="Do not stop for prompts",
+)
+
+if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        main(args.max_workers, args.keep_going, args.commit, args.packages, args.skip_prompt)
+        main(
+            args.max_workers,
+            args.keep_going,
+            args.commit,
+            args.packages,
+            args.skip_prompt,
+        )
     except KeyboardInterrupt as e:
         # Let’s cancel outside of the main loop too.
         sys.exit(130)

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Any, Generator
 import argparse
 import asyncio
 import contextlib
@@ -19,11 +19,11 @@ class UpdateFailedException(Exception):
     pass
 
 
-def eprint(*args, **kwargs):
+def eprint(*args: Any, **kwargs: Any) -> None:
     print(*args, file=sys.stderr, **kwargs)
 
 
-async def check_subprocess_output(*args, **kwargs):
+async def check_subprocess_output(*args: str, **kwargs: Any) -> bytes:
     """
     Emulate check and capture_output arguments of subprocess.run function.
     """
@@ -48,7 +48,7 @@ async def run_update_script(
     temp_dir: tuple[str, str] | None,
     package: dict,
     keep_going: bool,
-):
+) -> None:
     worktree: str | None = None
 
     update_script_command = package["updateScript"]
@@ -153,7 +153,7 @@ async def check_changes(
     package: dict,
     worktree: str,
     update_info: str,
-):
+) -> list[dict]:
     if "commit" in package["supportedFeatures"]:
         changes = json.loads(update_info)
     else:
@@ -230,7 +230,7 @@ async def updater(
     packages_to_update: asyncio.Queue[dict | None],
     keep_going: bool,
     commit: bool,
-):
+) -> None:
     while True:
         package = await packages_to_update.get()
         if package is None:
@@ -248,7 +248,7 @@ async def start_updates(
     keep_going: bool,
     commit: bool,
     packages: list[dict],
-):
+) -> None:
     merge_lock = asyncio.Lock()
     packages_to_update: asyncio.Queue[dict | None] = asyncio.Queue()
 

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -152,7 +152,7 @@ async def commit_changes(
 async def check_changes(
     package: dict,
     worktree: str,
-    update_info: str,
+    update_info: bytes,
 ) -> list[dict]:
     if "commit" in package["supportedFeatures"]:
         changes = json.loads(update_info)
@@ -208,7 +208,7 @@ async def check_changes(
 async def merge_changes(
     merge_lock: asyncio.Lock,
     package: dict,
-    update_info: str,
+    update_info: bytes,
     temp_dir: tuple[str, str] | None,
 ) -> None:
     if temp_dir is not None:

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -93,14 +93,19 @@ async def run_update_script(
         raise asyncio.exceptions.CancelledError()
     except CalledProcessError as e:
         eprint(f" - {package['name']}: ERROR")
-        eprint()
-        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
-        eprint()
-        eprint(e.stderr.decode("utf-8"))
-        with open(f"{package['pname']}.log", "wb") as logfile:
-            logfile.write(e.stderr)
-        eprint()
-        eprint(f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------")
+        if e.stderr is not None:
+            eprint()
+            eprint(
+                f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------"
+            )
+            eprint()
+            eprint(e.stderr.decode("utf-8"))
+            with open(f"{package['pname']}.log", "wb") as logfile:
+                logfile.write(e.stderr)
+            eprint()
+            eprint(
+                f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------"
+            )
 
         if not keep_going:
             raise UpdateFailedException(

--- a/pkgs/common-updater/combinators.nix
+++ b/pkgs/common-updater/combinators.nix
@@ -169,18 +169,21 @@ rec {
 
     assert lib.assertMsg (lib.all validateFeatures scripts)
       "Combining update scripts with features enabled (other than “silent” scripts and an optional single script with “commit”) is currently unsupported.";
+
     assert lib.assertMsg (
       builtins.length (
         lib.unique (
-          builtins.map (
-            {
-              attrPath ? null,
-              ...
-            }:
-            attrPath
-          ) scripts
+          builtins.filter (attrPath: attrPath != null) (
+            builtins.map (
+              {
+                attrPath ? null,
+                ...
+              }:
+              attrPath
+            ) scripts
+          )
         )
-      ) == 1
+      ) <= 1
     ) "Combining update scripts with different attr paths is currently unsupported.";
 
     {

--- a/pkgs/desktops/gnome/update.nix
+++ b/pkgs/desktops/gnome/update.nix
@@ -108,4 +108,5 @@ in
   supportedFeatures = [
     "commit"
   ];
+  inherit attrPath;
 }


### PR DESCRIPTION
Previously, when updating multiple packages, we just updated them in arbitrary order. However, when some of those packages depended on each other, it could happen that some of the intermediary commits would not build because of version constraints on dependencies.

If we want each commit in the history to build when feasible, we need to consider four different scenarios:

1. Updated dependant is compatible with both the old and the new version of the dependency. Order of commits does not matter. But updating dependents first (i.e. reverse topological order) is useful since it allows building each package on the commit that updates it with minimal rebuilds.
2. Updated dependant raises the minimal dependency version. Dependency needs to be updated first (i.e. topological order).
3. Old dependant sets the maximal dependency version. Dependant needs to be updated first (i.e. reverse topological order).
4. Updated dependant depends on exact version of dependency and they are expected to be updated in lockstep. The earlier commit will be broken no matter the order.

This change allows selecting the order of updates to facilitate the first three scenarios. Since most package sets only have loose version constraints, the reverse topological order will generally be the most convenient. In major package set updates like bumping GNOME release, there will be exceptions (e.g. libadwaita typically requires GTK 4 from the same release) but those were probably in broken order before as well.

The downside of this feature is that it is quite slow – it requires instantiating each package and then querying Nix store for requisites.
It may also fail to detect dependency if there are multiple variants of the package and dependant uses a different one than the canonical one.

Testing with:

```shell
env GNOME_UPDATE_STABILITY=unstable NIX_PATH=nixpkgs=$HOME/Projects/nixpkgs nix-shell maintainers/scripts/update.nix --arg predicate '(path: pkg: path == ["gnome-shell"] || path == ["mutter"] || path == ["glib"] || path == ["gtk3"] || path == ["pango"] || path == ["gnome-text-editor"])' --argstr order reverse-topological --argstr commit true --argstr max-workers 4
```

Also include some cleanups of the Python script and some fixes of update scripts that were required for updating GNOME to work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
