### PR TITLE
SDL_compat: use SDL3 through sdl2-compat

### DIFF
--- a/pkgs/by-name/sd/SDL_compat/package.nix
+++ b/pkgs/by-name/sd/SDL_compat/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       autoSignDarwinBinariesHook
     ];
 
-  propagatedBuildInputs =
+  buildInputs =
     [
       libX11
       sdl2-compat
@@ -71,14 +71,12 @@ stdenv.mkDerivation (finalAttrs: {
           if stdenv.hostPlatform.isDarwin then
             ''
               install_name_tool ${
-                lib.strings.concatMapStrings (
-                  x: " -add_rpath ${lib.makeLibraryPath [ x ]} "
-                ) finalAttrs.propagatedBuildInputs
+                lib.strings.concatMapStrings (x: " -add_rpath ${lib.makeLibraryPath [ x ]} ") finalAttrs.buildInputs
               } "$lib"
             ''
           else
             ''
-              patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath finalAttrs.propagatedBuildInputs}" "$lib"
+              patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath finalAttrs.buildInputs}" "$lib"
             ''
         }
       fi

--- a/pkgs/by-name/sd/SDL_compat/package.nix
+++ b/pkgs/by-name/sd/SDL_compat/package.nix
@@ -1,11 +1,12 @@
 {
   lib,
-  SDL2,
+  sdl2-compat,
   cmake,
   darwin,
   fetchFromGitHub,
   libGLU,
   libiconv,
+  libX11,
   mesa,
   pkg-config,
   stdenv,
@@ -39,7 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   propagatedBuildInputs =
-    [ SDL2 ]
+    [
+      libX11
+      sdl2-compat
+    ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       libiconv
       Cocoa


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I have manually tested all the packages depending on `SDL_compat`:

- `rott` (shareware version): menu doesn't render with the currently packaged `sdl2-compat` version (2.30.52), but upgrading to 2.32.52 fixes the issue
- `dosbox`: runs fine
- `openxcom` (with "X-COM: UFO Defense" Steam files): runs fine
- `katawa-shoujo`: boots to black screen with the currently packaged `sdl2-compat` version (2.30.52), but upgrading to 2.32.52 fixes the issue
- `zandronum` (with Doom 1 shareware): runs fine
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
