### PR TITLE
nixos/boot/systemd: enable tracefs

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -88,6 +88,7 @@ let
       "sys-fs-fuse-connections.mount"
       ] ++ (optional (!config.boot.isContainer) "sys-kernel-config.mount") ++ [
       "sys-kernel-debug.mount"
+      "sys-kernel-tracing.mount"
 
       # Maintaining state across reboots.
       "systemd-random-seed.service"


### PR DESCRIPTION
`tracefs` is a special-purpose filesystem in Linux used for tracing filesystem and kernel operations.

This was added to the kernel back in 2015 to replace debugfs. For security reasons, some system do not mount debugfs at all. Tracefs reduces the attack surface by allowing to trace without mounting debugfs. Additionally it provides features not supported by debugfs (such as calls for mkdir and rmdir

Debian and Arch Linux both enable this by default. RHEL 8 and later, they enable tracefs by default.

Closes https://github.com/NixOS/nixpkgs/issues/388743

Just enabling `tracefs` should be a non-breaking change.