### PR TITLE
chromium,chromedriver: 134.0.6998.35 -> 134.0.6998.88

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "134.0.6998.35",
+    "version": "134.0.6998.88",
     "chromedriver": {
-      "hash_darwin": "sha256-5TirtxNycNy8l9BbZ0D5P27LjKzwTl0t1vUoTIxCQcE=",
-      "hash_darwin_aarch64": "sha256-Fp1x43sQ6H7sYjtntxanbifmur6hDEri+Hw7947XZPM="
+      "hash_darwin": "sha256-UtXlvBUnMZpCXT/xI7l4nfv3EgJZgugP1/fVg4rKgk4=",
+      "hash_darwin_aarch64": "sha256-yWRVP5LaEEhHfKkV0UmC7cpEuSnU5sgL3C/Aa2Ri3sc="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "ea6ef4c2ac15ae95d2cfd65682da62c093415099",
-        "hash": "sha256-Y/3V1cmna7nSJkS05SYsDxtPTz8bF7Q8fWYxVhVSy/g=",
+        "rev": "7e3d5c978c6d3a6eda25692cfac7f893a2b20dd0",
+        "hash": "sha256-4RRB7uYI3I7c1dSypU2gzF9TCA2MJ7yStKEvm6vfSnE=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -240,8 +240,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "044764a564924c9aa0897ba8c50149acc7ddf364",
-        "hash": "sha256-T8BlvYNMF77BubiR4tMvW8iAhqS0ppPAESO48/mNX3w="
+        "rev": "65b3f414b81ffe4df49202af6fc75bc26a3cb109",
+        "hash": "sha256-rdBpJWdQ5VtFnIfbr/Vq1q1euSvkbY8iIqyuTMAS2KM="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -780,8 +780,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "debba63b78f8791411bff379835982cb2e8cabfa",
-        "hash": "sha256-iOpnf4jq4bl0CJlHngJ1BV6b0VY1PigJIIjVXk4rqOE="
+        "rev": "a57459aad9ec3ed5f78d9ded700d52e31029efd2",
+        "hash": "sha256-IE1X6lfMyoXsN+7ebJ3RWXAgpR98AjituL3faQbNag0="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/03/stable-channel-update-for-desktop_10.html

This update includes 5 security fixes.

CVEs:
CVE-2025-1920 CVE-2025-2135 CVE-2025-2136 CVE-2025-2137

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
