### PR TITLE
mpvScripts.twitch-chat: refactor

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -24,6 +24,7 @@ lib.makeOverridable (
       {
         pname,
         extraScripts ? [ ],
+        runtime-dependencies ? [ ],
         ...
       }@args:
       let
@@ -75,9 +76,20 @@ lib.makeOverridable (
           runHook postInstall
         '';
 
-        passthru = {
-          inherit scriptName;
-        };
+        passthru =
+          {
+            inherit scriptName;
+          }
+          // lib.optionalAttrs (runtime-dependencies != [ ]) {
+            extraWrapperArgs =
+              [
+                "--prefix"
+                "PATH"
+                ":"
+              ]
+              ++ (map lib.makeBinPath runtime-dependencies)
+              ++ args.passthru.extraWrapperArgs or [ ];
+          };
         meta =
           {
             platforms = lib.platforms.all;

--- a/pkgs/applications/video/mpv/scripts/twitch-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/twitch-chat.nix
@@ -13,14 +13,12 @@ buildLua {
     owner = "CrendKing";
     repo = "mpv-twitch-chat";
     rev = "bb0c2e84675f4f1e0c221c8e1d3516b60242b985";
-    hash = "sha256-WyNPUiAs5U/vrjNbAgyqkfoxh9rabLmuZ1zG5uZYxaw=";
+    hash = "sha256-lnWYcr49koI60Su85OWbcxrARWTfXW2zIvfCZ6c3GtI=";
+
+    postFetch = "rm $out/screenshot.webp";
   };
 
-  installPhase = ''
-    runHook preInstall
-    install -D main.lua $out/share/mpv/scripts/twitch-chat.lua
-    runHook postInstall
-  '';
+  scriptPath = ".";
 
   runtime-dependencies = [ curl ];
 

--- a/pkgs/applications/video/mpv/scripts/twitch-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/twitch-chat.nix
@@ -22,12 +22,7 @@ buildLua (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.extraWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    (lib.makeBinPath [ curl ])
-  ];
+  runtime-dependencies = [ curl ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];

--- a/pkgs/applications/video/mpv/scripts/twitch-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/twitch-chat.nix
@@ -5,7 +5,7 @@
   lib,
   nix-update-script,
 }:
-buildLua (finalAttrs: {
+buildLua {
   pname = "twitch-chat";
   version = "0-unstable-2024-06-23";
 
@@ -34,4 +34,4 @@ buildLua (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.naho ];
   };
-})
+}


### PR DESCRIPTION
In `mpvScripts.twitch-chat`:
- replace `PATH`-wrangling with `buildLua`'s `runtime-dependencies`
  (the `buildLua` feature is implemented in cb5b5f1553c2395f400d445e2a6c507da5c3a2fe, taken from #388475)
- turn explicitely-recursive attrset into a regular one (no self-reference was used)
- replace custom `installPhase` with `scriptPath`
  in the process, treat this as a directory-packaged script, as upstream released (may make future updates easier)
- exclude `screenshot.webp` from source archive (and subsequently from the packaged script)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  @trueNAHO, could you help test this?
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
