### PR TITLE
minbrowser: init at 1.34.1

### DIFF
--- a/pkgs/by-name/mi/minbrowser/package.nix
+++ b/pkgs/by-name/mi/minbrowser/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  dpkg,
+  autoPatchelfHook,
+
+  libxkbcommon,
+  libxcb,
+  xorg,
+  alsa-lib,
+  nss,
+  at-spi2-core,
+  mesa,
+  cairo,
+  pango,
+  cups,
+  gtk3,
+  glib,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "min";
+  version = "1.34.1";
+
+  src = fetchurl {
+    url = "https://github.com/minbrowser/min/releases/download/v${finalAttrs.version}/min-${finalAttrs.version}-amd64.deb";
+    hash = "sha256-gpkjGYuHwBY3IwK5bXhzIPPosSTZ67hclmGLT4PTsG4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libxkbcommon # libxkbcommon.so
+    libxcb # libxcb.so
+    at-spi2-core # libatspi.so
+    mesa # libdbm.so libexpat.so
+    cairo # libcairo.so
+    cups # libcups.so
+    gtk3 # libgtk-3.so
+    pango # libpango-1.0.so
+    (with xorg; [
+      libX11 # libX11.so
+      libXcomposite # libXcomposite.so
+      libXdamage # libXdamage.so
+      libXext # libXext.so
+      libXfixes # libXfixes.so
+      libXrandr # libXrandr.so
+    ])
+    nss # libnss3.so
+    alsa-lib # libasound.so
+    glib # libglib-2.0.so libgobject-2.0.so libgio.so
+    stdenv.cc.cc.lib # libgcc_s.so
+  ];
+
+  unpackPhase = "dpkg-deb -x $src $out";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A fast, minimal browser that protects your privacy";
+    homepage = "https://github.com/minbrowser/min";
+    changelog = "https://github.com/minbrowser/min/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kashw2 ];
+  };
+})

--- a/pkgs/by-name/mi/minbrowser/package.nix
+++ b/pkgs/by-name/mi/minbrowser/package.nix
@@ -59,7 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
     stdenv.cc.cc.lib # libgcc_s.so
   ];
 
-  unpackPhase = "dpkg-deb -x $src $out";
+  unpackPhase = "
+    dpkg-deb -x $src $out
+    mv $out/usr/share $out
+    mkdir -p $out/bin
+    ln -s $out/opt/Min/min $out/bin/min
+  ";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mi/minbrowser/package.nix
+++ b/pkgs/by-name/mi/minbrowser/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A fast, minimal browser that protects your privacy";
+    description = "Fast, minimal browser that protects your privacy";
     homepage = "https://github.com/minbrowser/min";
     changelog = "https://github.com/minbrowser/min/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;


### PR DESCRIPTION
This PR adds the package [minbrowser](https://github.com/minbrowser/min), closing #229341. Actually it is credit to @kashw2 (#253613) .

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
