### PR TITLE
services/cloudflare-dyndns: require that apiTokenFile be an api token

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -227,6 +227,8 @@
 
 - `pkgs.nextcloud28` has been removed since it's out of support upstream.
 
+- `services.cloudflare-dyndns.apiTokenFile` now must be just your Cloudflare api token. Previously it was supposed to be a file of the form `CLOUDFLARE_API_TOKEN=...`.
+
 - `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
 
   Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.

--- a/nixos/modules/services/networking/cloudflare-dyndns.nix
+++ b/nixos/modules/services/networking/cloudflare-dyndns.nix
@@ -15,12 +15,13 @@ in
       package = lib.mkPackageOption pkgs "cloudflare-dyndns" { };
 
       apiTokenFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
+        type = lib.types.pathWith {
+          absolute = true;
+          inStore = false;
+        };
+
         description = ''
           The path to a file containing the CloudFlare API token.
-
-          The file must have the form `CLOUDFLARE_API_TOKEN=...`
         '';
       };
 
@@ -91,19 +92,35 @@ in
           Type = "simple";
           DynamicUser = true;
           StateDirectory = "cloudflare-dyndns";
-          EnvironmentFile = cfg.apiTokenFile;
           Environment = [ "XDG_CACHE_HOME=%S/cloudflare-dyndns/.cache" ];
-          ExecStart =
-            let
-              args =
-                [ "--cache-file /var/lib/cloudflare-dyndns/ip.cache" ]
-                ++ (if cfg.ipv4 then [ "-4" ] else [ "-no-4" ])
-                ++ (if cfg.ipv6 then [ "-6" ] else [ "-no-6" ])
-                ++ lib.optional cfg.deleteMissing "--delete-missing"
-                ++ lib.optional cfg.proxied "--proxied";
-            in
-            "${lib.getExe cfg.package} ${toString args}";
+          LoadCredential = [
+            "apiToken:${cfg.apiTokenFile}"
+          ];
         };
+
+        script =
+          let
+            args =
+              [ "--cache-file /var/lib/cloudflare-dyndns/ip.cache" ]
+              ++ (if cfg.ipv4 then [ "-4" ] else [ "-no-4" ])
+              ++ (if cfg.ipv6 then [ "-6" ] else [ "-no-6" ])
+              ++ lib.optional cfg.deleteMissing "--delete-missing"
+              ++ lib.optional cfg.proxied "--proxied";
+          in
+          ''
+            export CLOUDFLARE_API_TOKEN=$(< "''${CREDENTIALS_DIRECTORY}/apiToken")
+
+            # Added 2025-03-10: `cfg.apiTokenFile` used to be passed as an
+            # `EnvironmentFile` to the service, which required it to be of
+            # the form "CLOUDFLARE_API_TOKEN=" rather than just the secret.
+            # If we detect this legacy usage, error out.
+            if [[ $CLOUDFLARE_API_TOKEN == CLOUDFLARE_API_TOKEN* ]]; then
+              echo "Error: your api token starts with 'CLOUDFLARE_API_TOKEN='. Remove that, and instead specify just the token." >&2
+              exit 1
+            fi
+
+            exec ${lib.getExe cfg.package} ${toString args}
+          '';
       }
       // lib.optionalAttrs (cfg.frequency != null) {
         startAt = cfg.frequency;


### PR DESCRIPTION
Previously, this option was supposed to be a file of the form `CLOUDFLARE_API_TOKEN=...`, which has a few problems:

- That's not an api token. It's an env file fit for passing to systemd's `EnvironmentFile` option. The user could typo the variable name, or intentionally/unintentionally include unrelated environment variables.
- It's not how secret files usually work in NixOS. Secret files are usually just the secret, and don't leak details about how the secret is passed to the service.
- This increases friction for people switching between cloudflare dyndns services, such as `services.cloudflare-dyndns` and `services.cfdyndns`, which both have a `apiToken` option, but (before this change) with different semantics.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
