### PR TITLE
wpsoffice-cn: 11.1.0.11723 -> 12.1.0.17900

### DIFF
--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  stdenv,
+  dpkg,
+  autoPatchelfHook,
+  alsa-lib,
+  at-spi2-core,
+  libtool,
+  libxkbcommon,
+  nspr,
+  mesa,
+  libtiff,
+  udev,
+  gtk3,
+  libsForQt5,
+  xorg,
+  cups,
+  pango,
+  libjpeg,
+  gtk2,
+  gdk-pixbuf,
+  libpulseaudio,
+  libbsd,
+  libusb1,
+  libmysqlclient,
+  llvmPackages,
+  dbus,
+  gcc-unwrapped,
+  freetype,
+  curl,
+  makeWrapper,
+  runCommandLocal,
+  cacert,
+  coreutils,
+}:
+let
+  pkgVersion = "12.1.0.17900";
+  url = "https://wps-linux-personal.wpscdn.cn/wps/download/ep/Linux2023/${lib.last (lib.splitVersion pkgVersion)}/wps-office_${pkgVersion}_amd64.deb";
+  hash = "sha256-i2EVCmDLE2gx7l2aAo+fW8onP/z+xlPIbQYwKhQ46+o=";
+  uri = builtins.replaceStrings [ "https://wps-linux-personal.wpscdn.cn" ] [ "" ] url;
+  securityKey = "7f8faaaa468174dc1c9cd62e5f218a5b";
+in
+stdenv.mkDerivation rec {
+  pname = "wpsoffice-cn";
+  version = pkgVersion;
+
+  src =
+    runCommandLocal "wps-office_${version}_amd64.deb"
+      {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = hash;
+
+        nativeBuildInputs = [
+          curl
+          coreutils
+        ];
+
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      }
+      ''
+        timestamp10=$(date '+%s')
+        md5hash=($(echo -n "${securityKey}${uri}$timestamp10" | md5sum))
+        curl \
+        --retry 3 --retry-delay 3 \
+        "${url}?t=$timestamp10&k=$md5hash" \
+        > $out
+      '';
+
+  unpackCmd = "dpkg -x $src .";
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    libtool
+    libjpeg
+    libxkbcommon
+    nspr
+    mesa
+    libtiff
+    udev
+    gtk3
+    libsForQt5.qt5.qtbase
+    xorg.libXdamage
+    xorg.libXtst
+    xorg.libXv
+    gtk2
+    gdk-pixbuf
+    libpulseaudio
+    xorg.libXScrnSaver
+    xorg.libXxf86vm
+    libbsd
+    libusb1
+    libmysqlclient
+    llvmPackages.openmp
+    dbus
+    libsForQt5.fcitx5-qt
+  ];
+
+  dontWrapQtApps = true;
+
+  runtimeDependencies = map lib.getLib [
+    cups
+    pango
+    freetype
+    gcc-unwrapped.lib
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    # distribution is missing libkappessframework.so
+    "libkappessframework.so"
+    # qt4 support is deprecated
+    "libQtCore.so.4"
+    "libQtNetwork.so.4"
+    "libQtXml.so.4"
+    # file manager integration. Not needed
+    "libnautilus-extension.so.1"
+    "libcaja-extension.so.1"
+    "libpeony.so.3"
+    # libuof.so is a exclusive library in WPS. No need to repatch it
+    "libuof.so"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    prefix=$out/opt/kingsoft/wps-office
+    mkdir -p $out
+    cp -r opt $out
+    cp -r usr/* $out
+    for i in wps wpp et wpspdf; do
+      substituteInPlace $out/bin/$i \
+        --replace /opt/kingsoft/wps-office $prefix
+    done
+    for i in $out/share/applications/*;do
+      substituteInPlace $i \
+        --replace /usr/bin $out/bin
+    done
+    # need system freetype and gcc lib to run properly
+    for i in wps wpp et wpspdf wpsoffice; do
+      wrapProgram $out/opt/kingsoft/wps-office/office6/$i \
+        --set LD_PRELOAD "${freetype}/lib/libfreetype.so" \
+        --set LD_LIBRARY_PATH "${lib.makeLibraryPath [ gcc-unwrapped.lib ]}"
+    done
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # The following libraries need libtiff.so.5, but nixpkgs provides libtiff.so.6
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so,addons/pdfbatchcompression/libpdfbatchcompressionapp.so}
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/addons/ksplitmerge/libksplitmergeapp.so
+    patchelf --add-needed libtiff.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
+    # Fix: Wrong JPEG library version: library is 62, caller expects 80
+    patchelf --add-needed libjpeg.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
+    # dlopen dependency
+    patchelf --add-needed libudev.so.1 $out/opt/kingsoft/wps-office/office6/addons/cef/libcef.so
+  '';
+
+  meta = with lib; {
+    description = "Office suite, formerly Kingsoft Office";
+    homepage = "https://www.wps.com";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    hydraPlatforms = [ ];
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [
+      mlatus
+      th0rgal
+      rewine
+      pokon548
+    ];
+  };
+}

--- a/pkgs/by-name/wp/wpsoffice/package.nix
+++ b/pkgs/by-name/wp/wpsoffice/package.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  stdenv,
+  dpkg,
+  autoPatchelfHook,
+  alsa-lib,
+  at-spi2-core,
+  libtool,
+  libxkbcommon,
+  nspr,
+  libgbm,
+  libtiff,
+  udev,
+  gtk3,
+  xorg,
+  cups,
+  pango,
+  runCommandLocal,
+  curl,
+  libsForQt5,
+  coreutils,
+  cacert,
+  libjpeg,
+}:
+let
+  pkgVersion = "11.1.0.11723";
+  url = "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/${lib.last (lib.splitVersion pkgVersion)}/wps-office_${pkgVersion}.XA_amd64.deb";
+  hash = "sha256-o8njvwE/UsQpPuLyChxGAZ4euvwfuaHxs5pfUvcM7kI=";
+in
+stdenv.mkDerivation rec {
+  pname = "wpsoffice";
+  version = pkgVersion;
+
+  src =
+    runCommandLocal "wps-office_${version}.XA_amd64.deb"
+      {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = hash;
+
+        nativeBuildInputs = [
+          curl
+          coreutils
+        ];
+
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      }
+      ''
+        curl \
+        --retry 3 --retry-delay 3 \
+        "${url}" \
+        > $out
+      '';
+
+  unpackCmd = "dpkg -x $src .";
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    libtool
+    libjpeg
+    libxkbcommon
+    nspr
+    libgbm
+    libtiff
+    udev
+    gtk3
+    libsForQt5.qt5.qtbase
+    xorg.libXdamage
+    xorg.libXtst
+    xorg.libXv
+  ];
+
+  dontWrapQtApps = true;
+
+  runtimeDependencies = map lib.getLib [
+    cups
+    pango
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    # distribution is missing libkappessframework.so
+    "libkappessframework.so"
+    # qt4 support is deprecated
+    "libQtCore.so.4"
+    "libQtNetwork.so.4"
+    "libQtXml.so.4"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    prefix=$out/opt/kingsoft/wps-office
+    mkdir -p $out
+    cp -r opt $out
+    cp -r usr/* $out
+    for i in wps wpp et wpspdf; do
+      substituteInPlace $out/bin/$i \
+        --replace /opt/kingsoft/wps-office $prefix
+    done
+    for i in $out/share/applications/*;do
+      substituteInPlace $i \
+        --replace /usr/bin $out/bin
+    done
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    # The following libraries need libtiff.so.5, but nixpkgs provides libtiff.so.6
+    patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/kingsoft/wps-office/office6/{libpdfmain.so,libqpdfpaint.so,qt/plugins/imageformats/libqtiff.so,addons/pdfbatchcompression/libpdfbatchcompressionapp.so}
+    patchelf --add-needed libtiff.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
+    # Fix: Wrong JPEG library version: library is 62, caller expects 80
+    patchelf --add-needed libjpeg.so $out/opt/kingsoft/wps-office/office6/libwpsmain.so
+    # dlopen dependency
+    patchelf --add-needed libudev.so.1 $out/opt/kingsoft/wps-office/office6/addons/cef/libcef.so
+  '';
+
+  meta = with lib; {
+    description = "Office suite, formerly Kingsoft Office";
+    homepage = "https://www.wps.com";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    hydraPlatforms = [ ];
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [
+      mlatus
+      th0rgal
+      rewine
+      pokon548
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16816,11 +16816,6 @@ with pkgs;
 
   worldengine-cli = python3Packages.worldengine;
 
-  wpsoffice = libsForQt5.callPackage ../applications/office/wpsoffice { };
-  wpsoffice-cn = libsForQt5.callPackage ../applications/office/wpsoffice {
-    useChineseVersion = true;
-  };
-
   wrapFirefox = callPackage ../applications/networking/browsers/firefox/wrapper.nix { };
 
   wrapThunderbird = callPackage ../applications/networking/mailreaders/thunderbird/wrapper.nix { };


### PR DESCRIPTION
Due to `wpsoffice` still not releasing `12` version in 2025, I decided to split `wpsoffice{-cn}` into separate packages and provide updates exclusively for `wpsoffice-cn`.

I will consider merge them into meta package again if `wpsoffice` bumps into `12`.

Replace https://github.com/NixOS/nixpkgs/pull/353978
Close https://github.com/NixOS/nixpkgs/issues/342772
Close https://github.com/NixOS/nixpkgs/issues/349441

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
