### PR TITLE
lib.attrsets.recurse: init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -679,19 +679,7 @@ rec {
     :::
   */
   filterAttrsRecursive =
-    pred:
-    set:
-    listToAttrs (
-      concatMap (name:
-        let v = set.${name}; in
-        if pred name v then [
-          (nameValuePair name (
-            if isAttrs v then filterAttrsRecursive pred v
-            else v
-          ))
-        ] else []
-      ) (attrNames set)
-    );
+    pred: set: recurse (f: attrs: mapAttrs f (filterAttrs pred attrs)) (_: _: true) (_: v: v) set;
 
    /**
     Like [`lib.lists.foldl'`](#function-library-lib.lists.foldl-prime) but for attribute sets.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1280,7 +1280,7 @@ rec {
     ```nix
     mapAttrsRecursiveCond
       (as: !(as ? "type" && as.type == "derivation"))
-      (x: x.name)
+      (_: x: x.name)
       attrs
     ```
     :::
@@ -1291,19 +1291,8 @@ rec {
     ```
   */
   mapAttrsRecursiveCond =
-    cond:
-    f:
-    set:
-    let
-      recurse = path:
-        mapAttrs
-          (name: value:
-            if isAttrs value && cond value
-            then recurse (path ++ [ name ]) value
-            else f (path ++ [ name ]) value);
-    in
-    recurse [ ] set;
-
+    cond: f: set:
+    recurse mapAttrs (_: cond) f set;
 
   /**
     Generate an attribute set by mapping a function over a list of

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -872,6 +872,102 @@ rec {
       [];
 
   /**
+    Recursively apply `fAttrs` function to a potentially nested attribute set
+    graph’s root and branches, and apply `f` to leaf attributes. The traversal
+    is depth-first pre-order, controlled by the `isBranch` predicate.
+
+    The root of a graph is a final argument `attrs`. Every attribute value that
+    is not an attribute set or does not satisfy `isBranch` is considered a leaf.
+    Branches are always attribute sets.
+
+    # Inputs
+
+    `fAttrs :: (String -> a -> b) -> AttrSet -> c`
+
+    : Given a function and an attribute set, produce the value by applying the
+      function to the set's attribute names and values.
+
+      The first argument is a function that either recurses into a branch using
+      `fAttrs` or applies `f` to a leaf attribute.
+
+    `isBranch :: [String] -> AttrSet -> Bool`
+
+    : Given a nested attribute set's path and value, determine if recursion
+      should continue, that is, whether the value is a branch.
+
+      If the predicate returns false, `recurse` does not recurse, but instead
+      applies the `f` mapping function.
+
+      If the predicate returns true, it does recurse, and does not apply the
+      mapping function.
+
+      If `isBranch` always returns false, `recurse` behaves like a non-recursive
+      `fAttrs` function.
+
+    `f :: [String] -> a -> b`
+
+    : Given an attribute's path and value, produce the value for a leaf
+      attribute mapped with `fAttrs`.
+
+      Note that `isAttrs value` implies `isBranch path value == false`.
+
+    `attrs`
+
+    : The attribute set to recurse into.
+
+    # Type
+
+    ```
+    recurse :: ((String -> a -> b) -> AttrSet -> c) -> ([String] -> AttrSet -> Bool) -> ([String] -> a -> b) -> AttrSet -> c
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.recurse` usage example
+
+    ```nix
+    attrs = {
+      a = 1;
+      b = attrs;
+    }
+    attrsets.recurse mapAttrs
+      (path: _: length path < 3)
+      (path: value: { inherit path value; })
+      attrs
+    => {
+         a = { path = [ "a" ]; value = 1; };
+         b = {
+           a = { path = [ "b" "a" ]; value = 1; };
+           b = {
+             a = { path = [ "b" "b" "a" ]; value = 1; };
+             b = { path = [ "b" "b" "b" ]; value = attrs; };
+           };
+         };
+       }
+    attrsets.recurse (_: attrs: attrs) (_: _: throw "no recursion") (_: _: throw "no recursion") { a = { }; }
+    => { a = { }; }
+    ```
+
+    :::
+  */
+  recurse =
+    fAttrs: isBranch: f: attrs:
+    let
+      recurse' =
+        path:
+        fAttrs (
+          name: value:
+          let
+            pathToValue = path ++ [ name ];
+            valueIsBranch = isAttrs value && isBranch pathToValue value;
+            visit = if valueIsBranch then recurse' else f;
+          in
+          visit pathToValue value
+        );
+    in
+    recurse' [ ] attrs;
+
+  /**
     Return the cartesian product of attribute set value combinations.
 
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -68,6 +68,7 @@ let
     hasInfix
     id
     ifilter0
+    init
     isStorePath
     lazyDerivation
     length
@@ -77,6 +78,7 @@ let
     makeIncludePath
     makeOverridable
     mapAttrs
+    mapAttrsToList
     mapCartesianProduct
     matchAttrs
     mergeAttrs
@@ -1226,6 +1228,99 @@ runTests {
       expr = attrsets.mergeAttrsList list;
       expected = foldl' mergeAttrs { } list;
     };
+
+  ## code from the example
+  testRecurseExample =
+    let
+      attrs = {
+        a = 1;
+        b = attrs;
+      };
+    in
+    {
+      expr = attrsets.recurse mapAttrs (path: _: length path < 3) (path: value: {
+        inherit path value;
+      }) attrs;
+      expected = {
+        a = {
+          path = [ "a" ];
+          value = 1;
+        };
+        b = {
+          a = {
+            path = [
+              "b"
+              "a"
+            ];
+            value = 1;
+          };
+          b = {
+            a = {
+              path = [
+                "b"
+                "b"
+                "a"
+              ];
+              value = 1;
+            };
+            b = {
+              path = [
+                "b"
+                "b"
+                "b"
+              ];
+              value = attrs;
+            };
+          };
+        };
+      };
+    };
+
+  testRecurseWithId = {
+    expr =
+      attrsets.recurse (_: attrs: attrs) (_: _: throw "isBranch not needed") (_: _: throw "f not needed")
+        {
+          a.b.c = 1;
+        };
+    expected = {
+      a.b.c = 1;
+    };
+  };
+
+  testRecurseMapAttrs = {
+    expr = attrNames (
+      attrsets.recurse mapAttrs (_: v: true) (_: v: v) {
+        a = "ok";
+        b = throw "not lazy enough";
+      }
+    );
+    expected = [
+      "a"
+      "b"
+    ];
+  };
+
+  testRecurseMapAttrsToList = {
+    expr = init (
+      attrsets.recurse mapAttrsToList (_: v: true) (_: v: v) {
+        a = "a";
+        b.x = "b.x";
+        b.y = "b.y";
+        c.c.c = "c.c.c";
+        d = "d";
+        e = throw "not lazy enough";
+      }
+    );
+    expected = [
+      "a"
+      [
+        "b.x"
+        "b.y"
+      ]
+      [ [ "c.c.c" ] ]
+      "d"
+    ];
+  };
 
   # code from the example
   testRecursiveUpdateUntil = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -49,6 +49,7 @@ let
     extends
     filter
     filterAttrs
+    filterAttrsRecursive
     fix
     fold
     foldAttrs
@@ -1170,6 +1171,18 @@ runTests {
         hello = true;
         world = false;
       };
+    };
+  };
+
+  # code from example
+  testFilterAttrsRecursive = {
+    expr = filterAttrsRecursive (n: v: v != null) {
+      foo = {
+        bar = null;
+      };
+    };
+    expected = {
+      foo = { };
     };
   };
 


### PR DESCRIPTION
This PR adds `lib.attrsets.recurse` function (based on `mapAttrsRecursiveCond`) that performs graph traversal on nested attribute sets and allows converting other functions like `mapAttrs`, `concatMapAttrs`, `mapAttrsToList`, etc, to recursive versions.

It also updates `mapAttrsRecursiveCond` and `filterAttrsRecursive` implementations to use `recurse`. In particular, this allows reusing `filterAttrs` for recursive implementation and should benefit from https://github.com/NixOS/nixpkgs/pull/345547.

See also #237776

Supersedes #221608 (`lib.{collect',flattenAttrs}` can be implemented using `attrsets.recurse`). E.g.
```nix
lib.attrsets.recurse lib.concatMapAttrs
  (_: v: v != { })
  (p: v: { ${lib.concatStringsSep "/" p} = v; })
  { a = 1; b.c.d = 2; x.y = { }; }
⇒ { a = 1; "b/c/d" = 2; "x/y" = { }; }
```

```nix
concatMapAttrsToList = f: attrs: builtins.concatMap (name: f name attrs.${name}) (builtins.attrNames attrs)
lib.attrsets.recurse concatMapAttrsToList
  (_: v: v != { })
  (path: value: [{ inherit path value; }])
  { a = 1; b.c.d = 2; x.y = { }; }
⇒ [
    { path = [ "a" ]; value = 1; }
    { path = [ "b" "c" "d" ]; value = 2; }
    { path = [ "x" "y" ]; value = { }; }
  ]
```

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
