### PR TITLE
libfprint: 1.94.8 -> 1.94.9, fprintd: 1.94.4 -> 1.94.5

### DIFF
--- a/pkgs/by-name/fp/fprintd/package.nix
+++ b/pkgs/by-name/fp/fprintd/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fprintd";
-  version = "1.94.4";
+  version = "1.94.5";
   outputs = [
     "out"
     "devdoc"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libfprint";
     repo = "fprintd";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-B2g2d29jSER30OUqCkdk3+Hv5T3DA4SUKoyiqHb8FeU=";
+    hash = "sha256-aGIz50S0zfE3rV6QJp8iQz3uUVn8WAL68KU70j8GyOU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libfprint/package.nix
+++ b/pkgs/by-name/li/libfprint/package.nix
@@ -9,18 +9,18 @@
   gusb,
   pixman,
   glib,
-  nss,
   gobject-introspection,
   cairo,
   libgudev,
   gtk-doc,
   docbook-xsl-nons,
   docbook_xml_dtd_43,
+  openssl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfprint";
-  version = "1.94.8";
+  version = "1.94.9";
   outputs = [
     "out"
     "devdoc"
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libfprint";
     repo = "libfprint";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PZr4ZeVnuCKYfI8CKvRqBwalxsz9Ka17kSuLflwl7mE=";
+    hash = "sha256-UiUdZokgi27LlyO419dd+NIcQD2RSUfdsC08sW3qzko=";
   };
 
   postPatch = ''
@@ -57,9 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
     gusb
     pixman
     glib
-    nss
     cairo
     libgudev
+    openssl
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`libfprint` now depends on `openssl` instead of `nss` (https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/133eaab06193e4bd66297c70c3a8c60328d1128c), but otherwise this is a straightforward version bump.

Tested on my own running system, but I couldn't figure out how to use `nixpkgs-review`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
