### PR TITLE
medusa: unstable-2018-12-16 -> 2.3

### DIFF
--- a/pkgs/by-name/me/medusa/package.nix
+++ b/pkgs/by-name/me/medusa/package.nix
@@ -2,33 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
-  pkg-config,
   freerdp,
-  openssl,
   libssh2,
+  openssl,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
-  pname = "medusa-unstable";
-  version = "2018-12-16";
+  pname = "medusa";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "jmk-foofus";
     repo = "medusa";
-    rev = "292193b3995444aede53ff873899640b08129fc7";
-    sha256 = "0njlz4fqa0165wdmd5y8lfnafayf3c4la0r8pf3hixkdwsss1509";
+    tag = version;
+    hash = "sha256-devirQMmS8mtxT5H5XafRRvCyfcvwoWxtTp0V1SJeSM=";
   };
-
-  patches = [
-    # Pull upstream fix for -fno-common tollchains like gcc-10:
-    #  https://github.com/jmk-foofus/medusa/pull/36
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/jmk-foofus/medusa/commit/a667656ad085b3eb95309932666c250d97a92767.patch";
-      sha256 = "01marqqhjd3qwar3ymp50y1h2im5ilgpaxk7wrc2kcxgmzvbdfxc";
-    })
-  ];
 
   outputs = [
     "out"
@@ -38,6 +27,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-module-ssh=yes" ];
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
     freerdp
     openssl
@@ -45,10 +35,11 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "https://github.com/jmk-foofus/medusa";
     description = "Speedy, parallel, and modular, login brute-forcer";
-    mainProgram = "medusa";
+    homepage = "https://github.com/jmk-foofus/medusa";
+    changelog = "https://github.com/jmk-foofus/medusa/releases/tag/${src.tag}";
     license = licenses.gpl2Plus;
     maintainers = [ ];
+    mainProgram = "medusa";
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/jmk-foofus/medusa/releases/tag/2.3

https://hydra.nixos.org/build/290728846
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
