### PR TITLE
bochs: 2.8 -> 3.0

### DIFF
--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bochs";
-  version = "2.8";
+  version = "3.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/bochs/bochs/${finalAttrs.version}/bochs-${finalAttrs.version}.tar.gz";
-    hash = "sha256-qFsTr/fYQR96nzVrpsM7X13B+7EH61AYzCOmJjnaAFk=";
+    hash = "sha256-y29UK1HzWizJIGsqmA21YCt80bfPLk7U8Ras1VB3gao=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The changes are to keep up with the latest improvements in the bochs emulator, changelog below:

Changes in 3.0 (February 16, 2025):

Brief summary :
 - Include Bochs debugger support in all release binaries.
   Bochs internal debugger and Bochs GUI debugger are compiled in by default and
   there are no special Bochs binaries with internal debugger support anymore.
 - Integrated softfloat3e library replacing older softfloat2a fpu-emulation code
 - Bugfixes for CPU emulation correctness (critical bugfixes for VMX, WAITPKG, LASS,
   XSAVEC/XSAVES, CPUID and SHA1 ISA implementation)
 - Added emulation of missing AMD 3DNow! instructions
 - Implemented AVX512_FP16 Intel instruction set based on softfloat3e library
   (enabled in Xeon Sapphire Rapids CPU definition)
 - Implemented MONITORLESS MWAIT instructions support
 - Implemented initial support for AVX10_1 + AVX10_2 ISA extensions and AVX10
   CPUID leaf 0x24 (AVX10_1 first to be enabled in Xeon Granite Rapids)
 - Implemented AMX-TF32 and AMX-AVX512 ISA extensions
 - Implemented RAO-INT ISA and MSR_IMM ISA extensions
 - CPUID: Added new CPU definitions: for i386, i486DX4, AMD Athlon XP and Intel Core i5 Arrow Lake CPUs
 - CPUID: Support for enabling/disabling of one or more CPU features from CPUID
   configuration (see "add_features" and "exclude_features" in bochsrc sample and documentation)
 ! CPUID: Old bx_generic CPUID model is deprecated with all associated .bochsrc
   CPUID configuration options, use pre-defined CPU models instead
 - Several fixes and improvements for the Cirrus and Voodoo emulation
 - USB: Added the USB Debugger support for xHCI and UHCI (Windows / GTK3)
 - Added USB boot option (requires i440fx.bin BIOS)
 - LGPL'd VGABIOS updated to version 0.9c (Cirrus / VBE fixes and extensions)
 - Added i440fx.bin BIOS written by Ben Lunt (https://github.com/fysnet/i440fx)
 - Documentation updates and fixes after transition to GIT

Detailed change log :

- CPU
  - Bugfixes for CPU emulation correctness (critical bugfixes for VMX, WAITPKG,
    LASS, XSAVEC/XSAVES, CPUID and SHA1 ISA implementation)
  - Integrated softfloat3e library replacing older softfloat2a fpu-emulation code
  - Implemented AVX512_FP16 Intel instruction set based on softfloat3e library
    (enabled in Xeon Sapphire Rapids CPU definition)
  - Implemented MONITORLESS MWAIT instructions support
  - Implemented initial support for AVX10_1 + AVX10_2 ISA extensions and AVX10
    CPUID leaf 0x24 (AVX10_1 first to be enabled in Xeon Granite Rapids)
  - Implemented AMX-TF32 and AMX-AVX512 ISA extensions
  - Implemented RAO-INT ISA extension
  - Implemented MSR_IMM ISA extension
  - VMX: Implemented VMX support for the IA32_SPEC_CTRL MSR
  - UINTR: Implemented FLEXIBLE UIRET support
  - Added emulation of missing AMD 3DNow! instructions

- CPUID: 
  - Added i386 CPU definition
    - Model=3, supports x87 FPU only, the FPU support can be disabled using 'exclude_features' option
  - Added i486DX4 CPU definition
    - Model=4, supports x87 FPU and VME only
  - Added AMD Athlon(tm) XP CPU definition
    - Model=6, supports P6 with 3DNow! + 3DNow! Ext and SSE
  - Added Arrow Lake CPU definition
    - Features AVX-VNNI, AVX-IFMA, AVX-VNNI-INT8, AVX-VNNI-INT16, AVX_NE_CONVERT,
      GFNI, VAES/VPCLMULQDQ, SHA512, SM3/SM4, CMPCCXADD, LASS, SERIALIZE, UINTR
  - Support for enabling/disabling of one or more CPU features from CPUID
    configuration (see "add_features" and "exclude_features" in bochsrc sample and documentation)
  - Old bx_generic CPUID model is deprecated with all associated .bochsrc CPUID
    configuration options, use pre-defined CPU models instead

- Bochs Debugger
  - Include Bochs debugger support in all release binaries.
    Bochs internal debugger and Bochs GUI debugger are compiled in by default and
    there are no special Bochs binaries with internal debugger support anymore.
    The debugger could be enabled if -dbg or -debugger option is included in the Bochs command line.
    Without these options, normal high performance execution invoked and impact
    on simulation performance is minimal.
    Note that simulation performance in debugger mode is still substantially lower.
  - Implemented 64-bit paging support in GUI debugger page table dump

- Configure and compile
  - Fixed compilation of plugin version with debugger enabled on Windows
  - Removed legacy libltdl code and force using library installed on host system
  - GTK-based gui debugger can now use GTK3 if GTK2 is not installed
  - Updated Android build manual, config files and scripts

- Config interface
  - Added USB boot option (requires BIOS from https://github.com/fysnet/i440fx)

- GUI and display libraries
  - Debugger gui can now use ini file from BXSHARE path when using gui option
    extension "gui_debug:globalini" (sdl, sdl2, win32, x11)
  - Debugger gui now updates the memory dump window if necessary
  - Added bitmap change support for the wxWidgets toolbar / Improved wxWidgets
    toolbar functionality
  - Fullscreen mode fixes for the legacy SDL and win32 gui
  - Fixed SDL2 fullscreen toggle
  - SDL/SDL2: Added support for keypad enter key in gui console mode
  - Fixed legacy SDL key handling issues
    - Scroll lock release now works again (Formerly used as fullscreen toggle)
    - Fix Pause / Ctrl+Break key handling (possibly SDL issue)
    - Fixed enter key in gui console mode on Android
  - Keymap: Added support for using language specifier instead of file name
  - Added mouse capture toggle choice "ctrl+alt+g" (currently used by Qemu)

- I/O Devices
  - VGA / Bochs VBE support
    - VGA core: added support for read/write modes in odd/even (text) mode
    - VGA core: fixed write mode 3 with data rotation
    - Added VBE memory size option (requires latest VGABIOS)
  - Cirrus SVGA
    - Added support for hardware cursor in VGA mode
    - Fixed text mode cursor blinking / text mode cursor rendering issues
    - VGA fixes to make original VGABIOS work correctly with WinXP
    - Fixed Cirrus PCI issues found with Windows 3.11 driver (missing /
      unreadable text in 8 bpp and 16 bpp modes)
    - Added support for graphics controller mode extensions in VGA mode
      Now the GD5446 PCI driver and the GD5430 ISA driver work correctly
    - Fixes for write mode 4 & 5 and PCI reads from MMIO space
    - Fixed lags caused by incorrect redraw value for backward BitBlt
  - Voodoo / Banshee
    - 3D core: Implemented trilinear filtering and fixed level of detail calculations
    - Banshee: Fixes for address wrap handling during display update
      Original Banshee / Voodoo3 VGABIOS reporting wrong number of image pages in
      VBE mode info of at least mode 640x480x8 (Issue found with vbetest program)
    - Added JSR and RET functions to CMDFIFO (Voodoo2/Banshee/Voodoo3)
    - Fixed Voodoo3 issue found with Diablo II game
    - Fixed Banshee / Voodoo3 issues with Windows 3.11 driver
    - Fix big-endian support in Banshee / Voodoo3 mem_read code
    - Implement 6 byte reads support for Voodoo 3
    - Banshee/Voodoo3: Added 16 bpp to 32 bpp pixel format conversion for screen-to-screen bitblt operation
    - Banshee: added host-to-screen stretching BitBlt support
    - Banshee/Voodoo3: Added support for combined desktop / overlay mode with
      chroma key check support
    - Banshee/Voodoo3: Added YUV planar space write support
    - Fixed deadlock after restore with Voodoo1 active
  - USB
    - Now includes the USB Debugger support for the xHCI and UHCI controllers
  - Sound
    - SB16: Don't raise IRQ at DSP reset
    - SB16: Calculate DSP DMA timer period based on DSP block size
    - Sound drivers: Moving audio buffers to waveout class fixes wavemode 2 & 3
    - Added PCM playback/recording support using PulseAudio simple API
    - ES1370: fixing status register access makes mixer work
  - Networking
    - Added support for using libslirp library instead of builtin slirp code
    - Updated builtin slirp based on libslirp 4.8.0 (including IPv6 support)
  - Mouse
    - If not in wheel-mouse mode, don't report the wheel button event
  - Hard drive / HD image
    - Fix corruption of vmdk files > 4 GB in size

- BIOS
  - Fixed crash of Windows 98 SE setup with BIOS-bochs-latest (Ported some ACPI code from SeaBIOS)
  - Allow BIOS ROM size up to 4MB to accommodate OVMF
  - Added panic in legacy BIOS in case no VGA BIOS ROM is found at C000:0000
  - Bochs BIOS: Fixed unwanted side effects caused by some helper functions
  - LGPL'd VGABIOS updated to version 0.9c (Cirrus / VBE fixes and extensions)
    - Now using ".bin" file extension for all VGABIOS images
  - Added i440fx.bin BIOS written by Ben Lunt (https://github.com/fysnet/i440fx)

- Misc
  - bximage: added simple partition table viewer to the info function
  - Documentation updates and fixes after transition to GIT

-------------------------------------------------------------------------

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
