### PR TITLE
cantata: 2.5.0 -> 3.3.1

### DIFF
--- a/pkgs/by-name/ca/cantata/dont-check-for-perl-in-PATH.diff
+++ b/pkgs/by-name/ca/cantata/dont-check-for-perl-in-PATH.diff
@@ -1,17 +1,16 @@
 diff --git a/playlists/dynamicplaylists.cpp b/playlists/dynamicplaylists.cpp
-index 07b6dce3..6a3f97c9 100644
+index b85e93b5..3c29f775 100644
 --- a/playlists/dynamicplaylists.cpp
 +++ b/playlists/dynamicplaylists.cpp
-@@ -211,11 +211,6 @@ void DynamicPlaylists::start(const QString &name)
-         return;
-     }
+@@ -205,11 +205,6 @@ void DynamicPlaylists::start(const QString& name)
+ 		return;
+ 	}
  
--    if (Utils::findExe("perl").isEmpty()) {
--        emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
--        return;
--    }
+-	if (Utils::findExe("perl").isEmpty()) {
+-		emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
+-		return;
+-	}
 -
-     QString fName(Utils::dataDir(rulesDir, false)+name+constExtension);
+ 	QString fName(Utils::dataDir(rulesDir, false) + name + constExtension);
  
-     if (!QFile::exists(fName)) {
-
+ 	if (!QFile::exists(fName)) {


### PR DESCRIPTION
## Things done

Original developer archived the repo a few years ago: https://github.com/CDrummond/cantata

Switched to an updated Qt6 fork: https://github.com/nullobsi/cantata

Added taglib 2 instead of replacing taglib 1 since it's not backwards compatible.

Also enabled libvlc for playback over http since I've never managed to get http playback working without it.

## Notes:

Reattempting: https://github.com/NixOS/nixpkgs/pull/317834

Closing: https://github.com/NixOS/nixpkgs/issues/315695

Wondering what happened: https://github.com/NixOS/nixpkgs/pull/373837

Pretending like I didn't just notice: https://github.com/NixOS/nixpkgs/pull/357341

( @FlyingWombat sorry :D )

- Built on platform(s)
  - [x] x86_64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
