### PR TITLE
descent3-unwrapped: 1.5.0-beta-unstable-2025-02-13 → 1.5.0-beta-unstable-2025-03-06

### DIFF
--- a/pkgs/by-name/de/descent3-unwrapped/package.nix
+++ b/pkgs/by-name/de/descent3-unwrapped/package.nix
@@ -1,10 +1,13 @@
 {
-  SDL2,
   cmake,
   fetchFromGitHub,
   glm,
+  httplib,
   lib,
+  openssl,
+  plog,
   runCommand,
+  sdl3,
   stdenv,
   unstableGitUpdater,
   writeShellScript,
@@ -17,12 +20,11 @@ stdenv.mkDerivation rec {
   # the wrapped version of Descent 3. Once there’s a stable version of Descent
   # 3 that supports the -additionaldir command-line option, we can stop using
   # an unstable version of Descent 3.
-  version = "1.5.0-beta-unstable-2025-02-13";
+  version = "1.5.0-beta-unstable-2025-03-06";
   src = fetchFromGitHub {
     owner = "DescentDevelopers";
     repo = "Descent3";
-    rev = "10a20d7cb769a08010e7887b4701a0ecfb142492";
-    fetchSubmodules = true;
+    rev = "c99e57cfabb16b2b428d4827eedb26b8cc20a1ee";
     leaveDotGit = true;
     # Descent 3 is supposed to display its Git commit hash in the bottom right
     # corner of the main menu. That feature only works if either the .git
@@ -48,14 +50,17 @@ stdenv.mkDerivation rec {
       git rev-parse --verify HEAD | tr --delete '\n' > git-hash.txt
       rm -r .git
     '';
-    hash = "sha256-Ufu6oHLUn0eI6OTp8cfHRLYpx+tZ3QwX4qz3KpTbQ68=";
+    hash = "sha256-HbEAv4HFZromeVfsH66m9PwinOG9qs5rQLGK5hkO3+A=";
   };
 
   hardeningDisable = [ "format" ];
   nativeBuildInputs = [ cmake ];
   buildInputs = [
-    SDL2
     glm
+    httplib
+    openssl
+    plog
+    sdl3
     zlib
   ];
   cmakeFlags = [ "-DFORCE_PORTABLE_INSTALL=OFF" ];


### PR DESCRIPTION
I tested this PR on NixOS 24.11, and everything seemed to work fine. Things checked:

- I was able to start a single player game on the Training Mission.
- I was able to beat Descent 3: Retribution level 6 in single player.
- I was able to beat Descent 3: Mercenary level 5 in single player.
- I was able to start a single player game on the Tri-Pod mission.
- I was able to host a dedicated anarchy server, and I was able to connect to that server with a single client.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
