### PR TITLE
amber-lang: generate bash completion; fix build on darwin

### DIFF
--- a/pkgs/by-name/am/amber-lang/fix_gnused_detection.patch
+++ b/pkgs/by-name/am/amber-lang/fix_gnused_detection.patch
@@ -1,0 +1,29 @@
+From cae2ad70d6202bc97623be8c7c123ee2736a4644 Mon Sep 17 00:00:00 2001
+From: aleksana <me@aleksana.moe>
+Date: Sun, 9 Mar 2025 21:19:27 +0800
+Subject: [PATCH] replace_regex: remove bash word boundary when detecting
+ gnused
+
+Bash linked against C libraries other than GLibc may not support GNU
+extensions of POSIX Extended Regular Regex. For example,
+
+> re='\bx'; [[ 'x' =~ $re ]] && echo "1"
+
+does not output the same result on Linux/GLibc and macOS.
+---
+ src/std/text.ab | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/std/text.ab b/src/std/text.ab
+index fe071e33..82449a02 100644
+--- a/src/std/text.ab
++++ b/src/std/text.ab
+@@ -19,7 +19,7 @@ pub fun replace_regex(source: Text, search: Text, replace: Text, extended: Bool
+             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
+             // but only via the "-r" option; use that if the version information
+             // contains "GNU sed".
+-            $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
++            $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+             let flag = status == 0 then "-r" else "-E"
+             return $ echo "{source}" | sed "{flag}" -e "s/{search}/{replace}/g" $
+         } else {

--- a/pkgs/by-name/am/amber-lang/package.nix
+++ b/pkgs/by-name/am/amber-lang/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   bc,
   util-linux,
+  gnused,
   makeWrapper,
   installShellFiles,
   stdenv,
@@ -22,6 +23,11 @@ rustPlatform.buildRustPackage rec {
     rev = version;
     hash = "sha256-N9G/2G8+vrpr1/K7XLwgW+X2oAyAaz4qvN+EbLOCU1Q=";
   };
+
+  patches = [
+    # https://github.com/amber-lang/amber/pull/686
+    ./fix_gnused_detection.patch
+  ];
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-e5+L7Qgd6hyqT1Pb9X7bVtRr+xm428Z5J4hhsYNnGtU=";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/380097

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
