### PR TITLE
electron-bin: don't wrap inside libexec

### DIFF
--- a/pkgs/by-name/bs/bs-manager/package.nix
+++ b/pkgs/by-name/bs/bs-manager/package.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/bin
     makeWrapper ${lib.getExe electron} $out/bin/bs-manager \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --add-flags $out/opt/BSManager/resources \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -151,31 +151,26 @@ let
     dontBuild = true;
 
     installPhase = ''
-      mkdir -p $out/libexec/electron $out/bin
+      mkdir -p $out/libexec/electron
       unzip -d $out/libexec/electron $src
-      ln -s $out/libexec/electron/electron $out/bin
       chmod u-x $out/libexec/electron/*.so*
     '';
 
-    # We use null here to not cause unnecessary rebuilds.
-    dontWrapGApps = if needsAarch64PageSizeFix then true else null;
-    preFixup =
-      if needsAarch64PageSizeFix then
-        ''
-          wrapProgram "$out/libexec/electron/chrome_crashpad_handler" "''${gappsWrapperArgs[@]}"
-          wrapProgram "$out/libexec/electron/chrome-sandbox" "''${gappsWrapperArgs[@]}"
-          wrapProgram "$out/libexec/electron/electron" "''${gappsWrapperArgs[@]}" \
-            --add-flags "--js-flags=--no-decommit-pooled-pages"
-        ''
-      else
-        null;
+    # We don't want to wrap the contents of $out/libexec automatically
+    dontWrapGApps = true;
+
+    preFixup = ''
+      makeWrapper "$out/libexec/electron/electron" $out/bin/electron \
+        "''${gappsWrapperArgs[@]}" \
+        ${lib.optionalString needsAarch64PageSizeFix "--add-flags '--js-flags=--no-decommit-pooled-pages'"}
+    '';
 
     postFixup = ''
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "${electronLibPath}:$out/libexec/electron" \
-        $out/libexec/electron/.electron-wrapped \
-        $out/libexec/electron/.chrome_crashpad_handler-wrapped
+        $out/libexec/electron/electron \
+        $out/libexec/electron/chrome_crashpad_handler
 
       # patch libANGLE
       patchelf \


### PR DESCRIPTION
This change helps bring electron-bin to a similar structure as the
source builds of electron.
The primary motivation of this change was to ensure that the `electron`
binary inside `libexec/electron` is an actual binary and not a wrapper.
This way `electron-fuses` will not complain about not being able to
find the necessary sentinel strings inside the binary.

---

This is the 2nd attempt at https://github.com/NixOS/nixpkgs/pull/384865 which I [reverted](https://github.com/NixOS/nixpkgs/pull/386669) since it [broke a package](https://github.com/NixOS/nixpkgs/issues/386591) and I didn't know what had gone wrong.

I have tracked down the actual issue:
`app.isPackaged` was true when using `electron-bin` before the PR, because the `electron` executable was renamed to `.electron-wrapped` (so it thought it was no longer just standalone electron)
after this PR `app.isPackaged` was false, since we didn't mess with the `electron` executable.

See [this link](https://github.com/electron/electron/blob/64158114aa2ac23433ad121263ff1e179c02cdca/shell/browser/api/electron_api_app.cc#L892-L907) for the relevant logic inside electron.

The solution was to use `ELECTRON_FORCE_IS_PACKAGED`

Related: https://github.com/NixOS/nixpkgs/issues/386591#issuecomment-2695279806

There is a chance there are some other apps need `ELECTRON_FORCE_IS_PACKAGED` to be set, but it's a low chance, since they have to have only ever benn using `electron-bin`.
(Source built electron builds always needed `ELECTRON_FORCE_IS_PACKAGED`, even before the PR)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
