### PR TITLE
pipewire: fix build for FreeBSD

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -10,7 +10,7 @@
   libinotify-kqueue,
   epoll-shim,
   systemd,
-  enableSystemd ? stdenv.hostPlatform.isLinux, # enableSystemd=false maintained by maintainers.qyliss.
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, # enableSystemd=false maintained by maintainers.qyliss.
   pkg-config,
   docutils,
   doxygen,
@@ -60,7 +60,7 @@
   ffadoSupport ?
     x11Support
     && lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform
-    && stdenv.hostPlatform.isLinux,
+    && lib.meta.availableOn stdenv.hostPlatform ffado,
   ffado,
   libselinux,
   libebur128,
@@ -73,7 +73,9 @@ let
   ];
 
   bluezSupport = stdenv.hostPlatform.isLinux;
-  modemmanagerSupport = stdenv.hostPlatform.isLinux;
+  modemmanagerSupport = lib.meta.availableOn stdenv.hostPlatform modemmanager;
+  libcameraSupport = lib.meta.availableOn stdenv.hostPlatform libcamera;
+  ldacbtSupport = lib.meta.availableOn stdenv.hostPlatform ldacbt;
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -153,8 +155,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.take 1 webrtc-audio-processings
     ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib
-    ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform ldacbt) ldacbt
-    ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform libcamera) libcamera
+    ++ lib.optional ldacbtSupport ldacbt
+    ++ lib.optional libcameraSupport libcamera
     ++ lib.optional zeroconfSupport avahi
     ++ lib.optional raopSupport openssl
     ++ lib.optional rocSupport roc-toolkit
@@ -218,9 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
     # source code is not easily obtainable
     (lib.mesonEnable "bluez5-codec-lc3plus" false)
     (lib.mesonEnable "bluez5-codec-lc3" bluezSupport)
-    (lib.mesonEnable "bluez5-codec-ldac" (
-      bluezSupport && (lib.meta.availableOn stdenv.hostPlatform ldacbt)
-    ))
+    (lib.mesonEnable "bluez5-codec-ldac" (bluezSupport && ldacbtSupport))
     (lib.mesonEnable "opus" true)
     (lib.mesonOption "sysconfdir" "/etc")
     (lib.mesonEnable "raop" raopSupport)


### PR DESCRIPTION
cc https://github.com/NixOS/nixpkgs/pull/328999

Not that I haven't booted a graphical environment with this yet - this is simply a dependency for openal-soft, which is a dependency of something else I wanted.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
