### PR TITLE
treewide: `finalAttrs.doCheck` -> `finalAttrs.finalPackage.doCheck`

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -184,7 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "CMAKE_DISABLE_FIND_PACKAGE_TFLogger" true)
       (lib.cmakeBool "CMAKE_DISABLE_FIND_PACKAGE_ViennaCL" true)
       (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;'${excludeTestsRegex}'")
-      (lib.cmakeBool "ENABLE_TESTING" finalAttrs.doCheck)
+      (lib.cmakeBool "ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
       (lib.cmakeBool "DISABLE_META_INTEGRATION_TESTS" true)
       (lib.cmakeBool "TRAVIS_DISABLE_META_CPP" true)
       (lib.cmakeBool "INTERFACE_PYTHON" pythonSupport)

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   # xvfb-run is available only on Linux
   doCheck = stdenv.hostPlatform.isLinux;
 
-  nativeCheckInputs = lib.optionals finalAttrs.doCheck [
+  nativeCheckInputs = lib.optionals finalAttrs.finalPackage.doCheck [
     xorgserver
     xvfb-run
     xdotool

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -53,11 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" stdenv.hostPlatform.hasSharedLibraries)
     (lib.cmakeBool "EIGEN" true)
-    (lib.cmakeBool "EXAMPLES" finalAttrs.doCheck)
+    (lib.cmakeBool "EXAMPLES" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "ICB" true)
     (lib.cmakeBool "INTERFACE64" (!useAccel && blas.isILP64))
     (lib.cmakeBool "MPI" useMpi)
-    (lib.cmakeBool "TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "TESTS" finalAttrs.finalPackage.doCheck)
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-DBLA_VENDOR=${if useAccel then "Apple" else "Generic"}"
   ];

--- a/pkgs/by-name/bl/blobdrop/package.nix
+++ b/pkgs/by-name/bl/blobdrop/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/co/convmv/package.nix
+++ b/pkgs/by-name/co/convmv/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   prePatch =
-    lib.optionalString finalAttrs.doCheck ''
+    lib.optionalString finalAttrs.finalPackage.doCheck ''
       tar -xf testsuite.tar
     ''
     + ''

--- a/pkgs/by-name/ge/gemrb/package.nix
+++ b/pkgs/by-name/ge/gemrb/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ] ++ lib.optionals (finalAttrs.doCheck or false) [ gtest ];
+  ] ++ lib.optionals (finalAttrs.finalPackage.doCheck or false) [ gtest ];
 
   cmakeFlags = [
     (lib.cmakeFeature "DATA_DIR" "${placeholder "out"}/share/gemrb")
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LAYOUT" "opt")
     (lib.cmakeFeature "OPENGL_BACKEND" backend)
     (lib.cmakeFeature "OpenGL_GL_PREFERENCE" "GLVND")
-    (lib.cmakeBool "USE_TESTS" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "USE_TESTS" (finalAttrs.finalPackage.doCheck or false))
   ];
 
   postInstall = ''

--- a/pkgs/by-name/gl/glog/package.nix
+++ b/pkgs/by-name/gl/glog/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     sha256 = "sha256-+nwWP6VBmhgU7GCPSEGUzvUSCc48wXME181WpJ5ABP4=";
   };
 
-  postPatch = lib.optionalString finalAttrs.doCheck ''
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
     substituteInPlace src/logging_unittest.cc \
       --replace-warn "/usr/bin/true" "${pkgsBuildHost.coreutils}/bin/true"
   '';

--- a/pkgs/by-name/hd/hdf4/package.nix
+++ b/pkgs/by-name/hd/hdf4/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "HDF4_ENABLE_SZIP_SUPPORT" szipSupport)
       (lib.cmakeBool "HDF4_ENABLE_SZIP_ENCODING" szipSupport)
       (lib.cmakeBool "HDF4_BUILD_JAVA" javaSupport)
-      (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+      (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     ]
     ++ lib.optionals javaSupport [
       (lib.cmakeFeature "JAVA_HOME" "${jdk}")

--- a/pkgs/by-name/li/lib2geom/package.nix
+++ b/pkgs/by-name/li/lib2geom/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-D2GEOM_BUILD_SHARED=ON"
     # For cross compilation.
-    (lib.cmakeBool "2GEOM_TESTING" finalAttrs.doCheck)
+    (lib.cmakeBool "2GEOM_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/by-name/li/libconfig/package.nix
+++ b/pkgs/by-name/li/libconfig/package.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags =
     lib.optional (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isStatic) "--disable-examples"
-    ++ lib.optional (!finalAttrs.doCheck) "--disable-tests";
+    ++ lib.optional (!finalAttrs.finalPackage.doCheck) "--disable-tests";
 
-  cmakeFlags = lib.optionals (!finalAttrs.doCheck) [ "-DBUILD_TESTS:BOOL=OFF" ];
+  cmakeFlags = lib.optionals (!finalAttrs.finalPackage.doCheck) [ "-DBUILD_TESTS:BOOL=OFF" ];
 
   meta = {
     homepage = "https://hyperrealm.github.io/libconfig/";

--- a/pkgs/by-name/li/libkazv/package.nix
+++ b/pkgs/by-name/li/libkazv/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cmakeFlags = [ (lib.cmakeBool "libkazv_BUILD_TESTS" finalAttrs.doCheck) ];
+  cmakeFlags = [ (lib.cmakeBool "libkazv_BUILD_TESTS" finalAttrs.finalPackage.doCheck) ];
 
   doCheck = true;
 

--- a/pkgs/by-name/li/libloot/package.nix
+++ b/pkgs/by-name/li/libloot/package.nix
@@ -83,11 +83,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LIBLOADORDER_LIBRARIES" "loadorder_ffi")
     (lib.cmakeFeature "LCI_LIBRARIES" "loot_condition_interpreter_ffi")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_TESTING-PLUGINS" "../testing-plugins")
-    (lib.cmakeBool "LIBLOOT_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "LIBLOOT_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "LIBLOOT_INSTALL_DOCS" withDocs)
   ];
 
-  postConfigure = lib.optionalString finalAttrs.doCheck ''
+  postConfigure = lib.optionalString finalAttrs.finalPackage.doCheck ''
     cp -r --no-preserve=all ${finalAttrs.passthru.testing-plugins} ../testing-plugins
   '';
 

--- a/pkgs/by-name/li/libwacom/package.nix
+++ b/pkgs/by-name/li/libwacom/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    (lib.mesonEnable "tests" finalAttrs.doCheck)
+    (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonOption "sysconfdir" "/etc")
   ];
 

--- a/pkgs/by-name/lu/luanti/package.nix
+++ b/pkgs/by-name/lu/luanti/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_CLIENT" buildClient)
     (lib.cmakeBool "BUILD_SERVER" buildServer)
-    (lib.cmakeBool "BUILD_UNITTESTS" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "BUILD_UNITTESTS" (finalAttrs.finalPackage.doCheck or false))
     (lib.cmakeBool "ENABLE_PROMETHEUS" buildServer)
     (lib.cmakeBool "USE_SDL2" useSDL2)
     # Ensure we use system libraries

--- a/pkgs/by-name/st/stp/package.nix
+++ b/pkgs/by-name/st/stp/package.nix
@@ -95,9 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "USE_CADICAL" useCadical)
       (lib.cmakeBool "NOCRYPTOMINISAT" useCadical)
       (lib.cmakeBool "FORCE_CMS" (!useCadical))
-      (lib.cmakeBool "ENABLE_TESTING" finalAttrs.doCheck)
+      (lib.cmakeBool "ENABLE_TESTING" finalAttrs.finalPackage.doCheck)
     ]
-    ++ lib.optional finalAttrs.doCheck (lib.cmakeFeature "LIT_ARGS" "-v")
+    ++ lib.optional finalAttrs.finalPackage.doCheck (lib.cmakeFeature "LIT_ARGS" "-v")
     ++ lib.optional useCadical (lib.cmakeFeature "CADICAL_DIR" (toString cadicalDependency));
 
   # Fixes the following warning in the aarch64 build on Linux:
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
         "-DPYTHON_LIB_INSTALL_DIR=$python_install_dir"
       )
     ''
-    + lib.optionalString finalAttrs.doCheck ''
+    + lib.optionalString finalAttrs.finalPackage.doCheck ''
       # Link in gtest and the output check utility.
       mkdir -p deps
       ln -s ${gtest.src} deps/gtest

--- a/pkgs/by-name/to/tomlplusplus/package.nix
+++ b/pkgs/by-name/to/tomlplusplus/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dbuild_tests=${lib.boolToString finalAttrs.doCheck}"
+    "-Dbuild_tests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-Dbuild_examples=true"
   ];
 

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -265,8 +265,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional (!isOptimized) "--unoptimized"
     ++ lib.optional (runtimeMode == "debug") "--no-stripped"
-    ++ lib.optional finalAttrs.doCheck "--enable-unittests"
-    ++ lib.optional (!finalAttrs.doCheck) "--no-enable-unittests";
+    ++ lib.optional finalAttrs.finalPackage.doCheck "--enable-unittests"
+    ++ lib.optional (!finalAttrs.finalPackage.doCheck) "--no-enable-unittests";
 
   # NOTE: Once https://github.com/flutter/flutter/issues/127606 is fixed, use "--no-prebuilt-dart-sdk"
   configurePhase =
@@ -318,7 +318,7 @@ stdenv.mkDerivation (finalAttrs: {
       find $out/out/$outName -name '*_unittests' -delete
       find $out/out/$outName -name '*_benchmarks' -delete
     ''
-    + lib.optionalString (finalAttrs.doCheck) ''
+    + lib.optionalString (finalAttrs.finalPackage.doCheck) ''
       rm $out/out/$outName/{display_list_rendertests,flutter_tester}
     ''
     + ''

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -64,7 +64,7 @@ let
 
       buildTargets =
         [ "cli" ]
-        ++ lib.optionals finalAttrs.doCheck [ "tests" ]
+        ++ lib.optionals finalAttrs.finalPackage.doCheck [ "tests" ]
         ++ lib.optionals static [ "static" ]
         ++ lib.optionals (!static) [ "shared" ];
 

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-shcReTJHwsQnY5FDkt+p/LnjcoyktKoRCtuNkV/ABok=";
   };
 
-  postPatch = lib.optionalString finalAttrs.doCheck ''
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
     patchShebangs tests/
   '';
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [ wayland ];
   strictDeps = true;
 
-  mesonFlags = [ "-Dtests=${lib.boolToString finalAttrs.doCheck}" ];
+  mesonFlags = [ "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}" ];
 
   meta = {
     description = "Wayland protocol extensions";

--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-Dsqlcipher=1"
-    (lib.cmakeBool "ENABLE_TESTING" (finalAttrs.doCheck or false))
+    (lib.cmakeBool "ENABLE_TESTING" (finalAttrs.finalPackage.doCheck or false))
   ];
 
   doCheck = true;

--- a/pkgs/tools/package-management/nix/2_26/src/perl/package.nix
+++ b/pkgs/tools/package-management/nix/2_26/src/perl/package.nix
@@ -31,7 +31,7 @@ perl.pkgs.toPerlModule (
         ./meson.build
         ./meson.options
       ]
-      ++ lib.optionals finalAttrs.doCheck [
+      ++ lib.optionals finalAttrs.finalPackage.doCheck [
         ./.yath.rc.in
         ./t
       ]
@@ -70,7 +70,7 @@ perl.pkgs.toPerlModule (
     mesonFlags = [
       (lib.mesonOption "dbi_path" "${perlPackages.DBI}/${perl.libPrefix}")
       (lib.mesonOption "dbd_sqlite_path" "${perlPackages.DBDSQLite}/${perl.libPrefix}")
-      (lib.mesonEnable "tests" finalAttrs.doCheck)
+      (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
     ];
 
     mesonCheckFlags = [


### PR DESCRIPTION
repeat of https://github.com/NixOS/nixpkgs/pull/271241, part of https://github.com/NixOS/nixpkgs/issues/346453

should be 0 rebuilds
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
