### PR TITLE
netgen: init at 6.2.2501

### DIFF
--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch2,
+  makeWrapper,
+  cmake,
+  python3Packages,
+  mpi,
+  mpiCheckPhaseHook,
+  metis,
+  opencascade-occt,
+  libGLU,
+  zlib,
+  tcl,
+  tk,
+  xorg,
+  libjpeg,
+  ffmpeg,
+  catch2,
+  avxSupport ? stdenv.hostPlatform.avxSupport,
+  avx2Support ? stdenv.hostPlatform.avx2Support,
+  avx512Support ? stdenv.hostPlatform.avx512Support,
+}:
+let
+  archFlags = toString (
+    lib.optional avxSupport "-mavx"
+    ++ lib.optional avx2Support "-mavx2"
+    ++ lib.optional avx512Support "-mavx512"
+  );
+  patchSource = "https://salsa.debian.org/science-team/netgen/-/raw/debian/6.2.2404+dfsg1-5/debian/patches";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "netgen";
+  version = "6.2.2501";
+
+  src = fetchFromGitHub {
+    owner = "ngsolve";
+    repo = "netgen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IzYulT3bo7XZiEEy8vNCct0zqHCnbQaH+y4fHMorzZw=";
+  };
+
+  patches = [
+    # disable some platform specified code used by downstream ngsolve
+    # can be enabled with -march=armv8.3-a+simd when compiling ngsolve
+    # note compiling netgen itself is not influenced by this feature
+    (fetchpatch2 {
+      url = "https://github.com/NGSolve/netgen/pull/197/commits/1d93dfba00f224787cfc2cde1af2ab5d7f5b87f7.patch";
+      hash = "sha256-3Nom4uGhGLtSGn/k+qKKSxVxrGtGTHqPtcNn3D/gkZU";
+    })
+
+    (fetchpatch2 {
+      url = "${patchSource}/use-local-catch2.patch";
+      hash = "sha256-h4ob8tl6mvGt5B0qXRFNcl9MxPXxRhYw+PrGr5iRGGk=";
+    })
+    (fetchpatch2 {
+      url = "${patchSource}/ffmpeg_link_libraries.patch";
+      hash = "sha256-S02OPH9hbJjOnBm6JMh6uM5XptcubV24vdyEF0FusoM=";
+    })
+    (fetchpatch2 {
+      url = "${patchSource}/fix_nggui_tcl.patch";
+      hash = "sha256-ODDT67+RWBzPhhq/equWsu78x9L/Yrs3U8VQ1Uu0zZw=";
+    })
+    (fetchpatch2 {
+      url = "${patchSource}/include_stdlib.patch";
+      hash = "sha256-W+NgGBuy/UmzVbPTSqR8FRUlyN/9dl9l9e9rxKklmIc=";
+    })
+    (fetchpatch2 {
+      url = "${patchSource}/fix-version.patch";
+      hash = "sha256-CT98Wq3UufB81z/jYLiH9nXvt+QzoZ7210OeuFXCfmc=";
+    })
+  ];
+
+  # when generating python stub file utilizing system python pybind11_stubgen module
+  # cmake need to inherit pythonpath
+  postPatch = ''
+    substituteInPlace python/CMakeLists.txt \
+      --replace-fail ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}' \
+                     ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}:$ENV{PYTHONPATH}'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    python3Packages.pybind11-stubgen
+  ];
+
+  buildInputs = [
+    metis
+    opencascade-occt
+    zlib
+    tcl
+    tk
+    libGLU
+    xorg.libXmu
+    libjpeg
+    ffmpeg
+    mpi
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    packaging
+    pybind11
+    mpi4py
+    numpy
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "NETGEN_VERSION_GIT" "v${finalAttrs.version}-0")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" archFlags)
+    (lib.cmakeBool "USE_MPI" true)
+    (lib.cmakeBool "USE_MPI4PY" true)
+    (lib.cmakeBool "PREFER_SYSTEM_PYBIND11" true)
+    (lib.cmakeBool "BUILD_STUB_FILES" true)
+    (lib.cmakeBool "USE_SUPERBUILD" false) # use system packages
+    (lib.cmakeBool "USE_NATIVE_ARCH" false)
+    (lib.cmakeBool "USE_JPEG" true)
+    (lib.cmakeBool "USE_MPEG" true)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+    (lib.cmakeBool "ENABLE_UNIT_TESTS" finalAttrs.finalPackage.doInstallCheck)
+  ];
+
+  # Tcl script used by netgen need to be aware of environment NETGENDIR
+  postInstall = ''
+    wrapProgram "$out/bin/netgen" --set NETGENDIR "$out/bin"
+  '';
+
+  # mesh generation differs on x86_64 and aarch64 platform
+  # tests will fail on aarch64 platform
+  doInstallCheck = stdenv.hostPlatform.isx86_64;
+
+  preInstallCheck = ''
+    export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
+  '';
+
+  installCheckTarget = "test";
+
+  nativeInstallCheckInputs = [
+    catch2
+    python3Packages.pytest
+    python3Packages.pytest-check
+    python3Packages.pytest-mpi
+    mpiCheckPhaseHook
+  ];
+
+  passthru = {
+    inherit avxSupport avx2Support avx512Support;
+  };
+
+  meta = {
+    homepage = "https://ngsolve.org";
+    description = "Atomatic 3d tetrahedral mesh generator";
+    license = with lib.licenses; [
+      lgpl2Plus
+      lgpl21Plus
+      lgpl21Only
+      bsd3
+      boost
+      publicDomain
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "netgen";
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9395,6 +9395,8 @@ self: super: with self; {
 
   netdisco = callPackage ../development/python-modules/netdisco { };
 
+  netgen = toPythonModule (pkgs.netgen.override { python3Packages = self; });
+
   nethsm = callPackage ../development/python-modules/nethsm { };
 
   netifaces = callPackage ../development/python-modules/netifaces { };


### PR DESCRIPTION
Netgen mesh generator

NETGEN is an automatic 3d tetrahedral mesh generator.

Used by ngsolve and other FEM project.

close https://github.com/NixOS/nixpkgs/issues/49532
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
