### PR TITLE
nixos/paperless: Update PrivateNetwork in case of using SQLite for pa…

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -342,7 +342,7 @@ in
         ExecStart = "${cfg.package}/bin/celery --app paperless beat --loglevel INFO";
         Restart = "on-failure";
         LoadCredential = lib.optionalString (cfg.passwordFile != null) "PAPERLESS_ADMIN_PASSWORD:${cfg.passwordFile}";
-        PrivateNetwork = cfg.database.createLocally; # defaultServiceConfig enables this by default, needs to be disabled for remote DBs
+        PrivateNetwork = cfg.database.createLocally or (cfg.settings ? PAPERLESS_DBHOST == false); # defaultServiceConfig enables this by default, needs to be disabled for remote DBs
       };
       environment = env;
 
@@ -421,7 +421,7 @@ in
         User = cfg.user;
         ExecStart = "${cfg.package}/bin/paperless-ngx document_consumer";
         Restart = "on-failure";
-        PrivateNetwork = cfg.database.createLocally; # defaultServiceConfig enables this by default, needs to be disabled for remote DBs
+        PrivateNetwork = cfg.database.createLocally or (cfg.settings ? PAPERLESS_DBHOST == false); # defaultServiceConfig enables this by default, needs to be disabled for remote DBs
       };
       environment = env;
       # Allow the consumer to access the private /tmp directory of the server.


### PR DESCRIPTION
…perless-scheduler & paperless-consumer

When [services.paperless.database.createLocally](https://github.com/NixOS/nixpkgs/blob/0a661d37339d9a7a189ed22b88a577e5e77b8604/nixos/modules/services/misc/paperless.nix#L256) is set to false (the [default](https://github.com/NixOS/nixpkgs/blob/0a661d37339d9a7a189ed22b88a577e5e77b8604/nixos/modules/services/misc/paperless.nix#L258)) **and** services.paperless.settings.PAPERLESS_DBHOST is not set, Paperless uses SQLite ([see](https://docs.paperless-ngx.com/configuration/\#PAPERLESS_DBHOST)). Currently, from the commit fe0b1ecf0a05895cee6b2ffd93ea9b8741e77c51, [systemd.services.paperless-consumer.serviceConfig.PrivateNetwork](https://github.com/NixOS/nixpkgs/blob/0a661d37339d9a7a189ed22b88a577e5e77b8604/nixos/modules/services/misc/paperless.nix#L424) & [systemd.services.paperless-scheduler.serviceConfig.PrivateNetwork](https://github.com/NixOS/nixpkgs/blob/0a661d37339d9a7a189ed22b88a577e5e77b8604/nixos/modules/services/misc/paperless.nix#L345), are set to false if services.paperless.database.createLocally is not set to true. However, I think it should be set to true if services.paperless.settings.PAPERLESS_DBHOST is not set because I don't think the network is needed for SQLite.

Just a thought :

Maybe it would be even better to check for the presence of a starting '/' in or the absence of PAPERLESS_DBHOST to determine if the database is either SQLite or a local database ? This way PrivateNetwork would be set to true if the user decides to handle a local database themselves (without using database.createLocally).
```(cfg.settings ? PAPERLESS_DBHOST == false) or (lib.hasPrefix "/" cfg.settings.PAPERLESS_DBHOST)``` could do the trick (would not even need to check for cfg.database.createLocally because this sets service.paperless.settings.PAPERLESS_DBHOST to postgres path).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
