### PR TITLE
ecc-rs: use `set` instead of `prefix` in wrapper

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -341,6 +341,7 @@ in {
   early-mount-options = handleTest ./early-mount-options.nix {};
   ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};
   ec2-nixops = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-nixops or {};
+  ecc = handleTest ./ecc.nix {};
   echoip = handleTest ./echoip.nix {};
   ecryptfs = handleTest ./ecryptfs.nix {};
   fscrypt = handleTest ./fscrypt.nix {};

--- a/nixos/tests/ecc.nix
+++ b/nixos/tests/ecc.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  let
+    # Well, we _can_ cross-compile from Linux :)
+    compileResult = pkgs.runCommand "empty.bpf.o" { } ''
+      touch empty.bpf.c
+      ${pkgs.ecc}/bin/ecc-rs empty.bpf.c
+      cp empty.bpf.o $out
+    '';
+  in
+  {
+    name = "ecc-rs";
+
+    meta.maintainers = with lib.maintainers; [ oluceps ];
+
+    nodes.machine = { };
+
+    testScript = ''
+      start_all()
+      machine.succeed("cat ${compileResult} >out")
+      machine.succeed("shutdown")
+    '';
+  }
+)

--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -6,6 +6,8 @@
   pkg-config,
   elfutils,
   zlib,
+  gnused,
+  bash,
 }:
 let
   inherit (rustPackages.rustc) llvmPackages;
@@ -112,15 +114,16 @@ rustPlatform.buildRustPackage rec {
 
   postFixup = ''
     wrapProgram $out/bin/ecc-rs \
-      --prefix LIBCLANG_PATH : ${lib.getLib llvmPackages.libclang}/lib \
-      --prefix PATH : ${
-        lib.makeBinPath (
-          with llvmPackages;
-          [
-            clang
-            bintools-unwrapped
-          ]
-        )
+      --unset NIX_HARDENING_ENABLE \
+      --set LIBCLANG_PATH ${lib.getLib llvmPackages.libclang}/lib \
+      --set-default EUNOMIA_HOME "\$HOME/.local/share/eunomia" \
+      --set PATH ${
+        lib.makeBinPath [
+          llvmPackages.clang
+          llvmPackages.bintools-unwrapped
+          gnused
+          bash
+        ]
       }
   '';
 

--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -8,6 +8,7 @@
   zlib,
   gnused,
   bash,
+  nixosTests,
 }:
 let
   inherit (rustPackages.rustc) llvmPackages;
@@ -126,6 +127,8 @@ rustPlatform.buildRustPackage rec {
         ]
       }
   '';
+
+  passthru.tests = { inherit (nixosTests) ecc; };
 
   meta = with lib; {
     homepage = "https://eunomia.dev";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix #388518

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
