### PR TITLE
libfprint-tod: 1.90.7+git20210222+tod1 -> 1.94.9+tod1

### DIFF
--- a/pkgs/by-name/li/libfprint-2-tod1-vfs0090/package.nix
+++ b/pkgs/by-name/li/libfprint-2-tod1-vfs0090/package.nix
@@ -66,5 +66,8 @@ stdenv.mkDerivation {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ valodim ];
+    # Does not compile against libfprint-tod, hasn't seen any maintenance
+    # since 2020.
+    broken = true;
   };
 }

--- a/pkgs/by-name/li/libfprint-tod/package.nix
+++ b/pkgs/by-name/li/libfprint-tod/package.nix
@@ -13,7 +13,7 @@ libfprint.overrideAttrs (
     ...
   }:
   let
-    version = "1.90.7+git20210222+tod1";
+    version = "1.94.9+tod1";
   in
   {
     pname = "libfprint-tod";
@@ -24,18 +24,22 @@ libfprint.overrideAttrs (
       owner = "3v1n0";
       repo = "libfprint";
       rev = "v${version}";
-      sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
+      hash = "sha256-xkywuFbt8EFJOlIsSN2hhZfMUhywdgJ/uT17uiO3YV4=";
     };
 
     mesonFlags = [
       # Include virtual drivers for fprintd tests
       "-Ddrivers=all"
       "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
+      "-Dudev_rules_dir=${placeholder "out"}/lib/udev/rules.d"
     ];
 
     postPatch = ''
       ${postPatch}
-      patchShebangs ./tests/*.py ./tests/*.sh
+      patchShebangs \
+        ./libfprint/tod/tests/*.sh \
+        ./tests/*.py \
+        ./tests/*.sh \
     '';
 
     meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This also fixes the build issue introduced by #388631.

Checked to work on a ThinkPad T14 Gen 5 AMD with a goodix fingerprint scanner.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
