### PR TITLE
build-npm-package, import-npm-lock: fix hooks with node-gyp

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -5,6 +5,8 @@ npmBuildHook() {
 
     runHook preBuild
 
+    export NIX_NODEJS_BUILDNPMPACKAGE=1
+
     if [ -z "${npmBuildScript-}" ]; then
         echo
         echo "ERROR: no build script was specified"

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -5,6 +5,8 @@ npmInstallHook() {
 
     runHook preInstall
 
+    export NIX_NODEJS_BUILDNPMPACKAGE=1
+
     local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
 
     # `npm pack` writes to cache so temporarily override it

--- a/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules-hook.sh
+++ b/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules-hook.sh
@@ -1,4 +1,6 @@
 linkNodeModulesHook() {
+    export NIX_NODEJS_BUILDNPMPACKAGE=1
+
     echo "Executing linkNodeModulesHook"
     runHook preShellHook
 

--- a/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/import-npm-lock/hooks/npm-config-hook.sh
@@ -15,6 +15,7 @@ npmConfigHook() {
     echo "Configuring npm"
 
     export HOME="$TMPDIR"
+    export NIX_NODEJS_BUILDNPMPACKAGE=1
     export npm_config_nodedir="@nodeSrc@"
     export npm_config_node_gyp="@nodeGyp@"
     npm config set offline true


### PR DESCRIPTION
node-gyp build requires NIX_NODEJS_BUILDNPMPACKAGE=1 to be set, so set it in all hooks

Fixes: #385035


export NIX_NODEJS_BUILDNPMPACKAGE=1in all build-npm-package and import-npm-lock hooks. This is required so packages using node-gyp can build without declaring more python dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux -- TODO
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable: -- NOT APPLICABLE
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) -- TODO
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes) -- NOT APPLICABLE
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
