### PR TITLE
python313Packages.buienradar: 1.0.7 -> 1.0.9

### DIFF
--- a/pkgs/development/python-modules/buienradar/default.nix
+++ b/pkgs/development/python-modules/buienradar/default.nix
@@ -9,22 +9,25 @@
   vincenty,
   xmltodict,
   pytestCheckHook,
+  requests-mock,
+  syrupy,
 }:
 
 buildPythonPackage rec {
   pname = "buienradar";
-  version = "1.0.7";
-  format = "setuptools";
+  version = "1.0.9";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mjj4791";
     repo = "python-buienradar";
-    # https://github.com/mjj4791/python-buienradar/issues/14
     tag = version;
-    hash = "sha256-DwOysdA6B9DMH1j/1Oetx2rCgqwk/UggCdH0lBVS6Hw=";
+    hash = "sha256-DTdxzBe9fBOH5fHME++oq62xMtBKnjY7BCevwjl8VZ8=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     docopt
     pytz
     requests
@@ -33,13 +36,30 @@ buildPythonPackage rec {
     xmltodict
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+    syrupy
+  ];
 
   disabledTests = [
     # require network connection
     "test_rain_data"
     "test_json_data"
     "test_xml_data"
+    # tests fail if run on a different day
+    "test_id_upper1"
+    "test_invalid_data"
+    "test_missing_data"
+    "test_readdata1_30"
+    "test_readdata1_60"
+    "test_readdata2_30"
+    "test_readdata2_60"
+    "test_readdata3"
+  ];
+
+  pytestFlagsArray = [
+    "--snapshot-warn-unused"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Diff: https://github.com/mjj4791/python-buienradar/compare/refs/tags/1.0.7...1.0.9

Changelog: https://github.com/mjj4791/python-buienradar/blob/1.0.9/CHANGLOG.rst

closes https://github.com/NixOS/nixpkgs/pull/387991
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
