### PR TITLE
lomiri.lomiri-docviewer-app: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-docviewer-app/default.nix
@@ -2,8 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
-  fetchpatch2,
   gitUpdater,
   nixosTests,
   cmake,
@@ -21,31 +19,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-docviewer-app";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-docviewer-app";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-zesBZmaMiMJwHtj3SoaNeHPiM9VNGEa4nTIiG8nskqI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U3Rn8KmvUKUI3FcgI8S5sVUb+lGvCz7Hmh5bB4GUAJo=";
   };
-
-  patches = [
-    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/76 merged & in release
-    # fetchpatch2 because there's a file rename
-    (fetchpatch2 {
-      name = "1041-lomiri-docviewer-app-Configurable-LibreOffice-path.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/6e1aee99b31b88a90b07f3c5fcf6340c54ce9aaa.patch";
-      hash = "sha256-KdHyKXM0hMMIFkuDn5JZJOEuitWAXT2QQOuR+1AolP0=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/merge_requests/81 merged & in release
-    (fetchpatch {
-      name = "1051-lomiri-docviewer-app-XDGify-icon.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/commit/a319e648ba15a7868d9ceb3a77ea15ad196e515b.patch";
-      hash = "sha256-JMSnN8EyWPHhqHzaJxy3JIhNaOvPLYkVDnNCrPGbO4E=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace cmake/modules/Click.cmake \


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/lomiri-docviewer-app/-/blob/v3.1.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
