### PR TITLE
pdisk: Modernise, fix build, 0.9 -> 0.10

### DIFF
--- a/pkgs/by-name/pd/pdisk/cmdline.patch
+++ b/pkgs/by-name/pd/pdisk/cmdline.patch
@@ -1,0 +1,13 @@
+--- a/cmdline.c	2021-10-05 22:29:41.000000000 -0700
++++ a/cmdline.c	2024-05-30 12:05:29.146787602 -0700
+@@ -22,10 +22,8 @@
+  * @APPLE_LICENSE_HEADER_END@
+  */
+ #include <stdio.h>
+-#ifndef __linux__
+ #include <stdlib.h>
+ #include <unistd.h>
+-#endif
+ #include <string.h>
+ #include <errno.h>
+ #include <fcntl.h>

--- a/pkgs/by-name/pd/pdisk/package.nix
+++ b/pkgs/by-name/pd/pdisk/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdisk";
-  version = "0.9";
+  version = "0.10";
 
   src = fetchFromGitHub {
     owner = "apple-oss-distributions";

--- a/pkgs/by-name/pd/pdisk/package.nix
+++ b/pkgs/by-name/pd/pdisk/package.nix
@@ -39,6 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/linux_strerror.patch?h=pdisk&id=d0c930ea8bcac008bbd0ade1811133a625caea54";
       sha256 = "sha256-HGJIS+vTn6456KtaETutIgTPPBm2C9OHf1anG8yaJPo=";
     })
+
+    # Fix missing includes on Linux
+    ./cmdline.patch
   ];
 
   postPatch =

--- a/pkgs/by-name/pd/pdisk/package.nix
+++ b/pkgs/by-name/pd/pdisk/package.nix
@@ -5,18 +5,16 @@
   fetchpatch,
   installShellFiles,
   libbsd,
-  CoreFoundation,
-  IOKit,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pdisk";
   version = "0.9";
 
   src = fetchFromGitHub {
     owner = "apple-oss-distributions";
-    repo = pname;
-    rev = "${pname}-${lib.versions.minor version}";
+    repo = "pdisk";
+    tag = "pdisk-${lib.versions.minor finalAttrs.version}";
     hash = "sha256-+gBgnk/1juEHE0nXaz7laUaH7sxrX5SzsLGr0PHsdHs=";
   };
 
@@ -46,25 +44,22 @@ stdenv.mkDerivation rec {
   postPatch =
     ''
       substituteInPlace makefile \
-        --replace 'cc' '${stdenv.cc.targetPrefix}cc'
+        --replace-fail 'cc' '${stdenv.cc.targetPrefix}cc'
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       substituteInPlace makefile \
-        --replace '-lbsd' '-framework CoreFoundation -framework IOKit'
+        --replace-fail '-lbsd' '-framework CoreFoundation -framework IOKit'
     '';
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
-  buildInputs =
-    lib.optionals (!stdenv.hostPlatform.isDarwin) [
-      libbsd
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-      CoreFoundation
-      IOKit
-    ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    libbsd
+  ];
 
   env.NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE";
 
@@ -73,8 +68,9 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 cvt_pt $out/bin/cvt_pt
-    install -Dm755 pdisk $out/bin/pdisk
+    for exe in pdisk cvt_pt; do
+      install -Dm755 -t $out/bin $exe
+    done
 
     installManPage pdisk.8
     install -Dm644 pdisk.html $out/share/doc/pdisk/pdisk.html
@@ -82,14 +78,15 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Low-level Apple partition table editor for Linux, OSS Apple version";
     homepage = "https://github.com/apple-oss-distributions/pdisk";
-    license = with licenses; [
+    license = with lib.licenses; [
       hpnd # original license statements seems to match this (in files that are shared with mac-fdisk)
       apple-psl10 # new files
     ];
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.unix;
+    mainProgram = "pdisk";
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3574,10 +3574,6 @@ with pkgs;
 
   gzip = callPackage ../tools/compression/gzip { };
 
-  pdisk = callPackage ../tools/system/pdisk {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
-  };
-
   plplot = callPackage ../development/libraries/plplot {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };


### PR DESCRIPTION
- Modernisations:
  - Switch to `finalAttrs`
  - Don't use `pname` in `src` args
  - `src.rev` -> `src.tag`
  - Use `--replace-fail`
  - Enable `strictDeps`
  - Drop meta-wide `with lib`
  - Add `meta.mainProgram`
  - Migrate to pkgs/by-name
- Added patch is from someone's AUR pdisk package fork: https://aur.archlinux.org/packages/pdisk#comment-975817
  Since there's no stability guarantee here, copied the patch into the tree.
- Yes, `src.hash` of version `0.10` is the same as `0.9`. No, that's not an error.
  Apple's import of `pdisk-10.tar.gz` into the repo seems to have produced no changes to any of the tracked files: https://github.com/apple-oss-distributions/pdisk/commit/01f7971998bcc1556e64905931569b19d5514ecb
  
  Making this a bump anyway, just to get the version increase of the way.

Darwin build is untested, should be tested to make sure removing the deprecated inheriting from `darwin.apple_sdk.frameworks` didn't break anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
