### PR TITLE
python3Packages.myst-parser: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
   flit-core,
   pythonOlder,
   defusedxml,
@@ -21,7 +20,7 @@
 }:
 buildPythonPackage rec {
   pname = "myst-parser";
-  version = "4.0.0";
+  version = "4.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -30,16 +29,8 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-QbFENC/Msc4pkEOPdDztjyl+2TXtAbMTHPJNAsUB978=";
+    hash = "sha256-/Prauz4zuJY39EK2BmgBbH1uwjF4K38e5X5hPYwRBl0=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      # Sphinx 8.1 compat
-      url = "https://github.com/executablebooks/MyST-Parser/commit/9fe724ebf1d02fd979632d82387f802c91e0d6f6.patch";
-      hash = "sha256-KkAV9tP+dFax9KuxqkhqNlGWx6wSO6M2dWpah+GYG0E=";
-    })
-  ];
 
   build-system = [ flit-core ];
 


### PR DESCRIPTION
Update `myst-parser` to 4.0.1, "small" update, applying the Sphinx 8.1+ patch, see [changelog](https://raw.githubusercontent.com/executablebooks/MyST-Parser/v4.0.1/CHANGELOG.md).
Tested successfully [here](https://github.com/loicreynier/nixpkgs-tests/tree/96d8f28262d1da16e04a2ec0309cb5c844cf071d/python-myst-parser).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
