### PR TITLE
miraclecast: 1.0-20231112 -> 1.0-unstable-2024-07-13

### DIFF
--- a/pkgs/by-name/mi/miraclecast/package.nix
+++ b/pkgs/by-name/mi/miraclecast/package.nix
@@ -1,30 +1,46 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
+  glib,
+  gst_all_1,
+  iproute2,
+  libtool,
+  makeBinaryWrapper,
   meson,
+  miraclecast,
   ninja,
   pkg-config,
-  glib,
   readline,
-  pcre,
-  systemd,
+  stdenv,
+  systemdLibs,
+  testers,
   udev,
-  iproute2,
+  wpa_supplicant,
+  relyUdev ? true,
 }:
 
+let
+  gstreamerPluginPaths = lib.concatMapStrings (pth: pth + "/lib/gstreamer-1.0:") [
+    (lib.getLib gst_all_1.gstreamer)
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+  ];
+in
 stdenv.mkDerivation {
   pname = "miraclecast";
-  version = "1.0-20231112";
+  version = "1.0-unstable-2024-07-13";
 
   src = fetchFromGitHub {
     owner = "albfan";
     repo = "miraclecast";
-    rev = "af6ab257eae83bb0270a776a8fe00c0148bc53c4";
-    hash = "sha256-3ZIAvA3w/ZhoJtVmUD444nch0PGD58PdBRke7zd9IuQ=";
+    rev = "937747fd4de64a33bccf5adb73924c435ceb821b";
+    hash = "sha256-y37+AOz8xYjtDk9ITxMB7UeWeMpDH+b6HQBczv+x5zo=";
   };
 
   nativeBuildInputs = [
+    makeBinaryWrapper
     meson
     ninja
     pkg-config
@@ -32,24 +48,44 @@ stdenv.mkDerivation {
 
   buildInputs = [
     glib
-    pcre
-    readline
-    systemd
-    udev
+    gst_all_1.gstreamer
     iproute2
+    libtool
+    readline
+    systemdLibs
+    udev
+    wpa_supplicant
   ];
 
-  mesonFlags = [
-    "-Drely-udev=true"
-    "-Dbuild-tests=true"
-    "-Dip-binary=${iproute2}/bin/ip"
-  ];
+  mesonFlags =
+    [
+      "-Dbuild-tests=true"
+      "-Dip-binary=${iproute2}/bin/ip"
+    ]
+    ++ lib.optionals relyUdev [
+      "-Drely-udev=true"
+    ];
+
+  postPatch = ''
+    substituteInPlace res/miracle-gst \
+      --replace-fail "/usr/bin/gst-launch-1.0" "${gst_all_1.gstreamer}/bin/gst-launch-1.0"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/miracle-gst --set GST_PLUGIN_SYSTEM_PATH_1_0 ${gstreamerPluginPaths}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = miraclecast;
+    command = "miracled --version";
+    version = "Miraclecast 1";
+  };
 
   meta = with lib; {
-    description = "Connect external monitors via Wi-Fi";
+    description = "Connect external monitors to your system via Wifi-Display specification also known as Miracast";
     homepage = "https://github.com/albfan/miraclecast";
     license = licenses.lgpl21Plus;
-    maintainers = [ ];
+    maintainers = [ maintainers.wizardlink ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Here](https://github.com/albfan/miraclecast/compare/af6ab257eae83bb0270a776a8fe00c0148bc53c4..937747fd4de64a33bccf5adb73924c435ceb821b) are the changes since version `1.0-20231112`. 

These aren't huge changes but since I have a personal need for the package, I might as well contribute the latest version to nixpkgs.

For the package changes, I've done the following:
- Removed unused `prce` package from inputs.
- Added missing packages  -
  - `gstreamer` and relevant plugins;
  - `libtool`;
  - `wpa_supplicant`;
- Use `systemdLibs` instead of `systemd`.
- Patch the `miracle-gst` script and wrap it.
- Created a version passthru test.
- Include an optional flag to enable/disable [rely udev](https://github.com/albfan/miraclecast/?tab=readme-ov-file#automatic-interface-selection-with-udev)
  - _Defaults to true, to maintain the previous behaviour._

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
