### PR TITLE
i3status-rust: make notmuch optional

### DIFF
--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -1,20 +1,21 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, makeWrapper
-, dbus
-, libpulseaudio
-, notmuch
-, openssl
-, ethtool
-, lm_sensors
-, iw
-, iproute2
-, pipewire
-, withICUCalendar ? false
-, withPipewire ? true
-, withNotmuch ? true
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  dbus,
+  libpulseaudio,
+  notmuch,
+  openssl,
+  ethtool,
+  lm_sensors,
+  iw,
+  iproute2,
+  pipewire,
+  withICUCalendar ? false,
+  withPipewire ? true,
+  withNotmuch ? true,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,19 +32,29 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-EFFmH9aG7DvSA5rsAuszc1B8kcLdruSk3Hhp4V9t9Gk=";
 
-  nativeBuildInputs = [ pkg-config makeWrapper ]
-    ++ (lib.optionals withPipewire [ rustPlatform.bindgenHook ]);
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ] ++ (lib.optionals withPipewire [ rustPlatform.bindgenHook ]);
 
-  buildInputs = [ dbus libpulseaudio openssl lm_sensors ]
+  buildInputs =
+    [
+      dbus
+      libpulseaudio
+      openssl
+      lm_sensors
+    ]
     ++ (lib.optionals withPipewire [ pipewire ])
     ++ (lib.optionals withNotmuch [ notmuch ]);
 
-  buildFeatures = [
-    "maildir"
-    "pulseaudio"
-  ] ++ (lib.optionals withICUCalendar [ "icu_calendar" ])
-  ++ (lib.optionals withPipewire [ "pipewire" ])
-  ++ (lib.optionals withNotmuch [ "notmuch" ]);
+  buildFeatures =
+    [
+      "maildir"
+      "pulseaudio"
+    ]
+    ++ (lib.optionals withICUCalendar [ "icu_calendar" ])
+    ++ (lib.optionals withPipewire [ "pipewire" ])
+    ++ (lib.optionals withNotmuch [ "notmuch" ]);
 
   prePatch = ''
     substituteInPlace src/util.rs \
@@ -56,7 +67,13 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postFixup = ''
-    wrapProgram $out/bin/i3status-rs --prefix PATH : ${lib.makeBinPath [ iproute2 ethtool iw ]}
+    wrapProgram $out/bin/i3status-rs --prefix PATH : ${
+      lib.makeBinPath [
+        iproute2
+        ethtool
+        iw
+      ]
+    }
   '';
 
   # Currently no tests are implemented, so we avoid building the package twice
@@ -67,7 +84,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/greshake/i3status-rust";
     license = licenses.gpl3Only;
     mainProgram = "i3status-rs";
-    maintainers = with maintainers; [ backuitist globin ];
+    maintainers = with maintainers; [
+      backuitist
+      globin
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -14,6 +14,7 @@
 , pipewire
 , withICUCalendar ? false
 , withPipewire ? true
+, withNotmuch ? true
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,15 +34,16 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config makeWrapper ]
     ++ (lib.optionals withPipewire [ rustPlatform.bindgenHook ]);
 
-  buildInputs = [ dbus libpulseaudio notmuch openssl lm_sensors ]
-    ++ (lib.optionals withPipewire [ pipewire ]);
+  buildInputs = [ dbus libpulseaudio openssl lm_sensors ]
+    ++ (lib.optionals withPipewire [ pipewire ])
+    ++ (lib.optionals withNotmuch [ notmuch ]);
 
   buildFeatures = [
-    "notmuch"
     "maildir"
     "pulseaudio"
   ] ++ (lib.optionals withICUCalendar [ "icu_calendar" ])
-  ++ (lib.optionals withPipewire [ "pipewire" ]);
+  ++ (lib.optionals withPipewire [ "pipewire" ])
+  ++ (lib.optionals withNotmuch [ "notmuch" ]);
 
   prePatch = ''
     substituteInPlace src/util.rs \


### PR DESCRIPTION
Hello,

With notmuch recently failling to build, it makes i3status-rust failling to build too. This PR make it possible to disable notmuch support if desire.

I'm currently using this patch as an overlay on my config and it works perfectly fine.

My editor has nixd configured for lsp and it format on save, so it format the file using `nixfmt-rfc-style`, I assume it is ok, but if it's not I'll revert those modification and only add the bits to make notmuch optional.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
