### PR TITLE
catppuccin: add element

### DIFF
--- a/pkgs/by-name/ca/catppuccin/package.nix
+++ b/pkgs/by-name/ca/catppuccin/package.nix
@@ -3,6 +3,7 @@ let
     "bat"
     "bottom"
     "btop"
+    "element"
     "grub"
     "hyprland"
     "k9s"
@@ -76,6 +77,14 @@ let
       repo = "btop";
       rev = "f437574b600f1c6d932627050b15ff5153b58fa3";
       hash = "sha256-mEGZwScVPWGu+Vbtddc/sJ+mNdD2kKienGZVUcTSl+c=";
+    };
+
+    element = fetchFromGitHub {
+      name = "element";
+      owner = "catppuccin";
+      repo = "element";
+      rev = "ddced941a2014107918484263b63e030889777fe";
+      hash = "sha256-8EP/IQW3rdtomHBfnQNIjGbiD6OapPzXPFLjziNDcmc=";
     };
 
     grub = fetchFromGitHub {
@@ -227,6 +236,11 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
       + lib.optionalString (lib.elem "bottom" themeList) ''
         mkdir -p "$out/bottom"
         cp "${sources.bottom}/themes/${variant}.toml" "$out/bottom/"
+
+      ''
+      + lib.optionalString (lib.elem "element" themeList) ''
+        mkdir -p "$out/element"
+        cp -r "${sources.element}/themes/Catppuccin-${variant}.json" "$out/element/"
 
       ''
       + lib.optionalString (lib.elem "grub" themeList) ''


### PR DESCRIPTION
Add https://github.com/catppuccin/element

Tested in element-desktop with:
```nix
element-web.override {
  conf = {
    setting_defaults = {
      custom_themes = [
        (lib.importJSON "${pkgs.catppuccin.override { variant = "mocha"; }}/element/Catppuccin-mocha.json")
      ];
    };
  };
};
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
