### PR TITLE
postgresqlPackages.{pg-semver,pgsodium}: fix passthru tests

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg-semver.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg-semver.nix
@@ -19,7 +19,6 @@ buildPostgresqlExtension (finalAttrs: {
   };
 
   passthru.tests = {
-    version = testers.testVersion { package = finalAttrs.finalPackage; };
     extension = postgresqlTestExtension {
       inherit (finalAttrs) finalPackage;
       sql = "CREATE EXTENSION semver;";

--- a/pkgs/servers/sql/postgresql/ext/pgsodium.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsodium.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  bash,
   libsodium,
   postgresql,
   postgresqlTestExtension,
@@ -20,6 +21,7 @@ buildPostgresqlExtension (finalAttrs: {
   };
 
   buildInputs = [
+    bash # required for patchShebangs
     libsodium
   ];
 


### PR DESCRIPTION
See commit messages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
