### PR TITLE
kuzu, python3Packages.kuzu: init at 0.9.0

### DIFF
--- a/pkgs/by-name/ku/kuzu/package.nix
+++ b/pkgs/by-name/ku/kuzu/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  python3,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kuzu";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "kuzudb";
+    repo = "kuzu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3B2E51PluPKl0OucmTPZYEa9BzYoU0Y8G1PQY86ynFA=";
+  };
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+
+  meta = {
+    changelog = "https://github.com/kuzudb/kuzu/releases/tag/v${finalAttrs.version}";
+    description = "Embeddable property graph database management system";
+    homepage = "https://kuzudb.com/";
+    license = lib.licenses.mit;
+    mainProgram = "kuzu";
+    maintainers = with lib.maintainers; [ sdht0 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ku/kuzu/package.nix
+++ b/pkgs/by-name/ku/kuzu/package.nix
@@ -5,6 +5,7 @@
   ninja,
   python3,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,6 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     python3
   ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "--version" ];
 
   meta = {
     changelog = "https://github.com/kuzudb/kuzu/releases/tag/v${finalAttrs.version}";

--- a/pkgs/development/python-modules/kuzu/default.nix
+++ b/pkgs/development/python-modules/kuzu/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools-scm,
+  cmake,
+}:
+
+buildPythonPackage rec {
+  pname = "kuzu";
+  version = "0.9.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Llnz1NH8OF6ekNeuCfBy7C9M/v9QhYJSOgA0zrB29us=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    setuptools-scm
+    cmake
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "kuzu" ];
+
+  meta = {
+    description = "Python bindings for Kuzu, an embeddable property graph database management system";
+    homepage = "https://kuzudb.com/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sdht0 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7398,6 +7398,8 @@ self: super: with self; {
 
   kurbopy = callPackage ../development/python-modules/kurbopy { };
 
+  kuzu = callPackage ../development/python-modules/kuzu { };
+
   l18n = callPackage ../development/python-modules/l18n { };
 
   labelbox = callPackage ../development/python-modules/labelbox { };


### PR DESCRIPTION
[Kuzu](https://kuzudb.com/) is an embeddable property graph database management system. 

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
