### PR TITLE
treewide: use mirror urls

### DIFF
--- a/pkgs/by-name/ac/activemq/package.nix
+++ b/pkgs/by-name/ac/activemq/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://archive.apache.org/dist/activemq/${version}/apache-activemq-${version}-bin.tar.gz";
+    url = "mirror://apache/activemq/${version}/apache-activemq-${version}-bin.tar.gz";
     hash = "sha256-JrLLSm6+Be1vSBTTryRcZfbiGK0PrmJ/pM2uYnGuN9E=";
   };
 

--- a/pkgs/by-name/li/libxmlxx5/package.nix
+++ b/pkgs/by-name/li/libxmlxx5/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "5.4";
 
   src = fetchurl {
-    url = "https://download.gnome.org/sources/libxml++/${version}/libxml++-${lib.versions.pad 3 version}.tar.xz";
+    url = "mirror://gnome/sources/libxml++/${version}/libxml++-${lib.versions.pad 3 version}.tar.xz";
     hash = "sha256-6aI8Q2aGqUaY0hOOa8uvhJEh1jv6D1DcNP77/XlWaEg=";
   };
 


### PR DESCRIPTION
repeat of #347454, part of #346453, should be 0 rebuilds

Made using

```
export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git reset
git restore .

nix eval -f pkgs/build-support/fetchurl/mirrors.nix --json |
    jq '
        to_entries[]
            | .key as $key
            | .value[]
            | @sh "rg \(.) -l pkgs/ -tnix | xe sd \(.) mirror://\($key)/"
        ' -r |
    bash -x

git restore -- pkgs/build-support/fetchurl/mirrors.nix
git restore -- pkgs/applications/networking/browsers/
git restore -- pkgs/development/haskell-modules/

test -s packages.json || ( set -x;
    time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --show-trace --no-allow-import-from-derivation > packages.json
)

MODIFIED="$(git ls-files --modified)"

jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
    sed -e "s#\t$(realpath .)/#\t#" |
    sed -e 's#:\([0-9]*\)$#\t\1#' |
    grep --fixed-strings "$MODIFIED" |
    while read attrpath position col; do
        if test -z $(git diff -- "$position"); then
            continue
        fi
        if nix-build . -A "$attrpath".src \
        && nix-build . -A "$attrpath".src --check \
        && nix-build . -A "$attrpath".patches \
        && nix-build . -A "$attrpath".patches --check
        then
            git add -- "$position"
        else
            git reset -- "$position"
            git restore -- "$position"
        fi
    done
```

Then I verified the FOD hashes for each `--patch` i accepted.

FOD hash verification:

```
$ nix-prefetch-url $(nix eval -f default.nix activemq.src.url --raw | tee >( cat >&2; echo >&2 )) | xargs nix hash to-sri --type sha256
mirror://apache/activemq/6.1.5/apache-activemq-6.1.5-bin.tar.gz
path is '/nix/store/gmh0hzsglbfyrcqkjiyf0kvwcyqqgz5p-apache-activemq-6.1.5-bin.tar.gz'
sha256-JrLLSm6+Be1vSBTTryRcZfbiGK0PrmJ/pM2uYnGuN9E=

$ nix-prefetch-url $(nix eval -f default.nix libxmlxx5.src.url --raw | tee >( cat >&2; echo >&2 )) | xargs nix hash to-sri --type sha256
mirror://gnome/sources/libxml++/5.4/libxml++-5.4.0.tar.xz
path is '/nix/store/8zy5makss1dcijprf5bilz5qqz59xg2p-libxml++-5.4.0.tar.xz'
sha256-6aI8Q2aGqUaY0hOOa8uvhJEh1jv6D1DcNP77/XlWaEg=
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
