### PR TITLE
python313Packages.simplekv: fix dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2726,17 +2726,11 @@
     name = "Brandon Elam Barker";
   };
   bbenne10 = {
-    email = "Bryan.Bennett@protonmail.com";
+    email = "Bryan.Bennett+nixpkgs@proton.me";
     matrix = "@bryan.bennett:matrix.org";
     github = "bbenne10";
     githubId = 687376;
     name = "Bryan Bennett";
-    keys = [
-      {
-        # compare with https://keybase.io/bbenne10
-        fingerprint = "41EA 00B4 00F9 6970 1CB2  D3AF EF90 E3E9 8B8F 5C0B";
-      }
-    ];
   };
   bbenno = {
     email = "nix@bbenno.com";

--- a/pkgs/development/python-modules/simplekv/default.nix
+++ b/pkgs/development/python-modules/simplekv/default.nix
@@ -1,12 +1,21 @@
 {
   lib,
   buildPythonPackage,
-  dulwich,
   fetchFromGitHub,
-  mock,
-  pytestCheckHook,
   pythonOlder,
   setuptools,
+
+  # optional dependencies
+  azure-storage-blob,
+  boto3,
+  dulwich,
+  google-cloud-storage,
+  pymongo,
+  redis,
+
+  # testing
+  mock,
+  pytestCheckHook,
   six,
 }:
 
@@ -27,11 +36,10 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   nativeCheckInputs = [
-    dulwich
     mock
     pytestCheckHook
     six
-  ];
+  ] ++ optional-dependencies.git;
 
   pythonImportsCheck = [ "simplekv" ];
 
@@ -39,6 +47,20 @@ buildPythonPackage rec {
     # Issue with fixture
     "test_concurrent_mkdir"
   ];
+
+  optional-dependencies = {
+    amazon = [ boto3 ];
+    azure = [ azure-storage-blob ];
+    google = [ google-cloud-storage ];
+    redis = [ redis ];
+    mongodb = [ pymongo ];
+    git = [ dulwich ];
+    /*
+      Additional potential dependencies not exposed here:
+        sqlalchemy: Our version is too new for simplekv
+        appengine-python-standard: Not packaged in nixpkgs
+    */
+  };
 
   meta = with lib; {
     description = "Simple key-value store for binary data";

--- a/pkgs/development/python-modules/simplekv/default.nix
+++ b/pkgs/development/python-modules/simplekv/default.nix
@@ -26,9 +26,8 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies = [ dulwich ];
-
   nativeCheckInputs = [
+    dulwich
     mock
     pytestCheckHook
     six

--- a/pkgs/development/python-modules/simplekv/default.nix
+++ b/pkgs/development/python-modules/simplekv/default.nix
@@ -67,6 +67,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/mbr/simplekv";
     changelog = "https://github.com/mbr/simplekv/releases/tag/${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [
+      fab
+      bbenne10
+    ];
   };
 }

--- a/pkgs/development/python-modules/simplekv/default.nix
+++ b/pkgs/development/python-modules/simplekv/default.nix
@@ -26,8 +26,9 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    dulwich
+  dependencies = [ dulwich ];
+
+  nativeCheckInputs = [
     mock
     pytestCheckHook
     six


### PR DESCRIPTION
## Things done

This fixes up python3Packages.simplekv to remove `pytestCheckHook` from `dependencies` (which ultimately end up in `propagatedBuildInputs` causing problems for downstream packages). Along the way I decided to include optional dependencies for each backend we can currently support. The other two backends we cannot support are also noted inline. Closes #382050. Supersedes / Closes #388393




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
