### PR TITLE
Dataframe_image init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13553,6 +13553,12 @@
     githubId = 516527;
     name = "Lukas Werling";
   };
+  lnajt = {
+    github = "ElleNajt";
+    githubId = 26446393;
+    name = "Elle Najt";
+    email = "lnajt4@gmail.com";
+  };
   lnl7 = {
     email = "daiderd@gmail.com";
     github = "LnL7";

--- a/pkgs/development/python-modules/dataframe_image/default.nix
+++ b/pkgs/development/python-modules/dataframe_image/default.nix
@@ -1,0 +1,126 @@
+{
+  stdenv,
+  pkgs,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python3Packages,
+  texlive,
+  chromium,
+  pandoc,
+  playwright-driver,
+}:
+
+let
+  version = "0.2.7";
+
+  pythonDeps = with python3Packages; [
+    notebook
+    ipykernel
+    pytest
+    pytest-asyncio
+    matplotlib
+    pandas
+    html2image
+    nbconvert
+    aiohttp
+    requests
+    pillow
+    packaging
+    mistune
+    lxml
+    beautifulsoup4
+    cssutils
+    playwright
+    chromium
+    pandoc
+    setuptools-scm
+    cssselect
+    # selenium
+  ];
+
+  testDeps = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  systemDeps = [
+    texlive.combined.scheme-small
+    playwright-driver.browsers
+    chromium
+    pandoc
+    # pkgs.firefox-unwrapped
+    # pkgs.geckodriver
+  ];
+
+in
+python3Packages.buildPythonPackage rec {
+  pname = "dataframe_image";
+  inherit version;
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "dexplo";
+    repo = "dataframe_image";
+    tag = "v${version}";
+    hash = "sha256-rX3afHEKGBZHkHPPKZFPiw6lt7lRYkpMhKvZIorXFok=";
+  };
+
+  nativeBuildInputs = testDeps ++ systemDeps;
+  buildInputs = with python3Packages; [ setuptools ];
+  propagatedBuildInputs = pythonDeps ++ systemDeps;
+  nativeCheckInputs = testDeps ++ systemDeps ++ (with python3Packages; [ pytestCheckHook ]);
+
+  pythonImportsCheck = [ "dataframe_image" ];
+  doCheck = true;
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    export JUPYTER_PLATFORM_DIRS=1
+    export MPLCONFIGDIR=$TMPDIR/matplotlib
+    export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
+    # export PATH="${pkgs.geckodriver}/bin:$PATH"
+  '';
+
+  makeWrapperArgs = [
+    "--set PLAYWRIGHT_BROWSERS_PATH ${playwright-driver.browsers}"
+    # "--prefix PATH : ${pkgs.geckodriver}/bin"
+  ];
+
+  pytestFlagsArray = [
+    "-k 'not selenium and not test_latex[playwright]'"
+    # The selenium tests are failing as firefox drivers cannot be found.
+    # test_latex[playwright] is timing out.
+    #
+    # As dfi.export( ... ,table_conversion="chrome") works with the current
+    # build, and therefore selenium seems unnecessary, I'm disabling these
+    # tests.
+    #
+    # More specifically, these are the errors I'm getting:
+    #
+    # E           selenium.common.exceptions.WebDriverException: Message:
+    # Unsupported platform/architecture combination: linux/aarch64
+    #
+    # E           selenium.common.exceptions.NoSuchDriverException: Message: Unable
+    # to obtain driver for firefox; For documentation on this error, please visit:
+    # https://www.selenium.dev/documentation/webdriver/troubleshooting/errors/driver_location
+    #
+    # For the latter, the solution described on the webpage is to add the driver
+    # location to the path. As the linked driver is gecko driver, I included this
+    # in dependencies and I added geckodriver's binary to PATH in preCheck and
+    # makeWrapperArgs. However, this did not resolve the test failures.
+    #
+    # I've left in selenium/firefox dependencies I used as comments for
+    # convenience.
+
+  ];
+
+  meta = {
+    description = "Embed pandas DataFrames as images in pdf and markdown files when converting from Jupyter Notebooks";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lnajt ];
+    homepage = "https://www.dexplo.org/dataframe_image/";
+    downloadPage = "https://github.com/dexplo/dataframe_image";
+    changelog = "https://github.com/dexplo/dataframe_image/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3035,6 +3035,8 @@ self: super: with self; {
 
   datadog = callPackage ../development/python-modules/datadog { };
 
+  dataframe_image = callPackage ../development/python-modules/dataframe_image { };
+
   datafusion = callPackage ../development/python-modules/datafusion {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration;
     protoc = pkgs.protobuf;


### PR DESCRIPTION
This adds the package [dataframe_image](https://github.com/dexplo/dataframe_image), which provides functions for converting pandas dataframes to images.

The selenium tests are failing, and I've marked them to be skipped with addition comments in the default.nix. 

However, the build works for code like the following snippet to save a styled pandas dataframe as a png, which is the main use case for me:

```python
import pandas as pd
import dataframe_image as dfi
df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
styled_df = df.style.background_gradient()
dfi.export(styled_df, "styled_df.png", table_conversion="chrome", dpi=400)
```

Broken on darwin with the error:

```
error: Package ‘chromium-134.0.6998.35’ in 
/Users/elle/code/nixpkgs/pkgs/applications/networking/browsers/chromium/browser.nix:86 
is not available on the requested hostPlatform:
hostPlatform.config = "aarch64-apple-darwin"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
