### PR TITLE
nixosTests.nomad: Use runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -798,7 +798,7 @@ in {
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   nixseparatedebuginfod = handleTest ./nixseparatedebuginfod.nix {};
   node-red = handleTest ./node-red.nix {};
-  nomad = handleTest ./nomad.nix {};
+  nomad = runTest ./nomad.nix;
   non-default-filesystems = handleTest ./non-default-filesystems.nix {};
   non-switchable-system = runTest ./non-switchable-system.nix;
   noto-fonts = handleTest ./noto-fonts.nix {};

--- a/nixos/tests/nomad.nix
+++ b/nixos/tests/nomad.nix
@@ -1,104 +1,102 @@
-import ./make-test-python.nix (
-  { lib, ... }:
-  {
-    name = "nomad";
-    nodes = {
-      default_server =
-        { pkgs, lib, ... }:
-        {
-          networking = {
-            interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-              {
-                address = "192.168.1.1";
-                prefixLength = 16;
-              }
-            ];
-          };
-
-          environment.etc."nomad.custom.json".source = (pkgs.formats.json { }).generate "nomad.custom.json" {
-            region = "universe";
-            datacenter = "earth";
-          };
-
-          services.nomad = {
-            enable = true;
-
-            settings = {
-              server = {
-                enabled = true;
-                bootstrap_expect = 1;
-              };
-            };
-
-            extraSettingsPaths = [ "/etc/nomad.custom.json" ];
-            enableDocker = false;
-          };
+{ lib, ... }:
+{
+  name = "nomad";
+  nodes = {
+    default_server =
+      { pkgs, lib, ... }:
+      {
+        networking = {
+          interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+            {
+              address = "192.168.1.1";
+              prefixLength = 16;
+            }
+          ];
         };
 
-      custom_state_dir_server =
-        { pkgs, lib, ... }:
-        {
-          networking = {
-            interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
-              {
-                address = "192.168.1.1";
-                prefixLength = 16;
-              }
-            ];
-          };
-
-          environment.etc."nomad.custom.json".source = (pkgs.formats.json { }).generate "nomad.custom.json" {
-            region = "universe";
-            datacenter = "earth";
-          };
-
-          services.nomad = {
-            enable = true;
-            dropPrivileges = false;
-
-            settings = {
-              data_dir = "/nomad/data/dir";
-              server = {
-                enabled = true;
-                bootstrap_expect = 1;
-              };
-            };
-
-            extraSettingsPaths = [ "/etc/nomad.custom.json" ];
-            enableDocker = false;
-          };
-
-          systemd.services.nomad.serviceConfig.ExecStartPre = "${pkgs.writeShellScript "mk_data_dir" ''
-            set -euxo pipefail
-
-            ${pkgs.coreutils}/bin/mkdir -p /nomad/data/dir
-          ''}";
+        environment.etc."nomad.custom.json".source = (pkgs.formats.json { }).generate "nomad.custom.json" {
+          region = "universe";
+          datacenter = "earth";
         };
-    };
 
-    testScript = ''
-      def test_nomad_server(server):
-          server.wait_for_unit("nomad.service")
+        services.nomad = {
+          enable = true;
 
-          # wait for healthy server
-          server.wait_until_succeeds(
-              "[ $(nomad operator raft list-peers | grep true | wc -l) == 1 ]"
-          )
+          settings = {
+            server = {
+              enabled = true;
+              bootstrap_expect = 1;
+            };
+          };
 
-          # wait for server liveness
-          server.succeed("[ $(nomad server members | grep -o alive | wc -l) == 1 ]")
+          extraSettingsPaths = [ "/etc/nomad.custom.json" ];
+          enableDocker = false;
+        };
+      };
 
-          # check the region
-          server.succeed("nomad server members | grep -o universe")
+    custom_state_dir_server =
+      { pkgs, lib, ... }:
+      {
+        networking = {
+          interfaces.eth1.ipv4.addresses = lib.mkOverride 0 [
+            {
+              address = "192.168.1.1";
+              prefixLength = 16;
+            }
+          ];
+        };
 
-          # check the datacenter
-          server.succeed("[ $(nomad server members | grep -o earth | wc -l) == 1 ]")
+        environment.etc."nomad.custom.json".source = (pkgs.formats.json { }).generate "nomad.custom.json" {
+          region = "universe";
+          datacenter = "earth";
+        };
+
+        services.nomad = {
+          enable = true;
+          dropPrivileges = false;
+
+          settings = {
+            data_dir = "/nomad/data/dir";
+            server = {
+              enabled = true;
+              bootstrap_expect = 1;
+            };
+          };
+
+          extraSettingsPaths = [ "/etc/nomad.custom.json" ];
+          enableDocker = false;
+        };
+
+        systemd.services.nomad.serviceConfig.ExecStartPre = "${pkgs.writeShellScript "mk_data_dir" ''
+          set -euxo pipefail
+
+          ${pkgs.coreutils}/bin/mkdir -p /nomad/data/dir
+        ''}";
+      };
+  };
+
+  testScript = ''
+    def test_nomad_server(server):
+        server.wait_for_unit("nomad.service")
+
+        # wait for healthy server
+        server.wait_until_succeeds(
+            "[ $(nomad operator raft list-peers | grep true | wc -l) == 1 ]"
+        )
+
+        # wait for server liveness
+        server.succeed("[ $(nomad server members | grep -o alive | wc -l) == 1 ]")
+
+        # check the region
+        server.succeed("nomad server members | grep -o universe")
+
+        # check the datacenter
+        server.succeed("[ $(nomad server members | grep -o earth | wc -l) == 1 ]")
 
 
-      servers = [default_server, custom_state_dir_server]
+    servers = [default_server, custom_state_dir_server]
 
-      for server in servers:
-          test_nomad_server(server)
-    '';
-  }
-)
+    for server in servers:
+        test_nomad_server(server)
+  '';
+}


### PR DESCRIPTION
About 30% quicker to eval
Supports running on macOS as VM host

- #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
