### PR TITLE
{tdb,samba}: fix cross-build for x86_64-freebsd

### DIFF
--- a/pkgs/by-name/td/tdb/answers-x86_64-freebsd
+++ b/pkgs/by-name/td/tdb/answers-x86_64-freebsd
@@ -1,0 +1,14 @@
+Checking uname sysname type: "FreeBSD"
+Checking uname machine type: "amd64"
+Checking uname release type: "14.0-RELEASE"
+Checking uname version type: "FreeBSD 14.0-RELEASE #0 releng/14.0-n265380-f9716eee8ab4: Fri Nov 10 05:57:23 UTC 2023     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC"
+rpath library support: OK
+-Wl,--version-script support: OK
+Checking getconf LFS_CFLAGS: (64, "")
+Checking for large file support without additional flags: OK
+Checking correct behavior of strtoll: OK
+Checking for working strptime: NO
+Checking for C99 vsnprintf: "1"
+Checking for HAVE_SHARED_MMAP: OK
+Checking for HAVE_INCOHERENT_MMAP: NO
+Checking for HAVE_SECURE_MKSTEMP: OK

--- a/pkgs/by-name/td/tdb/package.nix
+++ b/pkgs/by-name/td/tdb/package.nix
@@ -13,6 +13,19 @@
   docbook_xml_dtd_45,
 }:
 
+let
+  needsAnswers =
+    stdenv.hostPlatform != stdenv.buildPlatform
+    && !(stdenv.hostPlatform.emulatorAvailable buildPackages);
+  answers =
+    {
+      # PYTHONHASHSEED=1 python3.9 ./buildtools/bin/waf configure --bundled-libraries=NONE --builtin-libraries=replace --cross-compile --cross-execute=' ' --cross-answers=answers
+      x86_64-freebsd = ./answers-x86_64-freebsd;
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "Need pre-generated answers file to compile for ${stdenv.hostPlatform.system}");
+in
+
 stdenv.mkDerivation rec {
   pname = "tdb";
   version = "1.4.12";
@@ -39,10 +52,15 @@ stdenv.mkDerivation rec {
 
   # otherwise the configure script fails with
   # PYTHONHASHSEED=1 missing! Don't use waf directly, use ./configure and make!
-  preConfigure = ''
-    export PKGCONFIG="$PKG_CONFIG"
-    export PYTHONHASHSEED=1
-  '';
+  preConfigure =
+    ''
+      export PKGCONFIG="$PKG_CONFIG"
+      export PYTHONHASHSEED=1
+    ''
+    + lib.optionalString needsAnswers ''
+      cp ${answers} answers
+      chmod +w answers
+    '';
 
   wafPath = "buildtools/bin/waf";
 
@@ -51,10 +69,21 @@ stdenv.mkDerivation rec {
       "--bundled-libraries=NONE"
       "--builtin-libraries=replace"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-      "--cross-compile"
-      "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
-    ];
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) (
+      [
+        "--cross-compile"
+      ]
+      ++ (
+        if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
+          [
+            "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
+          ]
+        else
+          [
+            "--cross-answers=answers"
+          ]
+      )
+    );
 
   postFixup =
     if stdenv.hostPlatform.isDarwin then

--- a/pkgs/by-name/td/tdb/package.nix
+++ b/pkgs/by-name/td/tdb/package.nix
@@ -69,21 +69,15 @@ stdenv.mkDerivation rec {
       "--bundled-libraries=NONE"
       "--builtin-libraries=replace"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) (
-      [
-        "--cross-compile"
-      ]
-      ++ (
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-compile"
+      (
         if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
-          [
-            "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
-          ]
+          "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
         else
-          [
-            "--cross-answers=answers"
-          ]
+          "--cross-answers=answers"
       )
-    );
+    ];
 
   postFixup =
     if stdenv.hostPlatform.isDarwin then

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -57,7 +57,7 @@
   enableGlusterFS ? false,
   glusterfs,
   libuuid,
-  enableAcl ? (!stdenv.hostPlatform.isDarwin),
+  enableAcl ? stdenv.hostPlatform.isLinux,
   acl,
   enableLibunwind ? (!stdenv.hostPlatform.isDarwin),
   libunwind,
@@ -76,6 +76,16 @@ let
   };
 
   inherit (lib) optional optionals;
+
+  needsAnswers =
+    stdenv.hostPlatform != stdenv.buildPlatform
+    && !(stdenv.hostPlatform.emulatorAvailable buildPackages);
+  answers =
+    {
+      x86_64-freebsd = ./answers-x86_64-freebsd;
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "Need pre-generated answers file to compile for ${stdenv.hostPlatform.system}");
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "samba";
@@ -103,6 +113,11 @@ stdenv.mkDerivation (finalAttrs: {
       name = "samba-reproducible-builds.patch";
       url = "https://gitlab.com/raboof/samba/-/commit/9995c5c234ece6888544cdbe6578d47e83dea0b5.patch";
       hash = "sha256-TVKK/7wGsfP1pVf8o1NwazobiR8jVJCCMj/FWji3f2A=";
+    })
+    (fetchpatch {
+      name = "cross-compile.patch";
+      url = "https://gitlab.com/samba-team/samba/-/merge_requests/3990/diffs.patch?commit_id=52af20db81f24cbfaa6fef8233584fc40fc72d34";
+      hash = "sha256-GMPxM6KMtMPRljhRI+dDD2fOp+y5kpRqbjqkj19Du4Q=";
     })
   ];
 
@@ -141,13 +156,15 @@ stdenv.mkDerivation (finalAttrs: {
       popt
       dbus
       jansson
-      libbsd
       libarchive
       zlib
       gnutls
       libtasn1
       tdb
       libxcrypt
+    ]
+    ++ optionals (!stdenv.hostPlatform.isBSD) [
+      libbsd
     ]
     ++ optionals stdenv.hostPlatform.isLinux [
       liburing
@@ -180,20 +197,33 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional enableLibunwind libunwind
     ++ optional enablePam pam;
 
-  postPatch = ''
-    # Removes absolute paths in scripts
-    sed -i 's,/sbin/,,g' ctdb/config/functions
+  postPatch =
+    ''
+      # Removes absolute paths in scripts
+      sed -i 's,/sbin/,,g' ctdb/config/functions
 
-    # Fix the XML Catalog Paths
-    sed -i "s,\(XML_CATALOG_FILES=\"\),\1$XML_CATALOG_FILES ,g" buildtools/wafsamba/wafsamba.py
+      # Fix the XML Catalog Paths
+      sed -i "s,\(XML_CATALOG_FILES=\"\),\1$XML_CATALOG_FILES ,g" buildtools/wafsamba/wafsamba.py
 
-    patchShebangs ./buildtools/bin
-  '';
+      patchShebangs ./buildtools/bin
+    ''
+    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      substituteInPlace wscript source3/wscript nsswitch/wscript_build lib/replace/wscript source4/ntvfs/sysdep/wscript_configure --replace-fail 'sys.platform' '"${stdenv.hostPlatform.parsed.kernel.name}"'
+    '';
 
-  preConfigure = ''
-    export PKGCONFIG="$PKG_CONFIG"
-    export PYTHONHASHSEED=1
-  '';
+  preConfigure =
+    ''
+      export PKGCONFIG="$PKG_CONFIG"
+      export PYTHONHASHSEED=1
+    ''
+    + lib.optionalString needsAnswers ''
+      cp ${answers} answers
+      chmod +w answers
+    '';
+
+  env.NIX_LDFLAGS = lib.optionalString (
+    stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17"
+  ) "--undefined-version";
 
   wafConfigureFlags =
     [
@@ -220,11 +250,16 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional enableProfiling "--with-profiling-data"
     ++ optional (!enableAcl) "--without-acl-support"
     ++ optional (!enablePam) "--without-pam"
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
       "--bundled-libraries=!asn1_compile,!compile_et"
       "--cross-compile"
-      "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
-    ]
+      (
+        if (stdenv.hostPlatform.emulatorAvailable buildPackages) then
+          "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
+        else
+          "--cross-answers=answers"
+      )
+    ])
     ++ optionals stdenv.buildPlatform.is32bit [
       # By default `waf configure` spawns as many as available CPUs. On
       # 32-bit systems with many CPUs (like `i686` chroot on `x86_64`

--- a/pkgs/servers/samba/answers-x86_64-freebsd
+++ b/pkgs/servers/samba/answers-x86_64-freebsd
@@ -1,0 +1,33 @@
+Checking uname sysname type: "FreeBSD"
+Checking uname machine type: "amd64"
+Checking uname release type: "14.0-RELEASE"
+Checking uname version type: "FreeBSD 14.0-RELEASE #0 releng/14.0-n265380-f9716eee8ab4: Fri Nov 10 05:57:23 UTC 2023     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC"
+rpath library support: OK
+-Wl,--version-script support: OK
+Checking getconf LFS_CFLAGS: (64, "")
+Checking for large file support without additional flags: OK
+Checking correct behavior of strtoll: OK
+Checking for working strptime: NO
+Checking for C99 vsnprintf: "1"
+Checking for HAVE_SHARED_MMAP: OK
+Checking for HAVE_INCOHERENT_MMAP: NO
+Checking for HAVE_SECURE_MKSTEMP: OK
+Checking for gnutls fips mode support: NO
+Checking value of NSIG: "32"
+Checking value of SIGRTMAX: "126"
+Checking value of SIGRTMIN: "65"
+Checking for a 64-bit host to support lmdb: OK
+Checking for *bsd style statfs with statfs.f_iosize: OK
+Checking errno of iconv for illegal multibyte sequence: OK
+Checking if can we convert from CP850 to UCS-2LE: OK
+Checking if can we convert from UTF-8 to UCS-2LE: OK
+Checking whether we can use Linux thread-specific credentials: NO
+Checking whether setreuid is available: OK
+Checking whether fcntl locking is available: OK
+Checking for the maximum value of the 'time_t' type: OK
+Checking whether the realpath function allows a NULL argument: OK
+Checking for ftruncate extend: OK
+Checking for readlink breakage: NO
+getcwd takes a NULL argument: OK
+checking for clnt_create(): OK
+for QUOTACTL_4B;  int quotactl(const char *path, int cmd, int id, char *addr): OK


### PR DESCRIPTION
This sucked! The answers file for tdb was easily generable with the given command but for samba it was very difficult to track down all the dependencies so that the configure script could run outside of nix. waf: not even once.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
