### PR TITLE
home-assistant: bump ecosystem packages

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "jwillemsen";
   domain = "daikin_onecta";
-  version = "4.2.2";
+  version = "4.2.3";
 
   src = fetchFromGitHub {
     owner = "jwillemsen";
     repo = "daikin_onecta";
     tag = "v${version}";
-    hash = "sha256-kjFBy+Nq9aQSsmvzWT2Wy/BwMpyd8GdgSXIrp44cMnA=";
+    hash = "sha256-ylVHgmE6zDLE73KpuIag0iUx77w6ujp3cF/+x2bJiA8=";
   };
 
   meta = {

--- a/pkgs/servers/home-assistant/custom-components/frigate/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/package.nix
@@ -2,24 +2,54 @@
   lib,
   fetchFromGitHub,
   buildHomeAssistantComponent,
-  pytz,
+
+  # dependencies
+  hass-web-proxy-lib,
+
+  # tests
+  homeassistant,
+  pytest-aiohttp,
+  pytest-cov-stub,
+  pytest-homeassistant-custom-component,
+  pytest-timeout,
+  pytestCheckHook,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "blakeblackshear";
   domain = "frigate";
-  version = "5.4.0";
+  version = "5.8.0";
 
   src = fetchFromGitHub {
     owner = "blakeblackshear";
     repo = "frigate-hass-integration";
-    rev = "v${version}";
-    hash = "sha256-V2Y+xUAA/Lu7u82WUlUI5CFi9SGWe6ocVQtlXeVg2ZA=";
+    tag = "v${version}";
+    hash = "sha256-sQgi3F44eT/iL3cE9YuKyjJmE4nZM+OcwirUyl3maGo=";
   };
 
-  dependencies = [ pytz ];
+  dependencies = [ hass-web-proxy-lib ];
 
   dontBuild = true;
+
+  nativeCheckInputs =
+    [
+      homeassistant
+      pytest-aiohttp
+      pytest-cov-stub
+      pytest-homeassistant-custom-component
+      pytest-timeout
+      pytestCheckHook
+    ]
+    ++ (homeassistant.getPackages "mqtt" homeassistant.python.pkgs)
+    ++ (homeassistant.getPackages "stream" homeassistant.python.pkgs);
+
+  disabledTests = [
+    # uses deprecated and removed constants
+    # https://github.com/blakeblackshear/frigate-hass-integration/issues/860
+    "test_duplicate"
+    "test_options_advanced"
+    "test_options"
+  ];
 
   meta = with lib; {
     description = "Provides Home Assistant integration to interface with a separately running Frigate service";

--- a/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "xZetsubou";
   domain = "localtuya";
-  version = "2025.3.0";
+  version = "2025.3.1";
 
   src = fetchFromGitHub {
     owner = "xZetsubou";
     repo = "hass-localtuya";
     rev = version;
-    hash = "sha256-ZtUK73aj2NKlcanlFZLeL35X1M9CrMLYLW0P0cILdr8=";
+    hash = "sha256-DZ0TS6vdMDBCYP661GeRm+pAmm387/+/DayIBkeuPQA=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/custom-components/smartir/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/smartir/package.nix
@@ -2,36 +2,26 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  fetchpatch,
   aiofiles,
-  broadlink,
+  distutils,
   nix-update-script,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "smartHomeHub";
   domain = "smartir";
-  version = "1.17.9";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "smartHomeHub";
     repo = "SmartIR";
-    rev = version;
-    hash = "sha256-E6TM761cuaeQzlbjA+oZ+wt5HTJAfkF2J3i4P1Wbuic=";
+    tag = version;
+    hash = "sha256-Sy1wxVUApKWm9TlDia2Gwd+mIi7WbDkzJrAtyb0tTbM=";
   };
-
-  patches = [
-    # Replace distutils.version.StrictVersion with packaging.version.Version
-    # https://github.com/smartHomeHub/SmartIR/pull/1250
-    (fetchpatch {
-      url = "https://github.com/smartHomeHub/SmartIR/commit/1ed8ef23a8f7b9dcae75721eeab8d5f79013b851.patch";
-      hash = "sha256-IhdnTDtUa7mS+Vw/+BqfqWIKK4hbshbVgJNjfKjgAvI=";
-    })
-  ];
 
   dependencies = [
     aiofiles
-    broadlink
+    distutils
   ];
 
   dontBuild = true;

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "al-one";
   domain = "xiaomi_miot";
-  version = "1.0.12";
+  version = "1.0.13";
 
   src = fetchFromGitHub {
     owner = "al-one";
     repo = "hass-xiaomi-miot";
     rev = "v${version}";
-    hash = "sha256-WU512UnKRHVoflerXK4vs/wJXxaerC1XVhfLN1YPh84=";
+    hash = "sha256-RjEhmdoImfWcvrQ09wX3WaWS8qKuzL2+2Rrz1BfEFFA=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "cdnninja";
   domain = "yoto";
-  version = "1.23.0";
+  version = "1.23.2";
 
   src = fetchFromGitHub {
     owner = "cdnninja";
     repo = "yoto_ha";
     tag = "v${version}";
-    hash = "sha256-FB711ofk5BV/U0ZWfa6Q2aheZkzbwxDUfqNDu9wj2aQ=";
+    hash = "sha256-RErsZGSoBhBGg852znZq6W8oDZmDDoPTZihUBhWCO5w=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/advanced-camera-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/advanced-camera-card/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "advanced-camera-card";
+  version = "7.3.2";
+
+  src = fetchzip {
+    url = "https://github.com/dermotduffy/advanced-camera-card/releases/download/v${version}/advanced-camera-card.zip";
+    hash = "sha256-N9G96yGas1hrB2zpUPrB+md7Nz2vg7/2NhyqNjFBlxM=";
+  };
+
+  # TODO: build from source once yarn berry support lands in nixpkgs
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out
+    install -m0644 *.js $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/dermotduffy/advanced-camera-card/releases/tag/v${version}";
+    description = "A comprehensive camera card for Home Assistant";
+    homepage = "https://github.com/dermotduffy/advanced-camera-card";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
@@ -9,18 +9,18 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "clock-weather-card";
-  version = "2.8.9";
+  version = "2.8.10";
 
   src = fetchFromGitHub {
     owner = "pkissling";
     repo = "clock-weather-card";
     tag = "v${version}";
-    hash = "sha256-7b0U6HelWLoCvkJrqzRbRyDnl0odi6OYYEp0sUOYnoU=";
+    hash = "sha256-ZmqtvA6kRkqkoRCBerLZXqRB1wwTF0jrc+KfigaE7Pw=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-9MFEJQ9JYUjded6sdDcF/kB+ZdGE6z4MZOzFk1Qb3vo=";
+    hash = "sha256-Z9UZHsmaRjaf7fIDYhNmlLU2T1l1hlFKvyEahPK3Y3E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -354,6 +354,7 @@ let
       });
 
       # internal python packages only consumed by home-assistant itself
+      hass-web-proxy-lib = self.callPackage ./python-modules/hass-web-proxy-lib { };
       home-assistant-frontend = self.callPackage ./frontend.nix { };
       home-assistant-intents = self.callPackage ./intents.nix { };
       homeassistant = self.toPythonModule home-assistant;

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.214";
+  version = "0.13.220";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-AbqDLFC/U+zJJF4pc1ovuzwmXLv37ojCpQQIzWUc/70=";
+    hash = "sha256-p/pC0dgKRVPlu3kOiSmeGhbfRW7cPm5W0Lr38XWlcnQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/python-modules/hass-web-proxy-lib/default.nix
+++ b/pkgs/servers/home-assistant/python-modules/hass-web-proxy-lib/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  fetchpatch2,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  aiohttp,
+
+  # tests
+  home-assistant,
+  pytest-aiohttp,
+  pytest-cov-stub,
+  pytest-homeassistant-custom-component,
+  pytest-timeout,
+  pytestCheckHook,
+
+  # reverse dependencies
+  home-assistant-custom-components,
+}:
+
+buildPythonPackage rec {
+  pname = "hass-web-proxy-lib";
+  version = "0.0.7";
+  pyproject = true;
+
+  # no tags on git
+  src = fetchPypi {
+    pname = "hass_web_proxy_lib";
+    inherit version;
+    hash = "sha256-bhz71tNOpZ+4tSlndS+UbC3w2WW5+dAMtpk7TnnFpuQ=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      name = "add-missing-build-system.patch";
+      url = "https://github.com/dermotduffy/hass-web-proxy-lib/commit/0eed7a57f503fc552948a45e7f490ddaff711896.patch";
+      hash = "sha256-ccOdhA0NhlTmdA51sNdB357Xh13E4PsLlvUTU4GQ9jk=";
+    })
+  ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    home-assistant
+    pytest-aiohttp
+    pytest-cov-stub
+    pytest-homeassistant-custom-component
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "hass_web_proxy_lib"
+  ];
+
+  passthru.tests = {
+    inherit (home-assistant-custom-components) frigate;
+  };
+
+  meta = {
+    description = "A library to proxy web traffic through Home Assistant integrations";
+    homepage = "https://github.com/dermotduffy/hass-web-proxy-lib";
+    license = lib.licenses.mit;
+    maintainers = home-assistant-custom-components.frigate.meta.maintainers;
+  };
+}

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.2.5";
+  version = "2025.3.0";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     rev = "refs/tags/${version}";
-    hash = "sha256-tqg7NHvtKrXJ8+czcWqoaPMLYfskjuoFmSOkhjmnr3g=";
+    hash = "sha256-4Chn8PRvTERiTQqhp3ScoV6woISvEWHFoohCKzLJCP8=";
   };
 
   build-system = [


### PR DESCRIPTION

    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.4.1
    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.5.0
    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.5.1
    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.6.0
    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.7.0
    https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v5.8.0
    https://github.com/pkissling/clock-weather-card/blob/v2.8.10/CHANGELOG.md
    https://github.com/cdnninja/yoto_ha/releases/tag/v1.23.2
    https://github.com/al-one/hass-xiaomi-miot/releases/tag/v1.0.13
    https://github.com/xZetsubou/hass-localtuya/releases/tag/2025.3.1
    https://github.com/jwillemsen/daikin_onecta/tag/v4.2.3
    https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/refs/tags/0.13.220/CHANGELOG.md
    https://github.com/KapJI/homeassistant-stubs/releases/tag/2025.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
