### PR TITLE
ppsspp-qt: Fix Qt wrapping

### DIFF
--- a/pkgs/by-name/pp/ppsspp/package.nix
+++ b/pkgs/by-name/pp/ppsspp/package.nix
@@ -89,6 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
       libffi
     ];
 
+  dontWrapQtApps = true;
+
   cmakeFlags = [
     (lib.cmakeBool "HEADLESS" (!enableQt))
     (lib.cmakeBool "USE_SYSTEM_FFMPEG" useSystemFfmpeg)
@@ -147,9 +149,16 @@ stdenv.mkDerivation (finalAttrs: {
         lib.optionals enableVulkan [
           "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}"
         ]
-        ++ lib.optionals (!enableQt) [
-          "--set SDL_VIDEODRIVER ${if forceWayland then "wayland" else "x11"}"
-        ]
+        ++ (
+          if enableQt then
+            [
+              "\${qtWrapperArgs[@]}"
+            ]
+          else
+            [
+              "--set SDL_VIDEODRIVER ${if forceWayland then "wayland" else "x11"}"
+            ]
+        )
       );
       binToBeWrapped = if enableQt then "PPSSPPQt" else "PPSSPPSDL";
     in


### PR DESCRIPTION
On master & nixos-24.11:

```
↪ /nix/store/l0viy52ldz8dp8jy26wv3i9485x2w06x-ppsspp-qt-1.18.1/bin/ppsspp 
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

fish: Job 1, '/nix/store/l0viy52ldz8dp8jy26wv…' terminated by signal SIGABRT (Aborted)
```

The necessary wrapper flags aren't being applied, because the `makeWrapper` call happens in `postFixup` which is after the automatic wrapping by `wrapQtAppsHook`. To fix this, and to avoid double-wrapping, disable the automatic wrapping & pass the wrapper args to the `makeWrapper` call.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
