### PR TITLE
nss: fix build for FreeBSD

### DIFF
--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -102,24 +102,35 @@ stdenv.mkDerivation rec {
           platform.parsed.cpu.name;
       # yes, this is correct. nixpkgs uses "host" for the platform the binary will run on whereas nss uses "host" for the platform that the build is running on
       target = getArch stdenv.hostPlatform;
+      target_system = stdenv.hostPlatform.uname.system;
       host = getArch stdenv.buildPlatform;
+
+      buildFlags =
+        [
+          "-v"
+          "--opt"
+          "--with-nspr=${nspr.dev}/include:${nspr.out}/lib"
+          "--system-sqlite"
+          "--enable-legacy-db"
+          "--target ${target}"
+          "-Dhost_arch=${host}"
+          "-Duse_system_zlib=1"
+          "--enable-libpkix"
+          "-j"
+          "$NIX_BUILD_CORES"
+        ]
+        ++ lib.optional enableFIPS "--enable-fips"
+        ++ lib.optional stdenv.hostPlatform.isDarwin "--clang"
+        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+          "-DOS=${target_system}"
+          "--disable-tests"
+        ];
     in
     ''
       runHook preBuild
 
       sed -i 's|nss_dist_dir="$dist_dir"|nss_dist_dir="'$out'"|;s|nss_dist_obj_dir="$obj_dir"|nss_dist_obj_dir="'$out'"|' build.sh
-      ./build.sh -v --opt \
-        --with-nspr=${nspr.dev}/include:${nspr.out}/lib \
-        --system-sqlite \
-        --enable-legacy-db \
-        --target ${target} \
-        -Dhost_arch=${host} \
-        -Duse_system_zlib=1 \
-        --enable-libpkix \
-        -j $NIX_BUILD_CORES \
-        ${lib.optionalString enableFIPS "--enable-fips"} \
-        ${lib.optionalString stdenv.hostPlatform.isDarwin "--clang"} \
-        ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-tests"}
+      ./build.sh ${lib.concatStringsSep " " buildFlags}
 
       runHook postBuild
     '';
@@ -134,6 +145,14 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isILP32 [
       "-DNS_PTR_LE_32=1" # See RNG_RandomUpdate() in drdbg.c
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+      "-D_XOPEN_SOURCE=700"
+      "-D__BSD_VISIBLE"
+      # uses compiler intrinsics gated behind runtime checks for cpu feature flags
+      "-mavx2"
+      "-maes"
+      "-mpclmul"
     ]
   );
 


### PR DESCRIPTION
Similar to https://github.com/NixOS/nixpkgs/pull/387505 but contains some concerning enough stuff I wanted to pull it to its own PR for discussion. Without the cpu feature flags, it literally throws compiler errors.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
