### PR TITLE
math-preview: fix by overriding nodejs from 22 to 20

### DIFF
--- a/pkgs/by-name/ma/math-preview/package.nix
+++ b/pkgs/by-name/ma/math-preview/package.nix
@@ -9,6 +9,7 @@
 buildNpmPackage rec {
   pname = "math-preview";
   version = "5.1.1";
+  inherit nodejs;
 
   src = fetchFromGitLab {
     owner = "matsievskiysv";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16894,6 +16894,10 @@ with pkgs;
     cudaSupport = true;
   };
 
+  math-preview = callPackage ../by-name/ma/math-preview/package.nix {
+    nodejs = nodejs_20;
+  };
+
   or-tools = callPackage ../development/libraries/science/math/or-tools {
     inherit (darwin) DarwinTools;
     stdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;


### PR DESCRIPTION
math-preview is broken after nodejs defaults to 22 in Nixpkgs. Before the upstream fixes the problem we need to override the version of nodejs to 20.

The problem can be reproduced by:

```shell
nix run github:nixos/nixpkgs/377d4f31201782471e43c6fab41a176e6aa83408#math-preview
```

Error message:

```text
  #  /nix/store/7l1wra7b87yci5dln0hm0k8rwww6f2xj-nodejs-22.14.0/bin/node[297187]: void node::fs::InternalModuleStat(const v8::FunctionCallbackInfo<v8::Value>&) at ../../src/node_file.cc:1040
  #  Assertion failed: (args.Length()) >= (2)

----- Native stack trace -----

 1: 0xe94793 node::Assert(node::AssertionInfo const&) [/nix/store/7l1wra7b87yci5dln0hm0k8rwww6f2xj-nodejs-22.14.0/bin/node]
 2: 0xe9d9b9  [/nix/store/7l1wra7b87yci5dln0hm0k8rwww6f2xj-nodejs-22.14.0/bin/node]
 3: 0x7f755fe0f5e2

----- JavaScript stack trace -----

1: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:34535
2: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:34176
3: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:34506
4: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:173374
5: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:173420
6: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:173521
7: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:258942
8: /nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:261569
9: e (/nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:262673)
10: get (/nix/store/lh11ji5d8lnadh96aab24adz2zcy7mfd-math-preview-5.1.1/lib/node_modules/math-preview/node_modules/esm/esm.js:1:262740)


zsh: IOT instruction (core dumped)  nix run
```

Test this PR by:

```shell
nix shell github:rennsax/nixpkgs/74818e25aed728d764886bfdeeecc29fa28e094d#math-preview
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
