### PR TITLE
laurel: 0.6.5 -> 0.7.0

### DIFF
--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -3,31 +3,21 @@
   fetchFromGitHub,
   lib,
   rustPlatform,
-  fetchpatch2,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "laurel";
-  version = "0.6.5";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "threathunters-io";
     repo = "laurel";
     tag = "v${version}";
-    hash = "sha256-1UjIye+btsNtf9Klti/3frgO7M+D05WkC1iP+TPQkZk=";
+    hash = "sha256-fToxRAcZOZvuuzaaWSjweqEwdUu3K2EKXY0K2Qixqpo=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-N5mgd2c/eD0QEUQ4Oe7JI/2yI0B1pawYfc4ZKZAu4Sk=";
-
-  patches = [
-    # https://github.com/threathunters-io/laurel/commit/d2fc51c83e78aecd5c4ce922582df649c2600e1e
-    # Unbreaks the userdb::test::userdb test. Will be part of the next release (likely v0.6.6).
-    (fetchpatch2 {
-      url = "https://github.com/threathunters-io/laurel/commit/d2fc51c83e78aecd5c4ce922582df649c2600e1e.patch?full_index=1";
-      hash = "sha256-OId5ZCF71ikoCSggyy3u4USR71onFJpirp53k4M17Vo=";
-    })
-  ];
+  cargoHash = "sha256-i5wsS7y65sIvICfgViVIAbQU9f1E0EmspX+YVKDSKOU=";
 
   postPatch = ''
     # Upstream started to redirect aarch64-unknown-linux-gnu to aarch64-linux-gnu-gcc


### PR DESCRIPTION
https://github.com/threathunters-io/laurel/releases/tag/v0.7.0

diff: https://github.com/threathunters-io/laurel/compare/v0.6.5...v0.7.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
