### PR TITLE
libinotify-kqueue: 20180201 -> 20240724

### DIFF
--- a/pkgs/by-name/li/libinotify-kqueue/package.nix
+++ b/pkgs/by-name/li/libinotify-kqueue/package.nix
@@ -2,23 +2,42 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libinotify-kqueue";
-  version = "20180201";
+  version = "20240724";
 
   src = fetchFromGitHub {
     owner = "libinotify-kqueue";
     repo = "libinotify-kqueue";
     rev = version;
-    sha256 = "sha256-9A5s8rPGlRv3KbxOukk0VB2IQrDxVjklO5RB+IA1cDY=";
+    sha256 = "sha256-m59GWrx5C+JXDbhVdKx+SNSn8wwIKyW+KlXabNi17A0=";
   };
+
+  patches = [
+    # https://github.com/libinotify-kqueue/libinotify-kqueue/pull/23
+    (fetchpatch {
+      name = "add-configure-caching.patch";
+      url = "https://github.com/libinotify-kqueue/libinotify-kqueue/commit/81a8f05c1ce6df819dc898f3754c9c874ee24b10.patch";
+      hash = "sha256-imKS2DuQrHSMnJH1gOYrVSeWTe2nhcl8Gm9IX5B9ZqI=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  doCheck = true;
+  configureFlags =
+    lib.optionals (with stdenv; buildPlatform != hostPlatform && hostPlatform.isFreeBSD)
+      [
+        "ik_cv_have_note_extend_in=yes"
+        "ik_cv_have_note_extend_out=yes"
+        "ik_cv_have_o_path=yes"
+        "ik_cv_have_o_empty_path=yes"
+        "ik_cv_have_at_empty_path=yes"
+      ];
+
   checkFlags = [ "test" ];
 
   meta = with lib; {


### PR DESCRIPTION
[changelog 20211018](https://github.com/libinotify-kqueue/libinotify-kqueue/releases/tag/20211018)
[changelog 20240724](https://github.com/libinotify-kqueue/libinotify-kqueue/releases/tag/20240724)

Also add a patch I submitted upstream which lets cross work correctly.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
