### PR TITLE
macos-instantview: init

### DIFF
--- a/pkgs/by-name/ma/macos-instantview/package.nix
+++ b/pkgs/by-name/ma/macos-instantview/package.nix
@@ -1,0 +1,50 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+  _7zz,
+}:
+
+stdenvNoCC.mkDerivation (self: {
+  pname = "instantview";
+  version = "V3.22R0002";
+
+  src = fetchurl {
+    url = "https://www.siliconmotion.com/downloads/macOS_InstantView_${self.version}.dmg";
+    hash = "sha256-PdgX9zCrVYtNbuOCYKVo9cegCG/VY7QXetivVsUltbg=";
+  };
+
+  nativeBuildInputs = [ _7zz ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/Applications"
+
+    # Extract the DMG using 7zip
+    7zz x "$src" -oextracted -y
+
+    # Find the extracted app bundle
+    appPath=$(find extracted -name 'macOS InstantView.app' -type d | head -n 1)
+
+    if [ -z "$appPath" ]; then
+      echo "Error: macOS InstantView.app not found in extracted DMG"
+      exit 1
+    fi
+
+    mv "$appPath" "$out/Applications/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    platforms = lib.platforms.darwin;
+    description = "SM76x driver: InstantView™ Enables USB Docking Station to Plugin-and-display! Enlarge Your Screen to Learn / Work from Home!";
+    homepage = "https://www.siliconmotion.com/events/instantview/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ aspauldingcode ];
+  };
+})

--- a/pkgs/by-name/ma/macos-instantview/package.nix
+++ b/pkgs/by-name/ma/macos-instantview/package.nix
@@ -27,15 +27,8 @@ stdenvNoCC.mkDerivation (self: {
     # Extract the DMG using 7zip
     7zz x "$src" -oextracted -y
 
-    # Find the extracted app bundle
-    appPath=$(find extracted -name 'macOS InstantView.app' -type d | head -n 1)
-
-    if [ -z "$appPath" ]; then
-      echo "Error: macOS InstantView.app not found in extracted DMG"
-      exit 1
-    fi
-
-    mv "$appPath" "$out/Applications/"
+    # Move the extracted contents to $out
+    cp -r extracted/* "$out/Applications/"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!-- 
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package macOS InstantView. Supports using displaylink docks hardware which utilize the propietary SOC developed by siliconmotion graphics.

Tested on aarch64-darwin. This init package version is V3.22R0002. This is a macOS only application. It is not available as a compilable source, thus I package as precompiled binary. There is an x11 driver, but it is barebones effort by siliconmotion and probably not worth the effort merging with this, likely doesn't support wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
