### PR TITLE
nixos/oci-containers: add autoRemoveOnStop option

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -381,6 +381,14 @@ let
           '';
         };
 
+        autoRemoveOnStop = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Automatically remove the container when it is stopped or killed
+          '';
+        };
+
         networks = mkOption {
           type = with types; listOf str;
           default = [ ];
@@ -468,7 +476,6 @@ let
         ++ map escapeShellArg container.preRunExtraOptions
         ++ [
           "run"
-          "--rm"
           "--name=${escapedName}"
           "--log-driver=${container.log-driver}"
         ]
@@ -489,6 +496,7 @@ let
         ++ (mapAttrsToList (k: v: "-l ${escapeShellArg k}=${escapeShellArg v}") container.labels)
         ++ optional (container.workdir != null) "-w ${escapeShellArg container.workdir}"
         ++ optional (container.privileged) "--privileged"
+        ++ optional (container.autoRemoveOnStop) "--rm"
         ++ mapAttrsToList (k: _: "--cap-add=${escapeShellArg k}") (
           filterAttrs (_: v: v == true) container.capabilities
         )


### PR DESCRIPTION
This PR adds the optional flag virtualisation.oci-containers.autoRemoveOnStop.
In the current version of nixpgs the flag this options controls (`--rm`) is hard-coded to true.
Adding this flag to a docker container means that the container is automatically cleaned up and removed when the container is stopped or killed. This behaviour is fine for most use-cases, but can create problems when the user wants to manage their running docker containers with tools other than systemd, such as an external dashboard.
The problem is that when a container is stopped manually (for example by pressing the stop button on their dashboard), the user is no longer able to start that container again, as it was just deleted.
Additionally, this option being always on makes it almost impossible to debug crashing containers with docker's own command line tools, as once a container is deleted, you can no longer inspect the logs.
As such, I propose making this flag into a configurable option, with the default being set to `true` to maintain backwards compatibility.  

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This is my first PR on this project, so please let me know if i did anything wrong or additional info is needed!
Unfortunately I do not currently have a way to properly test these changes. However, I don't expect anything to break with this relatively minor change.