### PR TITLE
leancrypto: init at 1.9.0, gnutls: build with leancrypto for PQC

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24767,6 +24767,12 @@
     githubId = 7116239;
     keys = [ { fingerprint = "E067 520F 5EF2 C175 3F60  50C0 BA46 725F 6A26 7442"; } ];
   };
+  solomonv = {
+    name = "Solomon Victorino";
+    github = "sgvictorino";
+    githubId = 9170316;
+    matrix = "@solomon:pub.solar";
+  };
   solson = {
     email = "scott@solson.me";
     matrix = "@solson:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26488,6 +26488,12 @@
     githubId = 73885403;
     keys = [ { fingerprint = "F779 4E05 D8BB A608 73D0  1312 4FD6 B0D5 1C9A B6BD"; } ];
   };
+  solomonv = {
+    name = "Solomon Victorino";
+    github = "sgvictorino";
+    githubId = 9170316;
+    matrix = "@solomon:pub.solar";
+  };
   solson = {
     email = "scott@solson.me";
     matrix = "@solson:matrix.org";

--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -25,6 +25,8 @@
   libunistring,
   withP11-kit ? !stdenv.hostPlatform.isStatic,
   p11-kit,
+  withLeancrypto ? true,
+  leancrypto,
   # certificate compression - only zlib now, more possible: zstd, brotli
 
   # for passthru.tests
@@ -130,6 +132,7 @@ stdenv.mkDerivation rec {
       "--enable-fast-install"
       "--with-unbound-root-key-file=${dns-root-data}/root.key"
       (lib.withFeature withP11-kit "p11-kit")
+      (lib.withFeature withLeancrypto "leancrypto")
       (lib.enableFeature cxxBindings "cxx")
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -161,6 +164,7 @@ stdenv.mkDerivation rec {
     libiconv
   ]
   ++ lib.optional withP11-kit p11-kit
+  ++ lib.optional withLeancrypto leancrypto
   ++ lib.optional (tpmSupport && stdenv.hostPlatform.isLinux) trousers;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -23,6 +23,8 @@
   libunistring,
   withP11-kit ? !stdenv.hostPlatform.isStatic,
   p11-kit,
+  withLeancrypto ? true,
+  leancrypto,
   # certificate compression - only zlib now, more possible: zstd, brotli
 
   # for passthru.tests
@@ -123,6 +125,7 @@ stdenv.mkDerivation rec {
       "--enable-fast-install"
       "--with-unbound-root-key-file=${dns-root-data}/root.key"
       (lib.withFeature withP11-kit "p11-kit")
+      (lib.withFeature withLeancrypto "leancrypto")
       (lib.enableFeature cxxBindings "cxx")
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -158,6 +161,7 @@ stdenv.mkDerivation rec {
     libiconv
   ]
   ++ lib.optional withP11-kit p11-kit
+  ++ lib.optional withLeancrypto leancrypto
   ++ lib.optional (tpmSupport && stdenv.hostPlatform.isLinux) trousers;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/le/leancrypto/package.nix
+++ b/pkgs/by-name/le/leancrypto/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  meson,
+  ninja,
+  doxygen,
+  # cert generators depend on GPL-2.0-only code, which conflicts with Apache
+  withCertGenerators ? false,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "leancrypto";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "leancrypto";
+    rev = "v${version}";
+    hash = "sha256-qDrCK7bOTdZ/DxYVNsTLgwK7i3JFwUjCKD7v7HUPLKw=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  postPatch = ''
+    patchShebangs addon/*.sh apps/tests/*.sh
+
+    # remove GPLv2 code that shouldn't be used for userspace builds
+    # https://github.com/smuellerDD/leancrypto/blob/8920e81b57504bf7504238bcb148f4abc12ae39b/LICENSE
+    rm internal/api/errno_private.h internal/api/errno_private-base.h
+  ''
+  # make sure we don't link this GPL-2.0-only file
+  + lib.optionalString (!withCertGenerators) ''
+    rm asn1/src/asn1_encoder_helper.c
+  '';
+
+  mesonFlags = [
+    (lib.mesonEnable "x509_generator" withCertGenerators)
+    (lib.mesonEnable "x509_csr_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs7_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs8_generator" withCertGenerators)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    doxygen
+  ];
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://leancrypto.org/";
+    description = "Lean cryptographic library usable for bare-metal environments";
+    license =
+      with lib.licenses;
+      [
+        gpl3Plus
+        gpl2Plus
+        bsd3
+        asl20
+        bsd2
+        mit
+        isc
+        unlicense
+        publicDomain
+        cc0
+      ]
+      ++ lib.optional withCertGenerators [
+        gpl2Only
+        unfree
+      ];
+    maintainers = with lib.maintainers; [
+      solomonv
+    ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/le/leancrypto/package.nix
+++ b/pkgs/by-name/le/leancrypto/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  meson,
+  ninja,
+  doxygen,
+  # cert generators depend on GPL-2.0-only code, which conflicts with Apache
+  withCertGenerators ? false,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "leancrypto";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "leancrypto";
+    rev = "v${version}";
+    hash = "sha256-76qzK2gDFqfIT2CJkHHmVYcM/bPCQsjUaW8kxqiK9nM=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  postPatch = ''
+    patchShebangs addon/*.sh apps/tests/*.sh
+
+    # remove GPLv2 code that shouldn't be used for userspace builds
+    # https://github.com/smuellerDD/leancrypto/blob/8920e81b57504bf7504238bcb148f4abc12ae39b/LICENSE
+    rm internal/api/errno_private.h internal/api/errno_private-base.h
+  ''
+  # make sure we don't link this GPL-2.0-only file
+  + lib.optionalString (!withCertGenerators) ''
+    rm asn1/src/asn1_encoder_helper.c
+  '';
+
+  mesonFlags = [
+    (lib.mesonEnable "x509_generator" withCertGenerators)
+    (lib.mesonEnable "x509_csr_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs7_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs8_generator" withCertGenerators)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    doxygen
+  ];
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://leancrypto.org/";
+    description = "Lean cryptographic library usable for bare-metal environments";
+    license =
+      with lib.licenses;
+      [
+        gpl3Plus
+        gpl2Plus
+        bsd3
+        asl20
+        bsd2
+        mit
+        isc
+        unlicense
+        publicDomain
+        cc0
+      ]
+      ++ lib.optional withCertGenerators [
+        gpl2Only
+        unfree
+      ];
+    maintainers = with lib.maintainers; [
+      solomonv
+    ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/le/leancrypto/package.nix
+++ b/pkgs/by-name/le/leancrypto/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  meson,
+  ninja,
+  doxygen,
+  # cert generators depend on GPL-2.0-only code, which conflicts with Apache
+  withCertGenerators ? false,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "leancrypto";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "smuellerDD";
+    repo = "leancrypto";
+    rev = "v${version}";
+    hash = "sha256-gGQqgsmZnkw4FAmiCK7gz/bgy13BDAEUIQKh1+19EIA=";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  postPatch = ''
+    patchShebangs addon/*.sh apps/tests/*.sh
+
+    # remove GPLv2 code that shouldn't be used for userspace builds
+    # https://github.com/smuellerDD/leancrypto/blob/8920e81b57504bf7504238bcb148f4abc12ae39b/LICENSE
+    rm internal/api/errno_private.h internal/api/errno_private-base.h
+  ''
+  # make sure we don't link this GPL-2.0-only file
+  + lib.optionalString (!withCertGenerators) ''
+    rm asn1/src/asn1_encoder_helper.c
+  '';
+
+  mesonFlags = [
+    (lib.mesonEnable "x509_generator" withCertGenerators)
+    (lib.mesonEnable "x509_csr_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs7_generator" withCertGenerators)
+    (lib.mesonEnable "pkcs8_generator" withCertGenerators)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    doxygen
+  ];
+
+  doCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://leancrypto.org/";
+    description = "Lean cryptographic library usable for bare-metal environments";
+    license =
+      with lib.licenses;
+      [
+        gpl3Plus
+        gpl2Plus
+        bsd3
+        asl20
+        bsd2
+        mit
+        isc
+        unlicense
+        publicDomain
+        cc0
+      ]
+      ++ lib.optional withCertGenerators [
+        gpl2Only
+        unfree
+      ];
+    maintainers = with lib.maintainers; [
+      solomonv
+    ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Enables post-quantum TLS for [gnutls 3.8.9](https://gitlab.com/gnutls/gnutls/-/blob/0967bf88052d72ebcc086c04d97313df50d72c05/NEWS#L8):

```sh
gnutls-cli --priority="NORMAL:+GROUP-X25519-MLKEM768" cloudflare.com
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
