### PR TITLE
pytestCheckHook: support inclusion and exclusion of path globs, test items, keywords, and markers

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -212,6 +212,29 @@ in
               ] ++ previousPythonAttrs.disabledTestPaths or [ ];
             })
           );
+          enabledTests = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTests-${previousPythonAttrs.pname}";
+            enabledTests = [
+              "TestBasic"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+          });
+          enabledTests-expression = objprint.overridePythonAttrs (previousPythonAttrs: {
+            __structuredAttrs = true;
+            pname = "test-pytestCheckHook-enabledTests-expression-${previousPythonAttrs.pname}";
+            enabledTests = [
+              "TestBasic and test_print"
+              "test_str"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+          });
+          enabledTests-disabledTests = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTests-disabledTests-${previousPythonAttrs.pname}";
+            enabledTests = [
+              "TestBasic"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+            disabledTests = [
+              "test_print"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+          });
           enabledTestPaths = objprint.overridePythonAttrs (previousPythonAttrs: {
             pname = "test-pytestCheckHook-enabledTestPaths-${previousPythonAttrs.pname}";
             enabledTestPaths = [

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -170,6 +170,14 @@ in
               "test_print"
             ] ++ previousPythonAttrs.disabledTests or [ ];
           });
+          disabledTests-expression = objprint.overridePythonAttrs (previousPythonAttrs: {
+            __structuredAttrs = true;
+            pname = "test-pytestCheckHook-disabledTests-expression-${previousPythonAttrs.pname}";
+            disabledTests = [
+              "TestBasic and test_print"
+              "test_str"
+            ] ++ previousPythonAttrs.disabledTests or [ ];
+          });
           disabledTestPaths = objprint.overridePythonAttrs (previousPythonAttrs: {
             pname = "test-pytestCheckHook-disabledTestPaths-${previousPythonAttrs.pname}";
             disabledTestPaths = [

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -204,6 +204,55 @@ in
               ] ++ previousPythonAttrs.disabledTestPaths or [ ];
             })
           );
+          enabledTestPaths = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTestPaths-${previousPythonAttrs.pname}";
+            enabledTestPaths = [
+              "tests/test_basic.py"
+            ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+          });
+          enabledTestPaths-nonexistent = testers.testBuildFailure (
+            objprint.overridePythonAttrs (previousPythonAttrs: {
+              pname = "test-pytestCheckHook-enabledTestPaths-nonexistent-${previousPythonAttrs.pname}";
+              enabledTestPaths = [
+                "tests/test_foo.py"
+              ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+            })
+          );
+          enabledTestPaths-dir = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTestPaths-dir-${previousPythonAttrs.pname}";
+            enabledTestPaths = [
+              "tests"
+            ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+          });
+          enabledTestPaths-dir-disabledTestPaths = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTestPaths-dir-disabledTestPaths-${previousPythonAttrs.pname}";
+            enabledTestPaths = [
+              "tests"
+            ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+            disabledTestPaths = [
+              "tests/test_basic.py"
+            ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+          });
+          enabledTestPaths-glob = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTestPaths-glob-${previousPythonAttrs.pname}";
+            enabledTestPaths = [
+              "tests/test_obj*.py"
+            ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+          });
+          enabledTestPaths-glob-nonexistent = testers.testBuildFailure (
+            objprint.overridePythonAttrs (previousPythonAttrs: {
+              pname = "test-pytestCheckHook-enabledTestPaths-glob-nonexistent-${previousPythonAttrs.pname}";
+              enabledTestPaths = [
+                "tests/test_foo*.py"
+              ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+            })
+          );
+          enabledTestPaths-item = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-enabledTestPaths-item-${previousPythonAttrs.pname}";
+            enabledTestPaths = [
+              "tests/test_basic.py::TestBasic"
+            ] ++ previousPythonAttrs.enabledTestPaths or [ ];
+          });
         };
       };
     } ./pytest-check-hook.sh

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -184,6 +184,12 @@ in
               ] ++ previousPythonAttrs.disabledTestPaths or [ ];
             })
           );
+          disabledTestPaths-item = objprint.overridePythonAttrs (previousPythonAttrs: {
+            pname = "test-pytestCheckHook-disabledTestPaths-item-${previousPythonAttrs.pname}";
+            disabledTestPaths = [
+              "tests/test_basic.py::TestBasic"
+            ] ++ previousPythonAttrs.disabledTestPaths or [ ];
+          });
           disabledTestPaths-glob = objprint.overridePythonAttrs (previousPythonAttrs: {
             pname = "test-pytestCheckHook-disabledTestPaths-glob-${previousPythonAttrs.pname}";
             disabledTestPaths = [

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -10,7 +10,33 @@ function pytestCheckPhase() {
     # Compose arguments
     local -a flagsArray=(-m pytest)
 
-    local -a _pathsArray=()
+    local -a _pathsArray
+    local path
+
+    _pathsArray=()
+    concatTo _pathsArray enabledTestPaths
+    for path in "${_pathsArray[@]}"; do
+        if [[ "$path" =~ "::" ]]; then
+            flagsArray+=("$path")
+        else
+            # The `|| kill "$$"` trick propagates the errors from the process substitutiton subshell,
+            # which is suggested by a StackOverflow answer: https://unix.stackexchange.com/a/217643
+            readarray -t -O"${#flagsArray[@]}" flagsArray < <(@pythonCheckInterpreter@ - "$path" <<EOF || kill "$$")
+import glob
+import sys
+path_glob=sys.argv[1]
+if not len(path_glob):
+    sys.exit('Got an empty enabled tests path glob. Aborting')
+path_expanded = glob.glob(path_glob)
+if not len(path_expanded):
+    sys.exit('Enabled tests path glob "{}" does not match any paths. Aborting'.format(path_glob))
+for path in path_expanded:
+    print(path)
+EOF
+        fi
+    done
+
+    _pathsArray=()
     concatTo _pathsArray disabledTestPaths
     for path in "${_pathsArray[@]}"; do
         if [[ "$path" =~ "::" ]]; then

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -57,7 +57,8 @@ EOF
     done
 
     if [ -n "${disabledTests[*]-}" ]; then
-        disabledTestsString="not $(concatStringsSep " and not " disabledTests)"
+        # not (keyword1) and not (keyword2)
+        disabledTestsString="not ($(concatStringsSep ") and not (" disabledTests))"
         flagsArray+=(-k "$disabledTestsString")
     fi
 

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -77,6 +77,10 @@ EOF
         flagsArray+=(-k "$(_pytestIncludeExcludeExpr enabledTests disabledTests)")
     fi
 
+    if [[ -n "${enabledTestMarks[*]-}" ]] || [[ -n "${disabledTestMarks[*]-}" ]]; then
+        flagsArray+=(-m "$(_pytestIncludeExcludeExpr enabledTestMarks disabledTestMarks)")
+    fi
+
     # Compatibility layer to the obsolete pytestFlagsArray
     eval "flagsArray+=(${pytestFlagsArray[*]-})"
 

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -13,8 +13,11 @@ function pytestCheckPhase() {
     local -a _pathsArray=()
     concatTo _pathsArray disabledTestPaths
     for path in "${_pathsArray[@]}"; do
-        # Check if every path glob matches at least one path
-        @pythonCheckInterpreter@ - "$path" <<EOF
+        if [[ "$path" =~ "::" ]]; then
+            flagsArray+=("--deselect=$path")
+        else
+            # Check if every path glob matches at least one path
+            @pythonCheckInterpreter@ - "$path" <<EOF
 import glob
 import sys
 path_glob=sys.argv[1]
@@ -23,7 +26,8 @@ if not len(path_glob):
 if next(glob.iglob(path_glob), None) is None:
     sys.exit('Disabled tests path glob "{}" does not match any paths. Aborting'.format(path_glob))
 EOF
-        flagsArray+=("--ignore-glob=$path")
+            flagsArray+=("--ignore-glob=$path")
+        fi
     done
 
     if [ -n "${disabledTests[*]-}" ]; then

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -9,10 +9,6 @@ function pytestCheckPhase() {
 
     # Compose arguments
     local -a flagsArray=(-m pytest)
-    if [ -n "${disabledTests[*]-}" ]; then
-        disabledTestsString="not $(concatStringsSep " and not " disabledTests)"
-        flagsArray+=(-k "$disabledTestsString")
-    fi
 
     local -a _pathsArray=()
     concatTo _pathsArray disabledTestPaths
@@ -29,6 +25,11 @@ if next(glob.iglob(path_glob), None) is None:
 EOF
         flagsArray+=("--ignore-glob=$path")
     done
+
+    if [ -n "${disabledTests[*]-}" ]; then
+        disabledTestsString="not $(concatStringsSep " and not " disabledTests)"
+        flagsArray+=(-k "$disabledTestsString")
+    fi
 
     # Compatibility layer to the obsolete pytestFlagsArray
     eval "flagsArray+=(${pytestFlagsArray[*]-})"

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -106,8 +106,10 @@ let
     "doInstallCheck"
     "pyproject"
     "format"
+    "disabledTestMarks"
     "disabledTestPaths"
     "disabledTests"
+    "enabledTestMarks"
     "enabledTestPaths"
     "enabledTests"
     "pytestFlags"
@@ -441,6 +443,7 @@ let
     }
     // optionalAttrs (attrs.doCheck or true) (
       getOptionalAttrs [
+        "disabledTestMarks"
         "disabledTestPaths"
         "disabledTests"
         "pytestFlags"
@@ -458,6 +461,7 @@ let
           )
           (
             getOptionalAttrs [
+              "enabledTestMarks"
               "enabledTestPaths"
               "enabledTests"
             ] attrs

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -108,6 +108,7 @@ let
     "format"
     "disabledTestPaths"
     "disabledTests"
+    "enabledTestPaths"
     "pytestFlags"
     "pytestFlagsArray"
     "unittestFlags"
@@ -446,6 +447,19 @@ let
         "unittestFlags"
         "unittestFlagsArray"
       ] attrs
+      //
+        lib.mapAttrs
+          (
+            name: value:
+            lib.throwIf (attrs.${name} == [ ])
+              "${lib.getName finalAttrs}: ${name} must be unspecified, null or a non-empty list."
+              attrs.${name}
+          )
+          (
+            getOptionalAttrs [
+              "enabledTestPaths"
+            ] attrs
+          )
     )
   );
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -109,6 +109,7 @@ let
     "disabledTestPaths"
     "disabledTests"
     "enabledTestPaths"
+    "enabledTests"
     "pytestFlags"
     "pytestFlagsArray"
     "unittestFlags"
@@ -451,13 +452,14 @@ let
         lib.mapAttrs
           (
             name: value:
-            lib.throwIf (attrs.${name} == [ ])
-              "${lib.getName finalAttrs}: ${name} must be unspecified, null or a non-empty list."
-              attrs.${name}
+            lib.throwIf (
+              attrs.${name} == [ ]
+            ) "${lib.getName finalAttrs}: ${name} must be unspecified, null or a non-empty list." attrs.${name}
           )
           (
             getOptionalAttrs [
               "enabledTestPaths"
+              "enabledTests"
             ] attrs
           )
     )

--- a/pkgs/development/python-modules/xyzservices/default.nix
+++ b/pkgs/development/python-modules/xyzservices/default.nix
@@ -24,9 +24,9 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  pytestFlagsArray = [
+  disabledTestMarks = [
     # requires network connections
-    "-m 'not request'"
+    "request"
   ];
 
   pythonImportsCheck = [ "xyzservices.providers" ];


### PR DESCRIPTION
If applied, pytestCheckHook will accept
- `enabledTestPaths` and `disabledTestPaths` to include/exclude either path globs or test items (`<file path>::<specifier>`)
- `enabledTests` and `disabledTests` to include/exclude keywords
- `enabledTestMarks` and `disabledTestMarks` to include/exclude markers

The inclusion corresponds to the positional arguments of `pytest`, as described by [the PyTest documentation](https://docs.pytest.org/en/stable/how-to/usage.html).

The path globs inside `enabledTestPaths` is expanded using an in-line Python script powered by the `glob` module from the Python Standard Library. `enabledTestPaths` is crucial for deprecating `pytestFlagsArray`, or we'll have to specify globbed paths inside `preCheck`. Other attributes also enhance the structural selection of the test cases.

This enhancement is essential to the tree-wide transition to deprecate the non `__structuredAttrs`-compatible `pytestFlagsArray` flags. See the previous discussion: https://github.com/NixOS/nixpkgs/pull/347194#issuecomment-2583298737

The keyword and markers expressions shares the same form `((inc1) or (inc2)) and not (exc1) and not (exc2)`, and are passed to `-k` and `-m` respectively.

I have considered renaming them to `includeTests` and `excludeTests`, but I'm unsure if tree-wide renaming from `disabledTests` to `excludeTests` would be worthwhile.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
