### PR TITLE
lib/modules: disallow setting config, options in specialArgs of evalModules

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -5,6 +5,7 @@ let
     addErrorContext
     all
     any
+    assertMsg
     attrByPath
     attrNames
     catAttrs
@@ -101,6 +102,8 @@ let
                 , # This would be remove in the future, Prefer _module.check option instead.
                   check ? true
                 }:
+    assert assertMsg (!specialArgs?config) "Do not set config in the specialArgs argument to evalModules.";
+    assert assertMsg (!specialArgs?options) "Do not set options in the specialArgs argument to evalModules.";
     let
       withWarnings = x:
         warnIf (evalModulesArgs?args) "The args argument to evalModules is deprecated. Please set config._module.args instead."

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -137,6 +137,9 @@ checkConfigOutput '^true$' config.result ./module-argument-default.nix
 # gvariant
 checkConfigOutput '^true$' config.assertion ./gvariant.nix
 
+# specialArgs checks for evalModules
+checkConfigError 'Do not set config in the specialArgs argument to evalModules\.' config.fail.config ./specialArgs-config.nix
+checkConfigError 'Do not set options in the specialArgs argument to evalModules\.' config.fail.config ./specialArgs-options.nix
 checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
 
 # https://github.com/NixOS/nixpkgs/pull/131205

--- a/lib/tests/modules/specialArgs-config.nix
+++ b/lib/tests/modules/specialArgs-config.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+{
+  config = {
+    _module.freeformType = lib.types.anything;
+
+    fail = lib.evalModules {
+      specialArgs = {
+        config = { };
+      };
+      modules = [
+        {
+          options.a = lib.mkEnableOption "a";
+          config.a = true;
+        }
+      ];
+    };
+  };
+}

--- a/lib/tests/modules/specialArgs-options.nix
+++ b/lib/tests/modules/specialArgs-options.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+{
+  config = {
+    _module.freeformType = lib.types.anything;
+
+    fail = lib.evalModules {
+      specialArgs = {
+        options = { };
+      };
+      modules = [
+        {
+          options.a = lib.mkEnableOption "a";
+          config.a = true;
+        }
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Seems like an easy win to prevent breaking the module system entirely, see https://discourse.nixos.org/t/cannot-find-attribute-programs-firefox/61401/7 for context

@Aleksanaa if you're interested to review


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
