### PR TITLE
python313Packages.ocrmypdf: 16.7.0 -> 16.10.0

### DIFF
--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  isPy27,
   fetchFromGitea,
   replaceVars,
   fetchpatch,
@@ -24,17 +23,15 @@
 
 buildPythonPackage rec {
   pname = "img2pdf";
-  version = "0.5.1";
-  disabled = isPy27;
-
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitea {
     domain = "gitlab.mister-muffin.de";
     owner = "josch";
     repo = "img2pdf";
-    rev = version;
-    hash = "sha256-mrNTc37GrHTc7NW0sYI1FlAOlnvXum02867enqHsAEQ=";
+    tag = version;
+    hash = "sha256-/nxXgGsnj5ktxUYt9X8/9tJzXgoU8idTjVgLh+8jol8=";
   };
 
   patches = [
@@ -48,16 +45,11 @@ buildPythonPackage rec {
             cp ${colord}/share/color/icc/colord/sRGB.icc $out
           '';
     })
-    (fetchpatch {
-      # https://gitlab.mister-muffin.de/josch/img2pdf/issues/178
-      url = "https://salsa.debian.org/debian/img2pdf/-/raw/4a7dbda0f473f7c5ffcaaf68ea4ad3f435e0920d/debian/patches/fix_tests.patch";
-      hash = "sha256-A1zK6yINhS+dvyckZjqoSO1XJRTaf4OXFdq5ufUrBs8=";
-    })
   ];
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pikepdf
     pillow
   ];
@@ -86,40 +78,20 @@ buildPythonPackage rec {
 
   disabledTests = [
     # https://gitlab.mister-muffin.de/josch/img2pdf/issues/178
-    "test_miff_cmyk16"
-    # https://gitlab.mister-muffin.de/josch/img2pdf/issues/205
+    "test_jpg_cmyk"
     "test_miff_cmyk8"
-    "test_miff_rgb8"
-    "test_tiff_ccitt_lsb_m2l_white"
-    "test_tiff_ccitt_msb_l2m_white"
-    "test_tiff_ccitt_msb_m2l_white"
-    "test_tiff_ccitt_nometa1"
-    "test_tiff_ccitt_nometa2"
     "test_tiff_cmyk8"
-    "test_tiff_cmyk16"
-    "test_tiff_float"
-    "test_tiff_gray1"
-    "test_tiff_gray2"
-    "test_tiff_gray4"
-    "test_tiff_gray8"
-    "test_tiff_gray16"
-    "test_tiff_multipage"
-    "test_tiff_palette8"
-    "test_tiff_rgb8"
-    "test_tiff_rgb12"
-    "test_tiff_rgb14"
-    "test_tiff_rgb16"
   ];
 
   pythonImportsCheck = [ "img2pdf" ];
 
-  meta = with lib; {
-    changelog = "https://gitlab.mister-muffin.de/josch/img2pdf/src/tag/${src.rev}/CHANGES.rst";
+  meta = {
+    changelog = "https://gitlab.mister-muffin.de/josch/img2pdf/src/tag/${src.tag}/CHANGES.rst";
     description = "Convert images to PDF via direct JPEG inclusion";
     homepage = "https://gitlab.mister-muffin.de/josch/img2pdf";
-    license = licenses.lgpl3Plus;
+    license = lib.licenses.lgpl3Plus;
     mainProgram = "img2pdf";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       veprbl
       dotlambda
     ];

--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -18,7 +18,6 @@
   pngquant,
   pytest-xdist,
   pytestCheckHook,
-  pythonOlder,
   rich,
   reportlab,
   replaceVars,
@@ -29,10 +28,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "16.7.0";
-
-  disabled = pythonOlder "3.10";
-
+  version = "16.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +41,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-81maXJjdGlzWy3TaQ8cabjJl6ZE5tbfc8m/+Px7ONhs=";
+    hash = "sha256-tRq3qskZK39xfSof4RUTWC2h9mi7eGDHR6nI7reltm4=";
   };
 
   patches = [


### PR DESCRIPTION
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v16.7.0...v16.10.0

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v16.10.0/docs/release_notes.rst
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
