### PR TITLE
cargo-pgrx: fix cross compilation

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -2,6 +2,7 @@
   lib,
   darwin,
   fetchCrate,
+  fetchpatch,
   openssl,
   pkg-config,
   rustPlatform,
@@ -14,6 +15,7 @@ let
       version,
       hash,
       cargoHash,
+      patches ? [ ],
     }:
     rustPlatform.buildRustPackage rec {
       pname = "cargo-pgrx";
@@ -34,6 +36,9 @@ let
       buildInputs = [
         openssl
       ];
+
+      inherit patches;
+      patchFlags = "-p2";
 
       preCheck = ''
         export PGRX_HOME=$(mktemp -d)
@@ -62,6 +67,19 @@ in
     version = "0.12.0-alpha.1";
     hash = "sha256-0m9oaqjU42RYyttkTihADDrRMjr2WoK/8sInZALeHws=";
     cargoHash = "sha256-zYjqE7LZLnTaVxWAPWC1ncEjCMlrhy4THtgecB7wBYY=";
+    patches = [
+      # https://github.com/pgcentralfoundation/pgrx/pull/1994
+      (fetchpatch {
+        name = "no-run.patch";
+        url = "https://github.com/rhelmot/pgrx/commit/1b23603d7344a28fca0a19875292ddab21d7a9ac.patch";
+        hash = "sha256-M2mu3wtBIo6WupodWNi11tDFyZl0GGoVvp/zm0bMRyU=";
+      })
+      (fetchpatch {
+        name = "cross-target.patch";
+        url = "https://github.com/rhelmot/pgrx/commit/aa08d873a0100f88d6c41a383718ccbed85153de.patch";
+        hash = "sha256-g5CP7ZQ25vx77QivSSYLk5SeyD/wJ45uJ0xzYqgjdBo=";
+      })
+    ];
   };
 
   cargo-pgrx_0_12_5 = generic {


### PR DESCRIPTION
I submitted the patches that enable this upstream, but since various plugins pin various versions of pgrx, I have a rebase of that PR on the version that my desired plugin (pgvecto-rs on FreeBSD) was using.

Probably don't merge this until https://github.com/NixOS/nixpkgs/pull/387727 is merged or at least a conclusion on pg_config_native is reached.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (x86_64-freebsd target)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
