### PR TITLE
 python3Packages.unsloth: init at 2025.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9903,6 +9903,12 @@
     githubId = 57007241;
     name = "hogcycle";
   };
+  hoh = {
+    email = "git@hugoherter.com";
+    github = "hoh";
+    githubId = 404665;
+    name = "Hugo Herter";
+  };
   holgerpeters = {
     name = "Holger Peters";
     email = "holger.peters@posteo.de";

--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  torch,
+  triton,
+
+  # optional-dependencies
+  accelerate,
+  datasets,
+  fire,
+  huggingface-hub,
+  pandas,
+  pytestCheckHook,
+  pythonAtLeast,
+  tqdm,
+  transformers,
+}:
+
+buildPythonPackage {
+  pname = "cut-cross-entropy";
+  version = "25.3.1";
+  pyproject = true;
+
+  # The `ml-cross-entropy` Pypi comes from a third-party.
+  # Apple recommends installing from the repo's main branch directly
+  src = fetchFromGitHub {
+    owner = "apple";
+    repo = "ml-cross-entropy";
+    rev = "24fbe4b5dab9a6c250a014573613c1890190536c"; # no tags
+    hash = "sha256-BVPon+T7chkpozX/IZU3KZMw1zRzlYVvF/22JWKjT2Y=";
+  };
+
+  # Python 3.13 support requires PyTorch 2.6, which is not merged into master yet
+  # https://github.com/NixOS/nixpkgs/pull/377785
+  disabled = pythonAtLeast "3.13";
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    torch
+    triton
+  ];
+
+  optional-dependencies = {
+    transformers = [ transformers ];
+    all = [
+      accelerate
+      datasets
+      fire
+      huggingface-hub
+      pandas
+      tqdm
+      transformers
+    ];
+    # `deepspeed` is not yet packaged in nixpkgs
+    # ++ lib.optionals (!stdenv.isDarwin) [
+    #   deepspeed
+    # ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "cut_cross_entropy"
+  ];
+
+  meta = {
+    description = "Memory-efficient cross-entropy loss implementation using Cut Cross-Entropy (CCE)";
+    homepage = "https://github.com/apple/ml-cross-entropy";
+    license = lib.licenses.aml;
+    maintainers = with lib.maintainers; [ hoh ];
+  };
+}

--- a/pkgs/development/python-modules/trl/default.nix
+++ b/pkgs/development/python-modules/trl/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  accelerate,
+  datasets,
+  rich,
+  transformers,
+}:
+
+buildPythonPackage rec {
+  pname = "trl";
+  version = "0.15.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "trl";
+    tag = "v${version}";
+    hash = "sha256-HsSmFXFqDOWVLa6VXdPZVS9C3bjYcsliR0TwNpPiQx4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    accelerate
+    datasets
+    rich
+    transformers
+  ];
+
+  # Many tests require internet access.
+  doCheck = false;
+
+  pythonImportsCheck = [ "trl" ];
+
+  meta = {
+    description = "Train transformer language models with reinforcement learning";
+    homepage = "https://github.com/huggingface/trl";
+    changelog = "https://github.com/huggingface/trl/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hoh ];
+  };
+}

--- a/pkgs/development/python-modules/tyro/default.nix
+++ b/pkgs/development/python-modules/tyro/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  docstring-parser,
+  rich,
+  shtab,
+  typeguard,
+  typing-extensions,
+
+  # tests
+  attrs,
+  flax,
+  jax,
+  ml-collections,
+  omegaconf,
+  pydantic,
+  pytestCheckHook,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "tyro";
+  version = "0.9.19";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "brentyi";
+    repo = "tyro";
+    tag = "v${version}";
+    hash = "sha256-A1Vplc84Xy8TufqmklPUzIdgiPpFcIjqV0eUgdKmYRM=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    docstring-parser
+    rich
+    shtab
+    typeguard
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    attrs
+    flax
+    jax
+    ml-collections
+    omegaconf
+    pydantic
+    pytestCheckHook
+    torch
+  ];
+
+  pythonImportsCheck = [ "tyro" ];
+
+  meta = {
+    description = "CLI interfaces & config objects, from types";
+    homepage = "https://github.com/brentyi/tyro";
+    changelog = "https://github.com/brentyi/tyro/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hoh ];
+  };
+}

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  accelerate,
+  cut-cross-entropy,
+  datasets,
+  hf-transfer,
+  huggingface-hub,
+  packaging,
+  peft,
+  psutil,
+  sentencepiece,
+  torch,
+  tqdm,
+  transformers,
+  trl,
+  tyro,
+}:
+
+buildPythonPackage rec {
+  pname = "unsloth-zoo";
+  version = "2025.4.1";
+  pyproject = true;
+
+  # no tags on GitHub
+  src = fetchPypi {
+    pname = "unsloth_zoo";
+    inherit version;
+    hash = "sha256-mRs/NMCNJWT52S7mtbQI332IQR6+/IaL29XmtMOz3fE=";
+  };
+
+  # pyproject.toml requires an obsolete version of protobuf,
+  # but it is not used.
+  # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
+  pythonRelaxDeps = [
+    "protobuf"
+  ];
+
+  patches = [
+    # Avoid circular dependency in Nix, since `unsloth` depends on `unsloth-zoo`.
+    ./dont-require-unsloth.patch
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    accelerate
+    cut-cross-entropy
+    datasets
+    hf-transfer
+    huggingface-hub
+    packaging
+    peft
+    psutil
+    sentencepiece
+    torch
+    tqdm
+    transformers
+    trl
+    tyro
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "unsloth_zoo"
+  ];
+
+  meta = {
+    description = "Utils for Unsloth";
+    homepage = "https://github.com/unslothai/unsloth_zoo";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hoh ];
+  };
+}

--- a/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
+++ b/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
@@ -1,0 +1,18 @@
+diff --git a/unsloth_zoo/__init__.py b/unsloth_zoo/__init__.py
+--- a/unsloth_zoo/__init__.py
++++ b/unsloth_zoo/__init__.py
+@@ -17,14 +17,10 @@
+ __version__ = "2025.3.17"
+ 
+ from importlib.util import find_spec
+-if find_spec("unsloth") is None:
+-    raise ImportError("Please install Unsloth via `pip install unsloth`!")
+ pass
+ del find_spec
+ 
+ import os
+-if not ("UNSLOTH_IS_PRESENT" in os.environ):
+-    raise ImportError("Please install Unsloth via `pip install unsloth`!")
+ pass
+ 
+ try:

--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  bitsandbytes,
+  numpy,
+  packaging,
+  torch,
+  unsloth-zoo,
+  xformers,
+  tyro,
+  transformers,
+  datasets,
+  sentencepiece,
+  tqdm,
+  accelerate,
+  trl,
+  peft,
+  protobuf,
+  huggingface-hub,
+  hf-transfer,
+  diffusers,
+  torchvision,
+}:
+
+buildPythonPackage rec {
+  pname = "unsloth";
+  version = "2025.4.1";
+  pyproject = true;
+
+  # Tags on the GitHub repo don't match
+  src = fetchPypi {
+    pname = "unsloth";
+    inherit version;
+    hash = "sha256-9LtDGfdWH7R3U/xi+aK3V4zA+vs83S6Cp0F2NQKvSdY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    bitsandbytes
+    numpy
+    packaging
+    torch
+    unsloth-zoo
+    xformers
+    tyro
+    transformers
+    datasets
+    sentencepiece
+    tqdm
+    accelerate
+    trl
+    peft
+    protobuf
+    huggingface-hub
+    hf-transfer
+    diffusers
+    torchvision
+  ];
+
+  # pyproject.toml requires an obsolete version of protobuf,
+  # but it is not used.
+  # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
+  pythonRelaxDeps = [
+    "protobuf"
+  ];
+
+  # The source repository contains no test
+  doCheck = false;
+
+  # Importing requires a GPU, else the following error is raised:
+  # NotImplementedError: Unsloth: No NVIDIA GPU found? Unsloth currently only supports GPUs!
+  dontUsePythonImportsCheck = true;
+
+  meta = {
+    description = "Finetune Llama 3.3, DeepSeek-R1 & Reasoning LLMs 2x faster with 70% less memory";
+    homepage = "https://github.com/unslothai/unsloth";
+    changelog = "https://github.com/unslothai/unsloth/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hoh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18277,6 +18277,8 @@ self: super: with self; {
 
   typst = callPackage ../development/python-modules/typst { };
 
+  tyro = callPackage ../development/python-modules/tyro { };
+
   tzdata = callPackage ../development/python-modules/tzdata { };
 
   tzlocal = callPackage ../development/python-modules/tzlocal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18433,6 +18433,8 @@ self: super: with self; {
 
   unrpa = callPackage ../development/python-modules/unrpa { };
 
+  unsloth-zoo = callPackage ../development/python-modules/unsloth-zoo { };
+
   unstructured = callPackage ../development/python-modules/unstructured { };
 
   unstructured-api-tools = callPackage ../development/python-modules/unstructured-api-tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18433,6 +18433,8 @@ self: super: with self; {
 
   unrpa = callPackage ../development/python-modules/unrpa { };
 
+  unsloth = callPackage ../development/python-modules/unsloth { };
+
   unsloth-zoo = callPackage ../development/python-modules/unsloth-zoo { };
 
   unstructured = callPackage ../development/python-modules/unstructured { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17667,6 +17667,8 @@ self: super: with self; {
 
   tritonclient = callPackage ../development/python-modules/tritonclient { };
 
+  trl = callPackage ../development/python-modules/trl { };
+
   trlib = toPythonModule (
     pkgs.trlib.override {
       pythonSupport = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3042,6 +3042,8 @@ self: super: with self; {
 
   customtkinter = callPackage ../development/python-modules/customtkinter { };
 
+  cut-cross-entropy = callPackage ../development/python-modules/cut-cross-entropy { };
+
   cvelib = callPackage ../development/python-modules/cvelib { };
 
   cvss = callPackage ../development/python-modules/cvss { };


### PR DESCRIPTION
This packages [Unsloth](https://unsloth.ai/), a reference library for LLM fine tuning, into nixpkgs.

A few dependencies were missing from `nixpkgs` and are included in this branch.

Version numbering proved slightly challenging in this branch, which is why I open it as Draft first. In all cases, the GitHub source was chosen over the PyPI files.

- Version numbering of `unsloth` [on PyPI](https://pypi.org/project/unsloth/#history) does not mach versioning [on GitHub](https://github.com/unslothai/unsloth/releases).
- `unsloth-zoo` has no tag or release [on GitHub](https://github.com/unslothai/unsloth-zoo/), only [on PyPI](https://pypi.org/project/unsloth-zoo/).
- `cut-cross-entropy` is authored by Apple [on GitHub](https://github.com/apple/ml-cross-entropy/), but uploaded by a third party [on PyPI](https://pypi.org/project/cut-cross-entropy/).
- `trl` No remark
- `tyro` No remark

Issue: https://github.com/NixOS/nixpkgs/pull/388735

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
