### PR TITLE
_1password-gui: Refactor update.sh to decrease manual work burden

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -10,46 +10,11 @@
 
 let
   pname = "1password";
-  version = if channel == "stable" then "8.10.60" else "8.10.68-12.BETA";
 
-  sources = {
-    stable = {
-      x86_64-linux = {
-        url = "https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz";
-        hash = "sha256-QCoV66LvGo6vA5fjuE3fG+LwehKVMPmgaDghh9YEvmA=";
-      };
-      aarch64-linux = {
-        url = "https://downloads.1password.com/linux/tar/stable/aarch64/1password-${version}.arm64.tar.gz";
-        hash = "sha256-E5TniXur9ATJ3ER/zTFc6EiBrH/kbNvIao0ADLyBZZE=";
-      };
-      x86_64-darwin = {
-        url = "https://downloads.1password.com/mac/1Password-${version}-x86_64.zip";
-        hash = "sha256-2Nv4CHKLgCFbU1TeJQhIq8YdkJSQJXtUw2S17B8cS4s=";
-      };
-      aarch64-darwin = {
-        url = "https://downloads.1password.com/mac/1Password-${version}-aarch64.zip";
-        hash = "sha256-drJiM8EiUM3M54+KPQdLvAmSfBH5YPqQk14yjHzoBtM=";
-      };
-    };
-    beta = {
-      x86_64-linux = {
-        url = "https://downloads.1password.com/linux/tar/beta/x86_64/1password-${version}.x64.tar.gz";
-        hash = "sha256-/0Y1qnCI/gXGKTHk9EIaUVbHTwRkOvwOOiMif6sRkqw=";
-      };
-      aarch64-linux = {
-        url = "https://downloads.1password.com/linux/tar/beta/aarch64/1password-${version}.arm64.tar.gz";
-        hash = "sha256-4J6a10r5n8ffqC5Y2pjO/GJLXY5AQDkQWmFNLYeK/Xw=";
-      };
-      x86_64-darwin = {
-        url = "https://downloads.1password.com/mac/1Password-${version}-x86_64.zip";
-        hash = "sha256-XvflRqqUI59ekuSiQXyACzS94VIrl8wJjemi0xAznZU=";
-      };
-      aarch64-darwin = {
-        url = "https://downloads.1password.com/mac/1Password-${version}-aarch64.zip";
-        hash = "sha256-UErp3pcSXz/C5s3JraLoBN89tL8ghgJ3XLpg7KtU8Sc=";
-      };
-    };
-  };
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
+  inherit (versions.${channel} or (throw "unknown channel ${channel}")) version;
+
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
 
   src = fetchurl {
     inherit

--- a/pkgs/applications/misc/1password-gui/sources.json
+++ b/pkgs/applications/misc/1password-gui/sources.json
@@ -1,0 +1,38 @@
+{
+  "stable": {
+    "x86_64-linux": {
+      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.60.x64.tar.gz",
+      "hash": "sha256-QCoV66LvGo6vA5fjuE3fG+LwehKVMPmgaDghh9YEvmA="
+    },
+    "aarch64-linux": {
+      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.60.arm64.tar.gz",
+      "hash": "sha256-E5TniXur9ATJ3ER/zTFc6EiBrH/kbNvIao0ADLyBZZE="
+    },
+    "x86_64-darwin": {
+      "url": "https://downloads.1password.com/mac/1Password-8.10.60-x86_64.zip",
+      "hash": "sha256-2Nv4CHKLgCFbU1TeJQhIq8YdkJSQJXtUw2S17B8cS4s="
+    },
+    "aarch64-darwin": {
+      "url": "https://downloads.1password.com/mac/1Password-8.10.60-aarch64.zip",
+      "hash": "sha256-drJiM8EiUM3M54+KPQdLvAmSfBH5YPqQk14yjHzoBtM="
+    }
+  },
+  "beta": {
+    "x86_64-linux": {
+      "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.10.68-12.BETA.x64.tar.gz",
+      "hash": "sha256-/0Y1qnCI/gXGKTHk9EIaUVbHTwRkOvwOOiMif6sRkqw="
+    },
+    "aarch64-linux": {
+      "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.10.68-12.BETA.arm64.tar.gz",
+      "hash": "sha256-4J6a10r5n8ffqC5Y2pjO/GJLXY5AQDkQWmFNLYeK/Xw="
+    },
+    "x86_64-darwin": {
+      "url": "https://downloads.1password.com/mac/1Password-8.10.68-12.BETA-x86_64.zip",
+      "hash": "sha256-XvflRqqUI59ekuSiQXyACzS94VIrl8wJjemi0xAznZU="
+    },
+    "aarch64-darwin": {
+      "url": "https://downloads.1password.com/mac/1Password-8.10.68-12.BETA-aarch64.zip",
+      "hash": "sha256-UErp3pcSXz/C5s3JraLoBN89tL8ghgJ3XLpg7KtU8Sc="
+    }
+  }
+}

--- a/pkgs/applications/misc/1password-gui/update.sh
+++ b/pkgs/applications/misc/1password-gui/update.sh
@@ -1,58 +1,83 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq
+#!nix-shell -i bash -p jq gnupg
 #shellcheck shell=bash
 
-CURRENT_HASH=""
+set -euo pipefail
 
-print_hash() {
-    OS="$1"
-    CHANNEL="$2"
-    ARCH="$3"
-    VERSION="$4"
+cd -- "$(dirname "${BASH_SOURCE[0]}")"
 
-    if [[ "$OS" == "linux" ]]; then
-        if [[ "$ARCH" == "x86_64" ]]; then
-            EXT="x64.tar.gz"
-        else
-            EXT="arm64.tar.gz"
-        fi
-        URL="https://downloads.1password.com/${OS}/tar/${CHANNEL}/${ARCH}/1password-${VERSION}.${EXT}"
+mk_url() {
+  local \
+    base_url="https://downloads.1password.com" \
+    os="$1" \
+    channel="$2" \
+    arch="$3" \
+    version="$4"
+
+  if [[ ${os} == "linux" ]]; then
+    if [[ ${arch} == "x86_64" ]]; then
+      ext="x64.tar.gz"
     else
-        EXT="$ARCH.zip"
-        URL="https://downloads.1password.com/${OS}/1Password-${VERSION}-${EXT}"
+      ext="arm64.tar.gz"
     fi
+    url="${base_url}/${os}/tar/${channel}/${arch}/1password-${version}.${ext}"
+  else
+    ext="${arch}.zip"
+    url="${base_url}/mac/1Password-${version}-${ext}"
+  fi
 
-    CURRENT_HASH=$(nix store prefetch-file "$URL" --json | jq -r '.hash')
-
-    echo "$CHANNEL ${ARCH}-${OS}: $CURRENT_HASH"
+  echo "${url}"
 }
 
-if [[ -z "$STABLE_VER" && -n "$1" ]]; then
-    STABLE_VER="$1"
-fi
+cleanup() {
+  if [[ -f ${GPG_KEYRING-} ]]; then
+    rm "${GPG_KEYRING}"
+  fi
 
-if [[ -z "$BETA_VER" && -n "$2" ]]; then
-    BETA_VER="$2"
-fi
+  if [[ -f ${JSON_HEAP-} ]]; then
+    rm "${JSON_HEAP}"
+  fi
+}
 
-if [[ "${BETA_VER: -4}" != "BETA" ]]; then
-    BETA_VER="$BETA_VER.BETA"
-fi
+trap cleanup EXIT
 
-if [[ -z "$STABLE_VER" ]]; then
-    echo "No 'STABLE_VER' environment variable provided, skipping"
-else
-    print_hash "linux" "stable" "x86_64" "$STABLE_VER"
-    print_hash "linux" "stable" "aarch64" "$STABLE_VER"
-    print_hash "mac" "stable" "x86_64" "$STABLE_VER"
-    print_hash "mac" "stable" "aarch64" "$STABLE_VER"
-fi
+# Get channel versions from versions.json
+declare -A version=(
+  ["stable"]=$(jq -r '.stable.version' versions.json)
+  ["beta"]=$(jq -r '.beta.version' versions.json)
+)
 
-if [[ -z "$BETA_VER" ]]; then
-    echo "No 'BETA_VER' environment variable provided, skipping"
-else
-    print_hash "linux" "beta" "x86_64" "$BETA_VER"
-    print_hash "linux" "beta" "aarch64" "$BETA_VER"
-    print_hash "mac" "beta" "x86_64" "$BETA_VER"
-    print_hash "mac" "beta" "aarch64" "$BETA_VER"
-fi
+#
+GPG_KEYRING=$(mktemp -t 1password.kbx.XXXXXX)
+gpg --no-default-keyring --keyring "${GPG_KEYRING}" \
+  --keyserver keyserver.ubuntu.com \
+  --receive-keys 3FEF9748469ADBE15DA7CA80AC2D62742012EA22
+
+JSON_HEAP=$(mktemp -t 1password-gui.jsonheap.XXXXXX)
+for channel in stable beta; do
+  for os in linux darwin; do
+    for arch in x86_64 aarch64; do
+      url=$(mk_url ${os} ${channel} ${arch} "${version[${channel}]}")
+      nix store prefetch-file --json "${url}" | jq "
+        {
+          \"${channel}\": {
+             \"${arch}-${os}\": {
+               \"url\": \"${url}\",
+               \"hash\": .hash,
+               \"storePath\": .storePath
+             }
+           }
+        }" >> "${JSON_HEAP}"
+
+      # For some reason 1Password PGP signs only Linux binaries.
+      if [[ ${os} == "linux" ]]; then
+         gpgv --keyring "${GPG_KEYRING}" \
+           $(nix store prefetch-file --json "${url}.sig" | jq -r .storePath) \
+           $(jq -r --slurp ".[-1].[].[].storePath" "${JSON_HEAP}")
+      fi
+    done
+  done
+done
+
+# Combine heap of hash+url objects into a single JSON object.
+jq --slurp 'reduce .[] as $x ({}; . * $x) | del (.[].[].storePath)' "${JSON_HEAP}" > sources.json

--- a/pkgs/applications/misc/1password-gui/versions.json
+++ b/pkgs/applications/misc/1password-gui/versions.json
@@ -1,0 +1,9 @@
+{
+  "stable": {
+    "version": "8.10.60"
+  },
+
+  "beta": {
+    "version": "8.10.68-12.BETA"
+  }
+}


### PR DESCRIPTION
- Move `sources` attrset into a JSON file
- update.sh:
  - Generates `sources.json` by getting the channel versions from `versions.json`
  - Checks the PGP signatures of the Linux binaries

Version bump maintenance is now streamlined to:
1) change one or two lines in versions.json
2) run update.sh
3) test
4) commit updated sources.json


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
