### PR TITLE
GNOME: 47 → 48

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -24,7 +24,13 @@
 
 - OpenSSH has been updated from 9.9p2 to 10.0p2, dropping support for DSA keys and adding a new `ssh-auth` binary to handle user authentication in a different address space from unauthenticated sessions. Additionally, we now enable a configure option by default that attempts to lock sshd into RAM to prevent it from being swapped out, which may improve performance if the system is under memory pressure. See the [full changelog](https://www.openwall.com/lists/oss-security/2025/04/09/1) for more details.
 
-- GNOME has been updated to version 48. Refer to the [GNOME release notes](https://release.gnome.org/48/) for more details.
+- GNOME has been updated to version 48.
+
+  - `decibels` music player is now installed by default. You can disable it using [](#opt-environment.gnome.excludePackages).
+  - `gnome-shell-extensions` extension collection (which included GNOME Classic extensions, Apps Menu, and User Themes, among others) are no longer installed by default. You can install them again with [](#opt-services.xserver.desktopManager.gnome.sessionPath).
+  - Option [](#opt-services.gnome.core-developer-tools.enable) now also installs `sysprof` and `d-spy`.
+
+  Refer to the [GNOME release notes](https://release.gnome.org/48/) for more details.
 
 - The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -24,6 +24,8 @@
 
 - OpenSSH has been updated from 9.9p2 to 10.0p2, dropping support for DSA keys and adding a new `ssh-auth` binary to handle user authentication in a different address space from unauthenticated sessions. Additionally, we now enable a configure option by default that attempts to lock sshd into RAM to prevent it from being swapped out, which may improve performance if the system is under memory pressure. See the [full changelog](https://www.openwall.com/lists/oss-security/2025/04/09/1) for more details.
 
+- GNOME has been updated to version 48. Refer to the [GNOME release notes](https://release.gnome.org/48/) for more details.
+
 - The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.
 
 - The Mattermost module ({option}`services.mattermost`) and packages (`mattermost` and `mmctl`) have been substantially updated:

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -29,6 +29,7 @@
   - `decibels` music player is now installed by default. You can disable it using [](#opt-environment.gnome.excludePackages).
   - `gnome-shell-extensions` extension collection (which included GNOME Classic extensions, Apps Menu, and User Themes, among others) are no longer installed by default. You can install them again with [](#opt-services.xserver.desktopManager.gnome.sessionPath).
   - Option [](#opt-services.gnome.core-developer-tools.enable) now also installs `sysprof` and `d-spy`.
+  - Option `services.gnome.core-utilities.enable` has been renamed to [](#opt-services.gnome.core-apps.enable).
 
   Refer to the [GNOME release notes](https://release.gnome.org/48/) for more details.
 

--- a/nixos/modules/services/x11/desktop-managers/gnome.md
+++ b/nixos/modules/services/x11/desktop-managers/gnome.md
@@ -19,7 +19,7 @@ To enable the GNOME desktop use:
 While it is not strictly necessary to use GDM as the display manager with GNOME, it is recommended, as some features such as screen lock [might not work](#sec-gnome-faq-can-i-use-lightdm-with-gnome) without it.
 :::
 
-The default applications used in NixOS are very minimal, inspired by the defaults used in [gnome-build-meta](https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/40.0/elements/core/meta-gnome-core-utilities.bst).
+The default applications used in NixOS are very minimal, inspired by the defaults used in [gnome-build-meta](https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/48.0/elements/core/meta-gnome-core-apps.bst).
 
 ### GNOME without the apps {#sec-gnome-without-the-apps}
 
@@ -27,7 +27,7 @@ If you’d like to only use the GNOME desktop and not the apps, you can disable 
 
 ```nix
 {
-  services.gnome.core-utilities.enable = false;
+  services.gnome.core-apps.enable = false;
 }
 ```
 

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -325,17 +325,9 @@ in
     })
 
     (lib.mkIf serviceCfg.core-shell.enable {
-      services.xserver.desktopManager.gnome.sessionPath =
-        let
-          mandatoryPackages = [
-            pkgs.gnome-shell
-          ];
-          optionalPackages = [
-            pkgs.gnome-shell-extensions
-          ];
-        in
-        mandatoryPackages
-        ++ utils.removePackagesByName optionalPackages config.environment.gnome.excludePackages;
+      services.xserver.desktopManager.gnome.sessionPath = [
+        pkgs.gnome-shell
+      ];
 
       services.colord.enable = mkDefault true;
       services.gnome.glib-networking.enable = true;
@@ -386,7 +378,7 @@ in
         source-sans
       ];
 
-      # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-38/elements/core/meta-gnome-core-shell.bst
+      # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-48/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages =
         let
           mandatoryPackages = [
@@ -399,7 +391,6 @@ in
             pkgs.gnome-bluetooth
             pkgs.gnome-color-manager
             pkgs.gnome-control-center
-            pkgs.gnome-shell-extensions
             pkgs.gnome-tour # GNOME Shell detects the .desktop file on first log-in.
             pkgs.gnome-user-docs
             pkgs.glib # for gsettings program
@@ -413,11 +404,12 @@ in
         ++ utils.removePackagesByName optionalPackages config.environment.gnome.excludePackages;
     })
 
-    # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/gnome-45/elements/core/meta-gnome-core-utilities.bst
+    # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/gnome-48/elements/core/meta-gnome-core-apps.bst
     (lib.mkIf serviceCfg.core-utilities.enable {
       environment.systemPackages = utils.removePackagesByName (
         [
           pkgs.baobab
+          pkgs.decibels
           pkgs.epiphany
           pkgs.gnome-text-editor
           pkgs.gnome-calculator
@@ -499,17 +491,19 @@ in
       ] config.environment.gnome.excludePackages;
     })
 
-    # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/3.38.0/elements/core/meta-gnome-core-developer-tools.bst
+    # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/gnome-48/elements/core/meta-gnome-core-developer-tools.bst
     (lib.mkIf serviceCfg.core-developer-tools.enable {
       environment.systemPackages = utils.removePackagesByName [
         pkgs.dconf-editor
         pkgs.devhelp
+        pkgs.d-spy
         pkgs.gnome-builder
         # boxes would make sense in this option, however
         # it doesn't function well enough to be included
         # in default configurations.
         # https://github.com/NixOS/nixpkgs/issues/60908
         # pkgs.gnome-boxes
+        pkgs.sysprof
       ] config.environment.gnome.excludePackages;
 
       services.sysprof.enable = notExcluded pkgs.sysprof;

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -84,12 +84,19 @@ in
     maintainers = lib.teams.gnome.members;
   };
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "gnome" "core-utilities" "enable" ]
+      [ "services" "gnome" "core-apps" "enable" ]
+    )
+  ];
+
   options = {
 
     services.gnome = {
       core-os-services.enable = mkEnableOption "essential services for GNOME3";
       core-shell.enable = mkEnableOption "GNOME Shell services";
-      core-utilities.enable = mkEnableOption "GNOME core utilities";
+      core-apps.enable = mkEnableOption "GNOME core apps";
       core-developer-tools.enable = mkEnableOption "GNOME core developer tools";
       games.enable = mkEnableOption "GNOME games";
     };
@@ -213,7 +220,7 @@ in
 
       services.gnome.core-os-services.enable = true;
       services.gnome.core-shell.enable = true;
-      services.gnome.core-utilities.enable = mkDefault true;
+      services.gnome.core-apps.enable = mkDefault true;
 
       services.displayManager.sessionPackages = [ pkgs.gnome-session.sessions ];
 
@@ -405,7 +412,7 @@ in
     })
 
     # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/gnome-48/elements/core/meta-gnome-core-apps.bst
-    (lib.mkIf serviceCfg.core-utilities.enable {
+    (lib.mkIf serviceCfg.core-apps.enable {
       environment.systemPackages = utils.removePackagesByName (
         [
           pkgs.baobab

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -211,7 +211,10 @@ in
       pkgs.gnome-session
       pkgs.gnome-shell
     ];
-    environment.systemPackages = [ pkgs.adwaita-icon-theme ];
+    environment.systemPackages = [
+      pkgs.adwaita-icon-theme
+      pkgs.gdm # For polkit rules
+    ];
 
     # We dont use the upstream gdm service
     # it has to be disabled since the gdm package has it

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.54.3";
+  version = "3.55.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-dGz4HvXDJa8X9Tsvq0bWcmDzsT2gFNiZTUrZ6Ea4Ves=";
+    hash = "sha256-d42YZQ0tZfDZ8QDdpS5cr5p07H2RqwBRAeEjWWrj9iY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.55.3";
+  version = "3.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-d42YZQ0tZfDZ8QDdpS5cr5p07H2RqwBRAeEjWWrj9iY=";
+    hash = "sha256-UUCc0w0mBGxW4jL6GV62FXGg2Q4t/i3qXFshKJaMT1g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.56.0";
+  version = "3.56.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-UUCc0w0mBGxW4jL6GV62FXGg2Q4t/i3qXFshKJaMT1g=";
+    hash = "sha256-39/lmRCdI5vFbajpYlssGVcGegGujv81BmOj2q50vRY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ad/adwaita-icon-theme/package.nix
+++ b/pkgs/by-name/ad/adwaita-icon-theme/package.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "adwaita-icon-theme";
-  version = "47.0";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/adwaita-icon-theme/${lib.versions.major version}/adwaita-icon-theme-${version}.tar.xz";
-    hash = "sha256-rQiKIpWMuEaeQdnxu6Dvsn5YaiECITzYnMJtsuACvf4=";
+    hash = "sha256-OM/bNTc2RDtkZq6DbqD/vz5MFZJBxculkWR/aX92xEU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ad/adwaita-icon-theme/package.nix
+++ b/pkgs/by-name/ad/adwaita-icon-theme/package.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "adwaita-icon-theme";
-  version = "48.beta";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/adwaita-icon-theme/${lib.versions.major version}/adwaita-icon-theme-${version}.tar.xz";
-    hash = "sha256-OM/bNTc2RDtkZq6DbqD/vz5MFZJBxculkWR/aX92xEU=";
+    hash = "sha256-hHBoiIZQ2WcxFb5tvyv9wxpGrrxSimqdtEIOYOZWuNQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.54.1";
+  version = "2.55.90";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-8HKeXIdl/rGWm7bB+6GK+iWCEmsDWap1oXP9oaz5PEw=";
+    hash = "sha256-rz3qkeGNKV72lFpxBGJMjq44P4EhsR4TQX8ZB2LBykc=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.55.90";
+  version = "2.56.0";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-rz3qkeGNKV72lFpxBGJMjq44P4EhsR4TQX8ZB2LBykc=";
+    hash = "sha256-gNfo6gvpJOBFUlNn+QnWZo390+h81AeSxs/QjmtY6Vw=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.56.0";
+  version = "2.56.1";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-gNfo6gvpJOBFUlNn+QnWZo390+h81AeSxs/QjmtY6Vw=";
+    hash = "sha256-/Rd/7NjJUAb/CjVer9cGb+EQouF+tetf4X/3Dkmk6s4=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "at-spi2-core";
-  version = "2.56.1";
+  version = "2.56.2";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/at-spi2-core/${lib.versions.majorMinor version}/at-spi2-core-${version}.tar.xz";
-    hash = "sha256-/Rd/7NjJUAb/CjVer9cGb+EQouF+tetf4X/3Dkmk6s4=";
+    hash = "sha256-4bHJg2qJR4UvdEDDLiMXkjTHa9mM2cxAAfN2QF+LeDs=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/ba/baobab/package.nix
+++ b/pkgs/by-name/ba/baobab/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "baobab";
-  version = "47.0";
+  version = "48.alpha";
 
   src = fetchurl {
     url = "mirror://gnome/sources/baobab/${lib.versions.major version}/baobab-${version}.tar.xz";
-    hash = "sha256-uI90+cBS08I4j3Bi0ijPXpJ1Raz3QIxWhB34DM0fnDc=";
+    hash = "sha256-2WGYniKdoRZHNbn9P4prfyH3xWoYPPmVQTnWdolED2c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ba/baobab/package.nix
+++ b/pkgs/by-name/ba/baobab/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "baobab";
-  version = "48.alpha";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/baobab/${lib.versions.major version}/baobab-${version}.tar.xz";
-    hash = "sha256-2WGYniKdoRZHNbn9P4prfyH3xWoYPPmVQTnWdolED2c=";
+    hash = "sha256-VFklBNSdgH8jWRvn5+7xDGyd/LesUnuBw6zVh4eyb9o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/d-/d-spy/package.nix
+++ b/pkgs/by-name/d-/d-spy/package.nix
@@ -14,19 +14,18 @@
   gnome,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "d-spy";
-  version = "47.0";
+  version = "48.rc";
 
   outputs = [
     "out"
-    "lib"
     "dev"
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/d-spy/${lib.versions.major version}/d-spy-${version}.tar.xz";
-    hash = "sha256-7/sw1DKtXkPmxEm9+OMX2il+VuAnQW5z4ulsTPGPaeg=";
+    url = "mirror://gnome/sources/d-spy/${lib.versions.major finalAttrs.version}/d-spy-${finalAttrs.version}.tar.xz";
+    hash = "sha256-feUoCoP8fS99DJJLM2/AUyxCuMTIbafZ6n/G54xOsC0=";
   };
 
   nativeBuildInputs = [
@@ -55,11 +54,8 @@ stdenv.mkDerivation rec {
     description = "D-Bus exploration tool";
     mainProgram = "d-spy";
     homepage = "https://gitlab.gnome.org/GNOME/d-spy";
-    license = with licenses; [
-      lgpl3Plus # library
-      gpl3Plus # app
-    ];
+    license = licenses.gpl3Plus;
     teams = [ teams.gnome ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/d-/d-spy/package.nix
+++ b/pkgs/by-name/d-/d-spy/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "d-spy";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/d-spy/${lib.versions.major finalAttrs.version}/d-spy-${finalAttrs.version}.tar.xz";
-    hash = "sha256-feUoCoP8fS99DJJLM2/AUyxCuMTIbafZ6n/G54xOsC0=";
+    hash = "sha256-D3oJAZBGGU2X/Dw0KzhOocOA4Qqc/IAlv83lfVlcODA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/de/decibels/package.nix
+++ b/pkgs/by-name/de/decibels/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchurl,
   appstream,
   blueprint-compiler,
   desktop-file-utils,
@@ -13,20 +13,15 @@
   pkg-config,
   typescript,
   wrapGAppsHook4,
-  nix-update-script,
+  gnome,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "decibels";
   version = "48.0";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    group = "GNOME";
-    owner = "Incubator";
-    repo = "decibels";
-    tag = version;
-    hash = "sha256-qtKiKfcxGLuV1bE3lb7l4s+reZRJXcjlV35M8eZmvHc=";
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "mirror://gnome/sources/decibels/${lib.versions.major finalAttrs.version}/decibels-${finalAttrs.version}.tar.xz";
+    hash = "sha256-IpsRqSYxR7y4w+If8NSvZZ+yYmL4rs5Uetz4xl4DH3Q=";
   };
 
   nativeBuildInputs = [
@@ -60,16 +55,21 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = gnome.updateScript {
+      packageName = "decibels";
+    };
   };
 
   meta = {
     description = "Play audio files";
-    homepage = "https://gitlab.gnome.org/GNOME/Incubator/decibels";
-    changelog = "https://gitlab.gnome.org/GNOME/decibels/-/blob/${version}/NEWS?ref_type=tags";
+    homepage = "https://gitlab.gnome.org/GNOME/decibels";
+    changelog = "https://gitlab.gnome.org/GNOME/decibels/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
     license = lib.licenses.gpl3Only;
-    teams = [ lib.teams.gnome-circle ];
+    teams = [
+      lib.teams.gnome
+      lib.teams.gnome-circle
+    ];
     mainProgram = "org.gnome.Decibels";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "epiphany";
-  version = "47.3.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
-    hash = "sha256-eV17gfGLdIfZ6b/Ayy1oqJPSIA9F+Tl81CyzOSsggak=";
+    hash = "sha256-4hwzNWx1+Js7n2tGZR9osvy/LIRL0b1YcGBUrSCsbVE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "epiphany";
-  version = "48.0";
+  version = "48.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ydH23/utA7CRZDaQHHcNowKHnKYKY20rcrJbFC7AX4A=";
+    hash = "sha256-2ilT5+K3O/dHPAozl5EE15NieVKV6qCio46hiFN9rxM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "epiphany";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
-    hash = "sha256-4hwzNWx1+Js7n2tGZR9osvy/LIRL0b1YcGBUrSCsbVE=";
+    hash = "sha256-ydH23/utA7CRZDaQHHcNowKHnKYKY20rcrJbFC7AX4A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ev/evince/package.nix
+++ b/pkgs/by-name/ev/evince/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "evince";
-  version = "46.3.1";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${lib.versions.major finalAttrs.version}/evince-${finalAttrs.version}.tar.xz";
-    hash = "sha256-lFwgpvI4ObDVMycpFxRY6QaA2oJk6Zxvn0HCGcfu7nw=";
+    hash = "sha256-obPvuB1KbIK4Rz7yKnzZmE31Ht7Hy0gqtVqqorFvOyU=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/ev/evince/package.nix
+++ b/pkgs/by-name/ev/evince/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "evince";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evince/${lib.versions.major finalAttrs.version}/evince-${finalAttrs.version}.tar.xz";
-    hash = "sha256-obPvuB1KbIK4Rz7yKnzZmE31Ht7Hy0gqtVqqorFvOyU=";
+    hash = "sha256-zS9lg1X6kHX9+eW0SqCvOn4JKMVWFOsQQrNhds9FESY=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/ev/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/by-name/ev/evolution-data-server/hardcode-gsettings.patch
@@ -66,10 +66,10 @@ index 5e65ec8..2cae29d 100644
  	g_mutex_unlock (&mutex);
  
 diff --git a/src/addressbook/libebook/e-book.c b/src/addressbook/libebook/e-book.c
-index e85a56b..59d3fe2 100644
+index a9b68e3..6a13b1b 100644
 --- a/src/addressbook/libebook/e-book.c
 +++ b/src/addressbook/libebook/e-book.c
-@@ -2587,7 +2587,18 @@ e_book_get_self (ESourceRegistry *registry,
+@@ -2586,7 +2586,18 @@ e_book_get_self (ESourceRegistry *registry,
  		return FALSE;
  	}
  
@@ -89,7 +89,7 @@ index e85a56b..59d3fe2 100644
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_object_unref (settings);
  
-@@ -2642,7 +2653,18 @@ e_book_set_self (EBook *book,
+@@ -2641,7 +2652,18 @@ e_book_set_self (EBook *book,
  	g_return_val_if_fail (E_IS_BOOK (book), FALSE);
  	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
  
@@ -109,7 +109,7 @@ index e85a56b..59d3fe2 100644
  	g_settings_set_string (
  		settings, SELF_UID_KEY,
  		e_contact_get_const (contact, E_CONTACT_UID));
-@@ -2670,7 +2692,18 @@ e_book_is_self (EContact *contact)
+@@ -2669,7 +2691,18 @@ e_book_is_self (EContact *contact)
  
  	g_return_val_if_fail (E_IS_CONTACT (contact), FALSE);
  
@@ -130,10 +130,10 @@ index e85a56b..59d3fe2 100644
  	g_object_unref (settings);
  
 diff --git a/src/addressbook/libedata-book/e-book-meta-backend.c b/src/addressbook/libedata-book/e-book-meta-backend.c
-index 3ab8908..6c4b210 100644
+index 752f83f..eaa3dad 100644
 --- a/src/addressbook/libedata-book/e-book-meta-backend.c
 +++ b/src/addressbook/libedata-book/e-book-meta-backend.c
-@@ -146,7 +146,18 @@ ebmb_is_power_saver_enabled (void)
+@@ -145,7 +145,18 @@ ebmb_is_power_saver_enabled (void)
  	GSettings *settings;
  	gboolean enabled = FALSE;
  
@@ -154,10 +154,10 @@ index 3ab8908..6c4b210 100644
  	if (g_settings_get_boolean (settings, "limit-operations-in-power-saver-mode")) {
  		GPowerProfileMonitor *power_monitor;
 diff --git a/src/calendar/backends/contacts/e-cal-backend-contacts.c b/src/calendar/backends/contacts/e-cal-backend-contacts.c
-index 047fb97..960f44c 100644
+index 9f8646a..079aba9 100644
 --- a/src/calendar/backends/contacts/e-cal-backend-contacts.c
 +++ b/src/calendar/backends/contacts/e-cal-backend-contacts.c
-@@ -1333,7 +1333,18 @@ e_cal_backend_contacts_init (ECalBackendContacts *cbc)
+@@ -1338,7 +1338,18 @@ e_cal_backend_contacts_init (ECalBackendContacts *cbc)
  		(GDestroyNotify) g_free,
  		(GDestroyNotify) contact_record_free);
  
@@ -204,10 +204,10 @@ index 2525856..7ecc1a8 100644
  				g_clear_object (&settings);
  			}
 diff --git a/src/calendar/libecal/e-reminder-watcher.c b/src/calendar/libecal/e-reminder-watcher.c
-index a83d3d3..dc7acac 100644
+index 026ae80..e3003c2 100644
 --- a/src/calendar/libecal/e-reminder-watcher.c
 +++ b/src/calendar/libecal/e-reminder-watcher.c
-@@ -2826,8 +2826,33 @@ e_reminder_watcher_init (EReminderWatcher *watcher)
+@@ -2844,8 +2844,33 @@ e_reminder_watcher_init (EReminderWatcher *watcher)
  
  	watcher->priv = e_reminder_watcher_get_instance_private (watcher);
  	watcher->priv->cancellable = g_cancellable_new ();
@@ -244,10 +244,10 @@ index a83d3d3..dc7acac 100644
  		g_signal_connect_object (
  			watcher->priv->desktop_settings,
 diff --git a/src/calendar/libedata-cal/e-cal-meta-backend.c b/src/calendar/libedata-cal/e-cal-meta-backend.c
-index f19ab22..abd3263 100644
+index 84ccbb0..9010429 100644
 --- a/src/calendar/libedata-cal/e-cal-meta-backend.c
 +++ b/src/calendar/libedata-cal/e-cal-meta-backend.c
-@@ -158,7 +158,18 @@ ecmb_is_power_saver_enabled (void)
+@@ -157,7 +157,18 @@ ecmb_is_power_saver_enabled (void)
  	GSettings *settings;
  	gboolean enabled = FALSE;
  
@@ -267,7 +267,7 @@ index f19ab22..abd3263 100644
  
  	if (g_settings_get_boolean (settings, "limit-operations-in-power-saver-mode")) {
  		GPowerProfileMonitor *power_monitor;
-@@ -2629,7 +2640,20 @@ ecmb_receive_object_sync (ECalMetaBackend *meta_backend,
+@@ -2628,7 +2639,20 @@ ecmb_receive_object_sync (ECalMetaBackend *meta_backend,
  			if (is_declined) {
  				GSettings *settings;
  
@@ -290,10 +290,10 @@ index f19ab22..abd3263 100644
  				g_clear_object (&settings);
  			}
 diff --git a/src/camel/camel-cipher-context.c b/src/camel/camel-cipher-context.c
-index d5a0823..2ae03f8 100644
+index d00fbd5..0f67653 100644
 --- a/src/camel/camel-cipher-context.c
 +++ b/src/camel/camel-cipher-context.c
-@@ -1631,7 +1631,18 @@ camel_cipher_can_load_photos (void)
+@@ -1630,7 +1630,18 @@ camel_cipher_can_load_photos (void)
  	GSettings *settings;
  	gboolean load_photos;
  
@@ -314,10 +314,10 @@ index d5a0823..2ae03f8 100644
  	g_clear_object (&settings);
  
 diff --git a/src/camel/camel-gpg-context.c b/src/camel/camel-gpg-context.c
-index 4c10de7..6c0ab5e 100644
+index 4594ab1..e71ce05 100644
 --- a/src/camel/camel-gpg-context.c
 +++ b/src/camel/camel-gpg-context.c
-@@ -744,7 +744,18 @@ gpg_ctx_get_executable_name (void)
+@@ -745,7 +745,18 @@ gpg_ctx_get_executable_name (void)
  		GSettings *settings;
  		gchar *path;
  
@@ -338,10 +338,10 @@ index 4c10de7..6c0ab5e 100644
  		g_clear_object (&settings);
  
 diff --git a/src/camel/camel-utils.c b/src/camel/camel-utils.c
-index e61160c..b6553a4 100644
+index 0c1c7dd..4188934 100644
 --- a/src/camel/camel-utils.c
 +++ b/src/camel/camel-utils.c
-@@ -362,7 +362,19 @@ void
+@@ -361,7 +361,19 @@ void
  _camel_utils_initialize (void)
  {
  	G_LOCK (mi_user_headers);
@@ -363,10 +363,10 @@ index e61160c..b6553a4 100644
  		G_CALLBACK (mi_user_headers_settings_changed_cb), NULL);
  	G_UNLOCK (mi_user_headers);
 diff --git a/src/camel/providers/imapx/camel-imapx-server.c b/src/camel/providers/imapx/camel-imapx-server.c
-index 396cf39..e31dc1a 100644
+index 8cf56f0..f4355d5 100644
 --- a/src/camel/providers/imapx/camel-imapx-server.c
 +++ b/src/camel/providers/imapx/camel-imapx-server.c
-@@ -5682,7 +5682,18 @@ camel_imapx_server_do_old_flags_update (CamelFolder *folder)
+@@ -5681,7 +5681,18 @@ camel_imapx_server_do_old_flags_update (CamelFolder *folder)
  	if (do_old_flags_update) {
  		GSettings *eds_settings;
  
@@ -387,10 +387,10 @@ index 396cf39..e31dc1a 100644
  		if (g_settings_get_boolean (eds_settings, "limit-operations-in-power-saver-mode")) {
  			GPowerProfileMonitor *power_monitor;
 diff --git a/src/camel/providers/smtp/camel-smtp-transport.c b/src/camel/providers/smtp/camel-smtp-transport.c
-index 38bedb6..f799c29 100644
+index f7c5d3c..67732c3 100644
 --- a/src/camel/providers/smtp/camel-smtp-transport.c
 +++ b/src/camel/providers/smtp/camel-smtp-transport.c
-@@ -1472,7 +1472,18 @@ smtp_helo (CamelSmtpTransport *transport,
+@@ -1471,7 +1471,18 @@ smtp_helo (CamelSmtpTransport *transport,
  		transport->authtypes = NULL;
  	}
  
@@ -507,10 +507,10 @@ index 3738359..f9ce2d9 100644
  		g_object_unref (settings);
  
 diff --git a/src/libedataserver/e-oauth2-service.c b/src/libedataserver/e-oauth2-service.c
-index 29c1dd2..84d42b7 100644
+index db775f9..fb524db 100644
 --- a/src/libedataserver/e-oauth2-service.c
 +++ b/src/libedataserver/e-oauth2-service.c
-@@ -94,7 +94,18 @@ eos_default_guess_can_process (EOAuth2Service *service,
+@@ -93,7 +93,18 @@ eos_default_guess_can_process (EOAuth2Service *service,
  	name_len = strlen (name);
  	hostname_len = strlen (hostname);
  
@@ -556,10 +556,10 @@ index 1539f8b..77cf123 100644
  	g_signal_connect (
  		registry->priv->settings, "changed",
 diff --git a/src/libedataserverui/e-reminders-widget.c b/src/libedataserverui/e-reminders-widget.c
-index 14b6481..7149b74 100644
+index b47a374..e812fbe 100644
 --- a/src/libedataserverui/e-reminders-widget.c
 +++ b/src/libedataserverui/e-reminders-widget.c
-@@ -1986,7 +1986,19 @@ static void
+@@ -1985,7 +1985,19 @@ static void
  e_reminders_widget_init (ERemindersWidget *reminders)
  {
  	reminders->priv = e_reminders_widget_get_instance_private (reminders);

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -51,7 +51,7 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.54.3";
+  version = "3.55.3";
 
   outputs = [
     "out"
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/evolution-data-server-${version}.tar.xz";
-    hash = "sha256-UQjcOO5cwfjvkVXof2xBKflkRVCglixa4j/4B7V8uNA=";
+    hash = "sha256-/oPlimEHuG2PYqcF54SB8JLV5xsYm994fT59R0hoFI0=";
   };
 
   patches = [

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -51,7 +51,7 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.55.3";
+  version = "3.56.0";
 
   outputs = [
     "out"
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/evolution-data-server-${version}.tar.xz";
-    hash = "sha256-/oPlimEHuG2PYqcF54SB8JLV5xsYm994fT59R0hoFI0=";
+    hash = "sha256-euVIKqTuKJRGdxbFvpglAOHVEd3fSrKbaP2xB9f4qP8=";
   };
 
   patches = [

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -51,7 +51,7 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.56.0";
+  version = "3.56.1";
 
   outputs = [
     "out"
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/evolution-data-server-${version}.tar.xz";
-    hash = "sha256-euVIKqTuKJRGdxbFvpglAOHVEd3fSrKbaP2xB9f4qP8=";
+    hash = "sha256-ZGzAA32j+fKVeUxjfZU5StdvjJvuImi+LEGD4ncgwTc=";
   };
 
   patches = [

--- a/pkgs/by-name/fi/five-or-more/package.nix
+++ b/pkgs/by-name/fi/five-or-more/package.nix
@@ -17,12 +17,12 @@
   vala,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "five-or-more";
   version = "3.32.3";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/five-or-more/${lib.versions.majorMinor version}/five-or-more-${version}.tar.xz";
+    url = "mirror://gnome/sources/five-or-more/${lib.versions.major finalAttrs.version}/five-or-more-${finalAttrs.version}.tar.xz";
     hash = "sha256-LRDXLu/esyS0R9YyrwwySW4l/BWjwB230vAMm1HQnvQ=";
   };
 
@@ -50,7 +50,9 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    updateScript = gnome.updateScript { packageName = "five-or-more"; };
+    updateScript = gnome.updateScript {
+      packageName = "five-or-more";
+    };
   };
 
   meta = with lib; {
@@ -61,4 +63,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/fi/five-or-more/package.nix
+++ b/pkgs/by-name/fi/five-or-more/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "five-or-more";
-  version = "3.32.3";
+  version = "48.alpha";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${lib.versions.major finalAttrs.version}/five-or-more-${finalAttrs.version}.tar.xz";
-    hash = "sha256-LRDXLu/esyS0R9YyrwwySW4l/BWjwB230vAMm1HQnvQ=";
+    hash = "sha256-L98o7qVvctKpmRAT89FVjRCG4lFMCw/tPM4Hp9GKa74=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/five-or-more/package.nix
+++ b/pkgs/by-name/fi/five-or-more/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "five-or-more";
-  version = "48.alpha";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${lib.versions.major finalAttrs.version}/five-or-more-${finalAttrs.version}.tar.xz";
-    hash = "sha256-L98o7qVvctKpmRAT89FVjRCG4lFMCw/tPM4Hp9GKa74=";
+    hash = "sha256-3/w3XAcVC8igBc+nTA6PC6UevLAoVkgiyxH+z9WZrnQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/five-or-more/package.nix
+++ b/pkgs/by-name/fi/five-or-more/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "five-or-more";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${lib.versions.major finalAttrs.version}/five-or-more-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3/w3XAcVC8igBc+nTA6PC6UevLAoVkgiyxH+z9WZrnQ=";
+    hash = "sha256-2UHOLjfqZsDYDx6BeX+8u+To72WnkLPMXla58QtepaM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -43,7 +43,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdm";
-  version = "47.0";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdm/${lib.versions.major finalAttrs.version}/gdm-${finalAttrs.version}.tar.xz";
-    hash = "sha256-xYWDJr+8yKzlgTUuK+RGItwOnlwoAchpD9Lu1QJgf4Q=";
+    hash = "sha256-rNZygkDTQkz4uTR5qBr8si8Fw2EKI9gwlK/joCb5zm0=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -43,7 +43,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdm";
-  version = "48.beta";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdm/${lib.versions.major finalAttrs.version}/gdm-${finalAttrs.version}.tar.xz";
-    hash = "sha256-rNZygkDTQkz4uTR5qBr8si8Fw2EKI9gwlK/joCb5zm0=";
+    hash = "sha256-G8Btr/CT7HteN+y0+S5do0dKGxugdu25FR7pZ9HDCt8=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gh/ghex/package.nix
+++ b/pkgs/by-name/gh/ghex/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghex";
-  version = "46.2";
+  version = "48.alpha";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/ghex/${lib.versions.major finalAttrs.version}/ghex-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qPJ2o2OXpw0guGL/fGZCQ9nPKJHeub4G10Wk8axmHzE=";
+    hash = "sha256-QP7kmZfZGhkmYmEXDEi7hy+zBupB+2WnIVBghow73+I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gj/gjs/package.nix
+++ b/pkgs/by-name/gj/gjs/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
   gnome,
   gtk3,
+  gtk4,
   atk,
   gobject-introspection,
   spidermonkey_128,
@@ -30,6 +31,7 @@
 let
   testDeps = [
     gtk3
+    gtk4
     atk
     pango.out
     gdk-pixbuf
@@ -39,7 +41,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gjs";
-  version = "1.82.1";
+  version = "1.83.90";
 
   outputs = [
     "out"
@@ -49,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor finalAttrs.version}/gjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+zmqVjZXbeDloRcfVqGlgl4r0aaZcvsSC6eL0Qm1aTw=";
+    hash = "sha256-zolGZsn/zfa53TQ4PRfmbo9x6dasxzRMkLkIcDfb//Q=";
   };
 
   patches = [
@@ -123,6 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $PWD/libgjs.so.0 $out/lib/libgjs.so.0
     ln -s $PWD/subprojects/gobject-introspection-tests/libgimarshallingtests.so $installedTests/libexec/installed-tests/gjs/libgimarshallingtests.so
     ln -s $PWD/subprojects/gobject-introspection-tests/libregress.so $installedTests/libexec/installed-tests/gjs/libregress.so
+    ln -s $PWD/subprojects/gobject-introspection-tests/libutility.so $installedTests/libexec/installed-tests/gjs/libutility.so
     ln -s $PWD/subprojects/gobject-introspection-tests/libwarnlib.so $installedTests/libexec/installed-tests/gjs/libwarnlib.so
     ln -s $PWD/installed-tests/js/libgjstesttools/libgjstesttools.so $installedTests/libexec/installed-tests/gjs/libgjstesttools.so
   '';
@@ -142,6 +145,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkPhase = ''
     runHook preCheck
+    GTK_A11Y=none \
+    HOME=$(mktemp -d) \
     xvfb-run -s '-screen 0 800x600x24' \
       meson test --print-errorlogs
     runHook postCheck

--- a/pkgs/by-name/gj/gjs/package.nix
+++ b/pkgs/by-name/gj/gjs/package.nix
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gjs";
-  version = "1.83.90";
+  version = "1.84.1";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor finalAttrs.version}/gjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zolGZsn/zfa53TQ4PRfmbo9x6dasxzRMkLkIcDfb//Q=";
+    hash = "sha256-RHlrkTGNu+IhoTkJ8A/Ycu+S84xoYD4ONXTka8a6wyw=";
   };
 
   patches = [

--- a/pkgs/by-name/gj/gjs/package.nix
+++ b/pkgs/by-name/gj/gjs/package.nix
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gjs";
-  version = "1.84.1";
+  version = "1.84.2";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${lib.versions.majorMinor finalAttrs.version}/gjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RHlrkTGNu+IhoTkJ8A/Ycu+S84xoYD4ONXTka8a6wyw=";
+    hash = "sha256-NRQu3zRXBWNjACkew6fVg/FJaf8/rg/zD0qVseZ0AWY=";
   };
 
   patches = [

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -75,7 +75,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glib";
-  version = "2.83.5";
+  version = "2.84.0";
 
   outputs = [
     "bin"
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+DQsTytxPJJtsbNLi9k91MslFaEQLYQZaG/pOULGBxw=";
+    hash = "sha256-+II2AMuFQl4oFc+tguog/apThIKrdOcpPViz9kpa/2o=";
   };
 
   patches =

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -75,7 +75,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glib";
-  version = "2.82.5";
+  version = "2.83.5";
 
   outputs = [
     "bin"
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BcIDH5vfa1q6egbKhPC0rO0osZvxtQxqslzGdSd8vD8=";
+    hash = "sha256-+DQsTytxPJJtsbNLi9k91MslFaEQLYQZaG/pOULGBxw=";
   };
 
   patches =

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -75,7 +75,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glib";
-  version = "2.84.0";
+  version = "2.84.1";
 
   outputs = [
     "bin"
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${lib.versions.majorMinor finalAttrs.version}/glib-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+II2AMuFQl4oFc+tguog/apThIKrdOcpPViz9kpa/2o=";
+    hash = "sha256-K0vC7ElhGl/DX4asqFXy7QGW5p5TCSura7czlr8weJo=";
   };
 
   patches =

--- a/pkgs/by-name/gl/glycin-loaders/fix-glycin-paths.patch
+++ b/pkgs/by-name/gl/glycin-loaders/fix-glycin-paths.patch
@@ -1,17 +1,17 @@
 diff --git a/vendor/glycin/src/sandbox.rs b/vendor/glycin/src/sandbox.rs
-index 7d00b36..aa70dc7 100644
+index 08db832..4f44b21 100644
 --- a/vendor/glycin/src/sandbox.rs
 +++ b/vendor/glycin/src/sandbox.rs
-@@ -165,7 +165,7 @@ impl Sandbox {
+@@ -202,7 +202,7 @@ impl Sandbox {
  
-                 args.push(self.command);
+                 args.push(self.exec());
  
 -                ("bwrap".into(), args, Some(seccomp_memfd))
 +                ("@bwrap@".into(), args, Some(seccomp_memfd))
              }
              SandboxMechanism::FlatpakSpawn => {
                  let memory_limit = Self::memory_limit();
-@@ -233,8 +233,8 @@ impl Sandbox {
+@@ -299,8 +299,8 @@ impl Sandbox {
                  "/",
                  // Make /usr available as read only
                  "--ro-bind",

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.2.rc";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-n9kqQEdMIJzUA75GBL1cT42jah6mXnuG0D3KPx7bxhE=";
+    hash = "sha256-FqtKSDmGOe9wHHw+J6LTEHWzDg3K8/FlLJB7GI9CkNA=";
   };
 
   patches = [

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-FqtKSDmGOe9wHHw+J6LTEHWzDg3K8/FlLJB7GI9CkNA=";
+    hash = "sha256-zMV46aPoPQ3BU1c30f2gm6qVxxZ/Xl7LFfeGZUCU7tU=";
   };
 
   patches = [

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.1.6";
+  version = "1.2.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2EzFaBTyKEEArTQ5pDCDe7IfD5jUbg0rWGifLBlwjwQ=";
+    hash = "sha256-n9kqQEdMIJzUA75GBL1cT42jah6mXnuG0D3KPx7bxhE=";
   };
 
   patches = [
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Glycin loaders for several formats";
-    homepage = "https://gitlab.gnome.org/sophie-h/glycin";
+    homepage = "https://gitlab.gnome.org/GNOME/glycin";
     teams = [ teams.gnome ];
     license = with licenses; [
       mpl20 # or

--- a/pkgs/by-name/gn/gnome-applets/package.nix
+++ b/pkgs/by-name/gn/gnome-applets/package.nix
@@ -25,11 +25,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-applets";
-  version = "3.54.0";
+  version = "3.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-applets/${lib.versions.majorMinor finalAttrs.version}/gnome-applets-${finalAttrs.version}.tar.xz";
-    hash = "sha256-FASM8amK2U4U715E/f6IVvo/KDZAHHkr/83mi4db2vk=";
+    hash = "sha256-+heu3JVa3ZgaouQ7TAcTU/aGu9HuwdcXqJCnNTIK0XE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-backgrounds/package.nix
+++ b/pkgs/by-name/gn/gnome-backgrounds/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-backgrounds";
-  version = "47.0";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-backgrounds/${lib.versions.major version}/gnome-backgrounds-${version}.tar.xz";
-    hash = "sha256-h0pKOcQmFzb2qFRyKDNAC2EkQcRoGqWYLZCxWryckf0=";
+    hash = "sha256-D6aqEG7lvPR20mNQWC8DacgCpkj403SHH9NgOUU/a+k=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-backgrounds/package.nix
+++ b/pkgs/by-name/gn/gnome-backgrounds/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-backgrounds";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-backgrounds/${lib.versions.major version}/gnome-backgrounds-${version}.tar.xz";
-    hash = "sha256-Yxb3CxfhKxBHjbc8AvRv+u05mYjpAz/F6ixhNY8GITg=";
+    hash = "sha256-LWuqAR7peATHVh9+HL2NR2PjC1W4gY3aePn3WvuNjQU=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-backgrounds/package.nix
+++ b/pkgs/by-name/gn/gnome-backgrounds/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-backgrounds";
-  version = "48.beta";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-backgrounds/${lib.versions.major version}/gnome-backgrounds-${version}.tar.xz";
-    hash = "sha256-D6aqEG7lvPR20mNQWC8DacgCpkj403SHH9NgOUU/a+k=";
+    hash = "sha256-Yxb3CxfhKxBHjbc8AvRv+u05mYjpAz/F6ixhNY8GITg=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-boxes/package.nix
+++ b/pkgs/by-name/gn/gnome-boxes/package.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "47.0";
+  version = "48.alpha";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${lib.versions.major version}/gnome-boxes-${version}.tar.xz";
-    hash = "sha256-Zb9sLeG/TVFpXJGSxbHmKFyzLJihiqlIo3bqMgOLx48=";
+    hash = "sha256-Ixc4I2M3x6+yhDC2JNM2Opv9nqNILX9xnKyJUCQK7Dk=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-boxes/package.nix
+++ b/pkgs/by-name/gn/gnome-boxes/package.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "48.alpha";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${lib.versions.major version}/gnome-boxes-${version}.tar.xz";
-    hash = "sha256-Ixc4I2M3x6+yhDC2JNM2Opv9nqNILX9xnKyJUCQK7Dk=";
+    hash = "sha256-0F9fQlaPr79tiHcRYbBu1fc51DEhJ41BjK6VxW5RPq0=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-builder/package.nix
+++ b/pkgs/by-name/gn/gnome-builder/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-builder";
-  version = "47.2";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-builder/${lib.versions.major finalAttrs.version}/gnome-builder-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Roe5PEfNHjNmWi3FA3kLYhPugnhy/ABNl40UvL+ptJU=";
+    hash = "sha256-+J4+A+1SESqjxN/I6p5+RO+3GlPhaKy3E2IGlmzFJjg=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-builder/package.nix
+++ b/pkgs/by-name/gn/gnome-builder/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-builder";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-builder/${lib.versions.major finalAttrs.version}/gnome-builder-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+J4+A+1SESqjxN/I6p5+RO+3GlPhaKy3E2IGlmzFJjg=";
+    hash = "sha256-ev6aejs8ZiF2i8RqYdaY3XiLNlP7RqcII4vcz03me6Q=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-calculator/package.nix
+++ b/pkgs/by-name/gn/gnome-calculator/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calculator";
-  version = "47.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/gnome-calculator-${version}.tar.xz";
-    hash = "sha256-vp+SJ5m35+ZclzSLm35kf/4zyDG7OlHTniwWjSrcQOA=";
+    hash = "sha256-P1QzImV/yhlKYA8+ApFDLGszhL7DhwfZeAVtCkQQNnM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-calculator/package.nix
+++ b/pkgs/by-name/gn/gnome-calculator/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calculator";
-  version = "48.0.2";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/gnome-calculator-${version}.tar.xz";
-    hash = "sha256-pM26s1viS7QBc1m5n/y2yK/ACEgpGtekcg5soHVwDcQ=";
+    hash = "sha256-vEvUGpuhkPRcvuDYxnUs3F0osM7xxr0MAeLa4fPBkWI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-calculator/package.nix
+++ b/pkgs/by-name/gn/gnome-calculator/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calculator";
-  version = "48.rc";
+  version = "48.0.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${lib.versions.major version}/gnome-calculator-${version}.tar.xz";
-    hash = "sha256-P1QzImV/yhlKYA8+ApFDLGszhL7DhwfZeAVtCkQQNnM=";
+    hash = "sha256-pM26s1viS7QBc1m5n/y2yK/ACEgpGtekcg5soHVwDcQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-calendar/package.nix
+++ b/pkgs/by-name/gn/gnome-calendar/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calendar";
-  version = "47.0";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calendar/${lib.versions.major version}/gnome-calendar-${version}.tar.xz";
-    hash = "sha256-OwMxPxxNEtyCHgfiCdFZbVPq+iVdSS0s5av5LtG1HnY=";
+    hash = "sha256-kCo4kVm8M6SKBE250y4kJWj2vigGvMiBMixF9+02A+4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-calendar/package.nix
+++ b/pkgs/by-name/gn/gnome-calendar/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-calendar";
-  version = "48.rc";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calendar/${lib.versions.major version}/gnome-calendar-${version}.tar.xz";
-    hash = "sha256-kCo4kVm8M6SKBE250y4kJWj2vigGvMiBMixF9+02A+4=";
+    hash = "sha256-Bs6t1cAL6ONYGB1CHs8mgs4K6i/LEtkDsw0pyjMonwI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-characters/package.nix
+++ b/pkgs/by-name/gn/gnome-characters/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-characters";
-  version = "47.0";
+  version = "48.alpha";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-characters/${lib.versions.major version}/gnome-characters-${version}.tar.xz";
-    hash = "sha256-a88Foi8w8THYqANbD2PYapVnAHpfbfXOhVa6Bnd7dXQ=";
+    hash = "sha256-2u12r65poP3EFT2xU0zKiAPhZigsk3ZDKzcxjuKXufY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-characters/package.nix
+++ b/pkgs/by-name/gn/gnome-characters/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-characters";
-  version = "48.alpha";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-characters/${lib.versions.major version}/gnome-characters-${version}.tar.xz";
-    hash = "sha256-2u12r65poP3EFT2xU0zKiAPhZigsk3ZDKzcxjuKXufY=";
+    hash = "sha256-osMspU2RHbJARCA1DTRC5pGi3Oiw9dAImfZs/4w8jXE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-chess/package.nix
+++ b/pkgs/by-name/gn/gnome-chess/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-chess";
-  version = "47.0";
+  version = "48.alpha2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-chess/${lib.versions.major version}/gnome-chess-${version}.tar.xz";
-    hash = "sha256-OkQ6LHiA5q0TG3Wt2AdO2+WYK3aruEKQT+PfnCxQ6H4=";
+    hash = "sha256-VzVNQ0ilDUcEbKCX4Hg18SuYOcXiVRp5Ej1eoLaxR9Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-chess/package.nix
+++ b/pkgs/by-name/gn/gnome-chess/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-chess";
-  version = "48.alpha2";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-chess/${lib.versions.major version}/gnome-chess-${version}.tar.xz";
-    hash = "sha256-VzVNQ0ilDUcEbKCX4Hg18SuYOcXiVRp5Ej1eoLaxR9Q=";
+    hash = "sha256-eDTEdvCLvyd5BrApNjLtMugDdMuUQyayGeqQVqapXz8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-clocks/package.nix
+++ b/pkgs/by-name/gn/gnome-clocks/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-clocks";
-  version = "47.0";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-clocks/${lib.versions.major finalAttrs.version}/gnome-clocks-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QovfS9F+Jt5s7wFM16fuvYkUPD8nMrJLfaaYErqlITE=";
+    hash = "sha256-D4+4bBDxcjdMVpqTrshlv2DO5R6f5HuLOzhVrODiIr4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-clocks/package.nix
+++ b/pkgs/by-name/gn/gnome-clocks/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-clocks";
-  version = "48.beta";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-clocks/${lib.versions.major finalAttrs.version}/gnome-clocks-${finalAttrs.version}.tar.xz";
-    hash = "sha256-D4+4bBDxcjdMVpqTrshlv2DO5R6f5HuLOzhVrODiIr4=";
+    hash = "sha256-YW7h+3UwCx8muXZiGelUdRNgyg+g9JExG8+DvzgIfGI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-connections/package.nix
+++ b/pkgs/by-name/gn/gnome-connections/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-connections";
-  version = "47.2.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-connections/${lib.versions.major finalAttrs.version}/gnome-connections-${finalAttrs.version}.tar.xz";
-    hash = "sha256-BSPjy4edSsC5Xn7l8y22YSi1q4QE/xGSMHHNVs/k2Lg=";
+    hash = "sha256-TsdR3bSBSU9NIkVwlTgI0ZyedQ5JlWqmTZlNEtkMAUw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-connections/package.nix
+++ b/pkgs/by-name/gn/gnome-connections/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-connections";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-connections/${lib.versions.major finalAttrs.version}/gnome-connections-${finalAttrs.version}.tar.xz";
-    hash = "sha256-TsdR3bSBSU9NIkVwlTgI0ZyedQ5JlWqmTZlNEtkMAUw=";
+    hash = "sha256-Nw75QFBrVybG8rfLl5ayI9HW1Chfg8/DOFvWdMMon9A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-console/package.nix
+++ b/pkgs/by-name/gn/gnome-console/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-console";
-  version = "47.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-console/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-0/YAtFtRcWaRrukocDMunJqMqJ1VNWXzEx2eKAdHJdA=";
+    hash = "sha256-pOokEmWfm3Cypm2wnke1yjGwbN4Fd/LgqD1baO0fYUk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-console/package.nix
+++ b/pkgs/by-name/gn/gnome-console/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-console";
-  version = "48.rc";
+  version = "48.0.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-console/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-pOokEmWfm3Cypm2wnke1yjGwbN4Fd/LgqD1baO0fYUk=";
+    hash = "sha256-AY6Qjk2uvPyxUNTxuyjZgnKqnRTWgV6vjaRfiJ2wXEk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-contacts/package.nix
+++ b/pkgs/by-name/gn/gnome-contacts/package.nix
@@ -29,11 +29,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-contacts";
-  version = "47.1.1";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-contacts/${lib.versions.major version}/gnome-contacts-${version}.tar.xz";
-    hash = "sha256-R+GuRbcEGgXV4nZJ2RLiwwAlYYisRg7cukaJnGYIpHg=";
+    hash = "sha256-Z0hqrghsPnsLDUGnPHKC5kcWwuqkOaLMPrx4DP8Q3v4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-contacts/package.nix
+++ b/pkgs/by-name/gn/gnome-contacts/package.nix
@@ -29,11 +29,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-contacts";
-  version = "48.beta";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-contacts/${lib.versions.major version}/gnome-contacts-${version}.tar.xz";
-    hash = "sha256-Z0hqrghsPnsLDUGnPHKC5kcWwuqkOaLMPrx4DP8Q3v4=";
+    hash = "sha256-onYplbWUJ+w/GF8otVlONwd7cqcM18GSF+1jRjfswbU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -74,11 +74,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "47.4";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-KMfbdNcg/MnyE8EtNy5+rMF2ekm8TKZrK9ILD9ECJmg=";
+    hash = "sha256-Dvey0wBObrQY/OcIC7GNGyQm+ylhs5/tnCEYurAebCQ=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -75,11 +75,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-FlIgLbNqK+dEEBm52v81dOgEKFmOgjlah0GAFajAZiQ=";
+    hash = "sha256-AYPbNlqqj4W0SyPMnK5nXRyDNgSf7BGoym6pvb6MSP4=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -65,6 +65,7 @@
   tzdata,
   udisks2,
   upower,
+  wayland-scanner,
   libepoxy,
   gnome-user-share,
   gnome-remote-desktop,
@@ -74,11 +75,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "48.beta";
+  version = "48.rc.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Dvey0wBObrQY/OcIC7GNGyQm+ylhs5/tnCEYurAebCQ=";
+    hash = "sha256-IMroFNkpicoW5Owmixb5Dp8jrvncTFMYl64do1PayIU=";
   };
 
   patches = [
@@ -98,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
     shared-mime-info
+    wayland-scanner
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -75,11 +75,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "48.rc.1";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    hash = "sha256-IMroFNkpicoW5Owmixb5Dp8jrvncTFMYl64do1PayIU=";
+    hash = "sha256-FlIgLbNqK+dEEBm52v81dOgEKFmOgjlah0GAFajAZiQ=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-flashback/fix-paths.patch
+++ b/pkgs/by-name/gn/gnome-flashback/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/system-indicators/si-input-sources.c b/system-indicators/si-input-sources.c
+index f13b262..2186b76 100644
+--- a/system-indicators/si-input-sources.c
++++ b/system-indicators/si-input-sources.c
+@@ -807,7 +807,7 @@ spawn_keyboard_display (const char *description)
+   flags = G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD;
+   error = NULL;
+ 
+-  argv[0] = g_strdup ("tecla");
++  argv[0] = g_strdup ("@tecla@");
+   argv[1] = g_strdup (description);
+   argv[2] = NULL;
+ 

--- a/pkgs/by-name/gn/gnome-flashback/package.nix
+++ b/pkgs/by-name/gn/gnome-flashback/package.nix
@@ -20,7 +20,9 @@
   pkg-config,
   polkit,
   gdm,
+  replaceVars,
   systemd,
+  tecla,
   upower,
   pam,
   wrapGAppsHook3,
@@ -64,12 +66,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-flashback";
-  version = "3.54.0";
+  version = "3.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-flashback/${lib.versions.majorMinor finalAttrs.version}/gnome-flashback-${finalAttrs.version}.tar.xz";
-    hash = "sha256-gkNa4wLNZK6xG25M0YTaj/+qzSSFFf+gIidZXDzPne4=";
+    hash = "sha256-LQ+iLzc9sIDq7w5Wk7lijN6ETyVjPVqQMTsEndlSkmA=";
   };
+
+  patches = [
+    (replaceVars ./fix-paths.patch {
+      tecla = lib.getExe tecla;
+    })
+  ];
 
   # make .desktop Execs absolute
   postPatch = ''

--- a/pkgs/by-name/gn/gnome-font-viewer/package.nix
+++ b/pkgs/by-name/gn/gnome-font-viewer/package.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-font-viewer";
-  version = "47.0";
+  version = "48.alpha.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-font-viewer/${lib.versions.major version}/gnome-font-viewer-${version}.tar.xz";
-    hash = "sha256-uOWgQuCyQbDHyuQ/dNoNX4jmQjAXqR/rhudhfttAgO0=";
+    hash = "sha256-j1ylIT8EOTKWz9zyHuu6FcpiLwLBGV3Mzby7lLReTxk=";
   };
 
   doCheck = true;

--- a/pkgs/by-name/gn/gnome-font-viewer/package.nix
+++ b/pkgs/by-name/gn/gnome-font-viewer/package.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-font-viewer";
-  version = "48.alpha.1";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-font-viewer/${lib.versions.major version}/gnome-font-viewer-${version}.tar.xz";
-    hash = "sha256-j1ylIT8EOTKWz9zyHuu6FcpiLwLBGV3Mzby7lLReTxk=";
+    hash = "sha256-cyYkIxtiT/XHrAOoznG+Ejk9qlNVHRFVCyDXsKOocqc=";
   };
 
   doCheck = true;

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-initial-setup";
-  version = "47.4";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-initial-setup/${lib.versions.major finalAttrs.version}/gnome-initial-setup-${finalAttrs.version}.tar.xz";
-    hash = "sha256-LAKZ3CtxaBGCNZUNWJijUclMuduP2AjarV1uS6lbh7g=";
+    hash = "sha256-DtQisaDPdijVBwNkst0UtJ16oOBY6D1Hysl2pkTbsuY=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-initial-setup";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-initial-setup/${lib.versions.major finalAttrs.version}/gnome-initial-setup-${finalAttrs.version}.tar.xz";
-    hash = "sha256-DtQisaDPdijVBwNkst0UtJ16oOBY6D1Hysl2pkTbsuY=";
+    hash = "sha256-erMN3erL44WWj/DYW0Cfkob7dFGTMJ/Ks2vlJ5gUFYk=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -37,11 +37,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-initial-setup";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-initial-setup/${lib.versions.major finalAttrs.version}/gnome-initial-setup-${finalAttrs.version}.tar.xz";
-    hash = "sha256-erMN3erL44WWj/DYW0Cfkob7dFGTMJ/Ks2vlJ5gUFYk=";
+    hash = "sha256-s9q/fnm2Zf8SJB+9umFUiVE9iGIkdZmGr49IZXWSMV4=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-keyring/package.nix
+++ b/pkgs/by-name/gn/gnome-keyring/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchurl,
   pkg-config,
+  meson,
+  ninja,
   dbus,
   libgcrypt,
   pam,
@@ -15,16 +17,17 @@
   libselinux,
   p11-kit,
   openssh,
-  wrapGAppsHook3,
+  wrapGAppsNoGuiHook,
   docbook-xsl-nons,
   docbook_xml_dtd_43,
   gnome,
+  writeText,
   useWrappedDaemon ? true,
 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-keyring";
-  version = "46.2";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -33,16 +36,18 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-keyring/${lib.versions.major version}/gnome-keyring-${version}.tar.xz";
-    hash = "sha256-vybJZriot/MoXsyLs+RnucIPlTW5TcRRycVZ3c/2GSU=";
+    hash = "sha256-JGNWvtqRLlTvaxJPSptZZGmlyrr5qWHhGZYVYGBX0Fg=";
   };
 
   nativeBuildInputs = [
     pkg-config
+    meson
+    ninja
     gettext
     libxslt
     docbook-xsl-nons
     docbook_xml_dtd_43
-    wrapGAppsHook3
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [
@@ -61,32 +66,37 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  configureFlags = [
-    "--with-pkcs11-config=${placeholder "out"}/etc/pkcs11/" # installation directories
-    "--with-pkcs11-modules=${placeholder "out"}/lib/pkcs11/"
+  mesonFlags = [
+    # installation directories
+    "-Dpkcs11-config=${placeholder "out"}/etc/pkcs11" # todo: this should probably be /share/p11-kit/modules
+    "-Dpkcs11-modules=${placeholder "out"}/lib/pkcs11"
     # gnome-keyring doesn't build with ssh-agent by default anymore, we need to
     # switch to using gcr https://github.com/NixOS/nixpkgs/issues/140824
-    "--enable-ssh-agent"
-    # cross compilation requires these paths to be explicitly declared:
-    "LIBGCRYPT_CONFIG=${lib.getExe' (lib.getDev libgcrypt) "libgcrypt-config"}"
-    "SSH_ADD=${lib.getExe' openssh "ssh-add"}"
-    "SSH_AGENT=${lib.getExe' openssh "ssh-agent"}"
+    "-Dssh-agent=true"
+    # TODO: enable socket activation
+    "-Dsystemd=disabled"
+    "--cross-file=${writeText "crossfile.ini" ''
+      [binaries]
+      ssh-add = '${lib.getExe' openssh "ssh-add"}'
+      ssh-agent = '${lib.getExe' openssh "ssh-agent"}'
+    ''}"
   ];
 
   # Tends to fail non-deterministically.
   # - https://github.com/NixOS/nixpkgs/issues/55293
   # - https://github.com/NixOS/nixpkgs/issues/51121
+  # - At least “gnome-keyring:gkm::xdg-store / xdg-trust” is still flaky on 48.beta.
   doCheck = false;
 
-  postPatch = ''
-    patchShebangs build
-  '';
-
   checkPhase = ''
+    runHook postCheck
+
     export HOME=$(mktemp -d)
     dbus-run-session \
       --config-file=${dbus}/share/dbus-1/session.conf \
-      make check
+      meson test --print-errorlogs
+
+    runHook preCheck
   '';
 
   # Use wrapped gnome-keyring-daemon with cap_ipc_lock=ep
@@ -109,7 +119,12 @@ stdenv.mkDerivation rec {
     description = "Collection of components in GNOME that store secrets, passwords, keys, certificates and make them available to applications";
     homepage = "https://gitlab.gnome.org/GNOME/gnome-keyring";
     changelog = "https://gitlab.gnome.org/GNOME/gnome-keyring/-/blob/${version}/NEWS?ref_type=tags";
-    license = licenses.gpl2;
+    license = [
+      # Most of the code (some is 2Plus)
+      licenses.lgpl21Plus
+      # Some stragglers
+      licenses.gpl2Plus
+    ];
     teams = [ teams.gnome ];
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/gn/gnome-keyring/package.nix
+++ b/pkgs/by-name/gn/gnome-keyring/package.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-keyring";
-  version = "48.beta";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-keyring/${lib.versions.major version}/gnome-keyring-${version}.tar.xz";
-    hash = "sha256-JGNWvtqRLlTvaxJPSptZZGmlyrr5qWHhGZYVYGBX0Fg=";
+    hash = "sha256-8gUYySDp6j+cm4tEvoxQ2Nf+7NDdViSWD3e9LKT7650=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-mahjongg/package.nix
+++ b/pkgs/by-name/gn/gnome-mahjongg/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mahjongg";
-  version = "47.2";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${lib.versions.major finalAttrs.version}/gnome-mahjongg-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Nd+SZBnzeCY4CjNGIHVjzYfH6ZoT3r4Ok6FAnYXMYVc=";
+    hash = "sha256-ibe/56wPRxiJm+ItVNuYhABIK9tUsIWZ+uhVkFgDfAc=";
   };
 
   nativeBuildInputs = [
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Disassemble a pile of tiles by removing matching pairs";
     mainProgram = "gnome-mahjongg";
     teams = [ teams.gnome ];
-    license = licenses.gpl3Plus;
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/gn/gnome-mahjongg/package.nix
+++ b/pkgs/by-name/gn/gnome-mahjongg/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mahjongg";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${lib.versions.major finalAttrs.version}/gnome-mahjongg-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ibe/56wPRxiJm+ItVNuYhABIK9tUsIWZ+uhVkFgDfAc=";
+    hash = "sha256-rrFvTJQL22pnDH2azdUN0OwgsyG9cHWphYkfu+vNT+0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-mahjongg/package.nix
+++ b/pkgs/by-name/gn/gnome-mahjongg/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mahjongg";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${lib.versions.major finalAttrs.version}/gnome-mahjongg-${finalAttrs.version}.tar.xz";
-    hash = "sha256-rrFvTJQL22pnDH2azdUN0OwgsyG9cHWphYkfu+vNT+0=";
+    hash = "sha256-3Ujg+BrKNL6tpGxdIhsyWRuO2B6dNhw6JY359rIiLIQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "47.4";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-GMXicPtSLP08AD7AEJPgZesvK40bJ4Dfwnngv3dzXgs=";
+    hash = "sha256-RLkRCf9CbitGizYy7UdCBhbNzuVeVdU/OTw2i/zUsnQ=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "48.1";
+  version = "48.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qyJkp2+FRY7gskOYSvoisKpRbtRottZTlZQcN4bYLps=";
+    hash = "sha256-rW3WEmiF+xaG7kv0mnh6clfHzF93nlQTQVWmgKMKjLk=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "48.rc";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RLkRCf9CbitGizYy7UdCBhbNzuVeVdU/OTw2i/zUsnQ=";
+    hash = "sha256-qyJkp2+FRY7gskOYSvoisKpRbtRottZTlZQcN4bYLps=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-mines/package.nix
+++ b/pkgs/by-name/gn/gnome-mines/package.nix
@@ -7,26 +7,25 @@
   vala,
   pkg-config,
   gnome,
-  adwaita-icon-theme,
-  gtk3,
-  wrapGAppsHook3,
+  gtk4,
+  libadwaita,
+  wrapGAppsHook4,
   librsvg,
   gettext,
   itstool,
-  python3,
   libxml2,
-  libgnome-games-support,
+  libgnome-games-support_2_0,
   libgee,
   desktop-file-utils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mines";
-  version = "40.1";
+  version = "48.alpha.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-mines/${lib.versions.major version}/gnome-mines-${version}.tar.xz";
-    hash = "sha256-NQLps/ccs7LnEcDmAZGH/rzCvKh349RW3KtwD3vjEnI=";
+    url = "mirror://gnome/sources/gnome-mines/${lib.versions.major finalAttrs.version}/gnome-mines-${finalAttrs.version}.tar.xz";
+    hash = "sha256-ABxs04IprPiNN3irQI/9sRkRoWk7cfV0WcFsbFsK1UM=";
   };
 
   nativeBuildInputs = [
@@ -36,27 +35,23 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     itstool
-    python3
     libxml2
-    wrapGAppsHook3
+    wrapGAppsHook4
     desktop-file-utils
   ];
 
   buildInputs = [
-    gtk3
+    gtk4
+    libadwaita
+    libgnome-games-support_2_0
     librsvg
-    adwaita-icon-theme
-    libgnome-games-support
     libgee
   ];
 
-  postPatch = ''
-    chmod +x build-aux/meson_post_install.py
-    patchShebangs build-aux/meson_post_install.py
-  '';
-
   passthru = {
-    updateScript = gnome.updateScript { packageName = "gnome-mines"; };
+    updateScript = gnome.updateScript {
+      packageName = "gnome-mines";
+    };
   };
 
   meta = with lib; {
@@ -67,4 +62,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/gn/gnome-mines/package.nix
+++ b/pkgs/by-name/gn/gnome-mines/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mines";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mines/${lib.versions.major finalAttrs.version}/gnome-mines-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7AgaFTKmSxKSDxdX1VKR94nNHEcBwZk1cMqln72jFoA=";
+    hash = "sha256-70stLd477GFBV+3eTZGJzGr+aSlSot1VsocOLmLtgQQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-mines/package.nix
+++ b/pkgs/by-name/gn/gnome-mines/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-mines";
-  version = "48.alpha.2";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mines/${lib.versions.major finalAttrs.version}/gnome-mines-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ABxs04IprPiNN3irQI/9sRkRoWk7cfV0WcFsbFsK1UM=";
+    hash = "sha256-7AgaFTKmSxKSDxdX1VKR94nNHEcBwZk1cMqln72jFoA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-music/package.nix
+++ b/pkgs/by-name/gn/gnome-music/package.nix
@@ -31,13 +31,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "47.1";
+  version = "48.beta";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-music/${lib.versions.major version}/gnome-music-${version}.tar.xz";
-    hash = "sha256-Zm8XX1YKGtnLq2HqDzA5PKL+0pRrpG5cAOrqEX28cNA=";
+    hash = "sha256-qIw01hGwr0zg2LFAvTPfhowpTSMYMQxTZJN9QwgmJOw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-music/package.nix
+++ b/pkgs/by-name/gn/gnome-music/package.nix
@@ -31,13 +31,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "48.beta";
+  version = "48.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-music/${lib.versions.major version}/gnome-music-${version}.tar.xz";
-    hash = "sha256-qIw01hGwr0zg2LFAvTPfhowpTSMYMQxTZJN9QwgmJOw=";
+    hash = "sha256-jNqs0FJitjuxYIolrK1RboksMyIyNXy5t/aPLPuG1m4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-nibbles/package.nix
+++ b/pkgs/by-name/gn/gnome-nibbles/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-nibbles";
-  version = "4.2.rc6";
+  version = "4.2.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-nibbles/${lib.versions.majorMinor finalAttrs.version}/gnome-nibbles-${finalAttrs.version}.tar.xz";
-    hash = "sha256-CfDIsjToOBxgJGXAMLDMoNoL1ylQEaFPo5dS37lh4B4=";
+    hash = "sha256-Umws/AsigNry9Upi5YFmVvrD3WBinQfBygbYKm1SRKE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-nibbles/package.nix
+++ b/pkgs/by-name/gn/gnome-nibbles/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   pkg-config,
   gnome,
+  gsound,
   gtk4,
   wrapGAppsHook4,
   librsvg,
@@ -21,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-nibbles";
-  version = "4.2.0";
+  version = "4.2.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-nibbles/${lib.versions.majorMinor finalAttrs.version}/gnome-nibbles-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Umws/AsigNry9Upi5YFmVvrD3WBinQfBygbYKm1SRKE=";
+    hash = "sha256-Pkofm68cV7joNd7fCGnjJy5lNKHdacTib64QxCAKrwA=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    gsound
     gtk4
     librsvg
     libadwaita

--- a/pkgs/by-name/gn/gnome-nibbles/package.nix
+++ b/pkgs/by-name/gn/gnome-nibbles/package.nix
@@ -7,7 +7,6 @@
   gtk4,
   wrapGAppsHook4,
   librsvg,
-  gsound,
   gettext,
   itstool,
   vala,
@@ -22,11 +21,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-nibbles";
-  version = "4.1.0";
+  version = "4.2.rc6";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-nibbles/${lib.versions.majorMinor finalAttrs.version}/gnome-nibbles-${finalAttrs.version}.tar.xz";
-    hash = "sha256-YyQb2KFfWRgKYYEgQeLo85hiJn3J5lLz0XNULFUNkpI=";
+    hash = "sha256-CfDIsjToOBxgJGXAMLDMoNoL1ylQEaFPo5dS37lh4B4=";
   };
 
   nativeBuildInputs = [
@@ -44,11 +43,17 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtk4
     librsvg
-    gsound
     libadwaita
     libgee
     libgnome-games-support_2_0
   ];
+
+  # The "we can link with libadwaita?" valac.links() check fails otherwise.
+  # Command line: `valac testfile.vala --pkg=libadwaita-1 --Xcc=-w --Xcc=-DVALA_STRICT_C` -> 1
+  # testfile.vala.c:50:46: error: passing argument 2 of 'adw_about_dialog_set_developers'
+  # from incompatible pointer type [-Wincompatible-pointer-types]
+  # 50 |         adw_about_dialog_set_developers (ad, s);
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
   passthru = {
     updateScript = gnome.updateScript { packageName = "gnome-nibbles"; };

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.52.3.1";
+  version = "3.53.2";
 
   outputs =
     [
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Se1yfW/ElHSZb6ft8JGbIeT8hW6jfm4w8XtQsQOvlwE=";
+    hash = "sha256-QNWo1yErqc9R52F8XGvvAEUD42wL9o+a0I6bsnMaFhY=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.53.2";
+  version = "3.54.1";
 
   outputs =
     [
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QNWo1yErqc9R52F8XGvvAEUD42wL9o+a0I6bsnMaFhY=";
+    hash = "sha256-nQWLOqyLLYtrKufLV8ioq+U55zyIIgwxW1uZ+Hzm79g=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts";
-  version = "3.54.1";
+  version = "3.54.2";
 
   outputs =
     [
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-online-accounts/${lib.versions.majorMinor finalAttrs.version}/gnome-online-accounts-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nQWLOqyLLYtrKufLV8ioq+U55zyIIgwxW1uZ+Hzm79g=";
+    hash = "sha256-D389KcBmb/vMUD8+DzOWNi7/25MX1BZkzmXfFH7zU3I=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/gn/gnome-panel/package.nix
+++ b/pkgs/by-name/gn/gnome-panel/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-panel";
-  version = "3.54.0";
+  version = "3.56.0";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-panel/${lib.versions.majorMinor finalAttrs.version}/gnome-panel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-lLnNUcpQ/zKiic1QWRNuexYMHxJrXWZp4QbcqIUEXCg=";
+    hash = "sha256-UoptZ92E7a5sgKXuZW+E+9lC87Nx1g+XottgZc9P0XA=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -13,6 +13,9 @@
   libei,
   libepoxy,
   libdrm,
+  libva,
+  vulkan-loader,
+  shaderc,
   nv-codec-headers-11,
   pipewire,
   systemd,
@@ -31,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "47.3";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-QE2wiHLmkDlD4nUam2Myf2NZcKnKodL2dTCcpEV8+cI=";
+    hash = "sha256-R/DZ7FjlfVc3eus+ndh9iLWmVZSKAiXjVFcP9Mylkio=";
   };
 
   nativeBuildInputs = [
@@ -44,6 +47,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
     asciidoc
+    shaderc # for glslc
     wrapGAppsHook3
   ];
 
@@ -58,6 +62,8 @@ stdenv.mkDerivation rec {
     libei
     libepoxy
     libdrm
+    libva
+    vulkan-loader
     nv-codec-headers-11
     libnotify
     libopus

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-R/DZ7FjlfVc3eus+ndh9iLWmVZSKAiXjVFcP9Mylkio=";
+    hash = "sha256-A4xC5I/h2JCEm+xdVnVmwVK9bX9GPq3uxZsero+7MqA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-remote-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-remote-desktop/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-remote-desktop/${lib.versions.major version}/gnome-remote-desktop-${version}.tar.xz";
-    hash = "sha256-A4xC5I/h2JCEm+xdVnVmwVK9bX9GPq3uxZsero+7MqA=";
+    hash = "sha256-vPN3D8oPrtovrjsaP/by6QoCd492pC6P0QPK4YYo9PI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-robots/package.nix
+++ b/pkgs/by-name/gn/gnome-robots/package.nix
@@ -24,17 +24,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-robots";
-  version = "41.1";
+  version = "41.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-robots/${lib.versions.major finalAttrs.version}/gnome-robots-${finalAttrs.version}.tar.xz";
-    hash = "sha256-K4BQcFrIPpOL56iREyYB62XHk/IJzX6RDGzWQphzBHg=";
+    hash = "sha256-kSHC+DaBIEP+7yumYc1dD9SOPWMZxDlBuf3RWLmw65E=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "gnome-robots-${finalAttrs.version}";
-    hash = "sha256-7kwjpZJqAqqKlt6mOFyjaaxZ1Tr2WuhE72jwjCZpX9E=";
+    hash = "sha256-1h9+XPmkapzdYsI6qtPPHtlwEEmyIzaAogLiYvIHJak=";
   };
 
   nativeBuildInputs = [
@@ -62,12 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
   ];
 
-  postPatch = ''
-    # https://gitlab.gnome.org/GNOME/gnome-robots/-/merge_requests/38
-    substituteInPlace data/icons/meson.build \
-      --replace-fail 'gtk-update-icon-cache' 'gtk4-update-icon-cache'
-  '';
-
   preFixup = ''
     # Seal GStreamer plug-ins so that we can notice when they are missing.
     gappsWrapperArgs+=(--set "GST_PLUGIN_SYSTEM_PATH_1_0" "$GST_PLUGIN_SYSTEM_PATH_1_0")
@@ -91,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
                   common-updater-scripts
                 ]
               }
-              update-source-version gnome-robots --ignore-same-version --source-key=cargoDeps > /dev/null
+              update-source-version gnome-robots --ignore-same-version --source-key=cargoDeps.vendorStaging > /dev/null
             ''
           ];
           # Experimental feature: do not copy!

--- a/pkgs/by-name/gn/gnome-session/fix-paths.patch
+++ b/pkgs/by-name/gn/gnome-session/fix-paths.patch
@@ -6,10 +6,10 @@ index b4b1f8fa..99d52cba 100755
     [ "x$XDG_SESSION_CLASS" != "xgreeter" ] &&
     [  -n "$SHELL" ]; then
    if [ "$1" != '-l' ]; then
--    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
+-    exec bash -c "exec -l '$SHELL' -c 'exec $0 -l $*'"
 +    # Make sure the shell actually sets up the environment.
 +    unset __NIXOS_SET_ENVIRONMENT_DONE
-+    exec @bash@ -c "exec -l '$SHELL' -c '$0 -l $*'"
++    exec @bash@ -c "exec -l '$SHELL' -c 'exec $0 -l $*'"
    else
      shift
    fi

--- a/pkgs/by-name/gn/gnome-session/package.nix
+++ b/pkgs/by-name/gn/gnome-session/package.nix
@@ -34,7 +34,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-session";
   # Also bump ./ctl.nix when bumping major version.
-  version = "47.0.1";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-session/${lib.versions.major finalAttrs.version}/gnome-session-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Vq6caOSZlXk+sglrzcRTOxEWaeHlTItuCx2VL2peinA=";
+    hash = "sha256-3ZCfvFsizb2y/E3xpH140bWUPMxeYeaiChhGJGNHxBc=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "47.2";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-HrdYhi6Ij1WghpGTCH8c+8x6EWNlTmMAmf9DQt0/alo=";
+    hash = "sha256-2n8M42iKyfG4k+OboKQ6IkjnCO4hD4Q+ML8KnYQ5pd0=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2n8M42iKyfG4k+OboKQ6IkjnCO4hD4Q+ML8KnYQ5pd0=";
+    hash = "sha256-89ogq0orpW/T6XuZHyvCZ5c9Vhm9WL+lFkEKoDYwXkU=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-settings-daemon";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-settings-daemon/${lib.versions.major finalAttrs.version}/gnome-settings-daemon-${finalAttrs.version}.tar.xz";
-    hash = "sha256-89ogq0orpW/T6XuZHyvCZ5c9Vhm9WL+lFkEKoDYwXkU=";
+    hash = "sha256-OGCi6iFNy8tmAK56HjNYpTiSFQh7w+SkfO4/h7ruBi4=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "47.4";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-VDN57FsNBCAO5iofa6JAcWoJ11rQrd3bIFvjjOgpP1g=";
+    hash = "sha256-XMVlp5VA4vs7qwQXCOy+8oyDMZ3lQ4j12r6dfDV4jGI=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Ht5XDUO2Hiih8Or3Ryy1zvPlIlXE5D/mRpWy7e0rl6I=";
+    hash = "sha256-8wG15zVNWtwByLsheTgQB04epAjeRTAPdn0QRFTbPjM=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-8wG15zVNWtwByLsheTgQB04epAjeRTAPdn0QRFTbPjM=";
+    hash = "sha256-m2f8LFgC2hcTp3sZ/6BCMY3XHnva6EN3lsX1GXlTOTw=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extensions";
-  version = "48.beta";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${lib.versions.major finalAttrs.version}/gnome-shell-extensions-${finalAttrs.version}.tar.xz";
-    hash = "sha256-XMVlp5VA4vs7qwQXCOy+8oyDMZ3lQ4j12r6dfDV4jGI=";
+    hash = "sha256-Ht5XDUO2Hiih8Or3Ryy1zvPlIlXE5D/mRpWy7e0rl6I=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/fix-paths.patch
+++ b/pkgs/by-name/gn/gnome-shell/fix-paths.patch
@@ -10,10 +10,10 @@ index de91167c5..1c9965678 100644
 +ExecStart=@gsettings@ set org.gnome.shell disable-user-extensions true
  Restart=no
 diff --git a/js/ui/extensionDownloader.js b/js/ui/extensionDownloader.js
-index 197cc1c1c..dd74aa167 100644
+index 53fd92846..89533cedc 100644
 --- a/js/ui/extensionDownloader.js
 +++ b/js/ui/extensionDownloader.js
-@@ -110,7 +110,7 @@ async function extractExtensionArchive(bytes, dir) {
+@@ -124,7 +124,7 @@ async function extractExtensionArchive(bytes, dir) {
      stream.close_async(GLib.PRIORITY_DEFAULT, null);
  
      const unzip = Gio.Subprocess.new(
@@ -22,7 +22,7 @@ index 197cc1c1c..dd74aa167 100644
          Gio.SubprocessFlags.NONE);
      await unzip.wait_check_async(null);
  
-@@ -132,7 +132,7 @@ async function extractExtensionArchive(bytes, dir) {
+@@ -146,7 +146,7 @@ async function extractExtensionArchive(bytes, dir) {
      }
  
      const compileSchema = Gio.Subprocess.new(
@@ -32,15 +32,15 @@ index 197cc1c1c..dd74aa167 100644
  
      try {
 diff --git a/js/ui/status/keyboard.js b/js/ui/status/keyboard.js
-index fff4e73c2..92859b099 100644
+index 1b43e1051..a31b0a304 100644
 --- a/js/ui/status/keyboard.js
 +++ b/js/ui/status/keyboard.js
-@@ -1092,6 +1092,6 @@ class InputSourceIndicator extends PanelMenu.Button {
-         if (xkbVariant.length > 0)
-             description = `${description}\t${xkbVariant}`;
+@@ -1104,6 +1104,6 @@ class InputSourceIndicator extends PanelMenu.Button {
+     _showLayout() {
+         Main.overview.hide();
  
--        Util.spawn(['tecla', description]);
-+        Util.spawn(['@tecla@', description]);
+-        Util.spawn(['tecla']);
++        Util.spawn(['@tecla@']);
      }
  });
 diff --git a/subprojects/extensions-tool/src/command-install.c b/subprojects/extensions-tool/src/command-install.c

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -69,7 +69,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "47.4";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-aAuvaU9F+PyDLSRa2mxjtfxLAwzPvrv8Dg47wo2i5G0=";
+    hash = "sha256-4MK+4aFnTGIoR/NTyuWew2v7Ei0sEXg0r/EgRF18Wys=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -69,7 +69,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "48.beta";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-4MK+4aFnTGIoR/NTyuWew2v7Ei0sEXg0r/EgRF18Wys=";
+    hash = "sha256-3Vscc9RggZymg6quDK8fEmu9VfYavIctRMim/NW1m8c=";
   };
 
   patches = [
@@ -183,7 +183,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    patchShebangs src/data-to-c.py
+    patchShebangs \
+      src/data-to-c.py \
+      meson/generate-app-list.py
 
     # We can generate it ourselves.
     rm -f man/gnome-shell.1

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -69,7 +69,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "48.0";
+  version = "48.1";
 
   outputs = [
     "out"
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NqrC7c3HWIqq22WM1Gh98mKze6C2ZxAty++/8MIjK8M=";
+    hash = "sha256-uk9FWv1iE/OHVFlG482dqjnJBPerFt2DCsd6c/8QAso=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -69,7 +69,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-3Vscc9RggZymg6quDK8fEmu9VfYavIctRMim/NW1m8c=";
+    hash = "sha256-NqrC7c3HWIqq22WM1Gh98mKze6C2ZxAty++/8MIjK8M=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-software/package.nix
+++ b/pkgs/by-name/gn/gnome-software/package.nix
@@ -48,11 +48,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-software";
-  version = "47.4";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major finalAttrs.version}/gnome-software-${finalAttrs.version}.tar.xz";
-    hash = "sha256-coHFS5t0jWai55LrjgMxyJec44+vrfct482ZnYDpe08=";
+    hash = "sha256-JhC1vKZQQlRnefnnASDTO19ibtz4pc5TTbtUEZvkVc8=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-software/package.nix
+++ b/pkgs/by-name/gn/gnome-software/package.nix
@@ -48,11 +48,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-software";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major finalAttrs.version}/gnome-software-${finalAttrs.version}.tar.xz";
-    hash = "sha256-JhC1vKZQQlRnefnnASDTO19ibtz4pc5TTbtUEZvkVc8=";
+    hash = "sha256-5gevVU6Dj9bQfBYx9jSyDovU5q3xb8dTXEUgh0r1RPc=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-software/package.nix
+++ b/pkgs/by-name/gn/gnome-software/package.nix
@@ -48,11 +48,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-software";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major finalAttrs.version}/gnome-software-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5gevVU6Dj9bQfBYx9jSyDovU5q3xb8dTXEUgh0r1RPc=";
+    hash = "sha256-CEqYUEApTDZFS0ZKIUT5gcAnSQa0xJ1xYT5hztapbo8=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -10,6 +10,7 @@
   gettext,
   gtk4,
   gnome,
+  blueprint-compiler,
   wrapGAppsHook4,
   libadwaita,
   libgee,
@@ -22,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "47.1.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-RyW0KDZGaysqzF5RZrU9jrEczd4lh9tofK+MjUc+uIk=";
+    hash = "sha256-QaA0Pipdm9Jc5rYfeJId8MqajjLi9VXgbxwBk8C1Ga8=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
     itstool
     libxml2
     desktop-file-utils
+    blueprint-compiler
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-QaA0Pipdm9Jc5rYfeJId8MqajjLi9VXgbxwBk8C1Ga8=";
+    hash = "sha256-mMOSADDdDCQB+JDIcdY0X6PBA/cGnY5YPaukNVi7QLY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-mMOSADDdDCQB+JDIcdY0X6PBA/cGnY5YPaukNVi7QLY=";
+    hash = "sha256-eXE62CpZkEzWlv8CJV627ZNk6I8+eDNDsfnQygnyx+M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-system-monitor/package.nix
+++ b/pkgs/by-name/gn/gnome-system-monitor/package.nix
@@ -7,6 +7,7 @@
   gtkmm4,
   libxml2,
   bash,
+  catch2_3,
   gtk4,
   libadwaita,
   glib,
@@ -25,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-system-monitor";
-  version = "47.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major finalAttrs.version}/gnome-system-monitor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-08VxT9kfp/BdZ3XmeXzNqzFJ8THRqndqM1LirdsRDwE=";
+    hash = "sha256-hm3Sxydjf2dTcF0WpW/GZ6sqakgJ8X75N0UuHFRURMs=";
   };
 
   patches = [
@@ -49,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     bash
+    catch2_3
     gtk4
     libadwaita
     glib

--- a/pkgs/by-name/gn/gnome-system-monitor/package.nix
+++ b/pkgs/by-name/gn/gnome-system-monitor/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-system-monitor";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major finalAttrs.version}/gnome-system-monitor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-hm3Sxydjf2dTcF0WpW/GZ6sqakgJ8X75N0UuHFRURMs=";
+    hash = "sha256-5OWzRfvU19wvQK1sYjBa5cfMK0Zc6VmIaSpUrzR1MqM=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-system-monitor/package.nix
+++ b/pkgs/by-name/gn/gnome-system-monitor/package.nix
@@ -26,11 +26,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-system-monitor";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-system-monitor/${lib.versions.major finalAttrs.version}/gnome-system-monitor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5OWzRfvU19wvQK1sYjBa5cfMK0Zc6VmIaSpUrzR1MqM=";
+    hash = "sha256-Ezw6bihjZuZZ/S2AWCQJp71e2uRW5jxPacz2btb8Zjg=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-tecla/package.nix
+++ b/pkgs/by-name/gn/gnome-tecla/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tecla";
-  version = "47.0";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tecla/${lib.versions.major finalAttrs.version}/tecla-${finalAttrs.version}.tar.xz";
-    hash = "sha256-B5C5nsKRN6VLVGxRBmGpmqbwOcjXXxDAjpKGgsCAT+U=";
+    hash = "sha256-Y/sHWmfGQzv/D5JfgmbGvflLVgaYjpEI9Rnf2NykKN8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-tecla/package.nix
+++ b/pkgs/by-name/gn/gnome-tecla/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tecla";
-  version = "48.rc";
+  version = "48.0.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tecla/${lib.versions.major finalAttrs.version}/tecla-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Y/sHWmfGQzv/D5JfgmbGvflLVgaYjpEI9Rnf2NykKN8=";
+    hash = "sha256-eD00ZNKiz36xUHZJ29n/Cc4khSwqbJoNNl24QGPT1AE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-terminal/package.nix
+++ b/pkgs/by-name/gn/gnome-terminal/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-terminal";
-  version = "3.54.4";
+  version = "3.55.91";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${lib.versions.majorMinor finalAttrs.version}/gnome-terminal-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RDqAaJM3EI5LGQOZlp5mq6BBzDxju5nFc4Ul1SixMrg=";
+    hash = "sha256-Y4lxh6VYZLnW7fMZ74RFQRYlx1BeWJBsololmtOeFeY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-terminal/package.nix
+++ b/pkgs/by-name/gn/gnome-terminal/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-terminal";
-  version = "3.55.91";
+  version = "3.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${lib.versions.majorMinor finalAttrs.version}/gnome-terminal-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Y4lxh6VYZLnW7fMZ74RFQRYlx1BeWJBsololmtOeFeY=";
+    hash = "sha256-2yDfVfbYTGbn73Apj7rVl+rtb6iLgqegXSY8yQgR/oE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-terminal/package.nix
+++ b/pkgs/by-name/gn/gnome-terminal/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-terminal";
-  version = "3.56.0";
+  version = "3.56.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${lib.versions.majorMinor finalAttrs.version}/gnome-terminal-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2yDfVfbYTGbn73Apj7rVl+rtb6iLgqegXSY8yQgR/oE=";
+    hash = "sha256-ojB1PlC9Qx27EwDhV7/XMXMA4lIm/zCJMxY2OhOGT/g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-text-editor/package.nix
+++ b/pkgs/by-name/gn/gnome-text-editor/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-text-editor";
-  version = "47.3";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-text-editor/${lib.versions.major finalAttrs.version}/gnome-text-editor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-RsZyv+huRN6YB5djaigPBcxer2zem0LcS8yVZAVilyU=";
+    hash = "sha256-YgYQKMfxowTQq3pOWurgTvtnVpYrDOqiHzTHR4RwOSQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-text-editor/package.nix
+++ b/pkgs/by-name/gn/gnome-text-editor/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-text-editor";
-  version = "48.rc";
+  version = "48.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-text-editor/${lib.versions.major finalAttrs.version}/gnome-text-editor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-YgYQKMfxowTQq3pOWurgTvtnVpYrDOqiHzTHR4RwOSQ=";
+    hash = "sha256-/B9dR1vdJ9TAQ5pbj+ENbkAbQvHbo9BLdWeDkDbuICs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-tour/package.nix
+++ b/pkgs/by-name/gn/gnome-tour/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-tour";
-  version = "47.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-tour/${lib.versions.major finalAttrs.version}/gnome-tour-${finalAttrs.version}.tar.xz";
-    hash = "sha256-cvqvieAGyJMkp+FXIEaRaWGziuujj21tTMQePT1GaUQ=";
+    hash = "sha256-uKA7JXTrlWq+mvFBQWHMsX+DDVNgC5wEmc7zu29BJ8U=";
   };
 
   cargoVendorDir = "vendor";

--- a/pkgs/by-name/gn/gnome-usage/package.nix
+++ b/pkgs/by-name/gn/gnome-usage/package.nix
@@ -12,20 +12,22 @@
   wrapGAppsHook4,
   glib,
   gtk4,
+  json-glib,
   libadwaita,
   libgee,
   libgtop,
+  networkmanager,
   gnome,
   tinysparql,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-usage";
-  version = "46.0";
+  version = "48.rc";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-GGrajgAYjIn4yrVPNZmO2XpG6rb9shiRAoNhvzhqybI=";
+    url = "mirror://gnome/sources/gnome-usage/${lib.versions.major finalAttrs.version}/gnome-usage-${finalAttrs.version}.tar.xz";
+    hash = "sha256-LUbc2QcKkY/sMUdxaaQDI2CdCFa5XHo3wBusqULTk+w=";
   };
 
   nativeBuildInputs = [
@@ -42,9 +44,11 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk4
+    json-glib
     libadwaita
     libgee
     libgtop
+    networkmanager
     tinysparql
   ];
 
@@ -55,7 +59,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gnome-usage";
     };
   };
 
@@ -67,4 +71,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     teams = [ teams.gnome ];
   };
-}
+})

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "47.2";
+  version = "47.5";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-2b8IuabChNHgT2/pI3pt7trRYeDlungQv/7PKF4rzd8=";
+    hash = "sha256-cnzTDYCoAUEr5Ahb/tyHD5YqSf0FfZBMbUJTS64fITM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-user-docs";
-  version = "47.5";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-cnzTDYCoAUEr5Ahb/tyHD5YqSf0FfZBMbUJTS64fITM=";
+    hash = "sha256-rJc9kk4AVFoUWNhqEQ1Hc+a743w3KEDXbtZAyyaMYf0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-share/package.nix
+++ b/pkgs/by-name/gn/gnome-user-share/package.nix
@@ -26,11 +26,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-share";
-  version = "48.alpha.1";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-share/${lib.versions.major finalAttrs.version}/gnome-user-share-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Rh05jFVo3G9iAzmhAX/fZYPFwN4Dsk8BNic8q4hLtnQ=";
+    hash = "sha256-tVgFBwGVwvZYQVuc0shbLNFOqYHWGCOlANTWK4v4OAE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/by-name/gn/gnome-user-share/package.nix
+++ b/pkgs/by-name/gn/gnome-user-share/package.nix
@@ -5,15 +5,19 @@
   gettext,
   meson,
   ninja,
+  rustc,
+  rustPlatform,
+  cargo,
   fetchurl,
   apacheHttpdPackages,
   pkg-config,
   glib,
   libxml2,
-  systemd,
   wrapGAppsNoGuiHook,
   itstool,
   gnome,
+  _experimental-update-script-combinators,
+  common-updater-scripts,
 }:
 
 let
@@ -22,18 +26,28 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-share";
-  version = "47.2";
+  version = "48.alpha.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-share/${lib.versions.major finalAttrs.version}/gnome-user-share-${finalAttrs.version}.tar.xz";
-    hash = "sha256-H6wbuIAN+kitnD4ZaQ9+EOZ6T5lNnLF8rh0b3/yRRLo=";
+    hash = "sha256-Rh05jFVo3G9iAzmhAX/fZYPFwN4Dsk8BNic8q4hLtnQ=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    name = "gnome-user-share-${finalAttrs.version}";
+    hash = "sha256-tQoP0yBOCesj2kwgBUoqmcVtFttwML2N+wfSULtfC4w=";
   };
 
   preConfigure =
     ''
-      sed -e 's,^LoadModule dnssd_module.\+,LoadModule dnssd_module ${mod_dnssd}/modules/mod_dnssd.so,' \
-        -e 's,''${HTTP_MODULES_PATH},${apacheHttpd}/modules,' \
-        -i data/dav_user_2.4.conf
+      substituteInPlace data/dav_user_2.4.conf \
+        --replace-fail \
+          'LoadModule dnssd_module ''${HTTP_MODULES_PATH}/mod_dnssd.so' \
+          'LoadModule dnssd_module ${mod_dnssd}/modules/mod_dnssd.so' \
+        --replace-fail \
+          '${"$"}{HTTP_MODULES_PATH}' \
+          '${apacheHttpd}/modules'
     ''
     + lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       substituteInPlace meson.build --replace-fail \
@@ -51,6 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     meson
     ninja
+    rustc
+    rustPlatform.cargoSetupHook
+    cargo
     gettext
     glib # for glib-compile-schemas
     itstool
@@ -60,16 +77,39 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glib
-    systemd
   ];
 
   doCheck = true;
   strictDeps = true;
 
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = "gnome-user-share";
-    };
+    updateScript =
+      let
+        updateSource = gnome.updateScript {
+          packageName = "gnome-user-share";
+        };
+
+        updateLockfile = {
+          command = [
+            "sh"
+            "-c"
+            ''
+              PATH=${
+                lib.makeBinPath [
+                  common-updater-scripts
+                ]
+              }
+              update-source-version gnome-user-share --ignore-same-version --source-key=cargoDeps.vendorStaging > /dev/null
+            ''
+          ];
+          # Experimental feature: do not copy!
+          supportedFeatures = [ "silent" ];
+        };
+      in
+      _experimental-update-script-combinators.sequence [
+        updateSource
+        updateLockfile
+      ];
   };
 
   meta = with lib; {

--- a/pkgs/by-name/gn/gnome-weather/package.nix
+++ b/pkgs/by-name/gn/gnome-weather/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-weather";
-  version = "47.0";
+  version = "48.beta";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-weather/${lib.versions.major version}/gnome-weather-${version}.tar.xz";
-    hash = "sha256-UV9YYjdN00bLyFqd3wMGstMnZXhQu2C2ycmGD86WIOY=";
+    hash = "sha256-c5dUg02ID+iKjzHMmVVhJdNW1vy3y4ImEppO1oKqtdg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-weather/package.nix
+++ b/pkgs/by-name/gn/gnome-weather/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-weather";
-  version = "48.beta";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-weather/${lib.versions.major version}/gnome-weather-${version}.tar.xz";
-    hash = "sha256-c5dUg02ID+iKjzHMmVVhJdNW1vy3y4ImEppO1oKqtdg=";
+    hash = "sha256-TAVps9gVri+UFtRxNMvTBWNAZA/xhtMalMhlgTtL27U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
+++ b/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gsettings-desktop-schemas";
-  version = "47.1";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-pgIE2cnAobJk1tDRNKODQLpfxgdqNLhNqUXYv8x6KBU=";
+    hash = "sha256-LSawXZl3I/Z/O+BSYikj2DrNBMy7rwG4BmiloCSaymc=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
+++ b/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gsettings-desktop-schemas";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-LSawXZl3I/Z/O+BSYikj2DrNBMy7rwG4BmiloCSaymc=";
+    hash = "sha256-5o8VWBO/GPhlqLLI6dRzWItsytyvu2Zqt4iFfGwtG9M=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gt/gtk-frdp/package.nix
+++ b/pkgs/by-name/gt/gtk-frdp/package.nix
@@ -16,14 +16,14 @@
 
 stdenv.mkDerivation {
   pname = "gtk-frdp";
-  version = "0-unstable-2024-12-23";
+  version = "0-unstable-2025-03-14";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "gtk-frdp";
-    rev = "46ca0beb9b5bf8c9b245a596231016bcca9baf6b";
-    sha256 = "zRC3YVe2WwOmVzEDaJwsct3YQ4ZbvYTr2CTyRmfCXFY=";
+    rev = "a0187fa02e1ff249e9583e8c09a2c2f5915ce2a3";
+    hash = "sha256-oi4Iwi9/elfUDKK0IhoNgtS8ORIzVUBagqBVdNRxGjI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gu/gupnp-tools/package.nix
+++ b/pkgs/by-name/gu/gupnp-tools/package.nix
@@ -16,13 +16,13 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gupnp-tools";
-  version = "0.12.1";
+  version = "0.12.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "U8+TEj85fo+PC46eQ2TIanUCpTNPTAvi4FSoJEeL1bo=";
+    url = "mirror://gnome/sources/gupnp-tools/${lib.versions.majorMinor finalAttrs.version}/gupnp-tools-${finalAttrs.version}.tar.xz";
+    sha256 = "TJLy0aPUVOwfX7Be8IyjTfnHQ69kyLWWXDWITUbLAFw=";
   };
 
   nativeBuildInputs = [
@@ -42,13 +42,9 @@ stdenv.mkDerivation rec {
     gtksourceview4
   ];
 
-  # new libxml2 version
-  # TODO: can be dropped on next update
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
-
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gupnp-tools";
       versionPolicy = "odd-unstable";
     };
   };
@@ -60,4 +56,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/gv/gvfs/package.nix
+++ b/pkgs/by-name/gv/gvfs/package.nix
@@ -47,11 +47,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gvfs";
-  version = "1.56.1";
+  version = "1.57.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gvfs/${lib.versions.majorMinor finalAttrs.version}/gvfs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-hnMczsZ5ZI+HNOI3sd4ZDr3ubkyMD1b0VMMViOUJqhA=";
+    hash = "sha256-8Wvvjsof1sEX6F2wEdIekVZpeQ1VhnNJxfGykSmelYU=";
   };
 
   patches = [

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
-  version = "1.7.rc";
+  version = "1.7.0";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "libadwaita";
     rev = finalAttrs.version;
-    hash = "sha256-bivO4x3WdxRKfNBiviJwZq0WW+wT9Rza0BSf/zf86j8=";
+    hash = "sha256-JD0lgsG6H8RJzsyEs55f8zB1o5SqPFPY2fScpfgmUF4=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
-  version = "1.6.4";
+  version = "1.7.rc";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "libadwaita";
     rev = finalAttrs.version;
-    hash = "sha256-7AI8Eb6o/Gysli9CprwsgAzz1cGmNU79Qm7OzlsaTFw=";
+    hash = "sha256-bivO4x3WdxRKfNBiviJwZq0WW+wT9Rza0BSf/zf86j8=";
   };
 
   depsBuildBuild = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags =
     [
-      "-Dgtk_doc=true"
+      "-Ddocumentation=true"
     ]
     ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
       "-Dtests=false"

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
-  version = "1.7.0";
+  version = "1.7.2";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GNOME";
     repo = "libadwaita";
     rev = finalAttrs.version;
-    hash = "sha256-JD0lgsG6H8RJzsyEs55f8zB1o5SqPFPY2fScpfgmUF4=";
+    hash = "sha256-3QrFoUaQe2uIUTV/D4Da31o9Ee2d39/9mz1Is1/x3As=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libdex/package.nix
+++ b/pkgs/by-name/li/libdex/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdex";
-  version = "0.8.1";
+  version = "0.9.1";
 
   outputs = [
     "out"
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libdex/${lib.versions.majorMinor finalAttrs.version}/libdex-${finalAttrs.version}.tar.xz";
-    hash = "sha256-lVR1rT5Dqr1vb3BDUmS17ne9JlvZVUUhH+4CawjTeKA=";
+    hash = "sha256-0rXsZXf8PmrwPdpIuMC+FE4xuqocySJKy5VuQeF0wVs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libdex/package.nix
+++ b/pkgs/by-name/li/libdex/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdex";
-  version = "0.9.1";
+  version = "0.10.0";
 
   outputs = [
     "out"
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libdex/${lib.versions.majorMinor finalAttrs.version}/libdex-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0rXsZXf8PmrwPdpIuMC+FE4xuqocySJKy5VuQeF0wVs=";
+    hash = "sha256-mKaWJqp2Rq1FW+p6f5LSof+kfkVZoVShv+mMFvpxHuE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libgepub/package.nix
+++ b/pkgs/by-name/li/libgepub/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libgepub";
-  version = "0.7.1";
+  version = "0.7.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "o+SzGiMmWdJqVLkSGziCw9c5fDz0SuXGS4ZwCYC8f2A=";
+    sha256 = "WlZpWqipEy1nwHkqQPJSzgpI2dAytOGops6YrxT9Xhs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libmanette/package.nix
+++ b/pkgs/by-name/li/libmanette/package.nix
@@ -12,18 +12,17 @@
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
-  gtk-doc,
-  docbook-xsl-nons,
-  docbook_xml_dtd_43,
+  gi-docgen,
   glib,
   libgudev,
   libevdev,
+  hidapi,
   gnome,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libmanette";
-  version = "0.2.9";
+  version = "0.2.11";
 
   outputs = [
     "out"
@@ -31,8 +30,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional withIntrospection "devdoc";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-KTZr5UUvYKdMZfxk/+LXTt3U5uaCTCzvpWekO9kraI8=";
+    url = "mirror://gnome/sources/libmanette/${lib.versions.majorMinor finalAttrs.version}/libmanette-${finalAttrs.version}.tar.xz";
+    hash = "sha256-uBK5TghjK6YqMJYKjeKSF6c6L/9dovEqzIpdR3GkmnA=";
   };
 
   nativeBuildInputs =
@@ -45,9 +44,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withIntrospection [
       vala
       gobject-introspection
-      gtk-doc
-      docbook-xsl-nons
-      docbook_xml_dtd_43
+      gi-docgen
     ]
     ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       mesonEmulatorHook
@@ -57,6 +54,7 @@ stdenv.mkDerivation rec {
     [
       glib
       libevdev
+      hidapi
     ]
     ++ lib.optionals withIntrospection [
       libgudev
@@ -71,9 +69,14 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "libmanette";
       versionPolicy = "odd-unstable";
     };
   };
@@ -86,4 +89,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libmanette/package.nix
+++ b/pkgs/by-name/li/libmanette/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmanette";
-  version = "0.2.11";
+  version = "0.2.12";
 
   outputs = [
     "out"
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libmanette/${lib.versions.majorMinor finalAttrs.version}/libmanette-${finalAttrs.version}.tar.xz";
-    hash = "sha256-uBK5TghjK6YqMJYKjeKSF6c6L/9dovEqzIpdR3GkmnA=";
+    hash = "sha256-SLNJJnGA8dw01AWp4ekLoW8FShnOkHkw5nlJPZEeodg=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/li/libmsgraph/package.nix
+++ b/pkgs/by-name/li/libmsgraph/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmsgraph";
-  version = "0.2.3";
+  version = "0.3.3";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/msgraph/${lib.versions.majorMinor finalAttrs.version}/msgraph-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7ULoAMt/CgdHfNnj50TNwaJApq16uWuKh1gGJnqf3bA=";
+    hash = "sha256-N9fhLyqZBJCuohGE8LJ+C5Feu05QlvTWYyxiBRwFQBI=";
   };
 
   nativeBuildInputs = [
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc/msgraph-0" "$devdoc"
+    moveToOutput "share/doc/msgraph-1" "$devdoc"
   '';
 
   passthru = {

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpanel";
-  version = "1.8.1";
+  version = "1.9.0";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpanel/${lib.versions.majorMinor finalAttrs.version}/libpanel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-uHuPqbeXaMxwQkN5PwFYoECh5G03uYiRiFRaf33Kpvs=";
+    hash = "sha256-DRErGnBfJri8LbI7wg6ulF8l6ZzCrblr+gfY/qvAx2s=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpanel";
-  version = "1.9.0";
+  version = "1.10.0";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpanel/${lib.versions.majorMinor finalAttrs.version}/libpanel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-DRErGnBfJri8LbI7wg6ulF8l6ZzCrblr+gfY/qvAx2s=";
+    hash = "sha256-V4zlEieP8rte7rtVCZOSxSU3pavZvQYpVn8QJTKziyU=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   pkg-config,
   meson,
   ninja,
@@ -50,7 +49,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "librsvg";
-  version = "2.59.2";
+  version = "2.60.0";
 
   outputs =
     [
@@ -63,39 +62,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/librsvg/${lib.versions.majorMinor finalAttrs.version}/librsvg-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7NKT+wzDOMFwFxu8e8++pnJdBByV8xOF3JNUCZM+RZc=";
+    hash = "sha256-C2/8zfbnCvyYdogvXSzp/88scTy6rxrZAXDap1Lh7sM=";
   };
-
-  patches = [
-    (fetchpatch {
-      # merged in 2.60.0-beta.0
-      name = "cross-introspection.patch";
-      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/84f24b1f5767f807f8d0442bbf3f149a0defcf78.patch";
-      hash = "sha256-FRyAYCCP3eu7YDUS6g7sKCdbq2nU8yQdbdVaQwLrlhE=";
-    })
-    (fetchpatch {
-      # merged in 2.60.0-beta.0; required for cross-gdk-pixbuf-loader.patch to apply
-      name = "Replace-CRLF-with-just-LF-in-a-few-remaining-files-that-had-them";
-      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/8c93369806283feafd060f4507111344e1110f79.patch";
-      hash = "sha256-FU6ZiWhXm8jPhGGuNKqlxDIEXu2bSfq1MWyQoADqLZA=";
-    })
-    (fetchpatch {
-      # merged in 2.60.0-beta.0; required for cross-gdk-pixbuf-loader.patch to apply
-      name = "do-not-look-for-gdk-pixbuf-query-loaders-in-cross-builds.patch";
-      url = "https://gitlab.gnome.org/GNOME/librsvg/-/commit/ce2957acb7b0b5d7f75f47a3c503f5532aa698a6.patch";
-      hash = "sha256-f0Mdt4GjycIkM/k68KRsR0Hv2C+gaieQ4WnhjPbA5vs=";
-    })
-    (fetchpatch {
-      name = "cross-gdk-pixbuf-loader.patch";
-      url = "https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/1095.patch";
-      hash = "sha256-4R/DfDkNn7WhgBy526v309FzK6znCt2dV/ooz4LYrVU=";
-    })
-  ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "librsvg-deps-${finalAttrs.version}";
-    hash = "sha256-M8iNNWpYgLIm0X3sTjAaRIFYLIHnMyrkcsayFrLg25Y=";
+    hash = "sha256-DMkYsskjw6ARQsaHDRautT0oy8VqW/BJBfBVErxUe88=";
     dontConfigure = true;
   };
 
@@ -166,15 +139,11 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs \
       meson/cargo_wrapper.py \
       meson/makedef.py \
+      meson/query-rustc.py
 
     # Fix thumbnailer path
     substituteInPlace gdk-pixbuf-loader/librsvg.thumbnailer.in \
       --replace-fail '@bindir@/gdk-pixbuf-thumbnailer' '${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer'
-
-    # Fix pkg-config file Requires section.
-    # https://gitlab.gnome.org/GNOME/librsvg/-/issues/1150
-    substituteInPlace rsvg/meson.build \
-      --replace-fail 'requires: library_dependencies_sole,' 'requires: [cairo_dep, gio_dep, glib_dep, pixbuf_dep],'
   '';
 
   preCheck = ''

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.3.2";
+  version = "1.4.rc";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+HYrvG4pbXi+H4Qi9W2kxAvI0Sr8cAKjJBcqkZju7Vw=";
+    hash = "sha256-pXuX272lW8sHxvAZf/AGEoUYwrLIj77ovqUWisvJuu4=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.4.rc";
+  version = "1.4.0";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-pXuX272lW8sHxvAZf/AGEoUYwrLIj77ovqUWisvJuu4=";
+    hash = "sha256-OYQ2jgJZhis4ENHdyG0trdbTcqKzI3bM9K/3wuSMbTA=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libspelling/package.nix
+++ b/pkgs/by-name/li/libspelling/package.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libspelling";
-  version = "0.4.7";
+  version = "0.4.8";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libspelling/${lib.versions.majorMinor finalAttrs.version}/libspelling-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QvEw8pX1rdtuno50zPu3CXlL0t/QISk+KHW5SBu9Tog=";
+    hash = "sha256-J3ZGKFgY2nspXvAHssXr2BXQkws60JdQWzztlpZa9Rc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libspelling/package.nix
+++ b/pkgs/by-name/li/libspelling/package.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libspelling";
-  version = "0.4.6";
+  version = "0.4.7";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libspelling/${lib.versions.majorMinor finalAttrs.version}/libspelling-${finalAttrs.version}.tar.xz";
-    hash = "sha256-MkiptTNuovcn0tuRLS8Ag6zMBQXOcHZ5s9m4JmwBAfU=";
+    hash = "sha256-QvEw8pX1rdtuno50zPu3CXlL0t/QISk+KHW5SBu9Tog=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/lightsoff/package.nix
+++ b/pkgs/by-name/li/lightsoff/package.nix
@@ -4,18 +4,15 @@
   fetchurl,
   vala,
   pkg-config,
-  gtk3,
+  glib,
+  gtk4,
+  libadwaita,
   gnome,
-  adwaita-icon-theme,
   gdk-pixbuf,
-  librsvg,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   gettext,
   itstool,
-  clutter,
-  clutter-gtk,
   libxml2,
-  appstream-glib,
   meson,
   ninja,
   python3,
@@ -23,20 +20,19 @@
 
 stdenv.mkDerivation rec {
   pname = "lightsoff";
-  version = "46.0";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/lightsoff/${lib.versions.major version}/lightsoff-${version}.tar.xz";
-    hash = "sha256-ZysVMuBkX64C8oN6ltU57c/Uw7pPcuWR3HP+R567i5I=";
+    hash = "sha256-9A4CJzSWBg/9WLveDCH5lUCuI96KqmdWSVveBEa9LkE=";
   };
 
   nativeBuildInputs = [
     vala
     pkg-config
-    wrapGAppsHook3
+    wrapGAppsHook4
     itstool
     gettext
-    appstream-glib
     libxml2
     meson
     ninja
@@ -44,17 +40,16 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk3
-    adwaita-icon-theme
-    gdk-pixbuf
-    librsvg
-    clutter
-    clutter-gtk
+    glib
+    gtk4
+    libadwaita
   ];
 
   postPatch = ''
     chmod +x build-aux/meson_post_install.py
     patchShebangs build-aux/meson_post_install.py
+    substituteInPlace build-aux/meson_post_install.py \
+      --replace-fail "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   passthru = {

--- a/pkgs/by-name/li/lightsoff/package.nix
+++ b/pkgs/by-name/li/lightsoff/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "lightsoff";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/lightsoff/${lib.versions.major version}/lightsoff-${version}.tar.xz";
-    hash = "sha256-9A4CJzSWBg/9WLveDCH5lUCuI96KqmdWSVveBEa9LkE=";
+    hash = "sha256-3mkpt0vcnC68Pz9Sx8sxQsCf1fPSZk45CmOH3a4MdoQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/lightsoff/package.nix
+++ b/pkgs/by-name/li/lightsoff/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "lightsoff";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/lightsoff/${lib.versions.major version}/lightsoff-${version}.tar.xz";
-    hash = "sha256-3mkpt0vcnC68Pz9Sx8sxQsCf1fPSZk45CmOH3a4MdoQ=";
+    hash = "sha256-LsmVAXE9vNE8WlZaLhGMxMwrUCg2s4enc2z7pAqLOYk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lo/localsearch/package.nix
+++ b/pkgs/by-name/lo/localsearch/package.nix
@@ -19,11 +19,11 @@
   bzip2,
   dbus,
   exempi,
+  ffmpeg,
   giflib,
   glib,
   gobject-introspection,
   gnome,
-  gst_all_1,
   icu,
   json-glib,
   libcue,
@@ -39,7 +39,6 @@
   libtiff,
   libuuid,
   libxml2,
-  networkmanager,
   poppler,
   systemd,
   taglib,
@@ -50,11 +49,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "localsearch";
-  version = "3.8.2";
+  version = "3.9.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/localsearch/${lib.versions.majorMinor finalAttrs.version}/localsearch-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zaaRlfaEU1eo2RwCNnDv6SI49NE4oe96FAH0WiqEA84=";
+    hash = "sha256-URqEYD5RT4icF7MnH5vD+9dUeyrkKBFE0TjyjdMZmMs=";
   };
 
   patches = [
@@ -87,16 +86,11 @@ stdenv.mkDerivation (finalAttrs: {
       bzip2
       dbus
       exempi
+      ffmpeg
       giflib
       gexiv2
       totem-pl-parser
       tinysparql
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-      gst_all_1.gst-plugins-bad
-      gst_all_1.gst-plugins-ugly
-      gst_all_1.gstreamer
-      gst_all_1.gst-libav
       icu
       json-glib
       libcue
@@ -116,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       libseccomp
-      networkmanager
       systemd
       upower
     ]

--- a/pkgs/by-name/lo/localsearch/package.nix
+++ b/pkgs/by-name/lo/localsearch/package.nix
@@ -49,11 +49,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "localsearch";
-  version = "3.9.rc";
+  version = "3.9.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/localsearch/${lib.versions.majorMinor finalAttrs.version}/localsearch-${finalAttrs.version}.tar.xz";
-    hash = "sha256-URqEYD5RT4icF7MnH5vD+9dUeyrkKBFE0TjyjdMZmMs=";
+    hash = "sha256-1C9AjcP7KP5U9amrv18d7PWBjbnC6exRwJRkvf0MFLk=";
   };
 
   patches = [

--- a/pkgs/by-name/lo/localsearch/tracker-landlock-nix-store-permission.patch
+++ b/pkgs/by-name/lo/localsearch/tracker-landlock-nix-store-permission.patch
@@ -1,8 +1,8 @@
-diff --git a/src/libtracker-miners-common/tracker-landlock.c b/src/libtracker-miners-common/tracker-landlock.c
-index 6d4510be1..1de5d5a90 100644
---- a/src/libtracker-miners-common/tracker-landlock.c
-+++ b/src/libtracker-miners-common/tracker-landlock.c
-@@ -184,6 +184,10 @@ gboolean
+diff --git a/src/common/tracker-landlock.c b/src/common/tracker-landlock.c
+index f26791d73..f03e8ddb9 100644
+--- a/src/common/tracker-landlock.c
++++ b/src/common/tracker-landlock.c
+@@ -185,6 +185,10 @@ gboolean
  tracker_landlock_init (const gchar * const *indexed_folders)
  {
  	TrackerLandlockRule stock_rules[] = {
@@ -11,5 +11,5 @@ index 6d4510be1..1de5d5a90 100644
 +		  LANDLOCK_ACCESS_FS_READ_FILE |
 +		  LANDLOCK_ACCESS_FS_READ_DIR) },
  		/* Allow access to the executable itself */
- 		{ LIBEXECDIR "/tracker-extract-3",
- 		 LANDLOCK_ACCESS_FS_READ_FILE |
+ 		{ LIBEXECDIR "/localsearch-extractor-3",
+ 		  LANDLOCK_ACCESS_FS_READ_FILE |

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -8,8 +8,6 @@
   meson,
   ninja,
   pkg-config,
-  jq,
-  moreutils,
   rustc,
   wrapGAppsHook4,
   gtk4,
@@ -19,21 +17,25 @@
   libseccomp,
   glycin-loaders,
   gnome,
+  common-updater-scripts,
+  _experimental-update-script-combinators,
+  rustPlatform,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "47.4";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-jckmgpqcM4gAyPQytaNHJG5ty9mtLdGiTEmOr90+ias=";
+    hash = "sha256-vNRw832vFsejBCrSJ+m1DtNp8j69sMgYJQS6AbCxfEA=";
   };
 
-  patches = [
-    # Fix paths in glycin library
-    glycin-loaders.passthru.glycinPathsPatch
-  ];
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    name = "loupe-deps-${finalAttrs.version}";
+    hash = "sha256-aR20tWdrjz2aI86amHj1aRjOEf5hVfIq1xS6QP/vOIs=";
+  };
 
   nativeBuildInputs = [
     cargo
@@ -42,9 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    jq
-    moreutils
     rustc
+    rustPlatform.cargoSetupHook
     wrapGAppsHook4
   ];
 
@@ -56,13 +57,12 @@ stdenv.mkDerivation (finalAttrs: {
     libseccomp
   ];
 
-  postPatch = ''
-    # Replace hash of file we patch in vendored glycin.
-    jq \
-      --arg hash "$(sha256sum vendor/glycin/src/sandbox.rs | cut -d' ' -f 1)" \
-      '.files."src/sandbox.rs" = $hash' \
-      vendor/glycin/.cargo-checksum.json \
-      | sponge vendor/glycin/.cargo-checksum.json
+  preConfigure = ''
+    # Dirty approach to add patches after cargoSetupPostUnpackHook
+    # We should eventually use a cargo vendor patch hook instead
+    pushd ../$(stripHash $cargoDeps)/glycin-2.*
+      patch -p3 < ${glycin-loaders.passthru.glycinPathsPatch}
+    popd
   '';
 
   preFixup = ''
@@ -73,8 +73,34 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  passthru.updateScript = gnome.updateScript {
-    packageName = "loupe";
+  passthru = {
+    updateScript =
+      let
+        updateSource = gnome.updateScript {
+          packageName = "loupe";
+        };
+
+        updateLockfile = {
+          command = [
+            "sh"
+            "-c"
+            ''
+              PATH=${
+                lib.makeBinPath [
+                  common-updater-scripts
+                ]
+              }
+              update-source-version loupe --ignore-same-version --source-key=cargoDeps.vendorStaging > /dev/null
+            ''
+          ];
+          # Experimental feature: do not copy!
+          supportedFeatures = [ "silent" ];
+        };
+      in
+      _experimental-update-script-combinators.sequence [
+        updateSource
+        updateLockfile
+      ];
   };
 
   meta = with lib; {

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -24,17 +24,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-vNRw832vFsejBCrSJ+m1DtNp8j69sMgYJQS6AbCxfEA=";
+    hash = "sha256-IUkrI4LrqGuXVxtMwIwesCAc5elr0rm1MziT+F+9HX0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "loupe-deps-${finalAttrs.version}";
-    hash = "sha256-aR20tWdrjz2aI86amHj1aRjOEf5hVfIq1xS6QP/vOIs=";
+    hash = "sha256-M4U1/TShAxPu8cYfsiFTPj3rrXi6lSk43Emy2U3zKlk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -24,17 +24,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "loupe";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/loupe/${lib.versions.major finalAttrs.version}/loupe-${finalAttrs.version}.tar.xz";
-    hash = "sha256-IUkrI4LrqGuXVxtMwIwesCAc5elr0rm1MziT+F+9HX0=";
+    hash = "sha256-EHE9PpZ4nQd659M4lFKl9sOX3fQ6UMBxy/4tEnJZcN4=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "loupe-deps-${finalAttrs.version}";
-    hash = "sha256-M4U1/TShAxPu8cYfsiFTPj3rrXi6lSk43Emy2U3zKlk=";
+    hash = "sha256-PKkyZDd4FLWGZ/kDKWkaSV8p8NDniSQGcR9Htce6uCg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/metacity/package.nix
+++ b/pkgs/by-name/me/metacity/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "metacity";
-  version = "3.54.0";
+  version = "3.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/metacity/${lib.versions.majorMinor version}/metacity-${version}.tar.xz";
-    hash = "sha256-WHifKLbzhSL9iMIkKRChB9ppNCF7LH3VKn1RLTlB1kM=";
+    hash = "sha256-dVSZcQSyb/DnmgKzeiuhib3058zVQibw+vSxpZAGyQE=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "48.beta";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Li/WoCTUpbD+2aNPTKJfyVBf6E8E2gzV3JAbcNhoujE=";
+    hash = "sha256-QzjYVCQmpwjYBCf1sZ8fhmg8BOxuL0NHmrsosRWrqG8=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "48.0";
+  version = "48.2";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nKF3/VhRpAd/F/aoiMRUR7fRFjyYeVgFl6H9g39H5X0=";
+    hash = "sha256-PBi6Tgk+qaN4ET3K+nvbXB+db1r5dlAmt+Zst42vYU4=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QzjYVCQmpwjYBCf1sZ8fhmg8BOxuL0NHmrsosRWrqG8=";
+    hash = "sha256-nKF3/VhRpAd/F/aoiMRUR7fRFjyYeVgFl6H9g39H5X0=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -9,6 +9,7 @@
   gobject-introspection,
   cairo,
   colord,
+  docutils,
   lcms2,
   pango,
   libstartup_notification,
@@ -70,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "47.5";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -81,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ZVGjPOiH5oQVsTlSr21rQw6VMG+Sl63IwRGVPplcUVs=";
+    hash = "sha256-Li/WoCTUpbD+2aNPTKJfyVBf6E8E2gzV3JAbcNhoujE=";
   };
 
   mesonFlags = [
@@ -107,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     desktop-file-utils
+    docutils # for rst2man
     gettext
     glib
     libxcvt
@@ -115,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
     pkg-config
     python3
+    python3.pkgs.argcomplete # for register-python-argcomplete
     wayland-scanner
     wrapGAppsHook4
     gi-docgen
@@ -183,7 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     # TODO: Move this into a directory devhelp can find.
-    moveToOutput "share/mutter-15/doc" "$devdoc"
+    moveToOutput "share/mutter-${finalAttrs.passthru.libmutter_api_version}/doc" "$devdoc"
   '';
 
   # Install udev files into our own tree.
@@ -193,7 +196,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   passthru = {
-    libdir = "${finalAttrs.finalPackage}/lib/mutter-15";
+    libmutter_api_version = "16"; # bumped each dev cycle
+    libdir = "${finalAttrs.finalPackage}/lib/mutter-${finalAttrs.passthru.libmutter_api_version}";
 
     tests = {
       libdirExists = runCommand "mutter-libdir-exists" { } ''

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -40,7 +40,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "47.2";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-fzIDR08uY3ShHGdU7zPzNg6vf1tehfXkd+igrg+nZNk=";
+    hash = "sha256-Tah3f3HmS8rpx0ry//MVJcl+YB8FJYapjVt4dziKeKY=";
   };
 
   patches = [

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -40,7 +40,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "48.beta";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Tah3f3HmS8rpx0ry//MVJcl+YB8FJYapjVt4dziKeKY=";
+    hash = "sha256-gTGzf0brSqYarJl9bOih+svTYE0Xf2G9OxdiBDW6qZ4=";
   };
 
   patches = [

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -40,7 +40,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "48.0";
+  version = "48.1";
 
   outputs = [
     "out"
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+eaky+HVu3rVmsRPDUOe3UsFB78H09kKLn5+bT9BbVc=";
+    hash = "sha256-eZWioXwp1LCav53ZrKFLje597DvXR3bdN5US8ubXNH8=";
   };
 
   patches = [

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -40,7 +40,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nautilus";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/nautilus/${lib.versions.major finalAttrs.version}/nautilus-${finalAttrs.version}.tar.xz";
-    hash = "sha256-gTGzf0brSqYarJl9bOih+svTYE0Xf2G9OxdiBDW6qZ4=";
+    hash = "sha256-+eaky+HVu3rVmsRPDUOe3UsFB78H09kKLn5+bT9BbVc=";
   };
 
   patches = [

--- a/pkgs/by-name/or/orca/fix-paths.patch
+++ b/pkgs/by-name/or/orca/fix-paths.patch
@@ -1,39 +1,34 @@
-diff --git a/src/orca/debug.py b/src/orca/debug.py
-index e17e2333e..595c8489d 100644
---- a/src/orca/debug.py
-+++ b/src/orca/debug.py
-@@ -529,7 +529,7 @@ def traceit(frame, event, arg):
-     return traceit
+diff --git a/src/orca/ax_utilities_application.py b/src/orca/ax_utilities_application.py
+index 60c172f78..e8dadf76d 100644
+--- a/src/orca/ax_utilities_application.py
++++ b/src/orca/ax_utilities_application.py
+@@ -189,7 +189,7 @@ class AXUtilitiesApplication:
  
- def getOpenFDCount(pid):
--    procs = subprocess.check_output([ 'lsof', '-w', '-Ff', '-p', str(pid)])
-+    procs = subprocess.check_output([ '@lsof@', '-w', '-Ff', '-p', str(pid)])
-     procs = procs.decode('UTF-8').split('\n')
-     files = list(filter(lambda s: s and s[0] == 'f' and s[1:].isdigit(), procs))
- 
-@@ -547,7 +547,7 @@ def getCmdline(pid):
-     return cmdline
- 
- def pidOf(procName):
--    openFile = subprocess.Popen(f'pgrep {procName}',
-+    openFile = subprocess.Popen(f'@pgrep@ {procName}',
-                                 shell=True,
-                                 stdout=subprocess.PIPE).stdout
-     pids = openFile.read()
+         pid = AXUtilitiesApplication.get_process_id(app)
+         try:
+-            state = subprocess.getoutput(f"cat /proc/{pid}/status | grep State")
++            state = subprocess.getoutput(f"@cat@ /proc/{pid}/status | @grep@ State")
+             state = state.split()[1]
+         except Exception as error:
+             tokens = [f"AXUtilitiesApplication: Exception checking state of pid {pid}: {error}"]
+diff --git a/src/orca/debugging_tools_manager.py b/src/orca/debugging_tools_manager.py
+index 740f1a690..85f74d2dc 100644
+--- a/src/orca/debugging_tools_manager.py
++++ b/src/orca/debugging_tools_manager.py
+@@ -243,7 +243,7 @@ class DebuggingToolsManager:
+             else:
+                 name = AXObject.get_name(app) or "[DEAD]"
+             try:
+-                cmdline = subprocess.getoutput(f"cat /proc/{pid}/cmdline")
++                cmdline = subprocess.getoutput(f"@cat@ /proc/{pid}/cmdline")
+             except Exception as error:
+                 cmdline = f"EXCEPTION: {error}"
+             else:
 diff --git a/src/orca/orca_bin.py.in b/src/orca/orca_bin.py.in
-index c3b23dec2..320597ae6 100755
+index 6cb4c7772..903b344f0 100755
 --- a/src/orca/orca_bin.py.in
 +++ b/src/orca/orca_bin.py.in
-@@ -63,7 +63,7 @@ class ListApps(argparse.Action):
-                 name = "[DEAD]"
- 
-             try:
--                cmdline = subprocess.getoutput('cat /proc/%s/cmdline' % pid)
-+                cmdline = subprocess.getoutput('@cat@ /proc/%s/cmdline' % pid)
-             except Exception:
-                 cmdline = '(exception encountered)'
-             else:
-@@ -199,7 +199,7 @@ def inGraphicalDesktop():
+@@ -186,7 +186,7 @@ def inGraphicalDesktop():
  def otherOrcas():
      """Returns the pid of any other instances of Orca owned by this user."""
  
@@ -43,33 +38,33 @@ index c3b23dec2..320597ae6 100755
                                  stdout=subprocess.PIPE).stdout
      pids = openFile.read()
 diff --git a/src/orca/orca_modifier_manager.py b/src/orca/orca_modifier_manager.py
-index 48c0dead5..8a4a04e74 100644
+index 3407be009..452297a3f 100644
 --- a/src/orca/orca_modifier_manager.py
 +++ b/src/orca/orca_modifier_manager.py
-@@ -200,7 +200,7 @@ class OrcaModifierManager:
-         debug.printMessage(debug.LEVEL_INFO, msg, True)
+@@ -230,7 +230,7 @@ class OrcaModifierManager:
+         debug.print_message(debug.LEVEL_INFO, msg, True)
  
          self.unset_orca_modifiers(reason)
--        p = subprocess.Popen(['xkbcomp', os.environ['DISPLAY'], '-'],
-+        p = subprocess.Popen(['@xkbcomp@', os.environ['DISPLAY'], '-'],
-             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-         self._original_xmodmap, _ = p.communicate()
+-        with subprocess.Popen(["xkbcomp", os.environ["DISPLAY"], "-"],
++        with subprocess.Popen(["@xkbcomp@", os.environ["DISPLAY"], "-"],
+                               stdout=subprocess.PIPE, stderr=subprocess.DEVNULL) as p:
+             self._original_xmodmap, _ = p.communicate()
          self._create_orca_xmodmap()
-@@ -232,7 +232,7 @@ class OrcaModifierManager:
+@@ -262,7 +262,7 @@ class OrcaModifierManager:
              return
  
          self._caps_lock_cleared = False
--        p = subprocess.Popen(['xkbcomp', '-w0', '-', os.environ['DISPLAY']],
-+        p = subprocess.Popen(['@xkbcomp@', '-w0', '-', os.environ['DISPLAY']],
-             stdin=subprocess.PIPE, stdout=None, stderr=None)
-         p.communicate(self._original_xmodmap)
+-        with subprocess.Popen(["xkbcomp", "-w0", "-", os.environ["DISPLAY"]],
++        with subprocess.Popen(["@xkbcomp@", "-w0", "-", os.environ["DISPLAY"]],
+                               stdin=subprocess.PIPE, stdout=None, stderr=None) as p:
+             p.communicate(self._original_xmodmap)
  
-@@ -293,7 +293,7 @@ class OrcaModifierManager:
-         if modified:
-             msg = "ORCA MODIFIER MANAGER: Updating xmodmap"
-             debug.printMessage(debug.LEVEL_INFO, msg, True)
--            p = subprocess.Popen(['xkbcomp', '-w0', '-', os.environ['DISPLAY']],
-+            p = subprocess.Popen(['@xkbcomp@', '-w0', '-', os.environ['DISPLAY']],
-                 stdin=subprocess.PIPE, stdout=None, stderr=None)
-             p.communicate(bytes('\n'.join(lines), 'UTF-8'))
+@@ -325,7 +325,7 @@ class OrcaModifierManager:
+             debug.print_message(debug.LEVEL_INFO, msg, True)
+ 
+ 
+-            with subprocess.Popen(["xkbcomp", "-w0", "-", os.environ["DISPLAY"]],
++            with subprocess.Popen(["@xkbcomp@", "-w0", "-", os.environ["DISPLAY"]],
+                               stdin=subprocess.PIPE, stdout=None, stderr=None) as p:
+                 p.communicate(bytes('\n'.join(lines), 'UTF-8'))
          else:

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -18,7 +18,7 @@
   dbus,
   xkbcomp,
   procps,
-  lsof,
+  gnugrep,
   coreutils,
   gsettings-desktop-schemas,
   speechd-minimal,
@@ -29,19 +29,19 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "47.3";
+  version = "48.beta";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
-    hash = "sha256-GwsUW7aFzXTso+KMt7cJf5jRPuHMWLce3u06j5BFIxs=";
+    hash = "sha256-aY9LD2KtXJm5lcJg1rZnCIp1d9YIk5vfQzNTMIlQ10c=";
   };
 
   patches = [
     (replaceVars ./fix-paths.patch {
       cat = "${coreutils}/bin/cat";
-      lsof = "${lsof}/bin/lsof";
+      grep = "${gnugrep}/bin/grep";
       pgrep = "${procps}/bin/pgrep";
       xkbcomp = "${xkbcomp}/bin/xkbcomp";
     })

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "48.beta";
+  version = "48.rc";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
-    hash = "sha256-aY9LD2KtXJm5lcJg1rZnCIp1d9YIk5vfQzNTMIlQ10c=";
+    hash = "sha256-vODDEKFz1GScHxO2Ho3015yVEBdkulH1xhkVQ1eYNJU=";
   };
 
   patches = [

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "48.rc";
+  version = "48.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
-    hash = "sha256-vODDEKFz1GScHxO2Ho3015yVEBdkulH1xhkVQ1eYNJU=";
+    hash = "sha256-tQgLdPRRkBexx1Np4o19QNn9Wd0fq3I6YGLjZXB0Awo=";
   };
 
   patches = [

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "48.0";
+  version = "48.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
-    hash = "sha256-tQgLdPRRkBexx1Np4o19QNn9Wd0fq3I6YGLjZXB0Awo=";
+    hash = "sha256-ZsbwmCIUnaJDpGM6fYSnsduq8UU0qf653yv+AaUFF4o=";
   };
 
   patches = [

--- a/pkgs/by-name/ry/rygel/package.nix
+++ b/pkgs/by-name/ry/rygel/package.nix
@@ -38,7 +38,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rygel";
-  version = "0.44.1";
+  version = "0.44.2";
 
   # TODO: split out lib
   outputs = [
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/rygel/${lib.versions.majorMinor finalAttrs.version}/rygel-${finalAttrs.version}.tar.xz";
-    hash = "sha256-eyxjG4QkCNonpUJC+Agqukm9HKAgQeeeHu+6DHAJqHs=";
+    hash = "sha256-eW7uSUzfYNwr+CsAuPmaFLocfPQNKUSBf/DBqmBz1aA=";
   };
 
   patches = [

--- a/pkgs/by-name/sn/snapshot/package.nix
+++ b/pkgs/by-name/sn/snapshot/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "snapshot";
-  version = "47.1";
+  version = "48.0.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/snapshot/${lib.versions.major finalAttrs.version}/snapshot-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5LFiZ5ryTH6W7m4itH1f8NqW4KD2FtE66xIHxgn4lIM=";
+    hash = "sha256-OTF2hZogt9I138MDAxuiDGhkQRBpiNyRHdkbe21m4f0=";
   };
 
   patches = [

--- a/pkgs/by-name/sw/swell-foop/package.nix
+++ b/pkgs/by-name/sw/swell-foop/package.nix
@@ -8,6 +8,7 @@
   vala,
   glib,
   gtk4,
+  libadwaita,
   libgee,
   libgnome-games-support_2_0,
   pango,
@@ -20,13 +21,13 @@
   python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "swell-foop";
-  version = "46.0";
+  version = "48.alpha";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/swell-foop/${lib.versions.major version}/swell-foop-${version}.tar.xz";
-    hash = "sha256-BvireAfXHOyUi4aDcfR/ut7vzLXDV+E9HvPISBiR/KM=";
+    url = "mirror://gnome/sources/swell-foop/${lib.versions.major finalAttrs.version}/swell-foop-${finalAttrs.version}.tar.xz";
+    hash = "sha256-h0AxrchfUtYzz2fVEkM0jyPmYOvkgvUIMldu+xPTebU=";
   };
 
   nativeBuildInputs = [
@@ -45,22 +46,25 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk4
+    libadwaita
     libgee
     libgnome-games-support_2_0
     pango
   ];
 
   passthru = {
-    updateScript = gnome.updateScript { packageName = "swell-foop"; };
+    updateScript = gnome.updateScript {
+      packageName = "swell-foop";
+    };
   };
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/GNOME/swell-foop";
-    changelog = "https://gitlab.gnome.org/GNOME/swell-foop/-/tree/${version}?ref_type=tags";
+    changelog = "https://gitlab.gnome.org/GNOME/swell-foop/-/tree/${finalAttrs.version}?ref_type=tags";
     description = "Puzzle game, previously known as Same GNOME";
     mainProgram = "swell-foop";
     teams = [ teams.gnome ];
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sw/swell-foop/package.nix
+++ b/pkgs/by-name/sw/swell-foop/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "swell-foop";
-  version = "48.alpha";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/swell-foop/${lib.versions.major finalAttrs.version}/swell-foop-${finalAttrs.version}.tar.xz";
-    hash = "sha256-h0AxrchfUtYzz2fVEkM0jyPmYOvkgvUIMldu+xPTebU=";
+    hash = "sha256-NL3uWJRqFMmGMVPJsQBs+8UfBCP8y82xLEXmDWbbvew=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sw/swell-foop/package.nix
+++ b/pkgs/by-name/sw/swell-foop/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "swell-foop";
-  version = "48.0";
+  version = "48.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/swell-foop/${lib.versions.major finalAttrs.version}/swell-foop-${finalAttrs.version}.tar.xz";
-    hash = "sha256-NL3uWJRqFMmGMVPJsQBs+8UfBCP8y82xLEXmDWbbvew=";
+    hash = "sha256-W5Ywh4/nAa7nUe1G/3ZcK82fgVpOVYJnajwmsxGCAxs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinysparql";
-  version = "3.8.2";
+  version = "3.9.rc";
 
   outputs = [
     "out"
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     url =
       with finalAttrs;
       "mirror://gnome/sources/tinysparql/${lib.versions.majorMinor version}/tinysparql-${version}.tar.xz";
-    hash = "sha256-u4ZDOGyO3FkaAyBdSg7aZh3N0glEc7/7m725TpNYnLI=";
+    hash = "sha256-IWxMRC1d09R2t0YVpMwrOSs4+21NFtFqo7kV3JLy0hM=";
   };
 
   strictDeps = true;
@@ -127,12 +127,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     chmod +x \
-      docs/reference/libtracker-sparql/embed-files.py \
-      docs/reference/libtracker-sparql/generate-svgs.sh
+      docs/reference/docgen-wrapper.sh \
+      docs/reference/embed-files.py \
+      docs/reference/generate-svgs.sh
     patchShebangs \
       utils/data-generators/cc/generate \
-      docs/reference/libtracker-sparql/embed-files.py \
-      docs/reference/libtracker-sparql/generate-svgs.sh
+      docs/reference/docgen-wrapper.sh \
+      docs/reference/embed-files.py \
+      docs/reference/generate-svgs.sh
 
     # File "/build/tinysparql-3.8.0/tests/functional-tests/test_cli.py", line 233, in test_help
     # self.assertIn("TINYSPARQL-IMPORT(1)", output, "Manpage not found")
@@ -155,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       # though, so we need to replace the absolute path with a local one during build.
       # We are using a symlink that will be overridden during installation.
       mkdir -p $out/lib
-      ln -s $PWD/src/libtracker-sparql/libtinysparql-3.0${darwinDot0}${extension} $out/lib/libtinysparql-3.0${darwinDot0}${extension}${linuxDot0}
+      ln -s $PWD/src/libtinysparql/libtinysparql-3.0${darwinDot0}${extension} $out/lib/libtinysparql-3.0${darwinDot0}${extension}${linuxDot0}
     '';
 
   checkPhase = ''

--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinysparql";
-  version = "3.9.rc";
+  version = "3.9.1";
 
   outputs = [
     "out"
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     url =
       with finalAttrs;
       "mirror://gnome/sources/tinysparql/${lib.versions.majorMinor version}/tinysparql-${version}.tar.xz";
-    hash = "sha256-IWxMRC1d09R2t0YVpMwrOSs4+21NFtFqo7kV3JLy0hM=";
+    hash = "sha256-mOiTO5RtjFSnfq2r1/HRTN3Yj6Q+7w0KzjwPzOZGcis=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinysparql";
-  version = "3.9.1";
+  version = "3.9.2";
 
   outputs = [
     "out"
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     url =
       with finalAttrs;
       "mirror://gnome/sources/tinysparql/${lib.versions.majorMinor version}/tinysparql-${version}.tar.xz";
-    hash = "sha256-mOiTO5RtjFSnfq2r1/HRTN3Yj6Q+7w0KzjwPzOZGcis=";
+    hash = "sha256-FM4DkCQTXhgQIrzOSxqtLgA3fdnH2BK5g5HM/HVtrY4=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -15,8 +15,6 @@
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   vala,
   python3,
-  gi-docgen,
-  graphviz,
   libxml2,
   glib,
   wrapGAppsNoGuiHook,
@@ -67,8 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
       gettext
       glib
       wrapGAppsNoGuiHook
-      gi-docgen
-      graphviz
       (python3.pythonOnBuildForHost.withPackages (p: [ p.pygobject3 ]))
     ]
     ++ lib.optionals withIntrospection [
@@ -126,15 +122,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   postPatch = ''
-    chmod +x \
-      docs/reference/docgen-wrapper.sh \
-      docs/reference/embed-files.py \
-      docs/reference/generate-svgs.sh
     patchShebangs \
-      utils/data-generators/cc/generate \
-      docs/reference/docgen-wrapper.sh \
-      docs/reference/embed-files.py \
-      docs/reference/generate-svgs.sh
+      utils/data-generators/cc/generate
 
     # File "/build/tinysparql-3.8.0/tests/functional-tests/test_cli.py", line 233, in test_help
     # self.assertIn("TINYSPARQL-IMPORT(1)", output, "Manpage not found")

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   fetchpatch,
+  desktop-file-utils,
   gettext,
   pkg-config,
   meson,
@@ -34,7 +35,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.78.4";
+  version = "0.79.91";
 
   outputs = [
     "out"
@@ -43,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-LepOQSJmWStkYKP+RIj149UHEvE5gVeQwOy0RxD34X4=";
+    hash = "sha256-rcpmfUCuGDm6JYtjcBzQX7okkwPXIlhxHMaSlLLLhkY=";
   };
 
   patches = [
@@ -55,26 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://git.alpinelinux.org/aports/plain/community/vte3/fix-W_EXITCODE.patch?id=4d35c076ce77bfac7655f60c4c3e4c86933ab7dd";
       hash = "sha256-FkVyhsM0mRUzZmS2Gh172oqwcfXv6PyD6IEgjBhy2uU=";
     })
-    # build: Add fast_float dependency
-    # https://gitlab.gnome.org/GNOME/vte/-/issues/2823
-    (fetchpatch {
-      name = "0003-build-Add-fast_float-dependency.patch";
-      url = "https://gitlab.gnome.org/GNOME/vte/-/commit/f6095fca4d1baf950817e7010e6f1e7c313b9e2e.patch";
-      hash = "sha256-EL9PPiI5pDJOXf4Ck4nkRte/jHx/QWbxkjDFRSsp+so=";
-    })
-    (fetchpatch {
-      name = "0003-widget-termprops-Use-fast_float.patch";
-      url = "https://gitlab.gnome.org/GNOME/vte/-/commit/6c2761f51a0400772f443f12ea23a75576e195d3.patch";
-      hash = "sha256-jjM9bhl8EhtylUIQ2nMSNX3ugnkZQP/2POvSUDW0LM0=";
-    })
-    (fetchpatch {
-      name = "0003-build-Use-correct-path-to-include-fast_float.h.patch";
-      url = "https://gitlab.gnome.org/GNOME/vte/-/commit/d09330585e648b5c9991dffab4a06d1f127bf916.patch";
-      hash = "sha256-YGVXt2VojljYgTcmahQ2YEZGEysyUSwk+snQfoipJ+E=";
-    })
   ];
 
   nativeBuildInputs = [
+    desktop-file-utils # for desktop-file-validate
     gettext
     gobject-introspection
     gperf
@@ -134,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs perf/*
+    patchShebangs src/app/meson_desktopfile.py
     patchShebangs src/parser-seq.py
     patchShebangs src/minifont-coverage.py
     patchShebangs src/modes.py

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -35,7 +35,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.80.0";
+  version = "0.80.1";
 
   outputs = [
     "out"
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Jn9jc5dl5WjPgRPQ4u6PWTAolGGHhUvr4mjHeOYmR8g=";
+    hash = "sha256-DNvQ6YOv2dIuBl4yOnQxYAcr9ktFPgCxXtvm8tzdpGw=";
   };
 
   patches = [

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -35,7 +35,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vte";
-  version = "0.79.91";
+  version = "0.80.0";
 
   outputs = [
     "out"
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/vte/${lib.versions.majorMinor finalAttrs.version}/vte-${finalAttrs.version}.tar.xz";
-    hash = "sha256-rcpmfUCuGDm6JYtjcBzQX7okkwPXIlhxHMaSlLLLhkY=";
+    hash = "sha256-Jn9jc5dl5WjPgRPQ4u6PWTAolGGHhUvr4mjHeOYmR8g=";
   };
 
   patches = [

--- a/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-gnome";
-  version = "47.3";
+  version = "48.rc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/xdg-desktop-portal-gnome/${lib.versions.major finalAttrs.version}/xdg-desktop-portal-gnome-${finalAttrs.version}.tar.xz";
-    hash = "sha256-n25LFLWDNnyRXpSUdk8ny4SSf6o/nm4Bi5O7vPM2HkQ=";
+    hash = "sha256-/ob+pnN1nkl0srEOJ/WqPlaNjvaI99fYDKvKuQqGnws=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-gnome";
-  version = "48.rc";
+  version = "48.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/xdg-desktop-portal-gnome/${lib.versions.major finalAttrs.version}/xdg-desktop-portal-gnome-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/ob+pnN1nkl0srEOJ/WqPlaNjvaI99fYDKvKuQqGnws=";
+    hash = "sha256-zRWsouE2TaMI6zeWu4rkpXfmDKT+EgBrMVIyz9GciGE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ze/zenity/package.nix
+++ b/pkgs/by-name/ze/zenity/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zenity";
-  version = "4.0.5";
+  version = "4.1.90";
 
   src = fetchurl {
     url = "mirror://gnome/sources/zenity/${lib.versions.majorMinor finalAttrs.version}/zenity-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ij/+d1G+1JenWCKezge+kRStTkagZquuTl8x1tpMDp4=";
+    hash = "sha256-vzZ5xiBf9I3OvR4d/zo6SmoLOlPhy8OwmKnsC2K9cjY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -129,8 +129,8 @@ let
 in
 rec {
   vala_0_56 = generic {
-    version = "0.56.17";
-    hash = "sha256-JhAMTk7wBJxhknXxQNl89WWIPQDHVDyCvM5aQmk07Wo=";
+    version = "0.56.18";
+    hash = "sha256-8q/+fUCrY9uOe57MP2vcnC/H4xNMhP8teV9IL+kmo4I=";
   };
 
   vala = vala_0_56;

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gcr";
-  version = "4.3.1";
+  version = "4.3.91";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gcr/${lib.versions.majorMinor finalAttrs.version}/gcr-${finalAttrs.version}.tar.xz";
-    hash = "sha256-svBw//GEDu9wVGoovoAjVCfBFqrcWTtbaMzIab46oJ0=";
+    hash = "sha256-nTJu09eK0Or7CEg5WgaK2+/ets/wTsVhXLPvdn2TOZA=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gcr";
-  version = "4.3.91";
+  version = "4.4.0.1";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gcr/${lib.versions.majorMinor finalAttrs.version}/gcr-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nTJu09eK0Or7CEg5WgaK2+/ets/wTsVhXLPvdn2TOZA=";
+    hash = "sha256-DDw0Hkn59PJTKkiEUJgEGQoMJmPmEgNguymMXRdKgJg=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/glibmm/2.68.nix
+++ b/pkgs/development/libraries/glibmm/2.68.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "glibmm";
-  version = "2.82.0";
+  version = "2.83.1";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-OGhM/zFyc2FcZ7j6mAbxYpnVHlUG2bkJuuFbWJ+pnLY=";
+    hash = "sha256-aDUKgjwz2orPsSY3FbsAKjbGg0a9RMGaxMPwvRkP0rE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/glibmm/2.68.nix
+++ b/pkgs/development/libraries/glibmm/2.68.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "glibmm";
-  version = "2.83.1";
+  version = "2.84.0";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-aDUKgjwz2orPsSY3FbsAKjbGg0a9RMGaxMPwvRkP0rE=";
+    hash = "sha256-Vu5fUcis/Ar99GlZMW5MhVTLUO0ra8XOOJ2XnLtkJQk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/glibmm/default.nix
+++ b/pkgs/development/libraries/glibmm/default.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "glibmm";
-  version = "2.66.7";
+  version = "2.66.8";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-/gLB5fWCWUDYK1a27DGhLAbAXBWDz+Yvk00HY+HlQrM=";
+    hash = "sha256-ZPEdO5WiTiqNQWbs/1GHMPeezCciLvQfr3x+A0D8kyk=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/gobject-introspection/0001-scanner-Prefer-some-getters-over-others.patch
+++ b/pkgs/development/libraries/gobject-introspection/0001-scanner-Prefer-some-getters-over-others.patch
@@ -1,0 +1,92 @@
+From 7b2d3699ad117199bc316c7007cc5984c3b09368 Mon Sep 17 00:00:00 2001
+From: Maximiliano Sandoval <msandova@gnome.org>
+Date: Thu, 20 Mar 2025 22:52:54 +0100
+Subject: [PATCH] scanner: Prefer some getters over others
+
+At the moment the current set of heuristics to determine a getter for a
+property is good for finding *a* getter. However, if there are multiple
+candidates we might declare the wrong method as a getter.
+
+We introduce a priority system to determine which getter candidate is
+the most appropriate as the getter. The weight were chosen with gaps in
+between so that new and better heuristics have space to thrive.
+
+For a property named `p`, these are the possible getter candidates:
+
+ - A method declared via the `(getter p)` annotation
+ - The method `get_p`
+ - The method `is_p`
+ - The method `p`
+
+we declare the getter to be the first candidate in the list for which a
+method of the same name is available.
+
+See https://gitlab.gnome.org/GNOME/gjs/-/issues/681.
+---
+ giscanner/maintransformer.py | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/giscanner/maintransformer.py b/giscanner/maintransformer.py
+index a81b1777..9aaf2578 100644
+--- a/giscanner/maintransformer.py
++++ b/giscanner/maintransformer.py
+@@ -1612,7 +1612,10 @@ method or constructor of some type."""
+             if not prop.introspectable:
+                 continue
+             setter = None
+-            getter = []
++            # They keys are method names of candidates for getters. The values
++            # are priority weights that measure how tasteful was the heuristic
++            # used to propose their candidate.
++            getter = {}
+             if prop.setter is None:
+                 if prop.writable and not prop.construct_only:
+                     setter = 'set_' + normalized_name
+@@ -1620,17 +1623,17 @@ method or constructor of some type."""
+                 setter = prop.setter
+             if prop.getter is None:
+                 if prop.readable:
+-                    getter = ['get_' + normalized_name]
++                    getter[f"get_{normalized_name}"] = 50
+                     # Heuristic: boolean properties can have getters that are
+                     # prefixed by is_property_name, like: gtk_window_is_maximized()
+                     if prop.type.is_equiv(ast.TYPE_BOOLEAN) and not normalized_name.startswith("is_"):
+-                        getter.append(f"is_{normalized_name}")
++                        getter[f"is_{normalized_name}"] = 25
+                     # Heuristic: read-only properties can have getters that are
+                     # just the property name, like: gtk_widget_has_focus()
+                     if not prop.writable and prop.type.is_equiv(ast.TYPE_BOOLEAN):
+-                        getter.append(normalized_name)
++                        getter[normalized_name] = 10
+             else:
+-                getter = [prop.getter]
++                getter[prop.getter] = 99
+             for method in node.methods:
+                 if not method.introspectable:
+                     continue
+@@ -1645,7 +1648,7 @@ method or constructor of some type."""
+                         method.set_property = prop.name
+                     prop.setter = method.name
+                     continue
+-                if getter is not [] and method.name in getter:
++                if getter is not {} and method.name in getter:
+                     if method.get_property is None:
+                         method.get_property = prop.name
+                     elif method.get_property != prop.name:
+@@ -1654,7 +1657,12 @@ method or constructor of some type."""
+                                           "mismatched '(get-property %s)' annotation" %
+                                           (method.symbol, prop.name, method.get_property))
+                         method.get_property = prop.name
+-                    prop.getter = method.name
++                    # Check the priority of the last matching getter
++                    current_priority = -1
++                    if current_getter := prop.getter:
++                        current_priority = getter.get(current_getter, -1)
++                    if getter[method.name] >= current_priority:
++                        prop.getter = method.name
+                     continue
+ 
+     def _pass_member_numeric_name(self, node):
+-- 
+2.48.1
+

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -43,7 +43,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gobject-introspection";
-  version = "1.83.4";
+  version = "1.84.0";
 
   # outputs TODO: share/gobject-introspection-1.0/tests is needed during build
   # by pygobject3 (and maybe others), but it's only searched in $out
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gobject-introspection/${lib.versions.majorMinor finalAttrs.version}/gobject-introspection-${finalAttrs.version}.tar.xz";
-    hash = "sha256-hvAuaJ/03zYrLQ8KmswmKs5dw+cckHi9umkkZ0ghOFU=";
+    hash = "sha256-lFtX2n7CYuXCZrieCR0UvoAMxCQnfYKgKHK315SoR3k=";
   };
 
   patches =

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -43,7 +43,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gobject-introspection";
-  version = "1.82.0";
+  version = "1.83.2";
 
   # outputs TODO: share/gobject-introspection-1.0/tests is needed during build
   # by pygobject3 (and maybe others), but it's only searched in $out
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gobject-introspection/${lib.versions.majorMinor finalAttrs.version}/gobject-introspection-${finalAttrs.version}.tar.xz";
-    hash = "sha256-D1pMGQhCS/JrxB6TYRaMNjaFCA+9uHoZbIkchAHKLwk=";
+    hash = "sha256-igRCUX1NeT5Exky+ydKE33HJTxnmQJp14hej2Cvajq4=";
   };
 
   patches =
@@ -69,13 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
         inherit nixStoreDir;
       })
 
-      # Add _Complex support for glibc-2.41:
-      #   https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/519
-      (fetchpatch {
-        name = "complex-clang.patch";
-        url = "https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/2812471365c75ab51347a9101771128f8ab283ab.patch";
-        hash = "sha256-MR0tCOVfoAAPUIlT/Y8IYWiz48j1EnhNjUBzvsCUsEI=";
-      })
+      # Fix getter heuristics regression
+      # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/529
+      ./0001-scanner-Prefer-some-getters-over-others.patch
     ]
     ++ lib.optionals x11Support [
       # Hardcode the cairo shared library path in the Cairo gir shipped with this package.

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -43,7 +43,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gobject-introspection";
-  version = "1.83.2";
+  version = "1.83.4";
 
   # outputs TODO: share/gobject-introspection-1.0/tests is needed during build
   # by pygobject3 (and maybe others), but it's only searched in $out
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gobject-introspection/${lib.versions.majorMinor finalAttrs.version}/gobject-introspection-${finalAttrs.version}.tar.xz";
-    hash = "sha256-igRCUX1NeT5Exky+ydKE33HJTxnmQJp14hej2Cvajq4=";
+    hash = "sha256-hvAuaJ/03zYrLQ8KmswmKs5dw+cckHi9umkkZ0ghOFU=";
   };
 
   patches =

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -68,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.17.5";
+  version = "4.17.6";
 
   outputs = [
     "out"
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-euurG2MEE1zXEQURqPzqPQe6EmHGGxAuT8lfDcv82k8=";
+    hash = "sha256-366boSY/hK+oOklNsu0UxzksZ4QLZzC/om63n94eE6E=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -4,7 +4,6 @@
   buildPackages,
   replaceVars,
   fetchurl,
-  fetchpatch,
   pkg-config,
   docutils,
   gettext,
@@ -69,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.16.12";
+  version = "4.17.5";
 
   outputs = [
     "out"
@@ -83,20 +82,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url =
-      with finalAttrs;
-      "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
-    hash = "sha256-7zG9vW8ILEQBY0ogyFCwBQyb8lLvHgeXZO6VoqDEyVo=";
+    url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
+    hash = "sha256-euurG2MEE1zXEQURqPzqPQe6EmHGGxAuT8lfDcv82k8=";
   };
-
-  patches = [
-    # Fix rendering glitches on vulkan drivers which do not support mipmaps for VK_IMAGE_TILING_LINEAR (Asahi Honeykrisp)
-    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8058
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/c9a3cdd396c5646382612ed25e93bb5f9664d043.patch";
-      hash = "sha256-K774FFu6eyyjnxBTy7oTDygkh8+7qp5/KssHkyEwRR8=";
-    })
-  ];
 
   depsBuildBuild = [
     pkg-config
@@ -272,7 +260,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Wrap demos
   postFixup =
     lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      demos=(gtk4-demo gtk4-demo-application gtk4-icon-browser gtk4-widget-factory)
+      demos=(gtk4-demo gtk4-demo-application gtk4-widget-factory)
 
       for program in ''${demos[@]}; do
         wrapProgram $dev/bin/$program \

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -68,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.17.6";
+  version = "4.18.2";
 
   outputs = [
     "out"
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-366boSY/hK+oOklNsu0UxzksZ4QLZzC/om63n94eE6E=";
+    hash = "sha256-zKVne+TD5QG0nxxQvK+suo3PS9Oi0BY4j4NO/ydNwVk=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -68,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.18.3";
+  version = "4.18.4";
 
   outputs = [
     "out"
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-CB4bwLF9tBqTWvjR9vCQ+xmIk2xC/3NNFJ89AEEZ+Ls=";
+    hash = "sha256-1Hg6wVA3wsQnWo8azJT1/t4opRYkP8y5L/VKEcFXdf8=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -68,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.18.2";
+  version = "4.18.3";
 
   outputs = [
     "out"
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zKVne+TD5QG0nxxQvK+suo3PS9Oi0BY4j4NO/ydNwVk=";
+    hash = "sha256-CB4bwLF9tBqTWvjR9vCQ+xmIk2xC/3NNFJ89AEEZ+Ls=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -68,7 +68,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
-  version = "4.18.4";
+  version = "4.18.5";
 
   outputs = [
     "out"
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor finalAttrs.version}/gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-1Hg6wVA3wsQnWo8azJT1/t4opRYkP8y5L/VKEcFXdf8=";
+    hash = "sha256-u1JnoGL1k2lH00yZmTkKZ0sLKw2Ko0cv4NBeIGSVWrw=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtkmm";
-  version = "3.24.9";
+  version = "3.24.10";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "MNW/5ARXHOVmqOk4yLrBdXZCDrUI8eJXg32mPxStRM4=";
+    sha256 = "erfiJmgIcW4mw5kkrOH7RtqGwX7znZiWJMQjFLMrWnY=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/gtkmm/4.x.nix
+++ b/pkgs/development/libraries/gtkmm/4.x.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gtkmm";
-  version = "4.16.0";
+  version = "4.17.0";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-OyP9Or+PsiOwDpmDtgEK8tuA44yJq2mUuLYjCqhdYPk=";
+    hash = "sha256-rYLA8idPXLVrQRTk3ByS12/SEoYMi78uC+wPRJ1JJQo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gtkmm/4.x.nix
+++ b/pkgs/development/libraries/gtkmm/4.x.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "gtkmm";
-  version = "4.17.0";
+  version = "4.18.0";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-rYLA8idPXLVrQRTk3ByS12/SEoYMi78uC+wPRJ1JJQo=";
+    hash = "sha256-LuMcFUefxNjpWLA8i1+7yOF7wSLCovVESXtOBWGeM+w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtksourceview";
-  version = "5.14.2";
+  version = "5.15.1";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtksourceview/${lib.versions.majorMinor finalAttrs.version}/gtksourceview-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Gm04emgHX4rv1OdSz0hxd8SmgjsU/4pDSYaFiurvYmQ=";
+    hash = "sha256-OcDIIUjAiKemV2XE+4+fBFWQvwtGSTC6Msn3CbKl9A4=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtksourceview";
-  version = "5.15.1";
+  version = "5.16.0";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtksourceview/${lib.versions.majorMinor finalAttrs.version}/gtksourceview-${finalAttrs.version}.tar.xz";
-    hash = "sha256-OcDIIUjAiKemV2XE+4+fBFWQvwtGSTC6Msn3CbKl9A4=";
+    hash = "sha256-qzXUIBAvPosFXdO4ZC06SCCfiIGJ5iVND/tLan6MNWY=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libgnome-games-support/2.0.nix
+++ b/pkgs/development/libraries/libgnome-games-support/2.0.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libgnome-games-support";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "U4Ifb+Mu3cue7zMk9kaqrIPMbT3gk339XyZkcNRT0qQ=";
+    sha256 = "AYbyXEiSyGx+rEOjB/wZ22lt9PGayn9U6DwiHfnZeQo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libpeas/2.x.nix
+++ b/pkgs/development/libraries/libpeas/2.x.nix
@@ -24,7 +24,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libpeas";
-  version = "2.0.5";
+  version = "2.0.7";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-N28vc9cxtU4T3bqx2Rtjgs9qmAUk3vRN9irdFUid5t0=";
+    hash = "sha256-HpqdaXYdIQnv9bfBHYyWtIZ8z6yiuSHt7UlAEZJ2nsk=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libsoup";
-  version = "3.6.4";
+  version = "3.6.5";
 
   outputs = [
     "out"
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-m1THb1J2sFvryvK2wqFBoYj8e7HQYk7aJZ2sE6ZmXIo=";
+    hash = "sha256-aJF2Wqw+lJAXlFw+rr2MyCFt93JFbcn0YJdvvbetojQ=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pango";
-  version = "1.56.2";
+  version = "1.56.3";
 
   outputs = [
     "bin"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/pango/${lib.versions.majorMinor finalAttrs.version}/pango-${finalAttrs.version}.tar.xz";
-    hash = "sha256-A7ev1+1zC+9lEVXL+1MgVWuO+SsNwEq7uXhNzUBXr+c=";
+    hash = "sha256-JgYlK8Jc2NJOG39+ksOicrN6zWc0NHtztHpIKDS6JJE=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/tools/profiling/sysprof/capture.nix
+++ b/pkgs/development/tools/profiling/sysprof/capture.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     "-Dtests=false"
     "-Dexamples=false"
     "-Dpolkit-agent=disabled" # only useful for sysprof-cli
+    "-Ddebuginfod=disabled"
   ];
 
   meta = sysprof.meta // {

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -3,6 +3,7 @@
   lib,
   desktop-file-utils,
   fetchurl,
+  elfutils,
   gettext,
   glib,
   gtk4,
@@ -25,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sysprof";
-  version = "47.2";
+  version = "48.beta";
 
   outputs = [
     "out"
@@ -35,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/sysprof/${lib.versions.major finalAttrs.version}/sysprof-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5LXt6f2XjsPw1aDUTQQpptIBw2K/bLRScxkDGuRixU8=";
+    hash = "sha256-0R19TtJRXXocY3B3Cw8dBTqTydfK2tVjejEC7kc/jd4=";
   };
 
   nativeBuildInputs = [
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    elfutils
     glib
     gtk4
     json-glib

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sysprof";
-  version = "48.beta";
+  version = "48.rc";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/sysprof/${lib.versions.major finalAttrs.version}/sysprof-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0R19TtJRXXocY3B3Cw8dBTqTydfK2tVjejEC7kc/jd4=";
+    hash = "sha256-KfA1DAoGungDtOgzRWw4ofZe6Fz/B0tLRvAgfKhjyu8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -26,7 +26,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sysprof";
-  version = "48.rc";
+  version = "48.0";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/sysprof/${lib.versions.major finalAttrs.version}/sysprof-${finalAttrs.version}.tar.xz";
-    hash = "sha256-KfA1DAoGungDtOgzRWw4ofZe6Fz/B0tLRvAgfKhjyu8=";
+    hash = "sha256-Gw8DgPLzBwi6h4KTIaBv7h2zbfqHeXu/B/CnrPRJjRg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This draft PR starts update work for the upcoming GNOME 48 release.

- Schedule: https://release.gnome.org/calendar/ Release: 2025-03-19
- Project: https://github.com/orgs/NixOS/projects/91
- Previous major releases: https://github.com/NixOS/nixpkgs/pull/333911, https://github.com/NixOS/nixpkgs/pull/291339
- Tool for reviewing changes: https://github.com/jtojnar/nonemast
- Release announcement: https://release.gnome.org/48/
- Hydra jobset: TBD <!-- https://hydra.nixos.org/jobset/nixpkgs/gnome -->

### Major changes

- GTK 4 apps will crash if init is not early enough: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7836
- GI bindings might use wrong getter https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/529
- pygobject3 switched to libgirepository-2.0, there are downstream reports of some libpeas plugins breaking https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1099164

### How to help

TBD

<!-- 
- test running your system from this branch (warning: you might not be able to roll back to 45 without dropping all configuration)
- test running new versions of software from this branch
- check hydra builds
  1. look at the latest evaluation in the [jobset](https://hydra.nixos.org/jobset/nixpkgs/gnome)
  2. check the _newly/still failing jobs_ tab, look for red crosses ❌ 
  3. open the individual failures' logs
  4. if you see any failures that look like dependency issue or anything that could be caused by this PR, report it in a comment, or open a PR against gnome-46 branch, if you are able to.
- report any and all problems!
-->

### Depends on

- #390268 