### PR TITLE
open-webui: add pyodide

### DIFF
--- a/pkgs/by-name/op/open-webui/update.sh
+++ b/pkgs/by-name/op/open-webui/update.sh
@@ -9,13 +9,14 @@ version="$(curl --silent "https://api.github.com/repos/open-webui/open-webui/rel
 
 update-source-version open-webui "${version:1}" --file="$path"
 
-# Fetch npm deps
+# Fetch npm deps and pyodide
 tmpdir=$(mktemp -d)
 curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/open-webui/open-webui/refs/tags/${version}/package-lock.json"
 curl -O --output-dir $tmpdir "https://raw.githubusercontent.com/open-webui/open-webui/refs/tags/${version}/package.json"
 pushd $tmpdir
 npm_hash=$(prefetch-npm-deps package-lock.json)
 sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' "$path"
+pyodide_version=$(sed -rn 's/^.*pyodide.*\^([0-9.]*)\".*$/\1/p' package.json)
 popd
+update-source-version open-webui.frontend "${pyodide_version}" --file="$path" --version-key=pyodideVersion --source-key=pyodide
 rm -rf $tmpdir
-


### PR DESCRIPTION
Previously, in-browser python execution functionality from open-webui was broken, as the pyodide static files are not served/bundled into the frontend. The upstream build script essentially just downloads the right release based on the package lock, but is disabled obviously. We can mirror that functionality in nix and in preBuild.

Just download the GitHub release, as being a browser JS/WASM package there is nothing different per system. Perhaps in the future we can build from source, but this is non-trivial. And, only a specific version is supported by open-webui.

This is working for me, and it even seems the github release already includes all the packages mentioned [here](https://github.com/open-webui/open-webui/blob/95cadaca72e676199caf894f40cc132d7c8416df/scripts/prepare-pyodide.js#L1).

This is now working perfectly for me.
![image](https://github.com/user-attachments/assets/08b7fc73-9e33-4549-ad82-301da4a954d4)

I added the frontend package to passthrough for the update script to work. The update script I really just bumbled with until it seemed to work... maybe it would be best that someone check that for best practices, as I had a hard time finding an example doing something similar with a sub-sub-fetchurl derivation.

If you test this, know open-webui's pyodide serving seems to be broken in recent firefox, complaining about MIME types in the console. And upstream issues are currently broken by GitHub... so not sure if this is known or not.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
