### PR TITLE
music-assistant: 2.3.6 -> 2.4.2

### DIFF
--- a/pkgs/by-name/mu/music-assistant/dont-install-deps.patch
+++ b/pkgs/by-name/mu/music-assistant/dont-install-deps.patch
@@ -1,8 +1,8 @@
 diff --git a/music_assistant/helpers/util.py b/music_assistant/helpers/util.py
-index b6e5f2b4..0edead16 100644
+index 8daf159d..af5a6f38 100644
 --- a/music_assistant/helpers/util.py
 +++ b/music_assistant/helpers/util.py
-@@ -424,29 +424,11 @@ async def load_provider_module(domain: str, requirements: list[str]) -> Provider
+@@ -429,30 +429,11 @@ async def load_provider_module(domain: str, requirements: list[str]) -> Provider
      def _get_provider_module(domain: str) -> ProviderModuleType:
          return importlib.import_module(f".{domain}", "music_assistant.providers")
  
@@ -29,7 +29,8 @@ index b6e5f2b4..0edead16 100644
 -    # try loading the provider again to be safe
 -    # this will fail if something else is wrong (as it should)
 -    return await asyncio.to_thread(_get_provider_module, domain)
-+        raise RuntimeError(f"Missing dependencies for provider {domain}")
- 
+-
++        raise RuntimeError(f"Missing dependencies for provider {domain}.")
  
  def create_tempfile():
+     """Return a (named) temporary file."""

--- a/pkgs/by-name/mu/music-assistant/ffmpeg.patch
+++ b/pkgs/by-name/mu/music-assistant/ffmpeg.patch
@@ -1,8 +1,8 @@
 diff --git a/music_assistant/helpers/audio.py b/music_assistant/helpers/audio.py
-index dad3c5db..d1398d66 100644
+index 482ab8e8..a02fc435 100644
 --- a/music_assistant/helpers/audio.py
 +++ b/music_assistant/helpers/audio.py
-@@ -74,7 +74,7 @@ async def crossfade_pcm_parts(
+@@ -80,7 +80,7 @@ async def crossfade_pcm_parts(
          await outfile.write(fade_out_part)
      args = [
          # generic args
@@ -11,7 +11,7 @@ index dad3c5db..d1398d66 100644
          "-hide_banner",
          "-loglevel",
          "quiet",
-@@ -135,7 +135,7 @@ async def strip_silence(
+@@ -141,7 +141,7 @@ async def strip_silence(
      reverse: bool = False,
  ) -> bytes:
      """Strip silence from begin or end of pcm audio using ffmpeg."""
@@ -20,16 +20,7 @@ index dad3c5db..d1398d66 100644
      args += [
          "-acodec",
          pcm_format.content_type.name.lower(),
-@@ -734,7 +734,7 @@ async def get_file_stream(
- async def check_audio_support() -> tuple[bool, bool, str]:
-     """Check if ffmpeg is present (with/without libsoxr support)."""
-     # check for FFmpeg presence
--    returncode, output = await check_output("ffmpeg", "-version")
-+    returncode, output = await check_output("@ffmpeg@", "-version")
-     ffmpeg_present = returncode == 0 and "FFmpeg" in output.decode()
- 
-     # use globals as in-memory cache
-@@ -789,7 +789,7 @@ async def get_silence(
+@@ -912,7 +912,7 @@ async def get_silence(
          return
      # use ffmpeg for all other encodings
      args = [
@@ -39,11 +30,11 @@ index dad3c5db..d1398d66 100644
          "-loglevel",
          "quiet",
 diff --git a/music_assistant/helpers/ffmpeg.py b/music_assistant/helpers/ffmpeg.py
-index 0405fc27..570f9157 100644
+index 7c1c8d83..501a7370 100644
 --- a/music_assistant/helpers/ffmpeg.py
 +++ b/music_assistant/helpers/ffmpeg.py
-@@ -213,7 +213,7 @@ def get_ffmpeg_args(  # noqa: PLR0915
- 
+@@ -218,7 +218,7 @@ def get_ffmpeg_args(
+         extra_args = []
      # generic args
      generic_args = [
 -        "ffmpeg",
@@ -51,11 +42,20 @@ index 0405fc27..570f9157 100644
          "-hide_banner",
          "-loglevel",
          loglevel,
+@@ -370,7 +370,7 @@ async def check_ffmpeg_version() -> None:
+     """Check if ffmpeg is present (with libsoxr support)."""
+     # check for FFmpeg presence
+     try:
+-        returncode, output = await check_output("ffmpeg", "-version")
++        returncode, output = await check_output("@ffmpeg@", "-version")
+     except FileNotFoundError:
+         raise AudioError(
+             "FFmpeg binary is missing from system. "
 diff --git a/music_assistant/helpers/tags.py b/music_assistant/helpers/tags.py
-index 55def74b..7c26e13d 100644
+index 06c8bcb5..a703aacd 100644
 --- a/music_assistant/helpers/tags.py
 +++ b/music_assistant/helpers/tags.py
-@@ -387,7 +387,7 @@ async def parse_tags(input_file: str, file_size: int | None = None) -> AudioTags
+@@ -438,7 +438,7 @@ def parse_tags(input_file: str, file_size: int | None = None) -> AudioTags:
      Input_file may be a (local) filename or URL accessible by ffmpeg.
      """
      args = (
@@ -64,7 +64,7 @@ index 55def74b..7c26e13d 100644
          "-hide_banner",
          "-loglevel",
          "fatal",
-@@ -448,7 +448,7 @@ async def get_embedded_image(input_file: str) -> bytes | None:
+@@ -553,7 +553,7 @@ async def get_embedded_image(input_file: str) -> bytes | None:
      Input_file may be a (local) filename or URL accessible by ffmpeg.
      """
      args = (

--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.9.16";
+  version = "2.11.11";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-bUtclj8GMq1JdC4tYNETl+l+TNF91y4yTANSpuOOm70=";
+    hash = "sha256-fPFszZfJjdc2KTQipeb2KVbIwWwL56bqFGba1LSJXuQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/music-assistant/librespot.patch
+++ b/pkgs/by-name/mu/music-assistant/librespot.patch
@@ -1,0 +1,29 @@
+diff --git a/music_assistant/providers/spotify/helpers.py b/music_assistant/providers/spotify/helpers.py
+index 8b6c4e78..20c2a269 100644
+--- a/music_assistant/providers/spotify/helpers.py
++++ b/music_assistant/providers/spotify/helpers.py
+@@ -11,23 +11,4 @@ from music_assistant.helpers.process import check_output
+ async def get_librespot_binary() -> str:
+     """Find the correct librespot binary belonging to the platform."""
+ 
+-    # ruff: noqa: SIM102
+-    async def check_librespot(librespot_path: str) -> str | None:
+-        try:
+-            returncode, output = await check_output(librespot_path, "--version")
+-            if returncode == 0 and b"librespot" in output:
+-                return librespot_path
+-        except OSError:
+-            return None
+-
+-    base_path = os.path.join(os.path.dirname(__file__), "bin")
+-    system = platform.system().lower().replace("darwin", "macos")
+-    architecture = platform.machine().lower()
+-
+-    if bridge_binary := await check_librespot(
+-        os.path.join(base_path, f"librespot-{system}-{architecture}")
+-    ):
+-        return bridge_binary
+-
+-    msg = f"Unable to locate Librespot for {system}/{architecture}"
+-    raise RuntimeError(msg)
++    return "@librespot@"

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -3,6 +3,7 @@
   python3,
   fetchFromGitHub,
   ffmpeg-headless,
+  librespot,
   nixosTests,
   replaceVars,
   providers ? [ ],
@@ -12,27 +13,16 @@ let
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
-      aiojellyfin = super.aiojellyfin.overridePythonAttrs (oldAttrs: rec {
-        version = "0.10.1";
-
-        src = fetchFromGitHub {
-          owner = "Jc2k";
-          repo = "aiojellyfin";
-          tag = "v${version}";
-          hash = "sha256-A+uvM1/7HntRMIdknfHr0TMGIjHk7BCwsZopXdVoEO8=";
-        };
-      });
-
       music-assistant-frontend = self.callPackage ./frontend.nix { };
 
       music-assistant-models = super.music-assistant-models.overridePythonAttrs (oldAttrs: rec {
-        version = "1.1.4";
+        version = "1.1.30";
 
         src = fetchFromGitHub {
           owner = "music-assistant";
           repo = "models";
           tag = version;
-          hash = "sha256-keig18o32X53q/QcoaPO0o9AT4XTEZ+dQ3L6u6BVkLU=";
+          hash = "sha256-ZLTRHarjVFAk+tYPkgLm192rE+C82vNzqs8PmJhGSeg=";
         };
 
         postPatch = ''
@@ -54,20 +44,23 @@ in
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.3.6";
+  version = "2.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-CSGpG1E4ou1TGz/S1mXFHyk49p7dStEwxUTB+xxfNEc=";
+    hash = "sha256-5FIIXIn4tEz6w/uAh6PGkU4tU+mz7Jpb3+bq1mRNr2Y=";
   };
 
   patches = [
     (replaceVars ./ffmpeg.patch {
       ffmpeg = "${lib.getBin ffmpeg-headless}/bin/ffmpeg";
       ffprobe = "${lib.getBin ffmpeg-headless}/bin/ffprobe";
+    })
+    (replaceVars ./librespot.patch {
+      librespot = lib.getExe librespot;
     })
 
     # Disable interactive dependency resolution, which clashes with the immutable Python environment
@@ -77,6 +70,8 @@ python.pkgs.buildPythonApplication rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "0.0.0" "${version}"
+
+    rm -rv music_assistant/providers/spotify/bin
   '';
 
   build-system = with python.pkgs; [
@@ -85,6 +80,7 @@ python.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "aiohttp"
+    "aiosqlite"
     "certifi"
     "colorlog"
     "cryptography"
@@ -123,8 +119,10 @@ python.pkgs.buildPythonApplication rec {
       memory-tempfile
       music-assistant-frontend
       music-assistant-models
+      mutagen
       orjson
       pillow
+      podcastparser
       python-slugify
       shortuuid
       unidecode
@@ -136,7 +134,6 @@ python.pkgs.buildPythonApplication rec {
   nativeCheckInputs =
     with python.pkgs;
     [
-      aiojellyfin
       pytest-aiohttp
       pytest-cov-stub
       pytest-timeout
@@ -144,7 +141,9 @@ python.pkgs.buildPythonApplication rec {
       syrupy
       pytest-timeout
     ]
-    ++ lib.flatten (lib.attrValues optional-dependencies);
+    ++ lib.flatten (lib.attrValues optional-dependencies)
+    ++ (providerPackages.jellyfin python.pkgs)
+    ++ (providerPackages.opensubsonic python.pkgs);
 
   pytestFlagsArray = [
     # blocks in poll()

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,12 +1,20 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.3.6";
+  version = "2.4.2";
   providers = {
     airplay = ps: [
     ];
     apple_music = ps: [
     ]; # missing pywidevine
+    audible =
+      ps: with ps; [
+        audible
+      ];
+    audiobookshelf =
+      ps: with ps; [
+        aioaudiobookshelf
+      ];
     bluesound =
       ps: with ps; [
         pyblu
@@ -19,8 +27,9 @@
       ];
     deezer =
       ps: with ps; [
+        deezer-python-async
         pycryptodome
-      ]; # missing deezer-python-async
+      ];
     dlna =
       ps: with ps; [
         async-upnp-client
@@ -41,6 +50,8 @@
       ];
     hass_players = ps: [
     ];
+    ibroadcast = ps: [
+    ]; # missing ibroadcastaio
     jellyfin =
       ps: with ps; [
         aiojellyfin
@@ -56,6 +67,10 @@
     plex =
       ps: with ps; [
         plexapi
+      ];
+    podcastfeed =
+      ps: with ps; [
+        podcastparser
       ];
     qobuz = ps: [
     ];
@@ -87,6 +102,8 @@
       ps: with ps; [
         pkce
       ];
+    spotify_connect = ps: [
+    ];
     template_player_provider = ps: [
     ];
     test = ps: [
@@ -101,6 +118,7 @@
     ];
     ytmusic =
       ps: with ps; [
+        duration-parser
         yt-dlp
         ytmusicapi
       ];

--- a/pkgs/development/python-modules/aioaudiobookshelf/default.nix
+++ b/pkgs/development/python-modules/aioaudiobookshelf/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  mashumaro,
+  python-socketio,
+}:
+
+buildPythonPackage rec {
+  pname = "aioaudiobookshelf";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "music-assistant";
+    repo = "aioaudiobookshelf";
+    tag = version;
+    hash = "sha256-rUd8TwmQDeMxXu7/UBnN426N+BMas2u6RNpTBXa3/5g=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aiohttp
+    mashumaro
+    python-socketio
+  ];
+
+  pythonImportsCheck = [
+    "aioaudiobookshelf"
+  ];
+
+  meta = {
+    description = "Async python library to interact with Audiobookshelf";
+    homepage = "https://github.com/music-assistant/aioaudiobookshelf";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/aiorun/default.nix
+++ b/pkgs/development/python-modules/aiorun/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "aiorun";
-  version = "2024.8.1";
+  version = "2025.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "cjrh";
     repo = "aiorun";
     tag = "v${version}";
-    hash = "sha256-D+4IceCdPg1Akq1YgPuSGF7yAOhDe8PmioNBE5X7yuQ=";
+    hash = "sha256-YqUlWf79EbC47BETBDjo8hzg5jhL4LiWLKGr1Qy4AbM=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/deezer-python-async/default.nix
+++ b/pkgs/development/python-modules/deezer-python-async/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  aiohttp,
+  asyncio-throttle,
+}:
+
+buildPythonPackage rec {
+  pname = "deezer-python-async";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "music-assistant";
+    repo = "deezer-python-async";
+    tag = "v${version}";
+    hash = "sha256-uuAB+SC/ECG50ox/6Bi+94bAt+YZokeQChpDQUAK+zc=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    aiohttp
+    asyncio-throttle
+  ];
+
+  doCheck = false; # requires access to the deezer api
+
+  pythonImportsCheck = [
+    "deezer"
+  ];
+
+  meta = {
+    description = "Deezer client for python *but async";
+    homepage = "https://github.com/music-assistant/deezer-python-async";
+    changelog = "https://github.com/music-assistant/deezer-python-async/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/duration-parser/default.nix
+++ b/pkgs/development/python-modules/duration-parser/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "duration-parser";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adriansahlman";
+    repo = "duration-parser";
+    tag = "v${version}";
+    hash = "sha256-Vn3H2JEMrJ6b/7eNG+h9tG5QzslGvaV3sunM7UO9Bok=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "duration_parser"
+  ];
+
+  meta = {
+    description = "A minimal duration parser written in python";
+    homepage = "https://github.com/adriansahlman/duration-parser";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -185,6 +185,8 @@ self: super: with self; {
 
   aioasuswrt = callPackage ../development/python-modules/aioasuswrt { };
 
+  aioaudiobookshelf = callPackage ../development/python-modules/aioaudiobookshelf { };
+
   aioautomower = callPackage ../development/python-modules/aioautomower { };
 
   aioazuredevops = callPackage ../development/python-modules/aioazuredevops { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3194,6 +3194,8 @@ self: super: with self; {
 
   deezer-python = callPackage ../development/python-modules/deezer-python { };
 
+  deezer-python-async = callPackage ../development/python-modules/deezer-python-async { };
+
   defang = callPackage ../development/python-modules/defang { };
 
   defcon = callPackage ../development/python-modules/defcon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4036,6 +4036,8 @@ self: super: with self; {
 
   duo-client = callPackage ../development/python-modules/duo-client { };
 
+  duration-parser = callPackage ../development/python-modules/duration-parser { };
+
   durationpy = callPackage ../development/python-modules/durationpy { };
 
   durus = callPackage ../development/python-modules/durus {  };


### PR DESCRIPTION
    https://github.com/music-assistant/server/releases/tag/2.4.0
    https://github.com/music-assistant/server/releases/tag/2.4.1
    https://github.com/music-assistant/server/releases/tag/2.4.2
    https://github.com/omnilib/aiosqlite/blob/v0.21.0/CHANGELOG.md
    https://github.com/cjrh/aiorun/blob/v2025.1.1/CHANGES

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
