### PR TITLE
nixos/szurubooru: init at 2.5-unstable-2025-02-11

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -551,6 +551,18 @@
   "module-services-youtrack-upgrade-2022_3-2023_1": [
     "index.html#module-services-youtrack-upgrade-2022_3-2023_1"
   ],
+  "module-services-szurubooru": [
+    "index.html#module-services-szurubooru"
+  ],
+  "module-services-szurubooru-basic-usage": [
+    "index.html#module-services-szurubooru-basic-usage"
+  ],
+  "module-services-szurubooru-reverse-proxy-configuration": [
+    "index.html#module-services-szurubooru-reverse-proxy-configuration"
+  ],
+  "module-services-szurubooru-extra-config": [
+    "index.html#module-services-szurubooru-extra-config"
+  ],
   "module-services-suwayomi-server": [
     "index.html#module-services-suwayomi-server"
   ],

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -32,6 +32,8 @@
 
 - [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
 
+- [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
+
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
 [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1663,6 +1663,7 @@
   ./services/web-apps/stirling-pdf.nix
   ./services/web-apps/strfry.nix
   ./services/web-apps/suwayomi-server.nix
+  ./services/web-apps/szurubooru.nix
   ./services/web-apps/trilium.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/vikunja.nix

--- a/nixos/modules/services/web-apps/szurubooru.md
+++ b/nixos/modules/services/web-apps/szurubooru.md
@@ -1,0 +1,80 @@
+# Szurubooru {#module-services-szurubooru}
+
+An image board engine dedicated for small and medium communities.
+
+## Configuration {#module-services-szurubooru-basic-usage}
+
+By default the module will execute Szurubooru server only, the web client only contains static files that can be reached via a reverse proxy.
+
+Here is a basic configuration:
+
+```nix
+{
+  services.szurubooru = {
+    enable = true;
+
+    server = {
+      port = 8080;
+
+      settings = {
+        domain = "https://szurubooru.domain.tld";
+        secretFile = /path/to/secret/file;
+      };
+    };
+
+    database = {
+      passwordFile = /path/to/secret/file;
+    };
+  };
+}
+```
+
+## Reverse proxy configuration {#module-services-szurubooru-reverse-proxy-configuration}
+
+The prefered method to run this service is behind a reverse proxy not to expose an open port. For example, here is a minimal Nginx configuration:
+
+```nix
+{
+  services.szurubooru = {
+    enable = true;
+
+    server = {
+      port = 8080;
+      ...
+    };
+
+    ...
+  };
+
+  services.nginx.virtualHosts."szurubooru.domain.tld" = {
+    locations = {
+      "/api/".proxyPass = "http://localhost:8080/";
+      "/data/".root = config.services.szurubooru.dataDir;
+      "/" = {
+        root = config.services.szurubooru.client.package;
+        tryFiles = "$uri /index.htm";
+      };
+    };
+  };
+}
+```
+
+## Extra configuration {#module-services-szurubooru-extra-config}
+
+Not all configuration options of the server are available directly in this module, but you can add them in `services.szurubooru.server.settings`:
+
+```nix
+{
+  services.szurubooru = {
+    enable = true;
+
+    server.settings = {
+      domain = "https://szurubooru.domain.tld";
+      delete_source_files = "yes";
+      contact_email = "example@domain.tld";
+    };
+  };
+}
+```
+
+You can find all of the options in the default config file available [here](https://github.com/rr-/szurubooru/blob/master/server/config.yaml.dist).

--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -1,0 +1,331 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.szurubooru;
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    types
+    ;
+  format = pkgs.formats.yaml { };
+  python = pkgs.python312;
+in
+
+{
+  options = {
+    services.szurubooru = {
+      enable = mkEnableOption "Szurubooru, an image board engine dedicated for small and medium communities";
+
+      user = mkOption {
+        type = types.str;
+        default = "szurubooru";
+        description = ''
+          User account under which Szurubooru runs.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "szurubooru";
+        description = ''
+          Group under which Szurubooru runs.
+        '';
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/szurubooru";
+        example = "/var/lib/szuru";
+        description = ''
+          The path to the data directory in which Szurubooru will store its data.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to open the firewall for the port in {option}`services.szurubooru.server.port`.
+        '';
+      };
+
+      server = {
+        package = mkPackageOption pkgs [
+          "szurubooru"
+          "server"
+        ] { };
+
+        port = mkOption {
+          type = types.port;
+          default = 8080;
+          example = 9000;
+          description = ''
+            Port to expose HTTP service.
+          '';
+        };
+
+        threads = mkOption {
+          type = types.int;
+          default = 4;
+          example = 6;
+          description = ''Number of waitress threads to start.'';
+        };
+
+        settings = mkOption {
+          type = types.submodule {
+            freeformType = format.type;
+            options = {
+              name = mkOption {
+                type = types.str;
+                default = "szurubooru";
+                example = "Szuru";
+                description = ''Name shown in the website title and on the front page.'';
+              };
+
+              domain = mkOption {
+                type = types.str;
+                example = "http://example.com";
+                description = ''Full URL to the homepage of this szurubooru site (with no trailing slash).'';
+              };
+
+              # NOTE: this is not a real upstream option
+              secretFile = mkOption {
+                type = types.path;
+                example = "/run/secrets/szurubooru-server-secret";
+                description = ''
+                  File containing a secret used to salt the users' password hashes and generate filenames for static content.
+                '';
+              };
+
+              delete_source_files = mkOption {
+                type = types.enum [
+                  "yes"
+                  "no"
+                ];
+                default = "no";
+                example = "yes";
+                description = ''Whether to delete thumbnails and source files on post delete.'';
+              };
+
+              smtp = {
+                host = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "localhost";
+                  description = ''Host of the SMTP server used to send reset password.'';
+                };
+
+                port = mkOption {
+                  type = types.nullOr types.port;
+                  default = null;
+                  example = 25;
+                  description = ''Port of the SMTP server.'';
+                };
+
+                user = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  example = "bot";
+                  description = ''User to connect to the SMTP server.'';
+                };
+
+                # NOTE: this is not a real upstream option
+                passFile = mkOption {
+                  type = types.nullOr types.path;
+                  default = null;
+                  example = "/run/secrets/szurubooru-smtp-pass";
+                  description = ''File containing the password associated to the given user for the SMTP server.'';
+                };
+              };
+
+              data_url = mkOption {
+                type = types.str;
+                default = "${cfg.server.settings.domain}/data/";
+                defaultText = lib.literalExpression ''"''${services.szurubooru.server.settings.domain}/data/"'';
+                example = "http://example.com/content/";
+                description = ''Full URL to the data endpoint.'';
+              };
+
+              data_dir = mkOption {
+                type = types.path;
+                default = "${cfg.dataDir}/data";
+                defaultText = lib.literalExpression ''"''${services.szurubooru.dataDir}/data"'';
+                example = "/srv/szurubooru/data";
+                description = ''Path to the static files.'';
+              };
+
+              debug = mkOption {
+                type = types.int;
+                default = 0;
+                example = 1;
+                description = ''Whether to generate server logs.'';
+              };
+
+              show_sql = mkOption {
+                type = types.int;
+                default = 0;
+                example = 1;
+                description = ''Whether to show SQL in server logs.'';
+              };
+            };
+          };
+          description = ''
+            Configuration to write to {file}`config.yaml`.
+            See <https://github.com/rr-/szurubooru/blob/master/server/config.yaml.dist> for more information.
+          '';
+        };
+      };
+
+      client = {
+        package = mkPackageOption pkgs [
+          "szurubooru"
+          "client"
+        ] { };
+      };
+
+      database = {
+        host = mkOption {
+          type = types.str;
+          default = "localhost";
+          example = "192.168.1.2";
+          description = ''Host on which the PostgreSQL database runs.'';
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 5432;
+          description = ''The port under which PostgreSQL listens to.'';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = cfg.database.user;
+          defaultText = lib.literalExpression "szurubooru.database.name";
+          example = "szuru";
+          description = ''Name of the PostgreSQL database.'';
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "szurubooru";
+          example = "szuru";
+          description = ''PostgreSQL user.'';
+        };
+
+        passwordFile = mkOption {
+          type = types.path;
+          example = "/run/secrets/szurubooru-db-password";
+          description = ''A file containing the password for the PostgreSQL user.'';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.server.port ];
+
+    users.groups = mkIf (cfg.group == "szurubooru") {
+      szurubooru = { };
+    };
+
+    users.users = mkIf (cfg.user == "szurubooru") {
+      szurubooru = {
+        group = cfg.group;
+        description = "Szurubooru Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.services.szurubooru =
+      let
+        configFile = format.generate "config.yaml" (
+          lib.pipe cfg.server.settings [
+            (
+              settings:
+              lib.recursiveUpdate settings {
+                secretFile = null;
+                secret = "$SZURUBOORU_SECRET";
+
+                smtp.pass = if settings.smtp.passFile != null then "$SZURUBOORU_SMTP_PASS" else null;
+                smtp.passFile = null;
+                smtp.enable = null;
+
+                database = "postgresql://${cfg.database.user}:$SZURUBOORU_DATABASE_PASSWORD@${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}";
+              }
+            )
+            (lib.filterAttrsRecursive (_: x: x != null))
+          ]
+        );
+        pyenv = python.buildEnv.override {
+          extraLibs = [ (python.pkgs.toPythonModule cfg.server.package) ];
+        };
+      in
+      {
+        description = "Server of Szurubooru, an image board engine dedicated for small and medium communities";
+
+        wantedBy = [
+          "multi-user.target"
+          "szurubooru-client.service"
+        ];
+        before = [ "szurubooru-client.service" ];
+        after = [
+          "network.target"
+          "network-online.target"
+        ];
+        wants = [ "network-online.target" ];
+
+        environment = {
+          PYTHONPATH = "${pyenv}/${pyenv.sitePackages}/";
+        };
+
+        path =
+          with pkgs;
+          [
+            envsubst
+            ffmpeg_4-full
+          ]
+          ++ (with python.pkgs; [
+            alembic
+            waitress
+          ]);
+
+        script = ''
+          export SZURUBOORU_SECRET="$(<${cfg.server.settings.secretFile})"
+          export SZURUBOORU_DATABASE_PASSWORD="$(<${cfg.database.passwordFile})"
+          ${lib.optionalString (cfg.server.settings.smtp.passFile != null) ''
+            export SZURUBOORU_SMTP_PASS=$(<${cfg.server.settings.smtp.passFile})
+          ''}
+          install -m0640 ${cfg.server.package.src}/config.yaml.dist ${cfg.dataDir}/config.yaml.dist
+          envsubst -i ${configFile} -o ${cfg.dataDir}/config.yaml
+          sed 's|script_location = |script_location = ${cfg.server.package.src}/|' ${cfg.server.package.src}/alembic.ini > ${cfg.dataDir}/alembic.ini
+          alembic upgrade head
+          waitress-serve --port ${toString cfg.server.port} --threads ${toString cfg.server.threads} szurubooru.facade:app
+        '';
+
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+
+          Type = "simple";
+          Restart = "on-failure";
+
+          StateDirectory = mkIf (cfg.dataDir == "/var/lib/szurubooru") "szurubooru";
+          WorkingDirectory = cfg.dataDir;
+        };
+      };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ ratcornu ];
+    doc = ./szurubooru.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1372,6 +1372,7 @@ in
   systemd-homed = runTest ./systemd-homed.nix;
   systemtap = handleTest ./systemtap.nix { };
   startx = import ./startx.nix { inherit pkgs runTest; };
+  szurubooru = handleTest ./szurubooru.nix { };
   taler = handleTest ./taler { };
   tandoor-recipes = runTest ./tandoor-recipes.nix;
   tandoor-recipes-script-name = runTest ./tandoor-recipes-script-name.nix;

--- a/nixos/tests/szurubooru.nix
+++ b/nixos/tests/szurubooru.nix
@@ -1,0 +1,52 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+  {
+    name = "szurubooru";
+    meta.maintainers = with lib.maintainers; [ ratcornu ];
+
+    nodes.machine =
+      let
+        dbpass = "changeme";
+      in
+
+      { config, ... }:
+      {
+        services.postgresql = {
+          enable = true;
+          initialScript = pkgs.writeText "init.sql" ''
+            CREATE USER ${config.services.szurubooru.database.user} WITH PASSWORD '${dbpass}';
+            CREATE DATABASE ${config.services.szurubooru.database.name} WITH OWNER ${config.services.szurubooru.database.user};
+          '';
+        };
+
+        services.szurubooru = {
+          enable = true;
+
+          dataDir = "/var/lib/szurubooru";
+
+          server = {
+            port = 6666;
+            settings = {
+              domain = "http://127.0.0.1";
+              secretFile = pkgs.writeText "secret" "secret";
+              debug = 1;
+            };
+          };
+
+          database = {
+            host = "localhost";
+            port = 5432;
+            name = "szurubooru";
+            user = "szurubooru";
+            passwordFile = pkgs.writeText "pass" "${dbpass}";
+          };
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("szurubooru.service")
+      machine.wait_for_open_port(6666)
+      machine.succeed('curl -H "Content-Type: application/json" -H "Accept: application/json" --fail http://127.0.0.1:6666/info')
+    '';
+  }
+)

--- a/pkgs/development/python-modules/heif-image-plugin/default.nix
+++ b/pkgs/development/python-modules/heif-image-plugin/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cffi,
+  piexif,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "heif-image-plugin";
+  version = "0.6.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "uploadcare";
+    repo = "heif-image-plugin";
+    rev = "v${version}";
+    hash = "sha256-SlnnlBscNelNH0XkOenq3nolyqzRMK10SzVii61Moi4=";
+  };
+
+  propagatedBuildInputs = [
+    cffi
+    piexif
+    pillow
+  ];
+
+  meta = {
+    description = "Simple HEIF/HEIC images plugin for Pillow base on pyhief library";
+    homepage = "https://github.com/uploadcare/heif-image-plugin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ratcornu ];
+  };
+}

--- a/pkgs/development/python-modules/pillow-avif-plugin/default.nix
+++ b/pkgs/development/python-modules/pillow-avif-plugin/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  libavif,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "pillow-avif-plugin";
+  version = "1.4.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-hVz1DQP2/Bbh/V42SzzqC3n0v5DTn/ISOWlzXYUeCLo=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+  buildInputs = [ libavif ];
+  propagatedBuildInputs = [ pillow ];
+
+  meta = {
+    description = "Pillow plugin that adds support for AVIF files";
+    homepage = "https://github.com/fdintino/pillow-avif-plugin";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ratcornu ];
+  };
+}

--- a/pkgs/servers/web-apps/szurubooru/client.nix
+++ b/pkgs/servers/web-apps/szurubooru/client.nix
@@ -1,0 +1,36 @@
+{
+  src,
+  version,
+  lib,
+  buildNpmPackage,
+}:
+
+buildNpmPackage {
+  pname = "szurubooru-client";
+  inherit version;
+
+  src = "${src}/client";
+
+  npmDepsHash = "sha256-HtcitZl2idgVleB6c0KCTSNLxh7hP8/G/RGdMaQG3iI=";
+  makeCacheWritable = true;
+
+  npmBuildFlags = [
+    "--gzip"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv ./public/* $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Client of szurubooru, an image board engine for small and medium communities";
+    homepage = "https://github.com/rr-/szurubooru";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ratcornu ];
+  };
+}

--- a/pkgs/servers/web-apps/szurubooru/default.nix
+++ b/pkgs/servers/web-apps/szurubooru/default.nix
@@ -1,0 +1,20 @@
+{
+  callPackage,
+  fetchFromGitHub,
+  recurseIntoAttrs,
+}:
+
+let
+  version = "2.5-unstable-2025-02-11";
+  src = fetchFromGitHub {
+    owner = "rr-";
+    repo = "szurubooru";
+    rev = "376f687c386f65522b2f65e98b998b21af26ee29";
+    hash = "sha256-4w1iOYp+CVg60dYxRilj08D4Hle6R9Y0v+Nd3fws1Zc=";
+  };
+in
+
+recurseIntoAttrs {
+  client = callPackage ./client.nix { inherit src version; };
+  server = callPackage ./server.nix { inherit src version; };
+}

--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -2,6 +2,7 @@
   src,
   version,
   lib,
+  nixosTests,
   fetchPypi,
   python3,
 }:
@@ -72,6 +73,8 @@ python.pkgs.buildPythonApplication {
     mkdir $out/bin
     install -m0755 $src/szuru-admin $out/bin/szuru-admin
   '';
+
+  passthru.tests.szurubooru = nixosTests.szurubooru;
 
   meta = with lib; {
     description = "Server of szurubooru, an image board engine for small and medium communities";

--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -1,0 +1,82 @@
+{
+  src,
+  version,
+  lib,
+  fetchPypi,
+  python3,
+}:
+
+let
+  overrides = [
+    (self: super: {
+      alembic = super.alembic.overridePythonAttrs (oldAttrs: rec {
+        version = "1.14.1";
+        src = fetchPypi {
+          pname = "alembic";
+          inherit version;
+          sha256 = "sha256-SW6IgkWlOt8UmPyrMXE6Rpxlg2+N524BOZqhw+kN0hM=";
+        };
+        doCheck = false;
+      });
+
+      pyheif = super.pyheif.overridePythonAttrs (oldAttrs: {
+        doCheck = false;
+      });
+
+      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
+        version = "1.3.23";
+        src = fetchPypi {
+          pname = "SQLAlchemy";
+          inherit version;
+          sha256 = "sha256-b8ozZyV4Zm9lfBMVUsTviXnBYG5JT3jNUZl0LfsmkYs=";
+        };
+
+        doCheck = false;
+      });
+    })
+  ];
+
+  python = python3.override {
+    self = python;
+    packageOverrides = lib.composeManyExtensions overrides;
+  };
+in
+
+python.pkgs.buildPythonApplication {
+  pname = "szurubooru-server";
+  inherit version;
+  pyproject = true;
+
+  src = "${src}/server";
+
+  nativeBuildInputs = with python.pkgs; [ setuptools ];
+  propagatedBuildInputs = with python.pkgs; [
+    alembic
+    certifi
+    coloredlogs
+    heif-image-plugin
+    numpy
+    pillow-avif-plugin
+    pillow
+    psycopg2-binary
+    pyheif
+    pynacl
+    pyrfc3339
+    pytz
+    pyyaml
+    sqlalchemy
+    yt-dlp
+  ];
+
+  postInstall = ''
+    mkdir $out/bin
+    install -m0755 $src/szuru-admin $out/bin/szuru-admin
+  '';
+
+  meta = with lib; {
+    description = "Server of szurubooru, an image board engine for small and medium communities";
+    homepage = "https://github.com/rr-/szurubooru";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ratcornu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9678,6 +9678,8 @@ with pkgs;
 
   svxlink = libsForQt5.callPackage ../applications/radio/svxlink { };
 
+  szurubooru = callPackage ../servers/web-apps/szurubooru { };
+
   tclap = tclap_1_2;
 
   tclap_1_2 = callPackage ../development/libraries/tclap/1.2.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11370,6 +11370,8 @@ self: super: with self; {
     inherit (pkgs.xorg) libxcb;
   };
 
+  pillow-avif-plugin = callPackage ../development/python-modules/pillow-avif-plugin { };
+
   pillow-heif = callPackage ../development/python-modules/pillow-heif { };
 
   pillow-jpls = callPackage ../development/python-modules/pillow-jpls { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6376,6 +6376,8 @@ self: super: with self; {
 
   hebg = callPackage ../development/python-modules/hebg { };
 
+  heif-image-plugin = callPackage ../development/python-modules/heif-image-plugin { };
+
   help2man = callPackage ../development/python-modules/help2man { };
 
   helpdev = callPackage ../development/python-modules/helpdev { };


### PR DESCRIPTION
[Szurubooru](https://github.com/rr-/szurubooru) is an image board engine inspired by services such as Danbooru dedicated for small and medium communities.

It has been tested with different configurations.

I added a package, some needed python dependencies, a nixos module calling the package, a small documentation of the module and a test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
