### PR TITLE
spotifyd: 0.3.5-unstable-2024-12-27 -> 0.4.0

### DIFF
--- a/pkgs/by-name/sp/spotifyd/package.nix
+++ b/pkgs/by-name/sp/spotifyd/package.nix
@@ -2,77 +2,74 @@
   lib,
   stdenv,
   config,
-  fetchFromGitHub,
-  rustPackages,
-  pkg-config,
-  openssl,
-  withALSA ? stdenv.hostPlatform.isLinux,
   alsa-lib,
-  withJack ? stdenv.hostPlatform.isLinux,
-  libjack2,
-  withPulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
-  libpulseaudio,
-  withPortAudio ? stdenv.hostPlatform.isDarwin,
-  portaudio,
-  withMpris ? stdenv.hostPlatform.isLinux,
-  withKeyring ? true,
+  cmake,
   dbus,
-  withPipe ? true,
+  fetchFromGitHub,
+  libjack2,
+  libpulseaudio,
   nix-update-script,
+  openssl,
+  pkg-config,
+  portaudio,
+  rustPlatform,
   testers,
-  spotifyd,
+  withALSA ? stdenv.hostPlatform.isLinux,
+  withJack ? stdenv.hostPlatform.isLinux,
+  withMpris ? stdenv.hostPlatform.isLinux,
+  withPortAudio ? stdenv.hostPlatform.isDarwin,
+  withPulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
 }:
 
-rustPackages.rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spotifyd";
-  version = "0.3.5-unstable-2024-12-27";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "Spotifyd";
     repo = "spotifyd";
-    rev = "c6e6af449b75225224158aeeef64de485db1139e";
-    hash = "sha256-0HDrnEeqynb4vtJBnXyItprJkP+ZOAKIBP68Ht9xr2c=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YBh5lcHXqYjyo/MjNNxnycY5AXjvlu+2gAzG6gM4Gjc=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-12yil8Xg3xHeOe/oq9O+Cvkgrx1KhmlQ11d9QHCxtsk=";
+  cargoHash = "sha256-waZ9XNYZ/scyMsNT7bZYqN4Ch4GbuQtwxAYaWTjNZwg=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
 
   buildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [ openssl ]
+    # The `dbus_mpris` feature works on other platforms, but only requires `dbus` on Linux
+    ++ lib.optional (withMpris && stdenv.hostPlatform.isLinux) dbus
     ++ lib.optional (withALSA || withJack) alsa-lib
     ++ lib.optional withJack libjack2
     ++ lib.optional withPulseAudio libpulseaudio
-    ++ lib.optional withPortAudio portaudio
-    # The `dbus_keying` feature works on other platforms, but only requires
-    # `dbus` on Linux
-    ++ lib.optional ((withMpris || withKeyring) && stdenv.hostPlatform.isLinux) dbus;
+    ++ lib.optional withPortAudio portaudio;
+
+  # `aws-lc-sys` fails with this enabled
+  hardeningDisable = [ "strictoverflow" ];
 
   buildNoDefaultFeatures = true;
   buildFeatures =
     lib.optional withALSA "alsa_backend"
     ++ lib.optional withJack "rodiojack_backend"
-    ++ lib.optional withPulseAudio "pulseaudio_backend"
-    ++ lib.optional withPortAudio "portaudio_backend"
     ++ lib.optional withMpris "dbus_mpris"
-    ++ lib.optional withPipe "pipe_backend"
-    ++ lib.optional withKeyring "dbus_keyring";
-
-  doCheck = false;
+    ++ lib.optional withPortAudio "portaudio_backend"
+    ++ lib.optional withPulseAudio "pulseaudio_backend";
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = spotifyd;
-      version = builtins.head (lib.splitString "-" version);
-    };
-    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Open source Spotify client running as a UNIX daemon";
     homepage = "https://spotifyd.rs/";
-    changelog = "https://github.com/Spotifyd/spotifyd/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/Spotifyd/spotifyd/releases/tag/${toString finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       anderslundstedt
@@ -82,4 +79,4 @@ rustPackages.rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.unix;
     mainProgram = "spotifyd";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/Spotifyd/spotifyd/compare/c6e6af449b75225224158aeeef64de485db1139e...v0.4.0

Changelog: https://github.com/Spotifyd/spotifyd/releases/tag/v0.4.0

Highlight of this bump is the new [OAuth support](https://docs.spotifyd.rs/configuration/auth.html#manual-login-via-oauth)

Tested with a Spotify Premium account


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
