### PR TITLE
chatgpt: 1.2025.014 -> 1.2025.057

### DIFF
--- a/pkgs/by-name/ch/chatgpt/source.nix
+++ b/pkgs/by-name/ch/chatgpt/source.nix
@@ -1,7 +1,7 @@
 {
-  version = "1.2025.014";
+  version = "1.2025.057";
   src = {
-    url = "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2025.014_1737150122.dmg";
-    hash = "sha256-NxCkrsPaptYNTZ+urkJqYeC4a0nGaEOFO/7SQL1Jmpc=";
+    url = "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2025.057_1741115522.dmg";
+    hash = "sha256-aVPBYPr1tMRBEvKgooVIzgiqClCIN8tWERjIcgP0UUk=";
   };
 }

--- a/pkgs/by-name/ch/chatgpt/update.sh
+++ b/pkgs/by-name/ch/chatgpt/update.sh
@@ -10,10 +10,13 @@ DOWNLOAD_URL=$(echo "$XML_DATA" | xmllint --xpath 'string(//item[1]/enclosure/@u
 
 HASH=$(nix-prefetch-url $DOWNLOAD_URL | xargs nix hash convert --hash-algo sha256)
 
-cat > source.nix << _EOF_
+NIXPKGS_CHATGPT_PATH="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
+SOURCE_NIX="${NIXPKGS_CHATGPT_PATH}"/source.nix
+
+cat > "${SOURCE_NIX}" << _EOF_
 {
   version = "$LATEST_VERSION";
-  src = fetchurl {
+  src = {
     url = "$DOWNLOAD_URL";
     sha256 = "$HASH";
   };

--- a/pkgs/by-name/ch/chatgpt/update.sh
+++ b/pkgs/by-name/ch/chatgpt/update.sh
@@ -10,15 +10,14 @@ DOWNLOAD_URL=$(echo "$XML_DATA" | xmllint --xpath 'string(//item[1]/enclosure/@u
 
 HASH=$(nix-prefetch-url $DOWNLOAD_URL | xargs nix hash convert --hash-algo sha256)
 
-NIXPKGS_CHATGPT_PATH="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
-SOURCE_NIX="${NIXPKGS_CHATGPT_PATH}"/source.nix
+SOURCE_NIX="$(dirname ${BASH_SOURCE[0]})/source.nix"
 
 cat > "${SOURCE_NIX}" << _EOF_
 {
   version = "$LATEST_VERSION";
   src = {
     url = "$DOWNLOAD_URL";
-    sha256 = "$HASH";
+    hash = "$HASH";
   };
 }
 _EOF_


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates chatgpt package to 1.2025.057 and fixes update script.

changelog: https://help.openai.com/en/articles/9703738-macos-app-release-notes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
