### PR TITLE
problemtools: init at v1.20231016

### DIFF
--- a/pkgs/by-name/pr/problemtools/package.nix
+++ b/pkgs/by-name/pr/problemtools/package.nix
@@ -1,0 +1,48 @@
+{
+  fetchFromGitHub,
+  python3Packages,
+  automake,
+  autoconf,
+  boost,
+  gmp,
+  lib,
+}: let
+  version = "1.20231016";
+in
+  python3Packages.buildPythonApplication {
+    inherit version;
+    pname = "problemtools";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "kattis";
+      repo = "problemtools";
+      rev = version;
+      hash = "sha256-3Tk+GMIAbnUMg/PvEYvU8ADbQunmGrD8mWDxmMjS5cY=";
+      fetchSubmodules = true;
+    };
+
+    patches = [./remove-git.patch];
+
+    nativeBuildInputs = [
+      python3Packages.setuptools
+      automake
+      autoconf
+    ];
+
+    propagatedBuildInputs = [
+      gmp
+      boost
+      python3Packages.pyyaml
+      python3Packages.plasTeX
+    ];
+
+    meta = {
+      description = "Tools to manage problem packages using the Kattis problem package format";
+      license = lib.licenses.mit;
+      mainProgram = "verifyproblem";
+      maintainers = with lib.maintainers; [TheColorman];
+      homepage = "https://github.com/Kattis/problemtools";
+      platforms = lib.platforms.linux;
+    };
+  }

--- a/pkgs/by-name/pr/problemtools/remove-git.patch
+++ b/pkgs/by-name/pr/problemtools/remove-git.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index 296634e..07b8904 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,4 +7,4 @@ builddeb: checktestdata
+ checktestdata: support/checktestdata/bootstrap
+ 
+ support/checktestdata/bootstrap:
+-	git submodule update --init
++	# git submodule update --init
+diff --git a/support/Makefile b/support/Makefile
+index d90a363..874540e 100644
+--- a/support/Makefile
++++ b/support/Makefile
+@@ -16,7 +16,7 @@ $(CONF): checktestdata/bootstrap
+ 	cd checktestdata && ./bootstrap
+ 
+ checktestdata/bootstrap:
+-	git submodule update --init
++	# git submodule update --init
+ 
+ clean:
+ 	$(foreach prog,$(PROGRAMS),$(MAKE) -C $(prog) clean;)
+


### PR DESCRIPTION
Problemtools is a collection of tools provided by Kattis to help authors of
programming problems create problems based on the Kattis problem package format.

Upstream: https://github.com/Kattis/problemtools\
Kattis: https://www.kattis.com/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [x] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  (or backporting
  [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  and
  [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [x] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
