### PR TITLE
types.functionTo: preserve function argument names

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -490,6 +490,7 @@ checkConfigOutput '^"b a"$' config.result ./functionTo/list-order.nix
 checkConfigOutput '^"a c"$' config.result ./functionTo/merging-attrs.nix
 checkConfigOutput '^"a bee"$' config.result ./functionTo/submodule-options.nix
 checkConfigOutput '^"fun.<function body>.a fun.<function body>.b"$' config.optionsResult ./functionTo/submodule-options.nix
+checkConfigOutput '^{"a":false,"b":false}$' config.result ./functionTo/function-args.nix
 
 # moduleType
 checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-variant.nix

--- a/lib/tests/modules/functionTo/function-args.nix
+++ b/lib/tests/modules/functionTo/function-args.nix
@@ -1,0 +1,18 @@
+{ lib, config, ... }:
+let
+  inherit (lib) types;
+in
+{
+  options = {
+    uniqFun = lib.mkOption {
+      type = types.uniq (types.functionTo types.str);
+    };
+
+    result = lib.mkOption {
+      type = types.unspecified;
+      default = lib.functionArgs config.uniqFun;
+    };
+  };
+
+  config.uniqFun = {a, b}: "";
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -6,6 +6,7 @@ let
   inherit (lib)
     elem
     flip
+    functionArgs
     isAttrs
     isBool
     isDerivation
@@ -15,6 +16,7 @@ let
     isList
     isString
     isStorePath
+    setFunctionArgs
     throwIf
     toDerivation
     toList
@@ -874,7 +876,13 @@ rec {
       descriptionClass = "composite";
       check = isFunction;
       merge = loc: defs:
-        fnArgs: (mergeDefinitions (loc ++ [ "<function body>" ]) elemType (map (fn: { inherit (fn) file; value = fn.value fnArgs; }) defs)).mergedValue;
+        let
+          merged = fnArgs: (mergeDefinitions (loc ++ [ "<function body>" ]) elemType (map (fn: { inherit (fn) file; value = fn.value fnArgs; }) defs)).mergedValue;
+          args = functionArgs (head defs).value;
+        in
+        if length defs == 1
+        then setFunctionArgs merged args
+        else merged;
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ [ "<function body>" ]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: functionTo (elemType.substSubModules m);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Preserve argument names with functions passed as `functionTo` without merging (e.g unique).

Makes the following definition work as expected for unique functions, as there is nothing to be "merged" (However I understand that underlying type might do something with merging of a single value itself).

```nix
       options.generator = mkOption {
         type = uniq (nullOr (functionTo package));
       ...
       config.generator = {a, b}: false;
       ...
       # Before:
       lib.functionArgs config.generator == {}
       # After:
       lib.functionArgs config.generator == { a = false; }
```

It would be great to make this behavior only enabled for unique functionTo types, but I don't think there is a way to perform such specialisation?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
