### PR TITLE
cups-pdf: misc improvements in package, module, vmtest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -343,7 +343,7 @@ in
   crabfit = handleTest ./crabfit.nix { };
   cri-o = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./cri-o.nix { };
   cryptpad = runTest ./cryptpad.nix;
-  cups-pdf = handleTest ./cups-pdf.nix { };
+  cups-pdf = runTest ./cups-pdf.nix;
   curl-impersonate = handleTest ./curl-impersonate.nix { };
   custom-ca = handleTest ./custom-ca.nix { };
   croc = handleTest ./croc.nix { };

--- a/nixos/tests/cups-pdf.nix
+++ b/nixos/tests/cups-pdf.nix
@@ -1,47 +1,45 @@
-import ./make-test-python.nix (
-  { lib, pkgs, ... }:
-  {
-    name = "cups-pdf";
+{ hostPkgs, lib, ... }:
+{
+  name = "cups-pdf";
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        imports = [ ./common/user-account.nix ];
-        environment.systemPackages = [ pkgs.poppler-utils ];
-        fonts.packages = [ pkgs.dejavu_fonts ]; # yields more OCR-able pdf
-        services.printing.cups-pdf.enable = true;
-        services.printing.cups-pdf.instances = {
-          opt = { };
-          noopt.installPrinter = false;
-        };
-        hardware.printers.ensurePrinters = [
-          {
-            name = "noopt";
-            model = "CUPS-PDF_noopt.ppd";
-            deviceUri = "cups-pdf:/noopt";
-          }
-        ];
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ./common/user-account.nix ];
+      environment.systemPackages = [ pkgs.poppler-utils ];
+      fonts.packages = [ pkgs.dejavu_fonts ]; # yields more OCR-able pdf
+      services.printing.cups-pdf.enable = true;
+      services.printing.cups-pdf.instances = {
+        opt = { };
+        noopt.installPrinter = false;
       };
+      hardware.printers.ensurePrinters = [
+        {
+          name = "noopt";
+          model = "CUPS-PDF_noopt.ppd";
+          deviceUri = "cups-pdf:/noopt";
+        }
+      ];
+    };
 
-    # we cannot check the files with pdftotext, due to
-    # https://github.com/alexivkin/CUPS-PDF-to-PDF/issues/7
-    # we need `imagemagickBig` as it has ghostscript support
+  # we cannot check the files with pdftotext, due to
+  # https://github.com/alexivkin/CUPS-PDF-to-PDF/issues/7
+  # we need `imagemagickBig` as it has ghostscript support
 
-    testScript = ''
-      from subprocess import run
-      machine.wait_for_unit("multi-user.target")
-      for name in ("opt", "noopt"):
-          text = f"test text {name}".upper()
-          machine.wait_until_succeeds(f"lpstat -v {name}")
-          machine.succeed(f"su - alice -c 'echo -e \"\n  {text}\" | lp -d {name}'")
-          # wait until the pdf files are completely produced and readable by alice
-          machine.wait_until_succeeds(f"su - alice -c 'pdfinfo /var/spool/cups-pdf-{name}/users/alice/*.pdf'")
-          machine.succeed(f"cp /var/spool/cups-pdf-{name}/users/alice/*.pdf /tmp/{name}.pdf")
-          machine.copy_from_vm(f"/tmp/{name}.pdf", "")
-          run(f"${pkgs.imagemagickBig}/bin/convert -density 300 $out/{name}.pdf $out/{name}.jpeg", shell=True, check=True)
-          assert text.encode() in run(f"${lib.getExe pkgs.tesseract} $out/{name}.jpeg stdout", shell=True, check=True, capture_output=True).stdout
-    '';
+  testScript = ''
+    from subprocess import run
+    machine.wait_for_unit("multi-user.target")
+    for name in ("opt", "noopt"):
+        text = f"test text {name}".upper()
+        machine.wait_until_succeeds(f"lpstat -v {name}")
+        machine.succeed(f"su - alice -c 'echo -e \"\n  {text}\" | lp -d {name}'")
+        # wait until the pdf files are completely produced and readable by alice
+        machine.wait_until_succeeds(f"su - alice -c 'pdfinfo /var/spool/cups-pdf-{name}/users/alice/*.pdf'")
+        machine.succeed(f"cp /var/spool/cups-pdf-{name}/users/alice/*.pdf /tmp/{name}.pdf")
+        machine.copy_from_vm(f"/tmp/{name}.pdf", "")
+        run(f"${hostPkgs.imagemagickBig}/bin/convert -density 300 $out/{name}.pdf $out/{name}.jpeg", shell=True, check=True)
+        assert text.encode() in run(f"${lib.getExe hostPkgs.tesseract} $out/{name}.jpeg stdout", shell=True, check=True, capture_output=True).stdout
+  '';
 
-    meta.maintainers = [ lib.maintainers.yarny ];
-  }
-)
+  meta.maintainers = [ lib.maintainers.yarny ];
+}

--- a/nixos/tests/cups-pdf.nix
+++ b/nixos/tests/cups-pdf.nix
@@ -37,7 +37,7 @@
         machine.wait_until_succeeds(f"su - alice -c 'pdfinfo /var/spool/cups-pdf-{name}/users/alice/*.pdf'")
         machine.succeed(f"cp /var/spool/cups-pdf-{name}/users/alice/*.pdf /tmp/{name}.pdf")
         machine.copy_from_vm(f"/tmp/{name}.pdf", "")
-        run(f"${hostPkgs.imagemagickBig}/bin/convert -density 300 $out/{name}.pdf $out/{name}.jpeg", shell=True, check=True)
+        run(f"${lib.getExe hostPkgs.imagemagickBig} -density 300 $out/{name}.pdf $out/{name}.jpeg", shell=True, check=True)
         assert text.encode() in run(f"${lib.getExe hostPkgs.tesseract} $out/{name}.jpeg stdout", shell=True, check=True, capture_output=True).stdout
   '';
 

--- a/pkgs/by-name/cu/cups-pdf-to-pdf/package.nix
+++ b/pkgs/by-name/cu/cups-pdf-to-pdf/package.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation {
   buildInputs = [ cups ];
 
   postPatch = ''
-    sed -r 's|(gscall, size, ")cp |\1${coreutils}/bin/cp |' cups-pdf.c -i
+    substituteInPlace cups-pdf.c \
+      --replace-fail '"cp ' '"${lib.getExe' coreutils "cp"} '
   '';
 
   # gcc command line is taken from original cups-pdf's README file

--- a/pkgs/by-name/cu/cups-pdf-to-pdf/package.nix
+++ b/pkgs/by-name/cu/cups-pdf-to-pdf/package.nix
@@ -45,11 +45,11 @@ stdenv.mkDerivation {
 
   passthru.tests.vmtest = nixosTests.cups-pdf;
 
-  meta = with lib; {
+  meta = {
     description = "CUPS backend that turns print jobs into searchable PDF files";
     homepage = "https://github.com/alexivkin/CUPS-PDF-to-PDF";
-    license = licenses.gpl2Only;
-    maintainers = [ maintainers.yarny ];
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.yarny ];
     longDescription = ''
       cups-pdf is a CUPS backend that generates a PDF file for each print job and puts this file
       into a folder on the local machine such that the print job's owner can access the file.


### PR DESCRIPTION
*   `cups-pdf-to-pdf` package: [remove `with lib;` from `meta`](https://github.com/NixOS/nixpkgs/issues/371862), drop unused `rec`, use `lib.getExe` and `substituteInPlace`
*   `cups-pdf` vm test: [migrate to `runTest`](https://github.com/NixOS/nixpkgs/issues/386873), use `lib.getExe'`, avoid deprecated `${pkgs.imageMagick}/bin/convert` program

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tries to rebuild 3000+ package and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc