### PR TITLE
mpvScripts.youtube-chat: refactor

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -86,8 +86,8 @@ lib.makeOverridable (
                 "--prefix"
                 "PATH"
                 ":"
+                (lib.makeBinPath runtime-dependencies)
               ]
-              ++ (map lib.makeBinPath runtime-dependencies)
               ++ args.passthru.extraWrapperArgs or [ ];
           };
         meta =

--- a/pkgs/applications/video/mpv/scripts/youtube-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-chat.nix
@@ -24,12 +24,7 @@ buildLua {
     runHook postInstall
   '';
 
-  passthru.extraWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    (lib.makeBinPath [ yt-dlp ])
-  ];
+  runtime-dependencies = [ yt-dlp ];
 
   meta = {
     description = "MPV script to overlay youtube chat on top of a video using yt-dlp";

--- a/pkgs/applications/video/mpv/scripts/youtube-chat.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-chat.nix
@@ -16,13 +16,8 @@ buildLua {
     hash = "sha256-uZC7iDYqLUuXnqSLke4j6rLoufc/vFTE6Ehnpu//dxY=";
   };
 
-  scriptPath = "youtube-chat";
-
-  installPhase = ''
-    runHook preInstall
-    install -D -t $out/share/mpv/scripts/youtube-chat main.lua
-    runHook postInstall
-  '';
+  scriptPath = ".";
+  passthru.scriptName = "youtube-chat";
 
   runtime-dependencies = [ yt-dlp ];
 


### PR DESCRIPTION
- Factor-out `PATH` declaration for the wrapper, using `buildLua`'s `runtime-dependencies`
  (the `buildLua` feature is implemented in cb5b5f1553c2395f400d445e2a6c507da5c3a2fe, taken from #388475)
- Fix inappropriate use of `scriptPath`, removing the need for a custom `installPhase`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  @FliegendeWurst, help with testing would be appreciated  :)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
