### PR TITLE
fumosay: init at 1.2.2

### DIFF
--- a/pkgs/by-name/fu/fumosay/package.nix
+++ b/pkgs/by-name/fu/fumosay/package.nix
@@ -1,0 +1,27 @@
+{
+  stdenv,
+  libunistring,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fumosay";
+  version = "1.2.2";
+
+  buildInputs = [
+    libunistring
+  ];
+
+  src = fetchFromGitHub {
+    owner = "randomtwdude";
+    repo = "fumosay";
+    rev = "baa28c814f45b6b36f7896729e4388ac56fb1136";
+    sha256 = "sha256-W6cOjYSw7EL5FCfsbmVBMPLGoXXx+7MoWJQEjtmvy/A=";
+  };
+
+  buildPhase = "$CC -o fumosay fumosay.c fumoutil.c fumolang.c -lm -lunistring";
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ./fumosay $out/bin
+  '';
+}


### PR DESCRIPTION
this commit adds the [fumosay](https://github.com/randomtwdude/fumosay) package following the install procedure described in its repository https://github.com/randomtwdude/fumosay?tab=readme-ov-file#install

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
