### PR TITLE
libqmi: unbreak cross compilation

### DIFF
--- a/pkgs/by-name/li/libqmi/build_doc_deps_by_default.patch
+++ b/pkgs/by-name/li/libqmi/build_doc_deps_by_default.patch
@@ -1,0 +1,12 @@
+diff --git a/docs/reference/libqmi-glib/meson.build b/docs/reference/libqmi-glib/meson.build
+index 2f5cfc3..14e1aea 100644
+--- a/docs/reference/libqmi-glib/meson.build
++++ b/docs/reference/libqmi-glib/meson.build
+@@ -57,6 +57,7 @@ sections_txt = custom_target(
+   capture: true,
+   command: [find_program('cat'), '@INPUT@'] + gen_sections,
+   depends: gen_sections_deps,
++  build_by_default: true,
+ )
+ 
+ version_xml = configure_file(

--- a/pkgs/by-name/li/libqmi/package.nix
+++ b/pkgs/by-name/li/libqmi/package.nix
@@ -88,6 +88,10 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+  patches = [
+    # https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/issues/124
+    ./build_doc_deps_by_default.patch
+  ];
 
   postPatch = ''
     patchShebangs \


### PR DESCRIPTION
With `meson` 1.7.0 files needed for testing are not built by default [1]. `libqmi` has incorrectly configured dependencies for gtk-doc generation thus they are not built unless tests are run [2]. Since check phase is skipped for cross compiling this was causing the build failures, while the regular builds were unaffected. Setting `doCheck` to false will cause the install phase to fail also when compiling the package natively.

[1]: https://mesonbuild.com/Release-notes-for-1-7-0.html#test-targets-no-longer-built-by-default
[2]: https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/issues/124

Fixes #384946

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-linux.pkgsCross.aarch64-multiplatform
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
