### PR TITLE
termusic: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/by-name/te/termusic/package.nix
+++ b/pkgs/by-name/te/termusic/package.nix
@@ -2,7 +2,6 @@
   alsa-lib,
   dbus,
   fetchFromGitHub,
-  fetchpatch,
   glib,
   gst_all_1,
   lib,
@@ -17,41 +16,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "termusic";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "tramhao";
     repo = "termusic";
     rev = "v${version}";
-    hash = "sha256-aEkg1j6R86QGn21HBimtZwmjmW1K9Wo+67G4DlpY960=";
+    hash = "sha256-Yd23Jk2BFuLtxgF8vgat0wTGq6ahHHBd/HjGI9BY9z4=";
   };
 
-  cargoPatches = [
-    # both following patches can be removed with the follow up release to 0.9.1 as they are cherry-picked from `termusic/master` branch
-    # fix build issue with 0.9.1 release and vendoring producing wrong hash for soundtouch-ffi
-    (fetchpatch {
-      url = "https://github.com/tramhao/termusic/commit/211fc3fe008932d052d31d3b836e8a80eade3cfe.patch";
-      hash = "sha256-11kSI28YonoTe5W31+R76lGhNiN1ZLAg94FrfYiZUAY=";
-    })
-    # fix a bug through previous patch
-    (fetchpatch {
-      url = "https://github.com/tramhao/termusic/commit/2a40b2f366dfa5c1f008c79a3ff5c1bbf53fe10f.patch";
-      hash = "sha256-b7CJ5SqxrU1Jr4GDaJe9sFutDHMqIQxGhXbBFGB6y84=";
-    })
-  ];
-
-  postPatch = ''
-    pushd $cargoDepsCopy/stream-download-0.6.0
-    oldHash=$(sha256sum src/lib.rs | cut -d " " -f 1)
-    substituteInPlace $cargoDepsCopy/stream-download-0.6.0/src/lib.rs \
-      --replace-warn '#![doc = include_str!("../README.md")]' ""
-    substituteInPlace .cargo-checksum.json \
-      --replace-warn $oldHash $(sha256sum src/lib.rs | cut -d " " -f 1)
-    popd
-  '';
-
   useFetchCargoVendor = true;
-  cargoHash = "sha256-LWatmnmLBDf4BFq5RMQBbN4wmptYuz3xqyzz6gJGzX8=";
+  cargoHash = "sha256-1WomL0O5QS2NHu4k6TuA2jLtDKyxlY0iVCgH9pb6CHI=";
 
   useNextest = true;
 


### PR DESCRIPTION
Update to latest `termusic` release `0.10.0` and remove deprecated patches.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
