### PR TITLE
ivpn-ui: init at 3.14.29

### DIFF
--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+  makeWrapper,
+  ivpn-service,
+}:
+let
+  version = "3.14.29";
+in
+buildNpmPackage {
+  pname = "ivpn-ui";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "ivpn";
+    repo = "desktop-app";
+    tag = "v${version}";
+    hash = "sha256-8JScty/sGyxzC2ojRpatHpCqEXZw9ksMortIhZnukoU=";
+  };
+
+  sourceRoot = "source/ui";
+
+  npmDepsHash = "sha256-2EsXYNo+rj2v+YkZT6ciEcDAirnEZ5MezFlf9zsb/os=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  postBuild = ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version} \
+      --config electron-builder.config.js
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/ivpn-ui
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/ivpn-ui
+
+    install -Dm644 $src/ui/References/Linux/ui/ivpnicon.svg $out/share/icons/hicolor/scalable/apps/ivpn-ui.svg
+
+    makeWrapper ${lib.getExe electron} $out/bin/ivpn-ui \
+      --prefix PATH : ${lib.makeBinPath [ ivpn-service ]} \
+      --add-flags $out/share/ivpn-ui/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ivpn-ui";
+      type = "Application";
+      desktopName = "IVPN";
+      genericName = "VPN Client";
+      comment = "UI interface for IVPN";
+      icon = "ivpn-ui";
+      exec = "ivpn-ui";
+      categories = [ "Network" ];
+      startupNotify = true;
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "UI interface for IVPN";
+    mainProgram = "ivpn-ui";
+    homepage = "https://www.ivpn.net";
+    downloadPage = "https://github.com/ivpn/desktop-app";
+    changelog = "https://github.com/ivpn/desktop-app/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ blenderfreaky ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Currently only the IVPN service and CLI are packaged.
This PR packages the desktop UI app as well.

Closes https://github.com/NixOS/nixpkgs/issues/210200 and supersedes https://github.com/NixOS/nixpkgs/pull/226518 (stale).

Minor open questions:
- Should `services.ivpn.enable = true;` add the desktop app to the environment like with other VPNs? (See https://github.com/NixOS/nixpkgs/issues/337129 also)
- Move IVPN from `pkgs/tools/networking` to `pkgs/by-name`? Right now `ivpn-ui` is in `by-name` but `ivpn` isn't, it'd make sense for them to be at the same spot.

Quick note about testing (in case someone else runs into the same issue):
If you run `nix run .#ivpn-ui` from a `vscode.fhs` terminal, sandboxing/"no new privileges" flag means the desktop app will launch, but wont be able to communicate with ivpn-service. For it to work normally, launch it from a regular terminal.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
