### PR TITLE
superlu_dist: init at 9.1.0

### DIFF
--- a/pkgs/by-name/su/superlu_dist/mc64ad_dist-stub.patch
+++ b/pkgs/by-name/su/superlu_dist/mc64ad_dist-stub.patch
@@ -1,0 +1,31 @@
+mc64ad_dist.c was removed (DFSG nonfree), create stubs
+--- /dev/null
++++ b/SRC/prec-independent/mc64ad_dist.c
+@@ -0,0 +1,27 @@
++/* The original mc64ad_dist.c is nonfree and has been removed.
++   We provide a stub interface here instead.
++*/
++
++#include <stdio.h>
++#include <stdlib.h>
++
++#include "superlu_ddefs.h"
++
++/* only mc64id_dist and mc64ad_dist are referenced by SuperLU-Dist code */
++
++/* Subroutine */ int_t mc64id_dist(int_t *icntl)
++{
++    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64id_dist.\n");
++    abort();
++    return 0;
++}
++
++int_t mc64ad_dist(int_t *job, int_t *n, int_t *ne, int_t *
++	ip, int_t *irn, double *a, int_t *num, int_t *cperm,
++	int_t *liw, int_t *iw, int_t *ldw, double *dw, int_t *
++	icntl, int_t *info)
++{
++    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64ad_dist.\n");
++    abort();
++    return 0;
++}

--- a/pkgs/by-name/su/superlu_dist/package.nix
+++ b/pkgs/by-name/su/superlu_dist/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchDebianPatch,
+  cmake,
+  gfortran,
+  blas,
+  lapack,
+  mpi,
+  mpiCheckPhaseHook,
+  metis,
+  parmetis,
+
+  # Todo: ask for permission of unfree parmetis
+  withParmetis ? false,
+}:
+
+assert (!blas.isILP64) && (!lapack.isILP64);
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "superlu_dist";
+  version = "9.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xiaoyeli";
+    repo = "superlu_dist";
+    tag = "v${finalAttrs.version}";
+    # Remove non‐free files.
+    postFetch = "rm $out/SRC/prec-independent/mc64ad_dist.c";
+    hash = "sha256-NMAEtTmTY189p8BlmsTugwMuxKZh+Bs1GyuwUHkLA1U=";
+  };
+
+  patches = [
+    ./mc64ad_dist-stub.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace SRC/prec-independent/util.c \
+      --replace-fail "LargeDiag_MC64" "NOROWPERM"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs =
+    [
+      mpi
+      lapack
+    ]
+    ++ lib.optionals withParmetis [
+      metis
+      parmetis
+    ];
+
+  propagatedBuildInputs = [ blas ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+      (lib.cmakeBool "enable_fortran" true)
+      (lib.cmakeBool "enable_complex16" true)
+      (lib.cmakeBool "TPL_ENABLE_INTERNAL_BLASLIB" false)
+      (lib.cmakeBool "TPL_ENABLE_LAPACKLIB" true)
+      (lib.cmakeBool "TPL_ENABLE_PARMETISLIB" withParmetis)
+    ]
+    ++ lib.optionals withParmetis [
+      (lib.cmakeFeature "TPL_PARMETIS_LIBRARIES" "-lmetis -lparmetis")
+      (lib.cmakeFeature "TPL_PARMETIS_INCLUDE_DIRS" "${lib.getDev parmetis}/include")
+    ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  meta = {
+    homepage = "https://portal.nersc.gov/project/sparse/superlu/";
+    license = with lib.licenses; [
+      # Files: *
+      # Lawrence Berkeley National Labs BSD variant license
+      bsd3Lbnl
+
+      # Files: SRC/prec-independent/symbfact.c
+      # Xerox code; actually `Boehm-GC` variant.
+      mit
+
+      # Files: SRC/include/*colamd.h
+      # University of Florida code; permissive COLAMD licence.
+      free
+
+      # Files: SRC/include/wingetopt.*
+      # Microsoft code; Obtained from https://github.com/iotivity/iotivity/tree/master/resource/c_common/windows.
+      asl20
+    ];
+    description = "Library for the solution of large, sparse, nonsymmetric systems of linear equations";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
superlu_dist is the distributed version of the linear solver superlu.
it is an optional dependency of petsc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
