### PR TITLE
pytestCheckHook: fix disabledTestPaths glob matching assertion

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -146,12 +146,59 @@ in
       };
 
   pytestCheckHook = callPackage (
-    { makePythonHook, pytest }:
+    {
+      makePythonHook,
+      pytest,
+      # For package tests
+      testers,
+      objprint,
+    }:
     makePythonHook {
       name = "pytest-check-hook";
       propagatedBuildInputs = [ pytest ];
       substitutions = {
         inherit pythonCheckInterpreter;
+      };
+      passthru = {
+        tests = {
+          basic = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-basic-${previousPythonAttrs.pname}";
+          });
+          disabledTests = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-disabledTests-${previousPythonAttrs.pname}";
+            disabledTests = [
+              "test_print"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+          });
+          disabledTestPaths = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-disabledTestPaths-${previousPythonAttrs.pname}";
+            disabledTestPaths = [
+              "tests/test_basic.py"
+            ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+          });
+          disabledTestPaths-nonexistent = testers.testBuildFailure (
+            objprint.overridePythonAttrs (previousPythonAttrs: {
+              pname = "test-pytestCheckHook-disabledTestPaths-nonexistent-${previousPythonAttrs.pname}";
+              disabledTestPaths = [
+                "tests/test_foo.py"
+              ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+            })
+          );
+          disabledTestPaths-glob = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-disabledTestPaths-glob-${previousPythonAttrs.pname}";
+            disabledTestPaths = [
+              "tests/test_obj*.py"
+            ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+          });
+          disabledTestPaths-glob-nonexistent = testers.testBuildFailure (
+            objprint.overridePythonAttrs (previousPythonAttrs: {
+              pname = "test-pytestCheckHook-disabledTestPaths-glob-nonexistent-${previousPythonAttrs.pname}";
+              disabledTestPaths = [
+                "tests/test_foo*.py"
+              ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+            })
+          );
+        };
       };
     } ./pytest-check-hook.sh
   ) { };

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -18,7 +18,7 @@ function pytestCheckPhase() {
     concatTo _pathsArray disabledTestPaths
     for path in "${_pathsArray[@]}"; do
         # Check if every path glob matches at least one path
-        @pythonCheckInterpreter@ <(cat <<EOF
+        @pythonCheckInterpreter@ - "$path" <<EOF
 import glob
 import sys
 path_glob=sys.argv[1]
@@ -27,7 +27,6 @@ if not len(path_glob):
 if next(glob.iglob(path_glob), None) is None:
     sys.exit('Disabled tests path glob "{}" does not match any paths. Aborting'.format(path_glob))
 EOF
-        ) "$path"
         flagsArray+=("--ignore-glob=$path")
     done
 


### PR DESCRIPTION
Errors in Bash's process substitution doesn't get propagated outside.

Replace the process substitution with Python's `-` as /dev/stdin and Bash's heredoc stdin redirection.

I didn't realize that Bash's process substitution (`<()`) doesn't propagate the error even if `set -o pipefail` when authoring #347194. This PR fixes the run-time assertion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
