### PR TITLE
reaper-sws-extension: init at 2.14.0.3

### DIFF
--- a/pkgs/by-name/re/reaper-sws-extension/darwin.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/darwin.nix
@@ -1,0 +1,52 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  pname,
+  version,
+  meta,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit
+    pname
+    version
+    meta
+    ;
+  srcs =
+
+    let
+      plugin = fetchurl {
+        url =
+          let
+            arch = if stdenvNoCC.hostPlatform.system == "x86_64-darwin" then "x86_64" else "arm64";
+          in
+          "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/reaper_sws-${arch}.dylib";
+        hash =
+          {
+            x86_64-darwin = "sha256-B185QWS9FaC/0XDhxUBbgr9zu2Ot8OIsfaPQ3sUHh4s=";
+            aarch64-darwin = "sha256-8gbyPlnIXdWtSD+Aj70xzacJhO34edTTG2IOryB67os=";
+          }
+          .${stdenvNoCC.hostPlatform.system};
+      };
+    in
+    [
+      plugin
+      (fetchurl {
+        url = "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/sws_python64.py";
+        hash = "sha256-Yujj60+jOEfdSZ74cRU1Wxoh7RL2fo/IhJIpa+BDYV0=";
+      })
+      (fetchurl {
+        url = "https://github.com/reaper-oss/sws/releases/download/v${finalAttrs.version}/sws_python32.py";
+        hash = "sha256-QktzdIDpTvNs9IrH7TOI6LTIBkfuQ3cqw06iqLxSSTI=";
+      })
+    ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D *.py -t $out/Scripts
+    install -D *.dylib -t $out/UserPlugins
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/re/reaper-sws-extension/linux.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/linux.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  php,
+  perl,
+  git,
+  pkg-config,
+  gtk3,
+
+  pname,
+  version,
+  meta,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version meta;
+
+  src = fetchFromGitHub {
+    owner = "reaper-oss";
+    repo = "sws";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-37pBbNACQuuEk1HJTiUHdb0mDiR2+ZsEQUOhz7mrPPg=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    git
+    perl
+    php
+    pkg-config
+  ];
+
+  buildInputs = [ gtk3 ];
+
+})

--- a/pkgs/by-name/re/reaper-sws-extension/package.nix
+++ b/pkgs/by-name/re/reaper-sws-extension/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenvNoCC,
+  callPackage,
+}:
+let
+  p = if stdenvNoCC.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix;
+in
+callPackage p {
+
+  pname = "reaper-sws-extension";
+  version = "2.14.0.3";
+  meta = {
+    description = "Reaper Plugin Extension";
+    longDescription = ''
+      The SWS / S&M extension is a collection of features that seamlessly integrate into REAPER, the Digital Audio Workstation (DAW) software by Cockos, Inc.
+      It is a collaborative and open source project.
+    '';
+    homepage = "https://www.sws-extension.org/";
+    maintainers = with lib.maintainers; [ pancaek ];
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
Following up on the work done in https://github.com/NixOS/nixpkgs/pull/285832#, I've gone ahead and picked up maintainership.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
