### PR TITLE
nixos/dunst: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -36,6 +36,8 @@
 
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).
 
+- [Dunst](https://github.com/dunst-project/dunst), a lightweight and customizable notification daemon. Available as [services.dunst](#opt-services.dunst.enable).
+
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
 - [Dawarich](https://dawarich.app/), a self-hostable location history tracker. Available as [services.dawarich](#opt-services.dawarich.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -558,6 +558,7 @@
   ./services/desktops/bonsaid.nix
   ./services/desktops/cpupower-gui.nix
   ./services/desktops/dleyna.nix
+  ./services/desktops/dunst.nix
   ./services/desktops/espanso.nix
   ./services/desktops/flatpak.nix
   ./services/desktops/geoclue2.nix

--- a/nixos/modules/services/desktops/dunst.nix
+++ b/nixos/modules/services/desktops/dunst.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  toml = pkgs.formats.toml { };
+  cfg = config.services.dunst;
+in
+{
+  options.services.dunst = {
+    enable = lib.mkEnableOption "Dunst notification daemon";
+
+    package = lib.mkPackageOption pkgs "dunst" { } // {
+      apply =
+        p:
+        p.override {
+          withX11 = cfg.enableX11;
+          withWayland = cfg.enableWayland;
+        };
+    };
+
+    settings = lib.mkOption {
+      type = toml.type;
+      default = { };
+      description = "Dunst configuration, see dunst(5)";
+      example = lib.literalExpression ''
+        {
+          global = {
+            width = 300;
+            height = 300;
+            offset = "30x50";
+            origin = "top-right";
+            transparency = 10;
+            frame_color = "#eceff1";
+            font = "Droid Sans 9";
+          };
+
+          urgency_normal = {
+            background = "#37474f";
+            foreground = "#eceff1";
+            timeout = 10;
+          };
+        };
+      '';
+    };
+
+    enableX11 = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to enable X11 support.";
+    };
+
+    enableWayland = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to enable Wayland support.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.enableX11 || cfg.enableWayland;
+        message = "Dunst must be built with at least either X11 support or Wayland support";
+      }
+    ];
+
+    environment = {
+      systemPackages = [ cfg.package ];
+      etc."xdg/dunst/dunstrc".source = toml.generate "dunstrc" cfg.settings;
+    };
+
+    services.dbus.packages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ nyukuru ];
+}

--- a/pkgs/by-name/du/dunst/package.nix
+++ b/pkgs/by-name/du/dunst/package.nix
@@ -77,7 +77,8 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "PREFIX=$(out)"
     "VERSION=$(version)"
-    "SYSCONFDIR=$(out)/etc"
+    "SYSCONFDIR=/etc/xdg"
+    "SYSCONF_FORCE_NEW=0"
     "SERVICEDIR_DBUS=$(out)/share/dbus-1/services"
     "SERVICEDIR_SYSTEMD=$(out)/lib/systemd/user"
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Initialized nixos module for dunst, the notification daemon.
SYSCONFDIR build flag for dunst was changed to reflect the more common configuration paradigm but can be reverted if needed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
