### PR TITLE
freebsd.libsysinfo: init

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/libsysinfo.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libsysinfo.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  mkDerivation,
+  fetchurl,
+  fetchFromGitHub,
+}:
+let
+  pcFile = fetchurl {
+    url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/a613e66a54d54251878412b74c1e99defdac4192/devel/libsysinfo/files/libsysinfo.pc.in";
+    hash = "sha256-KeCOYLCYeoJm+AwaagygKve2f+jNaIfaO7c/UnMegAg=";
+  };
+in
+mkDerivation rec {
+  pname = "libsysinfo";
+  path = "...";
+  version = "0.0.3";
+  src = fetchFromGitHub {
+    owner = "bsdimp";
+    repo = "libsysinfo";
+    rev = "e535d95d1598932a0084a027402104d6e0276479";
+    hash = "sha256-HFgaYRR9HQM0iVJBWq1nrPGZIl/Y/5C0JJUunlzCZLI=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
+  env.NIX_LDFLAGS = "-lkvm";
+
+  # bash-sh syntax differences
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail 'then else' 'then :; else'
+    substituteInPlace Makefile --replace-fail 'mkdir' 'mkdir -p'
+  '';
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    substitute ${pcFile} $out/lib/pkgconfig/libsysinfo.pc \
+      --replace-fail '%%PREFIX%%' "$out" \
+      --replace-fail '%%COMMENT%%' "${meta.description}" \
+      --replace-fail '%%PORTVERSION%%' "${version}"
+
+    mkdir -p $out/include/sys
+    ln -s ../sysinfo.h $out/include/sys/sysinfo.h
+  '';
+
+  meta = {
+    description = "GNU libc's sysinfo port for FreeBSD";
+    homepage = "https://github.com/bsdimp/libsysinfo";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rhelmot ];
+    platforms = lib.platforms.freebsd;
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
