### PR TITLE
errbot: missing setuptools dependency for pkg_resources

### DIFF
--- a/pkgs/by-name/er/errbot/package.nix
+++ b/pkgs/by-name/er/errbot/package.nix
@@ -35,6 +35,7 @@ python3.pkgs.buildPythonApplication rec {
     pygments-markdown-lexer
     pyopenssl
     requests
+    setuptools
     slixmpp
     python-telegram-bot
     webtest


### PR DESCRIPTION

errbot needs setuptools as dependency for loading plugins, resolves this error: `ModuleNotFoundError: No module named 'pkg_resources'`


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
