### PR TITLE
nixos/libvirtd: generate firmware json for ovmf

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
@@ -215,26 +220,34 @@ in
 {
 
   imports = [
-    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "enableKVM" ]
-      "Set the option `virtualisation.libvirtd.qemu.package' instead.")
+    (mkRemovedOptionModule [
+      "virtualisation"
+      "libvirtd"
+      "enableKVM"
+    ] "Set the option `virtualisation.libvirtd.qemu.package' instead.")
     (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuPackage" ]
-      [ "virtualisation" "libvirtd" "qemu" "package" ])
+      [ "virtualisation" "libvirtd" "qemu" "package" ]
+    )
     (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuRunAsRoot" ]
-      [ "virtualisation" "libvirtd" "qemu" "runAsRoot" ])
+      [ "virtualisation" "libvirtd" "qemu" "runAsRoot" ]
+    )
     (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuVerbatimConfig" ]
-      [ "virtualisation" "libvirtd" "qemu" "verbatimConfig" ])
+      [ "virtualisation" "libvirtd" "qemu" "verbatimConfig" ]
+    )
     (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuOvmf" ]
-      [ "virtualisation" "libvirtd" "qemu" "ovmf" "enable" ])
-    (mkRemovedOptionModule
-      [ "virtualisation" "libvirtd" "qemuOvmfPackage" ]
-      "If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead.")
+      [ "virtualisation" "libvirtd" "qemu" "ovmf" "enable" ]
+    )
+    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "qemuOvmfPackage" ]
+      "If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead."
+    )
     (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuSwtpm" ]
-      [ "virtualisation" "libvirtd" "qemu" "swtpm" "enable" ])
+      [ "virtualisation" "libvirtd" "qemu" "swtpm" "enable" ]
+    )
   ];
 
   ###### interface
@@ -273,7 +286,10 @@ in
     };
 
     onBoot = mkOption {
-      type = types.enum [ "start" "ignore" ];
+      type = types.enum [
+        "start"
+        "ignore"
+      ];
       default = "start";
       description = ''
         Specifies the action to be done to / on the guests when the host boots.
@@ -285,7 +301,10 @@ in
     };
 
     onShutdown = mkOption {
-      type = types.enum [ "shutdown" "suspend" ];
+      type = types.enum [
+        "shutdown"
+        "suspend"
+      ];
       default = "suspend";
       description = ''
         When shutting down / restarting the host what method should
@@ -368,7 +387,6 @@ in
     };
   };
 
-
   ###### implementation
 
   config = mkIf cfg.enable {
@@ -377,8 +395,8 @@ in
       {
         assertion = config.virtualisation.libvirtd.qemu.ovmf.package == null;
         message = ''
-        The option virtualisation.libvirtd.qemu.ovmf.package is superseded by virtualisation.libvirtd.qemu.ovmf.packages.
-        If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead.
+          The option virtualisation.libvirtd.qemu.ovmf.package is superseded by virtualisation.libvirtd.qemu.ovmf.packages.
+          If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead.
         '';
       }
       {
@@ -389,11 +407,13 @@ in
 
     environment = {
       # this file is expected in /etc/qemu and not sysconfdir (/var/lib)
-      etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n"
-        (e:
-          "allow ${e}")
-        cfg.allowedBridges;
-      systemPackages = with pkgs; [ libressl.nc iptables cfg.package cfg.qemu.package ];
+      etc."qemu/bridge.conf".text = lib.concatMapStringsSep "\n" (e: "allow ${e}") cfg.allowedBridges;
+      systemPackages = with pkgs; [
+        libressl.nc
+        iptables
+        cfg.package
+        cfg.qemu.package
+      ];
       etc.ethertypes.source = "${pkgs.iptables}/etc/ethertypes";
     };
 
@@ -449,34 +469,44 @@ in
 
         ln -s --force ${cfg.qemu.package}/bin/qemu-pr-helper /run/${dirName}/nix-helpers/
 
-        ${optionalString cfg.qemu.ovmf.enable (let
-          ovmfpackage = pkgs.buildEnv {
-            name = "qemu-ovmf";
-            paths = cfg.qemu.ovmf.packages;
-          };
-        in
+        ${optionalString cfg.qemu.ovmf.enable (
+          let
+            ovmfpackage = pkgs.buildEnv {
+              name = "qemu-ovmf";
+              paths = cfg.qemu.ovmf.packages;
+            };
+          in
           ''
-          ln -s --force ${ovmfpackage}/FV/AAVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
-          ln -s --force ${ovmfpackage}/FV/OVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
-          ln -s --force ${ovmfpackage}/FV/AAVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
-          ln -s --force ${ovmfpackage}/FV/OVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
-        '')}
+            ln -s --force ${ovmfpackage}/FV/AAVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
+            ln -s --force ${ovmfpackage}/FV/OVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
+            ln -s --force ${ovmfpackage}/FV/AAVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
+            ln -s --force ${ovmfpackage}/FV/OVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
+          ''
+        )}
 
         # Symlink hooks to /var/lib/libvirt
-        ${concatStringsSep "\n" (map (driver:
-          ''
-          mkdir -p /var/lib/${dirName}/hooks/${driver}.d
-          rm -rf /var/lib/${dirName}/hooks/${driver}.d/*
-          ${concatStringsSep "\n" (mapAttrsToList (name: value:
-            "ln -s --force ${value} /var/lib/${dirName}/hooks/${driver}.d/${name}") cfg.hooks.${driver})}
-        '') (attrNames cfg.hooks))}
+        ${concatStringsSep "\n" (
+          map (driver: ''
+            mkdir -p /var/lib/${dirName}/hooks/${driver}.d
+            rm -rf /var/lib/${dirName}/hooks/${driver}.d/*
+            ${concatStringsSep "\n" (
+              mapAttrsToList (
+                name: value: "ln -s --force ${value} /var/lib/${dirName}/hooks/${driver}.d/${name}"
+              ) cfg.hooks.${driver}
+            )}
+          '') (attrNames cfg.hooks)
+        )}
       '';
 
       serviceConfig = {
         Type = "oneshot";
         RuntimeDirectoryPreserve = "yes";
         LogsDirectory = subDirs [ "qemu" ];
-        RuntimeDirectory = subDirs [ "nix-emulators" "nix-helpers" "nix-ovmf" ];
+        RuntimeDirectory = subDirs [
+          "nix-emulators"
+          "nix-helpers"
+          "nix-ovmf"
+        ];
         StateDirectory = subDirs [ "dnsmasq" ];
       };
     };
@@ -484,8 +514,7 @@ in
     systemd.services.libvirtd = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "libvirtd-config.service" ];
-      after = [ "libvirtd-config.service" ]
-        ++ optional vswitch.enable "ovs-vswitchd.service";
+      after = [ "libvirtd-config.service" ] ++ optional vswitch.enable "ovs-vswitchd.service";
 
       environment.LIBVIRTD_ARGS = escapeShellArgs (
         [
@@ -493,10 +522,15 @@ in
           configFile
           "--timeout"
           "120" # from ${libvirt}/var/lib/sysconfig/libvirtd
-        ] ++ cfg.extraOptions
+        ]
+        ++ cfg.extraOptions
       );
 
-      path = [ cfg.qemu.package pkgs.netcat ] # libvirtd requires qemu-img to manage disk images
+      path =
+        [
+          cfg.qemu.package
+          pkgs.netcat
+        ] # libvirtd requires qemu-img to manage disk images
         ++ optional vswitch.enable vswitch.package
         ++ optional cfg.qemu.swtpm.enable cfg.qemu.swtpm.package;
 
@@ -517,7 +551,11 @@ in
       wantedBy = [ "multi-user.target" ];
       requires = [ "libvirtd.service" ];
       after = [ "libvirtd.service" ];
-      path = with pkgs; [ coreutils gawk cfg.package ];
+      path = with pkgs; [
+        coreutils
+        gawk
+        cfg.package
+      ];
       restartIfChanged = false;
 
       environment.ON_BOOT = "${cfg.onBoot}";
@@ -554,16 +592,18 @@ in
     # https://libvirt.org/daemons.html#monolithic-systemd-integration
     systemd.sockets.libvirtd.wantedBy = [ "sockets.target" ];
 
-    systemd.tmpfiles.rules = let
-      vhostUserCollection = pkgs.buildEnv {
-        name = "vhost-user";
-        paths = cfg.qemu.vhostUserPackages;
-        pathsToLink = [ "/share/qemu/vhost-user" ];
-      };
-    in [
-      "L+ /var/lib/qemu/vhost-user - - - - ${vhostUserCollection}/share/qemu/vhost-user"
-      "L+ /var/lib/qemu/firmware - - - - ${cfg.qemu.package}/share/qemu/firmware"
-    ];
+    systemd.tmpfiles.rules =
+      let
+        vhostUserCollection = pkgs.buildEnv {
+          name = "vhost-user";
+          paths = cfg.qemu.vhostUserPackages;
+          pathsToLink = [ "/share/qemu/vhost-user" ];
+        };
+      in
+      [
+        "L+ /var/lib/qemu/vhost-user - - - - ${vhostUserCollection}/share/qemu/vhost-user"
+        "L+ /var/lib/qemu/firmware - - - - ${cfg.qemu.package}/share/qemu/firmware"
+      ];
 
     security.polkit = {
       enable = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #378894

If OVMF is enabled for libvirtd, instead of linking qemu's framework json files to `/var/lib/qemu/firmware`, generate files based on the packages in `virtualisation.libvirtd.qemu.ovmf.packages`. Use the stable `/run/libvirtd/nix-ovmf` paths instead of store paths so that the references to these files that end up in domain XML files continue working when the store path changes.

Other distros seem to include static json files in their OVMF package (e.g. [Fedora](https://src.fedoraproject.org/rpms/edk2/tree/rawhide)), but given the flexibility we have in how we build OVMF, generating the json files in the module based on metadata from the package itself seems to be our best equivalent.

If OVMF is not enabled, this continues linking the firmware json from the qemu package. We should maybe consider removing that, since it's going to continue having issues with the paths changing over time.

I also removed the nvram setting for qemu.conf, as I believe that isn't used anymore in favor of these JSON files, at least for libvirtd.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
