### PR TITLE
endless-sky: 0.10.10 -> 0.10.12

### DIFF
--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -51,7 +51,6 @@ index de27023e..4225051f 100644
 +
 +	resources = "%NIXPKGS_RESOURCES_PATH%";
 +
-	}
  	dataPath = resources + "data/";
  	imagePath = resources + "images/";
  	soundPath = resources + "sounds/";

--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -48,10 +48,10 @@ index de27023e..4225051f 100644
 -		if(!resources.has_parent_path() || resources.parent_path() == resources)
 -			throw runtime_error("Unable to find the resource directories!");
 -		resources = resources.parent_path();
--	}
 +
 +	resources = "%NIXPKGS_RESOURCES_PATH%";
 +
+	}
  	dataPath = resources + "data/";
  	imagePath = resources + "images/";
  	soundPath = resources + "sounds/";

--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -12,13 +12,26 @@ index 48fd080..419b40d 100644
  # Install the desktop file:
  env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")
 diff --git a/source/Files.cpp b/source/Files.cpp
-index de27023e..4225051f 100644
+index 8e550d0dd..bb7dd1281 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
-@@ -108,32 +108,9 @@ void Files::Init(const char * const *argv)
- 		resources = str;
- 		SDL_free(str);
+@@ -84,49 +84,8 @@ void Files::Init(const char * const *argv)
+ 
  	}
+ 
+-	if(resources.empty())
+-	{
+-		// Find the path to the resource directory. This will depend on the
+-		// operating system, and can be overridden by a command line argument.
+-		char *basePath = SDL_GetBasePath();
+-		if(!basePath)
+-			throw runtime_error("Unable to get path to resource directory!");
+-		resources = basePath;
+-		SDL_free(basePath);
+-
+-		if(Exists(resources))
+-			resources = filesystem::canonical(resources);
+-
 -#if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
 -		// Special case, for Linux: the resource files are not in the same place as
 -		// the executable, but are under the same prefix (/usr or /usr/local).
@@ -48,9 +61,9 @@ index de27023e..4225051f 100644
 -		if(!resources.has_parent_path() || resources.parent_path() == resources)
 -			throw runtime_error("Unable to find the resource directories!");
 -		resources = resources.parent_path();
-+
+-	}
 +	resources = "%NIXPKGS_RESOURCES_PATH%";
 +
- 	dataPath = resources + "data/";
- 	imagePath = resources + "images/";
- 	soundPath = resources + "sounds/";
+ 	dataPath = resources / "data/";
+ 	imagePath = resources / "images/";
+ 	soundPath = resources / "sounds/";

--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -19,31 +19,35 @@ index de27023e..4225051f 100644
  		resources = str;
  		SDL_free(str);
  	}
--#if defined _WIN32
--	FixWindowsSlashes(resources);
--#endif
--	if(resources.back() != '/')
--		resources += '/';
 -#if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
--	// Special case, for Linux: the resource files are not in the same place as
--	// the executable, but are under the same prefix (/usr or /usr/local).
--	static const string LOCAL_PATH = "/usr/local/";
--	static const string STANDARD_PATH = "/usr/";
--	static const string RESOURCE_PATH = "share/games/endless-sky/";
--	if(!resources.compare(0, LOCAL_PATH.length(), LOCAL_PATH))
--		resources = LOCAL_PATH + RESOURCE_PATH;
--	else if(!resources.compare(0, STANDARD_PATH.length(), STANDARD_PATH))
--		resources = STANDARD_PATH + RESOURCE_PATH;
+-		// Special case, for Linux: the resource files are not in the same place as
+-		// the executable, but are under the same prefix (/usr or /usr/local).
+-		// When used as an iterator, a trailing / will create an empty item at
+-		// the end, so parent paths do not include it.
+-		static const filesystem::path LOCAL_PATH = "/usr/local";
+-		static const filesystem::path STANDARD_PATH = "/usr";
+-		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
+-
+-		const auto IsParent = [](const auto parent, const auto child) -> bool {
+-			if(distance(child.begin(), child.end()) < distance(parent.begin(), parent.end()))
+-				return false;
+-			return equal(parent.begin(), parent.end(), child.begin());
+-		};
+-
+-		if(IsParent(LOCAL_PATH, resources))
+-			resources = LOCAL_PATH / RESOURCE_PATH;
+-		else if(IsParent(STANDARD_PATH, resources))
+-			resources = STANDARD_PATH / RESOURCE_PATH;
 -#endif
+-	}
 -	// If the resources are not here, search in the directories containing this
 -	// one. This allows, for example, a Mac app that does not actually have the
 -	// resources embedded within it.
--	while(!Exists(resources + "credits.txt"))
+-	while(!Exists(resources / "credits.txt"))
 -	{
--		size_t pos = resources.rfind('/', resources.length() - 2);
--		if(pos == string::npos || pos == 0)
+-		if(!resources.has_parent_path() || resources.parent_path() == resources)
 -			throw runtime_error("Unable to find the resource directories!");
--		resources.erase(pos + 1);
+-		resources = resources.parent_path();
 -	}
 +
 +	resources = "%NIXPKGS_RESOURCES_PATH%";

--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -12,58 +12,14 @@ index 48fd080..419b40d 100644
  # Install the desktop file:
  env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")
 diff --git a/source/Files.cpp b/source/Files.cpp
-index 8e550d0dd..bb7dd1281 100644
+index f5dec21..ad57c55 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
-@@ -84,49 +84,8 @@ void Files::Init(const char * const *argv)
- 
+@@ -115,6 +115,7 @@ void Files::Init(const char * const *argv)
+ 		else if(IsParent(STANDARD_PATH, resources))
+ 			resources = STANDARD_PATH / RESOURCE_PATH;
+ #endif
++		resources = "%NIXPKGS_RESOURCES_PATH%";
  	}
- 
--	if(resources.empty())
--	{
--		// Find the path to the resource directory. This will depend on the
--		// operating system, and can be overridden by a command line argument.
--		char *basePath = SDL_GetBasePath();
--		if(!basePath)
--			throw runtime_error("Unable to get path to resource directory!");
--		resources = basePath;
--		SDL_free(basePath);
--
--		if(Exists(resources))
--			resources = filesystem::canonical(resources);
--
--#if defined __linux__ || defined __FreeBSD__ || defined __DragonFly__
--		// Special case, for Linux: the resource files are not in the same place as
--		// the executable, but are under the same prefix (/usr or /usr/local).
--		// When used as an iterator, a trailing / will create an empty item at
--		// the end, so parent paths do not include it.
--		static const filesystem::path LOCAL_PATH = "/usr/local";
--		static const filesystem::path STANDARD_PATH = "/usr";
--		static const filesystem::path RESOURCE_PATH = "share/games/endless-sky/";
--
--		const auto IsParent = [](const auto parent, const auto child) -> bool {
--			if(distance(child.begin(), child.end()) < distance(parent.begin(), parent.end()))
--				return false;
--			return equal(parent.begin(), parent.end(), child.begin());
--		};
--
--		if(IsParent(LOCAL_PATH, resources))
--			resources = LOCAL_PATH / RESOURCE_PATH;
--		else if(IsParent(STANDARD_PATH, resources))
--			resources = STANDARD_PATH / RESOURCE_PATH;
--#endif
--	}
--	// If the resources are not here, search in the directories containing this
--	// one. This allows, for example, a Mac app that does not actually have the
--	// resources embedded within it.
--	while(!Exists(resources / "credits.txt"))
--	{
--		if(!resources.has_parent_path() || resources.parent_path() == resources)
--			throw runtime_error("Unable to find the resource directories!");
--		resources = resources.parent_path();
--	}
-+	resources = "%NIXPKGS_RESOURCES_PATH%";
-+
- 	dataPath = resources / "data/";
- 	imagePath = resources / "images/";
- 	soundPath = resources / "sounds/";
+ 	// If the resources are not here, search in the directories containing this
+ 	// one. This allows, for example, a Mac app that does not actually have the

--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "endless-sky";
     repo = "endless-sky";
     tag = "v${version}";
-    hash = "sha256-wulDRzYDteMsL7P18EOl0DiQUMbVaSyVpJ2kWyfAHdY=";
+    hash = "sha256-cT/bklRGQnS9Nm8J0oH1mG20JQOe58FAAHToNDpvPpQ=";
   };
 
   patches = [

--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "endless-sky";
-  version = "0.10.10";
+  version = "0.10.12";
 
   src = fetchFromGitHub {
     owner = "endless-sky";
     repo = "endless-sky";
-    rev = "v${version}";
-    sha256 = "sha256-FjQluOFU+fPr4/3WveScRRabDjD/bq8YmXvCU9w9yo8=";
+    tag = "v${version}";
+    hash = "sha256-wulDRzYDteMsL7P18EOl0DiQUMbVaSyVpJ2kWyfAHdY=";
   };
 
   patches = [


### PR DESCRIPTION
Updated Endless Sky to 0.10.12, which was released about a month ago.
https://github.com/endless-sky/endless-sky/compare/v0.10.10...v0.10.12

## Things done

Thanks to momeemt:

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
