### PR TITLE
bristol: fix build with gcc 14, modernize

### DIFF
--- a/pkgs/by-name/br/bristol/package.nix
+++ b/pkgs/by-name/br/bristol/package.nix
@@ -5,8 +5,10 @@
   alsa-lib,
   libjack2,
   pkg-config,
+  libX11,
+  libXext,
+  xorgproto,
   libpulseaudio,
-  xorg,
   copyDesktopItems,
   makeDesktopItem,
 }:
@@ -17,20 +19,21 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/bristol/${pname}-${version}.tar.gz";
-    sha256 = "1fi2m4gmvxdi260821y09lxsimq82yv4k5bbgk3kyc3x1nyhn7vx";
+    hash = "sha256-fR8LvQ19MD/HfGuVSbYXCNeoO03AB4GAEbH1XR+pIro=";
   };
 
   nativeBuildInputs = [
     pkg-config
     copyDesktopItems
   ];
+
   buildInputs = [
     alsa-lib
     libjack2
     libpulseaudio
-    xorg.libX11
-    xorg.libXext
-    xorg.xorgproto
+    libX11
+    libXext
+    xorgproto
   ];
 
   postPatch = ''
@@ -38,7 +41,10 @@ stdenv.mkDerivation rec {
     sed -i '35i void doPitchWheel(Baudio *baudio);' bristol/bristolmemorymoog.c
   '';
 
-  configurePhase = "./configure --prefix=$out --enable-jack-default-audio --enable-jack-default-midi";
+  configureFlags = [
+    "--enable-jack-default-audio"
+    "--enable-jack-default-midi"
+  ];
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:
@@ -67,10 +73,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Range of synthesiser, electric piano and organ emulations";
     homepage = "https://bristol.sourceforge.net";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/by-name/br/bristol/package.nix
+++ b/pkgs/by-name/br/bristol/package.nix
@@ -33,7 +33,10 @@ stdenv.mkDerivation rec {
     xorg.xorgproto
   ];
 
-  patchPhase = "sed -i '41,43d' libbristolaudio/audioEngineJack.c"; # disable alsa/iatomic
+  postPatch = ''
+    sed -i '41,43d' libbristolaudio/audioEngineJack.c  # disable alsa/iatomic
+    sed -i '35i void doPitchWheel(Baudio *baudio);' bristol/bristolmemorymoog.c
+  '';
 
   configurePhase = "./configure --prefix=$out --enable-jack-default-audio --enable-jack-default-midi";
 
@@ -41,7 +44,7 @@ stdenv.mkDerivation rec {
   # gcc-10. Otherwise build fails as:
   #  ld: brightonCLI.o:/build/bristol-0.60.11/brighton/brightonCLI.c:139: multiple definition of
   #    `event'; brightonMixerMenu.o:/build/bristol-0.60.11/brighton/brightonMixerMenu.c:1182: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env.NIX_CFLAGS_COMPILE = "-fcommon -Wno-implicit-int";
 
   preInstall = ''
     sed -e "s@\`which bristol\`@$out/bin/bristol@g" -i bin/startBristol


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/388196
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
