### PR TITLE
ioquake3: enable build on darwin and add high-res mods

### DIFF
--- a/pkgs/by-name/io/ioquake3/package.nix
+++ b/pkgs/by-name/io/ioquake3/package.nix
@@ -19,6 +19,7 @@
   freetype,
   mumble,
   unstableGitUpdater,
+  bc,
 }:
 
 stdenv.mkDerivation {
@@ -37,6 +38,7 @@ stdenv.mkDerivation {
     makeBinaryWrapper
     pkg-config
     which
+    bc
   ];
 
   buildInputs = [
@@ -59,16 +61,50 @@ stdenv.mkDerivation {
     cp ${./Makefile.local} ./Makefile.local
   '';
 
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace-fail \
+        "-I/Library/Frameworks/SDL2.framework/Headers" \
+        "-I${lib.getDev SDL2}/include/SDL2" \
+      --replace-fail \
+        "CLIENT_LIBS += -framework SDL2" \
+        "CLIENT_LIBS += -L${lib.getLib SDL2}/lib -lSDL2" \
+      --replace-fail \
+        "RENDERER_LIBS += -framework SDL2" \
+        "RENDERER_LIBS += -L${lib.getLib SDL2}/lib -lSDL2" \
+      --replace-fail \
+        "-I/System/Library/Frameworks/OpenAL.framework/Headers" \
+        "-I${lib.getDev openal}/include/AL" \
+      --replace-fail \
+        "CLIENT_LIBS += -framework OpenAL" \
+        "CLIENT_LIBS += -L${lib.getLib openal}/lib -lopenal" \
+      --replace-fail \
+        "TOOLS_CC = gcc" \
+        "TOOLS_CC = clang"
+  '';
+
+  postBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    echo "Building Application Bundle for Darwin / macOS"
+    # The following script works without extensive patching (see preBuild), as the regular buil already
+    # built all the c code and libraries.
+    ./make-macosx.sh ${stdenv.hostPlatform.darwinArch}
+  '';
+
   installTargets = [ "copyfiles" ];
 
   installFlags = [ "COPYDIR=$(out)/share/ioquake3" ];
 
-  postInstall = ''
-    install -Dm644 misc/quake3.svg $out/share/icons/hicolor/scalable/apps/ioquake3.svg
+  postInstall =
+    ''
+      install -Dm644 misc/quake3.svg $out/share/icons/hicolor/scalable/apps/ioquake3.svg
 
-    makeWrapper $out/share/ioquake3/ioquake3.* $out/bin/ioquake3
-    makeWrapper $out/share/ioquake3/ioq3ded.* $out/bin/ioq3ded
-  '';
+      makeWrapper $out/share/ioquake3/ioquake3.* $out/bin/ioquake3
+      makeWrapper $out/share/ioquake3/ioq3ded.* $out/bin/ioq3ded
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      mv build/release-darwin-${stdenv.hostPlatform.darwinArch}/ioquake3.app $out/Applications/
+    '';
 
   desktopItems = [
     (makeDesktopItem {
@@ -96,6 +132,6 @@ stdenv.mkDerivation {
       drupol
       rvolosatovs
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/io/ioquake3/package.nix
+++ b/pkgs/by-name/io/ioquake3/package.nix
@@ -22,7 +22,7 @@
   bc,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ioquake3";
   version = "0-unstable-2025-05-15";
 
@@ -111,7 +111,7 @@ stdenv.mkDerivation {
       name = "IOQuake3";
       exec = "ioquake3";
       icon = "ioquake3";
-      comment = "A fast-paced 3D first-person shooter, a community effort to continue supporting/developing id's Quake III Arena";
+      comment = finalAttrs.meta.description;
       desktopName = "ioquake3";
       categories = [
         "Game"
@@ -134,4 +134,4 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/games/quake3/content/arena.nix
+++ b/pkgs/games/quake3/content/arena.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  requireFile,
+}:
+
+let
+  version = "1.32c";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "quake3arenadata";
+  inherit version;
+
+  src = requireFile rec {
+    name = "pak0.pk3";
+    hash = "sha256-fOizkQYgzVCgnk8RAPQm6MYYD2iJXVifgOa9la9UvK4=";
+    message = ''
+      Quake 3 Arena requires the original ${name} file, from any legal source of the game.
+
+      This could be an old CD-ROM you have lying around or you can try to buy the game.
+
+      To my knowledge the Steam Quake-Collection-Package, is about the last legal way to get it.
+
+      Please note, there are plenty of versions of this file online like:
+
+      - https://github.com/nrempel/q3-server/raw/master/baseq3/pak0.pk3
+      - https://archive.org/details/quake-3-arena
+
+      However, none of these have the blessing of ID-Software and thus do not qualify.
+
+      Once you download a version or checked your old CD-ROM, locate the ${name} file
+      inside the baseq3 folder and then run the following command on it:
+
+      nix-prefetch-url file:///path/to/baseq3/${name}
+    '';
+  };
+
+  buildCommand = ''
+    mkdir -p $out/baseq3
+    echo 'wwwwwwwwwwwwwwww' > $out/baseq3/q3key
+    ln -s $src $out/baseq3/pak0.pk3
+  '';
+
+  preferLocalBuild = true;
+
+  meta = {
+    description = "Quake 3 Arena content";
+    longDescription = ''
+      Quake III Arena and it's demo don't offer current wide screen resolutions in the menu.
+
+      To switch to such a resolution, you will have to enter something like this in the quake console (invoke with ~ by default)
+
+      r_mode -1; r_customwidth 1920; r_customheight 1080; r_fullscreen 1; vid_restart
+
+      Or call the quake commandline with these parameters
+
+      $  +set r_mode -1 +set r_customwidth 1920 +set r_customheight 1080 +set r_fullscreen 1 +vid_restart
+    '';
+    homepage = "https://www.idsoftware.com/";
+    license = lib.licenses.unfreeRedistributable;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ abbradar ];
+  };
+})

--- a/pkgs/games/quake3/content/arena.nix
+++ b/pkgs/games/quake3/content/arena.nix
@@ -51,11 +51,11 @@ stdenv.mkDerivation (finalAttrs: {
 
       To switch to such a resolution, you will have to enter something like this in the quake console (invoke with ~ by default)
 
-      r_mode -1; r_customwidth 1920; r_customheight 1080; r_fullscreen 1; vid_restart
+      r_mode -1; r_customwidth 2560; r_customheight 1440; r_fullscreen 1; vid_restart
 
       Or call the quake commandline with these parameters
 
-      $  +set r_mode -1 +set r_customwidth 1920 +set r_customheight 1080 +set r_fullscreen 1 +vid_restart
+      $ quake3 +set r_mode -1 +set r_customwidth 2560 +set r_customheight 1440 +set r_fullscreen 1
     '';
     homepage = "https://www.idsoftware.com/";
     license = lib.licenses.unfreeRedistributable;

--- a/pkgs/games/quake3/content/demo.nix
+++ b/pkgs/games/quake3/content/demo.nix
@@ -32,11 +32,11 @@ stdenv.mkDerivation {
 
       To switch to such a resolution, you will have to enter something like this in the quake console (invoke with ~ by default)
 
-      r_mode -1; r_customwidth 1920; r_customheight 1080; r_fullscreen 1; vid_restart
+      r_mode -1; r_customwidth 2560; r_customheight 1440; r_fullscreen 1; vid_restart
 
       Or call the quake commandline with these parameters
 
-      $ quake3 +set r_mode -1 +set r_customwidth 1920 +set r_customheight 1080 +set r_fullscreen 1 +vid_restart
+      $ quake3 +set r_mode -1 +set r_customwidth 2560 +set r_customheight 1440 +set r_fullscreen 1
     '';
     homepage = "https://www.idsoftware.com/";
     license = licenses.unfreeRedistributable;

--- a/pkgs/games/quake3/content/demo.nix
+++ b/pkgs/games/quake3/content/demo.nix
@@ -26,7 +26,19 @@ stdenv.mkDerivation {
   preferLocalBuild = true;
 
   meta = with lib; {
-    description = "Quake 3 Arena demo content";
+    description = "Demo of Quake 3 Arena, a classic first-person shooter";
+    longDescription = ''
+      Quake III Arena and it's demo don't offer current wide screen resolutions in the menu.
+
+      To switch to such a resolution, you will have to enter something like this in the quake console (invoke with ~ by default)
+
+      r_mode -1; r_customwidth 1920; r_customheight 1080; r_fullscreen 1; vid_restart
+
+      Or call the quake commandline with these parameters
+
+      $ quake3 +set r_mode -1 +set r_customwidth 1920 +set r_customheight 1080 +set r_fullscreen 1 +vid_restart
+    '';
+    homepage = "https://www.idsoftware.com/";
     license = licenses.unfreeRedistributable;
     platforms = platforms.all;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -3,6 +3,7 @@
   lib,
   fetchzip,
   fetchurl,
+  fetchFromGitHub,
   libarchive,
 }:
 
@@ -23,15 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   # https://www.moddb.com/mods/high-quality-quake
   # TODO check if that file needs renaming to something that starts with z_* so it actually overrides anything in pak0.pk3
   extra-pack-resolution = fetchurl {
-    # url = "https://github.com/diegoulloao/ioquake3-mac-install/raw/master/extras/extra-pack-resolution.pk3";
     url = "https://web.archive.org/web/20250310093216/https://fmt3.dl.dbolical.com/dl/2018/11/06/q3a-hqq-v37.zip?st=0XzNnNvOYWrJAi_6AB3mKw==&e=1741602736";
     hash = "sha256-0nAXkrf4ahlct75TgO18PjuT9IkH8fpDhtTflJfPpPM=";
-  };
-
-  # backport of sound files from quake 3 live
-  quake3-live-sounds = fetchurl {
-    url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/quake3-live-sounds.pk3";
-    hash = "sha256-kdHP6lNMuq5+OfWQuxgeVPijYEm8JcZveAzZDoYCrc4=";
   };
   # https://www.moddb.com/mods/cz45modbundle/addons/cz45-q3a-weapon-model-remake-v10
   # https://www.moddb.com/downloads/mirror/255463/130/9de70b5dc7ebb1baa44acf91458b04f9/
@@ -42,16 +36,20 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://web.archive.org/web/20250310101737/https://fmt1.dl.dbolical.com/dl/2023/08/13/czq3hdweaprem_v10.zip?st=XBoRCpVmvTYtc60xxi36VQ==&e=1741605457";
     hash = "sha256-pL7MsEFsKJV+a+z45Ns16SPdQB3i2D6T3x7tBqWtm1s=";
   };
-  zpack-weapons = fetchurl {
-    url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/zpack-weapons.pk3";
-    hash = "sha256-RG9pgJc8BHB9sfkmMQI3bEzAf+xO0HPD2bxJ9CxRtek";
+
+  # I would like to find the original sources of the quake3-live-sounds.pk3 and zpack-weapons.pk3 files
+  # Any hints are welcome
+  ioquake3_mac = fetchFromGitHub {
+    owner = "diegoulloao";
+    repo = "ioquake3-mac-install";
+    rev = "3a767ff0131742ec517fd5f13ddca16dee91927d";
+    hash = "sha256-uY3pybCnQ7lZatP3s9AiT779/4xj8N3R4qx8V6991aM=";
   };
 
   buildCommand = ''
     mkdir -p $out/baseq3
     install -Dm444 $src/xcsv_bq3hi-res.pk3 $out/baseq3/xcsv_bq3hi-res.pk3
     install -Dm444 ${finalAttrs.extra-pack-resolution} $out/baseq3/pak9hqq37test20181106.pk3
-    install -Dm444 ${finalAttrs.quake3-live-sounds} $out/baseq3/quake3-live-sounds.pk3
 
     bsdunzip ${finalAttrs.hd-weapons}
     install -Dm444 zzczhdwr1.pk3 $out/baseq3/zzczhdwr1.pk3
@@ -59,7 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     # install -Dm444 zzczhdwr2.pk3 $out/baseq3/zzczhdwr2.pk3
     # install -Dm444 zzczhdwr3.pk3 $out/baseq3/zzczhdwr3.pk3
 
-    install -Dm444 ${finalAttrs.zpack-weapons} $out/baseq3/zpack-weapons.pk3
+    install -Dm444 ${finalAttrs.ioquake3_mac}/extras/quake3-live-sounds.pk3 $out/baseq3/quake3-live-sounds.pk3
+    install -Dm444 ${finalAttrs.ioquake3_mac}/extras/zpack-weapons.pk3 $out/baseq3/zpack-weapons.pk3
   '';
 
   preferLocalBuild = true;

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quake3hires";
-  version = "2020-01-20"; # Unknown version, used the date of web.archive.org capture.
+  version = "unstable-2020-01-20"; # Unknown version, used the date of web.archive.org capture.
 
   nativeBuildInputs = [
     libarchive

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -37,8 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-pL7MsEFsKJV+a+z45Ns16SPdQB3i2D6T3x7tBqWtm1s=";
   };
 
-  # I would like to find the original sources of the quake3-live-sounds.pk3 and zpack-weapons.pk3 files
-  # Any hints are welcome
+  # According to the @diegoulloao (see https://github.com/diegoulloao/ioquake3-mac-install/issues/23#issuecomment-2817031996)
+  # quake3-live-sounds.pk3 is likely a custom repack from https://www.moddb.com/addons/quake-live-announcers-pack
+  # zpack-weapons.pk3 is an amalgamation of multiple mods, where he can't recall which ones he used exactly.
+  # It still makes him the authorative source for these file.
   ioquake3_mac = fetchFromGitHub {
     owner = "diegoulloao";
     repo = "ioquake3-mac-install";

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -25,13 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
   extra-pack-resolution = fetchurl {
     # url = "https://github.com/diegoulloao/ioquake3-mac-install/raw/master/extras/extra-pack-resolution.pk3";
     url = "https://web.archive.org/web/20250310093216/https://fmt3.dl.dbolical.com/dl/2018/11/06/q3a-hqq-v37.zip?st=0XzNnNvOYWrJAi_6AB3mKw==&e=1741602736";
-    sha256 = "sha256-0nAXkrf4ahlct75TgO18PjuT9IkH8fpDhtTflJfPpPM=";
+    hash = "sha256-0nAXkrf4ahlct75TgO18PjuT9IkH8fpDhtTflJfPpPM=";
   };
 
   # backport of sound files from quake 3 live
   quake3-live-sounds = fetchurl {
     url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/quake3-live-sounds.pk3";
-    sha256 = "sha256-0vODIpA3/5BPNno5PKhc/ISI2rFYXYyumKdzUFyXn3M=";
+    hash = "sha256-kdHP6lNMuq5+OfWQuxgeVPijYEm8JcZveAzZDoYCrc4=";
   };
   # https://www.moddb.com/mods/cz45modbundle/addons/cz45-q3a-weapon-model-remake-v10
   # https://www.moddb.com/downloads/mirror/255463/130/9de70b5dc7ebb1baa44acf91458b04f9/
@@ -40,11 +40,11 @@ stdenv.mkDerivation (finalAttrs: {
   hd-weapons = fetchurl {
     name = "czq3hdweaprem_v10.zip";
     url = "https://web.archive.org/web/20250310101737/https://fmt1.dl.dbolical.com/dl/2023/08/13/czq3hdweaprem_v10.zip?st=XBoRCpVmvTYtc60xxi36VQ==&e=1741605457";
-    sha256 = "sha256-pL7MsEFsKJV+a+z45Ns16SPdQB3i2D6T3x7tBqWtm1s=";
+    hash = "sha256-pL7MsEFsKJV+a+z45Ns16SPdQB3i2D6T3x7tBqWtm1s=";
   };
   zpack-weapons = fetchurl {
     url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/zpack-weapons.pk3";
-    sha256 = "sha256-RSK0wZvNqrC3lTT6jhSmEgGL6TiaFz+f+YoI7lr7ckA=";
+    hash = "sha256-RG9pgJc8BHB9sfkmMQI3bEzAf+xO0HPD2bxJ9CxRtek";
   };
 
   buildCommand = ''

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -6,7 +6,7 @@
   libarchive,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "quake3hires";
   version = "2020-01-20"; # Unknown version, used the date of web.archive.org capture.
 
@@ -50,16 +50,16 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     mkdir -p $out/baseq3
     install -Dm444 $src/xcsv_bq3hi-res.pk3 $out/baseq3/xcsv_bq3hi-res.pk3
-    install -Dm444 ${extra-pack-resolution} $out/baseq3/pak9hqq37test20181106.pk3
-    install -Dm444 ${quake3-live-sounds} $out/baseq3/quake3-live-sounds.pk3
+    install -Dm444 ${finalAttrs.extra-pack-resolution} $out/baseq3/pak9hqq37test20181106.pk3
+    install -Dm444 ${finalAttrs.quake3-live-sounds} $out/baseq3/quake3-live-sounds.pk3
 
-    bsdunzip ${hd-weapons}
+    bsdunzip ${finalAttrs.hd-weapons}
     install -Dm444 zzczhdwr1.pk3 $out/baseq3/zzczhdwr1.pk3
     # https://github.com/diegoulloao/ioquake3-mac-install takes only the first file, following his lead for now
     # install -Dm444 zzczhdwr2.pk3 $out/baseq3/zzczhdwr2.pk3
     # install -Dm444 zzczhdwr3.pk3 $out/baseq3/zzczhdwr3.pk3
 
-    install -Dm444 ${zpack-weapons} $out/baseq3/zpack-weapons.pk3
+    install -Dm444 ${finalAttrs.zpack-weapons} $out/baseq3/zpack-weapons.pk3
   '';
 
   preferLocalBuild = true;
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ rvolosatovs ];
   };
-}
+})

--- a/pkgs/games/quake3/content/hires.nix
+++ b/pkgs/games/quake3/content/hires.nix
@@ -2,11 +2,17 @@
   stdenv,
   lib,
   fetchzip,
+  fetchurl,
+  libarchive,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "quake3hires";
   version = "2020-01-20"; # Unknown version, used the date of web.archive.org capture.
+
+  nativeBuildInputs = [
+    libarchive
+  ];
 
   src = fetchzip {
     url = "https://web.archive.org/web/20200120024216/http://ioquake3.org/files/xcsv_hires.zip";
@@ -14,9 +20,46 @@ stdenv.mkDerivation {
     stripRoot = false;
   };
 
+  # https://www.moddb.com/mods/high-quality-quake
+  # TODO check if that file needs renaming to something that starts with z_* so it actually overrides anything in pak0.pk3
+  extra-pack-resolution = fetchurl {
+    # url = "https://github.com/diegoulloao/ioquake3-mac-install/raw/master/extras/extra-pack-resolution.pk3";
+    url = "https://web.archive.org/web/20250310093216/https://fmt3.dl.dbolical.com/dl/2018/11/06/q3a-hqq-v37.zip?st=0XzNnNvOYWrJAi_6AB3mKw==&e=1741602736";
+    sha256 = "sha256-0nAXkrf4ahlct75TgO18PjuT9IkH8fpDhtTflJfPpPM=";
+  };
+
+  # backport of sound files from quake 3 live
+  quake3-live-sounds = fetchurl {
+    url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/quake3-live-sounds.pk3";
+    sha256 = "sha256-0vODIpA3/5BPNno5PKhc/ISI2rFYXYyumKdzUFyXn3M=";
+  };
+  # https://www.moddb.com/mods/cz45modbundle/addons/cz45-q3a-weapon-model-remake-v10
+  # https://www.moddb.com/downloads/mirror/255463/130/9de70b5dc7ebb1baa44acf91458b04f9/
+  # this is only part of the mod, only the weapons skins
+  # url = "https://github.com/diegoulloao/ioquake3-mac-install/raw/master/extras/hd-weapons.pk3";
+  hd-weapons = fetchurl {
+    name = "czq3hdweaprem_v10.zip";
+    url = "https://web.archive.org/web/20250310101737/https://fmt1.dl.dbolical.com/dl/2023/08/13/czq3hdweaprem_v10.zip?st=XBoRCpVmvTYtc60xxi36VQ==&e=1741605457";
+    sha256 = "sha256-pL7MsEFsKJV+a+z45Ns16SPdQB3i2D6T3x7tBqWtm1s=";
+  };
+  zpack-weapons = fetchurl {
+    url = "https://github.com/diegoulloao/ioquake3-mac-install/blob/3a767ff0131742ec517fd5f13ddca16dee91927d/extras/zpack-weapons.pk3";
+    sha256 = "sha256-RSK0wZvNqrC3lTT6jhSmEgGL6TiaFz+f+YoI7lr7ckA=";
+  };
+
   buildCommand = ''
     mkdir -p $out/baseq3
     install -Dm444 $src/xcsv_bq3hi-res.pk3 $out/baseq3/xcsv_bq3hi-res.pk3
+    install -Dm444 ${extra-pack-resolution} $out/baseq3/pak9hqq37test20181106.pk3
+    install -Dm444 ${quake3-live-sounds} $out/baseq3/quake3-live-sounds.pk3
+
+    bsdunzip ${hd-weapons}
+    install -Dm444 zzczhdwr1.pk3 $out/baseq3/zzczhdwr1.pk3
+    # https://github.com/diegoulloao/ioquake3-mac-install takes only the first file, following his lead for now
+    # install -Dm444 zzczhdwr2.pk3 $out/baseq3/zzczhdwr2.pk3
+    # install -Dm444 zzczhdwr3.pk3 $out/baseq3/zzczhdwr3.pk3
+
+    install -Dm444 ${zpack-weapons} $out/baseq3/zpack-weapons.pk3
   '';
 
   preferLocalBuild = true;

--- a/pkgs/games/quake3/default.nix
+++ b/pkgs/games/quake3/default.nix
@@ -1,0 +1,46 @@
+callPackage: rec {
+  # main entry point to create a runnable quake3
+  quake3wrapper = callPackage ./wrapper { };
+
+  # data files
+  quake3arenadata = callPackage ./content/arena.nix { };
+  quake3demodata = callPackage ./content/demo.nix { };
+  quake3pointrelease = callPackage ./content/pointrelease.nix { };
+  quake3hires = callPackage ./content/hires.nix { };
+
+  # runnable quakes with different configurations / mods
+
+  quake3arena = quake3wrapper {
+    pname = "quake3";
+    paks = [
+      quake3arenadata
+      quake3pointrelease
+    ];
+  };
+
+  quake3arena-hires = quake3wrapper {
+    pname = "quake3";
+    paks = [
+      quake3arenadata
+      quake3pointrelease
+      quake3hires
+    ];
+  };
+
+  quake3demo = quake3wrapper {
+    pname = "quake3-demo";
+    paks = [
+      quake3demodata
+      quake3pointrelease
+    ];
+  };
+
+  quake3demo-hires = quake3wrapper {
+    pname = "quake3-demo";
+    paks = [
+      quake3demodata
+      quake3pointrelease
+      quake3hires
+    ];
+  };
+}

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation {
     '';
 
   meta = {
+    mainProgram = "${pname}";
     inherit ((lib.head paks).meta)
       description
       longDescription

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -10,6 +10,8 @@
 {
   paks,
   name ? (lib.head paks).name,
+  pname ? (lib.head paks).pname,
+  version ? (lib.head paks).version,
   description ? "",
 }:
 
@@ -36,18 +38,18 @@ stdenv.mkDerivation {
       # We add Mesa to the end of $LD_LIBRARY_PATH to provide fallback
       # software rendering. GCC is needed so that libgcc_s.so can be found
       # when Mesa is used.
-      makeWrapper ${env}/bin/ioquake3* $out/bin/quake3 \
+      makeWrapper ${env}/bin/ioquake3* $out/bin/${pname} \
         --suffix-each LD_LIBRARY_PATH ':' "${libPath}" \
         --add-flags "+set fs_basepath ${env} +set r_allowSoftwareGL 1"
 
-      makeWrapper ${env}/bin/ioq3ded* $out/bin/quake3-server \
+      makeWrapper ${env}/bin/ioq3ded* $out/bin/${pname}-server \
         --add-flags "+set fs_basepath ${env}"
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications $out/bin
-      makeWrapper ${env}/bin/ioquake3 $out/bin/ioquake3 \
+      makeWrapper ${env}/bin/ioquake3 $out/bin/${pname} \
         --add-flags "+set fs_basepath ${env}"
-      makeWrapper ${env}/bin/ioq3ded $out/bin/ioq3ded \
+      makeWrapper ${env}/bin/ioq3ded $out/bin/${pname}-server \
         --add-flags "+set fs_basepath ${env}"
 
       # Renaming application packages on darwin is not quite as simple as they internally

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -9,7 +9,6 @@
 
 {
   paks,
-  name ? (lib.head paks).name,
   pname ? (lib.head paks).pname,
   version ? (lib.head paks).version,
   description ? "",
@@ -27,7 +26,8 @@ let
 
 in
 stdenv.mkDerivation {
-  name = "${name}-${ioquake3.name}";
+  pname = "${pname}-${ioquake3.name}";
+  inherit version;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -65,6 +65,12 @@ stdenv.mkDerivation {
     '';
 
   meta = {
-    inherit description;
+    inherit ((lib.head paks).meta)
+      description
+      longDescription
+      homepage
+      license
+      ;
+    inherit (ioquake3.meta) platforms;
   };
 }

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -32,25 +32,28 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   buildCommand =
+    let
+      setBasepath = "+set fs_basepath ${env}";
+    in
     lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/bin
 
       # We add Mesa to the end of $LD_LIBRARY_PATH to provide fallback
       # software rendering. GCC is needed so that libgcc_s.so can be found
       # when Mesa is used.
-      makeWrapper ${env}/bin/ioquake3* $out/bin/${pname} \
+      makeWrapper ${env}/bin/ioquake3 $out/bin/${pname} \
         --suffix-each LD_LIBRARY_PATH ':' "${libPath}" \
-        --add-flags "+set fs_basepath ${env} +set r_allowSoftwareGL 1"
+        --add-flags "${setBasepath} +set r_allowSoftwareGL 1"
 
-      makeWrapper ${env}/bin/ioq3ded* $out/bin/${pname}-server \
-        --add-flags "+set fs_basepath ${env}"
+      makeWrapper ${env}/bin/ioq3ded $out/bin/${pname}-server \
+        --add-flags "${setBasepath}"
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications $out/bin
       makeWrapper ${env}/bin/ioquake3 $out/bin/${pname} \
-        --add-flags "+set fs_basepath ${env}"
+        --add-flags "${setBasepath}"
       makeWrapper ${env}/bin/ioq3ded $out/bin/${pname}-server \
-        --add-flags "+set fs_basepath ${env}"
+        --add-flags "${setBasepath}"
 
       # Renaming application packages on darwin is not quite as simple as they internally
       # refer to the old name in many places. So we shelve that for now.
@@ -58,9 +61,9 @@ stdenv.mkDerivation {
       chmod -R +w $out/Applications/
 
       wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioquake3 \
-        --add-flags "+set fs_basepath ${env}"
+        --add-flags "${setBasepath}"
       wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioq3ded \
-        --add-flags "+set fs_basepath ${env}"
+        --add-flags "${setBasepath}"
     '';
 
   meta = {

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -45,9 +45,9 @@ stdenv.mkDerivation {
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications $out/bin
-      makeWrapper ${env}/bin/ioquake3* $out/bin/ioquake3 \
+      makeWrapper ${env}/bin/ioquake3 $out/bin/ioquake3 \
         --add-flags "+set fs_basepath ${env}"
-      makeWrapper ${env}/bin/ioq3ded* $out/bin/ioq3ded \
+      makeWrapper ${env}/bin/ioq3ded $out/bin/ioq3ded \
         --add-flags "+set fs_basepath ${env}"
 
       # Renaming application packages on darwin is not quite as simple as they internally

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -55,14 +55,12 @@ stdenv.mkDerivation {
       makeWrapper ${env}/bin/ioq3ded $out/bin/${pname}-server \
         --add-flags "${setBasepath}"
 
-      # Renaming application packages on darwin is not quite as simple as they internally
-      # refer to the old name in many places. So we shelve that for now.
-      cp -RL ${env}/Applications/ioquake3.app $out/Applications/
+      cp -RL ${env}/Applications/ioquake3.app/ $out/Applications/${pname}.app
       chmod -R +w $out/Applications/
 
-      wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioquake3 \
+      wrapProgram $out/Applications/${pname}.app/Contents/MacOS/ioquake3 \
         --add-flags "${setBasepath}"
-      wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioq3ded \
+      wrapProgram $out/Applications/${pname}.app/Contents/MacOS/ioq3ded \
         --add-flags "${setBasepath}"
     '';
 

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -29,19 +29,37 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildCommand = ''
-    mkdir -p $out/bin
+  buildCommand =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/bin
 
-    # We add Mesa to the end of $LD_LIBRARY_PATH to provide fallback
-    # software rendering. GCC is needed so that libgcc_s.so can be found
-    # when Mesa is used.
-    makeWrapper ${env}/bin/ioquake3* $out/bin/quake3 \
-      --suffix-each LD_LIBRARY_PATH ':' "${libPath}" \
-      --add-flags "+set fs_basepath ${env} +set r_allowSoftwareGL 1"
+      # We add Mesa to the end of $LD_LIBRARY_PATH to provide fallback
+      # software rendering. GCC is needed so that libgcc_s.so can be found
+      # when Mesa is used.
+      makeWrapper ${env}/bin/ioquake3* $out/bin/quake3 \
+        --suffix-each LD_LIBRARY_PATH ':' "${libPath}" \
+        --add-flags "+set fs_basepath ${env} +set r_allowSoftwareGL 1"
 
-    makeWrapper ${env}/bin/ioq3ded* $out/bin/quake3-server \
-      --add-flags "+set fs_basepath ${env}"
-  '';
+      makeWrapper ${env}/bin/ioq3ded* $out/bin/quake3-server \
+        --add-flags "+set fs_basepath ${env}"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications $out/bin
+      makeWrapper ${env}/bin/ioquake3* $out/bin/ioquake3 \
+        --add-flags "+set fs_basepath ${env}"
+      makeWrapper ${env}/bin/ioq3ded* $out/bin/ioq3ded \
+        --add-flags "+set fs_basepath ${env}"
+
+      # Renaming application packages on darwin is not quite as simple as they internally
+      # refer to the old name in many places. So we shelve that for now.
+      cp -RL ${env}/Applications/ioquake3.app $out/Applications/
+      chmod -R +w $out/Applications/
+
+      wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioquake3 \
+        --add-flags "+set fs_basepath ${env}"
+      wrapProgram $out/Applications/ioquake3.app/Contents/MacOS/ioq3ded \
+        --add-flags "+set fs_basepath ${env}"
+    '';
 
   meta = {
     inherit description;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15173,49 +15173,17 @@ with pkgs;
     protobuf = protobuf_21;
   };
 
-  quake3wrapper = callPackage ../games/quake3/wrapper { };
-
-  quake3arena = quake3wrapper {
-    pname = "quake3";
-    paks = [
-      quake3arenadata
-      quake3pointrelease
-    ];
-  };
-
-  quake3arena-hires = quake3wrapper {
-    pname = "quake3";
-    paks = [
-      quake3arenadata
-      quake3pointrelease
-      quake3hires
-    ];
-  };
-
-  quake3demo = quake3wrapper {
-    pname = "quake3-demo";
-    paks = [
-      quake3demodata
-      quake3pointrelease
-    ];
-  };
-
-  quake3demo-hires = quake3wrapper {
-    pname = "quake3-demo";
-    paks = [
-      quake3demodata
-      quake3pointrelease
-      quake3hires
-    ];
-  };
-
-  quake3arenadata = callPackage ../games/quake3/content/arena.nix { };
-
-  quake3demodata = callPackage ../games/quake3/content/demo.nix { };
-
-  quake3pointrelease = callPackage ../games/quake3/content/pointrelease.nix { };
-
-  quake3hires = callPackage ../games/quake3/content/hires.nix { };
+  inherit (import ../games/quake3 pkgs.callPackage)
+    quake3wrapper
+    quake3arenadata
+    quake3demodata
+    quake3pointrelease
+    quake3arena
+    quake3arena-hires
+    quake3demo
+    quake3demo-hires
+    quake3hires
+    ;
 
   quakespasm = callPackage ../games/quakespasm { };
   vkquake = callPackage ../games/quakespasm/vulkan.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15184,6 +15184,16 @@ with pkgs;
     ];
   };
 
+  quake3demo-hires = quake3wrapper {
+    name = "quake3-demo-${lib.getVersion quake3demodata}";
+    description = "Demo of Quake 3 Arena, a classic first-person shooter";
+    paks = [
+      quake3pointrelease
+      quake3demodata
+      quake3hires
+    ];
+  };
+
   quake3demodata = callPackage ../games/quake3/content/demo.nix { };
 
   quake3pointrelease = callPackage ../games/quake3/content/pointrelease.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15182,19 +15182,15 @@ with pkgs;
       quake3pointrelease
     ];
   };
-      quake3demodata
-    ];
-  };
-
   quake3demo-hires = quake3wrapper {
-    name = "quake3-demo-${lib.getVersion quake3demodata}";
-    description = "Demo of Quake 3 Arena, a classic first-person shooter";
+    pname = "quake3-demo";
     paks = [
-      quake3pointrelease
       quake3demodata
+      quake3pointrelease
       quake3hires
     ];
   };
+
 
   quake3demodata = callPackage ../games/quake3/content/demo.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15176,11 +15176,12 @@ with pkgs;
   quake3wrapper = callPackage ../games/quake3/wrapper { };
 
   quake3demo = quake3wrapper {
-    name = "quake3-demo-${lib.getVersion quake3demodata}";
     pname = "quake3-demo";
-    description = "Demo of Quake 3 Arena, a classic first-person shooter";
     paks = [
+      quake3demodata
       quake3pointrelease
+    ];
+  };
       quake3demodata
     ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15175,6 +15175,23 @@ with pkgs;
 
   quake3wrapper = callPackage ../games/quake3/wrapper { };
 
+  quake3arena = quake3wrapper {
+    pname = "quake3";
+    paks = [
+      quake3arenadata
+      quake3pointrelease
+    ];
+  };
+
+  quake3arena-hires = quake3wrapper {
+    pname = "quake3";
+    paks = [
+      quake3arenadata
+      quake3pointrelease
+      quake3hires
+    ];
+  };
+
   quake3demo = quake3wrapper {
     pname = "quake3-demo";
     paks = [
@@ -15182,6 +15199,7 @@ with pkgs;
       quake3pointrelease
     ];
   };
+
   quake3demo-hires = quake3wrapper {
     pname = "quake3-demo";
     paks = [
@@ -15191,6 +15209,7 @@ with pkgs;
     ];
   };
 
+  quake3arenadata = callPackage ../games/quake3/content/arena.nix { };
 
   quake3demodata = callPackage ../games/quake3/content/demo.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15177,6 +15177,7 @@ with pkgs;
 
   quake3demo = quake3wrapper {
     name = "quake3-demo-${lib.getVersion quake3demodata}";
+    pname = "quake3-demo";
     description = "Demo of Quake 3 Arena, a classic first-person shooter";
     paks = [
       quake3pointrelease


### PR DESCRIPTION
- Update to current tip of the tree of ioquake3
- Fix Darwin build

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
