### PR TITLE
python312Packages.shiny: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/shiny/default.nix
+++ b/pkgs/development/python-modules/shiny/default.nix
@@ -2,10 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+
+  # build-system
   setuptools,
   setuptools-scm,
 
+  # dependencies
   appdirs,
   asgiref,
   click,
@@ -26,41 +28,34 @@
   watchfiles,
   websockets,
 
+  # tests
   anthropic,
   cacert,
   google-generativeai,
   langchain-core,
   ollama,
   openai,
-  pytestCheckHook,
-  pytest-asyncio,
-  pytest-playwright,
-  pytest-xdist,
-  pytest-timeout,
-  pytest-rerunfailures,
   pandas,
   polars,
+  pytest-asyncio,
+  pytest-playwright,
+  pytest-rerunfailures,
+  pytest-timeout,
+  pytest-xdist,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "shiny";
-  version = "1.2.1";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "posit-dev";
     repo = "py-shiny";
     tag = "v${version}";
-    hash = "sha256-8bo2RHuIP7X7EaOlHd+2m4XU287owchAwiqPnpjKFjI=";
+    hash = "sha256-YCPHjelGPYYo23Vzxy5+8Kn9fVlSZy1Qva7zp93+nzg=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-narwhals-test.patch";
-      url = "https://github.com/posit-dev/py-shiny/commit/184a9ebd81ff730439513f343576a68f8c1f6eb9.patch";
-      hash = "sha256-DsGnuHQXODzGwpe8ZUHeXGzRFxxduwxCRk82RJaYZg0=";
-    })
-  ];
 
   build-system = [
     setuptools
@@ -104,30 +99,32 @@ buildPythonPackage rec {
     langchain-core
     ollama
     openai
-    pytestCheckHook
-    pytest-asyncio
-    pytest-playwright
-    pytest-xdist
-    pytest-timeout
-    pytest-rerunfailures
     pandas
     polars
+    pytest-asyncio
+    pytest-playwright
+    pytest-rerunfailures
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
   disabledTests = [
+    # Requires unpackaged brand-yml
+    "test_theme_from_brand_base_case_compiles"
     # ValueError: A tokenizer is required to impose `token_limits` on messages
     "test_chat_message_trimming"
-    # https://github.com/posit-dev/py-shiny/pull/1791
-    "test_as_ollama_message"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
-    changelog = "https://github.com/posit-dev/py-shiny/blob/${src.tag}/CHANGELOG.md";
     description = "Build fast, beautiful web applications in Python";
-    license = lib.licenses.mit;
     homepage = "https://shiny.posit.co/py";
+    changelog = "https://github.com/posit-dev/py-shiny/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
   };
 }


### PR DESCRIPTION
## Things done

Diff: https://github.com/posit-dev/py-shiny/compare/refs/tags/v1.2.1...v1.3.0

Changelog: https://github.com/posit-dev/py-shiny/blob/v1.3.0/CHANGELOG.md

cc @Sigmanificient 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
