### PR TITLE
nixos/fan2go: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -135,6 +135,8 @@
 
 - [Prometheus Node Cert Exporter](https://github.com/amimof/node-cert-exporter), a prometheus exporter to check for SSL cert expiry. Available under [services.prometheus.exporters.node-cert](#opt-services.prometheus.exporters.node-cert.enable).
 
+- [fan2go](https://github.com/markusressel/fan2go), a simple daemon providing dynamic fan speed control based on temperature sensors. Available as [services.fan2go](#opt-services.fan2go.enable).
+
 - [Actual Budget](https://actualbudget.org/), a local-first personal finance app. Available as [services.actual](#opt-services.actual.enable).
 
 - [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy), a proxy for sharing Immich albums without exposing the Immich API. Available as [services.immich-public-proxy](#opt-services.immich-public-proxy.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -616,6 +616,7 @@
   ./services/hardware/buffyboard.nix
   ./services/hardware/ddccontrol.nix
   ./services/hardware/display.nix
+  ./services/hardware/fan2go.nix
   ./services/hardware/fancontrol.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix

--- a/nixos/modules/services/hardware/fan2go.nix
+++ b/nixos/modules/services/hardware/fan2go.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fan2go;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "config.yaml" cfg.settings;
+in
+{
+  options.services.fan2go = {
+    enable = lib.mkEnableOption "fan2go";
+
+    package = lib.mkPackageOption pkgs "fan2go" { };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      example = {
+        fans = [
+          {
+            id = "cpu";
+            hwmon = {
+              platform = "nct6798";
+              rpmChannel = 1;
+              pwmChannel = 1;
+            };
+            neverStop = true;
+            curve = "cpu_curve";
+          }
+        ];
+        sensors = [
+          {
+            id = "cpu_package";
+            hwmon = {
+              platform = "coretemp";
+              index = 1;
+            };
+          }
+        ];
+        curves = [
+          {
+            id = "cpu_curve";
+            linear = {
+              sensor = "cpu_package";
+              min = 40;
+              max = 80;
+            };
+          }
+        ];
+      };
+      description = ''
+        Contents of the fan2go YAML config.
+        Please refer to the [documentation](https://github.com/markusressel/fan2go/blob/master/README.md#configuration).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.fan2go = {
+      description = "fan2go daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${lib.getExe cfg.package} -c ${configFile}
+        '';
+
+        Restart = "always";
+        RestartSec = "1s";
+        Type = "simple";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ BonusPlay ];
+}


### PR DESCRIPTION
fan2go is a simple daemon providing dynamic fan speed control based on temperature sensors. While we had it packaged in nixpkgs for some time, it's usage is as a daemon, so having module seems natural to me.

I've deployed it to [my homelab](https://github.com/BonusPlay/sysconf/blob/efb0450/machines/glacius/fan2go.nix) and it seems to be working just fine. As the daemon has to be running as root, I've removed most of sandboxing in systemd service config, if someone more knowledgeable in the area wants more restricted permissions, please show me an example.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
