### PR TITLE
mpvScripts: miscelaneous refactors

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -86,8 +86,8 @@ lib.makeOverridable (
                 "--prefix"
                 "PATH"
                 ":"
+                (lib.makeBinPath runtime-dependencies)
               ]
-              ++ (map lib.makeBinPath runtime-dependencies)
               ++ args.passthru.extraWrapperArgs or [ ];
           };
         meta =

--- a/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-notify-send.nix
@@ -17,12 +17,7 @@ buildLua rec {
     hash = "sha256-H8WIKfQnle27eiwnz2sxC8D1EwQplY4N7Qg5+c1e/uU=";
   };
 
-  passthru.extraWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    (lib.makeBinPath [ libnotify ])
-  ];
+  runtime-dependencies = [ libnotify ];
 
   passthru.updateScript = unstableGitUpdater { };
 

--- a/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
+++ b/pkgs/applications/video/mpv/scripts/mpv-osc-tethys.nix
@@ -3,7 +3,7 @@
   buildLua,
   fetchFromGitHub,
 }:
-buildLua (finalAttrs: {
+buildLua {
   pname = "mpv-osc-tethys";
   version = "0-unstable-2024-08-19";
 
@@ -23,4 +23,4 @@ buildLua (finalAttrs: {
     license = lib.licenses.unfree; # no license specified
     maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
   };
-})
+}

--- a/pkgs/applications/video/mpv/scripts/thumbfast.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbfast.nix
@@ -18,12 +18,7 @@ buildLua {
   };
   passthru.updateScript = unstableGitUpdater { };
 
-  passthru.extraWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    (lib.makeBinPath [ mpv-unwrapped ])
-  ];
+  runtime-dependencies = [ mpv-unwrapped ];
 
   meta = {
     description = "High-performance on-the-fly thumbnailer for mpv";

--- a/pkgs/applications/video/mpv/scripts/vr-reversal.nix
+++ b/pkgs/applications/video/mpv/scripts/vr-reversal.nix
@@ -1,33 +1,26 @@
 {
   lib,
-  stdenvNoCC,
+  buildLua,
   fetchFromGitHub,
   gitUpdater,
   ffmpeg,
 }:
 
-stdenvNoCC.mkDerivation rec {
+buildLua rec {
   pname = "vr-reversal";
   version = "1.1";
 
   src = fetchFromGitHub {
     owner = "dfaker";
-    repo = pname;
+    repo = "vr-reversal";
     rev = "v${version}";
     sha256 = "1wn2ngcvn7wcsl3kmj782x5q9130qw951lj6ilrkafp6q6zscpqr";
   };
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
-  dontBuild = true;
-
   # reset_rot is only available in ffmpeg 5.0, see 5bcc61ce87922ecccaaa0bd303a7e195929859a8
   postPatch = lib.optionalString (lib.versionOlder ffmpeg.version "5.0") ''
     substituteInPlace 360plugin.lua --replace-fail ":reset_rot=1:" ":"
-  '';
-
-  installPhase = ''
-    mkdir -p $out/share/mpv/scripts
-    cp -r 360plugin.lua $out/share/mpv/scripts/
   '';
 
   passthru.scriptName = "360plugin.lua";
@@ -36,7 +29,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Script for mpv to play VR video with optional saving of head tracking data";
     homepage = "https://github.com/dfaker/VR-reversal";
     license = licenses.unlicense;
-    platforms = platforms.all;
     maintainers = with maintainers; [ schnusch ];
   };
 }


### PR DESCRIPTION
Under `mpvScripts`:
- `buildLua`: add `runtime-dependencies`, DRY-out the `PATH`-wrangling
- `mpv-osc-tethys`: de-recursify attrsets
- `vr-reversal`: convert to `buildLua`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
