### PR TITLE
tytools: 0.9.9 -> 0.9.8

### DIFF
--- a/pkgs/development/embedded/tytools/default.nix
+++ b/pkgs/development/embedded/tytools/default.nix
@@ -5,58 +5,34 @@
   cmake,
   pkg-config,
   wrapQtAppsHook,
-  qt6,
+  qtbase,
 }:
 
 stdenv.mkDerivation rec {
   pname = "tytools";
-  version = "0.9.9";
+  version = "0.9.8";
 
   src = fetchFromGitHub {
     owner = "Koromix";
-    repo = "rygel";
-    tag = "tytools/${version}";
-    hash = "sha256-nQZaNYOTkx79UC0RHencKIQFSYUnQ9resdmmWTmgQxA=";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-MKhh0ooDZI1Ks8vVuPRiHhpOqStetGaAhE2ulvBstxA=";
   };
 
   nativeBuildInputs = [
+    cmake
     pkg-config
-    qt6.wrapQtAppsHook
+    wrapQtAppsHook
   ];
-
   buildInputs = [
-    qt6.qtbase
+    qtbase
   ];
 
-  buildPhase = ''
-    runHook preBuild
-
-    ./bootstrap.sh
-    ./felix -p Fast tyuploader
-    ./felix -p Fast tycmd
-    ./felix -p Fast tycommander
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin $out/share/applications
-    cp bin/Fast/tyuploader $out/bin/
-    cp bin/Fast/tycmd $out/bin/
-    cp bin/Fast/tycommander $out/bin/
-    cp src/tytools/tycommander/tycommander_linux.desktop $out/share/applications/tycommander.desktop
-    cp src/tytools/tyuploader/tyuploader_linux.desktop $out/share/applications/tyuploader.desktop
-
-    runHook postInstall
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "Collection of tools to manage Teensy boards";
     homepage = "https://koromix.dev/tytools";
-    license = lib.licenses.unlicense;
-    platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ahuzik ];
+    license = licenses.unlicense;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ahuzik ];
   };
 }


### PR DESCRIPTION
This reverts #385393 because apparently the download hash is different on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
