### PR TITLE
Firefox: 135.0.1 -> 136.0; 128.7.0esr -> 128.8.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1241 +1,1241 @@
 {
-  version = "135.0.1";
+  version = "136.0";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ach/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ach/firefox-136.0.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "85f54d601a54340e8f2ea32d10fd90b74540eb235e5947c83b786e49e4a3dbe9";
+      sha256 = "b15d3d158ceb1c30aa3ed1ae53419e020d0c5d8043386ea88dd2d6082463c002";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/af/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/af/firefox-136.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "e10153197ee408118aa303bda76d0e97b0c4a62b85b39076739adef247848de9";
+      sha256 = "8b5dce40400b8bb87bcd32758718b824680d183a5d59c85ef14bdea8929e5413";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/an/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/an/firefox-136.0.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d7f063a5dd361c0000b387482919604767d615cbd3532cdff31fdc15b698f0f4";
+      sha256 = "b79f252a63fed01858f9364473c44d8073fd7d932a9c223c540bee5c299ed912";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ar/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ar/firefox-136.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "7b93dcb47d37d19d46203627aee494ace37b1e1629a79314a1c1aa0a008c2521";
+      sha256 = "b8bdf544fb7a5e6b609818ad160f8e29bc6cd7f299aa9c150fd23fa32f2e30e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ast/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ast/firefox-136.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "8d114c39a8d24ac91da7354476ba1e8c99c9573567fe300aa556b26d9dd020d5";
+      sha256 = "d15f45039332ab553b9c2499eab0581a0d5609508299c39e4532a70321299fe3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/az/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/az/firefox-136.0.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "9f9791f7f85d1a87a2c3dab83bbd9d95640cc077737127b948a5aea77293edf6";
+      sha256 = "35027ce4948b821b94cdb6edb52dfb8dfafd0905bf3b8471a98287767cd136d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/be/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/be/firefox-136.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "4f9298489d5fcd9ff3426d1ea7be509747262e49a1967c7ae12891266065a5b0";
+      sha256 = "cde28a512fd506abe3b40ed547d404437b6991ed55487bb1a7357921e045ddba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/bg/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/bg/firefox-136.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "b8499ea04a2db8bdd75b5936e371c2015884fd5dbf6989bffcf9db2cb0100370";
+      sha256 = "d7e21bd14455525ee1817ffcd96c3751e8073850cc389f5251ab7237c5342bfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/bn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/bn/firefox-136.0.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "2b3e1c660fa829676b0e9969589e0dbf1d5cf633f1df18dd60bb8eb0f550b1bd";
+      sha256 = "f661f20fbfed9fc354901e3849457fe53e2668b85b7365a36574f5b630489a36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/br/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/br/firefox-136.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "14cb1e8a9941c94768bb87152719e89bfd9beab394317c8790139bd440d84234";
+      sha256 = "f935148146a2954e1e7dad54c0790be523af9c4fb126c42bb5877d0994b60df2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/bs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/bs/firefox-136.0.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "31bcbf6c483156208faa629fcbc8f9bc158795aca261531f670c7a6da8510d4d";
+      sha256 = "e584de078948b46afb7e04fe5c021b564b8deab31957eb9ae2810e1f4e77c3ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ca-valencia/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ca-valencia/firefox-136.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "45bb5481a4d145c89d863a55130ec12ec066ba4449478822f4d8af60b2db678b";
+      sha256 = "a8cc1a8012102286919995b0e33cb49d479d5ab43108ad30872e4c961652d568";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ca/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ca/firefox-136.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "d760dc6e37eb091b4e03a18843e6ed2c49e055d2be4eae15b8b0f56508e03294";
+      sha256 = "86c73a79a22bafbbe6dd7b19c3f77c69705cdc5b3acc138b415e6cf07e989979";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/cak/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/cak/firefox-136.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "6026da8bac996273b82c8e06d8797f3537c0a5c84fcaa92c9e13ff0f40563180";
+      sha256 = "71aec201f5c41fb72d00d2c94d601a15d320817cdc936cac92eca0b18d229b24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/cs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/cs/firefox-136.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f686b0f9902b61fea029d3839c0285639e1ba71eb5ef6d6133b6b468d7273381";
+      sha256 = "0482fe0298aa60c5dca222a959595d1d96621bd82a75eb1f51a064dfab1784e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/cy/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/cy/firefox-136.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "e799431f1a5df2ed9b1c570c2cf605ddab3593c9c0443b0229b006aaac548217";
+      sha256 = "a7ed50818db530aa0fa1ff3f7793239ccdb038904f143570c39b23fa25184c8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/da/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/da/firefox-136.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "2d98f25400b2bb6336ab3d142dda68e1487e34f5c213e25b5fcf27857d7354ba";
+      sha256 = "790db27f382096228f6536ecdb9dbaf4cf628178002d6b17f48bda846c308c24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/de/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/de/firefox-136.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "66d8c8e64ff9d207798e778306dec390d99ccf701357d079f98a231266bd8224";
+      sha256 = "61f354191174e987b827681651dd15c27b37abaf884591faf30810bf6f1ff6a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/dsb/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/dsb/firefox-136.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "821e3ff15d1f164f26b59ff48153fd980dde556ab37746e9357259020cd74d91";
+      sha256 = "54532e97bb41bb660310533aff9c52ec8c662aca85fa4f55c4661b96348690d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/el/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/el/firefox-136.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f3c29ea42946d8183cd835ac3810c785acadb8c88a64988837d91a7dfd8b55d1";
+      sha256 = "4d9b6e72230f3616c0a11cec4af0f8316b7dfeb0d39efa6d3c467d3e6b91d3bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/en-CA/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/en-CA/firefox-136.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8ded99749c418c8cac6ff852c6fdd7e1d674c3ebf4152bbf187528b6e648608a";
+      sha256 = "6a82492385caa448a7cec49a2cae34bfb0541b95b144a0e26bd8eb2b774c5766";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/en-GB/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/en-GB/firefox-136.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "4a66152c914635f4fecbec370a3775ecc87f2f50c7eb17d52b9ea95e472652ce";
+      sha256 = "efc6b4bddfe47edb6cc4535bbd3333b3251182249dfa09b9fea2bc7360307489";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/en-US/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/en-US/firefox-136.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "4f76c45196cd4d7cacbdc9038d80757cc9bbe387dd43e2b81bd8a7748d630ee8";
+      sha256 = "5222f51caacfccaf0f0cf795117f0ad37422fe9d413ef18f2c171e1622b9455a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/eo/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/eo/firefox-136.0.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "d0dfb267fe91da8ae11e31c3df62e5789f2652d88cb5b5d7b0320814ad00b9c3";
+      sha256 = "cb58eddc94762a0125615b08e6592f88ccc7aafa918c84d06777e73398ec5faf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/es-AR/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/es-AR/firefox-136.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "587c6a1837db53eaf365e675c5b1790ccb00c0ffbe5a48dd0e6ea71a2a501dd6";
+      sha256 = "a341133cf1c958d57b7f93660e839db02b7b6371f30e6caa71b4282215d95f4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/es-CL/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/es-CL/firefox-136.0.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "99abb3aecd6d1064e5073635a691b7eacc72d5304a1793f0c23120eea2593fba";
+      sha256 = "004b6b643e40c178afca9683c72cb2f5e0984ba5a618fe8951904e34149b0a66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/es-ES/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/es-ES/firefox-136.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "0ba144c3d86c93dbe3131ce8cc400ecbef1fe2ddbf652bea91fa9234039a65bf";
+      sha256 = "eeeaab196889f34a50242c1c139edffcfe2ee1344aa3a65efc229d63c4aea2b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/es-MX/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/es-MX/firefox-136.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "e1fa322eea3e8c8680424544e23938b5a2f53188687ce42da57b8f51d7f48de3";
+      sha256 = "cb47b40782ee2407f92950cd2f6d669e96be536c96606e11a611a7c5947e7931";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/et/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/et/firefox-136.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "1c40069708c67ad9f6b69e30c4c90eacc2c55c4803f9bdd6e2ab87c88d4c0490";
+      sha256 = "640b0df3b2cf3b97a4a318f717e8f231f4006ad6ab5d02d165f1397e5734c245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/eu/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/eu/firefox-136.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "641ceee7d60d3afeb49781bb82c2b0f599dee7342d837eaa47d39a1830dbfa22";
+      sha256 = "57f24c141a609de904dbe16c7423340dc054e47d142f97bb63441742356c3cdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/fa/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/fa/firefox-136.0.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "3fde1e08a577f2fe2c5d4f9accab679cb2c00a68410c904628a88ffb3eb6deae";
+      sha256 = "9d21f32afa3137f128403b860d189e006f9d10587538cd81a7574c7a6a87a9c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ff/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ff/firefox-136.0.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "e304b6019ca397f76adf8798b648142e46452cc99ce133571b35455b80d8ddda";
+      sha256 = "6765004fde25111263bb356666593d48eec5acc5458c05185b28b6a207f933f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/fi/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/fi/firefox-136.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "3f67277f06a45ac65459f43b0cb9a4366a6963b62985cdbd68dba3ef9ba1756b";
+      sha256 = "941193f427a6ed3f0b9cf603ae88b10fde68b920b5e86e7593890ab8af4666e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/fr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/fr/firefox-136.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "132cff32e22ace6b88411ff5af29281c07908363bf2fc951aeee1fb7224af9d0";
+      sha256 = "e15bb37a0e4eca51b3959ac5e8016f6d83e16d356928ee5fb1285ccfc4c844f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/fur/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/fur/firefox-136.0.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "d00fed3e2125981c1aee361192128f6fbb513f38fd8df43725b9f9d0167e5633";
+      sha256 = "4df59c4005738e33f9e629b3ea6793d423275ddb011c7423ebe181a1e35b8597";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/fy-NL/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/fy-NL/firefox-136.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "91e032552cecca42eabe114f61eef772ed4ff1b5a6f3aab8a2878b4e19349939";
+      sha256 = "cf4d03d35346bb4e7bf49099dee920fbd208e54e1dcffcc5afdb852490da6393";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ga-IE/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ga-IE/firefox-136.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "f2f74d2cc1058f872863523d5f92af386373b1f0cecbe7f63cca223f26ddc241";
+      sha256 = "b10ab4f91d789fb99bfb91ae7b2756d83618e042b8964261bcf894c9ebfa9481";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/gd/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/gd/firefox-136.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "6f5e31d2f351feb3e1e7a5959ed7a4152627b15d0e7ac5145618290c02a01a7b";
+      sha256 = "57ed057072f63e3084174bc1dbf5cb526cdc08120537e294c98a2dbffa9ebe45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/gl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/gl/firefox-136.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "3cfa4db7dd654d02caeb4f94d9a384c28b3966326d5874fdc5e7cba82d5ec95c";
+      sha256 = "b442d8e5235586327f488b9a27e01c23c53e52fee4ed2273b14d92bb90f827f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/gn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/gn/firefox-136.0.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "dff5fd3ec38a386a12f0c22ad48b9839eb374576caa458449e6238f609517dc5";
+      sha256 = "bd07522d7f0337640e77d5dc89ae392c736fe8607ab1490cb0c097ec916a846d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/gu-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/gu-IN/firefox-136.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "a40f2abd3af7f02e538397a263f87eb5e4fcd9e111a715b60ae2bc49c97f406c";
+      sha256 = "755ce6839edc507578b57bae03f393491c6fc49a17ab6e10746bfdc678bca7f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/he/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/he/firefox-136.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "32bd9eb3e13731084245257224c5224a7faa01cfccecbf34f293e3ea8e487435";
+      sha256 = "ff10766f06414ffe9b5c8eb8c1a674887a128c09059e660eeb8140ed8404d3a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/hi-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/hi-IN/firefox-136.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "98851d1ec53e8181afc99809a346530ba85982109d81f05379fccac40d792abe";
+      sha256 = "ff135c05637306b138c84f3757d9006801f0091f50187f2f33318ee939bad64a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/hr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/hr/firefox-136.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "be37998e147f5a49bbd9fea5c8d978a9720bca3f48941e0b9611c24aa97d859d";
+      sha256 = "5798d5f33877fe764130a5518d8b3ac31358b34e66a94172b99deb075cd7c528";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/hsb/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/hsb/firefox-136.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "acc2fc5c8b535732df36b29b66ac9e6e57aaef836fa81584ddca50282166de14";
+      sha256 = "4cc2b54239248a790e3ee9b23adae92543d239984a182e9497f6c8172e17be76";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/hu/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/hu/firefox-136.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "b8db7bd380a88798f3940f9aba34be6415d8a55964ec93d25edc66aa857985a6";
+      sha256 = "14c80b4a5f19056f53fac0b65c2d33ff41cae6acc0b5ba12812147aa68955cae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/hy-AM/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/hy-AM/firefox-136.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1f05f5a57f4456685ecd91407a934af22b2d4c747b6c6e3bb7ea5fd12bdd185f";
+      sha256 = "7322059762b6bfedfe7ce49c2aaee1c813da98d8aa6ca458222f2fca4d19babe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ia/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ia/firefox-136.0.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "7e6ee73ffe85a5c0a271918ecc9adfb50022b5e09a653443fd617ab47e860637";
+      sha256 = "89ae4e060475c24bbeb650226f2e5d8828b502580bb0d193f4245e88d189c80c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/id/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/id/firefox-136.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "065f5bf64bba19939f8b841e5f49eac1cdf9b9f7cfbf26bc005b77ad30bc746d";
+      sha256 = "96be79fb8140f8f0f239ff9480e4bd67904a3e2ad426e2f0e843868213b4353b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/is/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/is/firefox-136.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "412e812053077448faaf7592361692e8bcaaeb4328d51289892fbf7bd517aae3";
+      sha256 = "97e53c0a714b858f6868db7e249df9443f6a1bead37a2c9a50009ccac8d691de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/it/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/it/firefox-136.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "acfbc59a9da22ffc60c39adc6c0410cdc514a810fbfa9d7d246a6d689fcd25d6";
+      sha256 = "d2dcecc364fa116d5c5f3fab734cdf43acb6934963fd65b092f737ca4ed0f630";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ja/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ja/firefox-136.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "3e321738351d2642898a5b99c6e54eb4ebf0e3f2a12d8d440ffe34d3dc1b030d";
+      sha256 = "22bf332ca6e751d38c44218d6ba7d87e08af0911a428052d69fe98026d7e53c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ka/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ka/firefox-136.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "987fec6c9d62316473a1e86a33c1550e8c3ef43d1984f8bb678aba0b03b6b72b";
+      sha256 = "fce144001716c858158159c676ce8233fdebe825740f1c38777b417b951b96ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/kab/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/kab/firefox-136.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f8b39495eaf6b5d9236e633cbd70df081a4f2cd330d6a41d92c18902f27aee5a";
+      sha256 = "82451783ebf5c079baf5e200ff9f693ff080cda7c72c34b6ddde7ebfb191b12b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/kk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/kk/firefox-136.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "04758df2c976f3545b9528c91c8f83ea8998354c3dc663250014970f1c6b69a7";
+      sha256 = "bd447d3fa32b945b7c020f2bc9bf7bfc75fecfb3424b9f3b90fc28e244985d9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/km/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/km/firefox-136.0.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "d7fe56786823bdbb27f9777891a82564d4279155c17ff10ea74dab2ce5c427e0";
+      sha256 = "db73f34d3616d9f9038bb653f4e3c9fd504211e97bec1110ab12f31914b33dee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/kn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/kn/firefox-136.0.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "bade2e71b45a2f1e2fa1c8870ec2f5e52bd28f7a3a13998938200ab4b0900a3b";
+      sha256 = "8ac9dc16dff94bb0ac4c6bf23139adfd931b7599e78cac73b0bab75c0bcd6b56";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ko/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ko/firefox-136.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "40743fd1c0c064a44ed81d5acd57f78994a6cb01ebcddf8e5e2876d4654a46ad";
+      sha256 = "6692641847e7b0598bf38ee0b0ed61767b943df13333abccc1aa812951ed54ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/lij/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/lij/firefox-136.0.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "be26468c3ae7d798abbdea470e1b3295ae93efd563c34358c0984366125091ab";
+      sha256 = "3a1f1b7bd6549294e0333bfd41c02478b6eba09d691071abb9ce8b1f186b7a39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/lt/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/lt/firefox-136.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "67ec58587fdede39ae054baffecfa9e7dcce5c5ea9811f97d1ba1de74c8f2a53";
+      sha256 = "f94133a2988c4ed1fd9273a3a1f582a9aaf6c1e5b4d90b394a3fa70c24bca3c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/lv/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/lv/firefox-136.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ce14f1ae6041fa1d790fc60196756169316d714d38b17563e50ff390887cdfec";
+      sha256 = "23c2a51f6371ba30c9e54de5eacaadf818a6e012e9d9cf2fe6172d5de4942242";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/mk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/mk/firefox-136.0.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "a06f5d0a075b8cb79e69c5e21dd4fa43bcd0b82680b56a39ebf215af15efe398";
+      sha256 = "81e700a2257b0496414ba811515ed832b07eaf7c6c766793d35015a7a6f8aaf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/mr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/mr/firefox-136.0.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "5c5ee80edd4d7854d9474474971a48d724a1c93c0cac60d62fd93687aa159eb1";
+      sha256 = "f052dd75a1697441e4c3b395a3e57c238bc7c860c3a46de2e7bc1848b6bd3192";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ms/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ms/firefox-136.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "bd3fb4ebd6ed6833cefeb147736a1eadee824a457053854a2ba5a16eac8273bc";
+      sha256 = "6d3560e432ffc8c677175c6780a36c91ea9bccc06fe52953f190b2b9bcce94de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/my/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/my/firefox-136.0.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "25cb3e2e364899be8c708411f591f8ae51e95af9f9ef726e7d1b58835ab33880";
+      sha256 = "0b1481e923188ebae7cec90bda2166c3798e4d0f1a714e828b362ddc85098b0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/nb-NO/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/nb-NO/firefox-136.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "0265a2be242623af393a43effa41ce35d4f7a7970a963c0d7fab406d1634d944";
+      sha256 = "f62492e978a320f32488d85f581963b858dc6897cca51949cb2453d94af7425f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ne-NP/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ne-NP/firefox-136.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "d0cb102fe9d54bee0a4b1db719afbdecb63dc4ef4447bfba6100ee5a96232fbd";
+      sha256 = "56db95460e0ee07fad875802b7aabb31038915779a780d7d231c0e48f59021f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/nl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/nl/firefox-136.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "aafedbe22664d2bc7c0638670c505bc4f8953d187fd3f879218c1131d3278b86";
+      sha256 = "43fd74b72b5f580be29bd332d6b3a429d339dd7e291cfca57eced20d3c4e9230";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/nn-NO/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/nn-NO/firefox-136.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "129627b922147601fe04d6f2419fcc0174f81943b0da660bd95fa6fb236fdc1c";
+      sha256 = "65676255bba5819b07d59de8b22f402a8b1dab0d252f7c34d5c1dbc92c2c368c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/oc/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/oc/firefox-136.0.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "8d392514cd05614334b931d04e6b6b8bbd58f0f43fab5dae9efdbba8ce30a001";
+      sha256 = "93da9cc423cd623512cc92d7cd39d58497a9dd3a17968fc67e705d201c6b1426";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/pa-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/pa-IN/firefox-136.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ec27efc20302616ffb4ecdf936a9eb7a1d4ce886b67f3a8fb66f4820a8246b76";
+      sha256 = "eacb82901e9b4c4550ae92a239d8bf2cf559954d55e3f6bbc434f73fa291eceb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/pl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/pl/firefox-136.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "7ac5b2a539050a06ec9a1940a923976222bd635dc07acc8a9a4e379c50d918ec";
+      sha256 = "a8eed53ebf6d52f3c98bd684a7c54dc0940bedca73059d4d6d1b25e33166279e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/pt-BR/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/pt-BR/firefox-136.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "6c81b880332d86f273a142986310de26a18a77597ace7c35e4d63923d39db070";
+      sha256 = "3c16a2c1c3548a2d6a4c491afbd32698c8a949dd17901075caa7cbb3bd76ae86";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/pt-PT/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/pt-PT/firefox-136.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "25cae3090f199ad7c4233463a4fe33aea7dcd2dedbaf699264eb7529eedbc4cb";
+      sha256 = "19e570e239cb1b6f0f02074b321397e7a89382605104c8bc15df3ddc803f3aef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/rm/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/rm/firefox-136.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "7c6c2602081870a8a6a37bf994da60d875decb48a5a8bc1d2dfe153224d9fd5e";
+      sha256 = "a3dbeba1a1cc3f2daf680e30d2bea8250f659f9149d61255fbb9691da37699a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ro/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ro/firefox-136.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "20bdf9c4c37ddf25f515064b0746a4a31f71b59e0b4a510f2dadbe71699a4234";
+      sha256 = "933f358726234ec7648d5e6d7c7051eb68c8f0c6ad3e63db4484f8aff4ab74eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ru/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ru/firefox-136.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "34a498efc44115d13aed6a494725e8c201da5b3e2c920a34bee7fc9da627a02c";
+      sha256 = "8516fb85d4b5365b1b1841418276602a73d20305e01b819ccbf217dce1189301";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sat/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sat/firefox-136.0.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "512c0ff90882875da0d8025942788dad94008a55a0e7e54fe6aa0a0ef4ce34cd";
+      sha256 = "1e025fed6e03d4f7ffe4b95ef003d014f025acbc759195df7748b33c7ba7f1cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sc/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sc/firefox-136.0.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "d31bf478b2fd3cc24b0bdefac89d1a78b1216f9ca7878bc7edc71a858d643e45";
+      sha256 = "3bca71b225c52e1114564df9f0ac6dec75cc47b1c87de6f660e84b0dfaa27b37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sco/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sco/firefox-136.0.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "a7fb73f110385a112b74077b08b0ecf28a294fcaedec516339d5bdf3784f6200";
+      sha256 = "448cc36231f5d3f38db1ddad75f14056328ea720f19427edc97d518fa63db333";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/si/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/si/firefox-136.0.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "cd4f6385ce73b65f4492310a9be81ef356c915047ecb6030c048de49c32f017c";
+      sha256 = "71609876033c6ac3040994f694c83d6806b3333625a66513697a3047cfecc8c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sk/firefox-136.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4ef13cc54f9065949238fa8bbc556c04d33fb2a72407d853e303a8b7652ea1f6";
+      sha256 = "5384b9e6967038caadcdfbf8c8fb1f4f845dd8462113702222e9e0e6a4da4277";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/skr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/skr/firefox-136.0.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "d51cd2574035a26ee977e050ebded2407fd82a4b8b1d8ef523aff6db06c3a4eb";
+      sha256 = "21917691d77ebd815fc713b44912424d8a7d5b19cca3ebd93086db1d55602b53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sl/firefox-136.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "4da326890042c183d7a929d5b85661e8c7e4913ff69d16615c01ca603324a55e";
+      sha256 = "9a302036985d0a5320635d5cb0326e5949c28191ed7c2fae742da813af3520d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/son/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/son/firefox-136.0.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "4864312286399cb2b4d03785fb686133078d60c191eb2d13a8378b7ecc6e78de";
+      sha256 = "f0f3c8cc68cce40c72c59e61d90b09ade1c012bd9074599b5c1b94d76fa5d9be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sq/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sq/firefox-136.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "218f269f88a1d6289ecdab29a11395647fe693e4144d767eb46305f5736359af";
+      sha256 = "a8f071be7a061be6b0fa8c8b82322e1164bd2e4f5d3929f31f45ad695677743d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sr/firefox-136.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a84d53bebe11310254c65455358daa0d0c40280575c9fbf6e0a4c0b578a6cda3";
+      sha256 = "661e98bc6a28fea90671e55e8af3854790b11b2e443dfce739b0c2d41ced0ebc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/sv-SE/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/sv-SE/firefox-136.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "46ff0638dff2df105f760852d3cb258f67ce7b70b3ec6092a7112f15ffc9553c";
+      sha256 = "99731b8cdedaab984e4bb29c51e12ef50825a34129eb10090264fb350a89e0b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/szl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/szl/firefox-136.0.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "da2bc83da355292b4914cf1766426ca6aa623f4a329fd6f16b0252708a8f1986";
+      sha256 = "6a8487a64d101e6ded104b472eafc4411827fae28c990a387f74e19b330bff01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ta/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ta/firefox-136.0.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "731dd9e89351143c923e99b71d8b18cd09cdcba01ef8781037826bcaff52c35d";
+      sha256 = "f72720040861bdf925044a75544a7d9ea8caa69c6d2aeecfb07f21b7f213a463";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/te/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/te/firefox-136.0.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "71d10251232991cfe2f2a7f37016ed93bb6ed1cb009732c05e72371e8d716495";
+      sha256 = "9c2a975548cccc5245f0b65a0c0a71454c4a790d94c36838f2a66bab442461a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/tg/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/tg/firefox-136.0.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "bcf402aaa8bdeeb48ab7d21a6ea5eef55ed97fa04c96e3931c0df063ce36719f";
+      sha256 = "7442cde792032a617abea549fbf5d1835a52ca0099fd894a4c85959ef18d7840";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/th/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/th/firefox-136.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c726adabe33ce9c9ef83ad2c3511cb5b3b14cfac740704b477f79d20db47faba";
+      sha256 = "24fb5e08ec008bd9f41d906ae9ca5d659ce270c566f19e81566f3899d787e8a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/tl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/tl/firefox-136.0.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "2603148fd61af0bc103564de6df46ac5813fc98f6408e2916ccdc1234fb3bade";
+      sha256 = "db4b826e9a2aa6083de672157a62d16f3c7c7181b41b0a9fab41bca1bd8c7334";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/tr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/tr/firefox-136.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "25678b5287864fc27a9eeb53b0fcc7cbd1ca5ac319e7a666659a549cf73d8d07";
+      sha256 = "b269e2cfbac1f58b3ef2526f224e1d54c5dd667e3ab167491026935baa495a65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/trs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/trs/firefox-136.0.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "7a7e0a7d6288add3a287bca63c4c8eeabbe909105774f26b5df19bf593f8abcc";
+      sha256 = "41c38d4655da7c47833dc7d05dbd14a9b90642a264d3c30e6281d17c8fb4b586";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/uk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/uk/firefox-136.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9ce9461aa559bb9572f71aab42d96a0dc42181b80cc5baa09c4ead7907e77c74";
+      sha256 = "0fe8e8ce66b85a1f915be9ffd5a187c30525ac169ab705a6aff29d4ffc0ab2e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/ur/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/ur/firefox-136.0.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "225cb95d842660b83f45ad2c6bf78500bc72ee47d774e22db51e43d5bbc09e8f";
+      sha256 = "0cc13615cc256ebd4d992b6b8a50fd7af69bb10511226146d5628656c3c24bfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/uz/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/uz/firefox-136.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ffffa772a552421e82c79472ea641a4255725947e1be14221fff4e8bbebf9c54";
+      sha256 = "743ae0e69c0bb866e32076797e7ad0a73246480b91255a9bb836a4e209ff9c36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/vi/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/vi/firefox-136.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "1fb27749f090584cf06f731d871c8317b0bcc5a85391a85b1bd2c9caddde5848";
+      sha256 = "655236781f9e4dceb165cd55df6a99d5f0a0e248ee57532ef8515ad01c10a839";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/xh/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/xh/firefox-136.0.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "47c7365321aa796f5a1bfb960a59e329fdcbcc8cd98c05736cbb3fcc3aa9cdf0";
+      sha256 = "36a4ab91f101f4eacd45a96154c885f65ff0ac057a9daf4b0ce72e71b6acfbb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/zh-CN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/zh-CN/firefox-136.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "3f192e56a3636945878d1c61b208cf37b3ba2761a9a0def06c2bf57f8e5e6868";
+      sha256 = "34802a495305869f8899b645ef23e93a2ec834c6ef6ac4d7d8ca008d4cd628e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-x86_64/zh-TW/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-x86_64/zh-TW/firefox-136.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "1a1bce8af641af3dfa42e3cd97fc092d4f122bc4cf8cf48bf600235b388a6c46";
+      sha256 = "f4ef8e63724bf8d7d2608f9c8bd52c6903f19034a4fac1503f93b0c7a2f5681c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ach/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ach/firefox-136.0.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "c82cd11cbeab8500505a974944bbe72f5c1a7812a385ed83f50d6c06c37b72c2";
+      sha256 = "3e4cac3a1e4401143ee4abd2b7a8876101ffd2631124c6b5ad17f08ed98b24f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/af/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/af/firefox-136.0.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "63a0ad22cf777230cb88b33998afa52851e510454e03bda5f9af3f08179eb303";
+      sha256 = "61f8f5a2a187b7dbedf0fc8364252601c42d822e886cc19ac87256af76fb6b31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/an/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/an/firefox-136.0.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "6e4561401df01b7a4b8a997270603171a781151cd31a4003677e076933de99c9";
+      sha256 = "ec87fbe4395d646158c26cff6a6b5ceed3cafae613290887bd0dae28240cee8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ar/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ar/firefox-136.0.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c7b7e1cff64f22436e13ee69344bc7c4d762c02f26afd69935b9c66c536b0b89";
+      sha256 = "d594ba0a21f51fc0edef6564748d2d50fdf08125b612d8f2ba6101e4ed8868b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ast/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ast/firefox-136.0.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "8fb6ee84c5bfa8c1a3843780f71672a47b5ba4f0f5de31e09946baf32f04e94e";
+      sha256 = "30a01d6dcde1ad68fb9ae4523b9c709d46d0c475938b976cfc48af4d374c7306";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/az/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/az/firefox-136.0.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "5b04b6afb8e278df645dfeafcdccf35b0d822b2af3f8b85d0834b4bbcd1d22dc";
+      sha256 = "39fbbaa8af5e000bafe33ea2e30c4d7c0e2d083833e70fdb661191b5b364021c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/be/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/be/firefox-136.0.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bfbf9a3ba109af1659c4569515bda7ae8becae2d52c89b20515c13552f02d679";
+      sha256 = "e45063ffbb17e61bc56ce354c08f2ee7aa24b1ad7bcd49dd1eef8ccfd3d74d01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/bg/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/bg/firefox-136.0.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "3268b534952c38b6d62badaca6a5feafc3be9fd895381233887e984dc70242a2";
+      sha256 = "1e53579ab2a49eacff250afc7b8884148b3f9e3de4210af97e3a85e4798224be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/bn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/bn/firefox-136.0.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "d70488e1e19a4b4a5d78ed76d810471597279596f87fa2a791f99b5d4980ba58";
+      sha256 = "bd3d06645d9710bb3ca03243b7fefc7074bf7150c7c199edbe86a39b54cb907c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/br/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/br/firefox-136.0.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ce36b6e4eeb9fe08f1ac8fa9ae3e39de455a84351a07f94190c1107138d2b42f";
+      sha256 = "6f6f7edc391a35655bddb378f8c0cd1ec8e62f864fed217677fc3effc38f737b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/bs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/bs/firefox-136.0.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "3a4b8f3a5cb0b12223e1b9effcccfa9080db3df224cc9fe4bacfdca7929286ef";
+      sha256 = "23046fdb7eef48f0380e0fcaf869e09afa45cde385ae417bf5154c2c8816ebc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ca-valencia/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ca-valencia/firefox-136.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "cfcaa98614b10f801eefbb577b649485e35609c5e5873ba7252431c322cf8ca2";
+      sha256 = "809eb3de2d1d0a8ab88083553bc50391898e33cdfb1fb337e8983062558dd694";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ca/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ca/firefox-136.0.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "0fc1404dc7fc6fe900065c3139efa8a5b564b2e31c43b14f3f12abbd9782b934";
+      sha256 = "7117fc9d07b07b24ef8d4771a212ddd929bd3a3fcdfdbd2e0ec28a9bf977cac8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/cak/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/cak/firefox-136.0.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "20516b513a9ed010c149b224f6571b1f58bc10659174a2b35f0895ac25066cbd";
+      sha256 = "3825bec6617a7a8deb533574a2e17d0f4ea7aae385d8b762c75722b6de1713d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/cs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/cs/firefox-136.0.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "50f2c076ad1fed32095b2df46fff544055876129f97dd0148b68105a400efcf8";
+      sha256 = "dff3d2a041100d4a778e1863104d539335e941a94758b2312c28197ca9a14c90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/cy/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/cy/firefox-136.0.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "e5ec5267bc359ea1b6d0558ca11e4759475694291e85b5e2284b26c0cb95b207";
+      sha256 = "04f6e09197a34cd173513f038ded117c9522afcddefe2fa0a1402624a45dec7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/da/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/da/firefox-136.0.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b94cd629ed241c78631af1999de1c428a628baa88d4efed600472f55c4f91d68";
+      sha256 = "5668e28734e82f988d02005c2bae6fb27913ace13a4ec985b70c1f20e776fae8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/de/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/de/firefox-136.0.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "2e534968130b9ae7ea8c47f66b29ba9f97c0f4017404760fe7e2a8a0ff8af4e7";
+      sha256 = "fe84c156862aa18bea062d9f6e407aa402ec471569e4f4bb65f5bd84ec077db9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/dsb/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/dsb/firefox-136.0.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "2afe07c907d965a26d6a165dd5ffd6b799d40208618233c4394a503c0e5693d2";
+      sha256 = "f93785d3ce8fec50bb99f163424bbe0b826a910f43d7c36180f12399ae936097";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/el/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/el/firefox-136.0.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a08417db97449e9f51c21b23f81a6627e860d5c2610f3f43064f40021864a91b";
+      sha256 = "c715b5411c45832484edd5098302363d47c08a0644dd757366abc4851481f5ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/en-CA/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/en-CA/firefox-136.0.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "bc263b9f5a082f49e59c8f8432a89f29e2b241ce32236b95dc3efca653789acc";
+      sha256 = "3e9824f7c04e70e7b304952e7b4b485dc13d6a8f02273da05cd1994ae16bcf0c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/en-GB/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/en-GB/firefox-136.0.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "eb8b857d57327915f5e7ba3b10170dcfbc90c76e317893fc435d4001c71615c2";
+      sha256 = "e0b674aa4b831732fae7b67359a480b46bf2f754befba02509c3bcdddd18919c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/en-US/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/en-US/firefox-136.0.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "067f19bd0eee8892418a1f56160322187c3f4ac081a7ae796dc32774921a56ba";
+      sha256 = "9a387467a5da1e9a05312fc4e43069eaf50924c3c7657af8f38121b18f31cf5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/eo/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/eo/firefox-136.0.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "211c205fd397da7979438e432240c53f2bbc0e9832a2dcbd7301c594b7924e46";
+      sha256 = "1b7acbaf458076721cd95afa2589ea78b8506f76950b0a9646a1ebe4aea9a784";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/es-AR/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/es-AR/firefox-136.0.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "dc5aa614418fd37b61c4a469156d85f9f37c27eccb8e570caa0448d1a2bf18b1";
+      sha256 = "cf02180d2d8db640d3496735da0fc2844000259ae7b1e65d0d0589bfafa4db6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/es-CL/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/es-CL/firefox-136.0.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "912a7cc7d8d94cc4494542d48870456f7920a4f3bc3153a6e9f96d7ae33b998b";
+      sha256 = "90566123e51d4ccb6fc8fcb4d5ae6cf3bf302bbd50ed22b8c2ce51868cbd4296";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/es-ES/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/es-ES/firefox-136.0.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "129be627e784c79f5cab7864fc9bce8f36fdbdad6eabb5d319438334149045a3";
+      sha256 = "a686222d0fa78d568f1631946468dde9c580108f0453b01a20b9cc21e5d27ae2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/es-MX/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/es-MX/firefox-136.0.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "95fcf3ddb9e19e402760a2065a50907e6d6bc7114ff0f40b62c6f240fd7ffc1b";
+      sha256 = "949be9223592ce5ca0d01b1e975eaa2ed2818276a7b65e045e1dcbc1036c7e1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/et/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/et/firefox-136.0.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "13685d04f661d5de4b47fff13c278b0d753941beff73f738bed6742e3bab740f";
+      sha256 = "ceda792622d72e5942b68e3c8da75d94d8f73cb60a35c10397363413b3e9a96c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/eu/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/eu/firefox-136.0.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "3b576d42d83bb25daf60b6ebaeb51ed90c0c6ba02bb303704eed99c5d9311277";
+      sha256 = "e9fd19c6dcb018722a6cb66b39a3aa776eb6870bc2e35649881cc50690b5954e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/fa/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/fa/firefox-136.0.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "af54fc246326c125b22f26f825a5354afc31a027a326cfddef2614f3016d6958";
+      sha256 = "b52326dd13a792948b669a26f7fd7db80a447d481e330def69d66e867963cd46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ff/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ff/firefox-136.0.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "b2baef68a972000a2efcd11cda6af5b3279ab1b80116f9bb44beb61532e132f8";
+      sha256 = "6dc07d581a9292ed0f6da5b3580421c7cf5d71a4e266959e1ea57085be608212";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/fi/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/fi/firefox-136.0.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "c1004e13cfcd6894503a6e13fad8dd97c8ebedfa69f52f9d003abde50f88c073";
+      sha256 = "3ff24fcb1fc97c91aade74914520a811a598ec849be07e606d743e02bed0c40f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/fr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/fr/firefox-136.0.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "ffa6a20adf5f77f5fd7ab38da6b886d7de4d940357c44e4fee161538b385d594";
+      sha256 = "6e8ba45ababaa7cbf70e9a3b67c0a479570e856d53546cd409b38849ff9e21ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/fur/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/fur/firefox-136.0.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "e5409602ca444c8b8ec3de997ee56f981bf398f27fb383429d5fb5d51a12d5c1";
+      sha256 = "862f8f060ff605ae4d164c2a56d4b242ce84c181437e4c2fe36c314828b0bade";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/fy-NL/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/fy-NL/firefox-136.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6965b6d0a81784a1b434edc47433216bc723fbf998f694543a16f80967c777e1";
+      sha256 = "60de836b4ad3dabcdd6a9d58f09957fad64a10a2c2cb0b64cb2a3a59c34254ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ga-IE/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ga-IE/firefox-136.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "b76b639a3f4b84cbd27b10946f744f9ebe77b51259043c322709a4221d81554a";
+      sha256 = "c0aa76fd1e9f31e7088cc7c4d262b2d5038083c233e1e13e842e8a7b9d37a707";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/gd/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/gd/firefox-136.0.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "e28e684bf152f76c7878f05fa796299349640239479e7edaaa1e136f4023dc18";
+      sha256 = "0b08c420e844c3b652b5ec3c278c607def41b513a73b8b80921e02eaa6eac7a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/gl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/gl/firefox-136.0.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8d28ed21f02efd61288323226275d91445b7fa524f3079b73e9cc67573993386";
+      sha256 = "fac969416598741e03fb725f48062f54d595099d101909d7b9fe63aa37932c0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/gn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/gn/firefox-136.0.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "84ac348eee05dd7688c80c24c14facf01227cc315f0a704076dfc75a8b860eed";
+      sha256 = "982d43c992bf6dcb820fa91f35126beb1144798c86028c1530d371927cf09ad4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/gu-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/gu-IN/firefox-136.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "c8a8ca67e03f1576a45cbd683fda752382acd72471db2ef9cc37c435cb918feb";
+      sha256 = "829fdafd57430131602777f9ec9f26b9b83f9b469b85f9a6b183d3452fc61ec1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/he/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/he/firefox-136.0.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "fb6e174f3a0262546ad9e4b5f083504fb2b0dc8e97f6bbdf8fd028e77519d961";
+      sha256 = "f3e26085bacb2a5e81d4b361605d25b4b9bd400cd3fbf5d6601cf0e4e264ed00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/hi-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/hi-IN/firefox-136.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "d615c947f4d005ff5f5c735dc51851a6cc581c673db92b6298188f0c2982e05a";
+      sha256 = "efae19dd73ff7b251ea93b61b23aeb0cb88d73637bc319560ed6eb57b2d274df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/hr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/hr/firefox-136.0.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "63ddf1729af345a5f695b8e253e347e8a232a77b6e2a949f87770bf769b7162b";
+      sha256 = "e33de9eac58acdbc3f2888e41b2fe98d1932963860ad33270eb4a60898f6462f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/hsb/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/hsb/firefox-136.0.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "60be97a59f23fe68f22e62e1fe9c95b723ae144f6c92dcf505f29985eb770af8";
+      sha256 = "c154bcaa3ab9543d64a191e231fc9738217b513a9dc26b8bfb31105b5569191d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/hu/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/hu/firefox-136.0.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "cf878262e5ac4668b03e53ba9ea8d06caddf5ae6062ed482c3ff53a4b42d5ab0";
+      sha256 = "06641b862904cc2587f8e71841b1813e8f83fc21d822f3dba1363aa5ea40ff58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/hy-AM/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/hy-AM/firefox-136.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "81916fa78ef8924cfbeeafd1544bd7f004394b0be9319a38cc9bf9daf2be0537";
+      sha256 = "f27fad94b9803b4c0241da85d75948a071e0fe80165cc87c7b492e3180565523";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ia/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ia/firefox-136.0.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "3c1fe474d0a6cea2bf7cf21800ab47e0079326e3eda3a1951d4d266b0c38a5cd";
+      sha256 = "93d101da04751df0d40e0f3810bf67986523720c15bcc18a0a605da2da971443";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/id/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/id/firefox-136.0.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "f06ee4c1d2f087278152810a47c0d22d2d95f56782a12e149281c281e490444d";
+      sha256 = "a393731d0b3c23b4af378a7d5a4cebb478b17f885877eef60a21a73d2c80a6b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/is/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/is/firefox-136.0.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "2c191208103635c58040f0a5fb29a8a4f71c28fc86ddf39ca0510885abda08af";
+      sha256 = "96893934c71388251c3fcc00d54acbdbe40c62805112b3a058af8008b8c4b5e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/it/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/it/firefox-136.0.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "0af746d1574f0ed4bd0ff0f6fe8297d8f30bf60ccaddc9bbd76989428f83cba0";
+      sha256 = "32b82e1ce3fc2a0b97ce3d819440b17450fa75fd1acb65413ea35a2fdbd52abf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ja/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ja/firefox-136.0.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "97650d3343a76441c61c89de9a4b1166472a1e8d9daf4cf80b09e7892448aec3";
+      sha256 = "58910cbd1b6cedfa72c38e0ba81ec9530c99e736f3c6802fd063953a1b8f39ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ka/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ka/firefox-136.0.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "8340484f793a2a957c742139663206621322739288d62ee32ebd8f531afcda89";
+      sha256 = "833bc46e16bc83181dba53f62a507e0208d903620da3273c87e175aabff6ce55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/kab/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/kab/firefox-136.0.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "3bdca715f792492e1f154f6282e875680507858da33dec14ef6fd81556eeb71b";
+      sha256 = "678dc3f449c349f48b5be0ced1dd222eebb615c2284831e12ca43f74829003c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/kk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/kk/firefox-136.0.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "e12f286e5da6cce0d6a12aa17d08f34371164acc6ca8a3aae9ed28df3ae4e2b8";
+      sha256 = "fbea11381a693b85b9e82130b7a67438997afbaf46f95ef27eda9a0d001289fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/km/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/km/firefox-136.0.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "13911d8099e669e5ceb77c089f8606e2556dd86beb32ae86a8d48d8d7f196b6a";
+      sha256 = "1157fa82ecc25b4dc8cc8cf405a510169da372bbccde19bdc2aeeafb48e7b6af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/kn/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/kn/firefox-136.0.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "dbc0696f90bace3fef21cfc7c816554ef500bbe123637467751b2572e28efce3";
+      sha256 = "73c34e495fd2cb87a80bec91bde978638498755078b4c488a7e42f1ac7b1d9fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ko/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ko/firefox-136.0.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "41a044fd8c2108137d07955e0fb8558d48d4c1e8eb28056b1f113d3c8866e124";
+      sha256 = "22b0d9befe6b4a2c8e3032ce48b91b1e119ddedcacb90d83c7dc8af87d1e9329";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/lij/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/lij/firefox-136.0.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "041982f1e4523807dce5c7f6b92b01c362255725b204974f7a42561a169e722d";
+      sha256 = "8d0273600905979d707d52f4083b069c7518caefde6a7b7a9213445bdc33e138";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/lt/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/lt/firefox-136.0.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5b9298fd6a0278d88876e2577233f37f0c109fa1523c296ebf495cbf65e14f61";
+      sha256 = "9ec15b2ea1f4dd138ada898cab8b8d5eb20245fab33bf2bb72135e7a8ddbc5d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/lv/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/lv/firefox-136.0.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "8b22d827132e87a32541d40c0fbaa9eb44b0033f558644ef9406216731b4426f";
+      sha256 = "e687f403b85e780c6bc8e0deb9a0d5658db5219c8c69b854b195f582047efbab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/mk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/mk/firefox-136.0.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "aed9daec2f23cf8d8a166e190e0c80e0701040fb57fa304de3c3c29ca3bf6933";
+      sha256 = "976665fa8ad8493c673671e493d71c38964598d17f16913b297b6eab10442ac6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/mr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/mr/firefox-136.0.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "f06cc784521054bb1ae02b3d99b6820055f6f3a7af9f7ef72fce63dd9d55e488";
+      sha256 = "e1617f24166256dfdf545ad806793357805b09ea4a41200d9901690373ab7314";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ms/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ms/firefox-136.0.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "16ed16efc1f850be47360ccfede38a43becc051e4417fea5c9ba4e42c69a9994";
+      sha256 = "1c66328870e48cb2917f57f0555910865a2011392c80e45eb4be956d49096399";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/my/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/my/firefox-136.0.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "1d27debaec3228fae7e56dc021df9f3985b45c1ddbd53a9f24ffcd84c833bf85";
+      sha256 = "fa70c26c86e337d2470ed8fb8ae0c4d53df4a6a412edec58412fb3f784b34951";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/nb-NO/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/nb-NO/firefox-136.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "62f259043d06b3468c94eb8088bdb1ad85c491bb37e7b6d4df9b2a3a5e941e8a";
+      sha256 = "9de3b87a20152f5f1a61d0deb49c3b0328be3e5541b62bcdff55391165dfd5f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ne-NP/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ne-NP/firefox-136.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "6a2b77fdfc2560d089a3181353782b68c99441819e964ddbd4a0724e36bf35fd";
+      sha256 = "4fef58f3bb9d65e52078a7d9b058b6646063ad8b42f1f62bc9d70e22e07cca12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/nl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/nl/firefox-136.0.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "a41cee355f500aca74fc45d01d82f671a7be30bc535dd66dd4aa656944d5c2f7";
+      sha256 = "c487ed53f135ca711a5f11f8cc3006454bfd7fff0191ff16887366c6b1ddc70e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/nn-NO/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/nn-NO/firefox-136.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e23dcd1a632ae9523a0c404beedfad11027d921d033a8eb877d7a23562c8b0b2";
+      sha256 = "721bd5206a0c9143e0a956f70a317c7ca2c0efcf43c3cd8dcb6f182a1341975a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/oc/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/oc/firefox-136.0.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d3f4e32079423d0ff4a17b3f65dd071a9343ead3ba70ecf2220779d58894212a";
+      sha256 = "6995744622944bea5a19a210349aac585d39326ec275054f50188732b7a73d36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/pa-IN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/pa-IN/firefox-136.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "ee0195d6c81d2444927a712b54e17ca610b327e93dc351721dbe92211e52830c";
+      sha256 = "1c89822452373a0d1b6c87239becbe035aa70a1c43eac8ecce708446fe08be0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/pl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/pl/firefox-136.0.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f760ae4af63044878bd30ca81e990368fb940240bddfb3970e3e365d6eeb7a0e";
+      sha256 = "7fe762f1ca1bd14f921b055ebad4708c7a9099f58a40dc31d98b6bd8baced384";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/pt-BR/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/pt-BR/firefox-136.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "7d5640b25e19264d7eb65b0a1d0d42f94cd3f23d2522dfbaa1dd6ef1cd11272f";
+      sha256 = "78796d45e8247dd8d393b9cc3b3a3658174308be154b6f59ae36401da139bca0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/pt-PT/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/pt-PT/firefox-136.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "5438be4a31c069bb24165a291997353eec760e1f6d293a738bddb04269309101";
+      sha256 = "0006adfd091c449de51d481b8f849d450ed5bb3e595966e0de19631918191be7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/rm/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/rm/firefox-136.0.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1f6bcaa34fc64e2df6e02327bb6908e6fc175709645a20354df3f5e10dd94689";
+      sha256 = "5bfbf82d83e5238226f8c22af59e4a9556227ff21c9314060f7e2aad9ca7cd3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ro/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ro/firefox-136.0.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "0d5f3918bdb99590fbfc9ba120161af625e2111f1c646dcc6e45562d45edf76d";
+      sha256 = "90e0e2a61165dad0de18017599a16981871d3598333dc7d8d4b3f698e58fffa0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ru/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ru/firefox-136.0.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "bc5712bdab6eae0ec4ad0f2ff2a2534baf0014f51b3c07279350a630d2b1aecc";
+      sha256 = "e0c13b929bc3964371f90bef5c678b8716cfa15fa48930da036f71262adde209";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sat/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sat/firefox-136.0.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "618408e39eb1f7b0ea6ab20f74666d35e4a7dcab839b61588671191421e1a2ee";
+      sha256 = "505f64e5d09af9c66aa2afbf766bdf27089b5579331231c3fd74757ab2b3a45c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sc/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sc/firefox-136.0.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "dbc95d8d5529e59642efd27637eb18ce89a56b40bdb7d6c9df4433e5718460c7";
+      sha256 = "57dc00e2eb6e177c65829138681133bbd4dad390696f24363e20f2058e225984";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sco/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sco/firefox-136.0.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "026d409e7e86646e558204a9d6cd410d854925116a06e289a2a42dd908fb10a6";
+      sha256 = "3b6cfafe0ccef212ba29772de7400bccc6683d9211eccbd42413ea31ad5e4c6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/si/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/si/firefox-136.0.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "202838316171552b6da2ef6b333c1d73941ccddb617cb103a40baa74552b067c";
+      sha256 = "fef402e51c8685526c646be9e02ab152991bc9957203033e924eae7bd89faff4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sk/firefox-136.0.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "f8966944f387e89bde5dc93b2d86b41922f778beb6fd17879831cfa738c812f6";
+      sha256 = "4d3578e67bfa78ca7a693c1b53d7ab7ce8558a88be1f3b787c7fd33c7edd8bf7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/skr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/skr/firefox-136.0.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "827176c3fcb0355d77364117e2b19c2d495e9aebdd86a4647fdff5a303d4a9ae";
+      sha256 = "4b22054981c330b2e74c306b802fc7bd1dc4bfcb95a6201759c86ba186bf12be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sl/firefox-136.0.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f727a0d7a7b78aa48ff95fe5139c39769b6595fd4d5d371e185dfb40130099b5";
+      sha256 = "2656e6e0db975504baec537d014acbecb9757dccc44eaf12da8bc1cecb71f546";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/son/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/son/firefox-136.0.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "c783330aadb74922bf02d9c0b45ea42066d9b4668979e91ef6006d32ce139fc6";
+      sha256 = "f384768cc33d6f590e527043c72166e4fa03f04fcae67360b30902a8c7ec70f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sq/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sq/firefox-136.0.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "1ebb5a0f44aa0a850930a7936aad40b43af0d702a68e9c91b63c40bfd6be24b7";
+      sha256 = "2b84d721975ceb1d28afca9893ede28c8f3def13c12ce8ce1da5ad860678f48c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sr/firefox-136.0.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "b0a53e48e940177ff013cb1d737e8ab9a3b36b7971aaad3d2977a49e2b3391f8";
+      sha256 = "021b84ac34cf7e9004fd2ed8d3f79da84f510ddc12668236b504327bdde7ee79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/sv-SE/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/sv-SE/firefox-136.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a878c834a3434ece1071e35ac7b641fec839caeb7944be935701d0f1a8827fab";
+      sha256 = "aa4cb9a60b0ac3538ce40fce75515a4a1ddbbbbe3a8a0d9e186423dfab963021";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/szl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/szl/firefox-136.0.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "225bb44e577cebfb5c00cca92d0bb727f1927e001800ed58436f05056b3f306e";
+      sha256 = "a9bb17c0129733c03ae47ae3d58640df95bd5776674b2e329ac8ef12bc8238c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ta/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ta/firefox-136.0.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d42227878cf9a9145ca25a2c8843f681c6fa8a04624ce9833d1e0f5bea9957d2";
+      sha256 = "d2e97e82452f835179064b2d4b64ccc57fae85344d453315766aa1e957d832c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/te/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/te/firefox-136.0.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "6c0e77f5bb0f63f87c7cb614119948823e3e18f4185691e9868e5fe9f0d23af6";
+      sha256 = "e30498879a5e2a252d92c2d65924955648182abdb72de6124e248079811df075";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/tg/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/tg/firefox-136.0.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "f52a5f70015e490fa1ed675f00cbfd07144baea736b72fab945f5419d02ce2b6";
+      sha256 = "63c929a610a0d726a589e0f0583ec6bd702a2c08a601b8473bfa648edd6fe8b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/th/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/th/firefox-136.0.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "8ff6b30726c51c7226256f4373266c54865d597617511c17ac544a302bff2768";
+      sha256 = "d9634e66410fd0f5f4e423a80c7bde22e717c43c92e91a47974b1d9e0c3d522d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/tl/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/tl/firefox-136.0.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "7f2cb41dee4c348e319f1532249bef98b115219e86abdfb144f0e102d7eadb65";
+      sha256 = "29a5a9771d40ba6410c469782fb72c3491a945fa5f25e6b56045adaa2b986637";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/tr/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/tr/firefox-136.0.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "bc15cf950bfddaf704d70eeedbddf710c7a53a4d0791e79d260a6a518fcbcad9";
+      sha256 = "faa976c14599104e1ecf5ced9b6df4ce40ba0376c261996945f2b4a21df320c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/trs/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/trs/firefox-136.0.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "ca2511c660fb97be8da00e8ad5b06d7e188b64b71f8d1ed1881d1150e1ff2a30";
+      sha256 = "d67a3721aaf23a2a1d0d752c0d108c723c7535f58148cea88fb1e301d8ca6d4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/uk/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/uk/firefox-136.0.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "e7dae85ef3bdf6b8b82bb79a38764106ac7077283e7fd39aa663ca424b9ed9ba";
+      sha256 = "5eca03078ddd751cf241b890e7f727e27569aedc752d2a6cef0f1e9abaa47cc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/ur/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/ur/firefox-136.0.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "83c97adb1e15085a39e470f07b53f06a2db7d98a4daf7439d41484f063ce6445";
+      sha256 = "07a3f10c13d6375b3e203d85bb5843b9a42d4ab0ad0eb2b73f7a5691d4d63e32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/uz/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/uz/firefox-136.0.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "ad03d75ac68688f7aba2a801017639e3510e46fd42b12f602b8aa66482d21bc4";
+      sha256 = "d726b160135bf3b3b64d45151f79586552013f1cc2a7eb7c39bcce56d39945fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/vi/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/vi/firefox-136.0.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "04d36020a4601df78adf1c18634765aed3e574fc709751eafa811e6a473738b3";
+      sha256 = "dd04f64b4c8a7ce042f6a122f4601cbb79c3025ea19b1e11fe191978147e5ad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/xh/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/xh/firefox-136.0.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "eca2beedc5ed43f9928c7fc83186f4beafa6b48e870f467dd06d1f9412383fa0";
+      sha256 = "1dec8f74da0bca5b06660c7b36bba9e5f7b9c353efc9e622efc08fca4788d0a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/zh-CN/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/zh-CN/firefox-136.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "80d155ac20cbbf3960fa4a9f108fa0ca6bc97ec5eeb64f684757019c9bb05ac2";
+      sha256 = "2a61e5664eda59d2608c6312deba5fce8462f39601a198c65c157d6bcdbfd750";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/135.0.1/linux-i686/zh-TW/firefox-135.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/136.0/linux-i686/zh-TW/firefox-136.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "ad7a84f4151bac75ff3d4e720fb2af7f329c115c510d6aa4cdc2f7fbf2ec3bcf";
+      sha256 = "8a03c4b584fbd52aa0e62864c622d38d6a89b4e1e5c01a8a392514511094c86b";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -68,7 +68,6 @@ in
 , gnum4
 , gtk3
 , icu73
-, icu74
 , libGL
 , libGLU
 , libevent
@@ -254,7 +253,8 @@ buildStdenv.mkDerivation {
   patches = lib.optionals (lib.versionAtLeast version "111" && lib.versionOlder version "133") [ ./env_var_for_system_dir-ff111.patch ]
   ++ lib.optionals (lib.versionAtLeast version "133") [ ./env_var_for_system_dir-ff133.patch ]
   ++ lib.optionals (lib.versionAtLeast version "96" && lib.versionOlder version "121") [ ./no-buildconfig-ffx96.patch ]
-  ++ lib.optionals (lib.versionAtLeast version "121") [ ./no-buildconfig-ffx121.patch ]
+  ++ lib.optionals (lib.versionAtLeast version "121" && lib.versionOlder version "136") [ ./no-buildconfig-ffx121.patch ]
+  ++ lib.optionals (lib.versionAtLeast version "136") [ ./no-buildconfig-ffx136.patch ]
   ++ lib.optionals (lib.versionOlder version "128.2" || (lib.versionAtLeast version "129" && lib.versionOlder version "130")) [
     (fetchpatch {
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1912663
@@ -448,7 +448,8 @@ buildStdenv.mkDerivation {
     # MacOS builds use bundled versions of libraries: https://bugzilla.mozilla.org/show_bug.cgi?id=1776255
     "--enable-system-pixman"
     "--with-system-ffi"
-    "--with-system-icu"
+    # Firefox 136 fails to link with our icu76.1
+    (lib.optionalString (lib.versionOlder version "136") "--with-system-icu")
     "--with-system-jpeg"
     "--with-system-libevent"
     "--with-system-libvpx"
@@ -532,9 +533,7 @@ buildStdenv.mkDerivation {
     ++ lib.optional  sndioSupport sndio
     ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
   ))
-  # icu74 fails to build on 127 and older
-  # https://bugzilla.mozilla.org/show_bug.cgi?id=1862601
-  ++ [ (if (lib.versionAtLeast version "134") then icu74 else icu73) ]
+  ++ lib.optionals (lib.versionOlder version "136") [ icu73 ]
   ++ lib.optional  gssSupport libkrb5
   ++ lib.optional  jemallocSupport jemalloc
   ++ extraBuildInputs;

--- a/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx136.patch
+++ b/pkgs/applications/networking/browsers/firefox/no-buildconfig-ffx136.patch
@@ -1,0 +1,26 @@
+diff --git a/docshell/base/nsAboutRedirector.cpp b/docshell/base/nsAboutRedirector.cpp
+index 16888323d7..b96450a247 100644
+--- a/docshell/base/nsAboutRedirector.cpp
++++ b/docshell/base/nsAboutRedirector.cpp
+@@ -90,9 +90,6 @@ static const RedirEntry kRedirMap[] = {
+     {"addons", "chrome://mozapps/content/extensions/aboutaddons.html",
+      nsIAboutModule::ALLOW_SCRIPT | nsIAboutModule::IS_SECURE_CHROME_UI},
+ #endif
+-    {"buildconfig", "chrome://global/content/buildconfig.html",
+-     nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+-         nsIAboutModule::IS_SECURE_CHROME_UI},
+     {"checkerboard", "chrome://global/content/aboutCheckerboard.html",
+      nsIAboutModule::URI_SAFE_FOR_UNTRUSTED_CONTENT |
+          nsIAboutModule::ALLOW_SCRIPT},
+diff --git a/toolkit/content/jar.mn b/toolkit/content/jar.mn
+index eb6c179b60..57568668b1 100644
+--- a/toolkit/content/jar.mn
++++ b/toolkit/content/jar.mn
+@@ -40,7 +40,6 @@ toolkit.jar:
+    content/global/aboutUrlClassifier.js
+    content/global/aboutUrlClassifier.xhtml
+    content/global/aboutUrlClassifier.css
+-*   content/global/buildconfig.html
+    content/global/buildconfig.css
+    content/global/contentAreaUtils.js
+    content/global/datepicker.xhtml

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
@@ -9,11 +9,11 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "128.7.0esr";
+  version = "128.8.0esr";
   applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "26f9661b395b85a44b42bd72ef1ad976c614216c68f6c2dd834d0ac8b84b9c9f398b8ac550a47396995d96e6bb5fa9a50064d7f2f526bddd45aed5039ef131b8";
+    sha512 = "7c0ef22bc14d4fa248cbae14d629174c9c967f891f4525f609760595f5a108aedf7dd804d1b63b97ec268613fa98378f4742a9b6ab562454351cf21175fdb802";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "135.0.1";
+  version = "136.0";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "9ff7c2ab6bc1660e339cdcd7745f8bdac5be25d3a79b9f0393385935270d7ef488599856bc38c22ae0b067389fa71a6999703b74804a6e0ea8265eb99788cea9";
+    sha512 = "a2b7e74e8404138b294f7b3c5f1eaeaeb8ce84c9aad25379e8ec785a9686f42def9f8c119d4bc276dd371d13d7bebbe4b1b092af41500aa8c2b2c827971445b4";
   };
 
   meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/136.0/releasenotes/
https://www.mozilla.org/en-US/firefox/128.8.0/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
