### PR TITLE
gridcoin-research: add package options for `withGui` `withQrencode` `withUpnp`, and enable `doCheck`

### DIFF
--- a/pkgs/applications/blockchains/gridcoin-research/default.nix
+++ b/pkgs/applications/blockchains/gridcoin-research/default.nix
@@ -16,6 +16,10 @@
   libtool,
   miniupnpc,
   hexdump,
+
+  withGui ? true,
+  withQrencode ? withGui,
+  withUpnp ? false,
 }:
 
 stdenv.mkDerivation rec {
@@ -31,32 +35,49 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapQtAppsHook
     autoreconfHook
     libtool
     hexdump
-  ];
+  ] ++ lib.optionals withGui [ wrapQtAppsHook ];
 
-  buildInputs = [
-    qttools
-    qtbase
-    qrencode
-    libevent
-    libzip
-    openssl
-    boost
-    miniupnpc
-    curl
-  ];
+  buildInputs =
+    [
+      libevent
+      libzip
+      openssl
+      boost
+      curl
+    ]
+    ++ lib.optionals withGui [
+      qtbase
+      qttools
+    ]
+    ++ lib.optionals withQrencode [
+      qrencode
+    ]
+    ++ lib.optionals withUpnp [
+      miniupnpc
+    ];
 
-  configureFlags = [
-    "--with-gui=qt5"
-    "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
-    "--with-qrencode"
-    "--with-boost-libdir=${boost.out}/lib"
-  ];
+  configureFlags =
+    [
+      "--with-boost-libdir=${boost.out}/lib"
+    ]
+    ++ lib.optionals withGui [
+      "--with-gui=qt5"
+      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+    ]
+    ++ lib.optionals withQrencode [
+      "--with-qrencode"
+    ]
+    ++ lib.optionals withUpnp [
+      "--with-miniupnpc"
+      "--enable-upnp-default"
+    ];
 
   enableParallelBuilding = true;
+
+  doCheck = true;
 
   meta = with lib; {
     description = "POS-based cryptocurrency that rewards users for participating on the BOINC network";


### PR DESCRIPTION
Add package options for `withGui` `withQrencode` `withUpnp`.
Enable `doCheck` so we actually use test binaries.

The gridcoin-research wallet can be run headless and/or as a 'full node', these options should help with the implementation of any future nixos module that allows a user to configure their wallet for 'normal' use, headless use, or full node use.

For reference: a potential nixos module can use the gridcoinresearch binary's launch options (https://gridcoin.us/wiki/cmd-options.html) to set config file location and other various settings

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
