### PR TITLE
electron_32-bin,  electron-chromedriver_32: 32.3.2 -> 32.3.3

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -67,14 +67,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "f644ac51590a5d2e16318aca9a2ad70f9b5c45cc2edf2524b33d15dd0add4193",
-            "aarch64-linux": "5223d8bb21aac0a55dd09587773d93b0ca4c8c4161ac56158d93199973c8200c",
-            "armv7l-linux": "153a37e43175064539c63550fee2104fc21b95279daaf8fc38dd617dbfcd2c52",
-            "headers": "1sdvj3a05yrvy3b8bgzn8b2diz2ivlh4jsvhcffid0wbb17in2xj",
-            "x86_64-darwin": "e85b8ca35d0710087c2915f5dab07828733b2a1aaad04ae4907f0754346a09c6",
-            "x86_64-linux": "6afd83962ecbfbad19fe06d101ae00ee0662f4612c70620deb61cf6fac5b8118"
+            "aarch64-darwin": "67e5f8ce2c395b6b5a4c896ee1f2558b0003d0a54a7f4aef3b7760409ffc5825",
+            "aarch64-linux": "6b18f435855284852be2b2c1b49e58df380a56784d78b358a13ea77bbace4a8a",
+            "armv7l-linux": "a067329d55cc6648e9f783fd8b01b93da45ac21892b8096d758b30a87505c1a7",
+            "headers": "0pb06wlx5zz0asrh05c90q0np14c4swkvhzrcqmcyfz7ihczqh5a",
+            "x86_64-darwin": "0499216feffc2ba56438d8c4ac89cf40117baee6335099f5b12457d339f465a6",
+            "x86_64-linux": "0e1f1540492e48e3b8805f87c5096c3b99995c4c1b581ee57e9c836538bae813"
         },
-        "version": "32.3.2"
+        "version": "32.3.3"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "50ffb73f7ac2705dc1500977dfe391f21895eefdb1eac642786ff9e3904f667e",
-            "aarch64-linux": "780c79bd0f96498c8934262c56b105c53ced1fe7a6b442d1c32bcf2737bc8782",
-            "armv7l-linux": "11aefc9f15b62c7102824927aa34ce07c479de9102212d00e96ff2f5ac268d89",
-            "headers": "1sdvj3a05yrvy3b8bgzn8b2diz2ivlh4jsvhcffid0wbb17in2xj",
-            "x86_64-darwin": "305ed9ef27305e8ee7a851e6ca169de360ee607497b5577174c67cfe4836f9ad",
-            "x86_64-linux": "27d0c689b9a8564220adae3aea2a6f42411c986795f779a729fe90aed93fee61"
+            "aarch64-darwin": "a5fd8e33f01833f567655900e9685ca7141be4a83ed05bbcb2f5b4e6af1c7c91",
+            "aarch64-linux": "2535230e99cf356285c19af32586940e3416c22546bea0b38d71e6dd2579fa8f",
+            "armv7l-linux": "bda58c490006c5df0e5a87038e38943ec2e8e222496bfb1ac590f4732e5ffcf6",
+            "headers": "0pb06wlx5zz0asrh05c90q0np14c4swkvhzrcqmcyfz7ihczqh5a",
+            "x86_64-darwin": "9fa0bb73f1c9d1c011f35c664beb3cdd06def063d4a72a581663776e5808579b",
+            "x86_64-linux": "adfb974ccb29edc2365b244e3c4d06dae6a0bd4f5cf280ff62271959a8aad10e"
         },
-        "version": "32.3.2"
+        "version": "32.3.3"
     },
     "33": {
         "hashes": {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Last security update for `electron_32`, it's now EOL.
https://github.com/electron/electron/releases/tag/v32.3.3

I'm only updating the `bin` variant of `electron_32`, because the `source` variant will soon be dropped, see #383660.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
