### PR TITLE
fetchFromGitHub: use of the API endpoint only when fetching tarball

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -44,7 +44,10 @@ let
     else fetchzip;
   privateAttrs = lib.optionalAttrs private {
     netrcPhase =
-      let machineName = if githubBase == "github.com" then "api.github.com" else githubBase;
+      # When using private repos:
+      # - Fetching with git works using https://github.com but not with the GitHub API endpoint
+      # - Fetching a tarball from a private repo requires to use the GitHub API endpoint
+      let machineName = if githubBase == "github.com" && !useFetchGit then "api.github.com" else githubBase;
       in ''
         if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
           echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/321484 introduced a bug when when`forceFetchGit=true`.

This PR revert the change only for this case.

The previous PR made work cases like:

```bash
nix-build -E 'let pkgs = import ./nixpkgs {}; in pkgs.fetchFromGitHub {owner = "<username>"; repo = "<repo>"; rev = "HEAD"; hash = ""; private=true; forceFetchGit=false; }'
```

You should see the download working and nix complaining about hash
mismatch.

Now if you take the case where `forceFetchGit=true`, this is a different
story:

```bash
nix-build -E 'let pkgs = import ./nixpkgs {}; in pkgs.fetchFromGitHub {owner = "<username>"; repo = "<repo>"; rev = "HEAD"; hash = ""; private=true; forceFetchGit=true; }'
```

Logs look like:

```
Initialized empty Git repository in /nix/store/<hash>-source/.git/
fatal: could not read Username for 'https://github.com': No such device or address
fatal: could not read Username for 'https://github.com': No such device or address
fatal: could not read Username for 'https://github.com': No such device or address
fatal: could not read Username for 'https://github.com': No such device or address
Unable to checkout HEAD from https://github.com/<username>/<repo>.git.
```

I was using `forceFetchGit` for the exact reason the previous PR was made, I will move to `forceFetchGit=false` now. 
I'm seeing the issue only now since I'm updating a project from 24.05 that wasn't affected to 24.11.

Still the previous PR was a broke usage of `fetchFromGitHub` force private repository when `forceFetchGit` is used.

I believe this should be backported to 24.11 too.
