### PR TITLE
treewide: replace references to SDL*.dev with lib.getDev and lib.getInclude

### DIFF
--- a/pkgs/by-name/ca/cadzinho/package.nix
+++ b/pkgs/by-name/ca/cadzinho/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = toString (
     [
-      "-I${SDL2.dev}/include/SDL2"
+      "-I${lib.getInclude SDL2}/include/SDL2"
       "-I${SDL2_net.dev}/include/SDL2"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/fi/fish-fillets-ng/package.nix
+++ b/pkgs/by-name/fi/fish-fillets-ng/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   # pass in correct sdl-config for cross builds
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
 
   makeFlags = [
     "AR=${stdenv.cc.targetPrefix}ar"

--- a/pkgs/by-name/fr/freedroidrpg/package.nix
+++ b/pkgs/by-name/fr/freedroidrpg/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     zlib
   ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/gl/gltron/package.nix
+++ b/pkgs/by-name/gl/gltron/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "AR=${stdenv.cc.targetPrefix}ar" ];
 
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
 
   buildInputs = [
     SDL

--- a/pkgs/by-name/hh/hheretic/package.nix
+++ b/pkgs/by-name/hh/hheretic/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
-    SDL.dev
+    (lib.getDev SDL)
   ];
 
   buildInputs = [

--- a/pkgs/by-name/hh/hhexen/package.nix
+++ b/pkgs/by-name/hh/hhexen/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
-    SDL.dev
+    (lib.getDev SDL)
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ke/keeperrl/package.nix
+++ b/pkgs/by-name/ke/keeperrl/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [
-    "-I${SDL2.dev}/include/SDL2"
+    "-I${lib.getInclude SDL2}/include/SDL2"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/li/libwtk-sdl2/package.nix
+++ b/pkgs/by-name/li/libwtk-sdl2/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2_image
   ];
   # From some reason, this is needed as otherwise SDL.h is not found
-  NIX_CFLAGS_COMPILE = "-I${SDL2.dev}/include/SDL2";
+  NIX_CFLAGS_COMPILE = "-I${lib.getInclude SDL2}/include/SDL2";
 
   outputs = [
     "out"

--- a/pkgs/by-name/pi/picoloop/package.nix
+++ b/pkgs/by-name/pi/picoloop/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libpulseaudio
     SDL2
-    SDL2.dev
+    (lib.getDev SDL2)
     SDL2_image
     SDL2_ttf
     alsa-lib
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "-f Makefile.PatternPlayer_debian_RtAudio_sdl20" ];
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${SDL2.dev}/include/SDL2" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-I${lib.getInclude SDL2}/include/SDL2" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/by-name/qu/quake3e/package.nix
+++ b/pkgs/by-name/qu/quake3e/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     SDL2
     glibc
   ];
-  env.NIX_CFLAGS_COMPILE = "-I${SDL2.dev}/include/SDL2";
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getInclude SDL2}/include/SDL2";
   enableParallelBuilding = true;
 
   postPatch = ''

--- a/pkgs/by-name/re/recastnavigation/package.nix
+++ b/pkgs/by-name/re/recastnavigation/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       # Expects SDL2.framework in specific location, which we don't have
       # Change where SDL2 headers are searched for to match what we do have
       substituteInPlace RecastDemo/CMakeLists.txt \
-        --replace 'include_directories(''${SDL2_LIBRARY}/Headers)' 'include_directories(${SDL2.dev}/include/SDL2)'
+        --replace 'include_directories(''${SDL2_LIBRARY}/Headers)' 'include_directories(${lib.getInclude SDL2}/include/SDL2)'
     '';
 
   doCheck = true;

--- a/pkgs/by-name/re/renpy/package.nix
+++ b/pkgs/by-name/re/renpy/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGLU
     libpng
     SDL2
-    SDL2.dev
+    (lib.getDev SDL2)
     zlib
   ];
 

--- a/pkgs/by-name/sd/SDL_gfx/package.nix
+++ b/pkgs/by-name/sd/SDL_gfx/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   # SDL_gfx.pc refers to sdl.pc and some SDL_gfx headers import SDL.h
   propagatedBuildInputs = [ SDL ];
 
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
 
   configureFlags = [
     (lib.enableFeature false "mmx")

--- a/pkgs/by-name/sd/SDL_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL_mixer/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # pass in correct *-config for cross builds
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
   env.SMPEG_CONFIG = lib.getExe' smpeg.dev "smpeg-config";
 
   configureFlags = [

--- a/pkgs/by-name/sd/SDL_sound/package.nix
+++ b/pkgs/by-name/sd/SDL_sound/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature enableSdltest "sdltest")
   ];
 
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
 
   strictDeps = true;
 

--- a/pkgs/by-name/sd/SDL_ttf/package.nix
+++ b/pkgs/by-name/sd/SDL_ttf/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # pass in correct *-config for cross builds
-  env.SDL_CONFIG = lib.getExe' SDL.dev "sdl-config";
+  env.SDL_CONFIG = lib.getExe' (lib.getDev SDL) "sdl-config";
   env.FREETYPE_CONFIG = lib.getExe' freetype.dev "freetype-config";
 
   configureFlags = [

--- a/pkgs/by-name/sd/sdlpop/package.nix
+++ b/pkgs/by-name/sd/sdlpop/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     substituteInPlace src/Makefile \
       --replace "CC = gcc" "CC = ${stdenv.cc.targetPrefix}cc" \
-      --replace "CFLAGS += -I/opt/local/include" "CFLAGS += -I${SDL2.dev}/include/SDL2 -I${SDL2_image}/include/SDL2"
+      --replace "CFLAGS += -I/opt/local/include" "CFLAGS += -I${lib.getInclude SDL2}/include/SDL2 -I${SDL2_image}/include/SDL2"
   '';
 
   # The prince binary expects two things of the working directory it is called from:

--- a/pkgs/by-name/sm/smpeg2/package.nix
+++ b/pkgs/by-name/sm/smpeg2/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     moveToOutput bin/smpeg2-config "$dev"
     wrapProgram $dev/bin/smpeg2-config \
       --prefix PATH ":" "${pkg-config}/bin" \
-      --prefix PKG_CONFIG_PATH ":" "${SDL2.dev}/lib/pkgconfig"
+      --prefix PKG_CONFIG_PATH ":" "${lib.getDev SDL2}/lib/pkgconfig"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/sp/sparrow3d/package.nix
+++ b/pkgs/by-name/sp/sparrow3d/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    SDL.dev
+    (lib.getDev SDL)
     SDL_image
     SDL_ttf
     SDL_mixer

--- a/pkgs/by-name/sr/srb2/package.nix
+++ b/pkgs/by-name/sr/srb2/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGME_INCLUDE_DIR=${game-music-emu}/include"
     "-DOPENMPT_INCLUDE_DIR=${libopenmpt.dev}/include"
     "-DSDL2_MIXER_INCLUDE_DIR=${lib.getDev SDL2_mixer}/include/SDL2"
-    "-DSDL2_INCLUDE_DIR=${lib.getDev SDL2.dev}/include/SDL2"
+    "-DSDL2_INCLUDE_DIR=${lib.getInclude SDL2}/include/SDL2"
   ];
 
   patches = [

--- a/pkgs/by-name/ta/tamatool/package.nix
+++ b/pkgs/by-name/ta/tamatool/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "-Clinux"
     "VERSION=${finalAttrs.version}"
-    "CFLAGS+=-I${SDL2.dev}/include/SDL2"
+    "CFLAGS+=-I${lib.getInclude SDL2}/include/SDL2"
     "CFLAGS+=-I${SDL2_image}/include/SDL2"
     "DIST_PATH=$(out)"
     "CC=${stdenv.cc.targetPrefix}cc"

--- a/pkgs/by-name/to/tome4/package.nix
+++ b/pkgs/by-name/to/tome4/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   # disable parallel building as it caused sporadic build failures
   enableParallelBuilding = false;
 
-  env.NIX_CFLAGS_COMPILE = "-I${SDL2.dev}/include/SDL2 -I${SDL2_image}/include/SDL2 -I${SDL2_ttf}/include/SDL2";
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getInclude SDL2}/include/SDL2 -I${SDL2_image}/include/SDL2 -I${SDL2_ttf}/include/SDL2";
 
   makeFlags = [ "config=release" ];
 

--- a/pkgs/by-name/tr/trigger/package.nix
+++ b/pkgs/by-name/tr/trigger/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     cd src
 
     sed s,lSDL2main,lSDL2, -i GNUmakefile
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${SDL2.dev}/include/SDL2"
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${lib.getInclude SDL2}/include/SDL2"
   '';
 
   makeFlags = [

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -117,7 +117,7 @@ buildPythonPackage rec {
 
   env =
     {
-      SDL_CONFIG = "${SDL2.dev}/bin/sdl2-config";
+      SDL_CONFIG = lib.getExe' (lib.getDev SDL2) "sdl2-config";
     }
     // lib.optionalAttrs stdenv.cc.isClang {
       NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";

--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -108,7 +108,7 @@ buildPythonPackage rec {
 
     export DOXYGEN=${doxygen}/bin/doxygen
     export PATH="${wxGTK}/bin:$PATH"
-    export SDL_CONFIG="${SDL.dev}/bin/sdl-config"
+    export SDL_CONFIG="${lib.getExe' (lib.getDev SDL) "sdl-config"}"
     export WAF=$PWD/bin/waf
 
     ${python.pythonOnBuildForHost.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py

--- a/pkgs/games/bugdom/default.nix
+++ b/pkgs/games/bugdom/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
     # Expects SDL2.framework in specific location, which we don't have
-    "-DSDL2_INCLUDE_DIRS=${SDL2.dev}/include/SDL2"
+    "-DSDL2_INCLUDE_DIRS=${lib.getInclude SDL2}/include/SDL2"
   ];
 
   installPhase =

--- a/pkgs/games/iortcw/sp.nix
+++ b/pkgs/games/iortcw/sp.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   env.NIX_CFLAGS_COMPILE = toString [
-    "-I${SDL2.dev}/include/SDL2"
+    "-I${lib.getInclude SDL2}/include/SDL2"
     "-I${opusfile.dev}/include/opus"
   ];
   NIX_CFLAGS_LINK = [ "-lSDL2" ];


### PR DESCRIPTION
Creating an overlay replacing `SDL` with `SDL_compat` currently fails, because `SDL_compat` has no `dev` output, yet some dependents assume `SDL.dev` to exist.
Calling `lib.getDev` bypasses this issue by returning `.dev` if it exists, and otherwise falling back to `out`.
This change causes no rebuilds, meaning it also does not break anything.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
