### PR TITLE
trakkr: init at 0.1.7

### DIFF
--- a/pkgs/by-name/tr/trakkr/custom_journal_path.patch
+++ b/pkgs/by-name/tr/trakkr/custom_journal_path.patch
@@ -1,0 +1,28 @@
+diff --git a/electron/events/journal.js b/electron/events/journal.js
+index 28d9481..9a7e510 100644
+--- a/electron/events/journal.js
++++ b/electron/events/journal.js
+@@ -5,12 +5,17 @@ const ships = require('../data/json/ships.json');
+ let currentWatcher = null;
+
+ function readJournalDir() {
+-    return path.join(
+-        process.env.HOME || process.env.USERPROFILE || '',
+-        'Saved Games',
+-        'Frontier Developments',
+-        'Elite Dangerous'
+-    );
++    if (process.env.TRAKKR_CUSTOM_JOURNAL_LOCATION) {
++        return process.env.TRAKKR_CUSTOM_JOURNAL_LOCATION;
++    }
++    else {
++        return path.join(
++            process.env.HOME || process.env.USERPROFILE || '',
++            'Saved Games',
++            'Frontier Developments',
++            'Elite Dangerous'
++        );
++    }
+ }
+
+ function sortJournal() {

--- a/pkgs/by-name/tr/trakkr/package.nix
+++ b/pkgs/by-name/tr/trakkr/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeDesktopItem,
+  copyDesktopItems,
+  bash,
+  zenity,
+  nodejs_20,
+  electron_36,
+}:
+buildNpmPackage rec {
+  pname = "trakkr";
+  version = "0.1.7";
+  nodejs = nodejs_20;
+
+  src = fetchFromGitHub {
+    owner = "skybreakdigital";
+    repo = "${pname}-app";
+    tag = "v${version}";
+    hash = "sha256-roL0PVytPPpmkz/6yCvrtaTUhNvqvEh0/uRyPWiJj7I=";
+  };
+
+  patches = [
+    ./custom_journal_path.patch
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  npmDepsHash = "sha256-qKnyFw2wnSTywKQIFADEAF/D8HsENICjqbSI4yWsZAU=";
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm exec vite -- build
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=${electron_36.dist} \
+      -c.electronVersion=${electron_36.version} \
+      --publish=never
+
+    runHook postBuild
+  '';
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${src}/public/icon.png $out/share/icons/hicolor/256x256/apps/Trakkr.png
+    install -Dm644 ${src}/public/favicon-16x16.png $out/share/icons/hicolor/16x16/apps/Trakkr.png
+    install -Dm644 ${src}/public/favicon-32x32.png $out/share/icons/hicolor/32x32/apps/Trakkr.png
+
+    mkdir -p "$out/share/lib/Trakkr"
+    cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/Trakkr"
+    cp ./dist/index.html "$out/share/lib/Trakkr"
+
+    mkdir -p $out/bin
+    cat << EOF > $out/bin/Trakkr
+    #!${bash}/bin/bash
+    if [[ -n "\$TRAKKR_CUSTOM_JOURNAL_LOCATION" ]] && [[ ! -d "\$TRAKKR_CUSTOM_JOURNAL_LOCATION" ]]; then
+      ${zenity}/bin/zenity --error --text="'TRAKKR_CUSTOM_JOURNAL_LOCATION' is set but leads to a non-existent directory!"
+      ${zenity}/bin/zenity --info --text="You must enter the live game at least once to generate the journal files."
+      exit 1
+    fi
+
+    if [[ -z "\$TRAKKR_CUSTOM_JOURNAL_LOCATION" ]] && [[ ! -d "\$HOME/Saved Games/Frontier Developments/Elite Dangerous" ]]; then
+      if [[ -d "\$HOME/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/" ]]; then
+        TRAKKR_CUSTOM_JOURNAL_LOCATION="\$HOME/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/"
+      else
+        ${zenity}/bin/zenity --error --text="Could not determine the location of journal files!"
+        ${zenity}/bin/zenity --info --text="Set the 'TRAKKR_CUSTOM_JOURNAL_LOCATION' environment variable to the correct directory."
+        exit 1
+      fi
+    fi
+
+    # Code relies on checking app.isPackaged, which returns false if the executable is electron.
+    # Set ELECTRON_FORCE_IS_PACKAGED=1.
+    # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
+    export ELECTRON_FORCE_IS_PACKAGED=1
+
+    export TRAKKR_CUSTOM_JOURNAL_LOCATION="\$TRAKKR_CUSTOM_JOURNAL_LOCATION"
+
+    '${electron_36}/bin/electron' $out/share/lib/Trakkr/resources/app.asar \
+      \''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} \
+      --disable-gpu \
+      --disable-gpu-rendering \
+      \$@
+    EOF
+
+    chmod +x $out/bin/Trakkr
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Trakkr";
+      exec = "Trakkr";
+      icon = "Trakkr";
+      desktopName = "Trakkr";
+      categories = [
+        "Game"
+        "Utility"
+      ];
+      comment = meta.description;
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    description = "Mission tracking tool for Elite: Dangerous";
+    longDescription = "Trakkr is specifically designed to assist Elite Dangerous missions, offering tailored support to enhance the efficiency and management of their operations.";
+    homepage = "https://github.com/skybreakdigital/trakkr-app";
+    changelog = "https://github.com/skybreakdigital/trakkr-app/releases/tag/v${version}";
+    mainProgram = "Trakkr";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jiriks74 ];
+  };
+}


### PR DESCRIPTION
This is, to my knowledge, the only working Linux build of this Tool.

---

- `Trakkr` repository: https://github.com/skybreakdigital/trakkr-app

From project's description:
Trakkr is specifically designed to assist Elite Dangerous missions, offering tailored support to enhance the efficiency and management of their operations.

This tool is for tracking missions in the game Elite: Dangerous. It's usefull for people that stack and share missions with other commanders.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
