### PR TITLE
soundalike: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2216,6 +2216,13 @@
     name = "tali auster";
     matrix = "@atalii:matrix.org";
   };
+  atar13 = {
+    name = "Anthony Tarbinian";
+    email = "atar137h@gmail.com";
+    github = "atar13";
+    githubId = 42757207;
+    matrix = "@atar13:matrix.org";
+  };
   ataraxiasjel = {
     email = "nix@ataraxiadev.com";
     github = "AtaraxiaSjel";

--- a/pkgs/by-name/so/soundalike/package.nix
+++ b/pkgs/by-name/so/soundalike/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+  chromaprint,
+  makeWrapper,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "soundalike";
+  version = "0.1.2";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "derat";
+    repo = "soundalike";
+    tag = "v${version}";
+    hash = "sha256-mpYUVTj3Zll6kNuK5Mdzv1R7k5FZy6XFghhzmAPPVM8=";
+  };
+
+  vendorHash = "sha256-7hRezOBcjB2wsx/SwV519wg3Azh+0kHMcAoc9aYPM3A=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.buildVersion=${version}"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    chromaprint
+  ];
+
+  doCheck = true;
+  # need to grab another repo for music test data
+  testDataVersion = "0.0.1";
+  testData = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "derat";
+    repo = "soundalike-testdata";
+    tag = "v${testDataVersion}";
+    hash = "sha256-7JQTnEjoYiiaQlnxsGcfj/9PYDWAkWq4/oxyczjEMo4=";
+  };
+  preCheck = ''
+    # add soundalike to PATH to be available for unit tests
+    export PATH="$GOPATH/bin:$PATH"
+    # need to symlink test data to a relative path
+    # that the unit tests are expecting
+    ln -sfv ${testData} ./testdata
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
+
+  # soundalike depends on fpcalc (chromparint) at runtime, so we
+  # need to use wrapProgram to make it available
+  postInstall = ''
+    wrapProgram $out/bin/soundalike \
+      --prefix PATH : ${lib.makeBinPath [ chromaprint ]}
+  '';
+
+  meta = with lib; {
+    description = "Find duplicate audio files using acoustic fingerprints";
+    homepage = "https://codeberg.org/derat/soundalike";
+    changelog = "https://codeberg.org/derat/soundalike/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ atar13 ];
+    mainProgram = "soundalike";
+  };
+}


### PR DESCRIPTION
Adding a package for [soundalike](https://codeberg.org/derat/soundalike), a command line tool for finding duplicate audio files using acoustic fingerprints.

Thanks to @aneeshusa for help packaging!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
