### PR TITLE
mopidy-local: use fetchPypi again

### DIFF
--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -2,7 +2,7 @@
   lib,
   mopidy,
   python3Packages,
-  fetchurl,
+  fetchPypi,
   fetchpatch,
 }:
 
@@ -10,11 +10,10 @@ python3Packages.buildPythonApplication rec {
   pname = "Mopidy-Local";
   version = "3.3.0";
 
-  # We can't use fetchPypi here because the name of the file does not match the
-  # name of the package.
-  src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/02/c5/d099a05df7d6b0687071aa7d2d7a3499802b3b4b641531cd46ec8e6e7035/mopidy_local-3.3.0.tar.gz";
-    sha256 = "cba6ed6c693952255a9f5efcc7b77d8eae4e4e728c6ee9621efd1a471b992b7a";
+  src = fetchPypi {
+    inherit version;
+    pname = "mopidy_local";
+    hash = "sha256-y6btbGk5UiVan178x7d9jq5OTnKMbuliHv0aRxuZK3o=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Trivial fix. Hash is the same

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).