### PR TITLE
tsm-client: 8.1.25.0 -> 8.1.27.0, drop old migration code

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -71,7 +71,7 @@ let
     {
       freeformType = attrsOf (either scalarType (listOf scalarType));
       # Client system-options file directives are explained here:
-      # https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=commands-processing-options
+      # https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=commands-processing-options
       options.servername = mkOption {
         type = servernameType;
         default = name;

--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -1,13 +1,9 @@
 {
   config,
   lib,
-  options,
   pkgs,
   ...
-}: # XXX migration code for freeform settings: `options` can be removed in 2025
-let
-  optionsGlobal = options;
-in
+}:
 
 let
 
@@ -150,27 +146,6 @@ let
       };
       config.commmethod = mkDefault "v6tcpip"; # uses v4 or v6, based on dns lookup result
       config.passwordaccess = if config.genPasswd then "generate" else "prompt";
-      # XXX migration code for freeform settings, these can be removed in 2025:
-      options.warnings = optionsGlobal.warnings;
-      options.assertions = optionsGlobal.assertions;
-      imports =
-        let
-          inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule;
-        in
-        [
-          (mkRemovedOptionModule [ "extraConfig" ]
-            "Please just add options directly to the server attribute set, cf. the description of `programs.tsmClient.servers`."
-          )
-          (mkRemovedOptionModule [ "text" ]
-            "Please just add options directly to the server attribute set, cf. the description of `programs.tsmClient.servers`."
-          )
-          (mkRenamedOptionModule [ "name" ] [ "servername" ])
-          (mkRenamedOptionModule [ "server" ] [ "tcpserveraddress" ])
-          (mkRenamedOptionModule [ "port" ] [ "tcpport" ])
-          (mkRenamedOptionModule [ "node" ] [ "nodename" ])
-          (mkRenamedOptionModule [ "passwdDir" ] [ "passworddir" ])
-          (mkRenamedOptionModule [ "includeExclude" ] [ "inclexcl" ])
-        ];
     };
 
   options.programs.tsmClient = {
@@ -291,16 +266,7 @@ let
         contain duplicate names
         (note that setting names are case insensitive).
       '';
-    }) cfg.servers)
-    # XXX migration code for freeform settings, this can be removed in 2025:
-    ++ (enrichMigrationInfos "assertions" (
-      addText:
-      { assertion, message }:
-      {
-        inherit assertion;
-        message = addText message;
-      }
-    ));
+    }) cfg.servers);
 
   makeDsmSysLines =
     key: value:
@@ -340,17 +306,6 @@ let
       attrs = removeAttrs serverCfg [
         "servername"
         "genPasswd"
-        # XXX migration code for freeform settings, these can be removed in 2025:
-        "assertions"
-        "warnings"
-        "extraConfig"
-        "text"
-        "name"
-        "server"
-        "port"
-        "node"
-        "passwdDir"
-        "includeExclude"
       ];
     in
     ''
@@ -369,16 +324,6 @@ let
     ${concatLines (map makeDsmSysStanza (attrValues cfg.servers))}
   '';
 
-  # XXX migration code for freeform settings, this can be removed in 2025:
-  enrichMigrationInfos =
-    what: how:
-    concatLists (
-      mapAttrsToList (
-        name: serverCfg:
-        map (how (text: "In `programs.tsmClient.servers.${name}`: ${text}")) serverCfg."${what}"
-      ) cfg.servers
-    );
-
 in
 
 {
@@ -393,8 +338,6 @@ in
       dsmSysApi = dsmSysCli;
     };
     environment.systemPackages = [ cfg.wrappedPackage ];
-    # XXX migration code for freeform settings, this can be removed in 2025:
-    warnings = enrichMigrationInfos "warnings" (addText: addText);
   };
 
   meta.maintainers = [ lib.maintainers.yarny ];

--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -71,7 +71,7 @@ let
     {
       freeformType = attrsOf (either scalarType (listOf scalarType));
       # Client system-options file directives are explained here:
-      # https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=commands-processing-options
+      # https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=commands-processing-options
       options.servername = mkOption {
         type = servernameType;
         default = name;

--- a/nixos/modules/services/backup/tsm.nix
+++ b/nixos/modules/services/backup/tsm.nix
@@ -89,7 +89,7 @@ in
       environment.HOME = "/var/lib/tsm-backup";
       serviceConfig = {
         # for exit status description see
-        # https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=clients-client-return-codes
+        # https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=clients-client-return-codes
         SuccessExitStatus = "4 8";
         # The `-se` option must come after the command.
         # The `-optfile` option suppresses a `dsm.opt`-not-found warning.

--- a/nixos/modules/services/backup/tsm.nix
+++ b/nixos/modules/services/backup/tsm.nix
@@ -89,7 +89,7 @@ in
       environment.HOME = "/var/lib/tsm-backup";
       serviceConfig = {
         # for exit status description see
-        # https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=clients-client-return-codes
+        # https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=clients-client-return-codes
         SuccessExitStatus = "4 8";
         # The `-se` option must come after the command.
         # The `-optfile` option suppresses a `dsm.opt`-not-found warning.

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -44,7 +44,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/storage-protect/8.1.25?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=solaris-set-api-environment-variables
 
 let
 
@@ -91,10 +91,10 @@ let
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     name = "tsm-client-${finalAttrs.version}-unwrapped";
-    version = "8.1.25.0";
+    version = "8.1.26.0";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
-      hash = "sha512-OPNjSMnWJ/8Ogy9O0wG0H4cEbYiOwyCVzkWhpG00v/Vm0LDxLzPteMnMOyH8L1egIDhy7lmQYSzI/EC4WWUDDA==";
+      hash = "sha512-Q4iPumiq2uI6TtbBK+0lUZZXp+yy/+LcjatGqJ0zwdkxgRcF4di52Z+O/8CYFPRqSxS+0AiJs6yDd27PbJsR1w==";
     };
     inherit meta passthru;
 

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -44,7 +44,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/storage-protect/8.1.26?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=solaris-set-api-environment-variables
 
 let
 
@@ -91,10 +91,10 @@ let
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     name = "tsm-client-${finalAttrs.version}-unwrapped";
-    version = "8.1.26.0";
+    version = "8.1.27.0";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
-      hash = "sha512-Q4iPumiq2uI6TtbBK+0lUZZXp+yy/+LcjatGqJ0zwdkxgRcF4di52Z+O/8CYFPRqSxS+0AiJs6yDd27PbJsR1w==";
+      hash = "sha512-nbQHoD7fUp4qBTgRJ6nHXF4PsZRTin7FGPi340jKc73O/9DCNb1JQG/gY+B2xzPM2g6agqWu/MX5J+Wt0nOEkA==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
*   `tsm-client` module: drop migration code that [got added in 2023 for freeform settings](https://github.com/NixOS/nixpkgs/pull/253428)
*   ~~`tsm-client-gui` vm test: [migrate to `runTest`](https://github.com/NixOS/nixpkgs/issues/386873)~~
    Edit 2025-05-29: Meanwhile [done in another pull request](https://github.com/NixOS/nixpkgs/pull/410569) and [already merged](https://github.com/NixOS/nixpkgs/pull/410569#event-17830837270), so the corresponding commit is now dropped from the pull request at hand.
*   Edit 2025-03-31: `tsm-client` package: update to newest version 8.1.26.0
*   Edit 2025-06-21: `tsm-client` package: update to newest version 8.1.27.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tries to rebuild 3000+ package and was therefore skipped.

Edit 2025-03-31 & Edit 2025-06-21: More:

- [x] Both test derivations (cli and gui) build/pass.
- [x] Successfully tested with a real tsm-server: uploaded some files for backup without errors/problems.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc