### PR TITLE
racket: 8.15 -> 8.16, restore static libraries

### DIFF
--- a/pkgs/development/interpreters/racket/manifest.json
+++ b/pkgs/development/interpreters/racket/manifest.json
@@ -1,11 +1,11 @@
 {
-  "version": "8.15",
+  "version": "8.16",
   "full": {
-    "filename": "racket-8.15-src.tgz",
-    "sha256": "602b848459daf1b2222a46a9094e85ae2d28e480067219957fa46af8400e1233"
+    "filename": "racket-8.16-src.tgz",
+    "sha256": "b233a968f4a561f7b005ce06f2c4c29428562f308c1a04d28e2e2286f6b945c3"
   },
   "minimal": {
-    "filename": "racket-minimal-8.15-src.tgz",
-    "sha256": "1ac132c56bc52312049fa4f0849237f66713e8e0a7ab6c4780504633ee8f1dc3"
+    "filename": "racket-minimal-8.16-src.tgz",
+    "sha256": "4e727db75574ab11d6bec7af5e5d72a084fa7f662e200c35d5bc200772f5ce96"
   }
 }

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -19,7 +19,7 @@
 let
   manifest = lib.importJSON ./manifest.json;
 
-  inherit (stdenv.hostPlatform) isDarwin isStatic;
+  inherit (stdenv.hostPlatform) isDarwin;
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--enable-libz"
     ]
     ++ lib.optional disableDocs "--disable-docs"
-    ++ lib.optionals (!isStatic) [
+    ++ lib.optionals (!(finalAttrs.dontDisableStatic or false)) [
       # instead of `--disable-static` that `stdenv` assumes
       "--disable-libs"
       # "not currently supported" in `configure --help-cs` but still emphasized in README
@@ -87,6 +87,9 @@ stdenv.mkDerivation (finalAttrs: {
       # "use Unix style (e.g., use Gtk) for Mac OS", which eliminates many problems
       "--enable-xonx"
     ];
+
+  # The upstream script builds static libraries by default.
+  dontAddStaticConfigureFlags = true;
 
   dontStrip = isDarwin;
 

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -69,7 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags =
     [
-      "--enable-check"
+      # > docs failure: ftype-ref: ftype mismatch for #<ftype-pointer>
+      # "--enable-check"
       "--enable-csonly"
       "--enable-liblz4"
       "--enable-libz"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7240,7 +7240,9 @@ with pkgs;
   wireplumber = callPackage ../development/libraries/pipewire/wireplumber.nix { };
 
   racket = callPackage ../development/interpreters/racket { };
-  racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
+  racket-minimal = callPackage ../development/interpreters/racket/minimal.nix {
+    stdenv = stdenvAdapters.makeStaticLibraries stdenv;
+  };
 
   rakudo = callPackage ../development/interpreters/rakudo { };
   moarvm = darwin.apple_sdk_11_0.callPackage ../development/interpreters/rakudo/moarvm.nix {


### PR DESCRIPTION
1. Update Racket from 8.15 to 8.16.
Changelog: https://blog.racket-lang.org/2025/03/racket-v8-16.html
This fixes a build error due to `--enable-check`, and closes  #388645.

2. Restore static libraries (`libracketcs.a`).
This is alternative to and closes #379188, which has stalled for 3 weeks and conflicts with the `master` branch.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
