### PR TITLE
python312Packages.pyiceberg: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -42,6 +42,7 @@
   # tests
   azure-core,
   azure-storage-blob,
+  datafusion,
   fastavro,
   moto,
   pyspark,
@@ -54,14 +55,14 @@
 
 buildPythonPackage rec {
   pname = "iceberg-python";
-  version = "0.8.1";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "iceberg-python";
     tag = "pyiceberg-${version}";
-    hash = "sha256-L3YlOtzJv9R4TLeJGzfMQ+0nYtQEsqmgNZpW9B6vVAI=";
+    hash = "sha256-PLxYe6MpKR6qILTNt0arujyx/nlVorwjhwokbXvdwb0=";
   };
 
   patches = [
@@ -161,6 +162,7 @@ buildPythonPackage rec {
     azure-core
     azure-storage-blob
     boto3
+    datafusion
     fastavro
     moto
     mypy-boto3-glue
@@ -187,6 +189,11 @@ buildPythonPackage rec {
 
   disabledTests =
     [
+      # Require unpackaged pyiceberg_core
+      "test_bucket_pyarrow_transforms"
+      "test_transform_consistency_with_pyarrow_transform"
+      "test_truncate_pyarrow_transforms"
+
       # botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL
       "test_checking_if_a_file_exists"
       "test_closing_a_file"
@@ -209,6 +216,8 @@ buildPythonPackage rec {
       "test_fsspec_new_abfss_output_file_adls"
       "test_fsspec_new_input_file_adls"
       "test_fsspec_pickle_round_trip_aldfs"
+      "test_partitioned_write"
+      "test_token_200_w_oauth2_server_uri"
 
       # TypeError: pyarrow.lib.large_list() takes no keyword argument
       # From tests/io/test_pyarrow_stats.py:


### PR DESCRIPTION
## Things done

Changelog: https://github.com/apache/iceberg-python/releases/tag/pyiceberg-0.9.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
