### PR TITLE
treewide: avoid using finalAttrs.pname

### DIFF
--- a/pkgs/by-name/ag/agorakit/package.nix
+++ b/pkgs/by-name/ag/agorakit/package.nix
@@ -10,8 +10,8 @@ php.buildComposerProject2 (finalAttrs: {
   version = "1.9.3";
 
   src = fetchFromGitHub {
-    owner = finalAttrs.pname;
-    repo = finalAttrs.pname;
+    owner = "agorakit";
+    repo = "agorakit";
     tag = finalAttrs.version;
     sha256 = "sha256-mBBl/8nXG3FsMeecbERLyY2tGFhh+5nS8A4nd7HI+8c=";
   };

--- a/pkgs/by-name/ba/base45/package.nix
+++ b/pkgs/by-name/ba/base45/package.nix
@@ -16,7 +16,7 @@ buildNimPackage (finalAttrs: {
   meta = finalAttrs.src.meta // {
     description = "Base45 library for Nim";
     license = lib.licenses.unlicense;
-    mainProgram = finalAttrs.pname;
+    mainProgram = "base45";
     maintainers = with lib.maintainers; [ ehmry ];
   };
 })

--- a/pkgs/by-name/ch/chsrc/package.nix
+++ b/pkgs/by-name/ch/chsrc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "RubyMetric";
-    repo = finalAttrs.pname;
+    repo = "chsrc";
     rev = "v${finalAttrs.version}";
     hash = "sha256-MwT6SuDisJ2ynxlOqAUA8WjhrTeUcyoAMArehnby8Yw=";
   };

--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -86,8 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "FRRouting";
-    repo = finalAttrs.pname;
-    rev = "${finalAttrs.pname}-${finalAttrs.version}";
+    repo = "frr";
+    rev = "frr-${finalAttrs.version}";
     hash = "sha256-TWqW6kI5dDl6IW2Ql6eeySDSyxp0fPgcJOOX1JxjAxs=";
   };
 

--- a/pkgs/by-name/ii/iio-oscilloscope/package.nix
+++ b/pkgs/by-name/ii/iio-oscilloscope/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "analogdevicesinc";
-    repo = finalAttrs.pname;
+    repo = "iio-oscilloscope";
     rev = "v${finalAttrs.version}-master";
     hash = "sha256-wCeOLAkrytrBaXzUbNu8z2Ayz44M+b+mbyaRoWHpZYU=";
   };

--- a/pkgs/by-name/mi/minutor/package.nix
+++ b/pkgs/by-name/mi/minutor/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "mrkite";
-    repo = finalAttrs.pname;
+    repo = "minutor";
     tag = finalAttrs.version;
     sha256 = "0ldjnrk429ywf8cxdpjkam5k73s6fq7lvksandfn3xn7gl9np5rk";
   };

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "misskey-dev";
-    repo = finalAttrs.pname;
+    repo = "misskey";
     rev = finalAttrs.version;
     hash = "sha256-uei5Ojx39kCbS8DCjHZ5PoEAsqJ5vC6SsFqIEIJ16n8=";
     fetchSubmodules = true;

--- a/pkgs/by-name/st/stellarsolver/package.nix
+++ b/pkgs/by-name/st/stellarsolver/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "rlancaste";
-    repo = finalAttrs.pname;
+    repo = "stellarsolver";
     rev = finalAttrs.version;
     sha256 = "sha256-6WDiHaBhi9POtXynGU/eTeuqZSK81JJeuZv4SxOeVoE=";
   };

--- a/pkgs/by-name/ta/tart/package.nix
+++ b/pkgs/by-name/ta/tart/package.nix
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       emilytrau
       aduh95
     ];
-    mainProgram = finalAttrs.pname;
+    mainProgram = "tart";
     platforms = [
       "aarch64-darwin"
       "x86_64-darwin"

--- a/pkgs/by-name/ts/tslib/package.nix
+++ b/pkgs/by-name/ts/tslib/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "libts";
-    repo = finalAttrs.pname;
+    repo = "tslib";
     rev = finalAttrs.version;
     sha256 = finalAttrs.hash;
   };

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     downloadPage = "https://github.com/ytmdesktop/ytmdesktop/releases";
     homepage = "https://ytmdesktop.app/";
     license = lib.licenses.gpl3Only;
-    mainProgram = finalAttrs.pname;
+    mainProgram = "ytmdesktop";
     maintainers = [ lib.maintainers.cjshearer ];
     inherit (electron_33.meta) platforms;
     # While the files we extract from the .deb are cross-platform (javascript), the installation

--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "zdharma-continuum";
-    repo = finalAttrs.pname;
+    repo = "zinit";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fnBV0LmC/wJm0pOITJ1mhiBqsg2F8AQJWvn0p/Bgo5Q=";
   };


### PR DESCRIPTION
located with rg `'(repo|owner|mainProgram) = finalAttrs\.pname'`, I built all the `.src` derivations with `--check`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
