### PR TITLE
python3Packages.uv-build: init at 0.6.6

### DIFF
--- a/pkgs/development/python-modules/uv-build/built-by-uv.nix
+++ b/pkgs/development/python-modules/uv-build/built-by-uv.nix
@@ -1,0 +1,22 @@
+{
+  buildPythonPackage,
+  uv,
+  uv-build,
+  anyio,
+  pytestCheckHook,
+}:
+buildPythonPackage {
+  pname = "built-by-uv";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = "${uv.src}/scripts/packages/built-by-uv";
+
+  build-system = [ uv-build ];
+
+  dependencies = [ anyio ];
+
+  pythonImportsCheck = [ "built_by_uv" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+}

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+  rustPlatform,
+  callPackage,
+}:
+
+buildPythonPackage {
+  pname = "uv-build";
+  pyproject = true;
+
+  inherit (pkgs.uv)
+    version
+    src
+    cargoDeps
+    cargoBuildFlags
+    ;
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  buildAndTestSubdir = "crates/uv-build";
+
+  # $src/.github/workflows/build-binaries.yml#L139
+  maturinBuildFlags = [ "--profile=minimal-size" ];
+
+  pythonImportsCheck = [ "uv_build" ];
+
+  # The package has no tests
+  doCheck = false;
+
+  # Run the tests of a package built by `uv_build`.
+  passthru.tests.built-by-uv = callPackage ./built-by-uv.nix { inherit (pkgs) uv; };
+
+  meta = {
+    description = "A minimal build backend for uv";
+    inherit (pkgs.uv.meta) homepage changelog license;
+    maintainers = with lib.maintainers; [ bengsparks ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18145,6 +18145,8 @@ self: super: with self; {
 
   uv = callPackage ../development/python-modules/uv { };
 
+  uv-build = callPackage ../development/python-modules/uv-build { };
+
   uv-dynamic-versioning = callPackage ../development/python-modules/uv-dynamic-versioning { };
 
   uvcclient = callPackage ../development/python-modules/uvcclient { };


### PR DESCRIPTION
Adds uv's new PEP-517 build-system to nixpkgs.
Tested by building the test package provided by uv, inspecting the contents of the wheel and testing said application.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
