### PR TITLE
yandex-music: 5.39.0 -> 5.46.0

### DIFF
--- a/pkgs/by-name/ya/yandex-music/package.nix
+++ b/pkgs/by-name/ya/yandex-music/package.nix
@@ -10,17 +10,32 @@
   electron,
   fetchFromGitHub,
   electronArguments ? "",
+
+  # Whether to enable tray menu by default
   trayEnabled ? true,
+  # Style of tray: 1 - default style, 2 - mono black, 3 - mono white
+  trayStyle ? 1,
+  # Whether to leave application in tray disregarding of its play state
+  trayAlways ? false,
+  # Whether to enable developers tools
+  devTools ? false,
+  # Vibe animation FPS can be  from 0 (black screen) to any reasonable number.
+  # Recommended 25 - 144. Default 25.
+  vibeAnimationMaxFps ? 25,
+  # Yandex Music's custom Windows-styled titlebar. Also makes the window frameless.
+  customTitleBar ? false,
 }:
+assert lib.assertMsg (trayStyle >= 1 && trayStyle <= 3) "Tray style must be withing 1 and 3";
+assert lib.assertMsg (vibeAnimationMaxFps >= 0) "Vibe animation max FPS must be greater then 0";
 stdenvNoCC.mkDerivation rec {
   pname = "yandex-music";
-  version = "5.39.0";
+  version = "5.46.0";
 
   src = fetchFromGitHub {
     owner = "cucumber-sp";
     repo = "yandex-music-linux";
     rev = "v${version}";
-    hash = "sha256-oEbbQRqvnK521N3Kerv18h1frVLbioFeHfb/FCkHC6Y=";
+    hash = "sha256-JyDpJCNHmPV1l9+//3sgJGkD+pewuoAb33hgTUi5Ukc=";
   };
 
   nativeBuildInputs = [
@@ -48,6 +63,27 @@ stdenvNoCC.mkDerivation rec {
     runHook postBuild
   '';
 
+  config =
+    let
+      inherit (lib) optionalString;
+    in
+    ''
+      ELECTRON_ARGS="${electronArguments}"
+      VIBE_ANIMATION_MAX_FPS=${toString vibeAnimationMaxFps}
+    ''
+    + optionalString trayEnabled ''
+      TRAY_ENABLED=${toString trayStyle}
+    ''
+    + optionalString trayAlways ''
+      ALWAYS_LEAVE_TO_TRAY=1
+    ''
+    + optionalString devTools ''
+      DEV_TOOLS=1
+    ''
+    + optionalString customTitleBar ''
+      CUSTOM_TITLE_BAR=1
+    '';
+
   installPhase = ''
     runHook preInstall
 
@@ -55,9 +91,7 @@ stdenvNoCC.mkDerivation rec {
     mv app/yandex-music.asar "$out/share/nodejs"
 
     CONFIG_FILE="$out/share/yandex-music.conf"
-    echo "TRAY_ENABLED=${if trayEnabled then "1" else "0"}" >> "$CONFIG_FILE"
-    echo "ELECTRON_ARGS=\"${electronArguments}\"" >> "$CONFIG_FILE"
-
+    echo "$config" >> "$CONFIG_FILE"
 
     install -Dm755 "$src/templates/yandex-music.sh" "$out/bin/yandex-music"
     substituteInPlace "$out/bin/yandex-music"                                  \

--- a/pkgs/by-name/ya/yandex-music/ym_info.json
+++ b/pkgs/by-name/ya/yandex-music/ym_info.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.39.0",
-  "exe_name": "Yandex_Music_x64_5.39.0.exe",
-  "exe_link": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.39.0.exe",
-  "exe_hash": "sha256-jOaxKDOkabsNQTXH5+UGwfdL+Srjm5gjQgHe/YuGiaQ="
+  "version": "5.46.0",
+  "exe_name": "Yandex_Music_x64_5.46.0.exe",
+  "exe_link": "https://music-desktop-application.s3.yandex.net/stable/Yandex_Music_x64_5.46.0.exe",
+  "exe_hash": "sha256-gvdJ/ucPeSG/oSD6ullFzWdRYzu0ovxo0qK8ZjLHi+g="
 }


### PR DESCRIPTION
Additionally add more configuration options:
 * traySyle;
 * trayAlways;
 * devTools;
 * vibeAnimationMaxFps;
 * customTitleBar.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
