### PR TITLE
nixos/startx: try to improve UX

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -272,6 +272,9 @@
   "sec-x11-auto-login": [
     "index.html#sec-x11-auto-login"
   ],
+  "sec-x11-startx": [
+    "index.html#sec-x11-startx"
+  ],
   "sec-x11--graphics-cards-intel": [
     "index.html#sec-x11--graphics-cards-intel"
   ],

--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -49,10 +49,5 @@ in
       );
       serviceConfig.Restart = "always";
     };
-
-    warnings = lib.mkIf (config.services.xserver.displayManager.startx.enable) [
-      "xss-lock service only works if a displayManager is set; it doesn't work when services.xserver.displayManager.startx.enable = true"
-    ];
-
   };
 }

--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -5,11 +5,15 @@
   ...
 }:
 
-with lib;
-
 let
 
   cfg = config.services.xserver.displayManager.startx;
+
+  # WM session script
+  # Note: this assumes a single WM has been enabled
+  sessionScript = lib.concatMapStringsSep "\n" (
+    i: i.start
+  ) config.services.xserver.windowManager.session;
 
 in
 
@@ -19,40 +23,93 @@ in
 
   options = {
     services.xserver.displayManager.startx = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
-          Whether to enable the dummy "startx" pseudo-display manager,
-          which allows users to start X manually via the "startx" command
-          from a vt shell. The X server runs under the user's id, not as root.
-          The user must provide a ~/.xinitrc file containing session startup
-          commands, see {manpage}`startx(1)`. This is not automatically generated
-          from the desktopManager and windowManager settings.
+          Whether to enable the dummy "startx" pseudo-display manager, which
+          allows users to start X manually via the `startx` command from a
+          virtual terminal.
+
+          ::: {.note}
+          The X server will run under the current user, not as root.
+          :::
         '';
       };
+
+      generateScript = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to generate the system-wide xinitrc script (/etc/X11/xinit/xinitrc).
+          This script will take care of setting up the session for systemd user
+          services, running the window manager and cleaning up on exit.
+
+          ::: {.note}
+          This script will only be used by `startx` when both `.xinitrc` does not
+          exists and the `XINITRC` environment variable is unset.
+          :::
+        '';
+      };
+
+      extraCommands = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Shell commands to be added to the system-wide xinitrc script.
+        '';
+      };
+
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
-    services.xserver = {
-      exportConfiguration = true;
-    };
+  config = lib.mkIf cfg.enable {
+    services.xserver.exportConfiguration = true;
 
     # Other displayManagers log to /dev/null because they're services and put
     # Xorg's stdout in the journal
     #
     # To send log to Xorg's default log location ($XDG_DATA_HOME/xorg/), we do
     # not specify a log file when running X
-    services.xserver.logFile = mkDefault null;
+    services.xserver.logFile = lib.mkDefault null;
 
     # Implement xserverArgs via xinit's system-wide xserverrc
     environment.etc."X11/xinit/xserverrc".source = pkgs.writeShellScript "xserverrc" ''
-      exec ${pkgs.xorg.xorgserver}/bin/X ${toString config.services.xserver.displayManager.xserverArgs} "$@"
+      exec ${pkgs.xorg.xorgserver}/bin/X \
+        ${toString config.services.xserver.displayManager.xserverArgs} "$@"
     '';
+
+    # Add a sane system-wide xinitrc script
+    environment.etc."X11/xinit/xinitrc".source = lib.mkIf cfg.generateScript (
+      pkgs.writeShellScript "xinitrc" ''
+        ${cfg.extraCommands}
+
+        # start user services
+        systemctl --user import-environment DISPLAY XDG_SESSION_ID
+        systemctl --user start nixos-fake-graphical-session.target
+
+        # run the window manager script
+        ${sessionScript}
+        wait $waitPID
+
+        # stop services and all subprocesses
+        systemctl --user stop nixos-fake-graphical-session.target
+        kill 0
+      ''
+    );
+
     environment.systemPackages = with pkgs; [ xorg.xinit ];
+
+    # Make graphical-session fail if the user environment has not been imported
+    systemd.user.targets.graphical-session = {
+      unitConfig.AssertEnvironment = [
+        "DISPLAY"
+        "XDG_SESSION_ID"
+      ];
+    };
+
   };
 
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1136,6 +1136,7 @@ in {
   systemd-userdbd = handleTest ./systemd-userdbd.nix {};
   systemd-homed = handleTest ./systemd-homed.nix {};
   systemtap = handleTest ./systemtap.nix {};
+  startx = runTest ./startx.nix;
   taler = handleTest ./taler {};
   tandoor-recipes = handleTest ./tandoor-recipes.nix {};
   tandoor-recipes-script-name = handleTest ./tandoor-recipes-script-name.nix {};

--- a/nixos/tests/startx.nix
+++ b/nixos/tests/startx.nix
@@ -1,0 +1,108 @@
+{ lib, ... }:
+
+{
+  name = "startx";
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.getty.autologinUser = "root";
+
+      environment.systemPackages = with pkgs; [
+        xdotool
+        catclock
+      ];
+
+      programs.bash.promptInit = "PS1='# '";
+
+      # startx+bspwm setup
+      services.xserver = {
+        enable = true;
+        windowManager.bspwm = {
+          enable = true;
+          configFile = pkgs.writeShellScript "bspwrc" ''
+            bspc config border_width 2
+            bspc config window_gap 12
+            bspc rule -a xclock state=floating sticky=on
+          '';
+          sxhkd.configFile = pkgs.writeText "sxhkdrc" ''
+            # open a terminal
+            super + Return
+              urxvtc
+            # quit bspwm
+            super + alt + Escape
+              bspc quit
+          '';
+        };
+        displayManager.startx = {
+          enable = true;
+          generateScript = true;
+          extraCommands = ''
+            xrdb -load ~/.Xresources
+            xsetroot -solid '#343d46'
+            xsetroot -cursor_name trek
+            xclock &
+          '';
+        };
+      };
+
+      # enable some user services
+      security.polkit.enable = true;
+      services.urxvtd.enable = true;
+      programs.xss-lock.enable = true;
+    };
+
+  testScript = ''
+    import textwrap
+
+    sysu = "env XDG_RUNTIME_DIR=/run/user/0 systemctl --user";
+    prompt = "# "
+
+    with subtest("Wait for the autologin"):
+        machine.wait_until_tty_matches("1", prompt)
+
+    with subtest("Setup dotfiles"):
+        machine.execute(textwrap.dedent("""
+          cat <<EOF > ~/.Xresources
+            urxvt*foreground: #9b9081
+            urxvt*background: #181b20
+            urxvt*scrollBar:  false
+            urxvt*title:      myterm
+            urxvt*geometry:   80x240+0+0
+            xclock*geometry:  164x164+24+440
+          EOF
+        """))
+
+    with subtest("Can start the X server"):
+        machine.send_chars("startx\n")
+        machine.wait_for_x()
+        machine.wait_for_window("xclock")
+
+    with subtest("Graphical services are running"):
+        machine.succeed(f"{sysu} is-active graphical-session.target")
+        machine.succeed(f"{sysu} is-active urxvtd")
+        machine.succeed(f"{sysu} is-active xss-lock")
+
+    with subtest("Can interact with the WM"):
+        machine.wait_until_succeeds("pgrep sxhkd")
+        machine.wait_until_succeeds("pgrep bspwm")
+        # spawn some terminals
+        machine.send_key("meta_l-ret", delay=0.5)
+        machine.send_key("meta_l-ret", delay=0.5)
+        machine.send_key("meta_l-ret", delay=0.5)
+        # Note: this tests that resources have beeen loaded
+        machine.wait_for_window("myterm")
+        machine.screenshot("screenshot.png")
+
+    with subtest("Can stop the X server"):
+        # kill the WM
+        machine.send_key("meta_l-alt-esc")
+        machine.wait_until_tty_matches("1", prompt)
+
+    with subtest("Graphical session has stopped"):
+        machine.fail(f"{sysu} is-active graphical-session.target")
+        machine.fail(f"{sysu} is-active urxvtd")
+        machine.fail(f"{sysu} is-active xss-lock")
+  '';
+}


### PR DESCRIPTION
A couple of changes to make `startx` easier to use without shooting yourself in the foot.

For context: https://github.com/NixOS/nixpkgs/pull/310880, https://github.com/NixOS/nixpkgs/pull/319435

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested with `nixosTests.startx`
- [x] Built manual with `nix build -f nixos/release.nix manual.x86_64-linux`
- [ ] Add a release note
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
