### PR TITLE
gcc: Fix native linux build targeted for FreeBSD

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   targetPackages,
+  targetConfig',
 
   withoutTargetLibc,
   libcCross,
@@ -302,7 +303,8 @@ let
       # Workaround build failures like:
       #   cc1: error: fp software completion requires '-mtrap-precision=i' [-Werror]
       "--disable-werror"
-    ];
+    ]
+    ++ lib.optional stdenv.targetPlatform.isFreeBSD "--target=${targetConfig'}";
 
 in
 configureFlags

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -5,6 +5,7 @@
   langD ? false,
   libcCross,
   threadsCross,
+  pkgsTargetTarget,
 }:
 
 let
@@ -29,7 +30,8 @@ in
         );
     in
     mkFlags libcCross langD
-    ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD);
+    ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD)
+    ++ lib.optionals targetPlatform.isFreeBSD (mkFlags pkgsTargetTarget.freebsd.libncurses-tinfo langD);
 
   EXTRA_LDFLAGS_FOR_TARGET =
     let

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -7,6 +7,7 @@
   langJit,
   enableShared,
   targetPlatform,
+  targetConfig,
   hostPlatform,
   withoutTargetLibc,
   libcCross,
@@ -51,7 +52,7 @@ lib.pipe drv
         (
           let
             targetPlatformSlash =
-              if lib.systems.equals hostPlatform targetPlatform then "" else "${targetPlatform.config}/";
+              if lib.systems.equals hostPlatform targetPlatform then "" else "${targetConfig}/";
 
             # If we are building a cross-compiler and the target libc provided
             # to us at build time has a libgcc, use that instead of building a

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -44,6 +44,7 @@
   gnused ? null,
   buildPackages,
   pkgsBuildTarget,
+  pkgsTargetTarget,
   libxcrypt,
   disableGdbPlugin ?
     !enablePlugin
@@ -102,12 +103,15 @@ let
   #   "14.2.1.20250322" -> "14.2.1"
   #   "14.2.0" -> "14.2.0"
   baseVersion = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
-
   disableBootstrap = atLeast11 && !stdenv.hostPlatform.isDarwin && (atLeast12 -> !profiledCompiler);
 
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
-  targetConfig =
-    if (!lib.systems.equals targetPlatform hostPlatform) then targetPlatform.config else null;
+  targetConfig' =
+    targetPlatform.config
+    + lib.optionalString targetPlatform.isFreeBSD (
+      lib.versions.major targetPackages.stdenv.cc.libc.version
+    );
+  targetConfig = if (!lib.systems.equals targetPlatform hostPlatform) then targetConfig' else null;
 
   patches = callFile ./patches { };
 
@@ -128,6 +132,7 @@ let
       hostPlatform
       targetPlatform
       targetConfig
+      targetConfig'
       patches
       crossMingw
       stageNameAddon
@@ -177,6 +182,7 @@ let
       patchelf
       perl
       pkgsBuildTarget
+      pkgsTargetTarget
       profiledCompiler
       reproducibleBuild
       staticCompiler
@@ -479,6 +485,7 @@ pipe
           langCC
           langJit
           targetPlatform
+          targetConfig
           hostPlatform
           withoutTargetLibc
           enableShared


### PR DESCRIPTION
iirc this also fixes gfortran and libgcc

Still doesn't fix pkgsCross.x86_64-freebsd.gcc due to invoking clang with the gcc-only -dumpspecs flag, but progress is progress.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
