### PR TITLE
pnetcdf: init at 1.14.0

### DIFF
--- a/pkgs/by-name/pn/pnetcdf/package.nix
+++ b/pkgs/by-name/pn/pnetcdf/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gfortran,
+  autoreconfHook,
+  perl,
+  mpi,
+  mpiCheckPhaseHook,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pnetcdf";
+  version = "1.14.0";
+
+  src = fetchFromGitHub {
+    owner = "Parallel-NetCDF";
+    repo = "PnetCDF";
+    tag = "checkpoint.${finalAttrs.version}";
+    hash = "sha256-Zyhzyvdh9Pf5GkcJW3duGgI6m3Dy0RR5B9YtA83Hpr4=";
+  };
+
+  nativeBuildInputs = [
+    perl
+    autoreconfHook
+    gfortran
+  ];
+
+  buildInputs = [ mpi ];
+
+  postPatch = ''
+    patchShebangs src/binding/f77/buildiface
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  checkTarget = lib.concatStringsSep " " [
+    # build all test programs (build only, no run)
+    "tests"
+    # run sequential test programs
+    "check"
+    # run parallel test programs on 3,4,6,8 MPI processes
+    "ptests"
+  ];
+
+  # cannot do parallel check otherwise failed
+  enableParallelChecking = false;
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "checkpoint.";
+  };
+
+  meta = {
+    homepage = "https://parallel-netcdf.github.io/";
+    license = with lib.licenses; [
+      # Files: *
+      # Copyright: (c) 2003 Northwestern University and Argonne National Laboratory
+      bsd3
+
+      # Files: src/drivers/common/utf8proc.c
+      # Copyright: (c) 2006-2007 Jan Behrens, FlexiGuided GmbH, Berlin
+      mit
+
+      # Files: src/drivers/common/utf8proc_data.c
+      # Copyright: 1991-2007 Unicode, Inc.
+      unicode-30
+    ];
+    description = "Parallel I/O Library for NetCDF File Access";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
another optional dep of petsc

some one fix me with the license of pnetcdf
see https://sources.debian.org/src/pnetcdf/1.14.0-2/debian/copyright/

i don't know how to name the license "Northwestern", my choice is to use ~~"free"~~ "bsd3". 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
