### PR TITLE
[Backport release-24.11] ceph: 19.2.0 -> 19.2.1

### DIFF
--- a/pkgs/tools/filesystems/ceph/boost-1.85.patch
+++ b/pkgs/tools/filesystems/ceph/boost-1.85.patch
@@ -1,0 +1,69 @@
+Backported from <https://github.com/ceph/ceph/commit/857eedbe6c9ed80ed0625bd0aa27b1a1e85f8d59>.
+
+Original author: Adam Emerson <aemerson@redhat.com>
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bbd63a6a006..bbd7c737feb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -666,7 +666,7 @@ option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
+ # Boost::thread depends on Boost::atomic, so list it explicitly.
+ set(BOOST_COMPONENTS
+   atomic chrono thread system regex random program_options date_time
+-  iostreams context coroutine)
++  iostreams context coroutine url)
+ set(BOOST_HEADER_COMPONENTS container)
+ 
+ if(WITH_MGR)
+diff --git a/src/mds/BoostUrlImpl.cc b/src/mds/BoostUrlImpl.cc
+deleted file mode 100644
+index 479f4c6d75d..00000000000
+--- a/src/mds/BoostUrlImpl.cc
++++ /dev/null
+@@ -1,8 +0,0 @@
+-/*
+- * https://www.boost.org/doc/libs/1_82_0/libs/url/doc/html/url/overview.html#url.overview.requirements
+- *
+- * To use the library as header-only; that is, to eliminate the requirement 
+- * to link a program to a static or dynamic Boost.URL library, 
+- * simply place the following line in exactly one source file in your project.
+- */
+-#include <boost/url/src.hpp>
+diff --git a/src/mds/CMakeLists.txt b/src/mds/CMakeLists.txt
+index 0c6c31a3c51..5c98db76e4d 100644
+--- a/src/mds/CMakeLists.txt
++++ b/src/mds/CMakeLists.txt
+@@ -45,12 +45,12 @@ set(mds_srcs
+   QuiesceDbManager.cc
+   QuiesceAgent.cc
+   MDSRankQuiesce.cc
+-  BoostUrlImpl.cc
+   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc
+   ${CMAKE_SOURCE_DIR}/src/common/MemoryModel.cc
+   ${CMAKE_SOURCE_DIR}/src/osdc/Journaler.cc
+   ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricTypes.cc)
+ add_library(mds STATIC ${mds_srcs})
+ target_link_libraries(mds PRIVATE
++  Boost::url
+   heap_profiler cpu_profiler osdc ${LUA_LIBRARIES})
+ target_include_directories(mds PRIVATE "${LUA_INCLUDE_DIR}")
+diff --git a/src/test/mds/CMakeLists.txt b/src/test/mds/CMakeLists.txt
+index f80abe75083..18ebb648e68 100644
+--- a/src/test/mds/CMakeLists.txt
++++ b/src/test/mds/CMakeLists.txt
+@@ -18,11 +18,10 @@ target_link_libraries(unittest_mds_sessionfilter mds osdc ceph-common global ${B
+ add_executable(unittest_mds_quiesce_db
+   TestQuiesceDb.cc
+   ../../../src/mds/QuiesceDbManager.cc
+-  ../../../src/mds/BoostUrlImpl.cc
+   $<TARGET_OBJECTS:unit-main>
+ )
+ add_ceph_unittest(unittest_mds_quiesce_db)
+-target_link_libraries(unittest_mds_quiesce_db ceph-common global)
++target_link_libraries(unittest_mds_quiesce_db ceph-common global Boost::url)
+ 
+ # unittest_mds_quiesce_agent
+ add_executable(unittest_mds_quiesce_agent
+-- 
+2.47.0
+

--- a/pkgs/tools/filesystems/ceph/boost-1.86-PyModule.patch
+++ b/pkgs/tools/filesystems/ceph/boost-1.86-PyModule.patch
@@ -1,0 +1,20 @@
+Excerpted from <https://aur.archlinux.org/cgit/aur.git/commit/?h=ceph&id=8c5cc7d8deec002f7596b6d0860859a0a718f12b>.
+
+Original author: Bazaah <github@luxolus.com>
+
+diff --git a/src/mgr/PyModule.cc b/src/mgr/PyModule.cc
+index 084cf3ffc1e..010a1177a88 100644
+--- a/src/mgr/PyModule.cc
++++ b/src/mgr/PyModule.cc
+@@ -36,6 +36,11 @@ std::string PyModule::mgr_store_prefix = "mgr/";
+ 
+ // Courtesy of http://stackoverflow.com/questions/1418015/how-to-get-python-exception-text
+ #define BOOST_BIND_GLOBAL_PLACEHOLDERS
++// Fix instances of "'BOOST_PP_ITERATION_02' was not declared in this scope; did you mean 'BOOST_PP_ITERATION_05'"
++// and related macro error bullshit that spans 300 lines of errors
++//
++// Apparently you can't include boost/python stuff _and_ have this header defined
++#undef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+ // Boost apparently can't be bothered to fix its own usage of its own
+ // deprecated features.
+ #include <boost/python/extract.hpp>

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -27,7 +27,16 @@
   # Runtime dependencies
   arrow-cpp,
   babeltrace,
-  boost186,
+  # Note when trying to upgrade boost:
+  # * When upgrading Ceph, it's recommended to check which boost version Ceph uses on Fedora,
+  #   and default to that.
+  # * The version that Ceph downloads if `-DWITH_SYSTEM_BOOST:BOOL=ON` is not given
+  #   is declared in `cmake/modules/BuildBoost.cmake` line `set(boost_version ...)`.
+  #
+  # If you want to upgrade to boost >= 1.86, you need a Ceph version that
+  # has this PR in:
+  #     https://github.com/ceph/ceph/pull/61312
+  boost183,
   bzip2,
   cryptsetup,
   cunit,
@@ -293,7 +302,7 @@ let
       };
   };
 
-  boost' = boost186.override {
+  boost' = boost183.override {
     enablePython = true;
     inherit python;
   };
@@ -343,10 +352,10 @@ let
   );
   inherit (ceph-python-env.python) sitePackages;
 
-  version = "19.2.0";
+  version = "19.2.1";
   src = fetchurl {
     url = "https://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    hash = "sha256-30vkW1j49hFIxyxzkssSKVSq0VqiwLfDtOb62xfxadM=";
+    hash = "sha256-QEX3LHxySVgLBg21iQga1DnyQsXFi6593e+WSjgT/h8=";
   };
 in
 rec {
@@ -361,12 +370,6 @@ rec {
         hash = "sha256-21fi5tMIs/JmuhwPYMWtampv/aqAe+EoPAXZLJlOvgo=";
         stripLen = 1;
         extraPrefix = "src/s3select/";
-      })
-
-      (fetchpatch2 {
-        name = "ceph-gcc-14.patch";
-        url = "https://github.com/ceph/ceph/commit/0eace4ea9ea42412d4d6a16d24a8660642e41173.patch?full_index=1";
-        hash = "sha256-v+AExf/npe4NgmVl2j6o8860nwF9YuzC/vR0TWxTrIE=";
       })
 
       ./boost-1.85.patch
@@ -473,9 +476,20 @@ rec {
       "${placeholder "out"}/${ceph-python-env.sitePackages}"
     ];
 
-    # replace /sbin and /bin based paths with direct nix store paths
-    # increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
+    # * `unset AS` because otherwise the Ceph CMake build errors with
+    #       configure: error: No modern nasm or yasm found as required. Nasm should be v2.11.01 or later (v2.13 for AVX512) and yasm should be 1.2.0 or later.
+    #   because the code at
+    #       https://github.com/intel/isa-l/blob/633add1b569fe927bace3960d7c84ed9c1b38bb9/configure.ac#L99-L191
+    #   doesn't even consider using `nasm` or `yasm` but instead uses `$AS`
+    #   from `gcc-wrapper`.
+    #   (Ceph's error message is extra confusing, because it says
+    #   `No modern nasm or yasm found` when in fact it found e.g. `nasm`
+    #   but then uses `$AS` instead.
+    # * replace /sbin and /bin based paths with direct nix store paths
+    # * increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
     preConfigure = ''
+      unset AS
+
       substituteInPlace src/common/module.c \
         --replace "char command[128];" "char command[256];" \
         --replace "/sbin/modinfo"  "${kmod}/bin/modinfo" \

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -26,7 +26,7 @@
   # Runtime dependencies
   arrow-cpp,
   babeltrace,
-  boost,
+  boost186,
   bzip2,
   cryptsetup,
   cunit,
@@ -286,7 +286,7 @@ let
       };
   };
 
-  boost' = boost.override {
+  boost' = boost186.override {
     enablePython = true;
     inherit python;
   };

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -26,7 +26,7 @@
   # Runtime dependencies
   arrow-cpp,
   babeltrace,
-  boost182, # using the version installed by ceph's `install-deps.sh`
+  boost,
   bzip2,
   cryptsetup,
   cunit,
@@ -286,7 +286,7 @@ let
       };
   };
 
-  boost = boost182.override {
+  boost' = boost.override {
     enablePython = true;
     inherit python;
   };
@@ -361,6 +361,20 @@ rec {
         url = "https://github.com/ceph/ceph/commit/0eace4ea9ea42412d4d6a16d24a8660642e41173.patch?full_index=1";
         hash = "sha256-v+AExf/npe4NgmVl2j6o8860nwF9YuzC/vR0TWxTrIE=";
       })
+
+      ./boost-1.85.patch
+
+      (fetchpatch2 {
+        name = "ceph-boost-1.86-uuid.patch";
+        url = "https://github.com/ceph/ceph/commit/01306208eac492ee0e67bff143fc32d0551a2a6f.patch?full_index=1";
+        hash = "sha256-OnDrr72inzGXXYxPFQevsRZImSvI0uuqFHqtFU2dPQE=";
+      })
+
+      # See:
+      # * <https://github.com/boostorg/python/issues/394>
+      # * <https://aur.archlinux.org/cgit/aur.git/commit/?h=ceph&id=8c5cc7d8deec002f7596b6d0860859a0a718f12b>
+      # * <https://github.com/ceph/ceph/pull/60999>
+      ./boost-1.86-PyModule.patch
     ];
 
     nativeBuildInputs = [
@@ -388,7 +402,7 @@ rec {
       ++ [
         arrow-cpp
         babeltrace
-        boost
+        boost'
         bzip2
         # Adding `ceph-python-env` here adds the env's `site-packages` to `PYTHONPATH` during the build.
         # This is important, otherwise the build system may not find the Python deps and then

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -259,6 +259,9 @@ let
           disabledTests = old.disabledTests or [ ] ++ [
             "test_export_md5_digest"
           ];
+          disabledTestPaths = old.disabledTestPaths or [ ] ++ [
+            "tests/test_ssl.py"
+          ];
           propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [
             self.flaky
           ];

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -19,6 +19,7 @@
   nasm,
   pkg-config,
   which,
+  openssl,
 
   # Tests
   nixosTests,
@@ -261,6 +262,9 @@ let
           propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [
             self.flaky
           ];
+          # hack: avoid building docs due to incompatibility with current sphinx
+          nativeBuildInputs = [ openssl ]; # old.nativeBuildInputs but without sphinx*
+          outputs = lib.filter (o: o != "doc") old.outputs;
         });
 
         fastapi = super.fastapi.overridePythonAttrs (old: rec {

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -242,11 +242,11 @@ let
             hash = "sha256-J9N1kDrIJhz+QEf2cJ0W99GNObHskqr3KvmJVSplDr0=";
           };
           cargoRoot = "src/_bcrypt";
-          cargoDeps = rustPlatform.fetchCargoTarball {
+          cargoDeps = rustPlatform.fetchCargoVendor {
             inherit src;
             sourceRoot = "${pname}-${version}/${cargoRoot}";
             name = "${pname}-${version}";
-            hash = "sha256-lDWX69YENZFMu7pyBmavUZaalGvFqbHSHfkwkzmDQaY=";
+            hash = "sha256-8PyCgh/rUO8uynzGdgylAsb5k55dP9fCnf40UOTCR/M=";
           };
         });
 
@@ -522,7 +522,7 @@ rec {
       #          |       ^~~~~~~~~~~~~~~~~~
       # Looks like `close()` is somehow not included.
       # But the relevant code is already removed in `open-telemetry` 1.10: https://github.com/open-telemetry/opentelemetry-cpp/pull/2031
-      # So it's proably not worth trying to fix that for this Ceph version,
+      # So it's probably not worth trying to fix that for this Ceph version,
       # and instead just disable Ceph's Jaeger support.
       "-DWITH_JAEGER:BOOL=OFF"
       "-DWITH_TESTS:BOOL=OFF"

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -355,6 +355,12 @@ rec {
         stripLen = 1;
         extraPrefix = "src/s3select/";
       })
+
+      (fetchpatch2 {
+        name = "ceph-gcc-14.patch";
+        url = "https://github.com/ceph/ceph/commit/0eace4ea9ea42412d4d6a16d24a8660642e41173.patch?full_index=1";
+        hash = "sha256-v+AExf/npe4NgmVl2j6o8860nwF9YuzC/vR0TWxTrIE=";
+      })
     ];
 
     nativeBuildInputs = [

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -173,6 +173,7 @@ let
       johanot
       krav
       nh2
+      benaryorg
     ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Manual backport of #381075 including several cherry-picks and one commit with partial picks to keep the code in sync with master, which, looking at the current date is probably not going to be useful to anyone as a new NixOS version is more likely to hit before another Ceph version.
Either way, this is the exact version that I have already tested in the original PR on 24.11, minus the *trustme* version, since that one is the current one in 24.11.

~~This is currently a draft, just so that nobody else starts working on the same backport while my tower is still compiling Ceph (and the linux kernel that's not built by upstream hydra, but which is required to run the tests on this commit).
I'll undraft it as soon as those tests are done.~~