### PR TITLE
armTrustedFirmwareTools: 2.10.0 -> 2.12.1

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -48,6 +48,13 @@ let
 
     # For Cortex-M0 firmware in RK3399
     nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
+    # Make the new toolchain guessing (from 2.11+) happy
+    # https://github.com/ARM-software/arm-trusted-firmware/blob/4ec2948fe3f65dba2f19e691e702f7de2949179c/make_helpers/toolchains/rk3399-m0.mk#L21-L22
+    rk3399-m0-oc = "${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}objcopy";
+
+    # Some platforms like sun50i_a64 have ENABLE_LTO := 1, which requires $(ARCH)-ld/cc-id == "gnu-gcc"
+    aarch64-cc-id = "gnu-gcc";
+    aarch64-ld-id = "gnu-gcc";
 
     buildInputs = [ openssl ];
 
@@ -55,10 +62,12 @@ let
       "HOSTCC=$(CC_FOR_BUILD)"
       "M0_CROSS_COMPILE=${pkgsCross.arm-embedded.stdenv.cc.targetPrefix}"
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-      # binutils 2.39 regression
-      # `warning: /build/source/build/rk3399/release/bl31/bl31.elf has a LOAD segment with RWX permissions`
-      # See also: https://developer.trustedfirmware.org/T996
-      "LDFLAGS=-no-warn-rwx-segments"
+      # Make the new toolchain guessing (from 2.11+) happy
+      "AS=${stdenv.cc.targetPrefix}cc"
+      "OC=${stdenv.cc.targetPrefix}objcopy"
+      "OD=${stdenv.cc.targetPrefix}objdump"
+      # Passing OpenSSL path according to docs/design/trusted-board-boot-build.rst
+      "OPENSSL_DIR=${openssl}"
     ] ++ (lib.optional (platform != null) "PLAT=${platform}")
       ++ extraMakeFlags;
 

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -39,13 +39,13 @@ let
       rec {
 
         pname = "arm-trusted-firmware${lib.optionalString (platform != null) "-${platform}"}";
-        version = "2.12.0";
+        version = "2.12.1";
 
         src = fetchFromGitHub {
           owner = "ARM-software";
           repo = "arm-trusted-firmware";
-          rev = "v${version}";
-          hash = "sha256-PCUKLfmvIBiJqVmKSUKkNig1h44+4RypZ04BvJ+HP6M=";
+          tag = "lts-v${version}";
+          hash = "sha256-yPWygW1swSwL3DrHPNIlTeTeV7XG4C9ALFA/+OTiz+4=";
         };
 
         patches = lib.optionals deleteHDCPBlobBeforeBuild [

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -26,13 +26,13 @@ let
            stdenv.mkDerivation (rec {
 
     pname = "arm-trusted-firmware${lib.optionalString (platform != null) "-${platform}"}";
-    version = "2.10.0";
+    version = "2.12.0";
 
     src = fetchFromGitHub {
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      hash = "sha256-CAuftVST9Fje/DWaaoX0K2SfWwlGMaUFG4huuwsTOSU=";
+      hash = "sha256-PCUKLfmvIBiJqVmKSUKkNig1h44+4RypZ04BvJ+HP6M=";
     };
 
     patches = lib.optionals deleteHDCPBlobBeforeBuild [
@@ -156,17 +156,6 @@ in {
     platform = "rk3588";
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
-
-    # TODO: remove this once the following get merged:
-    # 1: https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/21840
-    # 2: https://review.trustedfirmware.org/c/ci/tf-a-ci-scripts/+/21833
-    src = fetchFromGitLab {
-      domain = "gitlab.collabora.com";
-      owner = "hardware-enablement/rockchip-3588";
-      repo = "trusted-firmware-a";
-      rev = "002d8e85ce5f4f06ebc2c2c52b4923a514bfa701";
-      hash = "sha256-1XOG7ILIgWa3uXUmAh9WTfSGLD/76OsmWrUhIxm/zTg=";
-    };
   };
 
   armTrustedFirmwareS905 = buildArmTrustedFirmware rec {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Based on #373685. Supersedes #378215.

Cross compilation tested with:

```nix
# Save this under your nixpkgs/test.nix and run `nix-build test.nix`
let
  pkgs = import ./. { };
  inherit (pkgs) lib;
in

pkgs.linkFarm "atf-all" (
  lib.mapAttrsToList
    (name: pkg: {
      inherit name;
      path = pkg;
    })
    (
      lib.mapAttrs
        (
          name: pkg:
          let
            inherit (pkg.meta) platforms;
          in
          if builtins.elem "x86_64-linux" platforms then
            pkgs.${name}
          else if builtins.elem "aarch64-linux" platforms then
            pkgs.pkgsCross.aarch64-multiplatform.${name}
          else if builtins.elem "armv7l-linux" platforms then
            pkgs.pkgsCross.armv7l-hf-multiplatform.${name}
          else if builtins.elem "riscv64-linux" platforms then
            pkgs.pkgsCross.riscv64.${name}
          else if builtins.elem "armv6l-linux" platforms then
            pkgs.pkgsCross.raspberryPi.${name}
          else if builtins.elem "armv5tel-linux" platforms then
            pkgs.pkgsCross.sheevaplug.${name}
          else
            builtins.throw "don't know how to build ${name} on platforms ${toString platforms}"
        )
        (
          lib.filterAttrs (
            name: _:
            (builtins.match "^armTrustedFirmware.*" name != null)
            && (! builtins.elem name [
              "armTrustedFirmwareTools" # did not define extraMeta.platforms
            ])
          ) pkgs
        ) // { armTrustedFirmwareTools = pkgs.armTrustedFirmwareTools; }
    )
)
```

Output:
```bash
nixpkgs on atf-2.12 [?] 
at 11:47:09 ❯ ls result
armTrustedFirmwareAllwinner    armTrustedFirmwareAllwinnerH616  armTrustedFirmwareRK3328  armTrustedFirmwareRK3588  armTrustedFirmwareTools
armTrustedFirmwareAllwinnerH6  armTrustedFirmwareQemu           armTrustedFirmwareRK3399  armTrustedFirmwareS905
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
