### PR TITLE
google-chrome: add libuuid to update script path

### DIFF
--- a/pkgs/by-name/go/google-chrome/update.sh
+++ b/pkgs/by-name/go/google-chrome/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p curl jq gawk libossp_uuid libxml2 nix
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gawk libossp_uuid libuuid libxml2 nix
 # shellcheck shell=bash
 
 set -euo pipefail


### PR DESCRIPTION
```
--- SHOWING ERROR LOG FOR google-chrome-127.0.6533.99 ----------------------

/var/cache/nixpkgs-update/worker/worktree/google-chrome/pkgs/by-name/go/google-chrome/update.sh: line 65: uuidgen: command not found
```

Apparently `ryantm` bot doesn't even have util-linux in its PATH.