### PR TITLE
{cfitsio,libvmaf}: fix cross build for FreeBSD

### DIFF
--- a/pkgs/by-name/cf/cfitsio/package.nix
+++ b/pkgs/by-name/cf/cfitsio/package.nix
@@ -31,6 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-reentrant"
   ];
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isFreeBSD {
+    # concerning. upstream defines XOPEN_SOURCE=700 which makes FreeBSD very insistent on
+    # not showing us gethostbyname()
+    NIX_CFLAGS_COMPILE = "-D__BSD_VISIBLE=1";
+  };
+
   hardeningDisable = [ "format" ];
 
   # Shared-only build
@@ -58,6 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
       xbreak
       hjones2199
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libvmaf/package.nix
+++ b/pkgs/by-name/li/libvmaf/package.nix
@@ -31,6 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
     xxd
   ];
 
+  postPatch = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
+    substituteInPlace meson.build --replace-fail '_XOPEN_SOURCE=600' '_XOPEN_SOURCE=700'
+  '';
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isFreeBSD {
+    NIX_CFLAGS_COMPILE = "-D__BSD_VISIBLE=1";
+  };
+
   mesonFlags = [ "-Denable_avx512=true" ];
 
   outputs = [


### PR DESCRIPTION
I can provide a more detailed report on request but the long and short of it is that XOPEN_SOURCE=700 (as per upstream) actually hides gethostbyname(3), and there's no "normal" define (i.e. only one underscore prefix) that can get it back because of the way sys/cdefs.h works as far as I can tell.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
