### PR TITLE
unity-test: refactor, add configuration options, pkg-config output, and check phase

### DIFF
--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -10,6 +10,8 @@
   ruby,
   validatePkgConfig,
   testers,
+  unity-test,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,56 +21,57 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "iniparser";
     repo = "iniparser";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-z10S9ODLprd7CbL5Ecgh7H4eOwTetYwFXiWBUm6fIr4=";
   };
 
-  patches = lib.optionals finalAttrs.finalPackage.doCheck [
-    (replaceVars ./remove-fetchcontent-usage.patch {
-      # Do not let cmake's fetchContent download unity
-      unitySrc = symlinkJoin {
-        paths = [
-          (fetchFromGitHub {
-            owner = "throwtheswitch";
-            repo = "unity";
-            rev = "v2.6.0";
-            hash = "sha256-SCcUGNN/UJlu3ALJiZ9bQKxYRZey3cm9QG+NOehp6Ow=";
-          })
-        ];
-        postBuild = ''
-          ln -s ${finalAttrs.src}/test/unity_config.h $out/src/unity_config.h
-        '';
-      };
-    })
-  ];
+  patches = lib.optional finalAttrs.doCheck (
+    # 1. Do not fetch the Unity GitHub repository
+    # 2. Lookup the Unity pkgconfig file
+    # 3. Get the generate_test_runner.rb file from the Unity share directory
+    replaceVars ./remove-fetchcontent-usage.patch {
+      # Get the test generator
+      UNITY-GENERATE-TEST-RUNNER = "${unity-test}/share/generate_test_runner.rb";
+    }
+  );
 
   nativeBuildInputs = [
     cmake
     doxygen
     validatePkgConfig
-  ] ++ lib.optionals finalAttrs.finalPackage.doCheck [ ruby ];
+  ];
 
-  cmakeFlags = [ "-DBUILD_TESTING=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}" ];
-
-  doCheck = false;
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
+  ];
+  doCheck = true;
+  nativeCheckInputs = [
+    ruby
+    ctestCheckHook
+  ];
+  checkInputs = [
+    (
+      (unity-test.override {
+        supportDouble = true;
+      }).overrideAttrs
+      {
+        doCheck = false;
+      }
+    )
+  ];
 
   postFixup = ''
     ln -sv $out/include/iniparser/*.h $out/include/
   '';
 
-  passthru.tests = {
-    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-    iniparser-with-tests = finalAttrs.overrideAttrs (_: {
-      doCheck = true;
-    });
-  };
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.com/iniparser/iniparser";
     description = "Free standalone ini file parsing library";
     changelog = "https://gitlab.com/iniparser/iniparser/-/releases/v${finalAttrs.version}";
-    license = licenses.mit;
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
     pkgConfigModules = [ "iniparser" ];
     maintainers = [ ];
   };

--- a/pkgs/by-name/in/iniparser/remove-fetchcontent-usage.patch
+++ b/pkgs/by-name/in/iniparser/remove-fetchcontent-usage.patch
@@ -1,17 +1,52 @@
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
-index b28d151..33a6bcf 100644
+index 0735d27..32c5cdb 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -28,10 +28,8 @@ set(FETCHCONTENT_QUIET OFF)
+@@ -26,16 +26,8 @@ endif()
  
- FetchContent_Declare(
-   unity
+ set(FETCHCONTENT_QUIET OFF)
+ 
+-FetchContent_Declare(
+-  unity
 -  GIT_REPOSITORY "https://github.com/throwtheswitch/unity.git"
 -  GIT_PROGRESS TRUE
 -  PATCH_COMMAND ${CMAKE_COMMAND} -E copy
 -                ${CMAKE_CURRENT_LIST_DIR}/unity_config.h ./src/)
-+  SOURCE_DIR @unitySrc@
-+)
+-
+-FetchContent_MakeAvailable(unity)
+-target_compile_definitions(unity PUBLIC UNITY_INCLUDE_CONFIG_H
+-                                        UNITY_USE_COMMAND_LINE_ARGS)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(UNITY REQUIRED unity)
  
- FetchContent_MakeAvailable(unity)
- target_compile_definitions(unity PUBLIC UNITY_INCLUDE_CONFIG_H)
+ function(create_test_runner)
+   set(options)
+@@ -52,7 +44,7 @@ function(create_test_runner)
+   add_custom_command(
+     OUTPUT test_${TEST_RUNNER_NAME}_runner.c
+     COMMAND
+-      ${RUBY_EXECUTABLE} ${unity_SOURCE_DIR}/auto/generate_test_runner.rb
++      @UNITY-GENERATE-TEST-RUNNER@
+       ${CMAKE_CURRENT_SOURCE_DIR}/test_${TEST_RUNNER_NAME}.c
+       test_${TEST_RUNNER_NAME}_runner.c ${CMAKE_CURRENT_LIST_DIR}/unity-config.yml
+     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test_${TEST_RUNNER_NAME}.c
+@@ -62,10 +54,18 @@ function(create_test_runner)
+                                           test_${TEST_RUNNER_NAME}_runner.c)
+   foreach(TARGET_TYPE ${TARGET_TYPES})
+     # if BUILD_STATIC_LIBS=ON shared takes precedence
++    target_include_directories(
++      test_${TEST_RUNNER_NAME}
++      PUBLIC
++      ${UNITY_INCLUDE_DIRS})
++    target_compile_options(
++      test_${TEST_RUNNER_NAME}
++      PUBLIC
++      ${UNITY_CFLAGS_OTHER})
+     target_link_libraries(
+       test_${TEST_RUNNER_NAME}
+       ${PROJECT_NAME}-${TARGET_TYPE}
+-      unity)
++      ${UNITY_LIBRARIES})
+   endforeach()
+ endfunction()
+ 

--- a/pkgs/by-name/un/unity-test/meson.patch
+++ b/pkgs/by-name/un/unity-test/meson.patch
@@ -1,0 +1,18 @@
+diff --git a/meson.build b/meson.build
+index 6585129..9489aef 100644
+--- a/meson.build
++++ b/meson.build
+@@ -64,10 +64,10 @@ unity_dep = declare_dependency(
+ if not meson.is_subproject()
+   pkg = import('pkgconfig')
+   pkg.generate(
+-    name: meson.project_name(),
++    unity_lib,
+     version: meson.project_version(),
+-    libraries: [ unity_lib ],
+-    description: 'C Unit testing framework.'
++    subdirs: 'unity',
++    extra_cflags: unity_args,
+   )
+ endif
+ 

--- a/pkgs/by-name/un/unity-test/package.nix
+++ b/pkgs/by-name/un/unity-test/package.nix
@@ -2,9 +2,33 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  cmake,
-}:
+  fetchpatch2,
+  meson,
+  ninja,
+  ruby,
+  python3Minimal,
+  nix-update-script,
+  testers,
+  iniparser,
+  validatePkgConfig,
+  # Adds test groups and extra CLI flags.
+  buildFixture ? false,
+  # Adds the ablilty to track malloc and free calls.
+  # Note that if fixtures are enabled, this option is ignored
+  # and will always be enabled.
+  buildMemory ? buildFixture,
+  # Adds double precision floating point assertions
+  supportDouble ? false,
 
+}:
+let
+  # On newer versions of Clang, Weverything is too much of everything.
+  ignoredErrors = [
+    "-Wno-unsafe-buffer-usage"
+    "-Wno-reserved-identifier"
+    "-Wno-extra-semi-stmt"
+  ];
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "unity-test";
   version = "2.6.1";
@@ -16,13 +40,85 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-g0ubq7RxGQmL1R6vz9RIGJpVWYsgrZhsTWSrL1ySEug=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  patches = [
+    # The meson file does not have the subdir set correctly
+    (fetchpatch2 {
+      url = "https://patch-diff.githubusercontent.com/raw/ThrowTheSwitch/Unity/pull/771.patch";
+      hash = "sha256-r8ldVb7WrzVwTC2CtGul9Jk4Rzt+6ejk+paYAfFlR5M=";
+    })
+    # Fix up the shebangs in the auto directory as not all are correct
+    (fetchpatch2 {
+      url = "https://patch-diff.githubusercontent.com/raw/ThrowTheSwitch/Unity/pull/790.patch";
+      hash = "sha256-K+OxMe/ZMXPPjZXjGhgc5ULLN7plBwL0hV5gwmgA3FM=";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs --build auto
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    meson
+    ninja
+    python3Minimal
+    validatePkgConfig
+  ];
+
+  # For the helper shebangs
+  buildInputs = [
+    python3Minimal
+    ruby
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "extension_memory" buildMemory)
+    (lib.mesonBool "extension_fixture" buildFixture)
+    (lib.mesonBool "support_double" supportDouble)
+  ];
+
   doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    make -C../test -j $NIX_BUILD_CORES ${lib.optionalString stdenv.cc.isClang "CC=clang"} E="-Weverything ${lib.escapeShellArgs ignoredErrors}" test
+
+    runHook postCheck
+  '';
+
+  # Various helpers
+  postInstall = ''
+    mkdir -p "$out/share"
+    install -Dm755 ../auto/* -t "$out/share/"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit iniparser;
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+        versionCheck = true;
+      };
+    };
+  };
 
   meta = {
     description = "Unity Unit Testing Framework";
     homepage = "https://www.throwtheswitch.org/unity";
+    changelog = "https://github.com/ThrowTheSwitch/Unity/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.i01011001 ];
+    platforms = lib.platforms.all;
+    pkgConfigModules = [ "unity" ];
+    maintainers = with lib.maintainers; [
+      i01011001
+      RossSmyth
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The unity-test package was recently added in #381665, which is great. But I think it could be improved slightly. Mainly to add pkg-config output so that cmake doesn't have to be pulled in to builds that don't require it.

## Things done

### Unity

1. Add build configuration options to the Unity package 
2. Add patch so the pkg-config is generated correctly
3. Add patch so that patchShebangs works correctly for the user tools
4. Add a dev output
5. Use Meson
6. Add checkPhase
7. On Darwin use the Clang tests
8. Install the helpers to the share directory
9. Add some passthru tests

### iniparser

1. Add unity-test from nixpkgs rather than pulling it from github
2. Add ctestCheckHook
3. Update patch to lookup unity-test via pkgconfig
4. Move checkPhase inputs to `nativeCheckInputs` and `checkInputs`
5. Enable checkPhase by default, as it runs very fast so there's not much reason to run it as a separate passthru test

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
