### PR TITLE
vscode-extensions.asciidoctor.asciidoctor-vscode: 2.8.9 -> 3.4.2

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/commands-abspath.patch
+++ b/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/commands-abspath.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 7ab70e8..2ebe541 100644
+--- a/package.json
++++ b/package.json
+@@ -437,7 +437,7 @@
+ 					},
+ 					"asciidoc.asciidoctorpdf_command": {
+ 						"type": "string",
+-						"default": "asciidoctor-pdf",
++						"default": "@ASCIIDOCTOR_PDF_BIN@",
+ 						"markdownDescription": "%asciidoc.asciidoctorpdf_command.desc%",
+ 						"markdownDeprecationMessage": "%asciidoc.asciidoctorpdf_command.deprecationMessage%",
+ 						"scope": "resource"

--- a/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/asciidoctor.asciidoctor-vscode/default.nix
@@ -8,17 +8,18 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "asciidoctor-vscode";
     publisher = "asciidoctor";
-    version = "2.8.9";
-    sha256 = "1xkxx5i3nhd0dzqhhdmx0li5jifsgfhv0p5h7xwsscz3gzgsdcyb";
+    version = "3.4.2";
+    hash = "sha256-HG3y7999xeE1erQZCnBgUPj/aC0Kwyn20PEZR9gKrxY=";
   };
 
+  patches = [
+    ./commands-abspath.patch
+  ];
+
   postPatch = ''
-    substituteInPlace dist/src/text-parser.js \
-      --replace "get('asciidoctor_command', 'asciidoctor')" \
-                "get('asciidoctor_command', '${asciidoctor}/bin/asciidoctor')"
-    substituteInPlace dist/src/commands/exportAsPDF.js \
-      --replace "get('asciidoctorpdf_command', 'asciidoctor-pdf')" \
-                "get('asciidoctorpdf_command', '${asciidoctor}/bin/asciidoctor-pdf')"
+    substituteInPlace package.json \
+        --replace-fail "@ASCIIDOCTOR_PDF_BIN@" \
+                       "${asciidoctor}/bin/asciidoctor-pdf"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

About the postPatch snippet: The 'asciidoctor' program is no longer used
for previews, instead the extension uses
https://docs.asciidoctor.org/asciidoctor.js (which is bundled with the
extension). See upstream:
https://github.com/asciidoctor/asciidoctor-vscode/issues/443
("Remove Asciidoctor CLI option for preview rendering").


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
