### PR TITLE
edmarketconnector: init at 5.13.1

### DIFF
--- a/pkgs/by-name/ed/edmarketconnector/package.nix
+++ b/pkgs/by-name/ed/edmarketconnector/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  python3,
+  makeWrapper,
+}:
+let
+  pythonEnv = python3.buildEnv.override {
+    extraLibs = with python3.pkgs; [
+      tkinter
+      requests
+      pillow
+      (watchdog.overrideAttrs {
+        disabledTests = [
+          "test_select_fd" # Avoid `Too many open files` error. See https://github.com/gorakhargosh/watchdog/issues/1095
+        ];
+      })
+      semantic-version
+      psutil
+    ];
+    ignoreCollisions = true;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "edmarketconnector";
+  version = "5.13.1";
+
+  src = fetchFromGitHub {
+    owner = "EDCD";
+    repo = "EDMarketConnector";
+    tag = "Release/${finalAttrs.version}";
+    hash = "sha256-50OPbAXrDKodN0o6UibGUmMqQ/accF2/gNHnms+8rOI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstallPhase
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps/
+    ln -s ${finalAttrs.src}/io.edcd.EDMarketConnector.png $out/share/icons/hicolor/512x512/apps/io.edcd.EDMarketConnector.png
+
+    mkdir -p "$out/share/applications/"
+    ln -s "${finalAttrs.src}/io.edcd.EDMarketConnector.desktop" "$out/share/applications/"
+
+    makeWrapper ${pythonEnv}/bin/python $out/bin/edmarketconnector \
+      --add-flags "${finalAttrs.src}/EDMarketConnector.py $@"
+
+    runHook postInstallPhase
+  '';
+
+  meta = {
+    homepage = "https://github.com/EDCD/EDMarketConnector";
+    description = "Uploads Elite: Dangerous market data to popular trading tools";
+    longDescription = "Downloads commodity market and other station data from the game Elite: Dangerous for use with all popular online and offline trading tools.";
+    changelog = "https://github.com/EDCD/EDMarketConnector/releases/tag/Release%2F${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.x86_64;
+    mainProgram = "edmarketconnector";
+    maintainers = with lib.maintainers; [ jiriks74 ];
+  };
+})


### PR DESCRIPTION
I'm aware that this package is probably not the best but it works. I'm open to any suggestions to make it better.

---

- [`EDMarketConnector` repository](https://github.com/EDCD/EDMarketConnector)

From project's description:
Downloads commodity market and other station data from the game Elite: Dangerous for use with all popular online and offline trading tools.

It's a helper tool for the game Elite: Dangerous. Since the in game tools for trading and searching aren't that good the community has to make their own. This tool pulls the information from game and uploads it to various databases for other players to use.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
