### PR TITLE
nixos/outline: remove non-existent systemd option

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -781,7 +781,6 @@ in
           Group = cfg.group;
           Restart = "always";
           ProtectSystem = "strict";
-          PrivateHome = true;
           PrivateTmp = true;
           UMask = "0007";
 


### PR DESCRIPTION
Maybe PrivateHome once existed? It doesn't now, though, and this is the only instance of it in all of nixpkgs!

    Mar 11 15:18:28 kala systemd[1]: /etc/systemd/system/outline.service:46: Unknown key 'PrivateHome' in section [Service], ignoring.

It was introduced at the same time the Outline package and module were first added to nixpkgs: https://github.com/NixOS/nixpkgs/commit/9898e975af5a0ccb6604553a7b22d5f0db2b9033#diff-9552b193b80a0033a21627544aeccb7e268522ba9e97c31f8124a4a19d05b749R763

At that time, it too was the only instance of `PrivateHome` in all of nixpkgs, so I'm guessing it's mistaken. There's a very similarly named `ProtectHome` option (which can take `true` among other values), so I'm guessing it was a typo? I'm not super motivated to find out which value would be correct, if any, so for now I'm just eliminating the warning.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
