### PR TITLE
pnpm.fetchDeps: ignore packageManager field in package.json

### DIFF
--- a/pkgs/by-name/ve/vencord/package.nix
+++ b/pkgs/by-name/ve/vencord/package.nix
@@ -7,25 +7,12 @@
   lib,
   nix-update,
   nodejs,
-  pnpm,
-  fetchurl,
+  pnpm_10,
   stdenv,
   writeShellScript,
   buildWebExtension ? false,
 }:
-let
-  # Credit to: @ScarsTRF (https://github.com/ScarsTRF/nixcord/blob/652dc8067b8004517ea43ebcc8d93a64f95d4327/vencord.nix#L28-L37)
-  # Due to pnpm package 10.5.2 there is a issue when building.
-  # Substituting pnpm with version 10.4.1 fixes this issue.
-  # This should be fixed in a newer version of pnpm.
-  pnpm_10-4 = pnpm.overrideAttrs (oldAttrs: {
-    version = "10.4.1";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz";
-      sha256 = "sha256-S3Aoh5hplZM9QwCDawTW0CpDvHK1Lk9+k6TKYIuVkZc=";
-    };
-  });
-in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "vencord";
   version = "1.11.6";
@@ -37,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8KAt7yFGT/DBlg2VJ7ejsOJ67Sp5cuuaKEWK3+VpL4E=";
   };
 
-  pnpmDeps = pnpm_10-4.fetchDeps {
+  pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname src;
     hash = "sha256-g9BSVUKpn74D9eIDj/lS1Y6w/+AnhCw++st4s4REn+A=";
   };
@@ -45,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     git
     nodejs
-    pnpm_10-4.configHook
+    pnpm_10.configHook
   ];
 
   env = {

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -68,6 +68,13 @@
             fi
 
             export HOME=$(mktemp -d)
+
+            # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
+            # any pnpm command would fail in that directory, the following disables this
+            pushd ..
+            pnpm config set manage-package-manager-versions false
+            popd
+
             pnpm config set store-dir $out
             # Some packages produce platform dependent outputs. We do not want to cache those in the global store
             pnpm config set side-effects-cache false

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -20,6 +20,13 @@ pnpmConfigHook() {
     cp -Tr "$pnpmDeps" "$STORE_PATH"
     chmod -R +w "$STORE_PATH"
 
+
+    # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
+    # any pnpm command would fail in that directory, the following disables this
+    pushd ..
+    pnpm config set manage-package-manager-versions false
+    popd
+
     pnpm config set store-dir "$STORE_PATH"
 
     if [[ -n "$pnpmWorkspace" ]]; then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Previously when trying to use a newer `pnpm_10` (eg. 10.6.1) with a project that pinned pnpm to an older version in `package.json` (eg. `  "packageManager": "pnpm@10.2.1",`), pnpm failed, as pnpm tried to use/install that specific version:
```console
 ERROR  Failed to switch pnpm to v10.2.1. Looks like pnpm CLI is missing at "/build/tmp.aCWufJoJHR/.local/share/pnpm/.tools/pnpm/10.2.1/bin" or is incorrect
```

This PR disabled the aforementioned behavior, packages depending on `pnpm_10` won't have to use the exact pnpm version. `pnpm_9` already behaved like this, and we have some checks to prevent pnpm version mismatchs or at last pnpm will throw a more specific error.

I noticed this issue when trying to update `n8n`, and I see this was an issue with `vencord` too (https://github.com/NixOS/nixpkgs/pull/387708).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
