### PR TITLE
btcpayserver: 1.13.7 -> 2.0.7

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -11,18 +11,38 @@
   },
   {
     "pname": "AWSSDK.Core",
-    "version": "3.3.104.14",
-    "hash": "sha256-oJjpVBjc3xZHXa+6LHNVZ8vtSijBoK3X1+EPsyZJ5pQ="
+    "version": "3.7.303.14",
+    "hash": "sha256-RtJmPF0tXcGmr0gWkqfZF4upP77GFL2HTnjHyP7UnNs="
   },
   {
     "pname": "AWSSDK.S3",
-    "version": "3.3.110.10",
-    "hash": "sha256-aDBLcfkMi9mSEL2vB01oje6cJVDAvg6Duk2k05eDwdE="
+    "version": "3.7.307.15",
+    "hash": "sha256-kZugED0UM5aLbwdsQl4JY7YvEltfX2Snu0b91AkIeak="
+  },
+  {
+    "pname": "Azure.Core",
+    "version": "1.36.0",
+    "hash": "sha256-lokfjW2wvgFu6bALLzNmDhXIz3HXoPuGX0WfGb9hmpI="
+  },
+  {
+    "pname": "Azure.Storage.Blobs",
+    "version": "12.19.1",
+    "hash": "sha256-E7QHJrhQjQjGhFq4GoQpyVGR6uKfA91NGcyziRfdr2U="
+  },
+  {
+    "pname": "Azure.Storage.Common",
+    "version": "12.18.1",
+    "hash": "sha256-M10Ov1bBV1/U8R3Sp05apS3qFHONQRmAQakQsd17X8I="
   },
   {
     "pname": "BIP78.Sender",
-    "version": "0.2.2",
-    "hash": "sha256-l9ynp6ibP6Qd+p4cWxDOJGHeb/gCpwQMYB8DVoYW9Yo="
+    "version": "0.2.4",
+    "hash": "sha256-4D1894cwcj+Wf7tm+u5cC/H3JdxDSxLz4hHr7ygkqLo="
+  },
+  {
+    "pname": "BouncyCastle.Cryptography",
+    "version": "2.4.0",
+    "hash": "sha256-DoDZNWtYM+0OLIclOEZ+tjcGXymGlXvdvq2ZMPmiAJA="
   },
   {
     "pname": "BTCPayServer.Hwi",
@@ -31,23 +51,18 @@
   },
   {
     "pname": "BTCPayServer.Lightning.All",
-    "version": "1.6.0",
-    "hash": "sha256-Ns8zNpYd6ZnUsBrx7zrqC1sq21rNScaVNVHn8uVxmHU="
+    "version": "1.6.9",
+    "hash": "sha256-pCCxZ1CW+Xc2KvG5yZ79vLYtcwr/PWsrz9A1x02ryb0="
   },
   {
     "pname": "BTCPayServer.Lightning.Charge",
-    "version": "1.5.1",
-    "hash": "sha256-zxzXvGpe2ruqq7z4K6bREF50t2bnlZ26x9i0EirEZuk="
+    "version": "1.5.2",
+    "hash": "sha256-98YtDZBzc5qKO2sK2fpDxodrnVqcfjBPQaagLFXxbss="
   },
   {
     "pname": "BTCPayServer.Lightning.CLightning",
-    "version": "1.6.0",
-    "hash": "sha256-wxd/fQX6XcY/9VkH6T5b0cDuDNlM17BhUV7cEBOLVa8="
-  },
-  {
-    "pname": "BTCPayServer.Lightning.Common",
-    "version": "1.3.21",
-    "hash": "sha256-RJduzM8UGT5d4K/TOxvVhZdylvUkcPAjfx+M1rXjXRA="
+    "version": "1.6.4",
+    "hash": "sha256-H6eskDDjfcgIcy6O1w44qrEwFLi2DrqOtgerj6sQhBQ="
   },
   {
     "pname": "BTCPayServer.Lightning.Common",
@@ -55,24 +70,29 @@
     "hash": "sha256-pIRtTzlMLdwElzqtrDW7E7Iwlh0Vo+3fuCAs0SyYxcs="
   },
   {
-    "pname": "BTCPayServer.Lightning.Eclair",
+    "pname": "BTCPayServer.Lightning.Common",
     "version": "1.5.2",
-    "hash": "sha256-oNx7IJptg4H06/j3rrDjhN55+8wbuUX+aukx4asxsvI="
+    "hash": "sha256-5SFwNAIJBBbrix/qqrtsad5QOKQbCUOm7Un/LDA8c6E="
+  },
+  {
+    "pname": "BTCPayServer.Lightning.Eclair",
+    "version": "1.5.7",
+    "hash": "sha256-UueCAJjSQtY6zH38M4Fc5qY1OaZDAvdNqgY8p6ARTng="
   },
   {
     "pname": "BTCPayServer.Lightning.LNBank",
-    "version": "1.5.2",
-    "hash": "sha256-lOdpv4K8ntngbzatG+UK/wmDGQMXSeMuzWosKsLZUjw="
+    "version": "1.5.3",
+    "hash": "sha256-zuiPaypkMAq0y0/9XYu1c7QmezdbvEUufOxpbo6CaoA="
   },
   {
     "pname": "BTCPayServer.Lightning.LND",
-    "version": "1.5.4",
-    "hash": "sha256-zXZVD8Fi+8V2ylcN6K7nXlYBXPrR40oJoDlhXYHxHUs="
+    "version": "1.5.6",
+    "hash": "sha256-dCx/TarqZSwio0TMQtwL/sxJ2GtnoHj72+Mwe+xoCf8="
   },
   {
     "pname": "BTCPayServer.Lightning.LNDhub",
-    "version": "1.5.2",
-    "hash": "sha256-/VPRakby3txF8tZkx52qwORpBDW94NxXOWakaPgwJiY="
+    "version": "1.5.3",
+    "hash": "sha256-CbSjeix4JCVtgb8WCfsKgThpl/YbnhbJ3wcPoexpSew="
   },
   {
     "pname": "BTCPayServer.NETCore.Plugins",
@@ -86,8 +106,8 @@
   },
   {
     "pname": "BTCPayServer.NTag424",
-    "version": "1.0.23",
-    "hash": "sha256-KbROPk6QSOpitvPXWrsco0lCdlZr9ZMY6Fjd4/dUYtU="
+    "version": "1.0.25",
+    "hash": "sha256-5BVesjksLa2/cgSaOKeYoAw7+lZmIcuKZgqQnRS+2zc="
   },
   {
     "pname": "CsvHelper",
@@ -101,73 +121,73 @@
   },
   {
     "pname": "DigitalRuby.ExchangeSharp",
-    "version": "1.0.4",
-    "hash": "sha256-qJ03XIpHpsINIqu/gamyHhYLjVI64R9cM7hnyYmmbcI="
+    "version": "1.2.0",
+    "hash": "sha256-yKgWUkLVpu8EapAOx8jXWEmwsHpUNWAbu2utD3CpNjI="
   },
   {
     "pname": "Fido2",
-    "version": "2.0.2",
-    "hash": "sha256-5C+Phw0Ty+b3dRH2J7wX3yMVMthKH9XOMPDUqxCZFPM="
+    "version": "3.0.1",
+    "hash": "sha256-v8hND0a17nQ94TC0lmfdr35j3I8y/fwO2Ay7oNyPKRs="
   },
   {
     "pname": "Fido2.AspNet",
-    "version": "2.0.2",
-    "hash": "sha256-QYXaTPNysnLwJqsYZj9KdLL3Yl+ilpAj8exc0DwPU3Q="
+    "version": "3.0.1",
+    "hash": "sha256-nVAXITj4CkcOD2NQaLBaoLr0QPDo/HE7rTrlBfcDXXM="
   },
   {
     "pname": "Fido2.Models",
-    "version": "2.0.2",
-    "hash": "sha256-j5Uvlb6pbUTVrOR3iHyaHea0zfRHCbglyA02sXWCZO4="
+    "version": "3.0.1",
+    "hash": "sha256-awp0JKQxYKZTTA9LygvIUqG36r36ZZWfs6sfcu9yU4U="
   },
   {
     "pname": "Google.Api.Gax",
-    "version": "2.5.0",
-    "hash": "sha256-ieq23E7g5XkdazV5bV+K/jb8wUaKNtveiCilfkeJ12A="
+    "version": "3.6.0",
+    "hash": "sha256-oE4abrFJqwZw8UthsGctxeIyQeJMenvL7AQxxYyJgr4="
   },
   {
     "pname": "Google.Api.Gax.Rest",
-    "version": "2.5.0",
-    "hash": "sha256-N4M7cx0OY0ij/UVELCIaRqt7DirTdlsx+Y1jA3+hcv4="
+    "version": "3.6.0",
+    "hash": "sha256-VUBV77XD9GaFvWsgC6SdUg1BKitH2Fg1svnanOkcgPU="
   },
   {
     "pname": "Google.Apis",
-    "version": "1.35.1",
-    "hash": "sha256-iTQTcoPJ7jJA9Yq4MnXquC7N/6wh0MTkzMOlfSqiQoA="
+    "version": "1.53.0",
+    "hash": "sha256-iiUK5x5sb3rZ0aT/N++CAPJasyODIGD9Ena/RYfCNGQ="
   },
   {
     "pname": "Google.Apis",
-    "version": "1.38.0",
-    "hash": "sha256-gDxUZ95xgNzJVmavqJ0oyMPXM2WPU2ATx8yAsGloQwY="
+    "version": "1.55.0",
+    "hash": "sha256-0thOeZeFuxm8X87nnXIi+VfZDVVkfOW3iiWoH+s2PLE="
   },
   {
     "pname": "Google.Apis.Auth",
-    "version": "1.35.1",
-    "hash": "sha256-Q8FGhfJYRtbhj7SJn5Ow4UcQ3Q2J81gl9c+thG1otuE="
+    "version": "1.53.0",
+    "hash": "sha256-9gnDNlwPoFGSmdIYIzelWn1M3hLKBqt3z4qWxe+c8EY="
   },
   {
     "pname": "Google.Apis.Auth",
-    "version": "1.38.0",
-    "hash": "sha256-/hzxAJWRhWHQSE/p+PkhayawddXKrZRcK7xL7CNva3Q="
+    "version": "1.55.0",
+    "hash": "sha256-WVvRgY3+bg4+VX/aOV75688F1n+0vACgexkb9iZMcRM="
   },
   {
     "pname": "Google.Apis.Core",
-    "version": "1.35.1",
-    "hash": "sha256-REndNVer+Cydo/vNSRMo6SSZNkUIh37qLYza2afgrgU="
+    "version": "1.53.0",
+    "hash": "sha256-e+8rtwtHSy9wcFhFeqL5y+2LB0MwyzVDISepChSkBTE="
   },
   {
     "pname": "Google.Apis.Core",
-    "version": "1.38.0",
-    "hash": "sha256-MslnhGUuv+aSE9iY1BdfaM008SIdW/m9w7uYbiHVTwQ="
+    "version": "1.55.0",
+    "hash": "sha256-WGhYUopf6ZotPHNu20/0hEQpGJapMoQp0jwffi6GO4M="
   },
   {
     "pname": "Google.Apis.Storage.v1",
-    "version": "1.38.0.1470",
-    "hash": "sha256-AgonIEYvQXPTfR25KXPur7/lbNVKXvfJ3XK5W9352VU="
+    "version": "1.55.0.2526",
+    "hash": "sha256-kyglNP8QyxZ53y7HdBGiTzOWRrtK2QXuKWN03jTLCpU="
   },
   {
     "pname": "Google.Cloud.Storage.V1",
-    "version": "2.3.0",
-    "hash": "sha256-xEhaoXQs1OZDPrEHmY6O2ZPm2mzifciQqKhVU03LUAY="
+    "version": "3.7.0",
+    "hash": "sha256-74ZmhfGXNP3twPcuejbdB/TBUcnaOn+5i4iuP9e8wvA="
   },
   {
     "pname": "HtmlSanitizer",
@@ -181,18 +201,18 @@
   },
   {
     "pname": "libsodium",
-    "version": "1.0.18",
-    "hash": "sha256-9utXm0Qv+uaQ769G2jEO/1MCqRkjy0jxVUr5MGahH5c="
+    "version": "1.0.18.2",
+    "hash": "sha256-gjaW2AYXQSb3LLjtQDjWSxkTmEiqIoIb7NFx0+AlrQs="
   },
   {
     "pname": "LNURL",
-    "version": "0.0.34",
-    "hash": "sha256-PbXCxvNQB9Un2XRFIEtqr3M8kYKND8OXdgXzY6nGc+k="
+    "version": "0.0.36",
+    "hash": "sha256-i1/RetQd7oJ1ElY/zAxwecVGIaGWveC8hrtloLCJe+k="
   },
   {
     "pname": "MailKit",
-    "version": "3.3.0",
-    "hash": "sha256-klBdW/zQ6ojikjMFG7R8el+n7v+ybcLjHKU0wvKUgKI="
+    "version": "4.8.0",
+    "hash": "sha256-ONvrVOwjxyNrIQM8FMzT5mLzlU56Kc8oOwkzegNAiXM="
   },
   {
     "pname": "Microsoft.AspNet.SignalR.Client",
@@ -211,43 +231,43 @@
   },
   {
     "pname": "Microsoft.AspNetCore.Connections.Abstractions",
-    "version": "8.0.0",
-    "hash": "sha256-iZELnFhItlhMCMTCM5AtibA7eYRsgvHbpp6Wqev3H3I="
+    "version": "8.0.11",
+    "hash": "sha256-46JBknVJqIAU3YF87sMs7kKZ0p9vMgxX7DpsGJMeA1Y="
   },
   {
     "pname": "Microsoft.AspNetCore.Cryptography.Internal",
-    "version": "8.0.7",
-    "hash": "sha256-10N8W6/uHUkWfp8sZKbI/AOE0UjJUnUY20CSOo4G2ro="
+    "version": "8.0.11",
+    "hash": "sha256-xEIbxQbMcTvkzNw7KKeYOK9wNMShbTAzhx7DR8QMrvM="
   },
   {
     "pname": "Microsoft.AspNetCore.Cryptography.KeyDerivation",
-    "version": "8.0.7",
-    "hash": "sha256-AhGoDSx+dA6vBDGu652KmOkp+iD+/Ntdms52C2BV+Mc="
+    "version": "8.0.11",
+    "hash": "sha256-qt8zkqW3Q8GbnWqPn7YaVGX8r35N5r4iPqENPmu8iPA="
   },
   {
     "pname": "Microsoft.AspNetCore.Http.Connections.Client",
-    "version": "8.0.0",
-    "hash": "sha256-G+cpqimrNCjJSoPkAH9OAYYKgfl04hXkWwyd57zic64="
+    "version": "8.0.11",
+    "hash": "sha256-umvY77/tqcwWRqrDwnjVwAW7HYurWOOElmqxRobSWj8="
   },
   {
     "pname": "Microsoft.AspNetCore.Http.Connections.Common",
-    "version": "8.0.0",
-    "hash": "sha256-66lyBfW1yRoGwtcq6QDqImIR7IAVh+rNMKMKfA3HFOQ="
+    "version": "8.0.11",
+    "hash": "sha256-v2kVUWConlb+5WjVt6pdWbWw43EMxBtpmNHJggGrWaY="
   },
   {
     "pname": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
-    "version": "8.0.7",
-    "hash": "sha256-AlQ4h8t8W8g3e8l20/pzpGrDaBnmKF7wlJZev1fb7a0="
+    "version": "8.0.11",
+    "hash": "sha256-CGnMxU5tYyhALmSnWEMeaNqQmmA1iXqV503HHoWMAfs="
   },
   {
     "pname": "Microsoft.AspNetCore.JsonPatch",
-    "version": "8.0.7",
-    "hash": "sha256-LP/OZQs56HKBp26Ok1XeL9BRmHL05y+dnuTCK1BzF3Y="
+    "version": "8.0.11",
+    "hash": "sha256-7n0O/CWYMjWyicwPZgUUh+YTmdNNZA02rWhBHAzPDPU="
   },
   {
     "pname": "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
-    "version": "8.0.7",
-    "hash": "sha256-oOb2m53qLEvX1diNvXoagEGI/uIt0HiSGbSqYRioJD0="
+    "version": "8.0.11",
+    "hash": "sha256-oaSZize0xvrX1qf45gjMmXHipD21tBGTp2pkr7ReS5U="
   },
   {
     "pname": "Microsoft.AspNetCore.Mvc.Razor.Extensions",
@@ -256,8 +276,8 @@
   },
   {
     "pname": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation",
-    "version": "8.0.6",
-    "hash": "sha256-s+MyQom7sv4sABfxjbHnuAcrF2uUAgJfizZVUqb0Qqo="
+    "version": "8.0.11",
+    "hash": "sha256-O+ssoIAS4R9X80bP+f8U/2c3KZhZkTV34qGsAHEAM7k="
   },
   {
     "pname": "Microsoft.AspNetCore.Razor.Language",
@@ -266,23 +286,38 @@
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Client",
-    "version": "8.0.0",
-    "hash": "sha256-19Z5xUHs23xCG5PtgJ7Q8V/+XdpIbDENH8aIRFTD8Vc="
+    "version": "8.0.11",
+    "hash": "sha256-Bh3scWPi7Zf0FidyILH5ANrUXNiImHKAyX74ToIEKAE="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Client.Core",
-    "version": "8.0.0",
-    "hash": "sha256-81RwKOAnRxltKXARyQdLmKJst0WEbGgYmzfXVmEbR4Q="
+    "version": "8.0.11",
+    "hash": "sha256-pYkxXOwUo+me25kUZSgmbDrJ9sed91tDOUMwuwgAFjI="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Common",
-    "version": "8.0.0",
-    "hash": "sha256-3rzIYKgWRjy5W7THkRhXHJiAgxScNlvrR0Cccsein0w="
+    "version": "8.0.11",
+    "hash": "sha256-Bq/maWmZpIZx8DTN81O9m617bepcgVeO5augSI8WiNU="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Protocols.Json",
-    "version": "8.0.0",
-    "hash": "sha256-tF8RprCiVP96RGsoBfOVpEFdgpaxJy6fdy4eTfMgSO0="
+    "version": "8.0.11",
+    "hash": "sha256-drCZEQdUBvWviUe4McpS5EuHmiNor8P3vxTlVnqkkOM="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson",
+    "version": "8.0.11",
+    "hash": "sha256-8TisgYgVIth+MGVxshkggCq4l4eRS29tKG718VjUeaM="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "1.0.0",
+    "hash": "sha256-cC29sl84h4uVyJq2IPiRNk1G27Zx/Ebn7hLPXbMqvQE="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "1.1.1",
+    "hash": "sha256-fAcX4sxE0veWM1CZBtXR/Unky+6sE33yrV7ohrWGKig="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
@@ -360,89 +395,29 @@
     "hash": "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0="
   },
   {
-    "pname": "Microsoft.Data.Sqlite.Core",
-    "version": "8.0.5",
-    "hash": "sha256-PH+ZS45SGfWSFcYZA+V3m0k1r3kxaDzD3DutVVRyqfQ="
-  },
-  {
     "pname": "Microsoft.EntityFrameworkCore",
-    "version": "8.0.6",
-    "hash": "sha256-T9Pz6bCGULBEYjzdUBd1KXSAnw1c4VljSkwgbTE2MmE="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore",
-    "version": "8.0.7",
-    "hash": "sha256-frnGwFjqiq2Ja451sYmH8ZbTtDtSPGyGurzStkDkIpk="
+    "version": "8.0.11",
+    "hash": "sha256-uvcAmj7ob2X/JKLleNwanpNs0X3PkJl3je6ZsHeWooE="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "8.0.4",
-    "hash": "sha256-ywVWOje6duVcJ8gSSC5HER2UO0mAzfg6VMtqloRmQfc="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "8.0.6",
-    "hash": "sha256-RdcIA9WUJnHyAFdlpBPs5qUusKMUH9uLFGusKBWDCX8="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "8.0.7",
-    "hash": "sha256-MuddWH+nSOJQzHmYeo6NBZDCFIhKXmkkmrJKYP1Gw9A="
+    "version": "8.0.11",
+    "hash": "sha256-qKe+WBIlyZ1CS2H9JGWsYiWxkUzGjwIHtx/q3FPCDr8="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Analyzers",
-    "version": "8.0.6",
-    "hash": "sha256-aTWfaOL0MfWYBbR+1Q1g+sxzmcjA4Q/OBFnVZDQqKJ8="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
-    "version": "8.0.7",
-    "hash": "sha256-iWgYqv1/162ldAjwmZ9piCMlzcuyzfPki8+ZU7DMdYU="
+    "version": "8.0.11",
+    "hash": "sha256-eKhcGqCN34F2i7/FeKSq1gyMjNq3ikq+UpE/1SbXecY="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Design",
-    "version": "8.0.6",
-    "hash": "sha256-svQdeAv19bCM/RQwWFA6wFssrXecqazqs5ctbdZCBgQ="
+    "version": "8.0.11",
+    "hash": "sha256-in7Ppl/tEEM/2r+l+uuSjWLXk7fHbJRVmLzskYfAhMQ="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.0",
-    "hash": "sha256-ga+Qp4dZpmxVEmIIn8AcC92HrhVQBaDICyHqE87s+lk="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.4",
-    "hash": "sha256-TRP/Ior708EQjD03GGxKom2eLOxcUYN1MoFqzk3lYp8="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.5",
-    "hash": "sha256-peIG9ZgXvvEB2wJ2QFxC3u+H8LnZ9xL/HIegw4R00Do="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.6",
-    "hash": "sha256-l2fkzSq3Tb15Uq7a879Bihat+Y7rijDwsrs/MDiApdw="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.7",
-    "hash": "sha256-cTIllPWauAbpiMFw5FdacpF6ZJr+ehf+eFG8RrA5Wjg="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Sqlite",
-    "version": "8.0.5",
-    "hash": "sha256-lED2YXKz6PzYAC5iIXW957N74KUuYtJ9cKvoPFiebpk="
-  },
-  {
-    "pname": "Microsoft.EntityFrameworkCore.Sqlite.Core",
-    "version": "8.0.5",
-    "hash": "sha256-+6AvDE+Fj0Oc7EfA4SXwFUdkOSvvX6jC5HPtbUhYQwE="
-  },
-  {
-    "pname": "Microsoft.Extensions.Caching.Abstractions",
-    "version": "2.2.0",
-    "hash": "sha256-osgeoVggP5UqGBG7GbrZmsVvBJmA47aCgsqJclthHUI="
+    "version": "8.0.11",
+    "hash": "sha256-st6V0S7j+FyK7r9X6uObpuhSoac/z5QOF1DUPnhffgE="
   },
   {
     "pname": "Microsoft.Extensions.Caching.Abstractions",
@@ -451,23 +426,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "8.0.0",
-    "hash": "sha256-RUQe2VgOATM9JkZ/wGm9mreKoCmOS4pPyvyJWBqMaC8="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration",
-    "version": "3.1.5",
-    "hash": "sha256-c5mtiYTD8MS/l90h8vO+LJ+KQUjVeatKMZf3Bx+q/8Q="
+    "version": "8.0.1",
+    "hash": "sha256-5Q0vzHo3ZvGs4nPBc/XlBF4wAwYO8pxq6EGdYjjXZps="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
     "version": "6.0.0",
     "hash": "sha256-SIO/Q+OD2bG+Q0EoOXRgJYzZMhahGXDG1fXZn0VUvv0="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "3.1.5",
-    "hash": "sha256-E0EkLtj6ZEi8V/v0DDmRPqqPkWAE4ZVCVyF077LEXA4="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
@@ -478,11 +443,6 @@
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
     "version": "8.0.0",
     "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "3.1.5",
-    "hash": "sha256-mwswBNxakF+xvZQvxFGkfNKOffZaDE3mmQqvxfO+IAw="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Binder",
@@ -506,13 +466,23 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "6.0.0",
+    "hash": "sha256-gZuMaunMJVyvvepuzNodGPRc6eqKH//bks3957dYkPI="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
     "version": "8.0.0",
     "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
   },
   {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "8.0.1",
+    "hash": "sha256-O9g0jWS+jfGoT3yqKwZYJGL+jGSIeSbwmvomKDC3hTU="
+  },
+  {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "3.1.5",
-    "hash": "sha256-dj+hc29ZsdbGGTSLApC3GNPBJBwPhcb5eEZeAqVCbvI="
+    "version": "6.0.0",
+    "hash": "sha256-SZke0jNKIqJvvukdta+MgIlGsrP2EdPkkS8lfLg7Ju4="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
@@ -520,9 +490,19 @@
     "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
   },
   {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.2",
+    "hash": "sha256-UfLfEQAkXxDaVPC7foE/J3FVEXd31Pu6uQIhTic3JgY="
+  },
+  {
     "pname": "Microsoft.Extensions.DependencyModel",
     "version": "8.0.0",
     "hash": "sha256-qkCdwemqdZY/yIW5Xmh7Exv74XuE39T8aHGHCofoVgo="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "8.0.2",
+    "hash": "sha256-PyuO/MyCR9JtYqpA1l/nXGh+WLKCq34QuAXN9qNza9Q="
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
@@ -531,8 +511,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Features",
-    "version": "8.0.0",
-    "hash": "sha256-njIDmindrlR+YXy4NVjCQzkF15ikvVCz3ilOCcS4HW0="
+    "version": "8.0.11",
+    "hash": "sha256-/q25irYLMbgzuvIHDva43NmKF+BuFCiZX4cmINKu2/4="
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Abstractions",
@@ -560,19 +540,34 @@
     "hash": "sha256-0JBx+wwt5p1SPfO4m49KxNOXPAzAU0A+8tEc/itvpQE="
   },
   {
+    "pname": "Microsoft.Extensions.Http",
+    "version": "6.0.0",
+    "hash": "sha256-JVUjIgj7kblLhiEPsbL1psav8pWrKmjB5Csr4d3GuvM="
+  },
+  {
     "pname": "Microsoft.Extensions.Identity.Core",
-    "version": "8.0.7",
-    "hash": "sha256-zPHu/A8MX/FNt7nVJO2gpzIXa1Yw23GHqLfI0IO/B+k="
+    "version": "8.0.11",
+    "hash": "sha256-5ZeJEyzyyQpBBjrS6/z3sWoD/o+jwtyFKksG35wLu3E="
   },
   {
     "pname": "Microsoft.Extensions.Identity.Stores",
-    "version": "8.0.7",
-    "hash": "sha256-E6rTtrvhV9bgAMks5RHMCbT1e26ttsWDNJWyGnECSNo="
+    "version": "8.0.11",
+    "hash": "sha256-75vJxLs+zzM3TtdxK1ccZx82xwdZzePNss0H/8DnAww="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "6.0.0",
+    "hash": "sha256-8WsZKRGfXW5MsXkMmNVf6slrkw+cR005czkOP2KUqTk="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
     "version": "8.0.0",
     "hash": "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "8.0.1",
+    "hash": "sha256-vkfVw4tQEg86Xg18v6QO0Qb4Ysz0Njx57d1XcNuj6IU="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
@@ -581,18 +576,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "3.1.5",
-    "hash": "sha256-UcI6YUOIzHiexHrn82h77qngx19UeJqUzZqJ4igUIlM="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
     "version": "6.0.0",
     "hash": "sha256-QNqcQ3x+MOK7lXbWkCzSOWa/2QyYNbdM/OEEbWN15Sw="
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "7.0.1",
-    "hash": "sha256-05mravm6SK0wNV3BKDTmN+8/1RxcPOM9kaUvGhjWY3c="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
@@ -600,9 +585,14 @@
     "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
   },
   {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.2",
+    "hash": "sha256-cHpe8X2BgYa5DzulZfq24rg8O2K5Lmq2OiLhoyAVgJc="
+  },
+  {
     "pname": "Microsoft.Extensions.Options",
-    "version": "3.1.5",
-    "hash": "sha256-+WZV8r4siPIaizWh3UifbHulrocfFAGe+JXCfRT2GGY="
+    "version": "6.0.0",
+    "hash": "sha256-DxnEgGiCXpkrxFkxXtOXqwaiAtoIjA8VSSWCcsW0FwE="
   },
   {
     "pname": "Microsoft.Extensions.Options",
@@ -615,26 +605,6 @@
     "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
   },
   {
-    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
-    "version": "3.1.5",
-    "hash": "sha256-8R461IHA7hhDPQqU0s39H5nMuiFgmZ/vhq9eKaRDh4M="
-  },
-  {
-    "pname": "Microsoft.Extensions.PlatformAbstractions",
-    "version": "1.1.0",
-    "hash": "sha256-l+nVRLM+JThXzwExIPHOdmh6N0vehrA2VXPcvcVGkmQ="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "2.2.0",
-    "hash": "sha256-DMCTC3HW+sHaRlh/9F1sDwof+XgvVp9IzAqzlZWByn4="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "3.1.5",
-    "hash": "sha256-Vcw5KWo/yuuTmrNyS9770PKQk76ka4FEEm1G5HWYV1g="
-  },
-  {
     "pname": "Microsoft.Extensions.Primitives",
     "version": "6.0.0",
     "hash": "sha256-AgvysszpQ11AiTBJFkvSy8JnwIWTj15Pfek7T7ThUc4="
@@ -645,19 +615,39 @@
     "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
   },
   {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "8.2.1",
+    "hash": "sha256-+9aIQ5tVPM915SEaquiiVUYaW2wk2MvkYWEMTzGYEl4="
+  },
+  {
     "pname": "Microsoft.IdentityModel.JsonWebTokens",
-    "version": "6.6.0",
-    "hash": "sha256-2ztdbgL1oSuinDqBZBWhYBN75zw6FtTjDa1dfGVQ5Rs="
+    "version": "6.17.0",
+    "hash": "sha256-mtryNDUNNApvIZLQ0jOiuNqLS/TH+7/zQUoViUvGVzQ="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "8.2.1",
+    "hash": "sha256-0tL7K87O8w2IOje7+WFZQiPiYFWLMqMRsVoHKVose+0="
   },
   {
     "pname": "Microsoft.IdentityModel.Logging",
-    "version": "6.6.0",
-    "hash": "sha256-OEspQH4bd331ELSE1AdjVWFMx12dfyFU0LwvRkjp89Y="
+    "version": "6.17.0",
+    "hash": "sha256-vdpxEm0mDravY2SQT/AVgmzkQMjhNe3BcoXxWU0ayLo="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "8.2.1",
+    "hash": "sha256-0FHmPBoogYIEAa7hxVvxIYy1jCCB3NmnVS5eoVWsjrU="
   },
   {
     "pname": "Microsoft.IdentityModel.Tokens",
-    "version": "6.6.0",
-    "hash": "sha256-0ks1h+Kq307izjdlCf4PDnYV/GnH8uyxPY6lXppeu0A="
+    "version": "6.17.0",
+    "hash": "sha256-XuYVKil1tUQ+cLAPnBe9+OWeLgy4AFAiIrXUhEPXLCg="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "8.2.1",
+    "hash": "sha256-kO/Xrv/XbJ0hKqA0PFWMKJA8EBCuAjBO7D6XoPH0l8k="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -668,6 +658,11 @@
     "pname": "Microsoft.NETCore.Platforms",
     "version": "1.1.0",
     "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.1",
+    "hash": "sha256-8hLiUKvy/YirCWlFwzdejD2Db3DaXhHxT7GSZx/znJg="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -685,29 +680,24 @@
     "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
   },
   {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.3",
+    "hash": "sha256-WLsf1NuUfRWyr7C7Rl9jiua9jximnVvzy6nk2D2bVRc="
+  },
+  {
     "pname": "Microsoft.Win32.Primitives",
     "version": "4.3.0",
     "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
   },
   {
-    "pname": "Microsoft.Win32.SystemEvents",
-    "version": "7.0.0",
-    "hash": "sha256-i6JojctqrqfJ4Wa+BDtaKZEol26jYq5DTQHar2M9B64="
-  },
-  {
     "pname": "MimeKit",
-    "version": "3.3.0",
-    "hash": "sha256-yAMLc3cNd1QE3NB4WinY4X0TsdniV7C1doKbTXntVGc="
+    "version": "4.8.0",
+    "hash": "sha256-4EB54ktBXuq5QRID9i8E7FzU7YZTE4wwH+2yr7ivi/Q="
   },
   {
     "pname": "Mono.TextTemplating",
     "version": "2.2.1",
     "hash": "sha256-4TYsfc8q74P8FuDwkIWPO+VYY0mh4Hs4ZL8v0lMaBsY="
-  },
-  {
-    "pname": "MySqlConnector",
-    "version": "2.3.1",
-    "hash": "sha256-tPKi3ntuV8bFnJ88qB27NanziMHRR3Cr70NVYesXRoo="
   },
   {
     "pname": "NBitcoin",
@@ -721,23 +711,43 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.1",
-    "hash": "sha256-h3eenwRrdKDpN+MGIcvrxQszdtNupzdQEGuycb28eBY="
-  },
-  {
-    "pname": "NBitcoin",
     "version": "7.0.31",
     "hash": "sha256-sybd3AOGVlN7U6rLuWSi1kVxtBeaXb8iy786gc0CIh4="
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.37",
-    "hash": "sha256-RclQZgot+Y8PZi9JEX7tgUJinkIBXs1Qgf4vGR2y4rc="
+    "version": "7.0.45",
+    "hash": "sha256-hWgtvAJvONk6jg1WiytE6M+ExkQJUCwO6cyVA6JE+8w="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "7.0.46",
+    "hash": "sha256-c5KHQ/TYGBTMoKKKo7XYR8r7VTJlaU0ZW6KqWRMjh2Y="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "7.0.48",
+    "hash": "sha256-IbiCGHu1cug4kDzwS+vpTqX4jYifxWegFpIctjb/bOA="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "7.0.49",
+    "hash": "sha256-0MQSBeQahSX9s1PPFWengy5J8pWiKR48Vx7dsh3I2p4="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "7.0.50",
+    "hash": "sha256-l3H70u5OAbd2hevX/yeVBdQyee/dUn5mp4iGvTnTcjk="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "3.0.24",
-    "hash": "sha256-MGxIuYtWPgSYj5JCMmZfP7u04ki/UpeN1+//gU6RsdI="
+    "version": "3.0.31",
+    "hash": "sha256-Mtaqj8Fl8jxeOBXz66fjZQKZ/yg6pARJKJTFW0V/wDA="
+  },
+  {
+    "pname": "NBitcoin.Altcoins",
+    "version": "3.0.33",
+    "hash": "sha256-0RYmRKcluGwfTEcOEmoREC/9CgECEi7piQZetMXHOxI="
   },
   {
     "pname": "NBitpayClient",
@@ -746,13 +756,8 @@
   },
   {
     "pname": "NBXplorer.Client",
-    "version": "4.3.1",
-    "hash": "sha256-hrgJwOoM0kD/90eUsqEK+nZLKCCItV+dQE/Gf1Gh4jc="
-  },
-  {
-    "pname": "NdefLibrary",
-    "version": "4.1.0",
-    "hash": "sha256-5gdhufJg34DtPlnhNGEZIEc7EWPqa9BGvmbCL42KDf8="
+    "version": "4.3.9",
+    "hash": "sha256-PSQfKk2kW0O0PB+JyjCaDx/aijNcfdmfj9dzb/fdxl8="
   },
   {
     "pname": "NETStandard.Library",
@@ -801,53 +806,28 @@
   },
   {
     "pname": "NLog",
-    "version": "5.1.3",
-    "hash": "sha256-ljrjt7A7NJ+3/STI0vuIuDRHVYVu6r6KfSV1xVK7CWQ="
+    "version": "5.3.4",
+    "hash": "sha256-Cwr1Wu9VbOcRz3GdVKkt7lIpNwC1E4Hdb0g+qEkEr3k="
   },
   {
     "pname": "Npgsql",
-    "version": "8.0.3",
-    "hash": "sha256-weBGo/IXKI5ufixBCuWG7OqDSyIqvGV07oxrG0XnQIQ="
+    "version": "8.0.6",
+    "hash": "sha256-HebK3NmiuFvq6KfjNwpUs6B/RqA5Uwl9QzTRfaOrK34="
   },
   {
     "pname": "Npgsql.EntityFrameworkCore.PostgreSQL",
-    "version": "8.0.4",
-    "hash": "sha256-T5yuMlQc/eUJtTjHygRqtEO4wKc9YQSVYDKU7ZS8WIU="
+    "version": "8.0.11",
+    "hash": "sha256-r4BpmSg4HGvA6TnfftY6QQRJsCeUdDsMLE82Oa8eleI="
   },
   {
     "pname": "NSec.Cryptography",
-    "version": "20.2.0",
-    "hash": "sha256-/Udj7zH38jfWcuBDhaEid8Sx8HkYWzMQiUijHUqUVKc="
-  },
-  {
-    "pname": "PeterO.Cbor",
-    "version": "4.1.3",
-    "hash": "sha256-1geszskkpoHWT0uBTZxLUnH57NNtUVLFU150CNeIAiE="
-  },
-  {
-    "pname": "PeterO.Numbers",
-    "version": "1.6.0",
-    "hash": "sha256-KMUdMwdMy5fu4L4ptauSuK9T7PrRvGNeMhAAk91sbhI="
-  },
-  {
-    "pname": "PeterO.URIUtility",
-    "version": "1.0.0",
-    "hash": "sha256-TLX5WAswWV6eOL/l2L0smtqJT4HCLMftrxo4KuZyMBI="
-  },
-  {
-    "pname": "Pomelo.EntityFrameworkCore.MySql",
-    "version": "8.0.0-beta.2",
-    "hash": "sha256-O8eqwVr1jCkmL+EQgOVj9Ky13eSVIl/Noil3oz9+Izk="
-  },
-  {
-    "pname": "Portable.BouncyCastle",
-    "version": "1.9.0",
-    "hash": "sha256-GOXM4TdTTodWlGzEfbMForTfTQI/ObJGnFZMSD6X8E4="
+    "version": "22.4.0",
+    "hash": "sha256-TVB8MDXan3dQphaYG/rLQMWgpYJ6WE5ORiqiQrfnCW0="
   },
   {
     "pname": "QRCoder",
-    "version": "1.4.3",
-    "hash": "sha256-it4WJGJVrpmYb8YLlTLeUrTbGW8AFm2rXskW7NvCtMI="
+    "version": "1.6.0",
+    "hash": "sha256-2Ev/6d7PH6K4dVYQQHlZ+ZggkCnDtrlaGygs65mDo28="
   },
   {
     "pname": "runtime.any.System.Collections",
@@ -1000,14 +980,29 @@
     "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
   },
   {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-EbnOqPOrAgI9eNheXLR++VnY4pHzMsEKw1dFPJ/Fl2c="
+  },
+  {
     "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
   },
   {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-mVg02TNvJc1BuHU03q3fH3M6cMgkKaQPBxraSHl/Btg="
+  },
+  {
     "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-g9Uiikrl+M40hYe0JMlGHe/lrR0+nN05YF64wzLmBBA="
   },
   {
     "pname": "runtime.native.System",
@@ -1030,11 +1025,6 @@
     "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
   },
   {
-    "pname": "runtime.native.System.Net.Security",
-    "version": "4.3.0",
-    "hash": "sha256-I8vYld/7WtU2/rrD4XfSRgpO/DY3qXghG14VQjiU2DY="
-  },
-  {
     "pname": "runtime.native.System.Security.Cryptography",
     "version": "4.0.0",
     "hash": "sha256-6Q8eYzC32BbGIiTHoQaE6B3cD81vYQcH5SCswYRSp0w="
@@ -1050,14 +1040,29 @@
     "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
   },
   {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-xqF6LbbtpzNC9n1Ua16PnYgXHU0LvblEROTfK4vIxX8="
+  },
+  {
     "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
   },
   {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-aJBu6Frcg6webvzVcKNoUP1b462OAqReF2giTSyBzCQ="
+  },
+  {
     "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-Mpt7KN2Kq51QYOEVesEjhWcCGTqWckuPf8HlQ110qLY="
   },
   {
     "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
@@ -1070,9 +1075,19 @@
     "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
   },
   {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-JvMltmfVC53mCZtKDHE69G3RT6Id28hnskntP9MMP9U="
+  },
+  {
     "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-QfFxWTVRNBhN4Dm1XRbCf+soNQpy81PsZed3x6op/bI="
   },
   {
     "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
@@ -1080,14 +1095,29 @@
     "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
   },
   {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-EaJHVc9aDZ6F7ltM2JwlIuiJvqM67CKRq682iVSo+pU="
+  },
+  {
     "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
   },
   {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-PHR0+6rIjJswn89eoiWYY1DuU8u6xRJLrtjykAMuFmA="
+  },
+  {
     "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
     "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-LFkh7ua7R4rI5w2KGjcHlGXLecsncCy6kDXLuy4qD/Q="
   },
   {
     "pname": "runtime.unix.Microsoft.Win32.Primitives",
@@ -1096,8 +1126,8 @@
   },
   {
     "pname": "runtime.unix.System.Console",
-    "version": "4.3.0",
-    "hash": "sha256-AHkdKShTRHttqfMjmi+lPpTuCrM5vd/WRy6Kbtie190="
+    "version": "4.3.1",
+    "hash": "sha256-dxyn/1Px4FKLZ2QMUrkFpW619Y1lhPeTiGLWYM6IbpY="
   },
   {
     "pname": "runtime.unix.System.Diagnostics.Debug",
@@ -1190,29 +1220,24 @@
     "hash": "sha256-gXrvlnNVi2TKtsFfjqoPkGZS3JM+p6vjvy3p2by/4A4="
   },
   {
+    "pname": "SocketIO.Core",
+    "version": "3.1.2",
+    "hash": "sha256-g7ufxzhK2gMboJj6KOl8vVQQoPn1nrPeUB7aXrdvvkE="
+  },
+  {
+    "pname": "SocketIO.Serializer.Core",
+    "version": "3.1.2",
+    "hash": "sha256-W86gxw+vfJsmAytm/N51oftjLC5Eax7LlGdBOFplrYk="
+  },
+  {
+    "pname": "SocketIO.Serializer.SystemTextJson",
+    "version": "3.1.2",
+    "hash": "sha256-ds3bYs0sZXUUTZsAZmDBl2GROCLN3osVQqB9ZfqVNpQ="
+  },
+  {
     "pname": "SocketIOClient",
-    "version": "3.0.8",
-    "hash": "sha256-m49zZSppF8Gce6biFUateXdf8b07evZbLsX7H6LVbMw="
-  },
-  {
-    "pname": "SQLitePCLRaw.bundle_e_sqlite3",
-    "version": "2.1.6",
-    "hash": "sha256-dZD/bZsYXjOu46ZH5Y/wgh0uhHOqIxC+S+0ecKhr718="
-  },
-  {
-    "pname": "SQLitePCLRaw.core",
-    "version": "2.1.6",
-    "hash": "sha256-RxWjm52PdmMV98dgDy0BCpF988+BssRZUgALLv7TH/E="
-  },
-  {
-    "pname": "SQLitePCLRaw.lib.e_sqlite3",
-    "version": "2.1.6",
-    "hash": "sha256-uHt5d+SFUkSd6WD7Tg0J3e8eVoxy/FM/t4PAkc9PJT0="
-  },
-  {
-    "pname": "SQLitePCLRaw.provider.e_sqlite3",
-    "version": "2.1.6",
-    "hash": "sha256-zHc/YZsd72eXlI8ba1tv58HZWUIiyjJaxq2CCP1hQe8="
+    "version": "3.1.2",
+    "hash": "sha256-1AYJeHxu4Aimg/MbSn20d2O9KS1LOFD7L6oWJuCousk="
   },
   {
     "pname": "SSH.NET",
@@ -1311,8 +1336,8 @@
   },
   {
     "pname": "System.Configuration.ConfigurationManager",
-    "version": "7.0.0",
-    "hash": "sha256-SgBexTTjRn23uuXvkzO0mz0qOfA23MiS4Wv+qepMLZE="
+    "version": "9.0.0",
+    "hash": "sha256-+pLnTC0YDP6Kjw5DVBiFrV/Q3x5is/+6N6vAtjvhVWk="
   },
   {
     "pname": "System.Console",
@@ -1336,13 +1361,23 @@
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "6.0.0",
+    "hash": "sha256-RY9uWSPdK2fgSwlj1OHBGBVo3ZvGQgBJNzAsS5OGMWc="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "6.0.1",
+    "hash": "sha256-Xi8wrUjVlioz//TPQjFHqcV/QGhTqnTfUcltsNlcCJ4="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
     "version": "8.0.0",
     "hash": "sha256-+aODaDEQMqla5RYZeq0Lh66j+xkPYxykrVvSCmJQ+Vs="
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "7.0.0",
-    "hash": "sha256-aSK1lQN9a/guffT8jUW+zKc5bOIvKRcds/XbVk766Jo="
+    "version": "9.0.0",
+    "hash": "sha256-tPvt6yoAp56sK/fe+/ei8M65eavY2UUhRnbrREj/Ems="
   },
   {
     "pname": "System.Diagnostics.Tools",
@@ -1360,14 +1395,14 @@
     "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
   },
   {
-    "pname": "System.Drawing.Common",
-    "version": "7.0.0",
-    "hash": "sha256-t4FBgTMhuOA5FA23fg0WQOGuH0njV7hJXST/Ln/Znks="
+    "pname": "System.Formats.Asn1",
+    "version": "8.0.1",
+    "hash": "sha256-may/Wg+esmm1N14kQTG4ESMBi+GQKPp0ZrrBo/o6OXM="
   },
   {
-    "pname": "System.Formats.Asn1",
+    "pname": "System.Formats.Cbor",
     "version": "6.0.0",
-    "hash": "sha256-KaMHgIRBF7Nf3VwOo+gJS1DcD+41cJDPWFh+TDQ8ee8="
+    "hash": "sha256-cm27ykIUZ/Ypj8/R73gd+mluE7m/WZFNlTsY5sYjAqQ="
   },
   {
     "pname": "System.Globalization",
@@ -1391,13 +1426,13 @@
   },
   {
     "pname": "System.IdentityModel.Tokens.Jwt",
-    "version": "6.6.0",
-    "hash": "sha256-AaKAwjUAoo4pKusKA/4N59NJytevneN7wnq68AZRJp4="
+    "version": "6.17.0",
+    "hash": "sha256-H3n0I6H3d5TmaVQ6kUZQ1/8BFrsQcVrwxAoty3eKTfg="
   },
   {
-    "pname": "System.Interactive.Async",
-    "version": "3.1.1",
-    "hash": "sha256-0Cof7GZZqLkREQWbG/9+bn5riOtQFv2bFktYgB8QOA4="
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "8.2.1",
+    "hash": "sha256-osV3VbG9k5Jb4XSlUsDxqbMEASNR3c7DA6+AKVXVhHQ="
   },
   {
     "pname": "System.IO",
@@ -1430,6 +1465,11 @@
     "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
   },
   {
+    "pname": "System.IO.Hashing",
+    "version": "6.0.0",
+    "hash": "sha256-gSxLJ/ujWthLknylguRv40mwMl/qNcqnFI9SNjQY6lE="
+  },
+  {
     "pname": "System.IO.Pipelines",
     "version": "6.0.3",
     "hash": "sha256-v+FOmjRRKlDtDW6+TfmyMiiki010YGVTa0EwXu9X7ck="
@@ -1456,16 +1496,6 @@
   },
   {
     "pname": "System.Memory",
-    "version": "4.5.1",
-    "hash": "sha256-7JhQNSvE6JigM1qmmhzOX3NiZ6ek82R4whQNb+FpBzg="
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.3",
-    "hash": "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk="
-  },
-  {
-    "pname": "System.Memory",
     "version": "4.5.4",
     "hash": "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E="
   },
@@ -1475,9 +1505,19 @@
     "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
   },
   {
+    "pname": "System.Memory.Data",
+    "version": "1.0.2",
+    "hash": "sha256-XiVrVQZQIz4NgjiK/wtH8iZhhOZ9MJ+X2hL2/8BrGN0="
+  },
+  {
     "pname": "System.Net.Http",
     "version": "4.3.0",
     "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
+  },
+  {
+    "pname": "System.Net.Http",
+    "version": "4.3.4",
+    "hash": "sha256-FMoU0K7nlPLxoDju0NL21Wjlga9GpnAoQjsFhFYYt00="
   },
   {
     "pname": "System.Net.NameResolution",
@@ -1490,29 +1530,14 @@
     "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
   },
   {
-    "pname": "System.Net.Security",
-    "version": "4.3.0",
-    "hash": "sha256-B7laE1z1+ldbo6JkjlDjZynG5JiMZ/3uNHPHMP6LRak="
-  },
-  {
     "pname": "System.Net.Sockets",
     "version": "4.3.0",
     "hash": "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus="
   },
   {
-    "pname": "System.Net.WebHeaderCollection",
-    "version": "4.3.0",
-    "hash": "sha256-wpRP3D/2YjpFmqU7Q42L/+/hChEVMlwU1sjysGVrQ1c="
-  },
-  {
-    "pname": "System.Net.WebSockets",
-    "version": "4.3.0",
-    "hash": "sha256-l3h3cF1cCC9zMhWLKSDnZBZvFADUd0Afe2+iAwBA0r0="
-  },
-  {
-    "pname": "System.Net.WebSockets.Client",
-    "version": "4.3.2",
-    "hash": "sha256-MwNKwIIpBJhC4Na6EYWMmVyPCa064Yp1aL0opx1FfoA="
+    "pname": "System.Numerics.Vectors",
+    "version": "4.5.0",
+    "hash": "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8="
   },
   {
     "pname": "System.ObjectModel",
@@ -1610,14 +1635,9 @@
     "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
   },
   {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.1",
-    "hash": "sha256-Lucrfpuhz72Ns+DOS7MjuNT2KWgi+m4bJkg87kqXmfU="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.7.0",
-    "hash": "sha256-pORThFo85P8TrmfZCCPIXysVPcV2nW8hRlO6z4jVJps="
+    "pname": "System.Runtime",
+    "version": "4.3.1",
+    "hash": "sha256-R9T68AzS1PJJ7v6ARz9vo88pKL1dWqLOANg4pkQjkA0="
   },
   {
     "pname": "System.Runtime.CompilerServices.Unsafe",
@@ -1686,8 +1706,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Cng",
-    "version": "4.7.0",
-    "hash": "sha256-MvVSJhAojDIvrpuyFmcSVRSZPl3dRYOI9hSptbA+6QA="
+    "version": "4.5.0",
+    "hash": "sha256-9llRbEcY1fHYuTn3vGZaCxsFxSAqXl4bDA6Rz9b0pN4="
   },
   {
     "pname": "System.Security.Cryptography.Csp",
@@ -1706,8 +1726,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "6.0.0",
-    "hash": "sha256-xMSJGgn+UGGe9eGNaZ04OsyiFO7fYtDfz7zsya/9AOE="
+    "version": "8.0.0",
+    "hash": "sha256-yqfIIeZchsII2KdcxJyApZNzxM/VKknjs25gDWlweBI="
   },
   {
     "pname": "System.Security.Cryptography.Primitives",
@@ -1716,18 +1736,13 @@
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
-    "version": "7.0.0",
-    "hash": "sha256-aS5fVYrujUCkAnth2QQPp8knG169BsK/BX8lqaHRSZc="
+    "version": "9.0.0",
+    "hash": "sha256-gPgPU7k/InTqmXoRzQfUMEKL3QuTnOKowFqmXTnWaBQ="
   },
   {
     "pname": "System.Security.Cryptography.X509Certificates",
     "version": "4.3.0",
     "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
-  },
-  {
-    "pname": "System.Security.Permissions",
-    "version": "7.0.0",
-    "hash": "sha256-DOFoX+AKRmrkllykHheR8FfUXYx/Ph+I/HYuReQydXI="
   },
   {
     "pname": "System.Security.Principal",
@@ -1766,8 +1781,8 @@
   },
   {
     "pname": "System.Text.Encodings.Web",
-    "version": "7.0.0",
-    "hash": "sha256-tF8qt9GZh/nPy0mEnj6nKLG4Lldpoi/D8xM5lv2CoYQ="
+    "version": "4.7.2",
+    "hash": "sha256-CUZOulSeRy1CGBm7mrNrTumA9od9peKiIDR/Nb1B4io="
   },
   {
     "pname": "System.Text.Encodings.Web",
@@ -1776,8 +1791,13 @@
   },
   {
     "pname": "System.Text.Json",
-    "version": "7.0.2",
-    "hash": "sha256-bkfxuc3XPxtYcOJTGRMc/AkJiyIU+fTLK7PxtbuN3sQ="
+    "version": "4.7.2",
+    "hash": "sha256-xA8PZwxX9iOJvPbfdi7LWjM2RMVJ7hmtEqS9JvgNsoM="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "5.0.2",
+    "hash": "sha256-3eHI5WsaclD9/iV4clLtSAurQxpcJ/qsZA82lkTjoG0="
   },
   {
     "pname": "System.Text.Json",
@@ -1785,9 +1805,14 @@
     "hash": "sha256-XFcCHMW1u2/WujlWNHaIWkbW1wn8W4kI0QdrwPtWmow="
   },
   {
+    "pname": "System.Text.Json",
+    "version": "8.0.5",
+    "hash": "sha256-yKxo54w5odWT6nPruUVsaX53oPRe+gKzGvLnnxtwP68="
+  },
+  {
     "pname": "System.Text.RegularExpressions",
-    "version": "4.3.0",
-    "hash": "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0="
+    "version": "4.3.1",
+    "hash": "sha256-DxsEZ0nnPozyC1W164yrMUXwnAdHShS9En7ImD/GJMM="
   },
   {
     "pname": "System.Threading",
@@ -1840,11 +1865,6 @@
     "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
   },
   {
-    "pname": "System.Windows.Extensions",
-    "version": "7.0.0",
-    "hash": "sha256-yRivIiENFKMxbSh8SZ/fmKjshwBdFXzbKmZcfDZwKYc="
-  },
-  {
     "pname": "System.Xml.ReaderWriter",
     "version": "4.3.0",
     "hash": "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA="
@@ -1856,33 +1876,28 @@
   },
   {
     "pname": "TwentyTwenty.Storage",
-    "version": "2.12.1",
-    "hash": "sha256-CxMzodzIZq/0WEbesCHI32C2bwkJkxkkcQDCwX5vgVQ="
+    "version": "2.24.2",
+    "hash": "sha256-RBMEajSVvYTJzJkhekjIzcXWX7ERQvLJ38TJXSBhvFc="
   },
   {
     "pname": "TwentyTwenty.Storage.Amazon",
-    "version": "2.12.1",
-    "hash": "sha256-8Jpb7L1yi8NmhjVG/xnFHAPaeT5Jk9RxDryMOOGe2Q4="
+    "version": "2.24.2",
+    "hash": "sha256-U/RYB3l16hQ6Ez8ARVkz3kyMIPMI0icxkHHjVKd2HS0="
   },
   {
     "pname": "TwentyTwenty.Storage.Azure",
-    "version": "2.12.1",
-    "hash": "sha256-m25ormO60RiC/rNfzjSKFDXCLcXqDvlzr//VifJ9B4M="
+    "version": "2.24.2",
+    "hash": "sha256-SrjAhf5KTMMvbCv+unogNT3m2MB6ZUbBsz5HsX0zEqE="
   },
   {
     "pname": "TwentyTwenty.Storage.Google",
-    "version": "2.12.1",
-    "hash": "sha256-F/4OZxllKpnW7beZSW5qp+oOHradj31bggPcvNI9GjU="
+    "version": "2.24.2",
+    "hash": "sha256-EJJnEJbSidOxsiRWBbiO0NhB6K5LdGcXSQ40+JrviiE="
   },
   {
     "pname": "TwentyTwenty.Storage.Local",
-    "version": "2.12.1",
-    "hash": "sha256-qEqPzie96dHRpv7s+3CYxRCSYFOqtk2WQuePHRrHsv4="
-  },
-  {
-    "pname": "WindowsAzure.Storage",
-    "version": "9.3.3",
-    "hash": "sha256-3bXdQwkgMx4cSliwLv+aVsRm5BwZPgSB9dsXJC1YYJE="
+    "version": "2.24.2",
+    "hash": "sha256-OD3TCPNH+So2SZeACLV1KN4Ifjft0csOuiROCuPNSsw="
   },
   {
     "pname": "YamlDotNet",

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -6,13 +6,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.13.7";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-NYeAa8F8LpLWVMW0M/KPVt1XCFOJP50Aug11dxLkSGw=";
+    sha256 = "sha256-LOyGNdlU8wvDFmYQ2v1H3Z12++ChVrGM53zBTWCCiCk=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/deps.json
+++ b/pkgs/by-name/nb/nbxplorer/deps.json
@@ -166,13 +166,13 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.46",
-    "hash": "sha256-c5KHQ/TYGBTMoKKKo7XYR8r7VTJlaU0ZW6KqWRMjh2Y="
+    "version": "7.0.50",
+    "hash": "sha256-l3H70u5OAbd2hevX/yeVBdQyee/dUn5mp4iGvTnTcjk="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "3.0.31",
-    "hash": "sha256-Mtaqj8Fl8jxeOBXz66fjZQKZ/yg6pARJKJTFW0V/wDA="
+    "version": "3.0.34",
+    "hash": "sha256-eh5Yft+UQqlLREJJ3kKAKLYYjAHOuMxhBI+tr3Ciya8="
   },
   {
     "pname": "NETStandard.Library",

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -7,13 +7,13 @@
 
 buildDotnetModule rec {
   pname = "nbxplorer";
-  version = "2.5.17";
+  version = "2.5.23";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     rev = "v${version}";
-    sha256 = "sha256-8tcE60SVhQ2CgoQu24hNL2rrv9JG+2+DuSJWtmycYA0=";
+    sha256 = "sha256-T7pKIj7e4ZOX0JRawLc53eqjMrAV2CV8m6BRjukJ+t4=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";


### PR DESCRIPTION
- [x] The [nix-bitcoin VM test](https://gist.github.com/erikarvstedt/9fb8eaf4b5aad042942bda1310dfc483) succeeds on `x86_64-linux`.

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/by-name/bt/btcpayserver/update.sh`.

cc @prusnak