### PR TITLE
stunner: init at 0.0.8

### DIFF
--- a/pkgs/by-name/st/stunner/package.nix
+++ b/pkgs/by-name/st/stunner/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+let
+  version = "0.0.8";
+in
+buildGoModule {
+  pname = "stunner";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "jaxxstorm";
+    repo = "stunner";
+    tag = "v${version}";
+    hash = "sha256-jZNM58aP2hBfuAIFjSCwdBkCbDA5KDTlZV8AkoWnhD4=";
+  };
+
+  vendorHash = "sha256-arWRaTqaN6Ji6MjTZdp8J7bs6NjbdY7YkueKMBdAAts=";
+
+  ldflags = [
+    "-X=main.Version=${version}"
+  ];
+
+  meta = {
+    description = "Detect your NAT quickly and easily, and that's the bottom line";
+    longDescription = ''
+      Stunner is a small Go CLI tool that sends STUN Binding Requests to
+      multiple Tailscale DERP servers (or any STUN servers you specify) and
+      reports the resulting NAT classification. This helps you determine
+      whether you're behind a Full Cone, Symmetric NAT, Restricted, or
+      otherwise, by analyzing how multiple STUN servers perceive your external
+      IP/port mapping.
+    '';
+    homepage = "https://github.com/jaxxstorm/stunner";
+    changelog = "https://github.com/jaxxstorm/stunner/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jk ];
+    mainProgram = "stunner";
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
λ ./result/bin/stunner
================= STUN Results =================
+----------------------------+-------+------------+---------+
|        STUN SERVER         | PORT  |     IP     | MAPPING |
+----------------------------+-------+------------+---------+
| derpXXX.tailscale.com:3478 | 57531 | XX.X.X.XXX | None    |
| derpXXX.tailscale.com:3478 | 57531 | XX.X.X.XXX | None    |
+----------------------------+-------+------------+---------+
================= NAT Type Detection =================
+--------+------------------------------+-----------+--------------------------------+-------------------------+
| RESULT |           NAT TYPE           | EASY/HARD |             DETAIL             | DIRECT CONNECTIONS WITH |
+--------+------------------------------+-----------+--------------------------------+-------------------------+
| Final  | Endpoint-Independent Mapping | Easy      | Reuses the same public port    | No NAT, Easy NAT        |
|        |                              |           | for all remote connections,    |                         |
|        |                              |           | enabling inbound hole punching |                         |
|        |                              |           | from any peer once an outbound |                         |
|        |                              |           | packet is sent.                |                         |
+--------+------------------------------+-----------+--------------------------------+-------------------------+
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
