### PR TITLE
bitbox-bridge: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10514,6 +10514,12 @@
     githubId = 94313;
     name = "Xianyi Lin";
   };
+  izelnakri = {
+    email = "contact@izelnakri.com";
+    github = "izelnakri";
+    githubId = 1190931;
+    name = "Izel Nakri";
+  };
   izorkin = {
     email = "Izorkin@gmail.com";
     github = "Izorkin";

--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  libudev-zero,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bitbox-bridge";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "BitBoxSwiss";
+    repo = "bitbox-bridge";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-+pMXWXGHyyBx3N0kiro9NS0mPmSQzzBmp+pkoBLH7z0=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-6vD0XjGH1PXjiRjgnHWSZSixXOc2Yecui8U5FAGefBU=";
+
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libudev-zero
+  ];
+
+  meta = {
+    description = "A bridge service that connects web wallets like Rabby to BitBox02";
+    homepage = "https://github.com/BitBoxSwiss/bitbox-bridge";
+    downloadPage = "https://bitbox.swiss/download/";
+    changelog = "https://github.com/BitBoxSwiss/bitbox-bridge/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      izelnakri
+      tensor5
+    ];
+    mainProgram = "bitbox-bridge";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
`bitbox-bridge` is an essential software that allows `BitBox2` hardware wallets to communicate with the target machine for blockchain transactions.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
