### PR TITLE
nixos/factorio: better support for Factorio mods

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.services.factorio;
   name = "Factorio";
@@ -36,9 +41,11 @@ let
   } // cfg.extraSettings;
   serverSettingsString = builtins.toJSON (lib.filterAttrsRecursive (n: v: v != null) serverSettings);
   serverSettingsFile = pkgs.writeText "server-settings.json" serverSettingsString;
-  playerListOption = name: list:
-    lib.optionalString (list != [])
-      "--${name}=${pkgs.writeText "${name}.json" (builtins.toJSON list)}";
+  playerListOption =
+    name: list:
+    lib.optionalString (
+      list != [ ]
+    ) "--${name}=${pkgs.writeText "${name}.json" (builtins.toJSON list)}";
   modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat;
 in
 {
@@ -67,8 +74,11 @@ in
         # --use-server-whitelist) so we can't implement that behaviour, so we
         # might as well match theirs.
         type = lib.types.listOf lib.types.str;
-        default = [];
-        example = [ "Rseding91" "Oxyd" ];
+        default = [ ];
+        example = [
+          "Rseding91"
+          "Oxyd"
+        ];
         description = ''
           If non-empty, only these player names are allowed to connect. The game
           will not be able to save any changes made in-game with the /whitelist
@@ -87,7 +97,7 @@ in
 
       admins = lib.mkOption {
         type = lib.types.listOf lib.types.str;
-        default = [];
+        default = [ ];
         example = [ "username" ];
         description = ''
           List of player names which will be admin.
@@ -167,7 +177,7 @@ in
       };
       mods = lib.mkOption {
         type = lib.types.listOf lib.types.package;
-        default = [];
+        default = [ ];
         description = ''
           Mods the server should install and activate.
 
@@ -202,8 +212,10 @@ in
       };
       extraSettings = lib.mkOption {
         type = lib.types.attrs;
-        default = {};
-        example = { max_players = 64; };
+        default = { };
+        example = {
+          max_players = 64;
+        };
         description = ''
           Extra game configuration that will go into server-settings.json
         '';
@@ -288,9 +300,9 @@ in
 
   config = lib.mkIf cfg.enable {
     systemd.services.factorio = {
-      description   = "Factorio headless server";
-      wantedBy      = [ "multi-user.target" ];
-      after         = [ "network.target" ];
+      description = "Factorio headless server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
 
       preStart =
         (toString [
@@ -299,11 +311,15 @@ in
           "${cfg.package}/bin/factorio"
           "--config=${cfg.configFile}"
           "--create=${mkSavePath cfg.saveName}"
-          (lib.optionalString (cfg.mods != []) "--mod-directory=${modDir}")
+          (lib.optionalString (cfg.mods != [ ]) "--mod-directory=${modDir}")
         ])
-        + (lib.optionalString (cfg.extraSettingsFile != null) ("\necho ${lib.strings.escapeShellArg serverSettingsString}"
+        + (lib.optionalString (cfg.extraSettingsFile != null) (
+          ''
+
+            echo ${lib.strings.escapeShellArg serverSettingsString}''
           + " \"$(cat ${cfg.extraSettingsFile})\" | ${lib.getExe pkgs.jq} -s add"
-          + " > ${stateDir}/server-settings.json"));
+          + " > ${stateDir}/server-settings.json"
+        ));
 
       serviceConfig = {
         Restart = "always";
@@ -318,15 +334,13 @@ in
           "--bind=${cfg.bind}"
           (lib.optionalString (!cfg.loadLatestSave) "--start-server=${mkSavePath cfg.saveName}")
           "--server-settings=${
-            if (cfg.extraSettingsFile != null)
-            then "${stateDir}/server-settings.json"
-            else serverSettingsFile
+            if (cfg.extraSettingsFile != null) then "${stateDir}/server-settings.json" else serverSettingsFile
           }"
           (lib.optionalString cfg.loadLatestSave "--start-server-load-latest")
-          (lib.optionalString (cfg.mods != []) "--mod-directory=${modDir}")
+          (lib.optionalString (cfg.mods != [ ]) "--mod-directory=${modDir}")
           (playerListOption "server-adminlist" cfg.admins)
           (playerListOption "server-whitelist" cfg.allowedPlayers)
-          (lib.optionalString (cfg.allowedPlayers != []) "--use-server-whitelist")
+          (lib.optionalString (cfg.allowedPlayers != [ ]) "--use-server-whitelist")
         ];
 
         # Sandboxing
@@ -338,7 +352,12 @@ in
         ProtectControlGroups = true;
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
         RestrictRealtime = true;
         RestrictNamespaces = true;
         MemoryDenyWriteExecute = true;

--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -46,7 +46,24 @@ let
     lib.optionalString (
       list != [ ]
     ) "--${name}=${pkgs.writeText "${name}.json" (builtins.toJSON list)}";
-  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat;
+  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat [
+    {
+      "name" = "base";
+      "enabled" = true;
+    }
+    {
+      "name" = "elevated-rails";
+      "enabled" = cfg.internalMods.elevatedRails;
+    }
+    {
+      "name" = "quality";
+      "enabled" = cfg.internalMods.quality;
+    }
+    {
+      "name" = "space-age";
+      "enabled" = cfg.internalMods.spaceAge;
+    }
+  ];
 in
 {
   options = {
@@ -194,6 +211,30 @@ in
           Mods settings can be changed by specifying a dat file, in the [mod
           settings file
           format](https://wiki.factorio.com/Mod_settings_file_format).
+        '';
+      };
+      internalMods.spaceAge = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable `Space Age` mod.
+          Requires Space Age expansion pack to join a server with this enabled.
+        '';
+      };
+      internalMods.quality = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable `Quality` mod.
+          Requires Space Age expansion pack to join a server with this enabled.
+        '';
+      };
+      internalMods.elevatedRails = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable `Elevated Rails` mod.
+          Requires Space Age expansion pack to join a server with this enabled.
         '';
       };
       game-name = lib.mkOption {

--- a/pkgs/by-name/fa/factorio/utils.nix
+++ b/pkgs/by-name/fa/factorio/utils.nix
@@ -14,49 +14,57 @@ let
     ;
 in
 {
-  mkModDirDrv = mods: modsDatFile: # a list of mod derivations
+  mkModDirDrv =
+    mods: modsDatFile: # a list of mod derivations
     let
-      recursiveDeps = modDrv: [modDrv] ++ map recursiveDeps modDrv.deps;
+      recursiveDeps = modDrv: [ modDrv ] ++ map recursiveDeps modDrv.deps;
       modDrvs = unique (flatten (map recursiveDeps mods));
     in
     stdenv.mkDerivation {
       name = "factorio-mod-directory";
 
       preferLocalBuild = true;
-      buildCommand = ''
-        mkdir -p $out
-        for modDrv in ${toString modDrvs}; do
-          # NB: there will only ever be a single zip file in each mod derivation's output dir
-          ln -s $modDrv/*.zip $out
-        done
-      '' + (optionalString (modsDatFile != null) ''
-       cp ${modsDatFile} $out/mod-settings.dat
-      '');
+      buildCommand =
+        ''
+          mkdir -p $out
+          for modDrv in ${toString modDrvs}; do
+            # NB: there will only ever be a single zip file in each mod derivation's output dir
+            ln -s $modDrv/*.zip $out
+          done
+        ''
+        + (optionalString (modsDatFile != null) ''
+          cp ${modsDatFile} $out/mod-settings.dat
+        '');
     };
 
-    modDrv = { allRecommendedMods, allOptionalMods }:
-      { src
-      , name ? null
-      , deps ? []
-      , optionalDeps ? []
-      , recommendedDeps ? []
-      }: stdenv.mkDerivation {
+  modDrv =
+    { allRecommendedMods, allOptionalMods }:
+    {
+      src,
+      name ? null,
+      deps ? [ ],
+      optionalDeps ? [ ],
+      recommendedDeps ? [ ],
+    }:
+    stdenv.mkDerivation {
 
-        inherit src;
+      inherit src;
 
-        # Use the name of the zip, but endstrip ".zip" and possibly the querystring that gets left in by fetchurl
-        name = replaceStrings ["_"] ["-"] (if name != null then name else removeSuffix ".zip" (head (splitString "?" src.name)));
+      # Use the name of the zip, but endstrip ".zip" and possibly the querystring that gets left in by fetchurl
+      name = replaceStrings [ "_" ] [ "-" ] (
+        if name != null then name else removeSuffix ".zip" (head (splitString "?" src.name))
+      );
 
-        deps = deps ++ optionals allOptionalMods optionalDeps
-                    ++ optionals allRecommendedMods recommendedDeps;
+      deps =
+        deps ++ optionals allOptionalMods optionalDeps ++ optionals allRecommendedMods recommendedDeps;
 
-        preferLocalBuild = true;
-        buildCommand = ''
-          mkdir -p $out
-          srcBase=$(basename $src)
-          srcBase=''${srcBase#*-}  # strip nix hash
-          srcBase=''${srcBase%\?*} # strip querystring leftover from fetchurl
-          cp $src $out/$srcBase
-        '';
-      };
+      preferLocalBuild = true;
+      buildCommand = ''
+        mkdir -p $out
+        srcBase=$(basename $src)
+        srcBase=''${srcBase#*-}  # strip nix hash
+        srcBase=''${srcBase%\?*} # strip querystring leftover from fetchurl
+        cp $src $out/$srcBase
+      '';
+    };
 }


### PR DESCRIPTION
Implement better support for Factorio mods.

Currently there is no good way to install mods for a Factorio server. There even isn't a way to disable the builtin mods introduced with Factorio Space Age.

The current plan is to create a Nix channel that contains all mods with their dependencies. Unfortunately this is bound to fail as there is no way curate versions of all mods that would work together. Indeed, the problem that needs to be solved is the problem of general dependency resolution that Nix isn't really suited to handle.

To still be able to install mods for the game, I propose we do what many modern programming languages do: we introduce lock files. I've written a [Factorio Mod Manager](https://github.com/henkkuli/factorio-mod-manager) that does exactly that, and I plan to open another PR for merging that into Nixpkgs.

This PR introduces the support for loading mods from a lock file. While at it, the PR also runs autoformatter with RFC 166, removes the existing stub `factorio-mods` package and allows disabling internal mods.

## Example usage

1. Describe the mods that should be installed in `factorio-mods.txt`:
    ```
    DiscoScience >= 2
    ```
2. Use `fmm update` to generate a lock file:
    ```json
    [
        {
            "name": "DiscoScience",
            "version": "2.0.1",
            "download_url": "/download/DiscoScience/671e62148e2875ce5b1a67b0",
            "file_name": "DiscoScience_2.0.1.zip",
            "sha1": "3542fd4fa3454c5a0eb1753f1b54c2c2f4d60537"
        }
    ]
    ```
3. Prefetch the mods to `/nix/store` using `fmm install --nix-prefetch --username xxx --token yyy`. This is necessary as to donwload the mods, one needs to have a Factorio account.
4. Configure NixOS service to use these mods:
    ```nix
    services.factorio = {
      enable = true;
      mods = pkgs.factorio-utils.modsFromLock ./factorio-mods.lock;
      # Disable some of the extension pack mods
      internalMods.spaceAge = false;
      internalMods.quality = false;
      # ...
    };
    ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
