### PR TITLE
scx.full: 1.0.9 -> 1.0.10

### DIFF
--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -2,6 +2,7 @@
   lib,
   callPackage,
   fetchFromGitHub,
+  fetchpatch2,
 }:
 let
   scx-common = rec {
@@ -15,6 +16,15 @@ let
       rev = "refs/tags/v${versionInfo.scx.version}";
       inherit (versionInfo.scx) hash;
     };
+
+    patches = [
+      # Remove after new release
+      (fetchpatch2 {
+        name = "fix-builds-on-debug-fs-kernels";
+        url = "https://github.com/sched-ext/scx/commit/3c09e8c8c62efd701107f4c2071211db02341d62.patch?full_index=1";
+        hash = "sha256-jLMlCKBYQKS6sf5pZy5z19iSmX9bu9rlXHmGVaxTOho=";
+      })
+    ];
 
     meta = {
       homepage = "https://github.com/sched-ext/scx";

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -26,7 +26,7 @@ let
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "scx_cscheds";
-  inherit (scx-common) version src;
+  inherit (scx-common) version src patches;
 
   # scx needs specific commits of bpftool and libbpf
   # can be found in meson.build of scx src

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -11,7 +11,7 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "scx_rustscheds";
-  inherit (scx-common) version src;
+  inherit (scx-common) version src patches;
 
   useFetchCargoVendor = true;
   inherit (scx-common.versionInfo.scx) cargoHash;

--- a/pkgs/os-specific/linux/scx/version.json
+++ b/pkgs/os-specific/linux/scx/version.json
@@ -1,8 +1,8 @@
 {
   "scx": {
-    "version": "1.0.9",
-    "hash": "sha256-9F6/fkNnyHa9Ud7Kcp2TvRLQE/QEt/rDFETvwiPtx8E=",
-    "cargoHash": "sha256-0K9NyvCgS1Y/puDSFgGoZmGJ5u9E/lEcFuiBUHReC7g="
+    "version": "1.0.10",
+    "hash": "sha256-IJn3MAPEwxImHUfHV7zPNlAlHXvzOkH0S7eJDNnupf0=",
+    "cargoHash": "sha256-d0TvLhBaDgqi4/dtVgL+UOn78uaqSpdFxm4kBdVyCR4="
   },
   "bpftool": {
     "rev": "183e7010387d1fc9f08051426e9a9fbd5f8d409e",


### PR DESCRIPTION
https://github.com/sched-ext/scx/releases/tag/v1.0.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
