### PR TITLE
deno: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/by-name/de/deno/librusty_v8.nix
+++ b/pkgs/by-name/de/deno/librusty_v8.nix
@@ -2,11 +2,11 @@
 { fetchLibrustyV8 }:
 
 fetchLibrustyV8 {
-  version = "134.4.0";
+  version = "134.5.0";
   shas = {
-    x86_64-linux = "sha256-yG9p8b0dQTtoa234eTRBumjQ5GWxWJFsKHbgNFCUUAA=";
-    aarch64-linux = "sha256-5IrviupPjTUHTeuwmeA3FHuOy2H8qc05WNqRmlE0UJk=";
-    x86_64-darwin = "sha256-RPEW5a51WjfYyPjvkKvFbs+fPTlsv9/2sFtqUdtz7EY=";
-    aarch64-darwin = "sha256-PFyJTOYHWw3YOoG85w+y0899vc0+psz0TtCMXORcsHI=";
+    x86_64-linux = "sha256-Mo7PJoU/GuEIPCIDeLshfwNoYpkpD5NilOljFRgjLgw=";
+    aarch64-linux = "sha256-h51n1SosveRhKlq47pnOMUMi5Avg23GLdMW24mj//PU=";
+    x86_64-darwin = "sha256-76AP6aLuPmf6wC3yrfI/dkomOAjqVJjJPkUQxjAgDhI=";
+    aarch64-darwin = "sha256-IpiLBL51Q06t402bwE8bFQew5dPuHBNvkFC8gsWXvsY=";
   };
 }

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -20,21 +20,21 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
     tag = "v${version}";
-    hash = "sha256-ogvrDDwiMmsTRRpXwlH5VWhtnrSkRZErfjj2lhirALQ=";
+    hash = "sha256-eYzDCQVjilm6Olc9Ko+EYlSCNN7UVl/YXuK55xeoOOg=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-eaB6e6DGWbQKVR+huHBUbXGjzrY/4xGYdu8tXp+6jBM=";
+  cargoHash = "sha256-Hmxz4bryk6wMbccaXcKg8XuD9H9BF+nuvMkiCNeYMXY=";
 
   postPatch = ''
     # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857
-    substituteInPlace ext/ffi/Cargo.toml --replace-fail "libffi = \"=3.2.0\"" "libffi = { version = \"3.2.0\", features = [\"system\"] }"
+    substituteInPlace Cargo.toml --replace-fail "libffi = \"=3.2.0\"" "libffi = { version = \"3.2.0\", features = [\"system\"] }"
   '';
 
   # uses zlib-ng but can't dynamically link yet


### PR DESCRIPTION
Marking as draft until https://github.com/NixOS/nixpkgs/pull/383902 reaches `master` because `deno_core` requires the 2024 Rust edition:

```
deno> Caused by:
deno>   failed to parse manifest at `/private/tmp/nix-build-deno-2.2.3.drv-0/deno-2.2.3-vendor/deno_core-0.340.0/Cargo.toml`
deno> 
deno> Caused by:
deno>   feature `edition2024` is required
deno> 
deno>   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.0 (66221abde 2024-11-19)).
deno>   Consider trying a more recent nightly release.
deno>   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
