### PR TITLE
steam: Allow overriding privateTmp

### DIFF
--- a/pkgs/by-name/st/steam/package.nix
+++ b/pkgs/by-name/st/steam/package.nix
@@ -10,11 +10,12 @@
   extraBwrapArgs ? [ ], # extra arguments to pass to bubblewrap (real default is at usage site)
   extraArgs ? "", # arguments to always pass to steam
   extraEnv ? { }, # Environment variables to pass to Steam
+  privateTmp ? true, # if the steam bubblewrap should isolate /tmp
 }:
 let
   steamEnv = { name, runScript, passthru ? {}, meta ? {} }:
   buildFHSEnv {
-    inherit name runScript passthru meta;
+    inherit name runScript passthru meta privateTmp;
 
     multiArch = true;
     includeClosures = true;
@@ -104,8 +105,6 @@ let
 
       ${extraProfile}
     '';
-
-    privateTmp = true;
 
     inherit extraPreBwrapCmds;
 


### PR DESCRIPTION
Some programs use /tmp to communicate, and steam having a private tmp causes issues with that. Allow disabling privateTmp in an override.

Things that rely on /tmp:
  - PROTON_DUMP_DEBUG_COMMANDS dumps files to /tmp, where they can't be retrieved because steam-run gets a different /tmp
  - I'm not sure why this is, but in my testing, running tasklist through proton + cmd.exe would only show running steam games when privateTmp was false. I wanted this to get the windows pid of a steam game for attaching to it with Textractor.
  - Communication between teamspeak/arma 3 as reported in https://github.com/NixOS/nixpkgs/issues/381923


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
