### PR TITLE
combblas: init at 2.0.0

### DIFF
--- a/pkgs/by-name/co/combblas/GraphGenlib_link_math.patch
+++ b/pkgs/by-name/co/combblas/GraphGenlib_link_math.patch
@@ -1,0 +1,17 @@
+diff --git a/graph500-1.2/generator/CMakeLists.txt b/graph500-1.2/generator/CMakeLists.txt
+index bf08d307..83ea8de6 100644
+--- a/graph500-1.2/generator/CMakeLists.txt
++++ b/graph500-1.2/generator/CMakeLists.txt
+@@ -7,6 +7,12 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+   target_compile_options(GraphGenlib PRIVATE "-restrict")
+ endif()
+ 
++include(CheckLibraryExists)
++CHECK_LIBRARY_EXISTS(m sqrt "" HAVE_LIB_M)
++if (HAVE_LIB_M)
++  target_link_libraries(GraphGenlib PUBLIC m)
++endif (HAVE_LIB_M)
++
+ install(DIRECTORY include/ DESTINATION include)
+ install(TARGETS GraphGenlib EXPORT CombBLASTargets
+   LIBRARY DESTINATION lib

--- a/pkgs/by-name/co/combblas/ReleaseTests_CMakeLists.txt.patch
+++ b/pkgs/by-name/co/combblas/ReleaseTests_CMakeLists.txt.patch
@@ -1,0 +1,14 @@
+diff --git a/ReleaseTests/CMakeLists.txt b/ReleaseTests/CMakeLists.txt
+index e37c57d1..195c7427 100644
+--- a/ReleaseTests/CMakeLists.txt
++++ b/ReleaseTests/CMakeLists.txt
+@@ -45,7 +45,7 @@ ADD_TEST(NAME HashSpGEMMTest COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 $<TARG
+ ADD_TEST(NAME Reduction_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:ReduceTest> ../TESTDATA/sprand10000 ../TESTDATA/sprand10000_sumcols ../TESTDATA/sprand10000_sumrows)
+ ADD_TEST(NAME Iterator_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:IteratorTest> ../TESTDATA sprand10000)
+ ADD_TEST(NAME Transpose_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:TransposeTest> ../TESTDATA betwinput_scale16 betwinput_transposed_scale16)
+-ADD_TEST(NAME Indexing_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:IndexingTest> ../TESTDATA B_100x100.txt B_10x30_Indexed.txt rand10outta100.txt rand30outta100.txt)
+-ADD_TEST(NAME SpAsgn_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:SpAsgnTest> ../TESTDATA A_100x100.txt A_with20x30hole.txt dense_20x30matrix.txt A_wdenseblocks.txt 20outta100.txt 30outta100.txt)
++# ADD_TEST(NAME Indexing_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:IndexingTest> ../TESTDATA B_100x100.txt B_10x30_Indexed.txt rand10outta100.txt rand30outta100.txt)
++# ADD_TEST(NAME SpAsgn_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:SpAsgnTest> ../TESTDATA A_100x100.txt A_with20x30hole.txt dense_20x30matrix.txt A_wdenseblocks.txt 20outta100.txt 30outta100.txt)
+ ADD_TEST(NAME GalerkinNew_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:GalerkinNew> ../TESTDATA/grid3d_k5.txt ../TESTDATA/offdiag_grid3d_k5.txt ../TESTDATA/diag_grid3d_k5.txt ../TESTDATA/restrict_T_grid3d_k5.txt)
+ ADD_TEST(NAME FindSparse_Test COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 $<TARGET_FILE:FindSparse> ../TESTDATA findmatrix.txt)

--- a/pkgs/by-name/co/combblas/package.nix
+++ b/pkgs/by-name/co/combblas/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  fetchurl,
+  fetchpatch,
+  fetchDebianPatch,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  mpi,
+  mpiCheckPhaseHook,
+}:
+let
+  testdata = fetchurl {
+    url = "http://eecs.berkeley.edu/~aydin/CombBLAS_FILES/testdata_combblas1.6.1.tgz";
+    hash = "sha256-B9VoPYQ1vxrm/rvwAhID/SNXC7q5xWr/4dwNzwI6wgc=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "combblas";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "PASSIONLab";
+    repo = "CombBLAS";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EANubRd2IZcjFoSJFqm6GoeAeWakI8yOewF7qPClmS4=";
+  };
+
+  prePatch = ''
+    mkdir build
+    tar xzf ${testdata} -C build
+  '';
+
+  patches = [
+    # These two commits are fetched by debian too
+    (fetchpatch {
+      url = "https://github.com/PASSIONLab/CombBLAS/commit/eb4811a59a4043a2d0c9d933b71a1e1ef1db287d.patch";
+      hash = "sha256-b6boolxY+/eF6C+MgiGecbv0uzEAa85Q08Q2gbQU0EY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/PASSIONLab/CombBLAS/commit/ecf96214a0c666662954cf24b84df97f61d52dc9.patch";
+      hash = "sha256-LWuLtSDvVm2NMdDY6RMvPVci6hL4RQaIlMloqRGavnA=";
+    })
+
+    (fetchDebianPatch {
+      pname = "combblas";
+      version = "2.0.0";
+      debianRevision = "6";
+      patch = "AWPM_library_38dd27e.patch";
+      hash = "sha256-T1Oq682z5gK2ZnY+3LBU4vg6ss5bRXleRI3IGT1GP0M=";
+    })
+    (fetchDebianPatch {
+      pname = "combblas";
+      version = "2.0.0";
+      debianRevision = "6";
+      patch = "mpi_build.patch";
+      hash = "sha256-EY9rBmbjpm76awLYx7ZKLNbQ7bnMXKCaLmtdI528gsI=";
+    })
+    ./GraphGenlib_link_math.patch
+    # Disable Indexing and SpAsgn test which are reported to fail on Debian and FreeBSD too, See
+    # 1. https://github.com/PASSIONLab/CombBLAS/issues/15
+    # 2. https://github.com/PASSIONLab/CombBLAS/issues/19
+    ./ReleaseTests_CMakeLists.txt.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    mpi
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  meta = {
+    homepage = "https://github.com/PASSIONLab/CombBLAS";
+    description = "Extensible distributed-memory parallel graph library";
+    changelog = "https://github.com/PASSIONLab/CombBLAS/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      # Files: *
+      # Lawrence Berkeley National Labs BSD variant license
+      bsd3Lbnl
+
+      # Files: graph500-1.2/*
+      # Copyright: 2010, Georgia Institute of Technology, USA
+      # Files: psort-1.0/include/psort/MersenneTwister.h
+      # Copyright: 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+      #  2000 - 2003, Richard J. Wagner
+      bsd3
+
+      # Files: graph500-1.2/kronecker.*
+      # Copyright: 2009-2010 The Trustees of Indiana University.
+      boost
+
+      # Files: usort/*
+      # Copyright: 2016 Hari Sundar
+      # Files: psort-1.0/*
+      # Copyright: 2009, David Cheng, Viral Shah <viral@mayin.org>
+      mit
+
+      # Files: psort-1.0/include/psort/funnel.* psort-1.0/include/psort/sort.*
+      # Copyright: 2005 Kristoffer Vinther
+      lgpl2Plus
+
+      # Files: include/Tommy/*
+      # Copyright: 2010, Andrea Mazzoleni
+      bsd2
+    ];
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
combblas is an extensible distributed-memory parallel graph library offering a small but powerful set of linear algebra primitives specifically targeting graph analytics.

It is an optional dep of superlu_dist, however, there are some missing header files required by superlu_dist in combblas output result. For now, combblas is an isolated library not used by any downstream packages.
Two tests did not passed with this nix configuration.

I will mark this pr as a draft for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
