### PR TITLE
adwaita-fonts: Remove unused dependencies

### DIFF
--- a/pkgs/by-name/ad/adwaita-fonts/package.nix
+++ b/pkgs/by-name/ad/adwaita-fonts/package.nix
@@ -1,15 +1,12 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitLab,
-  pkg-config,
   meson,
   ninja,
-  glib,
-  gnome-common,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "adwaita-fonts";
   version = "48.2";
 
@@ -22,14 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    pkg-config
     meson
     ninja
-  ];
-
-  buildInputs = [
-    glib
-    gnome-common
   ];
 
   meta = {
@@ -37,6 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/GNOME/adwaita-fonts";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.qxrein ];
+    maintainers = [ lib.maintainers.qxrein ] ++ lib.teams.gnome.members;
   };
 })

--- a/pkgs/by-name/ad/adwaita-fonts/package.nix
+++ b/pkgs/by-name/ad/adwaita-fonts/package.nix
@@ -1,27 +1,31 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitLab,
+  fetchurl,
   meson,
   ninja,
+  gnome,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "adwaita-fonts";
   version = "48.2";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    owner = "GNOME";
-    repo = "adwaita-fonts";
-    tag = "${finalAttrs.version}";
-    hash = "sha256-rXr4U5k0MUz766F5kVssZfM6Ra/hQOe/HLpGss2aZuo=";
+  src = fetchurl {
+    url = "mirror://gnome/sources/adwaita-fonts/${lib.versions.major finalAttrs.version}/adwaita-fonts-${finalAttrs.version}.tar.xz";
+    hash = "sha256-FW9+kvL4LlJ/xzwwnbsjfApKXDqVvF7pSl77aUfFU+A=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
   ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "adwaita-fonts";
+    };
+  };
 
   meta = {
     description = "Adwaita Sans, a variation of Inter, and Adwaita Mono, Iosevka customized to match Inter";


### PR DESCRIPTION
The upstream meson.build only contains a single install_data() and
gnome-common is dead.

ref https://github.com/GNOME/adwaita-fonts/blob/48.2/meson.build
cc https://github.com/GNOME/gsettings-desktop-schemas/commit/067cb4b155b67db6f358a666d4bdced7059c6e00


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

