### PR TITLE
SDL_compat: patch sdl-config to use setup-hook

### DIFF
--- a/pkgs/by-name/sd/SDL_compat/find-headers.patch
+++ b/pkgs/by-name/sd/SDL_compat/find-headers.patch
@@ -1,0 +1,26 @@
+diff --git a/sdl-config.in b/sdl-config.in
+index ce332b3..359d574 100755
+--- a/sdl-config.in
++++ b/sdl-config.in
+@@ -50,14 +50,18 @@ while test $# -gt 0; do
+       echo @PROJECT_VERSION@
+       ;;
+     --cflags)
+-      echo -I${includedir}/SDL @SDL_CFLAGS@
++      SDL_CFLAGS=""
++      for i in @includedir@/SDL $SDL_PATH; do
++        SDL_CFLAGS="$SDL_CFLAGS -I$i"
++      done
++      echo $SDL_CFLAGS @SDL_CFLAGS@
+       ;;
+ @ENABLE_SHARED_TRUE@    --libs)
+-@ENABLE_SHARED_TRUE@      echo -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@
++@ENABLE_SHARED_TRUE@      echo -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@ $SDL_LIB_PATH
+ @ENABLE_SHARED_TRUE@      ;;
+ @ENABLE_STATIC_TRUE@@ENABLE_SHARED_TRUE@    --static-libs)
+ @ENABLE_STATIC_TRUE@@ENABLE_SHARED_FALSE@    --libs|--static-libs)
+-@ENABLE_STATIC_TRUE@      echo -L${libdir} @SDL_LIBS@ @SDL_STATIC_LIBS@
++@ENABLE_STATIC_TRUE@      echo -L${libdir} @SDL_LIBS@ @SDL_STATIC_LIBS@ $SDL_LIB_PATH
+ @ENABLE_STATIC_TRUE@      ;;
+     *)
+       echo "${usage}" 1>&2

--- a/pkgs/by-name/sd/SDL_compat/package.nix
+++ b/pkgs/by-name/sd/SDL_compat/package.nix
@@ -48,13 +48,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  setupHook = ./setup-hook.sh;
-
   postInstall = ''
     # allow as a drop in replacement for SDL
     # Can be removed after treewide switch from pkg-config to pkgconf
     ln -s $out/lib/pkgconfig/sdl12_compat.pc $out/lib/pkgconfig/sdl.pc
   '';
+
+  # The setup hook scans paths of buildInputs to find SDL related packages and
+  # adds their include and library paths to environment variables. The sdl-config
+  # is patched to use these variables to produce correct flags for compiler.
+  patches = [ ./find-headers.patch ];
+  setupHook = ./setup-hook.sh;
 
   postFixup = ''
     for lib in $out/lib/*${stdenv.hostPlatform.extensions.sharedLibrary}* ; do

--- a/pkgs/games/rott/default.nix
+++ b/pkgs/games/rott/default.nix
@@ -44,12 +44,6 @@ stdenv.mkDerivation rec {
     "SHAREWARE=${if buildShareware then "1" else "0"}"
   ];
 
-  # when using SDL_compat instead of SDL1, SDL_mixer isn't correctly detected,
-  # but there is no harm just specifying it
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${lib.getDev SDL_mixer}/include/SDL"
-  ];
-
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
The setup hook creating SDL_PATH variable was copied from the SDL1, however, the necessary patch to `sdl-config.in` was not adapted making the hook useless.

This will allow to use the SDL_compat as SDL replacement without manual hacks like this:
https://github.com/NixOS/nixpkgs/blob/d223cfb7425424a17207bd6255fbb3690be5129d/pkgs/games/rott/default.nix#L47-L51


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
