### PR TITLE
mcpelauncher-client: 1.1.2-qt6 -> 1.2.0-qt6

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -3,7 +3,6 @@
   clangStdenv,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   openssl,
@@ -23,10 +22,10 @@
   xdg-utils,
 }:
 
-# gcc doesn't support __has_feature
+# Bionic libc part doesn't compile with GCC
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "mcpelauncher-client";
-  version = "1.1.2-qt6";
+  version = "1.2.0-qt6";
 
   # NOTE: check mcpelauncher-ui-qt when updating
   src = fetchFromGitHub {
@@ -34,34 +33,19 @@ clangStdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-PmCq6Zgtp17UV0kIbNouFwj/DMiTqwE31+tTb2LUp5o=";
+    hash = "sha256-SyIiBUZCGcV4NFD7IcQv8YdRkDGhkBeqE0qVsKp+44Y=";
   };
 
-  patches = [
-    ./dont_download_glfw_client.patch
-    # These are upcoming changes that have been merged upstream. Once these get in a release, remove these patches.
-    (fetchpatch {
-      url = "https://github.com/minecraft-linux/game-window/commit/feea8c0e0720eea7093ed95745c17f36d6c40671.diff";
-      hash = "sha256-u4uveoKwwklEooT+i+M9kZ0PshjL1IfWhlltmulsQJo=";
-      stripLen = 1;
-      extraPrefix = "game-window/";
-    })
-    (fetchpatch {
-      url = "https://github.com/minecraft-linux/mcpelauncher-client/commit/db9c31e46d7367867c85a0d0aba42c8144cdf795.diff";
-      hash = "sha256-za/9oZYwKCYyZ1BXQ/zeEjRy81B1NpTlPHEfWAOtzHk=";
-      stripLen = 1;
-      extraPrefix = "mcpelauncher-client/";
-    })
-  ];
+  patches = [ ./dont_download_glfw_client.patch ];
 
   # Path hard-coded paths.
   postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace mcpelauncher-client/src/jni/main_activity.cpp \
       --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open \
-      --replace-fail /usr/bin/zenity ${zenity}/bin/zenity
+      --replace-fail /usr/bin/zenity ${lib.getExe zenity}
 
     substituteInPlace file-picker/src/file_picker_zenity.cpp \
-      --replace-fail /usr/bin/zenity ${zenity}/bin/zenity
+      --replace-fail 'EXECUTABLE_NAME = "zenity"' 'EXECUTABLE_NAME = "${lib.getExe zenity}"'
   '';
 
   # FORTIFY_SOURCE breaks libc_shim and the project will fail to compile

--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -109,6 +109,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       aleksana
       morxemplum
+      phanirithvij
     ];
     mainProgram = "mcpelauncher-client";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "mcpelauncher-ui-manifest";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-R9wE1lS7x1IIPgVahXjF5Yg2ca+GsiQuF41pWf2edXY=";
+    hash = "sha256-333PwfBWhdfJSi1XrJNHidMYZrzSReb8s4VxBASFQ6Q=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/minecraft-linux/mcpelauncher-manifest/releases/tag/v1.2.0-qt6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
