### PR TITLE
python312Packages.textual: 1.0.0 -> 2.1.2, python312Packages.textual-autocomplete: 3.0.0a13 -> 4.0.0a0

### DIFF
--- a/pkgs/development/python-modules/textual-autocomplete/default.nix
+++ b/pkgs/development/python-modules/textual-autocomplete/default.nix
@@ -1,30 +1,29 @@
 {
   lib,
-  python3,
-  fetchFromGitHub,
+  buildPythonPackage,
+  fetchPypi,
   poetry-core,
   textual,
   typing-extensions,
   hatchling,
 }:
-python3.pkgs.buildPythonPackage rec {
-  pname = "textual_autocomplete";
-  version = "3.0.0a13";
+buildPythonPackage rec {
+  pname = "textual-autocomplete";
+  version = "4.0.0a0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "darrenburns";
-    repo = "textual-autocomplete";
-    rev = "2cb572bf5b1ea0554b396d0833dfb398cb45dc9b";
-    hash = "sha256-jfGYC3xDspwEr+KGApGB05VFuzluDe5S9a/Sjg5HtdI=";
+  src = fetchPypi {
+    pname = "textual_autocomplete";
+    inherit version;
+    hash = "sha256-wsjmgODvFgfbyqxW3jsH88JC8z0TZQOChLgics7wAHY=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
     hatchling
   ];
 
-  pythonRelaxDeps = true;
+  # pythonRelaxDeps = true;
 
   dependencies = [
     textual
@@ -35,6 +34,9 @@ python3.pkgs.buildPythonPackage rec {
     "textual"
     "typing_extensions"
   ];
+
+  # No tests in the Pypi archive
+  doCheck = false;
 
   meta = {
     description = "Python library that provides autocomplete capabilities to textual";

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -23,19 +23,18 @@
   pytestCheckHook,
   syrupy,
   time-machine,
-  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "textual";
-  version = "1.0.0";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Textualize";
     repo = "textual";
     tag = "v${version}";
-    hash = "sha256-3pNUDkkq9X3W9DdWp4M4h4ddHN+GzUxLCFNJJdAtRJM=";
+    hash = "sha256-VKo1idLu5sYGtuK8yZzVE6QrrMOciYIesbGVlqzNjfk=";
   };
 
   build-system = [ poetry-core ];
@@ -75,28 +74,18 @@ buildPythonPackage rec {
     "tests/test_focus.py"
   ];
 
-  disabledTests =
-    [
-      # Assertion issues
-      "test_textual_env_var"
+  disabledTests = [
+    # Assertion issues
+    "test_textual_env_var"
 
-      # Requirements for tests are not quite ready
-      "test_register_language"
+    # Requirements for tests are not quite ready
+    "test_register_language"
 
-      # Requires python bindings for tree-sitter languages
-      # https://github.com/Textualize/textual/issues/5449
-      "test_setting_unknown_language"
-      "test_update_highlight_query"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      # https://github.com/Textualize/textual/issues/5327
-      "test_cursor_page_up"
-      "test_cursor_page_down"
-    ];
-
-  # Some tests in groups require state from previous tests
-  # See https://github.com/Textualize/textual/issues/4924#issuecomment-2304889067
-  pytestFlagsArray = [ "--dist=loadgroup" ];
+    # Requires python bindings for tree-sitter languages
+    # https://github.com/Textualize/textual/issues/5449
+    "test_setting_unknown_language"
+    "test_update_highlight_query"
+  ];
 
   pythonImportsCheck = [ "textual" ];
 


### PR DESCRIPTION
## Things done

- **python312Packages.textual: 1.0.0 -> 2.1.2**
- **python312Packages.textual-autocomplete: 3.0.0a13 -> 4.0.0a0**

cc @gepbird jorikvanveen

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
