### PR TITLE
electron{,-bin}: add direct support for the NIXOS_OZONE_WL env var, remove treewide duplication

### DIFF
--- a/pkgs/applications/audio/youtube-music/default.nix
+++ b/pkgs/applications/audio/youtube-music/default.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     makeWrapper ${electron}/bin/electron $out/bin/youtube-music \
       --add-flags $out/share/lib/youtube-music/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -278,7 +278,6 @@ stdenv.mkDerivation (
           }
         # Add gio to PATH so that moving files to the trash works when not using a desktop environment
         --prefix PATH : ${glib.bin}/bin
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
         --add-flags ${lib.escapeShellArg commandLineArgs}
       )
     '';

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation rec {
 
       makeWrapper '${electron}/bin/electron' "$out/bin/drawio" \
         --add-flags "$out/share/lib/drawio/resources/app.asar" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --inherit-argv0
     ''
     + ''

--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -96,8 +96,7 @@ stdenv.mkDerivation rec {
       "$out/share/icons/hicolor/64x64/apps/whalebird.png"
 
     makeWrapper "${electron}/bin/electron" "$out/bin/whalebird" \
-      --add-flags "$out/opt/Whalebird/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "$out/opt/Whalebird/resources/app.asar"
 
     runHook postInstall
   '';

--- a/pkgs/applications/science/math/geogebra/geogebra6.nix
+++ b/pkgs/applications/science/math/geogebra/geogebra6.nix
@@ -62,8 +62,7 @@ let
       mkdir -p $out/libexec/geogebra/ $out/bin
       cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
       makeWrapper ${lib.getBin electron}/bin/electron $out/bin/geogebra \
-        --add-flags "$out/resources/app" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        --add-flags "$out/resources/app"
       install -Dm644 "${desktopItem}/share/applications/"* \
         -t $out/share/applications/
 

--- a/pkgs/by-name/af/affine-bin/package.nix
+++ b/pkgs/by-name/af/affine-bin/package.nix
@@ -115,7 +115,6 @@ stdenvNoCC.mkDerivation (
             makeWrapper "${electron}/bin/electron" $out/bin/${binName} \
               --inherit-argv0 \
               --add-flags $out/lib/${binName}/resources/app.asar \
-              --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
               --add-flags ${lib.escapeShellArg commandLineArgs}
 
             runHook postInstall

--- a/pkgs/by-name/af/affine/package.nix
+++ b/pkgs/by-name/af/affine/package.nix
@@ -189,7 +189,6 @@ stdenv.mkDerivation (finalAttrs: {
         makeWrapper "${lib.getExe electron}" $out/bin/${binName} \
           --inherit-argv0 \
           --add-flags $out/lib/${binName}/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --add-flags ${lib.escapeShellArg commandLineArgs}
 
         runHook postInstall

--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -89,7 +89,6 @@ buildNpmPackage {
 
     makeWrapper '${lib.getExe electron}' $out/bin/anytype \
       --set-default ELECTRON_IS_DEV 0 \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags $out/lib/node_modules/anytype/ \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 

--- a/pkgs/by-name/ap/appium-inspector/package.nix
+++ b/pkgs/by-name/ap/appium-inspector/package.nix
@@ -53,7 +53,6 @@ buildNpmPackage {
 
     makeWrapper '${electron}/bin/electron' "$out/bin/appium-inspector" \
       --add-flags "$out/share/appium-inspector/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set NODE_ENV production
 
     install -m 444 -D 'app/common/renderer/assets/images/icon.png' \

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -184,7 +184,6 @@ buildNpmPackage' rec {
 
       makeWrapper '${lib.getExe electron}' "$out/bin/bitwarden" \
         --add-flags $out/opt/Bitwarden/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --set-default ELECTRON_IS_DEV 0 \
         --inherit-argv0
 

--- a/pkgs/by-name/bl/blockbench/package.nix
+++ b/pkgs/by-name/bl/blockbench/package.nix
@@ -71,7 +71,6 @@ buildNpmPackage rec {
 
       makeWrapper ${lib.getExe electron} $out/bin/blockbench \
           --add-flags $out/share/blockbench/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --inherit-argv0
     ''}
 

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -153,7 +153,6 @@ buildNpmPackage rec {
 
           makeWrapper ${lib.getExe electron} $out/bin/bruno \
             --add-flags $out/opt/bruno/resources/app.asar \
-            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
             --set-default ELECTRON_IS_DEV 0 \
             --inherit-argv0
 

--- a/pkgs/by-name/bs/bs-manager/package.nix
+++ b/pkgs/by-name/bs/bs-manager/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${lib.getExe electron} $out/bin/bs-manager \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --add-flags $out/opt/BSManager/resources \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
 
     runHook postInstall

--- a/pkgs/by-name/ca/caprine/package.nix
+++ b/pkgs/by-name/ca/caprine/package.nix
@@ -49,7 +49,6 @@ buildNpmPackage rec {
 
       makeWrapper ${lib.getExe electron} $out/bin/caprine \
           --add-flags $out/share/caprine/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --set-default ELECTRON_IS_DEV 0 \
           --inherit-argv0
 

--- a/pkgs/by-name/ch/cherry-studio/package.nix
+++ b/pkgs/by-name/ch/cherry-studio/package.nix
@@ -129,7 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper "${lib.getExe electron}" $out/bin/cherry-studio \
       --inherit-argv0 \
       --add-flags $out/lib/cherry-studio/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall

--- a/pkgs/by-name/dd/ddm/package.nix
+++ b/pkgs/by-name/dd/ddm/package.nix
@@ -43,7 +43,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       ln -s $out/share/ddm/icon.png $out/share/icons/hicolor/512x512/apps/ddm.png
 
       makeWrapper ${lib.getExe electron} $out/bin/ddm \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags "$out/share/ddm"
 
       # Install externally-downloaded campaign packs & cube lists

--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${lib.getExe electron} $out/bin/${finalAttrs.meta.mainProgram} \
       --add-flags $out/opt/DeltaChat/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
 
     runHook postInstall

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -102,7 +102,6 @@ stdenv.mkDerivation (
       makeWrapper '${electron}/bin/electron' "$out/bin/${executableName}" \
         --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher.so \
         --add-flags "$out/share/element/electron" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags ${lib.escapeShellArg commandLineArgs}
 
       runHook postInstall

--- a/pkgs/by-name/en/ente-desktop/package.nix
+++ b/pkgs/by-name/en/ente-desktop/package.nix
@@ -109,8 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper '${electron}/bin/electron' "$out/bin/ente-desktop" \
       --set ELECTRON_FORCE_IS_PACKAGED 1 \
       --set ELECTRON_IS_DEV 0 \
-      --add-flags "$out/share/ente-desktop/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "$out/share/ente-desktop/resources/app.asar"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -110,8 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${electron}/bin/electron $out/bin/equibop \
       --add-flags $out/opt/Equibop/resources/app.asar \
       ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
-      ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""}
   '';
 
   desktopItems = makeDesktopItem {

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -115,7 +115,6 @@ buildNpmPackage {
       # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
       makeWrapper ${lib.getExe electron} $out/bin/feishin \
         --add-flags $out/share/feishin/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --set ELECTRON_FORCE_IS_PACKAGED=1 \
         --inherit-argv0
 

--- a/pkgs/by-name/fo/follow/package.nix
+++ b/pkgs/by-name/fo/follow/package.nix
@@ -91,8 +91,7 @@ stdenv.mkDerivation rec {
     makeWrapper "${electron}/bin/electron" "$out/bin/follow" \
       --inherit-argv0 \
       --add-flags --disable-gpu-compositing \
-      --add-flags $out/share/follow \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags $out/share/follow
 
     install -m 444 -D "${desktopItem}/share/applications/"* \
         -t $out/share/applications/

--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -69,8 +69,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       cp -r build/*-unpacked/{locales,resources{,.pak}} -t $out/share/freetube
 
       makeWrapper ${lib.getExe electron} $out/bin/freetube \
-        --add-flags "$out/share/freetube/resources/app.asar" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        --add-flags "$out/share/freetube/resources/app.asar"
 
       install -D _icons/icon.svg $out/share/icons/hicolor/scalable/apps/freetube.svg
     ''

--- a/pkgs/by-name/gd/gdlauncher-carbon/package.nix
+++ b/pkgs/by-name/gd/gdlauncher-carbon/package.nix
@@ -98,7 +98,6 @@ stdenv.mkDerivation (finalAttrs: {
         --set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${libPath} \
         --suffix PATH : "${binPath}" \
         --set ELECTRON_FORCE_IS_PACKAGED 1 \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --add-flags $out/share/gdlauncher-carbon/resources/app.asar
     '';
 

--- a/pkgs/by-name/gf/gfn-electron/package.nix
+++ b/pkgs/by-name/gf/gfn-electron/package.nix
@@ -59,8 +59,7 @@ buildNpmPackage {
 
   postFixup = ''
     makeWrapper $out/dist/geforcenow-electron $out/bin/geforcenow-electron \
-      --add-flags "--no-sandbox --disable-gpu-sandbox" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "--no-sandbox --disable-gpu-sandbox"
 
     substituteInPlace $out/share/applications/com.github.hmlendea.geforcenow-electron.desktop \
       --replace-fail "/opt/geforcenow-electron/geforcenow-electron" "geforcenow-electron" \

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
 
           makeWrapper ${lib.getExe electron} $out/bin/gitify \
               --add-flags $out/share/gitify/resources/app.asar \
-              --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
               --inherit-argv0
         ''
     }

--- a/pkgs/by-name/ht/httptoolkit/package.nix
+++ b/pkgs/by-name/ht/httptoolkit/package.nix
@@ -62,7 +62,6 @@ buildNpmPackage rec {
 
       makeWrapper ${lib.getExe electron} $out/bin/httptoolkit \
           --add-flags $out/share/httptoolkit/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --inherit-argv0
     ''}
 

--- a/pkgs/by-name/it/itch/package.nix
+++ b/pkgs/by-name/it/itch/package.nix
@@ -87,7 +87,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper ${steam-run}/bin/steam-run $out/bin/itch \
       --add-flags ${electron}/bin/electron \
       --add-flags $out/share/itch/resources/app \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set BROTH_USE_LOCAL butler,itch-setup \
       --prefix PATH : ${butler}/bin/:${itch-setup}
   '';

--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -102,7 +102,6 @@ buildNpmPackage rec {
 
       makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
           --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --set-default ELECTRON_IS_DEV 0 \
           --inherit-argv0
 

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -106,7 +106,6 @@ buildNpmPackage rec {
 
       makeWrapper ${lib.getExe electron} $out/bin/kando \
           --add-flags $out/share/kando/resources/app \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --inherit-argv0
     ''}
 

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     makeShellWrapper ${lib.getExe electron} $out/bin/koodo-reader \
       --add-flags $out/share/lib/koodo-reader/resources/app.asar \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
   '';

--- a/pkgs/by-name/ku/kuro/package.nix
+++ b/pkgs/by-name/ku/kuro/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     # executable wrapper
     makeWrapper '${electron}/bin/electron' "$out/bin/kuro" \
       --add-flags "$out/share/lib/kuro/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
 
     runHook postInstall

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     makeShellWrapper "${lib.getExe electron_34}" "$out/bin/legcord" \
       --add-flags "$out/share/lib/legcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
 

--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation {
     makeWrapper ${electron_32}/bin/electron $out/bin/lx-music-desktop \
         --add-flags $out/opt/lx-music-desktop/resources/app.asar \
         --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags ${lib.escapeShellArg commandLineArgs} \
   '';
 

--- a/pkgs/by-name/ma/marktext/package.nix
+++ b/pkgs/by-name/ma/marktext/package.nix
@@ -149,8 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r build/*-unpacked/{locales,resources{,.pak}} $out/opt/marktext
 
     makeWrapper ${lib.getExe electron} $out/bin/marktext \
-      --add-flags $out/opt/marktext/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+      --add-flags $out/opt/marktext/resources/app.asar
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -74,8 +74,7 @@ buildNpmPackage rec {
 
     makeWrapper '${lib.getExe electron}' $out/bin/${pname} \
       --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/share/${pname}/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags $out/share/${pname}/app.asar
 
     runHook postInstall
   '';

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -122,7 +122,6 @@ stdenv.mkDerivation rec {
 
       makeWrapper '${electron}/bin/electron' "$out/bin/mqtt-explorer" \
         --add-flags "$out/share/mqtt-explorer/app/resources/app.asar" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
         --set-default ELECTRON_IS_DEV 0 \
         --inherit-argv0

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -69,7 +69,6 @@ buildNpmPackage rec {
 
     makeWrapper '${lib.getExe electron}' "$out/bin/netron" \
       --add-flags $out/opt/netron/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
 

--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -79,7 +79,6 @@ let
       mkdir -p $out/bin
       makeWrapper ${electron}/bin/electron $out/bin/obsidian \
         --add-flags $out/share/obsidian/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true}}" \
         --add-flags ${lib.escapeShellArg commandLineArgs}
       install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
       install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar

--- a/pkgs/by-name/pe/penpot-desktop/package.nix
+++ b/pkgs/by-name/pe/penpot-desktop/package.nix
@@ -76,7 +76,6 @@ buildNpmPackage rec {
 
     makeWrapper '${lib.getExe electron}' "$out/bin/penpot-desktop" \
       --add-flags $out/opt/Penpot/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
 

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
       --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
   '' + ''
 

--- a/pkgs/by-name/pr/proton-pass/package.nix
+++ b/pkgs/by-name/pr/proton-pass/package.nix
@@ -46,7 +46,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   preFixup = ''
     makeWrapper ${lib.getExe electron} $out/bin/proton-pass \
       --add-flags $out/share/proton-pass/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0

--- a/pkgs/by-name/pr/protonmail-desktop/package.nix
+++ b/pkgs/by-name/pr/protonmail-desktop/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation {
   preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     makeWrapper ${lib.getExe electron} $out/bin/${mainProgram} \
       --add-flags $out/share/proton-mail/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0

--- a/pkgs/by-name/r2/r2modman/package.nix
+++ b/pkgs/by-name/r2/r2modman/package.nix
@@ -86,8 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper '${lib.getExe electron}' "$out/bin/r2modman" \
       --inherit-argv0 \
-      --add-flags "$out/share/r2modman" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "$out/share/r2modman"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -138,7 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper '${electron}/bin/electron' "$out/bin/redisinsight" \
       --add-flags "$out/share/redisinsight/app/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --inherit-argv0
 

--- a/pkgs/by-name/re/revolt-desktop/package.nix
+++ b/pkgs/by-name/re/revolt-desktop/package.nix
@@ -73,8 +73,7 @@
 
         postFixup = ''
           makeWrapper ${electron}/bin/electron $out/bin/revolt-desktop \
-            --add-flags $out/share/revolt-desktop/resources/app.asar \
-            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+            --add-flags $out/share/revolt-desktop/resources/app.asar
         '';
       }
     else

--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -108,7 +108,6 @@ buildNpmPackage rec {
       cp -r locales resources{,.pak} $out/share/ride
       makeShellWrapper ${lib.getExe electron} $out/bin/ride \
           --add-flags $out/share/ride/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
           --inherit-argv0
     ''}
 

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -129,7 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
         --chdir $out/share/siyuan/resources \
         --add-flags $out/share/siyuan/resources/app \
         --set ELECTRON_FORCE_IS_PACKAGED 1 \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --inherit-argv0
 
     install -Dm644 src/assets/icon.svg $out/share/icons/hicolor/scalable/apps/siyuan.svg

--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -91,7 +91,6 @@ buildNpmPackage rec {
 
           makeWrapper '${lib.getExe electron}' "$out/bin/super-productivity" \
             --add-flags "$out/share/super-productivity/app/resources/app.asar" \
-            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
             --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
             --inherit-argv0
         ''

--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -79,8 +79,7 @@ buildNpmPackage rec {
             which
           ]
         } \
-        --add-flags "$out/share/teams-for-linux/app.asar" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        --add-flags "$out/share/teams-for-linux/app.asar"
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications

--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     makeShellWrapper '${lib.getExe electron}' $out/bin/tetrio \
       --prefix LD_LIBRARY_PATH : ${addDriverRunpath.driverLink}/lib \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags $out/share/TETR.IO/app.asar
   '';
 

--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -106,7 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     makeWrapper $out/opt/tidal-hifi/tidal-hifi $out/bin/tidal-hifi \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       "''${gappsWrapperArgs[@]}"
     substituteInPlace $out/share/applications/tidal-hifi.desktop \
       --replace "/opt/tidal-hifi/tidal-hifi" "tidal-hifi"

--- a/pkgs/by-name/uh/uhk-agent/package.nix
+++ b/pkgs/by-name/uh/uhk-agent/package.nix
@@ -61,7 +61,6 @@ stdenvNoCC.mkDerivation {
 
     makeWrapper "${electron}/bin/electron" "$out/bin/${pname}" \
       --add-flags "$out/opt/${pname}/app.asar.unpacked" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
 

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -140,8 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper ${electron}/bin/electron $out/bin/vesktop \
         --add-flags $out/opt/Vesktop/resources/app.asar \
         ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
-        ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+        ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""}
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       makeWrapper $out/Applications/Vesktop.app/Contents/MacOS/Vesktop $out/bin/vesktop

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
 
       makeWrapper ${lib.getExe electron} $out/bin/voicevox \
         --add-flags $out/share/voicevox/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --inherit-argv0
     ''}
 

--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -57,7 +57,6 @@ buildNpmPackage rec {
       # Add xdg-utils to path via suffix, per PR #181171
       makeWrapper '${lib.getExe electron}' $out/bin/webcord \
         --suffix PATH : "${binPath}" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags $out/lib/node_modules/webcord/
 
       runHook postInstall

--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -140,10 +140,6 @@ let
       libdbusmenu
     ];
 
-    preFixup = ''
-      gappsWrapperArgs+=(--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}")
-    '';
-
     postFixup = ''
       makeWrapper $out/opt/Wire/wire-desktop $out/bin/wire-desktop \
         "''${gappsWrapperArgs[@]}"

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${lib.getExe electron_33} $out/bin/ytmdesktop \
       --add-flags $out/lib/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook preFixup

--- a/pkgs/by-name/za/zap-chip/package.nix
+++ b/pkgs/by-name/za/zap-chip/package.nix
@@ -76,7 +76,6 @@ buildNpmPackage rec {
       rm $out/bin/zap
       makeWrapper '${lib.getExe electron}' "$out/bin/zap" \
         --add-flags $out/opt/zap-chip/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --set-default ELECTRON_IS_DEV 0 \
         --inherit-argv0
     '';

--- a/pkgs/by-name/ze/zepp-simulator/package.nix
+++ b/pkgs/by-name/ze/zepp-simulator/package.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation {
     makeWrapper ${lib.getExe electron} $out/bin/simulator \
       --add-flags "--no-sandbox" \
       --add-flags $out/opt/simulator/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       --set-default NODE_ENV production \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \

--- a/pkgs/by-name/zu/zulip/package.nix
+++ b/pkgs/by-name/zu/zulip/package.nix
@@ -50,7 +50,6 @@ buildNpmPackage rec {
 
     makeShellWrapper '${lib.getExe electron_32}' "$out/bin/zulip" \
       --add-flags "$out/share/lib/zulip/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-wayland-ime=true}}" \
       --inherit-argv0
 
     runHook postInstall

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -155,7 +155,8 @@ let
 
     preFixup = ''
       makeWrapper "$out/libexec/electron/electron" $out/bin/electron \
-        "''${gappsWrapperArgs[@]}"
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
     '';
 
     postFixup = ''

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -29,8 +29,9 @@ stdenv.mkDerivation {
   buildCommand = ''
     gappsWrapperArgsHook
     mkdir -p $out/bin
-    makeWrapper "${electron-unwrapped}/libexec/electron/electron" "$out/bin/electron" \
+    makeShellWrapper "${electron-unwrapped}/libexec/electron/electron" "$out/bin/electron" \
       "''${gappsWrapperArgs[@]}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set CHROME_DEVEL_SANDBOX $out/libexec/electron/chrome-sandbox
 
     ln -s ${electron-unwrapped}/libexec $out/libexec

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -89,8 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
       --inherit-argv0 \
       --set ELECTRON_FORCE_IS_PACKAGED 1 \
       --add-flags --disable-gpu-compositing \
-      --add-flags $out/opt/heroic/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags $out/opt/heroic/resources/app.asar
 
     install -D "flatpak/com.heroicgameslauncher.hgl.desktop" "$out/share/applications/com.heroicgameslauncher.hgl.desktop"
     install -D "src/frontend/assets/heroic-icon.svg" "$out/share/icons/hicolor/scalable/apps/com.heroicgameslauncher.hgl.svg"

--- a/pkgs/tools/security/bitwarden-directory-connector/default.nix
+++ b/pkgs/tools/security/bitwarden-directory-connector/default.nix
@@ -85,7 +85,6 @@ in
 
       makeWrapper ${lib.getExe electron} $out/bin/bitwarden-directory-connector \
         --add-flags $out/share/bitwarden-directory-connector/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --set-default ELECTRON_IS_DEV 0 \
         --inherit-argv0
 


### PR DESCRIPTION
Note: this was reverted in https://github.com/NixOS/nixpkgs/pull/389939

My main question is: is there a reason why this wasn't done before?
The chromium derivation also does [something similar](https://github.com/NixOS/nixpkgs/blob/1e34cc0ca2ce00bd8c1d7345c26862030ecbc32b/pkgs/applications/networking/browsers/chromium/default.nix#L176).

TODO: figure out what should be done with `goofcord`, `morgen`, as they have additional flags behind the `NIXOS_OZONE_WL` variable.


Note: This change makes the wrapping be done via `makeShellWrapper` to allow the usage of shell variable expansion.
This does not affect darwin, since the source build only works on linux and I only changed the linux logic for electron-bin.

Note: I have never actually wanted to use these flags yet, I was just annoyed by the duplication.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
