### PR TITLE
zed-editor: 0.175.5 -> 0.176.1

### DIFF
--- a/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
+++ b/pkgs/by-name/ze/zed-editor/0001-generate-licenses.patch
@@ -1,10 +1,10 @@
 diff --git a/script/generate-licenses b/script/generate-licenses
-index 51749a91e2..d3fd7ee351 100755
+index 368f63b..c2bf3a5 100644
 --- a/script/generate-licenses
 +++ b/script/generate-licenses
-@@ -16,28 +16,17 @@ cat assets/icons/LICENSES >> $OUTPUT_FILE
- 
- echo -e "\n# ###### CODE LICENSES ######\n" >> $OUTPUT_FILE
+@@ -18,17 +18,9 @@ echo -n "" > "$OUTPUT_FILE"
+     echo -e "\n# ###### CODE LICENSES ######\n"
+ } >> "$OUTPUT_FILE"
  
 -if ! cargo install --list | grep "cargo-about v$CARGO_ABOUT_VERSION" > /dev/null; then
 -  echo "Installing cargo-about@$CARGO_ABOUT_VERSION..."
@@ -12,22 +12,11 @@ index 51749a91e2..d3fd7ee351 100755
 -else
 -  echo "cargo-about@$CARGO_ABOUT_VERSION is already installed."
 -fi
- 
+-
  echo "Generating cargo licenses"
- 
- stderr_file=$(mktemp)
  
  cargo about generate \
 -    --fail \
      -c script/licenses/zed-licenses.toml \
-     "${TEMPLATE_FILE}" \
-     2> >(tee "$stderr_file") \
-     >> $OUTPUT_FILE
+     "$TEMPLATE_FILE" >> "$OUTPUT_FILE"
  
--if cat "$stderr_file" | grep -v "\[WARN\]" > /dev/null; then
--    echo "Error: License check failed - warnings found" >&2
--    exit 1
--fi
- 
- sed -i.bak 's/&quot;/"/g' $OUTPUT_FILE
- sed -i.bak 's/&#x27;/'\''/g' $OUTPUT_FILE # The ` '\'' ` thing ends the string, appends a single quote, and re-opens the string

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -96,7 +96,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "zed-editor";
-  version = "0.175.5";
+  version = "0.176.1";
 
   outputs = [ "out" ] ++ lib.optional buildRemoteServer "remote_server";
 
@@ -104,7 +104,7 @@ rustPlatform.buildRustPackage rec {
     owner = "zed-industries";
     repo = "zed";
     tag = "v${version}";
-    hash = "sha256-CeuZv5GFZ9tttpj+4JAgQZcKtPpbE+NxawcW5W0CFws=";
+    hash = "sha256-Onf3mce327oLbvBPTkJIzJNAf145/ogFK+J6+Asuh9w=";
   };
 
   patches = [
@@ -130,7 +130,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-UJAH1hCf/p974GNJtvNMzZs8RkxtJQeLhUBCJjLsapU=";
+  cargoHash = "sha256-hlX4IMpsEqwYrzDvzFUhh6PVqM9U+4kp/bBYG08BPQA=";
 
   nativeBuildInputs =
     [


### PR DESCRIPTION
Updating zed-editor to the latest stable version 0.176.1, from 0.175.5. 

Changelogs:
* [0.176.1](https://github.com/zed-industries/zed/releases/tag/v0.176.1)
* [0.175.6](https://github.com/zed-industries/zed/releases/tag/v0.175.6)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
