### PR TITLE
mdk4: unstable-2021-04-27 -> unstable-2024-08-16, unbreak

### DIFF
--- a/pkgs/by-name/md/mdk4/package.nix
+++ b/pkgs/by-name/md/mdk4/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "mdk4";
-  version = "unstable-2021-04-27";
+  version = "4.2-unstable-2024-08-16";
 
   src = fetchFromGitHub {
     owner = "aircrack-ng";
     repo = "mdk4";
-    rev = "e94422ce8e4b8dcd132d658345814df7e63bfa41";
-    sha256 = "sha256-pZS7HQBKlSZJGqoZlSyBUzXC3osswcB56cBzgm+Sbwg=";
+    rev = "36ca143a2e6c0b75b5ec60143b0c5eddd3d2970c";
+    hash = "sha256-iwESQgvt9gLQeDKVkf9KcztQmjdCLOE0+Q0FlfbbjEU=";
   };
 
   preBuild = ''
@@ -37,11 +37,13 @@ stdenv.mkDerivation {
     "SBINDIR=$(PREFIX)/bin"
   ];
 
-  meta = with lib; {
+  enableParallelBuilding = true;
+
+  meta = {
     description = "Tool that injects data into wireless networks";
     homepage = "https://github.com/aircrack-ng/mdk4";
-    maintainers = with maintainers; [ moni ];
-    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ moni ];
+    license = lib.licenses.gpl3Plus;
     mainProgram = "mdk4";
   };
 }


### PR DESCRIPTION
Unbreak and update mdk4. The build error was fixed in https://github.com/aircrack-ng/mdk4/commit/7106e38db19b72a123ebf09b771312cbeee2298f.

Fixes #384779

Homepage: https://github.com/aircrack-ng/mdk4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
