### PR TITLE
tailscale: use buildGoModule and enable tests

### DIFF
--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   stdenv,
-  buildGo123Module,
+  buildGoModule,
   tailscale,
 }:
 
-buildGo123Module {
+buildGoModule {
   pname = "tailscale-nginx-auth";
   inherit (tailscale) version src vendorHash;
 
@@ -27,11 +27,11 @@ buildGo123Module {
     install -D -m0444 -t $out/lib/systemd/system ./cmd/nginx-auth/tailscale.nginx-auth.socket
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://tailscale.com";
     description = "Tool that allows users to use Tailscale Whois authentication with NGINX as a reverse proxy";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     mainProgram = "tailscale.nginx-auth";
-    maintainers = with maintainers; [ phaer ];
+    maintainers = with lib.maintainers; [ phaer ];
   };
 }

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -65,6 +65,12 @@ buildGoModule {
     "cmd/tsidp"
   ];
 
+  excludedPackages = [
+    # exlude integration tests which fail to work
+    # and require additional tooling
+    "tstest/integration"
+  ];
+
   ldflags = [
     "-w"
     "-s"
@@ -76,7 +82,59 @@ buildGoModule {
     "ts_include_cli"
   ];
 
-  doCheck = false;
+  # remove vendored tooling to ensure it's not used
+  # also avoids some unnecessary tests
+  preBuild = ''
+    rm -rf ./tool
+  '';
+
+  preCheck = ''
+    # feed in all tests for testing
+    # subPackages above limits what is built to just what we
+    # want but also limits the tests
+    unset subPackages
+
+    # several tests hang
+    rm tsnet/tsnet_test.go
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # dislikes vendoring
+        "TestPackageDocs" # .
+        # tries to start tailscaled
+        "TestContainerBoot" # cmd/containerboot
+
+        # just part of a tool which generates yaml for k8s CRDs
+        # requires helm
+        "Test_generate" # cmd/k8s-operator/generate
+        # self reported potentially flakey test
+        "TestConnMemoryOverhead" # control/controlbase
+
+        # interacts with `/proc/net/route` and need a default route
+        "TestDefaultRouteInterface" # net/netmon
+        "TestRouteLinuxNetlink" # net/netmon
+        "TestGetRouteTable" # net/routetable
+
+        # remote udp call to 8.8.8.8
+        "TestDefaultInterfacePortable" # net/netutil
+
+        # launches an ssh server which works when provided openssh
+        # also requires executing commands but nixbld user has /noshell
+        "TestSSH" # ssh/tailssh
+        # wants users alice & ubuntu
+        "TestMultipleRecorders" # ssh/tailssh
+        "TestSSHAuthFlow" # ssh/tailssh
+        "TestSSHRecordingCancelsSessionsOnUploadFailure" # ssh/tailssh
+        "TestSSHRecordingNonInteractive" # ssh/tailssh
+
+        # test for a dev util which helps to fork golang.org/x/crypto/acme
+        # not necessary and fails to match
+        "TestSyncedToUpstream" # tempfork/acme
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall =
     ''

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -1,25 +1,30 @@
 {
   lib,
   stdenv,
-  buildGo123Module,
+
+  buildGoModule,
   fetchFromGitHub,
   fetchpatch,
+
   makeWrapper,
+  installShellFiles,
+  # runtime tooling - linux
   getent,
   iproute2,
   iptables,
-  lsof,
   shadow,
   procps,
+  # runtime tooling - darwin
+  lsof,
+
   nixosTests,
-  installShellFiles,
   tailscale-nginx-auth,
 }:
 
 let
   version = "1.80.2";
 in
-buildGo123Module {
+buildGoModule {
   pname = "tailscale";
   inherit version;
 
@@ -93,9 +98,9 @@ buildGo123Module {
       wrapProgram $out/bin/tailscaled \
         --prefix PATH : ${
           lib.makeBinPath [
+            getent
             iproute2
             iptables
-            getent
             shadow
           ]
         } \
@@ -116,13 +121,13 @@ buildGo123Module {
     inherit tailscale-nginx-auth;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://tailscale.com";
     description = "Node agent for Tailscale, a mesh VPN built on WireGuard";
     changelog = "https://github.com/tailscale/tailscale/releases/tag/v${version}";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     mainProgram = "tailscale";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       mbaillie
       jk
       mfrw


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **tailscale: move back to buildGoModule**
- **tailscale-nginx-auth: move back to buildGoModule**
- **tailscale: re-enable tests**

Tests add about 3m to the (existing very quick) build on my machine

Need to see how the tests work on Darwin


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true` (non nixos)
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
