### PR TITLE
datalad: 1.2.1 -> 1.2.2, add missing runtime dependency, remove obsolete substitution, add maintainer

### DIFF
--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -51,20 +51,17 @@
 
 buildPythonPackage rec {
   pname = "datalad";
-  version = "1.2.1";
+  version = "1.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "datalad";
     repo = "datalad";
     tag = version;
-    hash = "sha256-QcKhMiJNlETlxmRoPwKKGYK7zKbJ0pQpbRZDyJ+yrN0=";
+    hash = "sha256-OjWOWdfAQoCQzc2EH5hBhJ3G/Z62U9oRgv8tp23L/Qw=";
   };
 
   postPatch = ''
-    # remove after release with https://github.com/datalad/datalad/commit/d8eac5682d794b2460d732a2c7637acefecfeb82
-    substituteInPlace datalad/distribution/create_sibling.py \
-      --replace-fail "/bin/ls" "${coreutils}/bin/ls"
     # Remove vendorized versioneer.py
     rm versioneer.py
   '';

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -62,6 +62,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
+    # remove after release with https://github.com/datalad/datalad/commit/d8eac5682d794b2460d732a2c7637acefecfeb82
     substituteInPlace datalad/distribution/create_sibling.py \
       --replace-fail "/bin/ls" "${coreutils}/bin/ls"
     # Remove vendorized versioneer.py
@@ -119,9 +120,11 @@ buildPythonPackage rec {
 
   postInstall = ''
     installShellCompletion --cmd datalad \
-         --bash <($out/bin/datalad shell-completion) \
-         --zsh  <($out/bin/datalad shell-completion)
-    wrapProgram $out/bin/datalad --prefix PYTHONPATH : "$PYTHONPATH"
+      --bash <($out/bin/datalad shell-completion) \
+      --zsh  <($out/bin/datalad shell-completion)
+    wrapProgram $out/bin/datalad \
+      --prefix PATH : "${git-annex}/bin" \
+      --prefix PYTHONPATH : "$PYTHONPATH"
   '';
 
   preCheck = ''
@@ -240,6 +243,9 @@ buildPythonPackage rec {
     description = "Keep code, data, containers under control with git and git-annex";
     homepage = "https://www.datalad.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ renesat malik ];
+    maintainers = with lib.maintainers; [
+      renesat
+      malik
+    ];
   };
 }

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -240,6 +240,6 @@ buildPythonPackage rec {
     description = "Keep code, data, containers under control with git and git-annex";
     homepage = "https://www.datalad.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ renesat ];
+    maintainers = with lib.maintainers; [ renesat malik ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pure script 
``` sh
#!/usr/bin/env nix-shell
#!nix-shell -i bash -p bash git nix
#!nix-shell --pure

REPO_ROOT=$(git rev-parse --show-toplevel)
cd "$REPO_ROOT"
NIX_SHELL_CMD="nix shell ./#dataladGit -c"


$NIX_SHELL_CMD datalad run -m "Update CITATION.cff" \
  --input flake.lock --input flake.nix --input ./pkgs/default.nix --input ./pkgs/utils.nix --input ./pkgs/citation-creator/default.nix --input ./pkgs/citation-creator/generator.dhall \
  --output CITATION.cff \
  "nix run .#utils.citation-creator"
```
creates the following error
```
CommandError: 'git -c diff.ignoreSubmodules=none -c core.quotepath=false status --porcelain --untracked-files=normal --ignore-submodules=none' failed with exitcode 128
git-annex filter-process: line 1: git-annex: command not found
fatal: the remote end hung up unexpectedly
```
[Adding git-annex to the propagatedBuildInputs](https://github.com/malikwirin/datalad-nix/commit/0cca71acfdf7de35e345b3e066ac74e3d8f9e2eb) fixed the issue as it is a essential runtime dependency.
Also added myself to maintainers as I am very motivated in development of the overlap between nix and datalad.

## Things done
- add git-annex to path
- add comment about patch that is no longer needed soon
- bump version for fix https://github.com/datalad/datalad/commit/d8eac5682d794b2460d732a2c7637acefecfeb82

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## Follow up
after adding the missing runtime dependency `git-annex`, deactivated unit tests should be reenabled in a future PR.
---
@renesat

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
