### PR TITLE
lib/systems: elaborate Go toolchain environment

### DIFF
--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -90,6 +90,223 @@ lib.runTests (
     expr = (lib.systems.elaborate { system = "i686-linux"; parsed = (lib.systems.elaborate "x86_64-linux").parsed; }).parsed.cpu.arch;
     expected = "i686";
   };
+
+  test_elaborate_go_osArch = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+      }).go.osArch;
+    expected = "linux/arm64";
+  };
+  test_elaborate_cgo_supported = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+      }).go.cgoSupported;
+    expected = true;
+  };
+  test_elaborate_cgo_unsupported = {
+    expr =
+      (lib.systems.elaborate {
+        system = "wasm64-wasi";
+      }).go.cgoSupported;
+    expected = false;
+  };
+  test_elaborate_go_raceDetectorSupported = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+      }).go.raceDetectorSupported;
+    expected = true;
+  };
+  test_elaborate_go_raceDetectorUnsupported = {
+    expr =
+      (lib.systems.elaborate {
+        system = "armv6l-linux";
+      }).go.raceDetectorSupported;
+    expected = false;
+  };
+  test_elaborate_go386_hardfloat = {
+    expr =
+      (lib.systems.elaborate {
+        config = "i686-unknown-linux-gnu";
+      }).go.env.GO386;
+    expected = "sse2";
+  };
+  test_elaborate_go386_softfloat = {
+    expr =
+      (lib.systems.elaborate {
+        config = "i686-unknown-linux-gnueabi";
+      }).go.env.GO386;
+    expected = "softfloat";
+  };
+  test_elaborate_goarm_from_cpu_version = {
+    expr =
+      (lib.systems.elaborate {
+        system = "armv6l-linux";
+      }).go.env.GOARM;
+    expected = "6,hardfloat";
+  };
+  test_elaborate_goarm_from_cpu_version_softfloat = {
+    expr =
+      (lib.systems.elaborate {
+        config = "armv6l-unknown-linux-gnueabi";
+      }).go.env.GOARM;
+    expected = "6,softfloat";
+  };
+  test_elaborate_goarm_from_cpu_version_hardfloat = {
+    expr =
+      (lib.systems.elaborate {
+        config = "armv6l-unknown-linux-gnueabihf";
+      }).go.env.GOARM;
+    expected = "6,hardfloat";
+  };
+  test_elaborate_goarm64_from_gcc_arch_with_version = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv8.3-a";
+      }).go.env.GOARM64;
+    expected = "v8.3";
+  };
+  test_elaborate_goarm64_from_gcc_arch_armv8 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv8-a";
+      }).go.env.GOARM64;
+    expected = "v8.0";
+  };
+  test_elaborate_goarm64_from_gcc_arch_armv9 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv9-a";
+      }).go.env.GOARM64;
+    expected = "v9.0";
+  };
+  test_elaborate_goarm64_from_gcc_arch_with_one_extension = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv8-a+crypto";
+      }).go.env.GOARM64;
+    expected = "v8.0,crypto";
+  };
+  test_elaborate_goarm64_from_gcc_arch_with_version_and_extensions = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv8.3-a+lse+unknown-filtered+crypto";
+      }).go.env.GOARM64;
+    expected = "v8.3,crypto,lse";
+  };
+  test_elaborate_goarm64_from_gcc_arch_disabled_extensions = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv8.3-a+noext+lse+crypto";
+      }).go.env.GOARM64;
+    expected = "v8.3";
+  };
+  test_elaborate_goarm64_from_gcc_arch_invalid_version = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+        gcc.arch = "armv99.99-x";
+      }).go.env.GOARM64;
+    expected = "v8.0";
+  };
+  test_elaborate_goarm64 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "aarch64-linux";
+      }).go.env.GOARM64;
+    expected = "v8.0";
+  };
+  test_elaborate_goamd64 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "x86_64-linux";
+      }).go.env.GOAMD64;
+    expected = "v1";
+  };
+  test_elaborate_goamd64_from_gcc_arch_unknown = {
+    expr =
+      (lib.systems.elaborate {
+        system = "x86_64-linux";
+        gcc.arch = "znver5";
+      }).go.env.GOAMD64;
+    expected = "v1";
+  };
+  test_elaborate_goamd64_from_gcc_arch_level = {
+    expr =
+      (lib.systems.elaborate {
+        system = "x86_64-linux";
+        gcc.arch = "x86-64-v3";
+      }).go.env.GOAMD64;
+    expected = "v3";
+  };
+  test_elaborate_gorisv64 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "riscv64-linux";
+      }).go.env.GORISCV64;
+    expected = "rva20u64";
+  };
+  test_elaborate_gorisv64_from_gcc_arch = {
+    expr =
+      (lib.systems.elaborate {
+        system = "riscv64-linux";
+        gcc.arch = "rva22u64";
+      }).go.env.GORISCV64;
+    expected = "rva22u64";
+  };
+  test_elaborate_gorisv64_from_gcc_arch_invalid = {
+    expr =
+      (lib.systems.elaborate {
+        system = "riscv64-linux";
+        gcc.arch = "rva22";
+      }).go.env.GORISCV64;
+    expected = "rva20u64";
+  };
+  test_elaborate_goppc64 = {
+    expr =
+      (lib.systems.elaborate {
+        config = "powerpc64le-unknown-linux-gnu";
+      }).go.env.GOPPC64;
+    expected = "power8";
+  };
+  test_elaborate_goppc64_from_gcc_cpu = {
+    expr =
+      (lib.systems.elaborate {
+        config = "powerpc64le-unknown-linux-gnu";
+        gcc.cpu = "power10";
+      }).go.env.GOPPC64;
+    expected = "power10";
+  };
+  test_elaborate_gowasm = {
+    expr =
+      (lib.systems.elaborate {
+        system = "wasm64-wasi";
+      }).go.env.GOWASM;
+    expected = "";
+  };
+  test_elaborate_gowasm_from_user = {
+    expr =
+      (lib.systems.elaborate {
+        system = "wasm64-wasi";
+        go.env.GOWASM = "satconv,signext";
+      }).go.env.GOWASM;
+    expected = "satconv,signext";
+  };
+  test_elaborate_goos_wasip1 = {
+    expr =
+      (lib.systems.elaborate {
+        system = "wasm64-wasi";
+      }).go.env.GOOS;
+    expected = "wasip1";
+  };
 }
 
 # Generate test cases to assert that a change in any non-function attribute makes a platform unequal

--- a/pkgs/development/compilers/go/1.22.nix
+++ b/pkgs/development/compilers/go/1.22.nix
@@ -20,27 +20,6 @@ let
 
   skopeoTest = skopeo.override { buildGoModule = buildGo122Module; };
 
-  goarch =
-    platform:
-    {
-      "aarch64" = "arm64";
-      "arm" = "arm";
-      "armv5tel" = "arm";
-      "armv6l" = "arm";
-      "armv7l" = "arm";
-      "i686" = "386";
-      "mips" = "mips";
-      "mips64el" = "mips64le";
-      "mipsel" = "mipsle";
-      "powerpc64" = "ppc64";
-      "powerpc64le" = "ppc64le";
-      "riscv64" = "riscv64";
-      "s390x" = "s390x";
-      "x86_64" = "amd64";
-      "wasm32" = "wasm";
-    }
-    .${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
@@ -95,25 +74,22 @@ stdenv.mkDerivation (finalAttrs: {
     ./go_no_vendor_checks-1.22.patch
   ];
 
-  GOOS = if stdenv.targetPlatform.isWasi then "wasip1" else stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
+  GOOS = stdenv.targetPlatform.go.env.GOOS;
+  GOARCH = stdenv.targetPlatform.go.env.GOARCH;
   # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
   # Go will nevertheless build a for host system that we will copy over in
   # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  GOHOSTOS = stdenv.buildPlatform.go.env.GOOS;
+  GOHOSTARCH = stdenv.buildPlatform.go.env.GOARCH;
 
   # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
   # to be different from CC/CXX
   CC_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}cc" else null;
   CXX_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}c++" else null;
 
-  GOARM = toString (
-    lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]
-  );
+  GOARM = stdenv.hostPlatform.go.env.GOARM or "";
   GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  # Wasi does not support CGO
-  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+  CGO_ENABLED = if stdenv.targetPlatform.go.cgoSupported then 1 else 0;
 
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
 

--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -20,27 +20,6 @@ let
 
   skopeoTest = skopeo.override { buildGoModule = buildGo123Module; };
 
-  goarch =
-    platform:
-    {
-      "aarch64" = "arm64";
-      "arm" = "arm";
-      "armv5tel" = "arm";
-      "armv6l" = "arm";
-      "armv7l" = "arm";
-      "i686" = "386";
-      "mips" = "mips";
-      "mips64el" = "mips64le";
-      "mipsel" = "mipsle";
-      "powerpc64" = "ppc64";
-      "powerpc64le" = "ppc64le";
-      "riscv64" = "riscv64";
-      "s390x" = "s390x";
-      "x86_64" = "amd64";
-      "wasm32" = "wasm";
-    }
-    .${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
@@ -95,25 +74,22 @@ stdenv.mkDerivation (finalAttrs: {
     ./go_no_vendor_checks-1.23.patch
   ];
 
-  GOOS = if stdenv.targetPlatform.isWasi then "wasip1" else stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
+  GOOS = stdenv.targetPlatform.go.env.GOOS;
+  GOARCH = stdenv.targetPlatform.go.env.GOARCH;
   # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
   # Go will nevertheless build a for host system that we will copy over in
   # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  GOHOSTOS = stdenv.buildPlatform.go.env.GOOS;
+  GOHOSTARCH = stdenv.buildPlatform.go.env.GOARCH;
 
   # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
   # to be different from CC/CXX
   CC_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}cc" else null;
   CXX_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}c++" else null;
 
-  GOARM = toString (
-    lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]
-  );
+  GOARM = stdenv.hostPlatform.go.env.GOARM or "";
   GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  # Wasi does not support CGO
-  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+  CGO_ENABLED = if stdenv.targetPlatform.go.cgoSupported then 1 else 0;
 
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
 

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -20,27 +20,6 @@ let
 
   skopeoTest = skopeo.override { buildGoModule = buildGo124Module; };
 
-  goarch =
-    platform:
-    {
-      "aarch64" = "arm64";
-      "arm" = "arm";
-      "armv5tel" = "arm";
-      "armv6l" = "arm";
-      "armv7l" = "arm";
-      "i686" = "386";
-      "mips" = "mips";
-      "mips64el" = "mips64le";
-      "mipsel" = "mipsle";
-      "powerpc64" = "ppc64";
-      "powerpc64le" = "ppc64le";
-      "riscv64" = "riscv64";
-      "s390x" = "s390x";
-      "x86_64" = "amd64";
-      "wasm32" = "wasm";
-    }
-    .${platform.parsed.cpu.name} or (throw "Unsupported system: ${platform.parsed.cpu.name}");
-
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
@@ -95,25 +74,22 @@ stdenv.mkDerivation (finalAttrs: {
     ./go_no_vendor_checks-1.23.patch
   ];
 
-  GOOS = if stdenv.targetPlatform.isWasi then "wasip1" else stdenv.targetPlatform.parsed.kernel.name;
-  GOARCH = goarch stdenv.targetPlatform;
+  GOOS = stdenv.targetPlatform.go.env.GOOS;
+  GOARCH = stdenv.targetPlatform.go.env.GOARCH;
   # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
   # Go will nevertheless build a for host system that we will copy over in
   # the install phase.
-  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
-  GOHOSTARCH = goarch stdenv.buildPlatform;
+  GOHOSTOS = stdenv.buildPlatform.go.env.GOOS;
+  GOHOSTARCH = stdenv.buildPlatform.go.env.GOARCH;
 
   # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
   # to be different from CC/CXX
   CC_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}cc" else null;
   CXX_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}c++" else null;
 
-  GOARM = toString (
-    lib.intersectLists [ (stdenv.hostPlatform.parsed.cpu.version or "") ] [ "5" "6" "7" ]
-  );
+  GOARM = stdenv.hostPlatform.go.env.GOARM or "";
   GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
-  # Wasi does not support CGO
-  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+  CGO_ENABLED = if stdenv.targetPlatform.go.cgoSupported then 1 else 0;
 
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
 


### PR DESCRIPTION
This PR adds `go` attribute/argument for the platforms returned by `lib.systems.elaborate`, similar to `rust`. I’ve tried to keep other changes to a minimum to avoid rebuilds and make reviews easier.

I have another branch where these variables are propagated from Go toolchain packages via `GOENV` set in setupHook, but this causes mass rebuild.

Example:
```
(lib.systems.elaborate "wasm64-wasi").go
⇒ {
  cgoSupported = false;
  env = {
    CGO_ENABLED = "0";
    GOARCH = "wasm";
    GOOS = "wasip1";
    GOWASM = "";
  };
  osArch = "wasip1/wasm";
  raceDetectorSupported = false;
}
```
```
(lib.systems.elaborate "aarch64-linux").go
⇒ {
  cgoSupported = true;
  env = {
    CGO_ENABLED = "1";
    GOARCH = "arm64";
    GOARM64 = "v8.0";
    GOOS = "linux";
  };
  osArch = "linux/arm64";
  raceDetectorSupported = true;
}
```

Supersedes (to some extent) #256761

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
