### PR TITLE
exist-db: init at 6.3.0

### DIFF
--- a/pkgs/by-name/ex/exist-db/fix-exist-parent.patch
+++ b/pkgs/by-name/ex/exist-db/fix-exist-parent.patch
@@ -1,0 +1,13 @@
+diff --git a/exist-parent/pom.xml b/exist-parent/pom.xml
+index 870649fedc..881cde28c1 100644
+--- a/exist-parent/pom.xml
++++ b/exist-parent/pom.xml
+@@ -27,7 +27,7 @@
+ 
+     <groupId>org.exist-db</groupId>
+     <artifactId>exist-parent</artifactId>
+-    <version>6.3.0</version>
++    <version>6.3.0-SNAPSHOT</version>
+     <packaging>pom</packaging>
+ 
+     <name>eXist-db Parent</name>

--- a/pkgs/by-name/ex/exist-db/package.nix
+++ b/pkgs/by-name/ex/exist-db/package.nix
@@ -1,0 +1,84 @@
+{
+  fetchFromGitHub,
+  git,
+  jdk11_headless,
+  makeWrapper,
+  lib,
+  maven,
+}:
+let
+  jdk = jdk11_headless;
+  jre = jdk11_headless;
+  initGit = ''
+    git init .
+    git config set user.email nobody@localhost
+    git config set user.name nobody
+    git add README
+    git commit -m 'Initial commit'
+  '';
+in
+maven.buildMavenPackage rec {
+  pname = "exist-db";
+  version = "6.3.0";
+
+  src = fetchFromGitHub {
+    owner = "eXist-db";
+    repo = "exist";
+    tag = "eXist-${version}";
+    hash = "sha256-NdE15sS/U8ae17JUV+YplYnZuzaa0ZCqyxgj8oAq9uk=";
+    leaveDotGit = true;
+  };
+
+  patches = [
+    ./fix-exist-parent.patch
+  ];
+
+  mvnHash = "sha256-dp9fxjSS38WITnZEoQU5HKUT/Ntidh8Xv49z1bEP3hE=";
+  mvnJdk = jdk;
+  mvnFetchExtraArgs = {
+    dontConfigure = true;
+    buildOffline = false;
+    preBuild = initGit;
+  };
+
+  buildOffline = false;
+  preBuild = initGit;
+
+  doCheck = false;
+
+  nativeBuildInputs = [
+    makeWrapper
+    git
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv exist-distribution/target/exist-distribution-${version}-dir/{autodeploy,bin,etc,lib} $out
+
+    substituteInPlace "$out/etc/conf.xml" \
+      --replace-fail '"../data"' '"/var/lib/exist-db/data"'
+    substituteInPlace "$out/etc/jetty/standard.enabled-jetty-configs" \
+      --replace-fail 'jetty-requestlog.xml' '#jetty-requestlog.xml'
+
+    for script in $out/bin/*.sh; do
+      makeWrapper $script ''${script%.sh} \
+        --prefix JAVA_HOME : ${jre.home}
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Native XML Database and Application Platform";
+    longDescription = ''
+      High-performance open source native XML (NoSQL document) database
+      and application platform built entirely around XML technologies.
+    '';
+    homepage = "https://exist-db.org/";
+    license = lib.licenses.lgpl21;
+    platforms = with lib.platforms; unix ++ windows;
+    maintainers = with lib.maintainers; [ afh ];
+  };
+}


### PR DESCRIPTION
# TODO:

- [x] ~~Properly configure data, logs, jetty directory~~ disabled request log for know, as I don't know how to force jetty to use a log location outside its base or home dir.
- [x] Current configuration does not show the exist DB jetty application
- [ ] How should writable directories (data, logs, etc.) be handled within the package? The MySQL packages seems to hard-code the data dir to `/var/lib/mysql`. For exist db there might be the need to have writable directories with pre-install files from the package (jetty keystore)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
