### PR TITLE
pinentry-dmenu: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22792,6 +22792,17 @@
     github = "sweenu";
     githubId = 7051978;
   };
+  sweiglbosker = {
+    email = "stefan@s00.xyz";
+    github = "sweiglbosker";
+    githubId = 124390044;
+    name = "Stefan Weigl-Bosker";
+    keys = [
+      {
+        fingerprint = "B520 0ABF BD21 3FC9 C17C  6DB9 1291 CBBC F3B9 F225";
+      }
+    ];
+  };
   swendel = {
     name = "Sebastian Wendel";
     email = "nixpkgs.aiX5ph@srx.digital";

--- a/pkgs/by-name/pi/pinentry-dmenu/package.nix
+++ b/pkgs/by-name/pi/pinentry-dmenu/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fontconfig,
+  gpgme,
+  libX11,
+  libXinerama,
+  libXft,
+  pkg-config,
+  zlib,
+  writeText,
+  libassuan,
+  libconfig,
+  libgpg-error,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pinentry-dmenu";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "ritze";
+    repo = "pinentry-dmenu";
+    tag = finalAttrs.version;
+    hash = "sha256-FmP9tI/oU7VM8x+Wu6bbeg1CVopZc6oOWnd4qUptVV8=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    fontconfig
+    gpgme
+    libassuan
+    libconfig
+    libgpg-error
+    libX11
+    libXinerama
+    libXft
+  ];
+
+  preConfigure = ''
+    makeFlagsArray+=(
+      PREFIX="$out"
+      CC="$CC"
+      # default config.mk hardcodes dependent libraries and include paths
+      INCS="`$PKG_CONFIG --cflags fontconfig x11 xft xinerama`"
+      LIBS="`$PKG_CONFIG --libs   fontconfig x11 xft xinerama`"
+    )
+  '';
+
+  meta = {
+    description = "Pinentry implementation based on dmenu";
+    homepage = "https://github.com/ritze/pinentry-dmenu";
+    changelog = "https://github.com/ritze/pinentry-dmenu/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ sweiglbosker ];
+    mainProgram = "pinentry-dmenu";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added package for [pinentry-dmenu](https://github.com/ritze/pinentry-dmenu), a pinentry fronted based on dmenu.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
