### PR TITLE
python3Packages.gnucash: Build from existing gnucash package

### DIFF
--- a/pkgs/by-name/gn/gnucash/0005-python-env.patch
+++ b/pkgs/by-name/gn/gnucash/0005-python-env.patch
@@ -1,0 +1,10 @@
+--- a/bindings/python/__init__.py
++++ b/bindings/python/__init__.py
+@@ -1,3 +1,7 @@
++import os
++os.environ['GNC_DBD_DIR'] = '@gnc_dbd_dir@'
++os.environ['GSETTINGS_SCHEMA_DIR'] = '@gsettings_schema_dir@'
++
+ # import all the symbols from gnucash_core, so basic gnucash stuff can be
+ # loaded with:
+ # >>> from gnucash import thingy

--- a/pkgs/by-name/gn/gnucash/package.nix
+++ b/pkgs/by-name/gn/gnucash/package.nix
@@ -26,6 +26,7 @@
   webkitgtk_4_0,
   wrapGAppsHook3,
   python3,
+  replaceVars,
 }:
 
 stdenv.mkDerivation rec {
@@ -86,20 +87,14 @@ stdenv.mkDerivation rec {
     ./0003-remove-valgrind.patch
     # this patch makes gnucash exec the Finance::Quote wrapper directly
     ./0004-exec-fq-wrapper.patch
+    # this patch adds in env vars to the Python lib that makes it able to find required resource files
+    ./0005-python-env.patch
   ];
 
   postPatch = ''
-    patch -p0 <<END_PATCH
-      +++ bindings/python/__init__.py
-      @@ -1,3 +1,7 @@
-      +import os
-      +os.environ['GNC_DBD_DIR'] = '${libdbiDrivers}/lib/dbd'
-      +os.environ['GSETTINGS_SCHEMA_DIR'] = '${glib.makeSchemaPath "$out" "gnucash-${version}"}'
-      +
-       # import all the symbols from gnucash_core, so basic gnucash stuff can be
-       # loaded with:
-       # >>> from gnucash import thingy
-        END_PATCH
+    substituteInPlace bindings/python/__init__.py \
+      --subst-var-by gnc_dbd_dir "${libdbiDrivers}/lib/dbd" \
+      --subst-var-by gsettings_schema_dir ${glib.makeSchemaPath "$out" "gnucash-${version}"};
   '';
 
   # this needs to be an environment variable and not a cmake flag to suppress

--- a/pkgs/by-name/gn/gnucash/package.nix
+++ b/pkgs/by-name/gn/gnucash/package.nix
@@ -25,11 +25,8 @@
   swig,
   webkitgtk_4_0,
   wrapGAppsHook3,
-  python ? null,
-  enablePython ? false,
+  python3,
 }:
-
-assert enablePython -> (python != null);
 
 stdenv.mkDerivation rec {
   pname = "gnucash";
@@ -49,7 +46,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  cmakeFlags = lib.optional enablePython [
+  cmakeFlags = [
     "-DWITH_PYTHON=\"ON\""
     "-DPYTHON_SYSCONFIG_BUILD=\"$out\""
   ];
@@ -72,13 +69,13 @@ stdenv.mkDerivation rec {
       libxslt
       swig
       webkitgtk_4_0
+      python3
     ]
     ++ (with perlPackages; [
       JSONParse
       FinanceQuote
       perl
-    ])
-    ++ lib.optional enablePython python;
+    ]);
 
   patches = [
     # this patch disables test-gnc-timezone and test-gnc-datetime which fail due to nix datetime challenges

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5605,6 +5605,11 @@ self: super: with self; {
 
   gntp = callPackage ../development/python-modules/gntp { };
 
+  gnucash = toPythonModule (pkgs.gnucash.override {
+    inherit (self) python;
+    enablePython = true;
+  });
+
   gnureadline = callPackage ../development/python-modules/gnureadline { };
 
   go2rtc-client = callPackage ../development/python-modules/go2rtc-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5605,10 +5605,11 @@ self: super: with self; {
 
   gntp = callPackage ../development/python-modules/gntp { };
 
-  gnucash = toPythonModule (pkgs.gnucash.override {
-    inherit (self) python;
-    enablePython = true;
-  });
+  gnucash = toPythonModule (
+    pkgs.gnucash.override {
+      python3 = python;
+    }
+  );
 
   gnureadline = callPackage ../development/python-modules/gnureadline { };
 


### PR DESCRIPTION
This packages the Python bindings included with Gnucash.

While the package seems to build correctly, running `import gnucash` in a Python REPL triggers a segfault. This is due to Gnucash not being able to find its glib schema. The Gnucash programs use wrappers to resolve this, but I do not know how to approach this with a Python library. In addition to `GSETTINGS_SCHEMA_DIR`, the `GNC_DBD_DIR` path also needs to be set in order to be able to open sqlite files.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
* The Python bindings are enabled via the respective CMake flag
* A Python package is implemented as a `toPythonModule` with feature flag of the gnucash package 

One new patch was added that solves some compilation issue due to an extra argument being introduced in a file generated by SWIG. The upstream Gnucash package declares that it still depends on SWIG 3, while Nix packages SWIG 4 and deprecated SWIG 3. My best guess is that this is due to that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
