### PR TITLE
python312Packages.langchain-*: 250306 update

### DIFF
--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -36,24 +36,34 @@
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.3.17";
+  version = "0.3.19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-community==${version}";
-    hash = "sha256-+10Q8em74G5RU6VtDqhQJuDsjJ4/EjGM4a3xQzs3Qzo=";
+    hash = "sha256-U7L60GyxRQL9ze22Wy7g6ZdI/IFyAtUe1bRCconv6pg=";
   };
 
   sourceRoot = "${src.name}/libs/community";
 
   build-system = [ pdm-backend ];
 
+  patches = [
+    # Remove dependency on blockbuster (not available in nixpkgs due to dependency on forbiddenfruit)
+    ./rm-blockbuster.patch
+  ];
+
   pythonRelaxDeps = [
+    "langchain" # Can fail during updates where building sees the old langchain
     "numpy"
     "pydantic-settings"
     "tenacity"
+  ];
+
+  pythonRemoveDeps = [
+    "blockbuster"
   ];
 
   dependencies = [
@@ -70,7 +80,6 @@ buildPythonPackage rec {
     sqlalchemy
     tenacity
   ];
-
   pythonImportsCheck = [ "langchain_community" ];
 
   nativeCheckInputs = [
@@ -111,6 +120,8 @@ buildPythonPackage rec {
     "test_proper_inputs"
     # pydantic.errors.PydanticUserError: `NatBotChain` is not fully defined; you should define `BaseCache`, then call `NatBotChain.model_rebuild()`.
     "test_variable_key_naming"
+    # Fails due to the lack of blockbuster
+    "test_group_dependencies"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/langchain-community/rm-blockbuster.patch
+++ b/pkgs/development/python-modules/langchain-community/rm-blockbuster.patch
@@ -1,0 +1,37 @@
+diff --git a/tests/unit_tests/conftest.py b/tests/unit_tests/conftest.py
+index 63f3a83e0..61c2d6ce3 100644
+--- a/tests/unit_tests/conftest.py
++++ b/tests/unit_tests/conftest.py
+@@ -5,22 +5,22 @@ from importlib import util
+ from typing import Dict, Sequence
+ 
+ import pytest
+-from blockbuster import blockbuster_ctx
++# from blockbuster import blockbuster_ctx
+ from pytest import Config, Function, Parser
+ 
+ 
+-@pytest.fixture(autouse=True)
+-def blockbuster() -> Iterator[None]:
+-    with blockbuster_ctx("langchain_community") as bb:
+-        (
+-            bb.functions["os.stat"]
+-            .can_block_in("langchain_community/utils/openai.py", "is_openai_v1")
+-            .can_block_in("httpx/_client.py", "_init_transport")
+-        )
+-        bb.functions["os.path.abspath"].can_block_in(
+-            "sqlalchemy/dialects/sqlite/pysqlite.py", "create_connect_args"
+-        )
+-        yield
++# @pytest.fixture(autouse=True)
++# def blockbuster() -> Iterator[None]:
++#     with blockbuster_ctx("langchain_community") as bb:
++#         (
++#             bb.functions["os.stat"]
++#             .can_block_in("langchain_community/utils/openai.py", "is_openai_v1")
++#             .can_block_in("httpx/_client.py", "_init_transport")
++#         )
++#         bb.functions["os.path.abspath"].can_block_in(
++#             "sqlalchemy/dialects/sqlite/pysqlite.py", "create_connect_args"
++#         )
++#         yield

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -35,21 +35,30 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.3.35";
+  version = "0.3.43";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-bwNSeXQJsfbc4c8mSd0GtlVsQ/HRilNiyP6XLcEzL20=";
+    hash = "sha256-NrUh/7+O5m3SisxeWEnKUpar99tNcwTdEzHsZxQbLzc=";
   };
 
   sourceRoot = "${src.name}/libs/core";
 
+  patches = [
+    # Remove dependency on blockbuster (not available in nixpkgs due to dependency on forbiddenfruit)
+    ./rm-blockbuster.patch
+  ];
+
   build-system = [ pdm-backend ];
 
   pythonRelaxDeps = [ "tenacity" ];
+
+  pythonRemoveDependencies = [
+    "blockbuster"
+  ];
 
   dependencies = [
     jsonpatch
@@ -147,6 +156,8 @@ buildPythonPackage rec {
       "test_rate_limit_ainvoke"
       "test_rate_limit_astream"
     ];
+
+  disabledTestPaths = [ "tests/unit_tests/runnables/test_runnable_events_v2.py" ];
 
   meta = {
     description = "Building applications with LLMs through composability";

--- a/pkgs/development/python-modules/langchain-core/rm-blockbuster.patch
+++ b/pkgs/development/python-modules/langchain-core/rm-blockbuster.patch
@@ -1,0 +1,155 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index a2cfc7adf..db37bd74a 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -53,7 +53,7 @@ test = [
+     "responses<1.0.0,>=0.25.0",
+     "pytest-socket<1.0.0,>=0.7.0",
+     "pytest-xdist<4.0.0,>=3.6.1",
+-    "blockbuster~=1.5.18",
++    # "blockbuster~=1.5.18",
+     "numpy<2.0.0,>=1.24.0; python_version < \"3.12\"",
+     "numpy<3,>=1.26.0; python_version >= \"3.12\"",
+     "langchain-tests",
+diff --git a/tests/unit_tests/conftest.py b/tests/unit_tests/conftest.py
+index 6438c3037..aa301c337 100644
+--- a/tests/unit_tests/conftest.py
++++ b/tests/unit_tests/conftest.py
+@@ -5,35 +5,35 @@ from importlib import util
+ from uuid import UUID
+ 
+ import pytest
+-from blockbuster import BlockBuster, blockbuster_ctx
++# from blockbuster import BlockBuster, blockbuster_ctx
+ from pytest import Config, Function, Parser
+ from pytest_mock import MockerFixture
+ 
+ 
+-@pytest.fixture(autouse=True)
+-def blockbuster() -> Iterator[BlockBuster]:
+-    with blockbuster_ctx("langchain_core") as bb:
+-        for func in ["os.stat", "os.path.abspath"]:
+-            (
+-                bb.functions[func]
+-                .can_block_in("langchain_core/_api/internal.py", "is_caller_internal")
+-                .can_block_in("langchain_core/runnables/base.py", "__repr__")
+-                .can_block_in(
+-                    "langchain_core/beta/runnables/context.py", "aconfig_with_context"
+-                )
+-            )
+-
+-        for func in ["os.stat", "io.TextIOWrapper.read"]:
+-            bb.functions[func].can_block_in(
+-                "langsmith/client.py", "_default_retry_config"
+-            )
+-
+-        for bb_function in bb.functions.values():
+-            bb_function.can_block_in(
+-                "freezegun/api.py", "_get_cached_module_attributes"
+-            )
+-
+-        yield bb
++# @pytest.fixture(autouse=True)
++# def blockbuster() -> Iterator[BlockBuster]:
++#     with blockbuster_ctx("langchain_core") as bb:
++#         for func in ["os.stat", "os.path.abspath"]:
++#             (
++#                 bb.functions[func]
++#                 .can_block_in("langchain_core/_api/internal.py", "is_caller_internal")
++#                 .can_block_in("langchain_core/runnables/base.py", "__repr__")
++#                 .can_block_in(
++#                     "langchain_core/beta/runnables/context.py", "aconfig_with_context"
++#                 )
++#             )
++
++#         for func in ["os.stat", "io.TextIOWrapper.read"]:
++#             bb.functions[func].can_block_in(
++#                 "langsmith/client.py", "_default_retry_config"
++#             )
++
++#         for bb_function in bb.functions.values():
++#             bb_function.can_block_in(
++#                 "freezegun/api.py", "_get_cached_module_attributes"
++#             )
++
++#         yield bb
+ 
+ 
+ def pytest_addoption(parser: Parser) -> None:
+diff --git a/tests/unit_tests/language_models/chat_models/test_rate_limiting.py b/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
+index ee6eefba9..4d39da58d 100644
+--- a/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
++++ b/tests/unit_tests/language_models/chat_models/test_rate_limiting.py
+@@ -2,17 +2,17 @@ import time
+ from typing import Optional as Optional
+ 
+ import pytest
+-from blockbuster import BlockBuster
++# from blockbuster import BlockBuster
+ 
+ from langchain_core.caches import InMemoryCache
+ from langchain_core.language_models import GenericFakeChatModel
+ from langchain_core.rate_limiters import InMemoryRateLimiter
+ 
+ 
+-@pytest.fixture(autouse=True)
+-def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
+-    # Deactivate BlockBuster to not disturb the rate limiter timings
+-    blockbuster.deactivate()
++# @pytest.fixture(autouse=True)
++# def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
++#     # Deactivate BlockBuster to not disturb the rate limiter timings
++#     blockbuster.deactivate()
+ 
+ 
+ def test_rate_limit_invoke() -> None:
+diff --git a/tests/unit_tests/runnables/test_runnable_events_v2.py b/tests/unit_tests/runnables/test_runnable_events_v2.py
+index e1e1f37b9..21d2f1600 100644
+--- a/tests/unit_tests/runnables/test_runnable_events_v2.py
++++ b/tests/unit_tests/runnables/test_runnable_events_v2.py
+@@ -15,7 +15,7 @@ from typing import (
+ )
+ 
+ import pytest
+-from blockbuster import BlockBuster
++# from blockbuster import BlockBuster
+ from pydantic import BaseModel
+ 
+ from langchain_core.callbacks import CallbackManagerForRetrieverRun, Callbacks
+@@ -2005,7 +2005,7 @@ EXPECTED_EVENTS = [
+ 
+ async def test_sync_in_async_stream_lambdas(blockbuster: BlockBuster) -> None:
+     """Test invoking nested runnable lambda."""
+-    blockbuster.deactivate()
++    # blockbuster.deactivate()
+ 
+     def add_one(x: int) -> int:
+         return x + 1
+diff --git a/tests/unit_tests/test_setup.py b/tests/unit_tests/test_setup.py
+index 1df3c73a2..58e94de9a 100644
+--- a/tests/unit_tests/test_setup.py
++++ b/tests/unit_tests/test_setup.py
+@@ -1,15 +1,15 @@
+ import time
+ 
+ import pytest
+-from blockbuster import BlockingError
++# from blockbuster import BlockingError
+ 
+ from langchain_core import sys_info
+ 
+ 
+-async def test_blockbuster_setup() -> None:
+-    """Check if blockbuster is correctly setup."""
+-    # Blocking call outside of langchain_core is allowed.
+-    time.sleep(0.01)  # noqa: ASYNC251
+-    with pytest.raises(BlockingError):
+-        # Blocking call from langchain_core raises BlockingError.
+-        sys_info.print_sys_info()
++# async def test_blockbuster_setup() -> None:
++#     """Check if blockbuster is correctly setup."""
++#     # Blocking call outside of langchain_core is allowed.
++#     time.sleep(0.01)  # noqa: ASYNC251
++#     with pytest.raises(BlockingError):
++#         # Blocking call from langchain_core raises BlockingError.
++#         sys_info.print_sys_info()

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  pdm-backend,
 
   # dependencies
   langchain-core,
@@ -17,19 +17,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-groq";
-  version = "0.2.4";
+  version = "0.2.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-groq==${version}";
-    hash = "sha256-hXY0xmt0rvV/AhMZTR+UxMz0ba7pJjRzBRVn6XvX6cA=";
+    hash = "sha256-TXmAaEOK2qNglNAa02M027NXmocsxFaQi3tUFdmFQUQ=";
   };
 
   sourceRoot = "${src.name}/libs/partners/groq";
 
-  build-system = [ poetry-core ];
+  build-system = [ pdm-backend ];
 
   pythonRelaxDeps = [ "langchain-core" ];
 

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-ollama";
-  version = "0.2.2";
+  version = "0.2.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-ollama==${version}";
-    hash = "sha256-Ex8GndMHPHwSSMKu1JxnfGpRj55fh3TR19b3E+KrLUs=";
+    hash = "sha256-G7faykRlpfmafSnSe/CdPW87uCtofBp7mLzbxZgBBhM=";
   };
 
   sourceRoot = "${src.name}/libs/partners/ollama";

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "0.3.5";
+  version = "0.3.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${version}";
-    hash = "sha256-we9LPZeR/eIr+4uDXbBlTm43iapC+MCB0BrbH49Uknw=";
+    hash = "sha256-ooqIUHel/tAI0jNI/j7OXD9ytAH3pXQ3QN5YMhFt2ac=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  pdm-backend,
 
   # dependencies
   httpx,
@@ -23,19 +23,19 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "0.3.8";
+  version = "0.3.13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-IZJo4EZFVKinBQdacM5xQ8ip3qTB64eqwZ9n+Z5mzWY=";
+    hash = "sha256-N209wUGdlHkOZynhSSE+ZHylL7cK+8H3PfZIG/wvMd0=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";
 
-  build-system = [ poetry-core ];
+  build-system = [ pdm-backend ];
 
   dependencies = [
     httpx

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -40,17 +40,22 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.3.18";
+  version = "0.3.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${version}";
-    hash = "sha256-oJ4lUbQqHNEqd9UdgLH0ZmTkdZpUbJ7UNsQyIrs8JvI=";
+    hash = "sha256-N209wUGdlHkOZynhSSE+ZHylL7cK+8H3PfZIG/wvMd0=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";
+
+  patches = [
+    # blockbuster isn't supported in nixpkgs
+    ./rm-blockbuster.patch
+  ];
 
   build-system = [ pdm-backend ];
 
@@ -59,6 +64,10 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "numpy"
     "tenacity"
+  ];
+
+  pythonRemoveDeps = [
+    "blockbuster"
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/langchain/rm-blockbuster.patch
+++ b/pkgs/development/python-modules/langchain/rm-blockbuster.patch
@@ -1,0 +1,68 @@
+diff --git a/tests/unit_tests/conftest.py b/tests/unit_tests/conftest.py
+index fed8dbec5..6144ad7b8 100644
+--- a/tests/unit_tests/conftest.py
++++ b/tests/unit_tests/conftest.py
+@@ -5,36 +5,36 @@ from importlib import util
+ from typing import Dict, Sequence
+ 
+ import pytest
+-from blockbuster import blockbuster_ctx
++# from blockbuster import blockbuster_ctx
+ from pytest import Config, Function, Parser
+ 
+ 
+-@pytest.fixture(autouse=True)
+-def blockbuster() -> Iterator[None]:
+-    with blockbuster_ctx("langchain") as bb:
+-        bb.functions["io.TextIOWrapper.read"].can_block_in(
+-            "langchain/__init__.py", "<module>"
+-        )
+-
+-        for func in ["os.stat", "os.path.abspath"]:
+-            (
+-                bb.functions[func]
+-                .can_block_in("langchain_core/runnables/base.py", "__repr__")
+-                .can_block_in(
+-                    "langchain_core/beta/runnables/context.py", "aconfig_with_context"
+-                )
+-            )
+-
+-        for func in ["os.stat", "io.TextIOWrapper.read"]:
+-            bb.functions[func].can_block_in(
+-                "langsmith/client.py", "_default_retry_config"
+-            )
+-
+-        for bb_function in bb.functions.values():
+-            bb_function.can_block_in(
+-                "freezegun/api.py", "_get_cached_module_attributes"
+-            )
+-        yield
++# @pytest.fixture(autouse=True)
++# def blockbuster() -> Iterator[None]:
++#     with blockbuster_ctx("langchain") as bb:
++#         bb.functions["io.TextIOWrapper.read"].can_block_in(
++#             "langchain/__init__.py", "<module>"
++#         )
++
++#         for func in ["os.stat", "os.path.abspath"]:
++#             (
++#                 bb.functions[func]
++#                 .can_block_in("langchain_core/runnables/base.py", "__repr__")
++#                 .can_block_in(
++#                     "langchain_core/beta/runnables/context.py", "aconfig_with_context"
++#                 )
++#             )
++
++#         for func in ["os.stat", "io.TextIOWrapper.read"]:
++#             bb.functions[func].can_block_in(
++#                 "langsmith/client.py", "_default_retry_config"
++#             )
++
++#         for bb_function in bb.functions.values():
++#             bb_function.can_block_in(
++#                 "freezegun/api.py", "_get_cached_module_attributes"
++#             )
++#         yield
+ 
+ 
+ def pytest_addoption(parser: Parser) -> None:


### PR DESCRIPTION
Version bumps:
* python312Packages.langchain-ollama: 0.2.2 -> 0.2.3
* python312Packages.langchain-openai: 0.3.5. -> 0.3.7
* python312Packages.langchain-community: 0.3.17 -> 0.3.19
  * Removed `blockbuster` as a dependency via patch (depends on `forbiddenfruit` which isn't available)
  * Relaxed deps on `langchain` to avoid build errors during an update 
* python312Packages.langchain-tests: 0.3.8 -> 0.3.13
  * Switched build backend to `pdm-backend` as langchain is migrating to it.
* python312Packages.langchain: 0.3.18 -> 0.3.20
* python3Packages.langchain-core: 0.3.35 -> 0.3.41
  * Removed blockbuster as a dependency via `pythonRemoveDependencies`
* python3Packages.langchain-groq: 0.2.4 -> 0.2.5
  * Updated build backend to `pdm-backend` to match change in source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
