### PR TITLE
joplin-desktop: XDG compliant desktop entry

### DIFF
--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -42,7 +42,7 @@ let
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 
-  linux = appimageTools.wrapType2 rec {
+  linux = appimageTools.wrapType2 {
     inherit pname version src meta;
     nativeBuildInputs = [ makeWrapper ];
 
@@ -51,12 +51,12 @@ let
     '';
 
     extraInstallCommands = ''
-      wrapProgram $out/bin/${pname} \
+      wrapProgram $out/bin/joplin-desktop \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
       install -Dm644 ${appimageContents}/@joplinapp-desktop.desktop $out/share/applications/joplin.desktop
       install -Dm644 ${appimageContents}/@joplinapp-desktop.png $out/share/pixmaps/joplin.png
       substituteInPlace $out/share/applications/joplin.desktop \
-        --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+        --replace-fail 'Exec=AppRun' 'Exec=joplin-desktop'
     '';
   };
 

--- a/pkgs/by-name/jo/joplin-desktop/package.nix
+++ b/pkgs/by-name/jo/joplin-desktop/package.nix
@@ -53,11 +53,10 @@ let
     extraInstallCommands = ''
       wrapProgram $out/bin/${pname} \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-      install -Dm444 ${appimageContents}/@joplinapp-desktop.desktop -t $out/share/applications
-      install -Dm444 ${appimageContents}/@joplinapp-desktop.png -t $out/share/pixmaps
-      substituteInPlace $out/share/applications/@joplinapp-desktop.desktop \
-        --replace 'Exec=AppRun' 'Exec=${pname}' \
-        --replace 'Icon=joplin' "Icon=@joplinapp-desktop"
+      install -Dm644 ${appimageContents}/@joplinapp-desktop.desktop $out/share/applications/joplin.desktop
+      install -Dm644 ${appimageContents}/@joplinapp-desktop.png $out/share/pixmaps/joplin.png
+      substituteInPlace $out/share/applications/joplin.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=${pname}'
     '';
   };
 


### PR DESCRIPTION
Two minor changes related to the desktop entry shipped with the package:

- Use `joplin.desktop`, an [XDG compliant][1] filename. As things stand, there are issues when using, for example, `uwsm app {path to desktop entry}` to launch Joplin [[2]].

- Install the application icon at `$out/share/pixmaps/joplin.png` and keep the `Icon=joplin` line in the desktop entry. Users of icon themes are then more likely to get the Joplin icon shipped by their icon theme to show up.

[1]:https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html
[2]:https://github.com/Vladimir-csp/uwsm/blob/master/uwsm/main.py#L204


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
