### PR TITLE
ISSUE_TEMPLATE: avoid using maintainer usernames as headings

### DIFF
--- a/.github/ISSUE_TEMPLATE/06_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_update_request.yml
@@ -82,6 +82,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/07_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/07_module_request.yml
@@ -62,6 +62,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/08_backport_request.yml
+++ b/.github/ISSUE_TEMPLATE/08_backport_request.yml
@@ -64,6 +64,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#368656 moved the issue templates to YAML; this is awesome, but had the (unintentional?) side-effect of making the low-effort way to tag maintainers use markdown heading markup for the tags, rather than the previously-used horizontal rule below them.

If you tag a maintainer like this:

![image](https://github.com/user-attachments/assets/90f19412-6921-4119-b49b-bbc795b123e0)

The result looks like this:

![image](https://github.com/user-attachments/assets/cfe1dcfc-816e-4e5b-9a05-af21d03fa883)

I suspect what was intended was instead this:

![image](https://github.com/user-attachments/assets/ee26a7c0-1967-465f-a1c1-de7722148250)

![image](https://github.com/user-attachments/assets/d00ad19f-13d3-4d74-b81e-6ead3c33d02b)

---

This change is already visible in recent issues, e.g. #387705:

![image](https://github.com/user-attachments/assets/38484f36-a23a-472e-8d82-0b698e072ec0)

whereas older issues (searching for `"note for maintainers" created:<2025-01-13`, e.g. #362118) consistently use normal text followed by a horizontal rule:

![image](https://github.com/user-attachments/assets/81cca088-124b-4163-acae-0c2640069ac2)

@SigmaSquadron as the author of #368656, please do shout if this change was deliberate!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
