### PR TITLE
postgresql: replace pg_config with custom script

### DIFF
--- a/doc/languages-frameworks/ruby.section.md
+++ b/doc/languages-frameworks/ruby.section.md
@@ -154,7 +154,7 @@ let
     defaultGemConfig = pkgs.defaultGemConfig // {
       pg = attrs: {
         buildFlags =
-        [ "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
+        [ "--with-pg-config=${pkgs."postgresql_${pg_version}".pg_config}/bin/pg_config" ];
       };
     };
   };
@@ -172,7 +172,7 @@ let
     gemConfig = pkgs.defaultGemConfig // {
       pg = attrs: {
         buildFlags =
-        [ "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config" ];
+        [ "--with-pg-config=${pkgs."postgresql_${pg_version}".pg_config}/bin/pg_config" ];
       };
     };
   };
@@ -190,7 +190,7 @@ let
         defaultGemConfig = super.defaultGemConfig // {
           pg = attrs: {
             buildFlags = [
-              "--with-pg-config=${lib.getDev pkgs."postgresql_${pg_version}"}/bin/pg_config"
+              "--with-pg-config=${pkgs."postgresql_${pg_version}".pg_config}/bin/pg_config"
             ];
           };
         };

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -11,6 +11,8 @@
 - `squid` has been updated to version 7, this release includes multiple breaking changes, like ESI removal.
   For more information, [check the release notes](https://github.com/squid-cache/squid/releases/tag/SQUID_7_0_1).
 
+- `postgresql` and `libpq` don't provide `pg_config` by default anymore. Instead, `pg_config` is available via `postgresql.pg_config` or `libpq.pg_config`. This allowed implementing it as a shell script, which can be build for both the build and host systems when cross-compiling. If your build fails to find `pg_config`, add `postgresql.pg_config` or `libpq.pg_config` to `nativeBuildInputs`.
+
 - The [`no-broken-symlinks` hook](https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh) was added to catch builds containing dangling or reflexive symlinks, as these are indicative of problems with packaging.
   The hook can be disabled by providing `dontCheckForBrokenSymlinks = true;` as an argument to `mkDerivation`.
   For more information, [check the docs](https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh) or [see this PR](https://github.com/NixOS/nixpkgs/pull/370750).

--- a/pkgs/by-name/ds/dspam/package.nix
+++ b/pkgs/by-name/ds/dspam/package.nix
@@ -59,7 +59,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional withPgSQL libpq
     ++ lib.optional withSQLite sqlite
     ++ lib.optional withDB db;
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    libpq.pg_config
+    makeWrapper
+  ];
   # patch out libmysql >= 5 check, since mariadb-connector is at 3.x
   postPatch = ''
     sed -i 's/atoi(m) >= 5/1/g' configure m4/mysql_drv.m4
@@ -87,8 +90,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withMySQL [
       "--with-mysql-includes=${mariadb-connector-c.dev}/include/mysql"
       "--with-mysql-libraries=${mariadb-connector-c.out}/lib/mysql"
-    ]
-    ++ lib.optional withPgSQL "--with-pgsql-libraries=${libpq}/lib";
+    ];
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:

--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -159,6 +159,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl
     pkg-config
+  ]
+  ++ lib.optionals (lib.elem "pgsql" extraModules) [
+    libpq.pg_config
   ];
   buildInputs = extraInputs;
 

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       "--localstatedir=/var"
       "--with-openssl=${lib.getDev openssl}"
     ]
-    ++ lib.optional withPostgres "--with-pgsql=${lib.getDev libpq}/bin/pg_config"
+    ++ lib.optional withPostgres "--with-pgsql=${libpq.pg_config}/bin/pg_config"
     ++ lib.optional withMysql "--with-mysql=${lib.getDev libmysqlclient}/bin/mysql_config";
 
   postConfigure = ''

--- a/pkgs/by-name/pg/pg_checksums/package.nix
+++ b/pkgs/by-name/pg/pg_checksums/package.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-joGaCoRMGpEqq7pnT4Qd7XySjZ5wlZPW27WfOv1UFF4=";
   };
 
-  nativeBuildInputs = [ libxslt.bin ];
+  nativeBuildInputs = [
+    libxslt.bin
+    postgresql.pg_config
+  ];
 
   buildInputs = [ postgresql ];
 

--- a/pkgs/by-name/pg/pgcopydb/package.nix
+++ b/pkgs/by-name/pg/pgcopydb/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    postgresql.pg_config
   ];
 
   buildInputs =

--- a/pkgs/by-name/pg/pgmanage/package.nix
+++ b/pkgs/by-name/pg/pgmanage/package.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation {
     openssl
   ];
 
+  nativeBuildInputs = [
+    libpq.pg_config
+  ];
+
   passthru.tests.sign-in = nixosTests.pgmanage;
 
   meta = with lib; {

--- a/pkgs/by-name/sp/spatialite-gui/package.nix
+++ b/pkgs/by-name/sp/spatialite-gui/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    libpq.pg_config
     pkg-config
   ] ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
 

--- a/pkgs/by-name/tn/tntdb/package.nix
+++ b/pkgs/by-name/tn/tntdb/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    libpq.pg_config
   ];
 
   buildInputs = [

--- a/pkgs/by-name/vi/virtualpg/package.nix
+++ b/pkgs/by-name/vi/virtualpg/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     validatePkgConfig
-    libpq # for pg_config
+    libpq.pg_config
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libgda/5.x.nix
+++ b/pkgs/development/libraries/libgda/5.x.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
     gtk-doc
     autoconf-archive
     yelp-tools
+    libpq.pg_config
   ];
 
   buildInputs =

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl
     pkg-config
-  ];
+  ] ++ lib.optional withPostgresql libpq.pg_config;
 
   buildInputs =
     [

--- a/pkgs/development/octave-modules/database/default.nix
+++ b/pkgs/development/octave-modules/database/default.nix
@@ -23,6 +23,10 @@ buildOctavePackage rec {
     libpq
   ];
 
+  nativeBuildInputs = [
+    libpq.pg_config
+  ];
+
   requiredOctavePackages = [
     struct
   ];

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -73,8 +73,7 @@ let
 
     nativeBuildInputs = [
       cython
-      # needed to find pg_config with strictDeps
-      libpq
+      libpq.pg_config
       setuptools
       tomli
     ];

--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     # some linker flags are added but the linker ignores them because they're incompatible
     # https://github.com/psycopg/psycopg2/blob/89005ac5b849c6428c05660b23c5a266c96e677d/setup.py
     substituteInPlace setup.py \
-      --replace-fail "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${lib.getDev buildPackages.libpq}/bin/pg_config"'
+      --replace-fail "self.pg_config_exe = self.build_ext.pg_config" 'self.pg_config_exe = "${libpq.pg_config}/bin/pg_config"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/psycopg2cffi/default.nix
+++ b/pkgs/development/python-modules/psycopg2cffi/default.nix
@@ -31,8 +31,7 @@ buildPythonPackage rec {
   '';
 
   buildInputs = [ libpq ];
-  # To find pg_config
-  nativeBuildInputs = [ libpq ];
+  nativeBuildInputs = [ libpq.pg_config ];
 
   build-system = [
     setuptools

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -483,7 +483,7 @@ let
     RODBC = [ pkgs.libiodbc ];
     rpanel = [ pkgs.tclPackages.bwidget ];
     Rpoppler = [ pkgs.poppler ];
-    RPostgreSQL = with pkgs; [ libpq ];
+    RPostgreSQL = with pkgs; [ libpq.pg_config ];
     RProtoBuf = [ pkgs.protobuf ];
     RSclient = [ pkgs.openssl.dev ];
     Rserve = [ pkgs.openssl ];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -669,7 +669,7 @@ in
     # Force pkg-config lookup for libpq.
     # See https://github.com/ged/ruby-pg/blob/6629dec6656f7ca27619e4675b45225d9e422112/ext/extconf.rb#L34-L55
     #
-    # Note that setting --with-pg-config=${lib.getDev postgresql}/bin/pg_config would add
+    # Note that setting --with-pg-config=${postgresql.pg_config}/bin/pg_config would add
     # an unnecessary reference to the entire postgresql package.
     buildFlags = [ "--with-pg-config=ignore" ];
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
@@ -93,7 +93,7 @@ let
   preBuildAndTest = ''
     export PGRX_HOME="$(mktemp -d)"
     export PGDATA="$PGRX_HOME/data-${pgrxPostgresMajor}/"
-    cargo-pgrx pgrx init "--pg${pgrxPostgresMajor}" ${lib.getDev postgresql}/bin/pg_config
+    cargo-pgrx pgrx init "--pg${pgrxPostgresMajor}" ${postgresql.pg_config}/bin/pg_config
 
     # unix sockets work in sandbox, too.
     export PGHOST="$(mktemp -d)"
@@ -140,7 +140,7 @@ let
       PGRX_BUILD_FLAGS="--frozen -j $NIX_BUILD_CORES ${builtins.concatStringsSep " " cargoBuildFlags}" \
       ${lib.optionalString stdenv.hostPlatform.isDarwin ''RUSTFLAGS="''${RUSTFLAGS:+''${RUSTFLAGS} }-Clink-args=-Wl,-undefined,dynamic_lookup"''} \
       cargo pgrx package \
-        --pg-config ${lib.getDev postgresql}/bin/pg_config \
+        --pg-config ${postgresql.pg_config}/bin/pg_config \
         ${maybeDebugFlag} \
         --features "${builtins.concatStringsSep " " buildFeatures}" \
         --out-dir "$out"

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -34,7 +34,10 @@ callPackage ../nginx/generic.nix args rec {
         --replace "b/" "b/bundle/nginx-${nginxVersion}/"
     '';
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [
+    libpq.pg_config
+    perl
+  ];
 
   buildInputs = [ libpq ];
 

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -50,7 +50,7 @@ import ./versions.nix (
     nativeBuildInputs = [
       autoreconfHook
       pkg-config
-    ];
+    ] ++ optional postgresqlSupport libpq.pg_config;
     buildInputs =
       [
         curl

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -76,6 +76,7 @@ postgresqlBuildExtension (finalAttrs: {
   dontDisableStatic = true;
 
   nativeCheckInputs = [
+    postgresql
     postgresqlTestHook
     cunit
     libxslt
@@ -93,6 +94,7 @@ postgresqlBuildExtension (finalAttrs: {
   '';
 
   configureFlags = [
+    "--with-pgconfig=${postgresql.pg_config}/bin/pg_config"
     "--with-gdalconfig=${gdal}/bin/gdal-config"
     "--with-jsondir=${json_c.dev}"
     "--disable-extension-upgrades-install"

--- a/pkgs/servers/sql/postgresql/pg_config.env.mk
+++ b/pkgs/servers/sql/postgresql/pg_config.env.mk
@@ -1,0 +1,13 @@
+# Everything that pg_config normally returns is put into pg_config.env, so
+# that we can read it from our own pg_config script later on.
+pg_config.env: $(top_builddir)/src/port/pg_config_paths.h | $(top_builddir)/src/include/pg_config.h
+	echo "CC=\"$(CC)\"" >$@
+	echo "CPPFLAGS=\"$(STD_CPPFLAGS)\"" >>$@
+	echo "CFLAGS=\"$(CFLAGS)\"" >>$@
+	echo "CFLAGS_SL=\"$(CFLAGS_SL)\"" >>$@
+	echo "LDFLAGS=\"$(STD_LDFLAGS)\"" >>$@
+	echo "LDFLAGS_EX=\"$(LDFLAGS_EX)\"" >>$@
+	echo "LDFLAGS_SL=\"$(LDFLAGS_SL)\"" >>$@
+	echo "LIBS=\"$(LIBS)\"" >>$@
+	cat $(top_builddir)/src/port/pg_config_paths.h $(top_builddir)/src/include/pg_config.h \
+	  | sed -nE 's/^#define ([^ ]+) ("?)(.*)\2$$/\1="\3"/p' >>$@

--- a/pkgs/servers/sql/postgresql/pg_config.nix
+++ b/pkgs/servers/sql/postgresql/pg_config.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  replaceVarsWith,
+  runtimeShell,
+  # PostgreSQL package
+  finalPackage,
+}:
+
+replaceVarsWith {
+  name = "pg_config";
+  src = ./pg_config.sh;
+  dir = "bin";
+  isExecutable = true;
+  replacements = {
+    inherit runtimeShell;
+    postgresql-dev = lib.getDev finalPackage;
+  };
+}

--- a/pkgs/servers/sql/postgresql/pg_config.sh
+++ b/pkgs/servers/sql/postgresql/pg_config.sh
@@ -1,37 +1,122 @@
+#!@runtimeShell@
 set -euo pipefail
 
-# The real pg_config needs to be in the same path as the "postgres" binary
-# to return proper paths. However, we want it in the -dev output to prevent
-# cyclic references and to prevent blowing up the runtime closure. Thus, we
-# have wrapped -dev/bin/pg_config to fake its argv0 to be in the default
-# output. Unfortunately, pg_config tries to be smart and tries to find itself -
-# which will then fail with:
-#   pg_config: could not find own program executable
-# To counter this, we're creating *this* fake pg_config script and put it into
-# the default output. The real pg_config is happy.
-# Some extensions, e.g. timescaledb, use the reverse logic and look for pg_config
-# in the same path as the "postgres" binary to support multi-version-installs.
-# Thus, they will end up calling this script during build, even though the real
-# pg_config would be available on PATH, provided by nativeBuildInputs. To help
-# this case, we're redirecting the call to pg_config to the one found in PATH,
-# iff we can be convinced that it belongs to our -dev output.
+# This replacement script for the pg_config binary is based on the original pg_config
+# shell script, which was removed from PostgreSQL's codebase in 2004:
+#   https://github.com/postgres/postgres/commit/cc07f8cfe73f56fce1ddda4ea25d7b0b6c4f0ae9
+#
+# The main reason for removal was the ability to relocate an existing installation, which
+# is exactly the one feature that we are trying to work around in nixpkgs.
+# Going back to a shell script is much better for cross compiling.
+#
+# This file is a combination of the following two files:
+#   https://github.com/postgres/postgres/blob/7510ac6203bc8e3c56eae95466feaeebfc1b4f31/src/bin/pg_config/pg_config.sh
+#   https://github.com/postgres/postgres/blob/master/src/bin/pg_config/pg_config.c
 
-# Avoid infinite recursion
-if [[ ! -v PG_CONFIG_CALLED ]]; then
-    # compares "path of *this* script" with "path, which pg_config on PATH believes it is in"
-    if [[ "$(readlink -f -- "$0")" == "$(PG_CONFIG_CALLED=1 pg_config --bindir)/pg_config" ]]; then
-        # The pg_config in PATH returns the same bindir that we're actually called from.
-        # This means that the pg_config in PATH is the one from "our" -dev output.
-        # This happens when the -dev output has been put in native build
-        # inputs and allows us to call the real pg_config without referencing
-        # the -dev output itself.
-        exec pg_config "$@"
-    fi
+source @postgresql-dev@/nix-support/pg_config.env
+
+help="
+pg_config provides information about the installed version of PostgreSQL.
+
+Usage:
+  pg_config [OPTION]...
+
+Options:
+  --bindir              show location of user executables
+  --docdir              show location of documentation files
+  --htmldir             show location of HTML documentation files
+  --includedir          show location of C header files of the client
+                        interfaces
+  --pkgincludedir       show location of other C header files
+  --includedir-server   show location of C header files for the server
+  --libdir              show location of object code libraries
+  --pkglibdir           show location of dynamically loadable modules
+  --localedir           show location of locale support files
+  --mandir              show location of manual pages
+  --sharedir            show location of architecture-independent support files
+  --sysconfdir          show location of system-wide configuration files
+  --pgxs                show location of extension makefile
+  --configure           show options given to \"configure\" script when
+                        PostgreSQL was built
+  --cc                  show CC value used when PostgreSQL was built
+  --cppflags            show CPPFLAGS value used when PostgreSQL was built
+  --cflags              show CFLAGS value used when PostgreSQL was built
+  --cflags_sl           show CFLAGS_SL value used when PostgreSQL was built
+  --ldflags             show LDFLAGS value used when PostgreSQL was built
+  --ldflags_ex          show LDFLAGS_EX value used when PostgreSQL was built
+  --ldflags_sl          show LDFLAGS_SL value used when PostgreSQL was built
+  --libs                show LIBS value used when PostgreSQL was built
+  --version             show the PostgreSQL version
+  -?, --help            show this help, then exit
+
+With no arguments, all known items are shown.
+
+Report bugs to <${PACKAGE_BUGREPORT}>.
+${PACKAGE_NAME} home page: <${PACKAGE_URL}>"
+
+show=()
+
+for opt; do
+    case "$opt" in
+        --bindir)               show+=("$PGBINDIR") ;;
+        --docdir)               show+=("$DOCDIR") ;;
+        --htmldir)              show+=("$HTMLDIR") ;;
+        --includedir)           show+=("$INCLUDEDIR") ;;
+        --pkgincludedir)        show+=("$PKGINCLUDEDIR") ;;
+        --includedir-server)    show+=("$INCLUDEDIRSERVER") ;;
+        --libdir)               show+=("$LIBDIR") ;;
+        --pkglibdir)            show+=("$PKGLIBDIR") ;;
+        --localedir)            show+=("$LOCALEDIR") ;;
+        --mandir)               show+=("$MANDIR") ;;
+        --sharedir)             show+=("$PGSHAREDIR") ;;
+        --sysconfdir)           show+=("$SYSCONFDIR") ;;
+        --pgxs)                 show+=("@postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk") ;;
+        --configure)            show+=("$CONFIGURE_ARGS") ;;
+        --cc)                   show+=("$CC") ;;
+        --cppflags)             show+=("$CPPFLAGS") ;;
+        --cflags)               show+=("$CFLAGS") ;;
+        --cflags_sl)            show+=("$CFLAGS_SL") ;;
+        --ldflags)              show+=("$LDFLAGS") ;;
+        --ldflags_ex)           show+=("$LDFLAGS_EX") ;;
+        --ldflags_sl)           show+=("$LDFLAGS_SL") ;;
+        --libs)                 show+=("$LIBS") ;;
+        --version)              show+=("PostgreSQL $PG_VERSION") ;;
+        --help|-\?)             echo "$help"
+                                exit 0 ;;
+        *)                      >&2 echo "pg_config: invalid argument: $opt"
+                                >&2 echo "Try \"pg_config --help\" for more information."
+                                exit 1 ;;
+    esac
+done
+
+if [ ${#show[@]} -gt 0 ]; then
+    printf '%s\n' "${show[@]}"
+    exit 0
 fi
 
-# This will happen in one of these cases:
-# - *this* script is the first on PATH
-# - np pg_config on PATH
-# - some other pg_config on PATH, not from our -dev output
-echo The real pg_config can be found in the -dev output.
-exit 1
+# no arguments -> print everything
+cat <<EOF
+BINDIR = $PGBINDIR
+DOCDIR = $DOCDIR
+HTMLDIR = $HTMLDIR
+INCLUDEDIR = $INCLUDEDIR
+PKGINCLUDEDIR = $PKGINCLUDEDIR
+INCLUDEDIR-SERVER = $INCLUDEDIRSERVER
+LIBDIR = $LIBDIR
+PKGLIBDIR = $PKGLIBDIR
+LOCALEDIR = $LOCALEDIR
+MANDIR = $MANDIR
+SHAREDIR = $PGSHAREDIR
+SYSCONFDIR = $SYSCONFDIR
+PGXS = @postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk
+CONFIGURE = $CONFIGURE_ARGS
+CC = $CC
+CPPFLAGS = $CPPFLAGS
+CFLAGS = $CFLAGS
+CFLAGS_SL = $CFLAGS_SL
+LDFLAGS = $LDFLAGS
+LDFLAGS_EX = $LDFLAGS_EX
+LDFLAGS_SL = $LDFLAGS_SL
+LIBS = $LIBS
+VERSION = PostgreSQL $PG_VERSION
+EOF

--- a/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix
+++ b/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix
@@ -86,7 +86,7 @@ let
 
       strictDeps = true;
       buildInputs = [ postgresql ] ++ prevAttrs.buildInputs or [ ];
-      nativeBuildInputs = [ postgresql ] ++ prevAttrs.nativeBuildInputs or [ ];
+      nativeBuildInputs = [ postgresql.pg_config ] ++ prevAttrs.nativeBuildInputs or [ ];
 
       installFlags = [
         "DESTDIR=${placeholder "out"}"

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7268,7 +7268,7 @@ with self; {
     buildInputs = [ pkgs.postgresql ];
     propagatedBuildInputs = [ DBI ];
 
-    makeMakerFlags = [ "POSTGRES_HOME=${pkgs.postgresql}" ];
+    nativeBuildInputs = [ pkgs.postgresql.pg_config ];
 
     # tests freeze in a sandbox
     doCheck = false;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -640,7 +640,7 @@ lib.makeScope pkgs.newScope (
               {
                 name = "pdo_pgsql";
                 internalDeps = [ php.extensions.pdo ];
-                configureFlags = [ "--with-pdo-pgsql=${lib.getDev libpq}" ];
+                configureFlags = [ "--with-pdo-pgsql=${libpq.pg_config}" ];
                 doCheck = false;
               }
               {
@@ -655,7 +655,7 @@ lib.makeScope pkgs.newScope (
                 buildInputs = [
                   pcre2
                 ];
-                configureFlags = [ "--with-pgsql=${lib.getDev libpq}" ];
+                configureFlags = [ "--with-pgsql=${libpq.pg_config}" ];
                 doCheck = false;
               }
               {


### PR DESCRIPTION
By replacing upstream's pg_config binary with a shell script, we:
- gain the ability to run pg_config easily when cross-compiling,
- can remove the fake pg_config in the default output,
- can remove the pg_config wrapper script dealing with special cases.

Some 20 years ago, pg_config *was* a shell script upstream, too. It was changed to a binary, when it was made "relocatable", so it would return paths depending on the location of the "postgres" binary. However, this is exactly the thing that just hurts us in nixpkgs - we don't want those paths to change, we want them to always point at the right outputs. By writing the script ourselves, this becomes a lot less painful.

This approach means more lines of codes, but all of them are dead simple and we have a lot less complexity overall.

Additionally, pg_config is now made a separate derivation, only exposed as "postgresql.pg_config". This has the nice side-effect, that all users of postgresql and libpq in nixpkgs must be very *explicit* about their dependency on pg_config. This gives a lot more visibility into the state of affairs regarding pkg-config support for libpq, which ultimately is the much better solution.

---

I only tested the postgresql extensions, so far - they all seem to work with this just fine. Everything outside the `postgresql` folder, I did not touch, yet.

TODO:
- [x] Fix all dependencies of `postgresql` and `libpq`, passing pg_config were needed.
- [x] Rebase on staging eventually.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
