### PR TITLE
python312Packages.mmengine: 0.10.6 -> 0.10.7

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -16,7 +16,7 @@
   termcolor,
   yapf,
 
-  # checks
+  # tests
   bitsandbytes,
   coverage,
   dvclive,
@@ -26,18 +26,19 @@
   parameterized,
   pytestCheckHook,
   transformers,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "mmengine";
-  version = "0.10.6";
+  version = "0.10.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "open-mmlab";
     repo = "mmengine";
     tag = "v${version}";
-    hash = "sha256-J9p+JCtNoBlBvvv4p57/DHUIifYs/jdo+pK+paD+iXI=";
+    hash = "sha256-hQnwenuxHQwl+DwQXbIfsKlJkmcRvcHV1roK7q2X1KA=";
   };
 
   build-system = [ setuptools ];
@@ -53,6 +54,8 @@ buildPythonPackage rec {
     yapf
   ];
 
+  pythonImportsCheck = [ "mmengine" ];
+
   nativeCheckInputs = [
     bitsandbytes
     coverage
@@ -63,49 +66,43 @@ buildPythonPackage rec {
     parameterized
     pytestCheckHook
     transformers
+    writableTmpDirAsHomeHook
   ];
 
   preCheck =
-    ''
-      export HOME=$(mktemp -d)
-    ''
     # Otherwise, the backprop hangs forever. More precisely, this exact line:
     # https://github.com/open-mmlab/mmengine/blob/02f80e8bdd38f6713e04a872304861b02157905a/tests/test_runner/test_activation_checkpointing.py#L46
     # Solution suggested in https://github.com/pytorch/pytorch/issues/91547#issuecomment-1370011188
-    + ''
+    ''
       export MKL_NUM_THREADS=1
     '';
 
-  pythonImportsCheck = [ "mmengine" ];
+  pytestFlagsArray = [
+    # Require unpackaged aim
+    "--deselect tests/test_visualizer/test_vis_backend.py::TestAimVisBackend"
 
-  disabledTestPaths = [
-    # AttributeError
-    "tests/test_fileio/test_backends/test_petrel_backend.py"
-    # Freezes forever?
-    "tests/test_runner/test_activation_checkpointing.py"
-    # missing dependencies
-    "tests/test_visualizer/test_vis_backend.py"
+    # Cannot find SSL certificate
+    # _pygit2.GitError: OpenSSL error: failed to load certificates: error:00000000:lib(0)::reason(0)
+    "--deselect tests/test_visualizer/test_vis_backend.py::TestDVCLiveVisBackend"
+
+    # AttributeError: type object 'MagicMock' has no attribute ...
+    "--deselect tests/test_fileio/test_backends/test_petrel_backend.py::TestPetrelBackend"
   ];
 
   disabledTests = [
-    # Tests are disabled due to sandbox
+    # Require network access
     "test_fileclient"
     "test_http_backend"
     "test_misc"
+
     # RuntimeError
     "test_dump"
     "test_deepcopy"
     "test_copy"
     "test_lazy_import"
-    # AssertionError
+
+    # AssertionError: os is not <module 'os' (frozen)>
     "test_lazy_module"
-    # Require unpackaged aim
-    "test_experiment"
-    "test_add_config"
-    "test_add_image"
-    "test_add_scalar"
-    "test_add_scalars"
-    "test_close"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

Changelog: https://github.com/open-mmlab/mmengine/releases/tag/v0.10.7

cc @benxiao

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
