### PR TITLE
iozone: 3.506 -> 3.507

### DIFF
--- a/pkgs/by-name/io/iozone/package.nix
+++ b/pkgs/by-name/io/iozone/package.nix
@@ -21,11 +21,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "iozone";
-  version = "3.506";
+  version = "3.507";
 
   src = fetchurl {
     url = "http://www.iozone.org/src/current/iozone${lib.replaceStrings [ "." ] [ "_" ] version}.tar";
-    hash = "sha256-EUzlwHGHO5ose6bnPQXV735mVkOSrL/NwLMmHbEPy+c=";
+    hash = "sha256-HoCHraBW9dgBjuC8dmhtQW/CJR7QMDgFXb0K940eXOM=";
   };
 
   license = fetchurl {
@@ -38,7 +38,10 @@ stdenv.mkDerivation rec {
 
   buildFlags = target;
 
-  enableParallelBuilding = true;
+  # The makefile doesn't define a rule for e.g. libbif.o
+  # Make will try to evaluate implicit built-in rules for these outputs if building in parallel
+  # Build in serial so that the main rule builds everything before the implicit ones are attempted
+  enableParallelBuilding = false;
 
   installPhase = ''
     mkdir -p $out/{bin,share/doc,libexec,share/man/man1}


### PR DESCRIPTION
iozone was failing to build on my NixOS 25.05.20250307.36fd87b (Warbler) system.
Hopefully it's ok to combine a bugfix and version bump but I can separate if necessary.

The issue was that libbif.c was building without `HAVE_ANSIC_C` defined and was therefore not compliant C.
The error thrown was `libbif.c:205:1: error: return type defaults to 'int'`.
This seems to have been allowed somehow on older systems (NixOS 24.11.715344.48913d8f9127 (Vicuna) compiles successfully).
The reason for the missing flag is that the `makefile` doesn't explicitly define rules for all of the object files. They do get built in a rule but with `enableParallelBuilding = true`, `make` uses implicit built-in rules for the c files. I've disabled parallel building so that the implicit rules are never evaluated since the object files already exist before they are attempted. I've left a quick explanation in a comment for anyone wanting to re-enable this in future.

The new version fixes a typo with `HAVE_ANSIC_C` but that doesn't meaningfully change compilation. Two new options are added to the `fileop` utility:
```
     -n        Fill files with non-compressible data.
     -L        Leave files behind.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
