### PR TITLE
nixos-rebuild-ng: only propagate nix's `bin` output

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -50,7 +50,7 @@ python3Packages.buildPythonApplication rec {
     # would silently downgrade the whole system to be i686 NixOS on the
     # next reboot.
     # The binary will be included in the wrapper for Python.
-    nix
+    (lib.getBin nix)
   ];
 
   postPatch = ''


### PR DESCRIPTION
Prior to this the `dev` output was also propagated, when it's not
actually used

```console
$ nix-store --query --references /nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0
/nix/store/11ciq72n4fdv8rw6wgjgasfv4mjs1jrw-bash-5.2p37
/nix/store/26yi95240650jxp5dj78xzch70i1kzlz-python3-3.12.9
/nix/store/xxh7mivp64xmzyw5wir2c2xbhy6cjzjd-nix-2.24.12
/nix/store/8jai5cxdfzgj9nsz4i26fh9sx5zsgilz-nix-2.24.12-dev
/nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0
```

```console
$ nix why-depends --all --precise /nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0 /nix/store/8jai5cxdfzgj9nsz4i26fh9sx5zsgilz-nix-2.24.12-dev
/nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0
└───nix-support/propagated-build-inputs: …/nix/store/8jai5cxdfzgj9nsz4i26fh9sx5zsgilz-nix-2.24.12-dev /nix/store/26yi…
    → /nix/store/8jai5cxdfzgj9nsz4i26fh9sx5zsgilz-nix-2.24.12-dev
```

```console
$ nvd diff /nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0 /nix/store/fqm81bhggzkqh7033np2z0jr8c0qrpbw-nixos-rebuild-ng-0.0.0
<<< /nix/store/ppw0flx4dbksxsnr84hq1gz4k0s0hpcq-nixos-rebuild-ng-0.0.0
>>> /nix/store/fqm81bhggzkqh7033np2z0jr8c0qrpbw-nixos-rebuild-ng-0.0.0
Version changes:
[C.]  #1  boehm-gc  8.2.8, 8.2.8-dev -> 8.2.8
[C*]  #2  nix       2.24.12, 2.24.12-dev, 2.24.12-man -> 2.24.12, 2.24.12-man
Removed packages:
[R.]  #1  nlohmann_json  3.11.3
Closure size: 66 -> 63 (1 paths added, 4 paths removed, delta -3, disk usage -1.9MiB).
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
