### PR TITLE
.editorconfig: unify free-standing bash indent with Nix-embedded bash indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,8 +35,12 @@ indent_size = 1
 [*.{json,lock,md,nix,rb}]
 indent_size = 2
 
-# Match perl/python/shell scripts, set indent width of four
-[*.{bash,pl,pm,py,sh}]
+# Match all the Bash code in Nix files, set indent width of two
+[*.{bash,sh}]
+indent_size = 2
+
+# Match Perl and Python scripts, set indent width of four
+[*.{pl,pm,py}]
 indent_size = 4
 
 # Match gemfiles, set indent to spaces with width of two


### PR DESCRIPTION
We (@connorbaker and I) believe these two should look the same.

The setting of four spaces dates back to the introduction of the file in 1c1143288495b33ab9a35ef58708417b6d401450.

## Things done

- [x] Looks great.
- [x] Tastes great.
- [ ] Super filling.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).