### PR TITLE
mullvad-browser: 14.0.5 -> 14.0.7

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
-  version = "14.0.5";
+  version = "14.0.7";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-y98IzCnojbBDDj6PcbxtTPwfHA4wZpw6g1qtmSgkpFA=";
+      hash = "sha256-PgNZR0Bh5l3y6Vwd8BPuz9Dm0MSp6T2io4Yjmy/cPH0=";
     };
   };
 


### PR DESCRIPTION
https://github.com/mullvad/mullvad-browser/releases/tag/14.0.7

This release includes [security fixes from firefox ESR 128.8.0](https://www.mozilla.org/en-US/security/advisories/mfsa2025-16/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

I don't know why it built all those pkgs, but it includes mullvad-browser. Manual testing of browsing and video was ok.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>hyprlandPlugins.hycov</li>
    <li>hyprlandPlugins.hyprfocus</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 39 packages built:</summary>
  <ul>
    <li>contour</li>
    <li>contour.terminfo</li>
    <li>glaze</li>
    <li>grimblast</li>
    <li>hdrop</li>
    <li>home-assistant-component-tests.kulersky</li>
    <li>hyprland</li>
    <li>hyprland.dev</li>
    <li>hyprland.man</li>
    <li>hyprlandPlugins.borders-plus-plus</li>
    <li>hyprlandPlugins.csgo-vulkan-fix</li>
    <li>hyprlandPlugins.hy3</li>
    <li>hyprlandPlugins.hypr-dynamic-cursors</li>
    <li>hyprlandPlugins.hyprbars</li>
    <li>hyprlandPlugins.hyprexpo</li>
    <li>hyprlandPlugins.hyprgrass</li>
    <li>hyprlandPlugins.hyprscroller</li>
    <li>hyprlandPlugins.hyprspace</li>
    <li>hyprlandPlugins.hyprsplit</li>
    <li>hyprlandPlugins.hyprtrails</li>
    <li>hyprlandPlugins.hyprwinwrap</li>
    <li>hyprshade</li>
    <li>hyprshade.dist</li>
    <li>hyprshot</li>
    <li>moar</li>
    <li>mullvad-browser</li>
    <li>nwg-panel</li>
    <li>nwg-panel.dist</li>
    <li>plantuml-server</li>
    <li>python312Packages.pykulersky</li>
    <li>python312Packages.pykulersky.dist</li>
    <li>python313Packages.pykulersky</li>
    <li>python313Packages.pykulersky.dist</li>
    <li>step-cli</li>
    <li>termbench-pro</li>
    <li>terraform-providers.okta</li>
    <li>waybar</li>
    <li>xdg-desktop-portal-hyprland</li>
    <li>yek</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
