### PR TITLE
lib/types: check paths in pathWith with hasStorePathPrefix

### DIFF
--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -165,7 +165,7 @@ let
     # This is a workaround for https://github.com/NixOS/nix/issues/12361 which
     # was needed during the experimental phase of ca-derivations and should be
     # removed once the issue has been resolved.
-    || match "[0-9a-z]{52}" (head components) != null;
+    || components != [ ] && match "[0-9a-z]{52}" (head components) != null;
 
 in
 # No rec! Add dependencies on this file at the top.

--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -110,6 +110,12 @@ let
       expected = false;
     };
 
+    # Root path (empty path components list)
+    testHasStorePathPrefixRoot = {
+      expr = hasStorePathPrefix /.;
+      expected = false;
+    };
+
     testHasStorePathPrefixExample1 = {
       expr = hasStorePathPrefix (storeDirPath + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo/bar/baz");
       expected = true;

--- a/lib/tests/modules/pathWith.nix
+++ b/lib/tests/modules/pathWith.nix
@@ -58,6 +58,9 @@ in
   pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
   pathInStore.ok2 = "${storeDir}/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15";
   pathInStore.ok3 = "${storeDir}/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15/bin/bash";
+  pathInStore.ok4 = "/1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab"; # CA derivation
+  pathInStore.ok5 = "/1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab/bin/bash"; # CA derivation
+  pathInStore.ok6 = /1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab; # CA derivation, path type
   pathInStore.bad1 = "";
   pathInStore.bad2 = "${storeDir}";
   pathInStore.bad3 = "${storeDir}/";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -669,7 +669,14 @@ let
             check =
               x:
               let
-                isInStore = builtins.match "${builtins.storeDir}/[^.].*" (toString x) != null;
+                isInStore = lib.path.hasStorePathPrefix (
+                  if builtins.isPath x then
+                    x
+                  # Discarding string context is necessary to convert the value to
+                  # a path and safe as the result is never used in any derivation.
+                  else
+                    /. + builtins.unsafeDiscardStringContext x
+                );
                 isAbsolute = builtins.substring 0 1 (toString x) == "/";
                 isExpectedType = (
                   if inStore == null || inStore then isStringLike x else isString x # Do not allow a true path, which could be copied to the store later on.


### PR DESCRIPTION
This permits usage of content‐addressed derivations and has the added benefit of checking normalised paths.

We could as an alternative introduce a function to check if a string is a store path _prefix_ that works directly on strings, without producing a temporary path.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
