### PR TITLE
dbx: 0.8.18 -> 0.8.19, fix

### DIFF
--- a/pkgs/by-name/db/dbx/package.nix
+++ b/pkgs/by-name/db/dbx/package.nix
@@ -1,39 +1,86 @@
 {
   lib,
-  fetchFromGitHub,
-  git,
+  stdenv,
   python3,
+  fetchFromGitHub,
+
+  # tests
+  addBinToPathHook,
+  gitMinimal,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 let
   python = python3.override {
     self = python;
-    packageOverrides = self: super: { pydantic = super.pydantic_1; };
+    packageOverrides = self: super: {
+      pydantic = super.pydantic_1;
+
+      # python-on-whales is the only aiohttp dependency that is incompatible with pydantic_1
+      # Override aiohttp to remove this dependency
+      aiohttp = super.aiohttp.overridePythonAttrs (old: {
+        # Remove python-on-whales from nativeCheckInputs
+        nativeCheckInputs = lib.filter (p: (p.pname or "") != "python-on-whales") old.nativeCheckInputs;
+
+        disabledTestPaths = [
+          # Requires python-on-whales
+          "tests/autobahn/test_autobahn.py"
+        ] ++ (old.disabledTestPaths or [ ]);
+      });
+
+      databricks-sdk = super.databricks-sdk.overridePythonAttrs (old: {
+        # Tests require langchain-openai which is incompatible with pydantic_1
+        doCheck = false;
+      });
+    };
   };
 in
 python.pkgs.buildPythonApplication rec {
   pname = "dbx";
-  version = "0.8.18";
+  version = "0.8.19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "databrickslabs";
     repo = "dbx";
     tag = "v${version}";
-    hash = "sha256-5qjEABNTSUD9I2uAn49HQ4n+gbAcmfnqS4Z2M9MvFXQ=";
+    hash = "sha256-DNVJcCDHyWCorTxNN6RR6TWNF2MrysXT44UbwegROTU=";
   };
+
+  postPatch = ''
+    # Probably a typo
+      substituteInPlace src/dbx/custom.py \
+        --replace-fail "_make_rich_rext" "_make_rich_text"
+
+    # dbx pins an old version of typer.
+    # In newer versions of typer, `callback` does not accept the 'name' argument anymore.
+    substituteInPlace src/dbx/cli.py \
+      --replace-fail 'name="dbx",' ""
+
+    # Fixes: TypeError: 'NoneType' object is not iterable
+    substituteInPlace src/dbx/utils/common.py \
+      --replace-fail \
+        '[t.split("=") for t in multiple_argument]' \
+        '[t.split("=") for t in multiple_argument] if multiple_argument else []'
+  '';
 
   pythonRelaxDeps = [
     "cryptography"
     "databricks-cli"
+    "pydantic"
     "rich"
+    "tenacity"
     "typer"
   ];
 
   pythonRemoveDeps = [ "mlflow-skinny" ];
 
-  build-system = with python.pkgs; [ setuptools ];
+  build-system = with python.pkgs; [
+    hatch-vcs
+    hatchling
+  ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  dependencies = with python.pkgs; [
     aiohttp
     click
     cookiecutter
@@ -47,12 +94,13 @@ python.pkgs.buildPythonApplication rec {
     requests
     retry
     rich
+    setuptools
     tenacity
     typer
     watchdog
   ];
 
-  optional-dependencies = with python3.pkgs; {
+  optional-dependencies = with python.pkgs; {
     aws = [ boto3 ];
     azure = [
       azure-storage-blob
@@ -62,20 +110,20 @@ python.pkgs.buildPythonApplication rec {
   };
 
   nativeCheckInputs =
-    [ git ]
-    ++ (with python3.pkgs; [
+    [
+      addBinToPathHook
+      gitMinimal
+      versionCheckHook
+      writableTmpDirAsHomeHook
+    ]
+    ++ (with python.pkgs; [
       pytest-asyncio
       pytest-mock
       pytest-timeout
+      pytest-xdist
       pytestCheckHook
     ]);
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-    export PATH="$PATH:$out/bin"
-  '';
-
-  pytestFlagsArray = [ "tests/unit" ];
+  versionCheckProgramArg = "--version";
 
   disabledTests = [
     # Fails because of dbfs CLI wrong call
@@ -85,32 +133,19 @@ python.pkgs.buildPythonApplication rec {
     "test_python_basic_sanity_check"
   ];
 
-  disabledTestPaths = [
-    "tests/unit/api/"
-    "tests/unit/api/test_build.py"
-    "tests/unit/api/test_destroyer.py"
-    "tests/unit/api/test_jinja.py"
-    "tests/unit/commands/test_configure.py"
-    "tests/unit/commands/test_deploy_jinja_variables_file.py"
-    "tests/unit/commands/test_deploy.py"
-    "tests/unit/commands/test_destroy.py"
-    "tests/unit/commands/test_execute.py"
-    "tests/unit/commands/test_help.py"
-    "tests/unit/commands/test_launch.py"
-    "tests/unit/models/test_deployment.py"
-    "tests/unit/models/test_destroyer.py"
-    "tests/unit/models/test_task.py"
-    "tests/unit/sync/test_commands.py"
-    "tests/unit/utils/test_common.py"
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # ERROR fsevents:fsevents.py:310 Unhandled exception in FSEventsEmitter
+    # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer instead.
+    "tests/unit/sync/test_event_handler.py"
   ];
 
   pythonImportsCheck = [ "dbx" ];
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool for advanced Databricks jobs management";
     homepage = "https://github.com/databrickslabs/dbx";
     changelog = "https://github.com/databrickslabs/dbx/blob/v${version}/CHANGELOG.md";
-    license = licenses.databricks-dbx;
-    maintainers = with maintainers; [ GuillaumeDesforges ];
+    license = lib.licenses.databricks-dbx;
+    maintainers = with lib.maintainers; [ GuillaumeDesforges ];
   };
 }

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -9,7 +9,6 @@
 
   # dependencies
   httpx,
-  langchain-core,
   orjson,
   pydantic,
   requests,


### PR DESCRIPTION
## Things done

Changelog: https://github.com/databrickslabs/dbx/blob/v0.8.19/CHANGELOG.md

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
