### PR TITLE
nixosTests.user-enable-option: fix build

### DIFF
--- a/nixos/tests/user-enable-option.nix
+++ b/nixos/tests/user-enable-option.nix
@@ -57,7 +57,7 @@ in
     machine.wait_for_unit("getty@tty1.service")
 
     with subtest("${normal-enabled} exists"):
-        check_fn = f"id ${normal-enabled}"
+        check_fn = "id ${normal-enabled}"
         machine.succeed(check_fn)
         machine.wait_until_tty_matches("1", "login: ")
         machine.send_chars("${normal-enabled}\n")
@@ -66,17 +66,17 @@ in
 
     with subtest("${normal-disabled} does not exist"):
         switch_to_tty(2)
-        check_fn = f"id ${normal-disabled}"
+        check_fn = "id ${normal-disabled}"
         machine.fail(check_fn)
 
     with subtest("${system-enabled} exists"):
         switch_to_tty(3)
-        check_fn = f"id ${system-enabled}"
+        check_fn = "id ${system-enabled}"
         machine.succeed(check_fn)
 
     with subtest("${system-disabled} does not exist"):
         switch_to_tty(4)
-        check_fn = f"id ${system-disabled}"
+        check_fn = "id ${system-disabled}"
         machine.fail(check_fn)
   '';
 }


### PR DESCRIPTION
Previously it failed in the linting phase as these f-strings were not needed. The test also passes, as it would have done if it skipped the listing phase.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).