### PR TITLE
freebsd: add patch for _PATH_LOCALE default value

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/patches/14.1/path-locale.patch
+++ b/pkgs/os-specific/bsd/freebsd/patches/14.1/path-locale.patch
@@ -1,0 +1,13 @@
+diff --git a/include/paths.h b/include/paths.h
+index f8861ea4e5a8..d6aac29ed5a8 100644
+--- a/include/paths.h
++++ b/include/paths.h
+@@ -71,7 +71,7 @@
+ #define	_PATH_IFCONFIG	"/sbin/ifconfig"
+ #define	_PATH_KMEM	"/dev/kmem"
+ #define	_PATH_LIBMAP_CONF	"/etc/libmap.conf"
+-#define	_PATH_LOCALE	"/usr/share/locale"
++#define	_PATH_LOCALE	"/run/current-system/sw/share/locale"
+ #define	_PATH_LOGIN	"/usr/bin/login"
+ #define	_PATH_MAILDIR	"/var/mail"
+ #define	_PATH_MAN	"/usr/share/man"


### PR DESCRIPTION
I noticed that locales weren't working correctly under sudo on nixbsd, and tracked this to the fact that the PATH_LOCALE environment variable is accessed through secure_getenv(), which returns NULL if it detects elevated privileges. This was my best attempt at making it work regardless.

This is a somewhat dangerous change, as it breaks locales on non-NixBSD FreeBSD systems. I'm hoping this PR can serve as an RFC.

Proposed alternatives:

- Change secure_getenv to getenv (unclear security ramifications)
- Symlink /usr/share/locale on NixBSD (unprecedented on NixOS)