### PR TITLE
nixos/echoip: improve systemd hardening

### DIFF
--- a/nixos/modules/services/web-apps/echoip.nix
+++ b/nixos/modules/services/web-apps/echoip.nix
@@ -75,9 +75,12 @@ in
         );
 
         # Hardening
+        AmbientCapabilities = "";
         CapabilityBoundingSet = [ "" ];
-        DeviceAllow = [ "" ];
+        DevicePolicy = "closed";
         LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateTmp = true;
         PrivateUsers = true;
@@ -91,15 +94,19 @@ in
         ProtectKernelTunables = true;
         ProtectProc = "invisible";
         ProtectSystem = "strict";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET AF_INET6 AF_UNIX" ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+          "setrlimit"
+        ];
+        UMask = "0077";
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -341,7 +341,7 @@ in {
   early-mount-options = handleTest ./early-mount-options.nix {};
   ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};
   ec2-nixops = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-nixops or {};
-  echoip = handleTest ./echoip.nix {};
+  echoip = runTest ./echoip.nix;
   ecryptfs = handleTest ./ecryptfs.nix {};
   fscrypt = handleTest ./fscrypt.nix {};
   fastnetmon-advanced = runTest ./fastnetmon-advanced.nix;

--- a/nixos/tests/echoip.nix
+++ b/nixos/tests/echoip.nix
@@ -1,29 +1,28 @@
-import ./make-test-python.nix (
-  { lib, ... }:
-  {
-    name = "echoip";
-    meta.maintainers = with lib.maintainers; [ defelo ];
+{ lib, ... }:
 
-    nodes.machine = {
-      services.echoip = {
-        enable = true;
-        virtualHost = "echoip.local";
-      };
+{
+  name = "echoip";
+  meta.maintainers = with lib.maintainers; [ defelo ];
 
-      networking.hosts = {
-        "127.0.0.1" = [ "echoip.local" ];
-        "::1" = [ "echoip.local" ];
-      };
+  nodes.machine = {
+    services.echoip = {
+      enable = true;
+      virtualHost = "echoip.local";
     };
 
-    testScript = ''
-      machine.wait_for_unit("echoip.service")
-      machine.wait_for_open_port(8080)
+    networking.hosts = {
+      "127.0.0.1" = [ "echoip.local" ];
+      "::1" = [ "echoip.local" ];
+    };
+  };
 
-      resp = machine.succeed("curl -4 http://echoip.local/ip")
-      assert resp.strip() == "127.0.0.1"
-      resp = machine.succeed("curl -6 http://echoip.local/ip")
-      assert resp.strip() == "::1"
-    '';
-  }
-)
+  testScript = ''
+    machine.wait_for_unit("echoip.service")
+    machine.wait_for_open_port(8080)
+
+    resp = machine.succeed("curl -4 http://echoip.local/ip")
+    assert resp.strip() == "127.0.0.1"
+    resp = machine.succeed("curl -6 http://echoip.local/ip")
+    assert resp.strip() == "::1"
+  '';
+}


### PR DESCRIPTION
Reduces the exposure level reported by `systemd-analyze security echoip.service` from 2.7 to 1.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
