### PR TITLE
milu: unbreak on GCC 14, modernize

### DIFF
--- a/pkgs/by-name/mi/milu/package.nix
+++ b/pkgs/by-name/mi/milu/package.nix
@@ -39,6 +39,12 @@ stdenv.mkDerivation {
     llvmPackages.libclang
   ];
 
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-incompatible-pointer-types"
+    "-Wno-implicit-function-declaration"
+    "-Wno-error=int-conversion"
+  ];
+
   meta = {
     description = "Higher Order Mutation Testing Tool for C and C++ programs";
     homepage = "https://github.com/yuejia/Milu";

--- a/pkgs/by-name/mi/milu/package.nix
+++ b/pkgs/by-name/mi/milu/package.nix
@@ -5,6 +5,7 @@
   unzip,
   pkg-config,
   glib,
+  llvm,
   llvmPackages,
 }:
 
@@ -13,37 +14,43 @@ stdenv.mkDerivation {
   version = "2016-05-09";
 
   src = fetchFromGitHub {
-    sha256 = "14cglw04cliwlpvw7qrs6rfm5sv6qa558d7iby5ng3wdjcwx43nk";
-    rev = "b5f2521859c0319d321ad3c1ad793b826ab5f6e1";
-    repo = "Milu";
     owner = "yuejia";
+    repo = "Milu";
+    rev = "b5f2521859c0319d321ad3c1ad793b826ab5f6e1";
+    hash = "sha256-0w7SOZONj2eLX/E0VIrCZutSXTY648P3pTxSRgCnj5E=";
   };
 
   hardeningDisable = [ "format" ];
 
   preConfigure = ''
-    sed -i 's#/usr/bin/##g' Makefile
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp bin/milu $out/bin
+    substituteInPlace Makefile \
+      --replace-fail /usr/bin/ "" \
+      --replace-fail bin/milu $out/bin/milu
   '';
 
   nativeBuildInputs = [
     pkg-config
     unzip
   ];
+
   buildInputs = [
     glib
+    llvm.dev
     llvmPackages.libclang
   ];
+
+  preBuild = ''
+    mkdir -p $out/bin
+  '';
 
   env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-incompatible-pointer-types"
     "-Wno-implicit-function-declaration"
     "-Wno-error=int-conversion"
   ];
+
+  # `make all` already installs the binaries
+  dontInstall = true;
 
   meta = {
     description = "Higher Order Mutation Testing Tool for C and C++ programs";


### PR DESCRIPTION
Unbreak milu on GCC 14 and modernize.

- https://github.com/NixOS/nixpkgs/issues/388196

ref. #356812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
