### PR TITLE
postgresqlPackages.pg_byteamagic: init at 0.2.4

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -58,6 +58,15 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  apm = {
+    scope = "Team for packages maintained by employees of Akademie für Pflegeberufe und Management GmbH.";
+    shortName = "apm employees";
+    # Edits to this list should only be done by an already existing member.
+    members = [
+      wolfgangwalther
+    ];
+  };
+
   bazel = {
     members = [
       mboes

--- a/pkgs/servers/sql/postgresql/ext/default.nix
+++ b/pkgs/servers/sql/postgresql/ext/default.nix
@@ -24,6 +24,8 @@ in {
 
     pg_auto_failover = super.callPackage ./pg_auto_failover.nix { };
 
+    pg_byteamagic = super.callPackage ./pg_byteamagic.nix { };
+
     pg_bigm = super.callPackage ./pg_bigm.nix { };
 
     pg_ed25519 = super.callPackage ./pg_ed25519.nix { };

--- a/pkgs/servers/sql/postgresql/ext/pg_byteamagic.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_byteamagic.nix
@@ -1,0 +1,43 @@
+{
+  buildPostgresqlExtension,
+  fetchFromGitHub,
+  file,
+  lib,
+  postgresql,
+  postgresqlTestExtension,
+}:
+
+buildPostgresqlExtension (finalAttrs: {
+  pname = "pg_byteamagic";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "nmandery";
+    repo = "pg_byteamagic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0RRElMMVUm3cXLI7G3SkIVr8yA/Rk3gBsgXG+EFU3CI=";
+  };
+
+  buildInputs = [
+    file
+  ];
+
+  passthru.tests = {
+    extension = postgresqlTestExtension {
+      inherit (finalAttrs) finalPackage;
+      sql = ''
+        CREATE EXTENSION byteamagic;
+        SELECT byteamagic_mime('test');
+      '';
+    };
+  };
+
+  meta = {
+    description = "PostgreSQL extension to determinate the filetypes of bytea BLOBs";
+    homepage = "https://github.com/nmandery/pg_byteamagic";
+    changelog = "https://raw.githubusercontent.com/nmandery/pg_byteamagic/refs/tags/v${finalAttrs.version}/Changes";
+    license = lib.licenses.bsd2WithViews;
+    maintainers = lib.teams.apm.members;
+    platforms = postgresql.meta.platforms;
+  };
+})


### PR DESCRIPTION
PostgreSQL extension to determinate the filetypes of bytea BLOBs.

URL: https://github.com/nmandery/pg_byteamagic

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
