### PR TITLE
python312Packages.nocturne: unstable-2022-10-15 -> 0-unstable-2024-06-19

### DIFF
--- a/pkgs/development/python-modules/hydra-core/default.nix
+++ b/pkgs/development/python-modules/hydra-core/default.nix
@@ -1,25 +1,33 @@
 {
   lib,
-  antlr4,
-  antlr4-python3-runtime,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # patches
+  replaceVars,
+  antlr4,
   fetchpatch,
-  importlib-resources,
+
+  # nativeBuildInputs
   jre_headless,
+
+  # dependencies
+  antlr4-python3-runtime,
   omegaconf,
   packaging,
+
+  # tests
   pytestCheckHook,
-  pythonOlder,
-  replaceVars,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "hydra-core";
   version = "1.3.2";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
@@ -44,17 +52,23 @@ buildPythonPackage rec {
     # We substitute the path to the jar with the one from our antlr4
     # package, so this file becomes unused
     rm -v build_helpers/bin/antlr*-complete.jar
-
-    sed -i 's/antlr4-python3-runtime==.*/antlr4-python3-runtime/' requirements/requirements.txt
   '';
+
+  build-system = [
+    setuptools
+  ];
 
   nativeBuildInputs = [ jre_headless ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "antlr4-python3-runtime"
+  ];
+
+  dependencies = [
     antlr4-python3-runtime
     omegaconf
     packaging
-  ] ++ lib.optionals (pythonOlder "3.9") [ importlib-resources ];
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -64,13 +78,18 @@ buildPythonPackage rec {
   ];
 
   # Test environment setup broken under Nix for a few tests:
-  disabledTests = [
-    "test_bash_completion_with_dot_in_path"
-    "test_install_uninstall"
-    "test_config_search_path"
-    # does not raise UserWarning
-    "test_initialize_compat_version_base"
-  ];
+  disabledTests =
+    [
+      "test_bash_completion_with_dot_in_path"
+      "test_install_uninstall"
+      "test_config_search_path"
+      # does not raise UserWarning
+      "test_initialize_compat_version_base"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # AssertionError: Regex pattern did not match
+      "test_failure"
+    ];
 
   disabledTestPaths = [ "tests/test_hydra.py" ];
 
@@ -80,10 +99,11 @@ buildPythonPackage rec {
     "hydra.version"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Framework for configuring complex applications";
     homepage = "https://hydra.cc";
-    license = licenses.mit;
-    maintainers = with maintainers; [ bcdarwin ];
+    changelog = "https://github.com/facebookresearch/hydra/blob/v${version}/NEWS.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
   };
 }

--- a/pkgs/development/python-modules/nocturne/default.nix
+++ b/pkgs/development/python-modules/nocturne/default.nix
@@ -1,27 +1,28 @@
 {
-  buildPythonPackage,
-  cmake,
-  fetchFromGitHub,
-  gtest,
-  hydra-core,
   lib,
+  buildPythonPackage,
+  fetchFromGitHub,
   nlohmann_json,
   pybind11,
-  pyvirtualdisplay,
-  sfml,
   replaceVars,
+  gtest,
+  setuptools,
+  cmake,
+  sfml,
+  hydra-core,
+  pyvirtualdisplay,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "nocturne";
-  version = "unstable-2022-10-15";
-  format = "setuptools";
+  version = "0-unstable-2024-06-19";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
-    repo = pname;
-    rev = "ae0a4e361457caf6b7e397675cc86f46161405ed";
-    hash = "sha256-pFVbl4m7qX1mJgleNabRboS9klDDsbzUa4PYL5+Jupc=";
+    repo = "nocturne";
+    rev = "6d1e0f329f7acbed01c934842b269333540af6d2";
+    hash = "sha256-Ufhvc+IZUrn8i6Fmu6o81LPjY1Jo0vzsso+eLbI1F2s=";
   };
 
   # Simulate the git submodules but with nixpkgs dependencies
@@ -37,13 +38,17 @@ buildPythonPackage rec {
     })
   ];
 
+  build-system = [
+    setuptools
+  ];
+
   nativeBuildInputs = [ cmake ];
   dontUseCmakeConfigure = true;
 
   buildInputs = [ sfml ];
 
   # hydra-core and pyvirtualdisplay are not declared as dependences but they are requirements
-  propagatedBuildInputs = [
+  dependencies = [
     hydra-core
     pyvirtualdisplay
   ];
@@ -53,10 +58,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "nocturne" ];
 
-  meta = with lib; {
+  meta = {
     description = "Data-driven, fast driving simulator for multi-agent coordination under partial observability";
     homepage = "https://github.com/facebookresearch/nocturne";
-    license = licenses.mit;
-    maintainers = with maintainers; [ samuela ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ samuela ];
   };
 }


### PR DESCRIPTION
## Things done

cc @samuela

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
