### PR TITLE
nixos/movim: fix minification options & document them

### DIFF
--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -61,14 +61,6 @@ let
         // lib.optionalAttrs (cfg.database.type == "mysql") {
           withMySQL = true;
         }
-        // lib.optionalAttrs (lib.isAttrs cfg.minifyStaticFiles) (
-          with cfg.minifyStaticFiles;
-          {
-            esbuild = esbuild.package;
-            lightningcss = lightningcss.package;
-            scour = scour.package;
-          }
-        )
       );
     in
     p.overrideAttrs (
@@ -258,18 +250,21 @@ in
       };
 
       minifyStaticFiles = mkOption {
-        type =
-          with types;
-          either bool (submodule {
+        type = types.either types.bool (
+          types.submodule {
             options = {
               script = mkOption {
                 type = types.submodule {
                   options = {
-                    enable = mkEnableOption "Script minification";
-                    package = mkPackageOption pkgs "esbuild" { };
+                    enable = mkEnableOption "Script minification via esbuild";
                     target = mkOption {
-                      type = with types; nullOr nonEmptyStr;
+                      type = types.nullOr types.nonEmptyStr;
                       default = null;
+                      description = ''
+                        esbuild target environment string. If not set, a sane
+                        default will be provided. See:
+                        <https://esbuild.github.io/api/#target>.
+                      '';
                     };
                   };
                 };
@@ -277,11 +272,15 @@ in
               style = mkOption {
                 type = types.submodule {
                   options = {
-                    enable = mkEnableOption "Script minification";
-                    package = mkPackageOption pkgs "lightningcss" { };
+                    enable = mkEnableOption "Script minification via Lightning CSS";
                     target = mkOption {
-                      type = with types; nullOr nonEmptyStr;
+                      type = types.nullOr types.nonEmptyStr;
                       default = null;
+                      description = ''
+                        Browserslists string target for browser compatibility.
+                        If not set, a sane default will be provided. See:
+                        <https://browsersl.ist>.
+                      '';
                     };
                   };
                 };
@@ -289,15 +288,34 @@ in
               svg = mkOption {
                 type = types.submodule {
                   options = {
-                    enable = mkEnableOption "SVG minification";
-                    package = mkPackageOption pkgs "scour" { };
+                    enable = mkEnableOption "SVG minification via Scour";
                   };
                 };
               };
             };
-          });
+          }
+        );
         default = true;
-        description = "Do minification on public static files";
+        description = ''
+          Do minification on public static files which reduces the size of
+          assets — saving data for the server & users as well as offering a
+          performance improvement. This adds typing for the `minifyStaticFiles`
+          attribute for the Movim package which *will* override any existing
+          override value. The default `true` will enable minification for all
+          supported asset types with sane defaults.
+        '';
+        example =
+          lib.literalExpression # nix
+            ''
+              {
+                script.enable = false;
+                style = {
+                  enable = true;
+                  target = "> 0.5%, last 2 versions, Firefox ESR, not dead";
+                };
+                svg.enable = true;
+              }
+            '';
       };
 
       precompressStaticFiles = mkOption {
@@ -818,4 +836,16 @@ in
       };
     };
   };
+
+  imports = [
+    (lib.mkRemovedOptionModule [ "minifyStaticFiles" "script" "package" ] ''
+      Override services.movim.package instead.
+    '')
+    (lib.mkRemovedOptionModule [ "minifyStaticFiles" "style" "package" ] ''
+      Override services.movim.package instead.
+    '')
+    (lib.mkRemovedOptionModule [ "minifyStaticFiles" "svg" "package" ] ''
+      Override services.movim.package instead.
+    '')
+  ];
 }


### PR DESCRIPTION
Removes the packages since this can be overridden with services.movim.package.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
