### PR TITLE
[staging-next] samsung-unified-linux-driver: fix library path, `with lib;`, `finalAttrs`

### DIFF
--- a/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
+++ b/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
@@ -112,16 +112,16 @@ stdenv.mkDerivation (finalAttrs: {
   # we did this in prefixup already
   dontPatchELF = true;
 
-  meta = with lib; {
+  meta = {
     description = "Unified Linux Driver for Samsung printers and scanners";
     homepage = "http://www.bchemnet.com/suldr";
     downloadPage = "http://www.bchemnet.com/suldr/driver/";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
 
     # Tested on linux-x86_64. Might work on linux-i386.
     # Probably won't work on anything else.
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
+++ b/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
@@ -13,13 +13,13 @@ let
   arch = if stdenv.system == "x86_64-linux" then "x86_64" else "i386";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "samsung-unified-linux-driver";
   version = "1.00.36";
 
   src = fetchurl {
     sha256 = "1a7ngd03x0bkdl7pszy5zqqic0plxvdxqm5w7klr6hbdskx1lir9";
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${version}.tar.gz";
+    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
   };
 
   buildInputs = [
@@ -124,4 +124,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/misc/cups/drivers/samsung/1.00.37.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.37.nix
@@ -12,13 +12,13 @@ let
   arch = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64" else "i386";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "samsung-unified-linux-driver";
   version = "1.00.37";
 
   src = fetchurl {
     sha256 = "0r66l9zp0p1qgakh4j08hynwsr4lsgq5yrpxyr0x4ldvl0z2b1bb";
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${version}.tar.gz";
+    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
   };
 
   buildInputs = [
@@ -105,4 +105,4 @@ stdenv.mkDerivation rec {
     # Probably won't work on anything else.
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/misc/cups/drivers/samsung/1.00.37.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.37.nix
@@ -94,15 +94,15 @@ stdenv.mkDerivation (finalAttrs: {
   # we did this in prefixup already
   dontPatchELF = true;
 
-  meta = with lib; {
+  meta = {
     description = "Unified Linux Driver for Samsung printers and scanners";
     homepage = "http://www.bchemnet.com/suldr";
     downloadPage = "http://www.bchemnet.com/suldr/driver/";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
 
     # Tested on linux-x86_64. Might work on linux-i386.
     # Probably won't work on anything else.
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -33,7 +33,7 @@ let
     + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib${appendPath}";
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "samsung-UnifiedLinuxDriver";
+  pname = "samsung-unified-linux-driver";
   version = "4.01.17";
 
   src = fetchurl {

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -30,7 +30,7 @@ let
       cups
       libusb-compat-0_1
     ]
-    + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib${appendPath}";
+    + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "samsung-unified-linux-driver";

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -92,12 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
     "rastertospl"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Samsung's Linux printing drivers; includes binaries without source code";
     homepage = "http://www.samsung.com/";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ joko ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ joko ];
   };
 })

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -32,12 +32,12 @@ let
     ]
     + ":$out/lib:${lib.getLib stdenv.cc.cc}/lib${appendPath}";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "samsung-UnifiedLinuxDriver";
   version = "4.01.17";
 
   src = fetchurl {
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${version}.tar.gz";
+    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
     sha256 = "1vv3pzvqpg1dq3xjr8161x2yp3v7ca75vil56ranhw5pkjwq66x0";
   };
 
@@ -100,4 +100,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ joko ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/380325 changed some library paths in `stdenv.cc.cc`.  `samsung-unified-linux-driver` v4.01.17 uses these paths to find `libstdc++.so` (and possibly more), and thus got broken by that change.

The pull request at hand adapts the build recipe of `samsung-unified-linux-driver` to use the new paths.  It also renames the derivation (`name` attribute) so that it matches the names of the other `samsung-unified-linux-driver` versions.

Furthermore, it [removes `with lib;` from `meta`](https://github.com/NixOS/nixpkgs/issues/371862) and replaces `rec` with the `finalAttrs` pattern in all three `samsung-unified-linux-driver` derivations.

Notifying maintainer of newest version (the other versions have no maintainer): @jokogr

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc