### PR TITLE
treewide: migrate to lib.cmakeBool and lib.cmakeFeature

### DIFF
--- a/pkgs/applications/audio/adlplug/default.nix
+++ b/pkgs/applications/audio/adlplug/default.nix
@@ -47,9 +47,9 @@ stdenv.mkDerivation rec {
   };
 
   cmakeFlags = [
-    "-DADLplug_CHIP=${chip}"
-    "-DADLplug_USE_SYSTEM_FMT=ON"
-    "-DADLplug_Jack=${if withJack then "ON" else "OFF"}"
+    (lib.cmakeFeature "ADLplug_CHIP" chip)
+    (lib.cmakeBool "ADLplug_USE_SYSTEM_FMT" true)
+    (lib.cmakeBool "ADLplug_Jack" withJack)
   ];
 
   NIX_LDFLAGS = toString (

--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -73,16 +73,16 @@ stdenv.mkDerivation rec {
     ];
 
   cmakeFlags = [
-    "-DGIT_VERSION=OFF"
-    "-DUSE_POPPLER=${if usePoppler then "ON" else "OFF"}"
-    "-DUSE_MUPDF=${if useMupdf then "ON" else "OFF"}"
-    "-DUSE_QTPDF=OFF"
-    "-DLINK_MUPDF_THIRD=OFF"
-    "-DUSE_EXTERNAL_RENDERER=${if useExternalRenderer then "ON" else "OFF"}"
-    "-DLINK_MUJS=OFF"
-    "-DLINK_GUMBO=ON"
-    "-DUSE_TRANSLATIONS=ON"
-    "-DQT_VERSION_MAJOR=${lib.versions.major qtbase.version}"
+    (lib.cmakeBool "GIT_VERSION" false)
+    (lib.cmakeBool "USE_POPPLER" usePoppler)
+    (lib.cmakeBool "USE_MUPDF" useMupdf)
+    (lib.cmakeBool "USE_QTPDF" false)
+    (lib.cmakeBool "LINK_MUPDF_THIRD" false)
+    (lib.cmakeBool "USE_EXTERNAL_RENDERER" useExternalRenderer)
+    (lib.cmakeBool "LINK_MUJS" false)
+    (lib.cmakeBool "LINK_GUMBO" true)
+    (lib.cmakeBool "USE_TRANSLATIONS" true)
+    (lib.cmakeFeature "QT_VERSION_MAJOR" (lib.versions.major qtbase.version))
   ];
 
   preFixup = ''

--- a/pkgs/by-name/am/amule/package.nix
+++ b/pkgs/by-name/am/amule/package.nix
@@ -66,16 +66,16 @@ stdenv.mkDerivation rec {
     ++ lib.optional client libX11;
 
   cmakeFlags = [
-    "-DBUILD_MONOLITHIC=${if monolithic then "ON" else "OFF"}"
-    "-DBUILD_DAEMON=${if enableDaemon then "ON" else "OFF"}"
-    "-DBUILD_REMOTEGUI=${if client then "ON" else "OFF"}"
-    "-DBUILD_WEBSERVER=${if httpServer then "ON" else "OFF"}"
+    (lib.cmakeBool "BUILD_MONOLITHIC" monolithic)
+    (lib.cmakeBool "BUILD_DAEMON" enableDaemon)
+    (lib.cmakeBool "BUILD_REMOTEGUI" client)
+    (lib.cmakeBool "BUILD_WEBSERVER" httpServer)
     # building only the daemon fails when these are not set... this is
     # due to mistakes in the Amule cmake code, but it does not cause
     # extra code to be built...
-    "-Dwx_NEED_GUI=ON"
-    "-Dwx_NEED_ADV=ON"
-    "-Dwx_NEED_NET=ON"
+    (lib.cmakeBool "wx_NEED_GUI" true)
+    (lib.cmakeBool "wx_NEED_ADV" true)
+    (lib.cmakeBool "wx_NEED_NET" true)
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "MPI" useMpi)
     (lib.cmakeBool "TESTS" finalAttrs.doCheck)
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DBLA_VENDOR=${if useAccel then "Apple" else "Generic"}"
+    (lib.cmakeFeature "BLA_VENDOR" (if useAccel then "Apple" else "Generic"))
   ];
 
   passthru = {

--- a/pkgs/by-name/bk/bkcrack/package.nix
+++ b/pkgs/by-name/bk/bkcrack/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
-    "-DBKCRACK_BUILD_TESTING=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
+    (lib.cmakeBool "BKCRACK_BUILD_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   postInstall = ''

--- a/pkgs/by-name/bn/bngblaster/package.nix
+++ b/pkgs/by-name/bn/bngblaster/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals finalAttrs.finalPackage.doCheck [ libpcap ];
 
   cmakeFlags = [
-    "-DBNGBLASTER_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DBNGBLASTER_VERSION=${finalAttrs.version}"
+    (lib.cmakeBool "BNGBLASTER_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeFeature "BNGBLASTER_VERSION" finalAttrs.version)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/cm/cminpack/package.nix
+++ b/pkgs/by-name/cm/cminpack/package.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation rec {
     ];
 
   cmakeFlags = [
-    "-DUSE_BLAS=${if withBlas then "ON" else "OFF"}"
-    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+    (lib.cmakeBool "USE_BLAS" withBlas)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
 
   meta = {

--- a/pkgs/by-name/cp/cpptoml/package.nix
+++ b/pkgs/by-name/cp/cpptoml/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
     # use libcxx via the Cmake find_package interface.
     # The default libcxx stdenv in llvmPackages doesn't provide
     # this and so will fail.
-    "-DENABLE_LIBCXX=${if libcxxCmakeModule then "ON" else "OFF"}"
-    "-DCPPTOML_BUILD_EXAMPLES=OFF"
+    (lib.cmakeBool "ENABLE_LIBCXX" libcxxCmakeModule)
+    (lib.cmakeBool "CPPTOML_BUILD_EXAMPLES" false)
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/di/dictu/package.nix
+++ b/pkgs/by-name/di/dictu/package.nix
@@ -45,14 +45,14 @@ stdenv.mkDerivation rec {
 
   cmakeFlags =
     [
-      "-DBUILD_CLI=${if cliSupport then "ON" else "OFF"}"
-      "-DDISABLE_HTTP=${if httpSupport then "OFF" else "ON"}"
-      "-DDISABLE_LINENOISE=${if linenoiseSupport then "OFF" else "ON"}"
+      (lib.cmakeBool "BUILD_CLI" cliSupport)
+      (lib.cmakeBool "DISABLE_HTTP" (!httpSupport))
+      (lib.cmakeBool "DISABLE_LINENOISE" (!linenoiseSupport))
     ]
     ++ lib.optionals enableLTO [
       # TODO: LTO with LLVM
-      "-DCMAKE_AR=${stdenv.cc.cc}/bin/gcc-ar"
-      "-DCMAKE_RANLIB=${stdenv.cc.cc}/bin/gcc-ranlib"
+      (lib.cmakeFeature "CMAKE_AR" "${stdenv.cc.cc}/bin/gcc-ar")
+      (lib.cmakeFeature "CMAKE_RANLIB" "${stdenv.cc.cc}/bin/gcc-ranlib")
     ];
 
   postBuild = ''

--- a/pkgs/by-name/gf/gflags/package.nix
+++ b/pkgs/by-name/gf/gflags/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
   preConfigure = "rm BUILD";
 
   cmakeFlags = [
-    "-DGFLAGS_BUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
-    "-DGFLAGS_BUILD_STATIC_LIBS=ON"
+    (lib.cmakeBool "GFLAGS_BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "GFLAGS_BUILD_STATIC_LIBS" true)
   ];
 
   doCheck = false;

--- a/pkgs/by-name/im/imagelol/package.nix
+++ b/pkgs/by-name/im/imagelol/package.nix
@@ -46,11 +46,10 @@ stdenv.mkDerivation rec {
     cp ./ImageLOL $out/bin
   '';
 
-  cmakeFlags =
-    [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-std=gnu90") ]
-    ++ lib.optional (
-      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
-    ) "-DPNG_ARM_NEON=off";
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_C_FLAGS" "-std=gnu90")
+    (lib.cmakeBool "PNG_ARM_NEON" (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)))
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/MCredstoner2004/ImageLOL";

--- a/pkgs/by-name/in/intel-media-sdk/package.nix
+++ b/pkgs/by-name/in/intel-media-sdk/package.nix
@@ -54,9 +54,9 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = [ gtest ];
 
   cmakeFlags = [
-    "-DBUILD_SAMPLES=OFF"
-    "-DBUILD_TESTS=${if doCheck then "ON" else "OFF"}"
-    "-DUSE_SYSTEM_GTEST=ON"
+    (lib.cmakeBool "BUILD_SAMPLES" false)
+    (lib.cmakeBool "BUILD_TESTS" doCheck)
+    (lib.cmakeBool "USE_SYSTEM_GTEST" true)
   ];
 
   doCheck = true;

--- a/pkgs/by-name/li/libdict/package.nix
+++ b/pkgs/by-name/li/libdict/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DLIBDICT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DLIBDICT_SHARED=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+    (lib.cmakeBool "LIBDICT_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "LIBDICT_SHARED" (!stdenv.hostPlatform.isStatic))
   ];
 
   env.NIX_CFLAGS_COMPILE = toString (

--- a/pkgs/by-name/li/libraspberrypi/package.nix
+++ b/pkgs/by-name/li/libraspberrypi/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     # -DARM64=ON disables all targets that only build on 32-bit ARM; this allows
     # the package to build on aarch64 and other architectures
-    "-DARM64=${if stdenv.hostPlatform.isAarch32 then "OFF" else "ON"}"
-    "-DVMCS_INSTALL_PREFIX=${placeholder "out"}"
+    (lib.cmakeBool "ARM64" (!stdenv.hostPlatform.isAarch32))
+    (lib.cmakeFeature "VMCS_INSTALL_PREFIX" (placeholder "out"))
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/li/libsolv/package.nix
+++ b/pkgs/by-name/li/libsolv/package.nix
@@ -27,21 +27,23 @@ stdenv.mkDerivation rec {
     hash = "sha256-3HOW3bip+0LKegwO773upeKKLiLv7JWUGEJcFiH0lcw=";
   };
 
-  cmakeFlags = [
-    "-DENABLE_COMPLEX_DEPS=true"
-    (lib.cmakeBool "ENABLE_CONDA" withConda)
-    "-DENABLE_LZMA_COMPRESSION=true"
-    "-DENABLE_BZIP2_COMPRESSION=true"
-    "-DENABLE_ZSTD_COMPRESSION=true"
-    "-DENABLE_ZCHUNK_COMPRESSION=true"
-    "-DWITH_SYSTEM_ZCHUNK=true"
-  ] ++ lib.optionals withRpm [
-    "-DENABLE_COMPS=true"
-    "-DENABLE_PUBKEY=true"
-    "-DENABLE_RPMDB=true"
-    "-DENABLE_RPMDB_BYRPMHEADER=true"
-    "-DENABLE_RPMMD=true"
-  ];
+  cmakeFlags =
+    [
+      (lib.cmakeBool "ENABLE_COMPLEX_DEPS" true)
+      (lib.cmakeBool "ENABLE_CONDA" withConda)
+      (lib.cmakeBool "ENABLE_LZMA_COMPRESSION" true)
+      (lib.cmakeBool "ENABLE_BZIP2_COMPRESSION" true)
+      (lib.cmakeBool "ENABLE_ZSTD_COMPRESSION" true)
+      (lib.cmakeBool "ENABLE_ZCHUNK_COMPRESSION" true)
+      (lib.cmakeBool "WITH_SYSTEM_ZCHUNK" true)
+    ]
+    ++ lib.optionals withRpm [
+      (lib.cmakeBool "ENABLE_COMPS" true)
+      (lib.cmakeBool "ENABLE_PUBKEY" true)
+      (lib.cmakeBool "ENABLE_RPMDB" true)
+      (lib.cmakeBool "ENABLE_RPMDB_BYRPMHEADER" true)
+      (lib.cmakeBool "ENABLE_RPMMD" true)
+    ];
 
   nativeBuildInputs = [ cmake ninja pkg-config ];
   buildInputs = [ zlib xz bzip2 zchunk zstd expat db ]

--- a/pkgs/by-name/li/libtoxcore/package.nix
+++ b/pkgs/by-name/li/libtoxcore/package.nix
@@ -27,9 +27,10 @@ stdenv.mkDerivation rec {
     };
 
   cmakeFlags = [
-    "-DDHT_BOOTSTRAP=ON"
-    "-DBOOTSTRAP_DAEMON=ON"
-  ] ++ lib.optional buildToxAV "-DMUST_BUILD_TOXAV=ON";
+    (lib.cmakeBool "DHT_BOOTSTRAP" true)
+    (lib.cmakeBool "BOOTSTRAP_DAEMON" true)
+    (lib.cmakeBool "MUST_BUILD_TOXAV" buildToxAV)
+  ];
 
   buildInputs =
     [

--- a/pkgs/by-name/pa/parallel-hashmap/package.nix
+++ b/pkgs/by-name/pa/parallel-hashmap/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DPHMAP_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DPHMAP_BUILD_EXAMPLES=OFF"
+    (lib.cmakeBool "PHMAP_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "PHMAP_BUILD_EXAMPLES" false)
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/re/read-edid/package.nix
+++ b/pkgs/by-name/re/read-edid/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional stdenv.hostPlatform.isx86 libx86;
 
-  cmakeFlags = [ "-DCLASSICBUILD=${if stdenv.hostPlatform.isx86 then "ON" else "OFF"}" ];
+  cmakeFlags = [ (lib.cmakeBool "CLASSICBUILD" stdenv.hostPlatform.isx86) ];
 
   meta = with lib; {
     description = "Tool for reading and parsing EDID data from monitors";

--- a/pkgs/by-name/sc/scream/package.nix
+++ b/pkgs/by-name/sc/scream/package.nix
@@ -41,10 +41,10 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DPULSEAUDIO_ENABLE=${if pulseSupport then "ON" else "OFF"}"
-    "-DALSA_ENABLE=${if alsaSupport then "ON" else "OFF"}"
-    "-DJACK_ENABLE=${if jackSupport then "ON" else "OFF"}"
-    "-DPCAP_ENABLE=${if pcapSupport then "ON" else "OFF"}"
+    (lib.cmakeBool "PULSEAUDIO_ENABLE" pulseSupport)
+    (lib.cmakeBool "ALSA_ENABLE" alsaSupport)
+    (lib.cmakeBool "JACK_ENABLE" jackSupport)
+    (lib.cmakeBool "PCAP_ENABLE" pcapSupport)
   ];
 
   cmakeDir = "../Receivers/unix";

--- a/pkgs/by-name/uh/uhub/package.nix
+++ b/pkgs/by-name/uh/uhub/package.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DSYSTEMD_SUPPORT=ON"
-    "-DSSL_SUPPORT=${if tlsSupport then "ON" else "OFF"}"
+    (lib.cmakeBool "SYSTEMD_SUPPORT" true)
+    (lib.cmakeBool "SSL_SUPPORT" tlsSupport)
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/wf/wfa2-lib/package.nix
+++ b/pkgs/by-name/wf/wfa2-lib/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = lib.optionals enableOpenMP [ llvmPackages.openmp ];
 
-  cmakeFlags = [ "-DOPENMP=${if enableOpenMP then "ON" else "OFF"}" ];
+  cmakeFlags = [ (lib.cmakeBool "OPENMP" enableOpenMP) ];
 
   meta = with lib; {
     description = "Wavefront alignment algorithm library v2";

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -155,11 +155,11 @@ stdenv.mkDerivation {
   hardeningDisable = [ "format" ];
 
   cmakeFlags =
-    [ "-DSWIPL_INSTALL_IN_LIB=ON" ]
+    [ (lib.cmakeBool "SWIPL_INSTALL_IN_LIB" true) ]
     ++ lib.optionals (!withNativeCompiler) [
       # without these options, the build will embed full compiler paths
-      "-DSWIPL_CC=${if stdenv.hostPlatform.isDarwin then "clang" else "gcc"}"
-      "-DSWIPL_CXX=${if stdenv.hostPlatform.isDarwin then "clang++" else "g++"}"
+      (lib.cmakeFeature "SWIPL_CC" (if stdenv.hostPlatform.isDarwin then "clang" else "gcc"))
+      (lib.cmakeFeature "SWIPL_CXX" (if stdenv.hostPlatform.isDarwin then "clang++" else "g++"))
     ];
 
   preInstall = ''

--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -39,10 +39,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional coreaudioSupport CoreAudio;
 
   cmakeFlags = [
-    "-DRTAUDIO_API_ALSA=${if alsaSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_PULSE=${if pulseaudioSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_JACK=${if jackSupport then "ON" else "OFF"}"
-    "-DRTAUDIO_API_CORE=${if coreaudioSupport then "ON" else "OFF"}"
+    (lib.cmakeBool "RTAUDIO_API_ALSA" alsaSupport)
+    (lib.cmakeBool "RTAUDIO_API_PULSE" pulseaudioSupport)
+    (lib.cmakeBool "RTAUDIO_API_JACK" jackSupport)
+    (lib.cmakeBool "RTAUDIO_API_CORE" coreaudioSupport)
   ];
 
   meta = with lib; {

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     );
 
   cmakeFlags = [
-    "-DCLIENT=${if buildClient then "ON" else "OFF"}"
+    (lib.cmakeBool "CLIENT" buildClient)
   ];
 
   postInstall = lib.optionalString buildClient (


### PR DESCRIPTION
I did this using bash not because I should've, but because I could. Next time however i think i'll reach for tree-sitter. Somewhere between the multiprocessing concurrency limiting, all the mutex logic, boolean expression rewriting using regex and making cmake configurations deterministic i started regretting my choices.

Candidates were made with

```shell
set -euo pipefail

N_WORKERS=4
NIX_BUILD_ARGS=( -j1 ) # remote builders to brrr

export GIT_FLOCK="$(mktemp)"
git-wait() {
    flock "$GIT_FLOCK" --command "git $(printf " %q" "$@")"
}

available_platforms=(
    x86_64-linux
    # aarch64-linux
    # x86_64-darwin
    # aarch64-darwin
)

get_cmake_config_drv_path() {
    local system="$1"
    local attrpath="$2"
    nix eval --impure --system "$system" -f default.nix "$attrpath" --apply "$(cat <<"EOF"
      x: (x.overrideAttrs (old: {
        phases = [ "unpackPhase" "patchPhase" "configurePhase" "installPhase" ];
        doBuild = false;
        doCheck = false;
        doInstallCheck = false;
        NIX_OUTPATH_USED_AS_RANDOM_SEED = "/nix/store/nj1na0qwqhpd128vr71p70hz9jyhnz5x";
        installPhase = ''
          shopt -s nullglob

          # remove external cached variables, essentially those from cmakeFlags, found between:
          # ########################
          # # EXTERNAL cache entries
          # ########################
          # ...
          # ########################
          # # INTERNAL cache entries
          # ########################
          test -s ./CMakeCache.txt && \
            sed -i '/^# EXTERNAL cache entries$/,/^# INTERNAL cache entries$/d' CMakeCache.txt

          # Cmake does not order makefile targets deterministically
          for fname in **/Makefile **/Makefile2; do
            data="$(cat "$fname")"
            sort <<<"$data" >$fname
          done

          # cat all configure files to $out, retain filenames
          find . -type f -print0 | sort --zero-terminated | xargs -0 --max-args=100 tail -n+1 \
            | sed -E 's@/nix/store/[^ /]+@@g' \
            >$out

          # Remove randomness from output.
          # I love how "deterministic builds" only care about the output
          # artifacts and not the intermediate build configuration artifacts.
          # The alternative to this find-replace madness would be to make mkdtemp(3) deterministic
          # https://github.com/Kitware/CMake/blob/3bdf63e84db42e63e4ce1b364d6274ef401009d4/Source/cmCoreTryCompile.cxx#L503-L505
          # https://github.com/Kitware/CMake/blob/3bdf63e84db42e63e4ce1b364d6274ef401009d4/Source/cmSystemTools.cxx#L1449
          sed_args=$(printf ' -e s@%q@xxxxx@g' $({
              strings $out | grep -oE '/build/[A-Za-z0-9]+\.(s|res)' | cut -d/ -f3 | cut -d. -f1 | grep -vE '(CMAKE|CMake|Linking)' | grep -E '^.{6}.*$'
              strings $out | grep -oE '/TryCompile-[A-Za-z0-9]+' | cut -d- -f2
              strings $out | grep -oE 'CMakeFiles/cmTC_[A-Za-z0-9]+\.dir' | cut -d/ -f2 | cut -d. -f1
          } | sort -u))
          sed -i $out $sed_args
          # echo "sed_args=$sed_args" >>$out
        '';
      })).drvPath
EOF
)" --raw
}

rewrite_cmake_flags() {
    for fname in "$@"; do

    sd '"-D([A-Za-z0-9_-]+)(?::STRING)?=((?:\$\{[^}]*\}|\\.|[^\\"$])*)"'                    '(lib.cmakeFeature "$1" "$2")'  "$fname"  # "-Dfoo=bar" -> (cmakeFeature "foo" "bar")
    sd '"-D([A-Za-z0-9_-]+):(?:BOOL|bool)=(?:ON|On|on|TRUE|True|true)"'                    '(lib.cmakeBool "$1" true)'     "$fname"  # "-Dfoo:bool=on" -> (cmakeBool "foo" true)
    sd '"-D([A-Za-z0-9_-]+):(?:BOOL|bool)="(?:OFF|Off|off|FALSE|False|false)"\)"'          '(lib.cmakeBool "$1" true)'     "$fname"  # "-Dfoo:bool=off" -> (cmakeBool "foo" false)
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" "\\"((?:\$\{[^}]*\}|\\.|[^ \\"$])*)\\""\)'  '(lib.cmakeFeature "$1" "$2")'  "$fname"  # "\"foo\"" -> "foo"
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" "(?:ON|On|on|TRUE|True|true)"\)'            '(lib.cmakeBool "$1" true)'     "$fname"  # cmakeFeature -> cmakeBool
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" "(?:OFF|Off|off|FALSE|False|false)"\)'      '(lib.cmakeBool "$1" false)'    "$fname"  # cmakeFeature -> cmakeBool
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" "\$\{([^}! ]*)\}"\)'                        '(lib.cmakeFeature "$1" $2)'    "$fname"  # "${foobar}" -> foobar
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" "\$\{([^}]*)\}"\)'                          '(lib.cmakeFeature "$1" ($2))'  "$fname"  # "${foo bar}" -> (foo bar)

    # (lib.cmakeFeature foo (if bar then "ON" else "OFF")) -> (lib.cmakeBool foo bar)
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" \(if (.*) then "(?:ON|on|TRUE|True|true)" else "(?:OFF|Off|off|FALSE|False|false)"\)\)'   '(lib.cmakeBool "$1" ($2))'     "$fname"
    sd '\(lib\.cmakeFeature "([A-Za-z0-9_-]+)" \(if (.*) then "(?:OFF|off|FALSE|False|false)" else "(?:ON|On|on|TRUE|True|true)"\)\)'    '(lib.cmakeBool "$1" (!($2)))'  "$fname"

    # ensure first `lib.optional (lib.cmakeBool ...)` is prefixed with `++`
    sd '^( *)cmakeFlags *=[ \n]*lib\.optional ' '${1}cmakeFlags = [\n$1  ]\n$1  ++ lib.optional ' "$fname"

    # lib.optional foo (lib.cmakeBool "asd" true) -> lib.cmakeBool "asd" foo
    sd ' \+\+ lib\.optional ([a-zA-Z0-9.]+) \(lib.cmakeBool "([A-Za-z0-9_-]+)" true\)'        ' ++ [ (lib.cmakeBool "$2" $1) ]'     "$fname"
    sd ' \+\+ lib\.optional ([a-zA-Z0-9.]+) \(lib.cmakeBool "([A-Za-z0-9_-]+)" false\)'       ' ++ [ (lib.cmakeBool "$2" (!$1)) ]'  "$fname"
    sd ' \+\+ lib\.optional \(([^)]+)\) \(lib.cmakeBool "([A-Za-z0-9_-]+)" true\)'            ' ++ [ (lib.cmakeBool "$2" ($1)) ]'   "$fname"
    sd ' \+\+ lib\.optional \(([^)]+)\) \(lib.cmakeBool "([A-Za-z0-9_-]+)" false\)'           ' ++ [ (lib.cmakeBool "$2" (!($1))) ]'  "$fname"

    # joining logic
    sd '^( *)\+\+ \[ \(lib.cmakeBool "([A-Za-z0-9_-]+)" (.*)\) \]'   '$1++ [\n$1  (lib.cmakeBool "$2" (!($3)))\n$1]'  "$fname"
    # sd '^( *)([^ ].*)( \+\+ lib\.optional ([a-zA-Z0-9.]+|\(([^)]+)\)) \(lib.cmakeBool "[A-Za-z0-9_-]+" .*\))'  '${1}${2}\n ${1}  $3'  "$fname"
    # split `] ++` into two lines
    sd '^( *)\] \+\+ ' '$1]\n$1++ ' "$fname"
    # strip `]\n++ [`
    sd '\n( *)\]\n *\+\+ \[$' '' "$fname"

    # undo ++ prefixing for first `lib.optional (lib.cmakeBool ...)`
    sd '^( *)cmakeFlags = \[\n *\]\n *\+\+ lib\.optional ' '${1}cmakeFlags =\n${1}  lib.optional ' "$fname"

    # simplify bool expressions
    # sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!!(.*)\)\)'                 '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!\(\((.*)\)\)\)\)'          '(lib.cmakeBool "$1" (!($2)))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!\(!(.*)\)\)\)'             '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(\((.*)\)\)'                 '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!(.*) == (.*)\)\)'          '(lib.cmakeBool "$1" ($2 != $3))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!(.*) != (.*)\)\)'          '(lib.cmakeBool "$1" ($2 == $3))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \((.*) == false\)\)'          '(lib.cmakeBool "$1" (!($2)))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \((.*) != false\)\)'          '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \((.*) == true\)\)'           '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \((.*) != true\)\)'           '(lib.cmakeBool "$1" (!($2)))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!\(!(.*)\)\)\)'             '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(\((.*)\)\)'                 '(lib.cmakeBool "$1" ($2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(!\(([A-Za-z0-9._-]+)\)\)\)' '(lib.cmakeBool "$1" (!$2))'  "$fname"
    sd '\(lib.cmakeBool "([A-Za-z0-9_-]+)" \(([A-Za-z0-9._-]+)\)\)'      '(lib.cmakeBool "$1" $2)'  "$fname"

    done
}

list_attrpath_fname_col() {
    test -s packages.json || ( set -x;
        time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --show-trace --no-allow-import-from-derivation > packages.json
    )

    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r \
        | sed -e "s#\t$(realpath .)/#\t#" \
        | sed -e 's#:\([0-9]*\)$#\t\1#' \
        | tr '0123456789' '9876543210' | sort | tr '0123456789' '9876543210' \
        | grep . \
        | grep -iv haskell \
        | grep -iv /top-level/ \
        | grep -iv chicken \
        | grep -iv build \
        | grep -E '/(package|default)\.nix'
}

git-wait restore .
rm -r results-configure || true
mkdir -p results-configure

flockdir=$(mktemp -d)
declare -i COUNT=0
while read attrpath fname col; do
    grep -q cmakeFlags "$fname" || continue
    grep -q -E '(lib\.cmakeFeature|"-D[A-Za-z0-9_-]+(:[A-Za-z]+)?=((\$\{[^}]*\}|[^"$])*)")' "$fname" || continue
    grep -q mesonFlags "$fname" && continue || true

    echo "$attrpath"
    echo | (
        # mutex on fname
        flock --nonblock 200 || {
            >&2 echo "failed to aquire lock for $fname"
            exit 1
        }

        was_formatted=$(nixfmt --check "$fname" >&/dev/null && echo true || echo false)

        config_pre_drv=()
        for system in "${available_platforms[@]}"; do
            config_pre_drv+=("$(get_cmake_config_drv_path "$system" "$attrpath")") || true
        done
        [[ -n "${config_pre_drv[*]}" ]] || exit

        rewrite_cmake_flags "$fname"
        if git-wait diff --exit-code --quiet "$fname"; then
            exit
        fi

        abort() {
            git-wait restore "$fname"
            exit 1
        }
        trap 'git-wait restore "$fname"' ERR EXIT

        if $was_formatted; then
            nixfmt "$fname" || abort # syntax error
        else
            nixfmt --verify "$fname" || abort # syntax error
        fi

        config_post_drv=()
        for system in "${available_platforms[@]}"; do
            config_post_drv+=("$(get_cmake_config_drv_path "$system" "$attrpath")") || true
        done
        [[ -n "${config_post_drv[*]}" ]] || abort

        if [[ "${config_pre_drv[*]}" = "${config_post_drv[*]}" ]]; then
            # unchanged eval
            git-wait add "$fname"
        else
            # config_pre="$( nix-build "${NIX_BUILD_ARGS[@]}" "${config_pre_drv[@]}"  --no-out-link)"
            # config_post="$(nix-build "${NIX_BUILD_ARGS[@]}" "${config_post_drv[@]}" --no-out-link)"
            mkdir -p results-configure/"$attrpath"
            config_pre="$( nix-build "${NIX_BUILD_ARGS[@]}" "${config_pre_drv[@]}"  -o results-configure/"$attrpath"/pre )" || abort
            config_post="$(nix-build "${NIX_BUILD_ARGS[@]}" "${config_post_drv[@]}" -o results-configure/"$attrpath"/post)" || abort

            if diff -q <(cat $config_pre) <(cat $config_post) ; then
                # unchanged configuration artifacts
                git-wait add "$fname"
            else
                diff -u <(cat $config_pre) <(cat $config_post) | delta --paging never
                git-wait restore "$fname"
            fi
        fi
    ) 200>"$flockdir"/"$(sha256sum - <<<"$fname" | cut -d' ' -f1)".lock &

    while [[ $(jobs -p | wc -l) -ge $N_WORKERS ]]; do
        wait -n < <(jobs -p) || true
    done

done < <(list_attrpath_fname_col)
wait
```

And picked with `--patch`.

I then compared `packages.json` from `nix-env ... --meta` to check for eval errors: this is the diff: https://gist.github.com/pbsds/631d39494827f121a0b170e85636a356


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
