### PR TITLE
perl: filter out reference to `apple-sdk` package

### DIFF
--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -273,6 +273,12 @@ stdenv.mkDerivation (
           --replace "${
             if stdenv.hasCC && stdenv.cc.cc != null then stdenv.cc.cc else "/no-such-path"
           }" /no-such-path \
+          --replace "${
+            if stdenv.hasCC && stdenv.cc.fallback_sdk or null != null then
+              stdenv.cc.fallback_sdk
+            else
+              "/no-such-path"
+          }" /no-such-path \
           --replace "$man" /no-such-path
       ''
       + lib.optionalString crossCompiling ''


### PR DESCRIPTION
The perl package started depending on `apple-sdk` via references in `lib/perl5/5.40.0/darwin-thread-multi-2level/Config_heavy.pl`:

```
fd --type=file . /nix/store/cwlch1mxd40ayx8qy7hl8q2scrwgqhg6-perl-5.40.0/lib/ -X rg "/nix/store/lsjl29pwp5if71jfgxlv8fifsrpax805-apple-sdk-11.3" {}
/nix/store/cwlch1mxd40ayx8qy7hl8q2scrwgqhg6-perl-5.40.0/lib/perl5/5.40.0/darwin-thread-multi-2level/Config_heavy.pl
1039:incpth='/nix/store/j3dhkx4m14m38drh3f40bccrwrgzlsg5-libcxx-19.1.7-dev/include /nix/store/hklang3njvw0f5mgra9vsvn3c2zi2v45-compiler-rt-libc-19.1.7-dev/include /nix/store/g4qcalcnvm5n393xq8p9swxd8rc0xxzj-libxcrypt-4.4.38/include /nix/store/f4z2y0zn2bmrwywp67y3h21cmb6ky547-libiconv-109-dev/include /nix/store/17a9rq4bw8drbhlr3dijrmxzfqlz8z85-libresolv-83-dev/include /nix/store/34bb5prqghfl0hpindhk8xlc5s2q2xjg-libsbuf-14.1.0-dev/include /nix/store/vzi6s9yh1i12bkj9abyfp43y6x1fdzpl-cups-headers-2.4.11/include /no-such-path/resource-root/include /nix/store/lsjl29pwp5if71jfgxlv8fifsrpax805-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include /no-such-path/include'
1087:libpth='/nix/store/g4qcalcnvm5n393xq8p9swxd8rc0xxzj-libxcrypt-4.4.38/lib /no-such-path/resource-root/lib /nix/store/lsjl29pwp5if71jfgxlv8fifsrpax805-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib /no-such-path/lib'
1092:libspath=' /nix/store/g4qcalcnvm5n393xq8p9swxd8rc0xxzj-libxcrypt-4.4.38/lib /no-such-path/resource-root/lib /nix/store/lsjl29pwp5if71jfgxlv8fifsrpax805-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib /no-such-path/lib'
1331:timeincl='/nix/store/lsjl29pwp5if71jfgxlv8fifsrpax805-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/time.h '
```

This change increases the closure size of `perl` from ~115MiB to ~1.11GiB on darwin systems.

`apple-sdk` seems to be referenced via `stdenv.cc.fallback_sdk`. Following the exisitng pattern in
`pkgs/development/interpreters/perl/interpreter.nix`, that removes removes references to `stdenv.cc` and `stdenv.cc.cc`, this commit also removes the reference to
`apple-sdk` / `stdenv.cc.fallback_sdk`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
