### PR TITLE
zeekstd: init at 0.2.2

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -24,6 +24,7 @@
   # compression tools
 , zstd
 , xz
+, zeekstd
 
   # arguments
 , name
@@ -89,11 +90,13 @@ let
   compressionPkg = {
     "zstd" = zstd;
     "xz" = xz;
+    "zstd-seekable" = zeekstd;
   }."${compression.algorithm}";
 
   compressionCommand = {
     "zstd" = "zstd --no-progress --threads=$NIX_BUILD_CORES -${toString compression.level}";
     "xz" = "xz --keep --verbose --threads=$NIX_BUILD_CORES -${toString compression.level}";
+    "zstd-seekable" = "zeekstd --quiet --max-frame-size 2M --compression-level ${toString compression.level}";
   }."${compression.algorithm}";
 in
   stdenvNoCC.mkDerivation (finalAttrs:

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -113,7 +113,7 @@ in
       enable = lib.mkEnableOption "Image compression";
 
       algorithm = lib.mkOption {
-        type = lib.types.enum [ "zstd" "xz" ];
+        type = lib.types.enum [ "zstd" "xz" "zstd-seekable" ];
         default = "zstd";
         description = "Compression algorithm";
       };
@@ -274,6 +274,7 @@ in
           {
             "zstd" = ".zst";
             "xz" = ".xz";
+            "zstd-seekable" = ".zst";
           }."${cfg.compression.algorithm}";
 
         makeClosure = paths: pkgs.closureInfo { rootPaths = paths; };
@@ -298,6 +299,7 @@ in
           level = lib.mkOptionDefault {
             "zstd" = 3;
             "xz" = 3;
+            "zstd-seekable" = 3;
           }."${cfg.compression.algorithm}";
         };
 

--- a/pkgs/by-name/ze/zeekstd/package.nix
+++ b/pkgs/by-name/ze/zeekstd/package.nix
@@ -3,30 +3,26 @@
   lib,
   rustPlatform,
 }:
-let
-  version = "0.2.2";
-in
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zeekstd";
-  inherit version;
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "rorosen";
     repo = "zeekstd";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Blyp5GpnytB3S4k6lp2fAwXueaUtXqPW+WLEmFNPZc0=";
   };
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-bbl0zHxd2HYkctX029mtxDciC2tnPVTlHxYyetmtuw0=";
-  stripAllList = [ "bin" ];
 
   meta = {
     description = "CLI tool that works with the zstd seekable format";
     homepage = "https://github.com/rorosen/zeekstd";
-    changelog = "https://github.com/rorosen/zeekstd/releases/tag/v${version}";
+    changelog = "https://github.com/rorosen/zeekstd/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.rorosen ];
     mainProgram = "zeekstd";
   };
-}
+})

--- a/pkgs/by-name/ze/zeekstd/package.nix
+++ b/pkgs/by-name/ze/zeekstd/package.nix
@@ -1,0 +1,32 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+}:
+let
+  version = "0.2.2";
+in
+rustPlatform.buildRustPackage {
+  pname = "zeekstd";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "rorosen";
+    repo = "zeekstd";
+    tag = "v${version}";
+    hash = "sha256-Blyp5GpnytB3S4k6lp2fAwXueaUtXqPW+WLEmFNPZc0=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-bbl0zHxd2HYkctX029mtxDciC2tnPVTlHxYyetmtuw0=";
+  stripAllList = [ "bin" ];
+
+  meta = {
+    description = "CLI tool that works with the zstd seekable format";
+    homepage = "https://github.com/rorosen/zeekstd";
+    changelog = "https://github.com/rorosen/zeekstd/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.rorosen ];
+    mainProgram = "zeekstd";
+  };
+}


### PR DESCRIPTION
Zeekstd is a CLI tool that works with the zstd seekable format.

The seekable format splits compressed data into a series of independent
frames, each of which can be decompressed individually. This allows to
distribute images in smaller chunks and allows image downloads to be
paused and resumed later from the same point.

Seekable archives as a whole can be decompressed with any regular zstd
decompressor. However, partial decompression requires to know the
starting position of the desired frame, which can be extracted from a
skippable frame (aka seektable) that is appended to the compressed data.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@nikstur @WilliButz 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
