### PR TITLE
lib.modules: simplified logic in usage of zipAttrsWith and minor cleanup

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -320,7 +320,6 @@ let
         prefix ? [],
         }:
           evalModules (evalModulesArgs // {
-            inherit class;
             modules = regularModules ++ modules;
             specialArgs = evalModulesArgs.specialArgs or {} // specialArgs;
             prefix = extendArgs.prefix or evalModulesArgs.prefix or [];
@@ -335,8 +334,7 @@ let
         options = checked options;
         config = checked (removeAttrs config [ "_module" ]);
         _module = checked (config._module);
-        inherit extendModules type;
-        class = class;
+        inherit extendModules type class;
       };
     in result;
 
@@ -602,7 +600,7 @@ let
       # an attrset 'name' => list of submodules that declare ‘name’.
       declsByName =
         zipAttrsWith
-          (n: concatLists)
+          (n: v: v)
           (map
             (module: let subtree = module.options; in
               if !(isAttrs subtree) then
@@ -614,7 +612,7 @@ let
               else
                 mapAttrs
                   (n: option:
-                    [{ inherit (module) _file; pos = unsafeGetAttrPos n subtree; options = option; }]
+                    { inherit (module) _file; pos = unsafeGetAttrPos n subtree; options = option; }
                   )
                   subtree
               )
@@ -657,12 +655,12 @@ let
       # extract the definitions for each loc
       rawDefinitionsByName =
         zipAttrsWith
-          (n: concatLists)
+          (n: v: v)
           (map
             (module:
               mapAttrs
                 (n: value:
-                  [{ inherit (module) file; inherit value; }]
+                  { inherit (module) file; inherit value; }
                 )
                 module.config
             )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Changes

I removed unnecessary code: the `inherit class` is not needed because class is already included in `evalModulesArgs`, which we are updating.
I also removed (in two places) an unnecessary singleton list paired in a `zipAttrsWith` that uses `concatLists` to merge the values. To me it looks like an unnecessary complication, but let me know if I'm wrong.

## Performance testing

I thought someone might've done it this way because of some weird performance reason, but when testing with a simple configuration the time was very similar (uncomparable) and the RAM usage seems to have gone slightly down.
The command I used was:
```bash
NIX_SHOW_STATS=1 NIX_PATH=nixpkgs=$PWD:nixos-config=/path/to/config.nix nix-instantiate '<nixpkgs/nixos>' -A system --eval
```

The bytes of `envs` after the change are higher, but the bytes of the other elements are either the same or lower (if summed up, after the changes the total is lower).
```bash
# envs - list - sets - symbols - values
93131832+13281416+275040016+1025990+253167720 = 635646974 # Before
93923000+12609096+274969520+1025990+251583648 = 634111254 # After

781223136 # gc.totalBytes Before
779688016 # gc.totalBytes After
```

Config used (with a bit less whitespace, if that's relevant):
```nix
{ pkgs, ... }:
{
  boot.loader.systemd-boot.enable = true;
  boot.loader.efi.canTouchEfiVariables = true;
  users.users.alice = {
    isNormalUser = true;
    extraGroups = [ "wheel" ];
    initialPassword = "test";
  };
  environment.systemPackages = with pkgs; [
    cowsay
    lolcat
  ];
  fileSystems."/" = {
    device = "/dev/disk/by-name/nixos";
    fsType = "ext4";
  };
  fileSystems."/boot" = {
    device = "/dev/disk/by-name/boot";
    fsType = "vfat";
  };
  system.stateVersion = "25.05";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
