### PR TITLE
amazing-marvin: init at 1.66.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19896,6 +19896,12 @@
     github = "OlivierNicole";
     githubId = 14031333;
   };
+  otisdog8 = {
+    name = "Jacob Root";
+    email = "me@rooty.dev";
+    github = "otisdog8";
+    githubId = 37094599;
+  };
   ottoblep = {
     name = "Severin Lochschmidt";
     email = "seviron53@gmail.com";

--- a/pkgs/by-name/am/amazing-marvin/package.nix
+++ b/pkgs/by-name/am/amazing-marvin/package.nix
@@ -1,0 +1,37 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+
+let
+  pname = "amazing-marvin";
+  version = "1.68.0";
+
+  src = fetchurl {
+    url = "https://amazingmarvin.s3.amazonaws.com/Marvin-${version}.AppImage";
+    hash = "sha256-c6ql3loog0nU7dcCHe5ba7PEhcyQ+MwTTIAKKT5aOB4=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraInstallCommands = ''
+    install -Dm 444 ${appimageContents}/marvin.desktop -t $out/share/applications
+    install -Dm 444 ${appimageContents}/usr/share/icons/hicolor/512x512/apps/marvin.png \
+      -t $out/share/icons/hicolor/512x512/apps/
+    substituteInPlace $out/share/applications/marvin.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=amazing-marvin'
+  '';
+
+  meta = {
+    description = "Desktop client for Amazing Marvin";
+    homepage = "https://amazingmarvin.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ otisdog8 ];
+    mainProgram = "amazing-marvin";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds Amazing Marvin (todolist app). It's an electron app packaged as an appimage. 

https://amazingmarvin.com/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].
