### PR TITLE
min-ed-launcher: init at 0.11.3

### DIFF
--- a/pkgs/by-name/mi/min-ed-launcher/deps.json
+++ b/pkgs/by-name/mi/min-ed-launcher/deps.json
@@ -1,0 +1,257 @@
+[
+  {
+    "pname": "Expecto",
+    "version": "10.2.1",
+    "hash": "sha256-DgwHFsPMySlnMag4kPTviTwrNOD7uPnnJLi9DCZif5s="
+  },
+  {
+    "pname": "Expecto.FsCheck",
+    "version": "10.2.1",
+    "hash": "sha256-+IDkxZKfEir5/TJrwxMFC4H6voWbSmCsvZUrjxcbc50="
+  },
+  {
+    "pname": "FsCheck",
+    "version": "2.16.5",
+    "hash": "sha256-+UXoE+QGCDN1LM+XgseKJ7c5Lj/Cblo3izmo7GtIE0A="
+  },
+  {
+    "pname": "FsConfig",
+    "version": "4.1.0",
+    "hash": "sha256-daaTrzhZjnJLDL49vOCkeXX6W5PWaLj5aqHuaYgiS1s="
+  },
+  {
+    "pname": "FSharp.Core",
+    "version": "8.0.200",
+    "hash": "sha256-wjYiedFiqOTKaM4mF6uT9kc/yKDJ78mqfw9qLoBFHOw="
+  },
+  {
+    "pname": "FSharp.Data",
+    "version": "6.4.0",
+    "hash": "sha256-8/iQA6anTybzseyvsvFV33jVVwrnYiKG1iqgwkqNeRc="
+  },
+  {
+    "pname": "FSharp.Data.Csv.Core",
+    "version": "6.4.0",
+    "hash": "sha256-jcw/6uDN0he/PhhopEvTydy2X13Xt3g3kKuVdt+8+oY="
+  },
+  {
+    "pname": "FSharp.Data.Html.Core",
+    "version": "6.4.0",
+    "hash": "sha256-HeljybTU019Z7HxFoErPM/HIAm32pJiKQM+kSyt63xw="
+  },
+  {
+    "pname": "FSharp.Data.Http",
+    "version": "6.4.0",
+    "hash": "sha256-Zn4dZCb46vr8LYR5donzeistFPSO8YYiXUU3Iqo+vKg="
+  },
+  {
+    "pname": "FSharp.Data.Json.Core",
+    "version": "6.4.0",
+    "hash": "sha256-dVhcVzUi//PFFFIML/5SWKrileeQ6IOd1VlGyEptaw0="
+  },
+  {
+    "pname": "FSharp.Data.Runtime.Utilities",
+    "version": "6.4.0",
+    "hash": "sha256-nD4U7mwZtFEUcD9XvPxhpot8FNl2YyhiLpjpjmFNAO0="
+  },
+  {
+    "pname": "FSharp.Data.WorldBank.Core",
+    "version": "6.4.0",
+    "hash": "sha256-ea2CZyHisqa1MnF70TBKfcMl6+W90MnLJ5Ctgjfk9SM="
+  },
+  {
+    "pname": "FSharp.Data.Xml.Core",
+    "version": "6.4.0",
+    "hash": "sha256-6eZWKdNjKMqufyOYolTximIS41gipBUNMKNn3HEiYw0="
+  },
+  {
+    "pname": "FSharpx.Collections",
+    "version": "3.1.0",
+    "hash": "sha256-CmDCfx19VNthqZHphYywOK0attxyJjOhu2srNKSky10="
+  },
+  {
+    "pname": "FsToolkit.ErrorHandling",
+    "version": "4.15.2",
+    "hash": "sha256-fzsnH7178Gr0pnFoXkJvqRc2s5c+MXuRKQHBifIhmQk="
+  },
+  {
+    "pname": "FsToolkit.ErrorHandling.TaskResult",
+    "version": "4.15.2",
+    "hash": "sha256-I/3BXTQQzVSlldcfaVZ849/PirOcozM5GLCmfL2qHWg="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.9.0",
+    "hash": "sha256-OaGa4+jRPHs+T+p/oekm2Miluqfd2IX8Rt+BmUx8kr4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "8.0.0",
+    "hash": "sha256-9BPsASlxrV8ilmMCjdb3TiUcm5vFZxkBnAI/fNBSEyA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "8.0.1",
+    "hash": "sha256-KYPQYYspiBGiez7JshmEjy4kFt7ASzVxQeVsygIEvHA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.FileExtensions",
+    "version": "8.0.0",
+    "hash": "sha256-BCxcjVP+kvrDDB0nzsFCJfU74UK4VBvct2JA4r+jNcs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Json",
+    "version": "8.0.0",
+    "hash": "sha256-Fi/ijcG5l0BOu7i96xHu96aN5/g7zO6SWQbTsI3Qetg="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-uQSXmt47X2HGoVniavjLICbPtD2ReQOYQMgy3l0xuMU="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Physical",
+    "version": "8.0.0",
+    "hash": "sha256-29y5ZRQ1ZgzVOxHktYxyiH40kVgm5un2yTGdvuSWnRc="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileSystemGlobbing",
+    "version": "8.0.0",
+    "hash": "sha256-+Oz41JR5jdcJlCJOSpQIL5OMBNi+1Hl2d0JUHfES7sU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "8.0.0",
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Extensions.TimeProvider.Testing",
+    "version": "8.5.0",
+    "hash": "sha256-ZGXrOV/qJVfjwrJsv3jtC80IVQyH3OLOw70gCIn6uIM="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.9.0",
+    "hash": "sha256-q/1AJ7eNlk02wvN76qvjl2xBx5iJ+h5ssiE/4akLmtI="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "5.0.0",
+    "hash": "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.9.0",
+    "hash": "sha256-iiXUFzpvT8OWdzMj9FGJDqanwHx40s1TXVY9l3ii+s0="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.9.0",
+    "hash": "sha256-1BZIY1z+C9TROgdTV/tq4zsPy7Q71GQksr/LoMKAzqU="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "Mono.Cecil",
+    "version": "0.11.4",
+    "hash": "sha256-HrnRgFsOzfqAWw0fUxi/vkzZd8dMn5zueUeLQWA9qvs="
+  },
+  {
+    "pname": "Mono.Posix.NETStandard",
+    "version": "5.20.1-preview",
+    "hash": "sha256-gLtcH308/VVYgZcrJtvXDkBIMIQjK8w35AcmuxYYTvM="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Serilog",
+    "version": "3.1.1",
+    "hash": "sha256-L263y8jkn7dNFD2jAUK6mgvyRTqFe39i1tRhVZsNZTI="
+  },
+  {
+    "pname": "Serilog.Sinks.Console",
+    "version": "5.0.1",
+    "hash": "sha256-aveoZM25ykc2haBHCXWD09jxZ2t2tYIGmaNTaO2V0jI="
+  },
+  {
+    "pname": "Serilog.Sinks.File",
+    "version": "5.0.0",
+    "hash": "sha256-GKy9hwOdlu2W0Rw8LiPyEwus+sDtSOTl8a5l9uqz+SQ="
+  },
+  {
+    "pname": "Serilog.Sinks.File.Header",
+    "version": "1.0.2",
+    "hash": "sha256-2igOXIHtojhhNlg/C5OhPwmVUoE5MpmgApi8dFmutx4="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "6.0.0",
+    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "1.6.0",
+    "hash": "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.0.0",
+    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "8.0.0",
+    "hash": "sha256-fb0pa9sQxN+mr0vnXg1Igbx49CaOqS+GDkTfWNboUvs="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "8.0.0",
+    "hash": "sha256-+YUPY+3HnTmfPLZzr+5qEk0RqalCbFZBgLXee1yCH1M="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "5.0.0",
+    "hash": "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "8.0.0",
+    "hash": "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "8.0.0",
+    "hash": "sha256-XFcCHMW1u2/WujlWNHaIWkbW1wn8W4kI0QdrwPtWmow="
+  },
+  {
+    "pname": "System.Windows.Extensions",
+    "version": "8.0.0",
+    "hash": "sha256-aHkz7LtmUDDRS7swQM0i6dDVUytRCMYeA2CfaeVA2Y0="
+  },
+  {
+    "pname": "TypeShape",
+    "version": "10.0.0",
+    "hash": "sha256-esJFuRvxuLXwBgi/7FjEVm1ATCGXU/yB2RtgN4ilZtg="
+  },
+  {
+    "pname": "YoloDev.Expecto.TestSdk",
+    "version": "0.14.3",
+    "hash": "sha256-3FIZM+GYsBsFGhLsasF7Ia9nXHSpqooQNe5H7ANy334="
+  }
+]

--- a/pkgs/by-name/mi/min-ed-launcher/package.nix
+++ b/pkgs/by-name/mi/min-ed-launcher/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDotnetModule,
+  fetchFromGitHub,
+  git,
+}:
+buildDotnetModule rec {
+  pname = "min-ed-launcher";
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "rfvgyhn";
+    repo = "min-ed-launcher";
+    tag = "v${version}";
+    hash = "sha256-HJIvbuTsCG51PPVieJbXGyAviqgM9/WPz0+0VhIWz9k=";
+
+    leaveDotGit = true; # During build the current commit is appended to the version
+  };
+
+  projectFile = "MinEdLauncher.sln";
+  nugetDeps = ./deps.json;
+  buildInputs = [
+    git # During build the current commit is appended to the version
+  ];
+
+  executables = [ "MinEdLauncher" ];
+
+  meta = {
+    homepage = "https://github.com/rfvgyhn/min-ed-launcher";
+    description = "Minimal Elite Dangerous Launcher";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.x86_64;
+    mainProgram = "MinEdLauncher";
+    maintainers = with lib.maintainers; [ jiriks74 ];
+  };
+}


### PR DESCRIPTION
- [`min-ed-launcher` repository](https://github.com/rfvgyhn/min-ed-launcher)

From project's description: Minimal Elite Dangerous Launcher

It's an alternative launcher for the game Elite: Dangerous. It has provides a faster way to get into game and provides more functionality than the official Frontier launcher.

Some of the advantages:
- Faster load times compared to the official launcher
- Auto-quit
- Can lauch (and quit) other programs (for interacting with the game)
  - For example EDMarketConnector https://github.com/EDCD/EDMarketConnector
- Can run Steam, Epic and Frontier Store accounts from a single game install
- Auto-restart

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
