### PR TITLE
clasp-common-lisp: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  llvmPackages_15,
+  llvmPackages_18,
   fetchzip,
   sbcl,
   pkg-config,
@@ -13,16 +13,16 @@
 }:
 
 let
-  inherit (llvmPackages_15) stdenv llvm libclang;
+  inherit (llvmPackages_18) stdenv llvm libclang;
 in
 
 stdenv.mkDerivation rec {
   pname = "clasp";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchzip {
     url = "https://github.com/clasp-developers/clasp/releases/download/${version}/clasp-${version}.tar.gz";
-    hash = "sha256-SiQ4RMha6dMV7V2fh+UxtAIgEEH/6/hF9fe+bPtoGIw=";
+    hash = "sha256-IoEwsMvY/bbb6K6git+7zRGP0DIJDROt69FBQuzApRk=";
   };
 
   patches = [
@@ -64,7 +64,14 @@ stdenv.mkDerivation rec {
       --package-path=/ \
       --bin-path=$out/bin \
       --lib-path=$out/lib \
-      --share-path=$out/share
+      --dylib-path=$out/lib \
+      --share-path=$out/share \
+      --pkgconfig-path=$out/lib/pkgconfig
+  '';
+
+  postInstall = ''
+    # --dylib-path not honored. Fix it in post.
+    mv $out/libclasp* $out/lib/
   '';
 
   meta = {


### PR DESCRIPTION
## Things done

Update to 2.7.0. Also fixes the build, as 2.6.0 was not building anymore.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
