### PR TITLE
treewide: replace `stdenv.is` with `stdenv.hostPlatform.is`

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
       (lib.cmakeBool "QUARTO_ENABLED" true)
       (lib.cmakeBool "RSTUDIO_CRASHPAD_ENABLED" false) # This is a NOOP except on x86_64-darwin
       (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (
-        (placeholder "out") + (if stdenv.isDarwin then "/Applications" else "/lib/rstudio")
+        (placeholder "out") + (if stdenv.hostPlatform.isDarwin then "/Applications" else "/lib/rstudio")
       ))
     ]
     ++ lib.optionals (!server) [

--- a/pkgs/applications/science/electronics/qucs-s/default.nix
+++ b/pkgs/applications/science/electronics/qucs-s/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ flex bison wrapQtAppsHook cmake ];
   buildInputs = [ qtbase qttools qtcharts qtsvg gperf adms ]
-    ++ lib.optionals stdenv.isLinux [ qtwayland libX11 ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ qtwayland libX11 ]
     ++ kernels;
 
   cmakeFlags = [

--- a/pkgs/applications/video/jellyfin-media-player/default.nix
+++ b/pkgs/applications/video/jellyfin-media-player/default.nix
@@ -82,7 +82,7 @@ mkDerivation rec {
     ln -s ${jellyfin-web}/share/jellyfin-web .
   '';
 
-  postInstall = lib.optionalString stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/bin $out/Applications
     mv "$out/Jellyfin Media Player.app" $out/Applications
     ln -s "$out/Applications/Jellyfin Media Player.app/Contents/MacOS/Jellyfin Media Player" $out/bin/jellyfinmediaplayer

--- a/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
+++ b/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
   versionCheckProgramArg = "-version";
 
   passthru = {
-    tests = lib.optionalAttrs stdenv.isLinux {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       inherit (nixosTests) amazon-cloudwatch-agent;
     };
 

--- a/pkgs/by-name/am/amneziawg-tools/package.nix
+++ b/pkgs/by-name/am/amneziawg-tools/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace $out/lib/systemd/system/awg-quick@.service \
         --replace-fail /usr/bin $out/bin
     ''
-    + lib.optionalString stdenv.isLinux ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
       for f in $out/bin/*; do
         # Which firewall and resolvconf implementations to use should be determined by the
         # environment, we provide the "default" ones as fallback.
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
           }
       done
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       for f in $out/bin/*; do
         wrapProgram $f \
           --prefix PATH : ${lib.makeBinPath [ amneziawg-go ]}

--- a/pkgs/by-name/cr/crusader/package.nix
+++ b/pkgs/by-name/cr/crusader/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
       makeWrapper
       pkg-config
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
     ];
 
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
       libgcc
       libxkbcommon
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       xorg.libX11
       xorg.libXcursor
       xorg.libXi

--- a/pkgs/by-name/dn/dnstap/package.nix
+++ b/pkgs/by-name/dn/dnstap/package.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
     homepage = "https://dnstap.info";
     changelog = "https://github.com/dnstap/golang-dnstap/releases/tag/${src.rev}";
     license = lib.licenses.asl20;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = [ lib.maintainers.azahi ];
     mainProgram = "dnstap";
   };

--- a/pkgs/by-name/ex/excalidraw_export/package.nix
+++ b/pkgs/by-name/ex/excalidraw_export/package.nix
@@ -35,6 +35,6 @@ buildNpmPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ venikx ];
     mainProgram = "excalidraw_export";
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/fl/flexget/package.nix
+++ b/pkgs/by-name/fl/flexget/package.nix
@@ -105,7 +105,7 @@ python3Packages.buildPythonApplication rec {
     python3Packages.paramiko
   ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   disabledTests = [
     # reach the Internet

--- a/pkgs/by-name/fo/foundry/package.nix
+++ b/pkgs/by-name/fo/foundry/package.nix
@@ -25,9 +25,11 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-vVRFS7o0zV+ek9ho+URks6peOryMpFCE1sDzN9g7uH0=";
 
-  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.isDarwin [ darwin.DarwinTools ];
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
 
-  buildInputs = [ solc ] ++ lib.optionals stdenv.isDarwin [ libusb1 ];
+  buildInputs = [ solc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libusb1 ];
 
   # Tests are run upstream, and many perform I/O
   # incompatible with the nix build sandbox.
@@ -44,7 +46,7 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     SVM_RELEASES_LIST_JSON =
-      if stdenv.isDarwin then
+      if stdenv.hostPlatform.isDarwin then
         # Confusingly, these are universal binaries, not amd64.
         # See: https://github.com/ethereum/solidity/issues/12291#issuecomment-1974771433
         "${./svm-lists/macosx-amd64.json}"

--- a/pkgs/by-name/g3/g3proxy/package.nix
+++ b/pkgs/by-name/g3/g3proxy/package.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage rec {
       c-ares
       lua5_4
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
     ];
 

--- a/pkgs/by-name/go/golden-cheetah/package.nix
+++ b/pkgs/by-name/go/golden-cheetah/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase =
-    if stdenv.isLinux then
+    if stdenv.hostPlatform.isLinux then
       ''
         runHook preInstall
 
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
 
         runHook postInstall
       ''
-    else if stdenv.isDarwin then
+    else if stdenv.hostPlatform.isDarwin then
       ''
         runHook preInstall
         mkdir -p $out/Applications

--- a/pkgs/by-name/ia/iamb/package.nix
+++ b/pkgs/by-name/ia/iamb/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  checkFlags = lib.optionals stdenv.isDarwin [
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     # Attempted to create a NULL object.
     "--skip=base::tests::test_complete_cmdbar"
     "--skip=base::tests::test_complete_msgbar"

--- a/pkgs/by-name/ki/kikoplay/package.nix
+++ b/pkgs/by-name/ki/kikoplay/package.nix
@@ -92,6 +92,6 @@ stdenv.mkDerivation rec {
     homepage = "https://kikoplay.fun";
     license = lib.licenses.gpl3Only;
     # See https://github.com/NixOS/nixpkgs/pull/354929
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/li/libcosmicAppHook/package.nix
+++ b/pkgs/by-name/li/libcosmicAppHook/package.nix
@@ -38,7 +38,7 @@ makeSetupHook {
       xorg.libXi
       xorg.libxcb
     ]
-    ++ lib.optionals (!stdenv.isDarwin) [
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       wayland
       vulkan-loader
     ];
@@ -64,7 +64,7 @@ makeSetupHook {
         # for x11rb
         "xcb"
       ]
-      ++ lib.optionals (!stdenv.isDarwin) [
+      ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
         # for wgpu-hal, wayland-sys
         "wayland-client"
         # for wgpu-hal

--- a/pkgs/by-name/li/librist/package.nix
+++ b/pkgs/by-name/li/librist/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   # avoid rebuild on Linux for now
-  patches = lib.optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
     # https://code.videolan.org/rist/librist/-/issues/192
     ./no-brew-darwin.diff
   ];

--- a/pkgs/by-name/li/livekit-libwebrtc/package.nix
+++ b/pkgs/by-name/li/livekit-libwebrtc/package.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation {
       cpio
       pkg-config
     ]
-    ++ lib.optionals stdenv.isDarwin [ xcbuild ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
   buildInputs =
     [ nasm ]

--- a/pkgs/by-name/ln/lnav/package.nix
+++ b/pkgs/by-name/ln/lnav/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       curl
       libarchive
     ]
-    ++ lib.optionals (!stdenv.isDarwin) [
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       gpm
     ];
 

--- a/pkgs/by-name/lo/logrotate/package.nix
+++ b/pkgs/by-name/lo/logrotate/package.nix
@@ -5,7 +5,7 @@
   gzip,
   popt,
   autoreconfHook,
-  aclSupport ? stdenv.isLinux,
+  aclSupport ? stdenv.hostPlatform.isLinux,
   acl,
   nixosTests,
 }:

--- a/pkgs/by-name/ma/mattermost/tests.nix
+++ b/pkgs/by-name/ma/mattermost/tests.nix
@@ -143,7 +143,7 @@ mattermost.overrideAttrs (
         "TestSessionStore/MySQL/SessionGetWithDeviceId"
         "TestSessionStore/MySQL/GetMobileSessionMetadata"
       ]
-      ++ optionals (!stdenv.isx86_64) [
+      ++ optionals (!stdenv.hostPlatform.isx86_64) [
         # aarch64: invalid operating system or processor architecture
         "TestCanIUpgradeToE0"
       ];

--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -55,7 +55,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   ];
 
   # Path hard-coded paths.
-  postPatch = lib.optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace mcpelauncher-client/src/jni/main_activity.cpp \
       --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open \
       --replace-fail /usr/bin/zenity ${zenity}/bin/zenity

--- a/pkgs/by-name/me/megacmd/package.nix
+++ b/pkgs/by-name/me/megacmd/package.nix
@@ -26,7 +26,7 @@ let
   pname = "megacmd";
   version = "1.7.0";
   srcOptions =
-    if stdenv.isLinux then
+    if stdenv.hostPlatform.isLinux then
       {
         tag = "${version}_Linux";
         hash = "sha256-UlSqwM8GQKeG8/K0t5DbM034NQOeBg+ujNi/MMsVCuM=";
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs =
-    lib.optionals stdenv.isLinux [ gcc-unwrapped ] # fix: ld: cannot find lib64/libstdc++fs.a
+    lib.optionals stdenv.hostPlatform.isLinux [ gcc-unwrapped ] # fix: ld: cannot find lib64/libstdc++fs.a
     ++ [
       c-ares
       cryptopp

--- a/pkgs/by-name/my/mydumper/package.nix
+++ b/pkgs/by-name/my/mydumper/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
       zlib
       zstd
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       libselinux
       libsepol
     ];
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
   ];
 
   env.NIX_CFLAGS_COMPILE = (
-    if stdenv.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       toString [
         "-Wno-error=deprecated-non-prototype"
         "-Wno-error=format"

--- a/pkgs/by-name/ox/oxide-rs/package.nix
+++ b/pkgs/by-name/ox/oxide-rs/package.nix
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage rec {
       openssl
       zlib
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.Security
       darwin.apple_sdk.frameworks.SystemConfiguration
     ];

--- a/pkgs/by-name/pr/proxychains-ng/package.nix
+++ b/pkgs/by-name/pr/proxychains-ng/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = lib.optionals stdenv.isDarwin [
+  configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "--hookmethod=${darwinHookMethod}"
   ];
 

--- a/pkgs/by-name/qo/qownnotes/package.nix
+++ b/pkgs/by-name/qo/qownnotes/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
         --fish <(xvfb-run $out/bin/${finalAttrs.appname} --completion fish)
     ''
     # Install shell completion on macOS
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       installShellCompletion --cmd ${finalAttrs.pname} \
         --bash <($out/bin/${finalAttrs.appname} --completion bash) \
         --fish <($out/bin/${finalAttrs.appname} --completion fish)

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -39,7 +39,7 @@ buildDotnetModule rec {
     hash = "sha256-pLzmfrdjpn2DTg2AJF1yyTJJPxHScQTX+yq9MbuzMHk=";
   };
 
-  nativeBuildInputs = lib.optional stdenv.isDarwin [
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin [
     cctools
     darwin.sigtool
   ];
@@ -75,17 +75,17 @@ buildDotnetModule rec {
       libGL
       SDL2
     ]
-    ++ lib.optional (!stdenv.isDarwin) [
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) [
       udev
       pulseaudio
     ]
-    ++ lib.optional stdenv.isDarwin [ moltenvk ];
+    ++ lib.optional stdenv.hostPlatform.isDarwin [ moltenvk ];
 
   projectFile = "Ryujinx.sln";
   testProjectFile = "src/Ryujinx.Tests/Ryujinx.Tests.csproj";
 
   # Tests on Darwin currently fail because of Ryujinx.Tests.Unicorn
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   dotnetFlags = [
     "/p:ExtraDefineConstants=DISABLE_UPDATER%2CFORCE_EXTERNAL_BASE_DIR"
@@ -107,7 +107,7 @@ buildDotnetModule rec {
   '';
 
   preFixup = ''
-    ${lib.optionalString stdenv.isLinux ''
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/{applications,icons/hicolor/scalable/apps,mime/packages}
 
       pushd ${src}/distribution/linux
@@ -121,7 +121,7 @@ buildDotnetModule rec {
     ''}
 
     # Don't make a softlink on OSX because of its case insensitivity
-    ${lib.optionalString (!stdenv.isDarwin) "ln -s $out/bin/Ryujinx $out/bin/ryujinx"}
+    ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "ln -s $out/bin/Ryujinx $out/bin/ryujinx"}
   '';
 
   passthru.updateScript = ./updater.sh;

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -47,7 +47,7 @@
   libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
   testSupport ? true,
-  waylandSupport ? stdenv.isLinux && !stdenv.hostPlatform.isAndroid,
+  waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
 }:
 

--- a/pkgs/by-name/so/sov/package.nix
+++ b/pkgs/by-name/so/sov/package.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ ];
     inherit (wayland.meta) platforms;
     # sys/timerfd.h header inexistent
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/st/stegseek/package.nix
+++ b/pkgs/by-name/st/stegseek/package.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation rec {
   ];
 
   # tests get stuck on aarch64-linux
-  doCheck = stdenv.isx86_64 && stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     description = "Tool to crack steganography";
     longDescription = ''
       Stegseek is a lightning fast steghide cracker that can be

--- a/pkgs/by-name/tr/tracy/package.nix
+++ b/pkgs/by-name/tr/tracy/package.nix
@@ -25,8 +25,8 @@
   wayland-protocols,
 }:
 
-assert withGtkFileSelector -> stdenv.isLinux;
-assert withWayland -> stdenv.isLinux;
+assert withGtkFileSelector -> stdenv.hostPlatform.isLinux;
+assert withWayland -> stdenv.hostPlatform.isLinux;
 
 stdenv.mkDerivation rec {
   pname = if withWayland then "tracy-wayland" else "tracy-glfw";
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       ninja
       pkg-config
     ]
-    ++ lib.optionals stdenv.isLinux [ wayland-scanner ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ wayland-scanner ]
     ++ lib.optionals stdenv.cc.isClang [ stdenv.cc.cc.libllvm ];
 
   buildInputs =
@@ -79,8 +79,8 @@ stdenv.mkDerivation rec {
       "-DDOWNLOAD_CAPSTONE=off"
       "-DTRACY_STATIC=off"
     ]
-    ++ lib.optional (stdenv.isLinux && withGtkFileSelector) "-DGTK_FILESELECTOR=ON"
-    ++ lib.optional (stdenv.isLinux && !withWayland) "-DLEGACY=on";
+    ++ lib.optional (stdenv.hostPlatform.isLinux && withGtkFileSelector) "-DGTK_FILESELECTOR=ON"
+    ++ lib.optional (stdenv.hostPlatform.isLinux && !withWayland) "-DLEGACY=on";
 
   env.NIX_CFLAGS_COMPILE = toString (
     [ ]

--- a/pkgs/by-name/tw/twitch-hls-client/package.nix
+++ b/pkgs/by-name/tw/twitch-hls-client/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-sqhB2Lj3RK1OyXy87Be9aOkfcksqz+5VfRTlKuswerU=";
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ thiagokokada ];
     license = licenses.watcom;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase =
-    if stdenv.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       ''
         runHook preInstall
 
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
           buildPhase =
             let
               Default_Data_Path =
-                if stdenv.isDarwin then
+                if stdenv.hostPlatform.isDarwin then
                   "$out/Applications/${appName}.app/Contents/share/${appName}"
                 else
                   "$out/share/${appName}";

--- a/pkgs/by-name/vs/vsmartcard-pcsc-relay/package.nix
+++ b/pkgs/by-name/vs/vsmartcard-pcsc-relay/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       ))
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.PCSC
     ];
 
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://frankmorgner.github.io/vsmartcard/pcsc-relay/README.html";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [ stargate01 ];
   };
 })

--- a/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
+++ b/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
@@ -46,18 +46,18 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       ))
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       darwin.apple_sdk.frameworks.PCSC
     ];
 
-  configureFlags = lib.optional stdenv.isDarwin "--enable-infoplist";
+  configureFlags = lib.optional stdenv.hostPlatform.isDarwin "--enable-infoplist";
 
   meta = {
     description = "Emulates a smart card and makes it accessible through PC/SC";
     homepage = "http://frankmorgner.github.io/vsmartcard/virtualsmartcard/README.html";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [ stargate01 ];
   };
 })

--- a/pkgs/by-name/zf/zfs-replicate/package.nix
+++ b/pkgs/by-name/zf/zfs-replicate/package.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = true;
 
-  disabledTestPaths = lib.optionals stdenv.isDarwin [
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: Expected SystemExit or FileNotFoundError
     "zfs_test/replicate_test/cli_test/main_test.py"
   ];

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     "lit"
     "gtest"
   ];
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isLinux;
 
   meta = with lib; {
     homepage = "https://github.com/WebAssembly/binaryen";

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Probably broken MIME type detection on Darwin.
   # Tests fail with imprecise rendering on i686.
-  doCheck = !stdenv.isDarwin && !stdenv.hostPlatform.isi686;
+  doCheck = !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isi686;
 
   env = {
     PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_QUERY_LOADERS = writeShellScript "gdk-pixbuf-loader-loaders-wrapped" ''

--- a/pkgs/development/libraries/qtspell/default.nix
+++ b/pkgs/development/libraries/qtspell/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       enchant
       qtbase
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       glib
       llvmPackages.clang
     ];

--- a/pkgs/development/python-modules/distutils/default.nix
+++ b/pkgs/development/python-modules/distutils/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   ];
 
   # jaraco-path depends ob pyobjc
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   meta = {
     description = "Distutils as found in cpython";

--- a/pkgs/development/python-modules/kaleido/default.nix
+++ b/pkgs/development/python-modules/kaleido/default.nix
@@ -93,7 +93,7 @@ buildPythonPackage rec {
       #ln -s ${dejavu_fonts}/share/fonts/truetype/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/dejavu/
       #ln -s ${lato}/share/fonts/lato/* $out/${python.sitePackages}/kaleido/executable/xdg/fonts/truetype/lato/
     ''
-    + lib.optionalString (!stdenv.isDarwin) ''
+    + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
       # Replace bundled swiftshader with libGL
       rm -rf $out/${python.sitePackages}/kaleido/executable/bin/swiftshader
       ln -s ${libGL}/lib $out/${python.sitePackages}/kaleido/executable/bin/swiftshader

--- a/pkgs/development/python-modules/libuuu/default.nix
+++ b/pkgs/development/python-modules/libuuu/default.nix
@@ -25,11 +25,11 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     udev
   ];
 

--- a/pkgs/development/python-modules/nidaqmx/default.nix
+++ b/pkgs/development/python-modules/nidaqmx/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
       click
       requests
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       distro
     ];
 

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -38,7 +38,7 @@ let
     # Remove bazel specific build file to make way for build directory
     # This is a problem on Darwin because of case-insensitive filesystem
     preBuild =
-      (lib.optionalString stdenv.isDarwin ''
+      (lib.optionalString stdenv.hostPlatform.isDarwin ''
         rm ../BUILD
       '')
       + oa.preBuild;

--- a/pkgs/development/python-modules/waitress/default.nix
+++ b/pkgs/development/python-modules/waitress/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
   disabledTests = [
     # access to socket
     "test_service_port"

--- a/pkgs/development/python-modules/zenoh/default.nix
+++ b/pkgs/development/python-modules/zenoh/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     rustc
   ];
 
-  buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Security;
 
   pythonImportsCheck = [
     "zenoh"

--- a/pkgs/tools/backup/monolith/default.nix
+++ b/pkgs/tools/backup/monolith/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Y2Z/monolith";
     license = licenses.cc0;
     platforms = lib.platforms.unix;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -44,7 +44,7 @@ in buildGo122Module rec {
 
   doCheck = false;
 
-  vendorHash = if stdenv.isDarwin
+  vendorHash = if stdenv.hostPlatform.isDarwin
                then "sha256-3Piq5DPMTZUEjqNkw5HZY25An2kATX6Jac9unQfZnZc="
                else "sha256-FR0Et3DvjJhbYUPy9mpN0QCJ7QDU4VRZFUTL0J1FSXw=";
 

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -66,8 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [ ncurses ]
-    ++ lib.optional stdenv.isLinux udev
-    ++ lib.optional stdenv.isDarwin apple-sdk_12
+    ++ lib.optional stdenv.hostPlatform.isLinux udev
+    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_12
     ++ lib.optional nvidia cudatoolkit
     ++ lib.optional needDrm libdrm;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3132,7 +3132,7 @@ with pkgs;
 
   tsm-client-withGui = callPackage ../by-name/ts/tsm-client/package.nix { enableGui = true; };
 
-  tracy = callPackage ../by-name/tr/tracy/package.nix { withWayland = stdenv.isLinux; };
+  tracy = callPackage ../by-name/tr/tracy/package.nix { withWayland = stdenv.hostPlatform.isLinux; };
   tracy-glfw = callPackage ../by-name/tr/tracy/package.nix { withWayland = false; };
   tracy-wayland = callPackage ../by-name/tr/tracy/package.nix { withWayland = true; };
 


### PR DESCRIPTION
Repeat of https://github.com/NixOS/nixpkgs/pull/341407, part of https://github.com/NixOS/nixpkgs/issues/346453

should be 0 rebuilds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
