### PR TITLE
sdl2-compat: add setup hook and minor fixes

### DIFF
--- a/pkgs/by-name/sd/sdl2-compat/find-headers.patch
+++ b/pkgs/by-name/sd/sdl2-compat/find-headers.patch
@@ -1,0 +1,31 @@
+diff --git a/SDL2Config.cmake.in b/SDL2Config.cmake.in
+index 80c1b99..54f50e6 100644
+--- a/SDL2Config.cmake.in
++++ b/SDL2Config.cmake.in
+@@ -45,7 +45,8 @@ endif()
+ set(SDL2_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
+ set(SDL2_EXEC_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
+ set(SDL2_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@/SDL2")
+-set(SDL2_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@;@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@/SDL2")
++set(SDL2_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@;@PACKAGE_CMAKE_INSTALL_FULL_INCLUDEDIR@/SDL2" $ENV{SDL2_PATH})
++separate_arguments(SDL2_INCLUDE_DIRS)
+ set(SDL2_BINDIR "@PACKAGE_CMAKE_INSTALL_FULL_BINDIR@")
+ set(SDL2_LIBDIR "@PACKAGE_CMAKE_INSTALL_FULL_LIBDIR@")
+ set(SDL2_LIBRARIES SDL2::SDL2)
+diff --git a/sdl2-config.in b/sdl2-config.in
+index d21b1b2..bb0d624 100644
+--- a/sdl2-config.in
++++ b/sdl2-config.in
+@@ -50,7 +50,11 @@ while test $# -gt 0; do
+       echo @PROJECT_VERSION@
+       ;;
+     --cflags)
+-      echo -I${includedir}/SDL2 @SDL_CFLAGS@
++      SDL_CFLAGS=""
++      for i in @includedir@/SDL2 $SDL2_PATH; do
++        SDL_CFLAGS="$SDL_CFLAGS -I$i"
++      done
++      echo $SDL_CFLAGS @SDL_CFLAGS@
+       ;;
+ @ENABLE_SHARED_TRUE@    --libs)
+ @ENABLE_SHARED_TRUE@      echo -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -44,21 +44,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputBin = "dev";
 
+  # SDL3 is dlopened at runtime, leave it in runpath
+  dontPatchELF = true;
+
   cmakeFlags = [
     (lib.cmakeBool "SDL2COMPAT_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3 ]))
   ];
 
   doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
-  postFixup =
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        install_name_tool -add_rpath ${lib.makeLibraryPath [ sdl3 ]} $out/lib/libSDL2.dylib
-      ''
-    else
-      ''
-        patchelf --add-rpath ${lib.makeLibraryPath [ sdl3 ]} $out/lib/libSDL2.so
-      '';
 
   patches = [ ./find-headers.patch ];
   setupHook = ./setup-hook.sh;
@@ -95,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/libsdl-org/sdl2-compat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ nadiaholmquist ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.all;
     pkgConfigModules = [ "sdl2_compat" ];
   };
 })

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3 ]))
   ];
 
+  # skip timing-based tests as those are flaky
+  env.SDL_TESTS_QUICK = 1;
+
   doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   patches = [ ./find-headers.patch ];

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
         patchelf --add-rpath ${lib.makeLibraryPath [ sdl3 ]} $out/lib/libSDL2.so
       '';
 
+  patches = [ ./find-headers.patch ];
+  setupHook = ./setup-hook.sh;
+
   passthru = {
     tests =
       let

--- a/pkgs/by-name/sd/sdl2-compat/setup-hook.sh
+++ b/pkgs/by-name/sd/sdl2-compat/setup-hook.sh
@@ -1,0 +1,7 @@
+addSDL2Path () {
+  if [ -e "$1/include/SDL2" ]; then
+    export SDL2_PATH="${SDL2_PATH-}${SDL2_PATH:+ }$1/include/SDL2"
+  fi
+}
+
+addEnvHooks "$hostOffset" addSDL2Path


### PR DESCRIPTION
This adds a setup hook analogous to the one used by SDL2 package that
picks up satelitte libraries during build time. This makes it possible
to replace SDL2 with sdl2-compat in packages using satelitte libraries
without further changes to build flags.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
