### PR TITLE
sqruff: 0.20.2 → 0.25.28

### DIFF
--- a/pkgs/by-name/sq/sqruff/disable-templaters-test.diff
+++ b/pkgs/by-name/sq/sqruff/disable-templaters-test.diff
@@ -1,0 +1,15 @@
+diff --git a/crates/lib/tests/templaters.rs b/crates/lib/tests/templaters.rs
+index f92604e1..84885f9f 100644
+--- a/crates/lib/tests/templaters.rs
++++ b/crates/lib/tests/templaters.rs
+@@ -32,6 +32,10 @@ impl Args {
+     }
+ }
+ 
++#[cfg(not(feature = "python"))]
++fn main() {}
++
++#[cfg(feature = "python")]
+ // FIXME: Simplify FluffConfig handling. It's quite chaotic right now.
+ fn main() {
+     let mut args = Args::default();

--- a/pkgs/by-name/sq/sqruff/disable-ui_with_dbt-test.diff
+++ b/pkgs/by-name/sq/sqruff/disable-ui_with_dbt-test.diff
@@ -1,0 +1,15 @@
+diff --git a/crates/cli/tests/ui_with_dbt.rs b/crates/cli/tests/ui_with_dbt.rs
+index d71a26c1..4d4ffe4f 100644
+--- a/crates/cli/tests/ui_with_dbt.rs
++++ b/crates/cli/tests/ui_with_dbt.rs
+@@ -3,6 +3,10 @@ use std::path::PathBuf;
+ use assert_cmd::Command;
+ use expect_test::expect_file;
+ 
++#[cfg(not(feature = "python"))]
++fn main() {}
++
++#[cfg(feature = "python")]
+ fn main() {
+     let sample_dbt_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+         .parent()

--- a/pkgs/by-name/sq/sqruff/disable-ui_with_jinja-test.diff
+++ b/pkgs/by-name/sq/sqruff/disable-ui_with_jinja-test.diff
@@ -1,0 +1,15 @@
+diff --git a/crates/cli/tests/ui_with_jinja.rs b/crates/cli/tests/ui_with_jinja.rs
+index 7c39f8a1..e4c96d41 100644
+--- a/crates/cli/tests/ui_with_jinja.rs
++++ b/crates/cli/tests/ui_with_jinja.rs
+@@ -4,6 +4,10 @@ use std::path::PathBuf;
+ use assert_cmd::Command;
+ use expect_test::expect_file;
+ 
++#[cfg(not(feature = "python"))]
++fn main() {}
++
++#[cfg(feature = "python")]
+ fn main() {
+     let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+     test_dir.push("tests/jinja");

--- a/pkgs/by-name/sq/sqruff/disable-ui_with_python-test.diff
+++ b/pkgs/by-name/sq/sqruff/disable-ui_with_python-test.diff
@@ -1,0 +1,15 @@
+diff --git a/crates/cli/tests/ui_with_python.rs b/crates/cli/tests/ui_with_python.rs
+index 826f399c..0fa5ae33 100644
+--- a/crates/cli/tests/ui_with_python.rs
++++ b/crates/cli/tests/ui_with_python.rs
+@@ -4,6 +4,10 @@ use std::path::PathBuf;
+ use assert_cmd::Command;
+ use expect_test::expect_file;
+ 
++#[cfg(not(feature = "python"))]
++fn main() {}
++
++#[cfg(feature = "python")]
+ fn main() {
+     let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+     test_dir.push("tests/python");


### PR DESCRIPTION
I've had to disable the `python` compiler feature because I couldn't get it working with Nix yet. I've also had to disable some integration tests with patches because they didn't work without the `python` feature, if someone knows a better way to do that then let me know.

Changelogs for
- [v0.21.0](https://github.com/quarylabs/sqruff/releases/tag/v0.21.0)
- [v0.22.0](https://github.com/quarylabs/sqruff/releases/tag/v0.22.0)
- [v0.23.0](https://github.com/quarylabs/sqruff/releases/tag/v0.23.0)
- [v0.24.0](https://github.com/quarylabs/sqruff/releases/tag/v0.24.0)
- [v0.25.0](https://github.com/quarylabs/sqruff/releases/tag/v0.25.0)
- [v0.25.10](https://github.com/quarylabs/sqruff/releases/tag/v0.25.10)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've run the binary on some simple SQL files/
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
