### PR TITLE
kstars: downgrade eigen

### DIFF
--- a/pkgs/applications/science/astronomy/kstars/default.nix
+++ b/pkgs/applications/science/astronomy/kstars/default.nix
@@ -3,6 +3,8 @@
   stdenv,
   extra-cmake-modules,
   fetchurl,
+  fetchFromGitLab,
+  fetchpatch,
   kconfig,
   kdoctools,
   kguiaddons,
@@ -35,6 +37,36 @@
   libxisf,
   curl,
 }:
+
+let
+  # reverts 'eigen: 3.4.0 -> 3.4.0-unstable-2022-05-19'
+  # https://github.com/nixos/nixpkgs/commit/d298f046edabc84b56bd788e11eaf7ed72f8171c
+  eigen' = eigen.overrideAttrs (old: rec {
+    version = "3.4.0";
+    src = fetchFromGitLab {
+      owner = "libeigen";
+      repo = "eigen";
+      rev = version;
+      hash = "sha256-1/4xMetKMDOgZgzz3WMxfHUEpmdAm52RqZvz6i0mLEw=";
+    };
+    patches = (old.patches or [ ]) ++ [
+      # Fixes e.g. onnxruntime on aarch64-darwin:
+      # https://hydra.nixos.org/build/248915128/nixlog/1,
+      # originally suggested in https://github.com/NixOS/nixpkgs/pull/258392.
+      #
+      # The patch is from
+      # ["Fix vectorized reductions for Eigen::half"](https://gitlab.com/libeigen/eigen/-/merge_requests/699)
+      # which is two years old,
+      # but Eigen hasn't had a release in two years either:
+      # https://gitlab.com/libeigen/eigen/-/issues/2699.
+      (fetchpatch {
+        url = "https://gitlab.com/libeigen/eigen/-/commit/d0e3791b1a0e2db9edd5f1d1befdb2ac5a40efe0.patch";
+        hash = "sha256-8qiNpuYehnoiGiqy0c3Mcb45pwrmc6W4rzCxoLDSvj0=";
+      })
+    ];
+  });
+in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "kstars";
   version = "3.7.4";
@@ -68,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtdatavis3d
     breeze-icons
     libsecret
-    eigen
+    eigen'
     zlib
     cfitsio
     indi-full


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/291193847
same fix as in https://github.com/NixOS/nixpkgs/pull/386914 and https://github.com/NixOS/nixpkgs/pull/386478

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
