### PR TITLE
nginxModules.zip: init

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -314,6 +314,7 @@ stdenv.mkDerivation {
         mainProgram = "nginx";
         homepage = "http://nginx.org";
         license = [ licenses.bsd2 ] ++ concatMap (m: m.meta.license) modules;
+        broken = lib.any (m: m.meta.broken or false) modules;
         platforms = platforms.all;
         maintainers =
           with maintainers;

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -4,6 +4,7 @@
 , fetchFromGitLab
 , fetchhg
 , runCommand
+, stdenv
 
 , arpa2common
 , brotli
@@ -1016,6 +1017,25 @@ let self = {
       homepage = "https://github.com/vozlt/nginx-module-vts";
       license = with licenses; [ bsd2 ];
       maintainers = with maintainers; [ SuperSandro2000 ];
+    };
+  };
+
+  zip = {
+    name = "zip";
+    src = fetchFromGitHub {
+      name = "zip";
+      owner = "evanmiller";
+      repo = "mod_zip";
+      rev = "8e65b82c82c7890f67a6107271c127e9881b6313";
+      hash = "sha256-2bUyGsLSaomzaijnAcHQV9TNSuV7Z3G9EUbrZzLG+mk=";
+    };
+
+    meta = with lib; {
+      description = "Streaming ZIP archiver for nginx";
+      homepage = "https://github.com/evanmiller/mod_zip";
+      license = with licenses; [ bsd3 ];
+      broken = stdenv.hostPlatform.isDarwin;
+      maintainers = teams.apm.members;
     };
   };
 


### PR DESCRIPTION
Streaming ZIP archiver for nginx.

https://github.com/evanmiller/mod_zip

Build fails on darwin, but neither `meta.platforms`, nor `meta.broken` had any effect in `nginxModules`.

@DutchGerman

## Things done

```
nix-build -E 'with import ./. { system = "<system>"; }; nginx.override { modules = [ nginxModules.zip ]; }'
```

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin :x:
  - [ ] aarch64-darwin :x:
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
