### PR TITLE
budgie-desktop: Backport fix for Vala 0.56.18

### DIFF
--- a/pkgs/by-name/bu/budgie-desktop/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop/package.nix
@@ -70,6 +70,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/ba8170b4f3108f9de28331b6a98a9d92bb0ed4de.patch";
       hash = "sha256-T//1/NmaV81j0jiIYK7vEp8sgKCgF2i10D+Rk9qAAeE=";
     })
+
+    # Resolve vala 0.56.18 compact class inheritance removal
+    # https://github.com/BuddiesOfBudgie/budgie-desktop/issues/679
+    (fetchpatch {
+      url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/46c83b1265b4230668da472d9ef6926941678418.patch";
+      hash = "sha256-qnA8iBEctZbE86qIPudI1vMbgFy4xDWrxxej517ORws=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backports https://github.com/BuddiesOfBudgie/budgie-desktop/commit/46c83b1265b4230668da472d9ef6926941678418.

- https://github.com/NixOS/nixpkgs/pull/388226 (also included in GNOME 48 PR)

To test with Vala 0.56.18 and avoid mass rebuild:

<details>

```diff
diff --git a/pkgs/by-name/bu/budgie-desktop/package.nix b/pkgs/by-name/bu/budgie-desktop/package.nix
index 6126ba0dd6e0..8aba2447b5f2 100644
--- a/pkgs/by-name/bu/budgie-desktop/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop/package.nix
@@ -36,7 +36,7 @@
   sassc,
   testers,
   upower,
-  vala,
+  vala_0_56_18,
   validatePkgConfig,
   xfce,
   wrapGAppsHook3,
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    vala
+    vala_0_56_18
     validatePkgConfig
     wrapGAppsHook3
   ];
diff --git a/pkgs/development/compilers/vala/default.nix b/pkgs/development/compilers/vala/default.nix
index 0c5c18277e2a..315b34dd4a5f 100644
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -135,5 +135,10 @@ rec {
     hash = "sha256-JhAMTk7wBJxhknXxQNl89WWIPQDHVDyCvM5aQmk07Wo=";
   };
 
+  vala_0_56_18 = generic {
+    version = "0.56.18";
+    hash = "sha256-8q/+fUCrY9uOe57MP2vcnC/H4xNMhP8teV9IL+kmo4I=";
+  };
+
   vala = vala_0_56;
 }
diff --git a/pkgs/top-level/all-packages.nix b/pkgs/top-level/all-packages.nix
index 9dc3848b4a9f..4592358d1cfc 100644
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6737,6 +6737,7 @@ with pkgs;
 
   inherit (callPackage ../development/compilers/vala { })
     vala_0_56
+    vala_0_56_18
     vala;
 
   vyper = with python3Packages; toPythonApplication vyper;
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

