### PR TITLE
nixos/gdm: add xorg option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -501,6 +501,8 @@
 
 - `services.cloudflared` now uses a dynamic user, and its `user` and `group` options have been removed. If the user or group is still necessary, they can be created manually.
 
+- GNOME/GDM's X11 session can be disabled via the new [](#opt-services.xserver.displayManager.gdm.xorg) option.
+
 - The Home Assistant module has new options {option}`services.home-assistant.blueprints.automation`, `services.home-assistant.blueprints.script`, and {option}`services.home-assistant.blueprints.template` that allow for the declarative installation of [blueprints](https://www.home-assistant.io/docs/blueprint/) into the appropriate configuration directories.
 
 - `services.dovecot2.modules` have been removed, now need to use `environment.systemPackages` to load additional Dovecot modules.

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -105,6 +105,14 @@ in
         '';
       };
 
+      xorg = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Allow GDM to run on Xorg.
+        '';
+      };
+
       autoSuspend = lib.mkOption {
         default = true;
         description = ''
@@ -147,6 +155,13 @@ in
 
   config = lib.mkIf cfg.gdm.enable {
 
+    assertions = [
+      {
+        assertion = cfg.gdm.wayland || cfg.gdm.xorg;
+        message = "Either the Wayland or Xorg session must be enabled.";
+      }
+    ];
+
     services.xserver.displayManager.lightdm.enable = false;
 
     users.users.gdm = {
@@ -168,9 +183,8 @@ in
       # Enable desktop session data
       enable = true;
 
-      environment =
+      environment = lib.mkMerge [
         {
-          GDM_X_SERVER_EXTRA_ARGS = toString (lib.filter (arg: arg != "-terminate") cfg.xserverArgs);
           XDG_DATA_DIRS = lib.makeSearchPath "share" [
             gdm # for gnome-login.session
             config.services.displayManager.sessionData.desktops
@@ -179,12 +193,18 @@ in
             pkgs.hicolor-icon-theme # empty icon theme as a base
           ];
         }
-        // lib.optionalAttrs (xSessionWrapper != null) {
+
+        (lib.mkIf cfg.gdm.xorg {
+          GDM_X_SERVER_EXTRA_ARGS = toString (lib.filter (arg: arg != "-terminate") cfg.xserverArgs);
+        })
+
+        (lib.mkIf (cfg.gdm.xorg && xSessionWrapper != null) {
           # Make GDM use this wrapper before running the session, which runs the
           # configured setupCommands. This relies on a patched GDM which supports
           # this environment variable.
           GDM_X_SESSION_WRAPPER = "${xSessionWrapper}";
-        };
+        })
+      ];
       execCmd = "exec ${gdm}/bin/gdm";
       preStart = lib.optionalString (defaultSessionName != null) ''
         # Set default session in session chooser to a specified values – basically ignore session history.
@@ -297,6 +317,7 @@ in
     services.xserver.displayManager.gdm.settings = {
       daemon = lib.mkMerge [
         { WaylandEnable = cfg.gdm.wayland; }
+        { XorgEnable = cfg.gdm.xorg; }
         # nested if else didn't work
         (lib.mkIf (config.services.displayManager.autoLogin.enable && cfg.gdm.autoLogin.delay != 0) {
           TimedLoginEnable = true;
@@ -315,7 +336,9 @@ in
 
     environment.etc."gdm/custom.conf".source = configFile;
 
-    environment.etc."gdm/Xsession".source = config.services.displayManager.sessionData.wrapper;
+    environment.etc."gdm/Xsession" = lib.mkIf cfg.gdm.xorg {
+      source = config.services.displayManager.sessionData.wrapper;
+    };
 
     # GDM LFS PAM modules, adapted somehow to NixOS
     security.pam.services = {

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -14,6 +14,7 @@
       services.xserver.displayManager = {
         gdm.enable = true;
         gdm.debug = true;
+        gdm.xorg = false;
       };
 
       services.displayManager.autoLogin = {


### PR DESCRIPTION
Adds a new ~~override to `gnome-session` and a~~ user friendly toggle in the GDM module for removing GNOME's X11 session

Work towards https://github.com/NixOS/nixpkgs/issues/382463

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
