### PR TITLE
nix-heuristic-gc: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -1,0 +1,53 @@
+# Heavily based on
+# https://github.com/risicle/nix-heuristic-gc/blob/0.6.0/default.nix
+{
+  lib,
+  fetchFromGitHub,
+  nix,
+  boost,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "nix-heuristic-gc";
+  version = "0.6.0";
+  src = fetchFromGitHub {
+    owner = "risicle";
+    repo = "nix-heuristic-gc";
+    tag = "v${version}";
+    hash = "sha256-lph+rm8qXoA6h2dJTYeuj9HJAx6PnKZSdsKBElbBUbY=";
+  };
+
+  # NIX_SYSTEM suggested at
+  # https://github.com/NixOS/nixpkgs/issues/386184#issuecomment-2692433531
+  NIX_SYSTEM = nix.stdenv.hostPlatform.system;
+  NIX_CFLAGS_COMPILE = [ "-I${lib.getDev nix}/include/nix" ];
+
+  buildInputs = [
+    boost
+    nix
+    python3Packages.pybind11
+    python3Packages.setuptools
+  ];
+  propagatedBuildInputs = [
+    python3Packages.humanfriendly
+    python3Packages.rustworkx
+  ];
+  checkInputs = [ python3Packages.pytestCheckHook ];
+
+  preCheck = "mv nix_heuristic_gc .nix_heuristic_gc";
+
+  meta = {
+    mainProgram = "nix-heuristic-gc";
+    description = "Discerning garbage collection for Nix";
+    longDescription = ''
+      A more discerning cousin of `nix-collect-garbage`, mostly intended as a
+      testbed to allow experimentation with more advanced selection processes.
+    '';
+    homepage = "https://github.com/risicle/nix-heuristic-gc";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [
+      ris
+      me-and
+    ];
+  };
+}


### PR DESCRIPTION
nix-heuristic-gc is an alternative to `nix-collect-garbage` that allows prioritising which derivations get deleted when collecting garbage.

Fixes #386184.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
