### PR TITLE
gocatcli: init at 1.0.6

### DIFF
--- a/pkgs/by-name/go/gocatcli/package.nix
+++ b/pkgs/by-name/go/gocatcli/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "gocatcli";
+  version = "1.0.6";
+
+  src = fetchFromGitHub {
+    owner = "deadc0de6";
+    repo = "gocatcli";
+    tag = "v${version}";
+    hash = "sha256-qB7BDPDGcngPhd82V4FrsycFd7CNb6hPaHJQ+ECmo48=";
+  };
+
+  vendorHash = "sha256-gJfqnxCTKXmTH8L4qjSXzTr+LsP+jzzivfQOplRkfao=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gocatcli \
+      --bash <($out/bin/gocatcli completion bash) \
+      --fish <($out/bin/gocatcli completion fish) \
+      --zsh <($out/bin/gocatcli completion zsh)
+  '';
+
+  nativeCheckInputs = [ versionCheckHook ];
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/deadc0de6/gocatcli";
+    changelog = "https://github.com/deadc0de6/gocatcli/releases/tag/v${version}";
+    description = "The command line catalog tool for your offline data";
+    longDescription = ''
+      gocatcli is a catalog tool for your offline data. It indexes external
+      media in a catalog file and allows to quickly find specific files or even
+      navigate in the catalog as if it was a mounted drive
+    '';
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nadir-ishiguro
+    ];
+    mainProgram = "gocatcli";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

From the readme:

> [gocatcli](https://github.com/deadc0de6/gocatcli) is a catalog tool for your offline data
> 
> Did you ever wanted to find back that specific file that should be on one of your backup DVDs or one of your external hard drives? You usually go through all of them hoping to find the right one on the first try? gocatcli indexes external media in a catalog file and allows to quickly find specific files or even navigate in the catalog as if it was a mounted drive.

It's the developer's intended successor to [catcli](https://github.com/deadc0de6/catcli), which is already packaged in nixpkgs. That means it might be a good idea to remove that package and the [PR I opened a few days ago to update it to 1.0](https://github.com/NixOS/nixpkgs/pull/387284).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
