### PR TITLE
dockerTools: add `CMD` override support to `streamNixShellImage`

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -384,9 +384,9 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/top-level/php-packages.nix         @jtojnar @aanderse @globin @ma27 @talyz
 
 # Docker tools
-/pkgs/build-support/docker                   @roberth
-/nixos/tests/docker-tools*                   @roberth
-/doc/build-helpers/images/dockertools.section.md  @roberth
+/pkgs/build-support/docker                       @roberth @commiterate @jhol
+/nixos/tests/docker-tools*                       @roberth @commiterate @jhol
+/doc/build-helpers/images/dockertools.section.md @roberth @commiterate @jhol
 
 # Blockchains
 /pkgs/applications/blockchains  @mmahut @RaghavSood

--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -1,6 +1,6 @@
 # pkgs.dockerTools {#sec-pkgs-dockerTools}
 
-`pkgs.dockerTools` is a set of functions for creating and manipulating Docker images according to the [Docker Image Specification v1.3.0](https://github.com/moby/moby/blob/46f7ab808b9504d735d600e259ca0723f76fb164/image/spec/spec.md#image-json-field-descriptions).
+`pkgs.dockerTools` is a set of functions for creating and manipulating Docker images according to the [Docker Image Specification v1.3.0](https://github.com/moby/docker-image-spec/blob/v1.3.1/spec.md).
 Docker itself is not used to perform any of the operations done by these functions.
 
 ## buildImage {#ssec-pkgs-dockerTools-buildImage}
@@ -130,7 +130,7 @@ Similarly, if you encounter errors similar to `Error_Protocol ("certificate has 
 `config` (Attribute Set or Null; _optional_)
 
 : Used to specify the configuration of the containers that will be started off the generated image.
-  Must be an attribute set, with each attribute as listed in the [Docker Image Specification v1.3.0](https://github.com/moby/moby/blob/46f7ab808b9504d735d600e259ca0723f76fb164/image/spec/spec.md#image-json-field-descriptions).
+  Must be an attribute set, with each attribute as listed in the [Docker Image Specification v1.3.0](https://github.com/moby/docker-image-spec/blob/v1.3.1/spec.md#image-json-field-descriptions).
 
   _Default value:_ `null`.
 
@@ -138,7 +138,7 @@ Similarly, if you encounter errors similar to `Error_Protocol ("certificate has 
 
 : Used to specify the image architecture.
   This is useful for multi-architecture builds that don't need cross compiling.
-  If specified, its value should follow the [OCI Image Configuration Specification](https://github.com/opencontainers/image-spec/blob/main/config.md#properties), which should still be compatible with Docker.
+  If specified, its value should follow the [OCI Image Configuration Specification](https://github.com/opencontainers/image-spec/blob/v1.1.1/config.md#properties), which should still be compatible with Docker.
   According to the linked specification, all possible values for `$GOARCH` in [the Go docs](https://go.dev/doc/install/source#environment) should be valid, but will commonly be one of `386`, `amd64`, `arm`, or `arm64`.
 
   _Default value:_ the same value from `pkgs.go.GOARCH`.
@@ -395,6 +395,10 @@ hello        latest   de2bf4786de6   About a minute ago   25.2MB
 :::
 
 ## buildLayeredImage {#ssec-pkgs-dockerTools-buildLayeredImage}
+
+::: {.warning}
+Deprecated in favor of [`streamLayeredImage`](#ssec-pkgs-dockerTools-streamLayeredImage) + [`writeImageStream`](#ssec-pkgs-dockerTools-writeImageStream).
+:::
 
 `buildLayeredImage` uses [`streamLayeredImage`](#ssec-pkgs-dockerTools-streamLayeredImage) underneath to build a compressed Docker-compatible repository tarball.
 Basically, `buildLayeredImage` runs the script created by `streamLayeredImage` to save the compressed image in the Nix store.
@@ -1186,7 +1190,7 @@ This is currently implemented by linking to the `env` binary from the `coreutils
 
 ### binSh {#sssec-pkgs-dockerTools-helpers-binSh}
 
-This provides a `/bin/sh` link to the `bash` binary from the `bashInteractive` package.
+This provides a `/bin/sh` link to the `bash` binary from the `bash` package.
 Because of this, it supports cases such as running a command interactively in a container (for example by running `docker container run -it <image_name>`).
 
 ### caCertificates {#sssec-pkgs-dockerTools-helpers-caCertificates}
@@ -1368,6 +1372,10 @@ dockerTools.buildLayeredImage {
 []{#ssec-pkgs-dockerTools-buildNixShellImage-arguments}
 ## buildNixShellImage {#ssec-pkgs-dockerTools-buildNixShellImage}
 
+::: {.warning}
+Deprecated in favor of [`streamNixShellImage`](#ssec-pkgs-dockerTools-streamNixShellImage) + [`writeImageStream`](#ssec-pkgs-dockerTools-writeImageStream).
+:::
+
 `buildNixShellImage` uses [`streamNixShellImage`](#ssec-pkgs-dockerTools-streamNixShellImage) underneath to build a compressed Docker-compatible repository tarball of an image that sets up an environment similar to that of running `nix-shell` on a derivation.
 Basically, `buildNixShellImage` runs the script created by `streamNixShellImage` to save the compressed image in the Nix store.
 
@@ -1490,7 +1498,7 @@ The environment in the image doesn't match `nix-shell` or `nix-build` exactly, a
   This shell is started when running the image.
   This can be seen as an equivalent of the `NIX_BUILD_SHELL` [environment variable](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html#environment-variables) for {manpage}`nix-shell(1)`.
 
-  _Default value:_ the `bash` binary from the `bashInteractive` package.
+  _Default value:_ the `bash` binary from the `bash` package.
 
 `command` (String or Null; _optional_)
 
@@ -1507,6 +1515,105 @@ The environment in the image doesn't match `nix-shell` or `nix-build` exactly, a
   This can be seen as an equivalent of the `--run` option in {manpage}`nix-shell(1)`.
 
   _Default value:_ `null`.
+
+`includeBuildDerivation` (Boolean; _optional_)
+
+: Whether to include a `buildDerivation` binary which builds the derivation.
+
+  _Default value:_ `true`.
+
+`extraContents` (Path or List of Paths or Null; _optional_)
+
+: Extra directories whose contents will be added to the generated image.
+  Things that coerce to paths (e.g. a derivation) can also be used.
+  This can be seen as an equivalent of `ADD extraContents/ /` in a `Dockerfile`.
+
+  All the contents specified by `extraContents` along with the base contents from this helper will be added as a final layer in the generated image.
+  They will be added as links to the actual files (e.g. links to the store paths). The actual files will be added in previous layers.
+
+  If not specified, some convenience extra contents are included by default:
+
+  - `/bin/sh`
+    - Symlink to `${bash}/bin/bash`.
+  - `/usr/bin/env`
+    - Symlink to `${coreutils}/bin/env`.
+
+  _Default value:_ `[ "{/bin/sh derivation}" "{/usr/bin/env derivation}" ]`.
+
+## writeImageStream {#ssec-pkgs-dockerTools-writeImageStream}
+
+`writeImageStream` takes an executable that outputs an image stream (e.g. `streamLayeredImage`, `streamNixShellImage`) and writes a Docker-compatible repository tarball with optional compression.
+
+This is preferred over helpers that create an image stream internally and return its compressor derivation (e.g. `buildLayeredImage`, `buildNixShellImage`) because streams can be composed with overrides.
+
+### Inputs {#ssec-pkgs-dockerTools-writeImageStream-inputs}
+
+`stream` (Path)
+
+: Path to the executable that outputs an image stream.
+
+`compressor` (String; _optional_)
+
+: Selects the algorithm used to compress the image.
+
+  _Default value:_ `"gz"`.\
+  _Possible values:_ `"none"`, `"gz"`, `"zstd"`.
+
+### Passthru outputs {#ssec-pkgs-dockerTools-writeImageStream-passthru-outputs}
+
+`writeImageStream` also defines its own [`passthru`](#chap-passthru) attributes:
+
+`stream` (Derivation)
+
+: Path to the executable that outputs an image stream.
+
+`imageTag` (String)
+
+: The tag of the generated image from the input image stream.
+  This is useful if no tag was specified in the attributes of the argument to the function, because an automatic tag will be used instead.
+  `imageTag` allows you to retrieve the value of the tag used in this case.
+
+### Examples {#ssec-pkgs-dockerTools-writeImageStream-examples}
+
+:::{.example #ex-dockerTools-writeImageStream-streamNixShellImage}
+# Writing a Nix shell image stream
+
+Without image stream attribute overrides.
+
+```nix
+{
+  dockerTools,
+  hello,
+}:
+dockerTools.writeImageStream {
+  stream = dockerTools.streamNixShellImage {
+    drv = hello;
+  };
+}
+```
+
+With image stream attribute overrides.
+
+```nix
+{
+  lib,
+  stdenv,
+  dockerTools,
+  hello,
+}:
+dockerTools.writeImageStream {
+  stream =
+    (dockerTools.streamNixShellImage {
+      drv = hello;
+    }).override
+      (prev: {
+        config = prev.config // {
+          Env = prev.config.Env ++ [ "LD_LIBRARY_PATH=${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" ];
+        };
+      });
+}
+```
+:::
 
 ### Examples {#ssec-pkgs-dockerTools-streamNixShellImage-examples}
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -101,6 +101,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-dockerTools-writeImageStream-streamNixShellImage": [
+    "index.html#ex-dockerTools-writeImageStream-streamNixShellImage"
+  ],
   "ex-pkgs-replace-vars": [
     "index.html#ex-pkgs-replace-vars",
     "index.html#ex-pkgs-substituteAll",
@@ -564,6 +567,18 @@
   ],
   "ssec-cosmic-settings-fallback": [
     "index.html#ssec-cosmic-settings-fallback"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-examples": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-examples"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-inputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-inputs"
+  ],
+  "ssec-pkgs-dockerTools-writeImageStream-passthru-outputs": [
+    "index.html#ssec-pkgs-dockerTools-writeImageStream-passthru-outputs"
   ],
   "ssec-stdenv-dependencies": [
     "index.html#ssec-stdenv-dependencies"

--- a/nixos/tests/docker-tools-nix-shell.nix
+++ b/nixos/tests/docker-tools-nix-shell.nix
@@ -68,6 +68,12 @@ in
             "docker run --rm -it nix-shell-command | grep 'This shell is interactive'"
         )
 
+    with subtest("buildNixShellImage: command override works"):
+        docker.succeed(
+            "${examples.nix-shell-command-override} | docker load",
+            "docker run --rm -it nix-shell-command-override /bin/sh -c hello | grep 'Hello, world!'"
+        )
+
     with subtest("buildNixShellImage: home directory is writable by default"):
         docker.succeed(
             "${examples.nix-shell-writable-home} | docker load",

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -1,5 +1,5 @@
 {
-  bashInteractive,
+  bash,
   buildPackages,
   cacert,
   callPackage,
@@ -575,24 +575,18 @@ rec {
       '';
     };
 
+  # Wrapper around `streamLayeredImage` to build an image from the result.
+  #
+  # Deprecated. Use `streamLayeredImage` + `writeImageStream` instead.
   buildLayeredImage = lib.makeOverridable (
     {
-      name,
       compressor ? "gz",
       ...
     }@args:
-    let
+    writeImageStream {
+      inherit compressor;
       stream = streamLayeredImage (removeAttrs args [ "compressor" ]);
-      compress = compressorForImage compressor name;
-    in
-    runCommand "${baseNameOf name}.tar${compress.ext}" {
-      inherit (stream) imageName;
-      passthru = {
-        inherit (stream) imageTag;
-        inherit stream;
-      };
-      nativeBuildInputs = compress.nativeInputs;
-    } "${stream} | ${compress.compress} > $out"
+    }
   );
 
   # 1. extract the base image
@@ -959,11 +953,11 @@ rec {
     ln -s ${coreutils}/bin/env $out/usr/bin
   '';
 
-  # This provides /bin/sh, pointing to bashInteractive.
-  # The use of bashInteractive here is intentional to support cases like `docker run -it <image_name>`, so keep these use cases in mind if making any changes to how this works.
+  # This provides /bin/sh, pointing to bash (interactive).
+  # The use of bash (interactive) here is intentional to support cases like `docker run -it <image_name>`, so keep these use cases in mind if making any changes to how this works.
   binSh = runCommand "bin-sh" { } ''
     mkdir -p $out/bin
-    ln -s ${bashInteractive}/bin/bash $out/bin/sh
+    ln -s ${bash}/bin/bash $out/bin/sh
   '';
 
   # This provides the ca bundle in common locations
@@ -1241,7 +1235,8 @@ rec {
     result
   );
 
-  # This function streams a docker image that behaves like a nix-shell for a derivation
+  # This function streams a docker image that behaves like a nix-shell for a derivation.
+  #
   # Docs: doc/build-helpers/images/dockertools.section.md
   # Tests: nixos/tests/docker-tools-nix-shell.nix
   streamNixShellImage =
@@ -1251,10 +1246,19 @@ rec {
       tag ? null,
       uid ? 1000,
       gid ? 1000,
+      # Default to `/build` instead of a non-existent `/homeless-shelter` for backwards compatibility.
+      #
+      # https://github.com/NixOS/nix/issues/6379
       homeDirectory ? "/build",
-      shell ? bashInteractive + "/bin/bash",
+      shell ? lib.getExe bash,
       command ? null,
       run ? null,
+      includeBuildDerivation ? true,
+      # Legacy convenience derivations for backwards compatibility.
+      extraContents ? [
+        binSh
+        usrBinEnv
+      ],
     }:
     assert lib.assertMsg (!(drv.drvAttrs.__structuredAttrs or false))
       "streamNixShellImage: Does not work with the derivation ${drv.name} because it uses __structuredAttrs";
@@ -1262,105 +1266,114 @@ rec {
       command == null || run == null
     ) "streamNixShellImage: Can't specify both command and run";
     let
-
-      # A binary that calls the command to build the derivation
-      builder = writeShellScriptBin "buildDerivation" ''
-        exec ${lib.escapeShellArg (valueToString drv.drvAttrs.builder)} ${lib.escapeShellArgs (map valueToString drv.drvAttrs.args)}
-      '';
-
-      staticPath = "${dirOf shell}:${lib.makeBinPath [ builder ]}";
-
-      # https://github.com/NixOS/nix/blob/2.8.0/src/nix-build/nix-build.cc#L493-L526
-      rcfile = writeText "nix-shell-rc" ''
-        unset PATH
-        dontAddDisableDepTrack=1
-        # TODO: https://github.com/NixOS/nix/blob/2.8.0/src/nix-build/nix-build.cc#L506
-        [ -e $stdenv/setup ] && source $stdenv/setup
-        PATH=${staticPath}:"$PATH"
-        SHELL=${lib.escapeShellArg shell}
-        BASH=${lib.escapeShellArg shell}
-        set +e
-        [ -n "$PS1" -a -z "$NIX_SHELL_PRESERVE_PROMPT" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '
-        if [ "$(type -t runHook)" = function ]; then
-          runHook shellHook
-        fi
-        unset NIX_ENFORCE_PURITY
-        shopt -u nullglob
-        shopt -s execfail
-        ${optionalString (command != null || run != null) ''
-          ${optionalString (command != null) command}
-          ${optionalString (run != null) run}
-          exit
-        ''}
-      '';
-
-      # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/globals.hh#L464-L465
-      sandboxBuildDir = "/build";
+      #
+      # Create an environment variable map.
+      #
 
       drvEnv =
-        devShellTools.unstructuredDerivationInputEnv { inherit (drv) drvAttrs; }
+        devShellTools.unstructuredDerivationInputEnv {
+          inherit (drv) drvAttrs;
+        }
         // devShellTools.derivationOutputEnv {
           outputList = drv.outputs;
           outputMap = drv;
         };
 
-      # Environment variables set in the image
-      envVars = {
+      # https://github.com/NixOS/nix/blob/2.28.2/src/libstore/include/nix/store/globals.hh#L686-L693
+      sandboxBuildDir = "/build";
 
-        # Root certificates for internet access
-        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-        NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1027-L1030
-        # PATH = "/path-not-set";
-        # Allows calling bash and `buildDerivation` as the Cmd
-        PATH = staticPath;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1032-L1038
+      # https://github.com/NixOS/nix/blob/2.28.2/src/libstore/unix/build/local-derivation-goal.cc#L1186
+      initEnv = {
+        # Not setting `PATH` since it's set by the Nix shell shim.
         HOME = homeDirectory;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1040-L1044
         NIX_STORE = storeDir;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1046-L1047
         # TODO: Make configurable?
         NIX_BUILD_CORES = "1";
-
       }
       // drvEnv
       // {
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1008-L1010
         NIX_BUILD_TOP = sandboxBuildDir;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1012-L1013
         TMPDIR = sandboxBuildDir;
         TEMPDIR = sandboxBuildDir;
         TMP = sandboxBuildDir;
         TEMP = sandboxBuildDir;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1015-L1019
         PWD = sandboxBuildDir;
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1071-L1074
-        # We don't set it here because the output here isn't handled in any special way
-        # NIX_LOG_FD = "2";
-
-        # https://github.com/NixOS/nix/blob/2.8.0/src/libstore/build/local-derivation-goal.cc#L1076-L1077
+        # Not setting `NIX_LOG_FD` since log messages don't need special handling in this context.
         TERM = "xterm-256color";
       };
 
+      # https://github.com/NixOS/nix/blob/2.28.2/src/libstore/unix/build/local-derivation-goal.cc#L1785
+      runChildEnv = {
+        # https://github.com/NixOS/nix/blob/2.28.2/src/libstore/include/nix/store/globals.hh#L1049-L1067
+        NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      };
+
+      env = initEnv // runChildEnv;
+
+      #
+      # Create a nix-shell shim.
+      #
+      # nix-shell proper relies on a startup file. Startup files are only run with certain (non-)interactive + (non-)login shell permutations.
+      #
+      # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html
+      #
+      # Use a nix-shell shim as the OCI container entrypoint instead.
+      #
+
+      path = lib.concatStringsSep ":" (
+        [
+          (dirOf shell)
+        ]
+        ++ lib.optionals includeBuildDerivation [
+          (lib.makeBinPath [
+            # A binary that builds the derivation.
+            (writeShellScriptBin "buildDerivation" ''
+              exec ${lib.escapeShellArg (valueToString drv.drvAttrs.builder)} ${lib.escapeShellArgs (map valueToString drv.drvAttrs.args)}
+            '')
+          ])
+        ]
+      );
+
+      # https://github.com/NixOS/nix/blob/2.28.2/src/nix-build/nix-build.cc#L601-L635
+      nixShell = writeScript "nix-shell" ''
+        #!${shell}
+
+        unset PATH
+        dontAddDisableDepTrack=1
+        # TODO: https://github.com/NixOS/nix/blob/2.28.2/src/nix-build/nix-build.cc#L612
+        [ -e $stdenv/setup ] && source $stdenv/setup
+        PATH=${path}:"$PATH"
+        SHELL=${lib.escapeShellArg shell}
+        BASH=${lib.escapeShellArg shell}
+        set +e
+        [ -n "$PS1" -a -z "$NIX_SHELL_PRESERVE_PROMPT" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '
+        if [ "$(type -t runHook)" = function ]; then runHook shellHook; fi
+        unset NIX_ENFORCE_PURITY
+        shopt -u nullglob
+        shopt -s execfail
+
+        exec "$@"
+      '';
+
+      nixShellScript = writeScript "nix-shell-script" ''
+        ${optionalString (command != null) command}
+        ${optionalString (run != null) run}
+        exit
+      '';
     in
     streamLayeredImage {
       inherit name tag;
       contents = [
-        binSh
-        usrBinEnv
         (fakeNss.override {
-          # Allows programs to look up the build user's home directory
-          # https://github.com/NixOS/nix/blob/ffe155abd36366a870482625543f9bf924a58281/src/libstore/build/local-derivation-goal.cc#L906-L910
-          # Slightly differs however: We use the passed-in homeDirectory instead of sandboxBuildDir.
-          # We're doing this because it's arguably a bug in Nix that sandboxBuildDir is used here: https://github.com/NixOS/nix/issues/6379
+          # Allows programs to look up the build user's home directory.
+          #
+          # https://github.com/NixOS/nix/blob/2.28.2/src/libstore/unix/build/local-derivation-goal.cc#L1069-L1075
+          #
+          # This slightly differs, however, since we use the passed-in `homeDirectory` instead of `sandboxBuildDir`.
+          # We're doing this because it's arguably a bug in Nix that `sandboxBuildDir` is used here.
+          #
+          # https://github.com/NixOS/nix/issues/6379
           extraPasswdLines = [
             "nixbld:x:${toString uid}:${toString gid}:Build user:${homeDirectory}:/noshell"
           ];
@@ -1368,57 +1381,78 @@ rec {
             "nixbld:!:${toString gid}:"
           ];
         })
-      ];
+      ]
+      ++ (if builtins.isList extraContents then extraContents else [ extraContents ]);
 
       fakeRootCommands = ''
         # Effectively a single-user installation of Nix, giving the user full
         # control over the Nix store. Needed for building the derivation this
-        # shell is for, but also in case one wants to use Nix inside the
-        # image
+        # shell is for, but also in case one wants to use Nix inside the image.
         mkdir -p ./nix/{store,var/nix} ./etc/nix
         chown -R ${toString uid}:${toString gid} ./nix ./etc/nix
 
-        # Gives the user control over the build directory
+        # Gives the user control over the build directory.
         mkdir -p .${sandboxBuildDir}
         chown -R ${toString uid}:${toString gid} .${sandboxBuildDir}
       '';
 
-      # Run this image as the given uid/gid
-      config.User = "${toString uid}:${toString gid}";
-      config.Cmd =
-        # https://github.com/NixOS/nix/blob/2.8.0/src/nix-build/nix-build.cc#L185-L186
-        # https://github.com/NixOS/nix/blob/2.8.0/src/nix-build/nix-build.cc#L534-L536
-        if run == null then
-          [
-            shell
-            "--rcfile"
-            rcfile
-          ]
-        else
-          [
-            shell
-            rcfile
-          ];
-      config.WorkingDir = sandboxBuildDir;
-      config.Env = lib.mapAttrsToList (name: value: "${name}=${value}") envVars;
+      config = {
+        # Run this image as the given uid/gid.
+        User = "${toString uid}:${toString gid}";
+        Env = lib.mapAttrsToList (name: value: "${name}=${value}") env;
+        Entrypoint = [ nixShell ];
+        Cmd =
+          # https://github.com/NixOS/nix/blob/2.28.2/src/nix-build/nix-build.cc#L223-L227
+          if (command != null) then
+            [
+              shell
+              "-i"
+              nixShellScript
+            ]
+          else if (run != null) then
+            [
+              shell
+              nixShellScript
+            ]
+          else
+            [ shell ];
+        WorkingDir = sandboxBuildDir;
+      };
     };
 
-  # Wrapper around streamNixShellImage to build an image from the result
+  # Wrapper around `streamNixShellImage` to build an image from the result.
+  #
+  # Deprecated. Use `streamNixShellImage` + `writeImageStream` instead.
+  #
   # Docs: doc/build-helpers/images/dockertools.section.md
   # Tests: nixos/tests/docker-tools-nix-shell.nix
   buildNixShellImage =
     {
-      drv,
       compressor ? "gz",
       ...
     }@args:
-    let
+    writeImageStream {
+      inherit compressor;
       stream = streamNixShellImage (removeAttrs args [ "compressor" ]);
-      compress = compressorForImage compressor drv.name;
+    };
+
+  # Writes out an image tarball stream with optional compression.
+  #
+  # Docs: doc/build-helpers/images/dockertools.section.md
+  writeImageStream =
+    {
+      stream,
+      compressor ? "gz",
+    }:
+    let
+      compress = compressorForImage compressor stream.name;
     in
-    runCommand "${drv.name}-env.tar${compress.ext}" {
+    runCommand "${stream.name}.tar${compress.ext}" {
       inherit (stream) imageName;
-      passthru = { inherit (stream) imageTag; };
+      passthru = {
+        inherit stream;
+        inherit (stream) imageTag;
+      };
       nativeBuildInputs = compress.nativeInputs;
     } "${stream} | ${compress.compress} > $out";
 }

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -88,7 +88,7 @@ rec {
     tag = "latest";
     copyToRoot = pkgs.buildEnv {
       name = "image-root";
-      paths = [ pkgs.bashInteractive ];
+      paths = [ pkgs.bash ];
       pathsToLink = [ "/bin" ];
     };
   };
@@ -541,7 +541,7 @@ rec {
     tag = "latest";
     compressor = "none";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   bashZstdCompressed = pkgs.dockerTools.buildImage {
@@ -549,20 +549,20 @@ rec {
     tag = "latest";
     compressor = "zstd";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   # buildImage without explicit tag
   bashNoTag = pkgs.dockerTools.buildImage {
     name = "bash-no-tag";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
-    copyToRoot = pkgs.bashInteractive;
+    copyToRoot = pkgs.bash;
   };
 
   # buildLayeredImage without explicit tag
   bashNoTagLayered = pkgs.dockerTools.buildLayeredImage {
     name = "bash-no-tag-layered";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage without compression
@@ -570,7 +570,7 @@ rec {
     name = "bash-layered-uncompressed";
     tag = "latest";
     compressor = "none";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage with zstd compression
@@ -578,13 +578,13 @@ rec {
     name = "bash-layered-zstd";
     tag = "latest";
     compressor = "zstd";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # streamLayeredImage without explicit tag
   bashNoTagStreamLayered = pkgs.dockerTools.streamLayeredImage {
     name = "bash-no-tag-stream-layered";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash;
   };
 
   # buildLayeredImage with non-root user
@@ -832,7 +832,7 @@ rec {
     tag = "latest";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
     copyToRoot = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -841,7 +841,7 @@ rec {
     name = "layered-image-with-path";
     tag = "latest";
     contents = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -852,7 +852,7 @@ rec {
     architecture = "arm64";
     # Not recommended. Use `buildEnv` between copy and packages to avoid file duplication.
     copyToRoot = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -862,7 +862,7 @@ rec {
     tag = "latest";
     architecture = "arm64";
     contents = [
-      pkgs.bashInteractive
+      pkgs.bash
       ./test-dummy
     ];
   };
@@ -948,6 +948,23 @@ rec {
       *) echo This shell is not interactive ;;
       esac
     '';
+  };
+
+  nix-shell-command-override = streamNixShellImage {
+    name = "nix-shell-command-override";
+    tag = "latest";
+    drv = pkgs.mkShell {
+      packages = [
+        pkgs.hello
+      ];
+    };
+    includeBuildDerivation = false;
+    extraContents = [
+      (pkgs.runCommand "bin-sh" { } ''
+        mkdir -p $out/bin
+        ln -s ${pkgs.bash}/bin/bash $out/bin/sh
+      '')
+    ];
   };
 
   nix-shell-writable-home = streamNixShellImage {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `CMD` override support to `dockerTools.streamNixShellImage` for CI/CD support.

Also adds `dockerTools.writeImageStream` to support composing image streams with overrides before writing them out.

Fixes https://github.com/NixOS/nixpkgs/issues/211454.

### Issue

The helper currently produces images that rely on their default `CMD` to start a Nix shell. CI/CD providers with bring-your-own-containerized-environments, however, overwrite `CMD` when starting the container.

For example, the GitLab Runner Docker executor essentially runs `docker run {image} sh -c "{build command}"` ([docs](https://docs.gitlab.com/runner/executors/docker/#configure-a-docker-entrypoint)) which overwrites `CMD` to `sh -c "{build command}"`.

These images have limited use when `CMD` is overwritten since the default `PATH` only has the specified shell and the `buildDerivation` binary. Users need to know the Bash startup file's path in the Nix store to include it in a `bash --rcfile {startup file Nix store path}` invocation which...well good luck.

### Context

At a high level, `nix-shell` sets up shells by:

1. Setting generic Nix environment variables (e.g. `NIX_STORE`).
2. Setting derivation-specific environment variables by invoking `$stdenv/setup` (e.g. adding build inputs to `PATH`).
3. Invoking the derivation's `shellHook`.

`nix-shell` does 2 + 3 by creating a Bash startup file and calling `bash --rcfile {startup file Nix store path}`.

The current helper does the same, with some additional modifications needed for containers.

Startup files, however, are only run for certain `bash`/`sh` + (non-)interactive + (non-)login shell permutations. In fact, some permutations ignore all shell startup files (e.g. `sh` + non-interactive + non-login).

https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html

Since users can specify the shell type, relying on Bash startup files isn't ideal.

### Changes

- __Move Nix shell initialization from a Bash startup file to a Nix shell shim executable.__
   - The shim will always be run unlike Bash startup files.
- __Make the Nix shell shim executable the image's default `ENTRYPOINT`.__
   - `{ENTRYPOINT} {CMD}` is executed when running a container ([doc](https://docs.docker.com/reference/dockerfile#understand-how-cmd-and-entrypoint-interact)).
      - Using `ENTRYPOINT` to run the Nix shell shim lets users overwrite `CMD`.
      - Lets users set `CMD` to `bash -c "{build command}"`/`sh -c "{build command}"` unlike when `ENTRYPOINT` is `bash --rcfile {startup file Nix store path} -c` (can't chain multiple `-c` options).
- __Make the `buildDerivation` binary optional.__
   - Including it by default for backwards compatibility.
- __Make `/usr/bin/env` and `/bin/sh` optional.__
   - Including them by default for backwards compatibility.
- __Allow extra non-store contents.__
   - For dealing with CI/CD providers that check for files in fixed locations (e.g. GitLab Runner shell detection).
- __Add `writeImageStream` to enable image overrides.__
   - `buildLayeredImage` and `buildNixShellImage` create the image stream internally and only return the compressor, so image stream attribute overrides aren't allowed.

### Testing

Created a test Clojure project that creates a Nix shell image from a `mkShell` derivation.

https://github.com/commiterate/test-nix-shell-image-rewrite

```shell
# Build the Nix shell image.
$ nix build .#nix-shell-image

# Load the Nix shell image.
$ docker image load -i result
# ...
Loaded image: nix-shell-image:h3w0kshs0lzrn06s6d4l6816rcdzwh00

# Try a command in the Nix shell.
$ docker run -it nix-shell-image:h3w0kshs0lzrn06s6d4l6816rcdzwh00 clojure --version
⚗️
Clojure CLI version 1.12.0.1530

# Try a command in a Bash subshell.
$ docker run -it nix-shell-image:h3w0kshs0lzrn06s6d4l6816rcdzwh00 bash -c 'echo "Hello!"'
⚗️
Hello!

# Try a command in an Sh subshell.
$ docker run -it nix-shell-image:h3w0kshs0lzrn06s6d4l6816rcdzwh00 sh -c 'echo "Hello!"'
⚗️
Hello!

# Try entering the Nix shell.
$ docker run -it nix-shell-image:h3w0kshs0lzrn06s6d4l6816rcdzwh00
⚗️

# Check if `PATH` has:
#
# - The specified shell.
# - The derivation's build inputs (added by `$stdenv/setup`).
bash-5.2$ printenv PATH | tr ":" "\n"
/nix/store/41pi0jiyvlhxgpfhxzvb44w1skc8yp4z-bash-interactive-5.2p37/bin
/nix/store/zhpgx7kcf8ii2awhk1lz6p565vv27jv5-attr-2.5.2-bin/bin
/nix/store/1191qk37q1bxyj43j0y1l534jvsckyma-acl-2.3.2-bin/bin
/nix/store/a15rc9v3f5zb0wdxll7mxcidbvp78nny-libarchive-3.7.8/bin
/nix/store/gwxwbrzzlvw1pr2d72ia9hnjpjh4amip-nix-2.28.3/bin
/nix/store/jg21p1hbfkjl2s8n3ig6js2x30jn1nc0-nixfmt-unstable-2025-04-04/bin
/nix/store/87fck6hm17chxjq7badb11mq036zbyv9-coreutils-9.7/bin
/nix/store/805a5wv1cyah5awij184yfad1ksmbh9f-git-2.49.0/bin
/nix/store/mwc7zfdg7hk7xb70p3samcwsym2p7gj5-git-lfs-3.6.1/bin
/nix/store/irjpjxgdk1rwvliw0v9pmq1hhfl0i88s-babashka-1.12.200/bin
/nix/store/41kih9qxbsfdm8yqw6yv9x4zy13hdxc2-clojure-1.12.0.1530/bin
/nix/store/8kz1q1mn6v4ahgcnamybd7wdjrc6a9s5-cljfmt-0.13.1/bin
/nix/store/cs5a6ylafbfhd5s97ps2jxddlp9qh6r7-clj-kondo-2025.04.07/bin
/nix/store/2jc1jmzis19adawjwhl8qhdvh7vlbk0q-patchelf-0.15.0/bin
/nix/store/0fsnicvfpf55nkza12cjnad0w84d6ba7-gcc-wrapper-14.2.1.20250322/bin
/nix/store/9ds850ifd4jwcccpp3v14818kk74ldf2-gcc-14.2.1.20250322/bin
/nix/store/303islqk386z1w2g1ngvxnkl4glfpgrs-glibc-2.40-66-bin/bin
/nix/store/hhfm5fkvb1alg1np5a69m2qlcjqhr062-binutils-wrapper-2.44/bin
/nix/store/v63bxfiacw082c7ijshf60alvvrpfxsq-binutils-2.44/bin
/nix/store/87fck6hm17chxjq7badb11mq036zbyv9-coreutils-9.7/bin
/nix/store/7y59hzi3svdj1xjddjn2k7km96pifcyl-findutils-4.10.0/bin
/nix/store/7h0sard22wnbz0jyz07w8y9y0fcs795r-diffutils-3.12/bin
/nix/store/clbb2cvigynr235ab5zgi18dyavznlk2-gnused-4.9/bin
/nix/store/gqmr3gixlddz3667ba1iyqck3c0dkpvd-gnugrep-3.11/bin
/nix/store/fcyn0dqszgfysiasdmkv1jh3syncajay-gawk-5.3.2/bin
/nix/store/wrxvqj822kz8746608lgns7h8mkpn79f-gnutar-1.35/bin
/nix/store/afhkqb5a94zlwjxigsnwsfwkf38h21dk-gzip-1.14/bin
/nix/store/1abbyfv3bpxalfjfgpmwg8jcy931bf76-bzip2-1.0.8-bin/bin
/nix/store/kv10h4pidkmx8cjs2sw2pi9rlcnighbc-gnumake-4.4.1/bin
/nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37/bin
/nix/store/x0kaspzb5jqvgp357bj27z6iq24ximfg-patch-2.7.6/bin
/nix/store/98zamhd8d0jq3skqwz28dlgph94mrqir-xz-5.8.1-bin/bin
/nix/store/imhzyxqr7swq08ip81az5kfa07r07kg0-file-5.46/bin

# Check if environment variables set by the shell hook are present.
bash-5.2$ printenv LD_LIBRARY_PATH | tr ":" "\n"
/nix/store/7c0v0kbrrdc2cqgisi78jdqxn73n3401-gcc-14.2.1.20250322-lib/lib
```

Manually inspected the image with `dive` (`/nix/store` is collapsed).

![dive-test-nix-shell-image-rewrite](https://github.com/user-attachments/assets/32e33897-3dde-499a-87bc-4c8a3228cff4)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
