### PR TITLE
emacs: support and enable __structuredAttrs in elisp build helpers

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -198,6 +198,9 @@
 
 - `pkgs.nextcloud28` has been removed since it's out of support upstream.
 
+- Emacs lisp build helpers, such as `emacs.pkgs.melpaBuild`, now enables `__structuredAttrs` by default.
+  Environment variables have to be passed via the `env` attribute.
+
 - `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
 
   Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.

--- a/pkgs/applications/editors/emacs/build-support/elpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/elpa.nix
@@ -43,7 +43,9 @@ lib.extendMkDerivation {
 
           emacs --batch -Q -l "$elpa2nix" \
               -f elpa2nix-install-package \
-              "$src" "$out/share/emacs/site-lisp/elpa"
+              "$src" "$out/share/emacs/site-lisp/elpa" \
+              ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"} \
+              ${if finalAttrs.ignoreCompilationError then "t" else "nil"}
 
           runHook postInstall
         '';

--- a/pkgs/applications/editors/emacs/build-support/elpa2nix.el
+++ b/pkgs/applications/editors/emacs/build-support/elpa2nix.el
@@ -5,8 +5,10 @@
   (if (not noninteractive)
       (error "`elpa2nix-install-package' is to be used only with -batch"))
   (pcase command-line-args-left
-    (`(,archive ,elpa)
-     (progn (setq package-user-dir elpa)
+    (`(,archive ,elpa ,turn-compilation-warning-to-error ,ignore-compilation-error)
+     (progn (setq byte-compile-error-on-warn (string= turn-compilation-warning-to-error "t"))
+            (setq byte-compile-debug (string= ignore-compilation-error "nil"))
+            (setq package-user-dir elpa)
             (elpa2nix-install-file archive)))))
 
 (defun elpa2nix-install-from-buffer ()
@@ -31,13 +33,3 @@ The file can either be a tar file or an Emacs Lisp file."
 
 ;; Allow installing package tarfiles larger than 10MB
 (setq large-file-warning-threshold nil)
-
-(let ((flag (getenv "turnCompilationWarningToError")))
-  (when (and flag
-             ;; we do not use `string-empty-p' because it requires subr-x in Emacs <= 26
-             (not (string= flag "")))
-    (setq byte-compile-error-on-warn t)))
-
-(let ((flag (getenv "ignoreCompilationError")))
-  (when (string= flag "")
-    (setq byte-compile-debug t)))

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -61,6 +61,7 @@ lib.extendMkDerivation {
       propagatedUserEnvPkgs = finalAttrs.packageRequires ++ propagatedUserEnvPkgs;
 
       strictDeps = args.strictDeps or true;
+      __structuredAttrs = args.__structuredAttrs or true;
 
       inherit turnCompilationWarningToError ignoreCompilationError;
 

--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -185,7 +185,9 @@ lib.extendMkDerivation {
           emacs --batch -Q \
               -l "$elpa2nix" \
               -f elpa2nix-install-package \
-              "$archive" "$out/share/emacs/site-lisp/elpa"
+              "$archive" "$out/share/emacs/site-lisp/elpa" \
+              ${if finalAttrs.turnCompilationWarningToError then "t" else "nil"} \
+              ${if finalAttrs.ignoreCompilationError then "t" else "nil"}
 
           runHook postInstall
         '';

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -153,8 +153,10 @@ let
         # https://github.com/Golevka/emacs-clang-complete-async/issues/90
         auto-complete-clang-async = (addPackageRequires super.auto-complete-clang-async [ self.auto-complete ]).overrideAttrs (old: {
           buildInputs = old.buildInputs ++ [ pkgs.llvmPackages.llvm ];
-          CFLAGS = "-I${lib.getLib pkgs.llvmPackages.libclang}/include";
-          LDFLAGS = "-L${lib.getLib pkgs.llvmPackages.libclang}/lib";
+          env = old.env or { } // {
+            CFLAGS = "-I${lib.getLib pkgs.llvmPackages.libclang}/include";
+            LDFLAGS = "-L${lib.getLib pkgs.llvmPackages.libclang}/lib";
+          };
         });
 
         # part of a larger package
@@ -242,7 +244,7 @@ let
           #   - https://github.com/vedang/pdf-tools/issues/102
           #   - https://github.com/vedang/pdf-tools/issues/103
           #   - https://github.com/vedang/pdf-tools/issues/109
-          CXXFLAGS = "-std=c++17";
+          env = old.env or { } // { CXXFLAGS = "-std=c++17"; };
 
           nativeBuildInputs = old.nativeBuildInputs ++ [
             pkgs.autoconf

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -294,7 +294,7 @@ let
 
         irony = super.irony.overrideAttrs (old: {
           cmakeFlags = old.cmakeFlags or [ ] ++ [ "-DCMAKE_INSTALL_BINDIR=bin" ];
-          env.NIX_CFLAGS_COMPILE = "-UCLANG_RESOURCE_DIR";
+          env = old.env or { } // { NIX_CFLAGS_COMPILE = "-UCLANG_RESOURCE_DIR"; };
           preConfigure = ''
             pushd server
           '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A step towards https://github.com/NixOS/nixpkgs/issues/205690.

This PR does not cause new elisp build failures.

FYI, [this](https://nixos.mayflower.consulting/blog/2020/01/20/structured-attrs/) is the motivation of `__structuredAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
