### PR TITLE
wordpressPackages: plugin and theme updates

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -6,10 +6,10 @@
     "version": "2.5.2"
   },
   "akismet": {
-    "path": "akismet/tags/5.3.3",
-    "rev": "3186042",
-    "sha256": "1rxzy5qm55q7q1m7x73hxy5wx6cz5g4rsii228icbi5giyaldk6b",
-    "version": "5.3.3"
+    "path": "akismet/tags/5.3.7",
+    "rev": "3240769",
+    "sha256": "11ln6ds20shdrcrq2iil06bfhl3vgwlwr944nx6h7bysb5qf0rkw",
+    "version": "5.3.7"
   },
   "antispam-bee": {
     "path": "antispam-bee/tags/2.11.7",
@@ -24,10 +24,10 @@
     "version": "2.21.08.31"
   },
   "breeze": {
-    "path": "breeze/tags/2.1.19",
-    "rev": "3188500",
-    "sha256": "0y9xaxdglsdh4724szpgn76pv46k0l159739jgapx9cc9s319cp5",
-    "version": "2.1.19"
+    "path": "breeze/tags/2.2.4",
+    "rev": "3242646",
+    "sha256": "1waa7jznmm1aj4dly1f8l7c198274hzsplj43bsjdj673hjlk6jz",
+    "version": "2.2.4"
   },
   "co-authors-plus": {
     "path": "co-authors-plus/tags/3.6.3",
@@ -42,10 +42,10 @@
     "version": "3.2.1"
   },
   "cookie-notice": {
-    "path": "cookie-notice/tags/2.4.18",
-    "rev": "3134111",
-    "sha256": "110g3jizsyy42vrzvhhzfdnvw6gx2vv2yn2kjgy3sspphzz0vdg8",
-    "version": "2.4.18"
+    "path": "cookie-notice/tags/2.5.5",
+    "rev": "3216483",
+    "sha256": "1alb4fpvvwv672m74mn7jwfjnggrvqix4q6c4mva7r8glc8sl5ab",
+    "version": "2.5.5"
   },
   "disable-xml-rpc": {
     "path": "disable-xml-rpc/tags/1.0.1",
@@ -60,16 +60,16 @@
     "version": "1.4.0"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/19.6.2",
-    "rev": "3188877",
-    "sha256": "1i8p2rdjh8vc4qgynlpzh652ciz1sicbr10a9zpamca30j9gsvn3",
-    "version": "19.6.2"
+    "path": "gutenberg/tags/20.3.0",
+    "rev": "3243375",
+    "sha256": "1x2b5gmcwn3rj69wjaf7xaxy22842x4xcl3ni9ayjh7g0finkpf2",
+    "version": "20.3.0"
   },
   "hcaptcha-for-forms-and-more": {
-    "path": "hcaptcha-for-forms-and-more/tags/4.7.1",
-    "rev": "3189857",
-    "sha256": "0kr1270af0visl2w4270pjf0063rswqpjly440hd801bkd9bdqfg",
-    "version": "4.7.1"
+    "path": "hcaptcha-for-forms-and-more/tags/4.11.0",
+    "rev": "3248039",
+    "sha256": "12585cds4j3qkkizsnni263dlj321izlk72b9xl9wsj2p5ifxnzs",
+    "version": "4.11.0"
   },
   "hello-dolly": {
     "path": "hello-dolly/tags/1.7.2",
@@ -78,16 +78,16 @@
     "version": "1.7.2"
   },
   "hkdev-maintenance-mode": {
-    "path": "hkdev-maintenance-mode/trunk",
-    "rev": "3098579",
-    "sha256": "1l8h3f4fmgjjnvk81vf35jmhdsnfc8j2gi3gqrb8mr2q3dbf9fkn",
-    "version": "3.0.2"
+    "path": "hkdev-maintenance-mode/tags/3.1.2",
+    "rev": "3250416",
+    "sha256": "02cpkc7s3w6r0wp30apjd9iszm5af41l3v3iy3v9983a0xdm9gmb",
+    "version": "3.1.2"
   },
   "jetpack": {
-    "path": "jetpack/tags/14.0",
-    "rev": "3183818",
-    "sha256": "0rybckv1qi0skh9pg9r98zi0p36w2yqpqv1dn2wmpc9c03xpra4p",
-    "version": "14.0"
+    "path": "jetpack/tags/14.4",
+    "rev": "3250468",
+    "sha256": "0vyfib87j86fg2k6gygyp1j0ib9pa5rn0lpm051fpfrlawv2hdry",
+    "version": "14.4"
   },
   "jetpack-lite": {
     "path": "jetpack-lite/tags/3.0.3",
@@ -96,10 +96,10 @@
     "version": "3.0.3"
   },
   "lightbox-photoswipe": {
-    "path": "lightbox-photoswipe/tags/5.5.1",
-    "rev": "3186048",
-    "sha256": "0a47hccpq9b6cya8bccm3impxj0k5s2g8mga9jgrr1dysbr0gx31",
-    "version": "5.5.1"
+    "path": "lightbox-photoswipe/tags/5.6.1",
+    "rev": "3213779",
+    "sha256": "1p6w9bcb8irq38zsr2m14lnaq4hdjqvrcw7dr0603p00wnr9hc3k",
+    "version": "5.6.1"
   },
   "login-lockdown": {
     "path": "login-lockdown/tags/2.11",
@@ -108,10 +108,10 @@
     "version": "2.11"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/5.3.7",
-    "rev": "3186516",
-    "sha256": "00xajzf3hvvhv0jvg6fagi0h64rsq60ccraj0xfxah6cs6zf5kr5",
-    "version": "5.3.7"
+    "path": "mailpoet/tags/5.8.1",
+    "rev": "3250491",
+    "sha256": "0rgzdg34q22w948m83n86h0dsm6xlsnp9lzcmry2wsasrmrzygk0",
+    "version": "5.8.1"
   },
   "merge-minify-refresh": {
     "path": "merge-minify-refresh/trunk",
@@ -120,15 +120,15 @@
     "version": "2.12"
   },
   "opengraph": {
-    "path": "opengraph/tags/1.12.1",
-    "rev": "3173888",
-    "sha256": "0g0avalaijazwgny7ncdj94ghinvhn5n6xbwd2cvjqzv8rzcry7n",
-    "version": "1.12.1"
+    "path": "opengraph/tags/2.0.2",
+    "rev": "3246616",
+    "sha256": "1jphg0w6mm021kxypgz7hh04hyw7v7g95gdm35mq34z39h29hkbp",
+    "version": "2.0.2"
   },
   "simple-login-captcha": {
     "path": "simple-login-captcha/tags/1.3.6",
-    "rev": "3122028",
-    "sha256": "0j2gda5zsi48ra1w57v06ygyng438kjpaq67hb11mpzz8a7s0vav",
+    "rev": "3190731",
+    "sha256": "1bs85hyjllfi2gbvb60kd6zk72ifzwfz72smdb0nxy0r81n15yfn",
     "version": "1.3.6"
   },
   "simple-mastodon-verification": {
@@ -162,10 +162,10 @@
     "version": "1.2.3"
   },
   "webp-converter-for-media": {
-    "path": "webp-converter-for-media/tags/6.1.2",
-    "rev": "3175897",
-    "sha256": "06zaxd6lrngmivvgyw5pb5sd53gzvmr54pyavnia74gd0n3lkzyi",
-    "version": "6.1.2"
+    "path": "webp-converter-for-media/tags/6.2.0",
+    "rev": "3248239",
+    "sha256": "1lnmj98z7zckn7jnh7as5fj05h93i5y2n40068935hxhfgp7kics",
+    "version": "6.2.0"
   },
   "webp-express": {
     "path": "webp-express/tags/0.25.9",
@@ -174,10 +174,10 @@
     "version": "0.25.9"
   },
   "wordpress-seo": {
-    "path": "wordpress-seo/tags/23.8",
-    "rev": "3182123",
-    "sha256": "1i2j998wggpj5bapkzvwqpry1nji94qg1d19h39wmq1fyw0yiyka",
-    "version": "23.8"
+    "path": "wordpress-seo/tags/24.6",
+    "rev": "3250161",
+    "sha256": "1vr2lpi21bmy45xvq4fg2z1cimnxlww98svmqxryjsqyywz832p5",
+    "version": "24.6"
   },
   "worker": {
     "path": "worker/tags/4.9.20",
@@ -192,22 +192,22 @@
     "version": "3.0"
   },
   "wp-fail2ban": {
-    "path": "wp-fail2ban/tags/5.3.2",
-    "rev": "3131194",
-    "sha256": "1svp2a3xr6ajfhabz2n4rqcf9bzfr9dilc2n27ral9akc86lj1ii",
-    "version": "5.3.2"
+    "path": "wp-fail2ban/tags/5.4.0.1",
+    "rev": "3230788",
+    "sha256": "1lzm42lx810h1fpn9qfi9az4ssmxsysx6lpcpfs6y815a4ik0dc4",
+    "version": "5.4.0.1"
   },
   "wp-fail2ban-addon-contact-form-7": {
     "path": "wp-fail2ban-addon-contact-form-7/tags/2.0.0",
-    "rev": "3069647",
-    "sha256": "05qfh64dja3dbzs4z7y0gn9b0bm2a03babr3qkjn6g9v4wa6m36i",
+    "rev": "3150733",
+    "sha256": "0xixgpkibyp9diwnfdr5pyyf3z1ll9wkps5cdhpqcikaapdpj45f",
     "version": "2.0.0"
   },
   "wp-fastest-cache": {
-    "path": "wp-fastest-cache/tags/1.3.2",
-    "rev": "3181365",
-    "sha256": "0yh0vabig7yfyq98awb4nccp786rl1jcv9981s3shirr43ys4ylw",
-    "version": "1.3.2"
+    "path": "wp-fastest-cache/tags/1.3.4",
+    "rev": "3236236",
+    "sha256": "0v3v41dz6rg6xk5imp99d815ar7lwcjr9ingbwv6hfbrssnwwvq7",
+    "version": "1.3.4"
   },
   "wp-gdpr-compliance": {
     "path": "wp-gdpr-compliance/tags/2.0.22",
@@ -222,22 +222,22 @@
     "version": "3.9.27"
   },
   "wp-mail-smtp": {
-    "path": "wp-mail-smtp/tags/4.2.0",
-    "rev": "3183227",
-    "sha256": "0f54pmap43f65wpvd7abp867bfk2wzf9kp5n13iq47mxjdickj80",
-    "version": "4.2.0"
+    "path": "wp-mail-smtp/tags/4.3.0",
+    "rev": "3206423",
+    "sha256": "1y8qcka8lk93h8p9vdfvb73ikh9mrbkk32322rwbsi68y577r4ln",
+    "version": "4.3.0"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/14.11.2",
-    "rev": "3182553",
-    "sha256": "1vpxa6kk6jlanhva5px46pg7kxrfaj33cs3z95bj18hr155v8vbv",
-    "version": "14.11.2"
+    "path": "wp-statistics/tags/14.12.5",
+    "rev": "3245191",
+    "sha256": "0ll76irsc15s8m7dayci31bjjc86sgbjs6wa6b9lg80cqylpskgw",
+    "version": "14.12.5"
   },
   "wp-swiper": {
     "path": "wp-swiper/trunk",
-    "rev": "3179903",
-    "sha256": "016qb2ydh43wsdzba4wg57qm0q30kyrrx06qfssdv71269n8dfqr",
-    "version": "1.2.13"
+    "rev": "3220490",
+    "sha256": "091rl79z5y9qvvdlcfx9czfrrji0ifipkg7l02n91331fi02ij07",
+    "version": "1.2.17"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",
@@ -246,9 +246,9 @@
     "version": "1.4.1"
   },
   "wpforms-lite": {
-    "path": "wpforms-lite/tags/1.9.2.1",
-    "rev": "3183825",
-    "sha256": "17h2p200vb0m3sw9xnslj9kj2p6asg04azrrki4kafigw7fgl66y",
-    "version": "1.9.2.1"
+    "path": "wpforms-lite/tags/1.9.4.1",
+    "rev": "3247860",
+    "sha256": "0mr9lf20s6gisf7wpcbf6x648a94kgniidlps1wa7f0dppgg0s5z",
+    "version": "1.9.4.1"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/themes.json
+++ b/pkgs/servers/web-apps/wordpress/packages/themes.json
@@ -12,10 +12,10 @@
     "version": "2.8"
   },
   "twentytwentyfive": {
-    "path": "twentytwentyfive/1.0",
-    "rev": "248589",
-    "sha256": "00360gxmnzq4z5z2b7z1wpziwfb6x8nz74qv3c9fpri2d9k4356f",
-    "version": "1.0"
+    "path": "twentytwentyfive/1.1",
+    "rev": "259400",
+    "sha256": "07imhv3n5rdmzlld3rw0jwr32pldv8270fqbfi6vnhxc99mrk054",
+    "version": "1.1"
   },
   "twentytwentyfour": {
     "path": "twentytwentyfour/1.3",


### PR DESCRIPTION
I ran `generate.sh` to pull in updates.

Since this is my first nixpkgs PR, I based it off of #356449, minus the Wordpress engine update.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested that Wordpress can see the updated twentytwentyfive theme, and that it's not asking for anything else to be updated.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
