### PR TITLE
{cosmic-randr,cosmic-bg,cosmic-launcher}: use mold linker

### DIFF
--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -52,7 +52,10 @@ rustPlatform.buildRustPackage.override
       homepage = "https://github.com/pop-os/cosmic-bg";
       description = "Applies Background for the COSMIC Desktop Environment";
       license = lib.licenses.mpl20;
-      maintainers = with lib.maintainers; [ nyabinary ];
+      maintainers = with lib.maintainers; [
+        nyabinary
+        HeitorAugustoLN
+      ];
       platforms = lib.platforms.linux;
       mainProgram = "cosmic-bg";
     };

--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -7,6 +7,7 @@
   libcosmicAppHook,
   just,
   nasm,
+  nix-update-script,
 
   withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
@@ -47,6 +48,15 @@ rustPlatform.buildRustPackage.override
 
     env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
       lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--version"
+        "unstable"
+        "--version-regex"
+        "epoch-(.*)"
+      ];
+    };
 
     meta = {
       homepage = "https://github.com/pop-os/cosmic-bg";

--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -14,14 +14,14 @@
 
 rustPlatform.buildRustPackage.override
   { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  rec {
+  (finalAttrs: {
     pname = "cosmic-bg";
     version = "1.0.0-alpha.6";
 
     src = fetchFromGitHub {
       owner = "pop-os";
       repo = "cosmic-bg";
-      tag = "epoch-${version}";
+      tag = "epoch-${finalAttrs.version}";
       hash = "sha256-4b4laUXTnAbdngLVh8/dD144m9QrGReSEjRZoNR6Iks=";
     };
 
@@ -69,4 +69,4 @@ rustPlatform.buildRustPackage.override
       platforms = lib.platforms.linux;
       mainProgram = "cosmic-bg";
     };
-  }
+  })

--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -4,11 +4,9 @@
   stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
+  libcosmicAppHook,
   just,
-  pkg-config,
-  makeBinaryWrapper,
-  libxkbcommon,
-  wayland,
+  nasm,
 
   withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
@@ -21,29 +19,22 @@ rustPlatform.buildRustPackage.override
 
     src = fetchFromGitHub {
       owner = "pop-os";
-      repo = pname;
-      rev = "epoch-${version}";
+      repo = "cosmic-bg";
+      tag = "epoch-${version}";
       hash = "sha256-4b4laUXTnAbdngLVh8/dD144m9QrGReSEjRZoNR6Iks=";
     };
 
     useFetchCargoVendor = true;
     cargoHash = "sha256-GLXooTjcGq4MsBNnlpHBBUJGNs5UjKMQJGJuj9UO2wk=";
 
-    postPatch = ''
-      substituteInPlace justfile --replace-fail '#!/usr/bin/env' "#!$(command -v env)"
-    '';
-
     nativeBuildInputs = [
       just
-      pkg-config
-      makeBinaryWrapper
-    ];
-    buildInputs = [
-      libxkbcommon
-      wayland
+      libcosmicAppHook
+      nasm
     ];
 
     dontUseJustBuild = true;
+    dontUseJustCheck = true;
 
     justFlags = [
       "--set"
@@ -57,17 +48,12 @@ rustPlatform.buildRustPackage.override
     env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
       lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
 
-    postInstall = ''
-      wrapProgram $out/bin/cosmic-bg \
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ wayland ]}"
-    '';
-
-    meta = with lib; {
+    meta = {
       homepage = "https://github.com/pop-os/cosmic-bg";
       description = "Applies Background for the COSMIC Desktop Environment";
-      license = licenses.mpl20;
-      maintainers = with maintainers; [ nyabinary ];
-      platforms = platforms.linux;
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [ nyabinary ];
+      platforms = lib.platforms.linux;
       mainProgram = "cosmic-bg";
     };
   }

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -13,14 +13,14 @@
 
 rustPlatform.buildRustPackage.override
   { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  rec {
+  (finalAttrs: {
     pname = "cosmic-launcher";
     version = "1.0.0-alpha.6";
 
     src = fetchFromGitHub {
       owner = "pop-os";
       repo = "cosmic-launcher";
-      tag = "epoch-${version}";
+      tag = "epoch-${finalAttrs.version}";
       hash = "sha256-BtYnL+qkM/aw+Air5yOKH098V+TQByM5mh1DX7v+v+s=";
     };
 
@@ -67,4 +67,4 @@ rustPlatform.buildRustPackage.override
       ];
       platforms = lib.platforms.linux;
     };
-  }
+  })

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -1,68 +1,70 @@
 {
   lib,
   stdenv,
+  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   just,
   libcosmicAppHook,
   nix-update-script,
+
+  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "cosmic-launcher";
-  version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage.override
+  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
+  rec {
+    pname = "cosmic-launcher";
+    version = "1.0.0-alpha.6";
 
-  src = fetchFromGitHub {
-    owner = "pop-os";
-    repo = "cosmic-launcher";
-    tag = "epoch-${version}";
-    hash = "sha256-BtYnL+qkM/aw+Air5yOKH098V+TQByM5mh1DX7v+v+s=";
-  };
+    src = fetchFromGitHub {
+      owner = "pop-os";
+      repo = "cosmic-launcher";
+      tag = "epoch-${version}";
+      hash = "sha256-BtYnL+qkM/aw+Air5yOKH098V+TQByM5mh1DX7v+v+s=";
+    };
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-g7Qr3C8jQg65KehXAhftdXCpEukag0w12ClvZFkxfqs=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-g7Qr3C8jQg65KehXAhftdXCpEukag0w12ClvZFkxfqs=";
 
-  nativeBuildInputs = [
-    just
-    libcosmicAppHook
-  ];
-
-  dontUseJustBuild = true;
-  dontUseJustCheck = true;
-
-  justFlags = [
-    "--set"
-    "prefix"
-    (placeholder "out")
-    "--set"
-    "bin-src"
-    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-launcher"
-  ];
-
-  postPatch = ''
-    substituteInPlace justfile --replace-fail '#!/usr/bin/env' "#!$(command -v env)"
-  '';
-
-  env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" = "--cfg tokio_unstable";
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version"
-      "unstable"
-      "--version-regex"
-      "epoch-(.*)"
+    nativeBuildInputs = [
+      just
+      libcosmicAppHook
     ];
-  };
 
-  meta = {
-    homepage = "https://github.com/pop-os/cosmic-launcher";
-    description = "Launcher for the COSMIC Desktop Environment";
-    mainProgram = "cosmic-launcher";
-    license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [
-      nyabinary
-      HeitorAugustoLN
+    dontUseJustBuild = true;
+    dontUseJustCheck = true;
+
+    justFlags = [
+      "--set"
+      "prefix"
+      (placeholder "out")
+      "--set"
+      "bin-src"
+      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-launcher"
     ];
-    platforms = lib.platforms.linux;
-  };
-}
+
+    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
+      "--cfg tokio_unstable${lib.optionalString withMoldLinker " -C link-arg=-fuse-ld=mold"}";
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--version"
+        "unstable"
+        "--version-regex"
+        "epoch-(.*)"
+      ];
+    };
+
+    meta = {
+      homepage = "https://github.com/pop-os/cosmic-launcher";
+      description = "Launcher for the COSMIC Desktop Environment";
+      mainProgram = "cosmic-launcher";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [
+        nyabinary
+        HeitorAugustoLN
+      ];
+      platforms = lib.platforms.linux;
+    };
+  }

--- a/pkgs/by-name/co/cosmic-randr/package.nix
+++ b/pkgs/by-name/co/cosmic-randr/package.nix
@@ -1,65 +1,73 @@
 {
   lib,
   stdenv,
+  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   just,
   pkg-config,
   wayland,
   nix-update-script,
+
+  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "cosmic-randr";
-  version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage.override
+  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
+  rec {
+    pname = "cosmic-randr";
+    version = "1.0.0-alpha.6";
 
-  src = fetchFromGitHub {
-    owner = "pop-os";
-    repo = "cosmic-randr";
-    tag = "epoch-${version}";
-    hash = "sha256-Sqxe+vKonsK9MmJGtbrZHE7frfrjkHXysm0WQt7WSU4=";
-  };
+    src = fetchFromGitHub {
+      owner = "pop-os";
+      repo = "cosmic-randr";
+      tag = "epoch-${version}";
+      hash = "sha256-Sqxe+vKonsK9MmJGtbrZHE7frfrjkHXysm0WQt7WSU4=";
+    };
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-UQ/fhjUiniVeHRQYulYko4OxcWB6UhFuxH1dVAfAzIY=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-UQ/fhjUiniVeHRQYulYko4OxcWB6UhFuxH1dVAfAzIY=";
 
-  nativeBuildInputs = [
-    just
-    pkg-config
-  ];
-
-  buildInputs = [ wayland ];
-
-  dontUseJustBuild = true;
-  dontUseJustCheck = true;
-
-  justFlags = [
-    "--set"
-    "prefix"
-    (placeholder "out")
-    "--set"
-    "bin-src"
-    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-randr"
-  ];
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version"
-      "unstable"
-      "--version-regex"
-      "epoch-(.*)"
+    nativeBuildInputs = [
+      just
+      pkg-config
     ];
-  };
 
-  meta = {
-    homepage = "https://github.com/pop-os/cosmic-randr";
-    description = "Library and utility for displaying and configuring Wayland outputs";
-    license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [
-      nyabinary
-      HeitorAugustoLN
+    buildInputs = [ wayland ];
+
+    dontUseJustBuild = true;
+    dontUseJustCheck = true;
+
+    justFlags = [
+      "--set"
+      "prefix"
+      (placeholder "out")
+      "--set"
+      "bin-src"
+      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-randr"
     ];
-    platforms = lib.platforms.linux;
-    mainProgram = "cosmic-randr";
-  };
-}
+
+    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
+      lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--version"
+        "unstable"
+        "--version-regex"
+        "epoch-(.*)"
+      ];
+    };
+
+    meta = {
+      homepage = "https://github.com/pop-os/cosmic-randr";
+      description = "Library and utility for displaying and configuring Wayland outputs";
+      license = lib.licenses.mpl20;
+      maintainers = with lib.maintainers; [
+        nyabinary
+        HeitorAugustoLN
+      ];
+      platforms = lib.platforms.linux;
+      mainProgram = "cosmic-randr";
+    };
+  }

--- a/pkgs/by-name/co/cosmic-randr/package.nix
+++ b/pkgs/by-name/co/cosmic-randr/package.nix
@@ -14,14 +14,14 @@
 
 rustPlatform.buildRustPackage.override
   { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  rec {
+  (finalAttrs: {
     pname = "cosmic-randr";
     version = "1.0.0-alpha.6";
 
     src = fetchFromGitHub {
       owner = "pop-os";
       repo = "cosmic-randr";
-      tag = "epoch-${version}";
+      tag = "epoch-${finalAttrs.version}";
       hash = "sha256-Sqxe+vKonsK9MmJGtbrZHE7frfrjkHXysm0WQt7WSU4=";
     };
 
@@ -70,4 +70,4 @@ rustPlatform.buildRustPackage.override
       platforms = lib.platforms.linux;
       mainProgram = "cosmic-randr";
     };
-  }
+  })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cosmic-settings is already done in #386420

https://github.com/pop-os/cosmic-launcher/blob/b617a9dc68b2365e65b7820a6c81980159956a1c/justfile#L16
https://github.com/pop-os/cosmic-randr/blob/c247019230c5d820dd1c3d47bc4e3c52fb03b42f/justfile#L3
https://github.com/pop-os/cosmic-bg/blob/b6adf25075383c0e606658a7309919a9b092ee54/justfile#L4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
