### PR TITLE
unicorn-angr: init at 2.0.1.post1, python313Packages.unicorn-angr: init at 2.0.1.post1

### DIFF
--- a/pkgs/by-name/un/unicorn-angr/package.nix
+++ b/pkgs/by-name/un/unicorn-angr/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  pkg-config,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "unicorn-angr";
+  # Version must follow what angr requires
+  version = "2.0.1.post1";
+
+  src = fetchFromGitHub {
+    owner = "unicorn-engine";
+    repo = "unicorn";
+    tag = version;
+    hash = "sha256-Jz5C35rwnDz0CXcfcvWjkwScGNQO1uijF7JrtZhM7mI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
+  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
+
+  cmakeFlags = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # Some x86 tests are interrupted by signal 10
+    "-DCMAKE_CTEST_ARGUMENTS=--exclude-regex;test_x86"
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Lightweight multi-platform CPU emulator library";
+    homepage = "https://www.unicorn-engine.org";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fab ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -30,7 +30,7 @@
   sortedcontainers,
   sqlalchemy,
   sympy,
-  unicorn,
+  unicorn-angr,
   unique-log-filter,
 }:
 
@@ -48,16 +48,7 @@ buildPythonPackage rec {
     hash = "sha256-rrJTYe3o/Ra8+EKAA7t0M02tWVN4Ul5ueUar7lpUvMg=";
   };
 
-  postPatch = ''
-    # unicorn is also part of build-system
-    substituteInPlace pyproject.toml \
-      --replace-fail "unicorn==2.0.1.post1" "unicorn"
-  '';
-
-  pythonRelaxDeps = [
-    "capstone"
-    "unicorn"
-  ];
+  pythonRelaxDeps = [ "capstone" ];
 
   build-system = [ setuptools ];
 
@@ -87,7 +78,7 @@ buildPythonPackage rec {
     sortedcontainers
     sqlalchemy
     sympy
-    unicorn
+    unicorn-angr
     unique-log-filter
   ];
 
@@ -117,7 +108,5 @@ buildPythonPackage rec {
     homepage = "https://angr.io/";
     license = with licenses; [ bsd2 ];
     maintainers = with maintainers; [ fab ];
-    # angr is pining unicorn
-    broken = versionAtLeast unicorn.version "2.0.1.post1";
   };
 }

--- a/pkgs/development/python-modules/unicorn-angr/default.nix
+++ b/pkgs/development/python-modules/unicorn-angr/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  distutils,
+  setuptools,
+  unicorn-angr,
+}:
+
+buildPythonPackage rec {
+  pname = "unicorn-angr";
+  version = lib.getVersion unicorn-angr;
+  pyproject = true;
+
+  src = unicorn-angr.src;
+
+  sourceRoot = "${src.name}/bindings/python";
+
+  prePatch = ''
+    ln -s ${unicorn-angr}/lib/libunicorn.* prebuilt/
+  '';
+
+  # Needed on non-x86 linux
+  setupPyBuildFlags =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      "--plat-name"
+      "linux"
+    ]
+    # aarch64 only available from MacOS SDK 11 onwards, so fix the version tag.
+    # otherwise, bdist_wheel may detect "macosx_10_6_arm64" which doesn't make sense.
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      "--plat-name"
+      "macosx_11_0"
+    ];
+
+  build-system = [
+    distutils
+    setuptools
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    mv unicorn unicorn.hidden
+    patchShebangs sample_*.py shellcode.py
+    sh -e sample_all.sh
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "unicorn" ];
+
+  meta = with lib; {
+    description = "Python bindings for Unicorn CPU emulator engine";
+    homepage = "https://www.unicorn-engine.org/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17970,6 +17970,10 @@ self: super: with self; {
     inherit (pkgs) unicorn;
   };
 
+  unicorn-angr = callPackage ../development/python-modules/unicorn-angr {
+    inherit (pkgs) unicorn-angr;
+  };
+
   unicurses = callPackage ../development/python-modules/unicurses { };
 
   unicrypto = callPackage ../development/python-modules/unicrypto { };


### PR DESCRIPTION
angr requires a specific version of unicorn. In the past we had an override but overrides in Python module are the very last resort to fix an issue.

Needed for #385864

Will no longer be needed after https://github.com/angr/angr/pull/5161

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
