### PR TITLE
python312Packages.enlighten: 1.13.0 -> 1.14.1

### DIFF
--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -43,11 +43,11 @@ buildPythonPackage rec {
       "test_autorefresh"
     ];
 
-  meta = with lib; {
+  meta = {
     description = "Enlighten Progress Bar for Python Console Apps";
     homepage = "https://github.com/Rockhopper-Technologies/enlighten";
     changelog = "https://github.com/Rockhopper-Technologies/enlighten/releases/tag/${version}";
-    license = with licenses; [ mpl20 ];
-    maintainers = with maintainers; [ veprbl ];
+    license = with lib.licenses; [ mpl20 ];
+    maintainers = with lib.maintainers; [ veprbl ];
   };
 }

--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchPypi,
   blessed,
@@ -11,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "enlighten";
-  version = "1.13.0";
+  version = "1.14.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7nGNqsaHPIP9Nwa8532kcsd2pR4Nb1+G9+YeJ/mtFmo=";
+    hash = "sha256-qfpY4o5i3+9wg5D+6w7jxOZHgsACdGqUhzOQ/sF3/v4=";
   };
 
   propagatedBuildInputs = [
@@ -29,19 +28,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "enlighten" ];
-
-  disabledTests =
-    [
-      # AssertionError: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'> is not...
-      "test_init"
-      # AssertionError: Invalid format specifier (deprecated since prefixed 0.4.0)
-      "test_floats_prefixed"
-      "test_subcounter_prefixed"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # https://github.com/Rockhopper-Technologies/enlighten/issues/44
-      "test_autorefresh"
-    ];
 
   meta = {
     description = "Enlighten Progress Bar for Python Console Apps";

--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -48,6 +48,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/Rockhopper-Technologies/enlighten";
     changelog = "https://github.com/Rockhopper-Technologies/enlighten/releases/tag/${version}";
     license = with lib.licenses; [ mpl20 ];
-    maintainers = with lib.maintainers; [ veprbl ];
+    maintainers = with lib.maintainers; [
+      veprbl
+      doronbehar
+    ];
   };
 }

--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -2,10 +2,14 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  pythonOlder,
+
+  # dependencies
   blessed,
   prefixed,
+
+  # tests
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -20,12 +24,14 @@ buildPythonPackage rec {
     hash = "sha256-qfpY4o5i3+9wg5D+6w7jxOZHgsACdGqUhzOQ/sF3/v4=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     blessed
     prefixed
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "enlighten" ];
 

--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "enlighten";
-  version = "1.14.0";
+  version = "1.14.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-qfpY4o5i3+9wg5D+6w7jxOZHgsACdGqUhzOQ/sF3/v4=";
+    hash = "sha256-hcNUEqmk84hrMzfUH4E0Qfq5ow2fW18MAVvQeKRBFHM=";
   };
 
   dependencies = [


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
