### PR TITLE
python3Packages.ducc0: 0.36.0 -> 0.37.1

### DIFF
--- a/pkgs/development/python-modules/ducc0/default.nix
+++ b/pkgs/development/python-modules/ducc0/default.nix
@@ -2,34 +2,51 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
-  numpy,
-  pybind11,
-  pytestCheckHook,
-  pythonOlder,
+  cmake,
+  nanobind,
+  ninja,
+  scikit-build-core,
   setuptools,
+  numpy,
+  pytestCheckHook,
+  scipy,
+  pytest-xdist,
 }:
 
 buildPythonPackage rec {
   pname = "ducc0";
-  version = "0.36.0";
+  version = "0.37.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitLab {
     domain = "gitlab.mpcdf.mpg.de";
     owner = "mtr";
     repo = "ducc";
-    rev = "ducc0_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-S/H3+EykNxqbs8Tca3T95SK3Hzst49hOPkO0ocs80t0=";
+    tag = "ducc0_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-aBKbDDUUiHIpVX7NtNJOQAH/hov7Zj5O5bE6J25ck10=";
   };
 
-  buildInputs = [ pybind11 ];
-  propagatedBuildInputs = [ numpy ];
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail '"pybind11>=2.6.0", ' ""
+  '';
+
+  DUCC0_USE_NANOBIND = "";
+  DUCC0_OPTIMIZATION = "portable";
+
+  build-system = [
+    cmake
+    nanobind
+    ninja
+    scikit-build-core
+    setuptools
+  ];
+  dontUseCmakeConfigure = true;
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    setuptools
+    scipy
+    pytest-xdist
   ];
   pytestFlagsArray = [ "python/test" ];
   pythonImportsCheck = [ "ducc0" ];
@@ -39,12 +56,10 @@ buildPythonPackage rec {
     cp -r ${src}/src/ducc0 $out/include
   '';
 
-  DUCC0_OPTIMIZATION = "portable-strip";
-
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.mpcdf.mpg.de/mtr/ducc";
     description = "Efficient algorithms for Fast Fourier transforms and more";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ parras ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ parras ];
   };
 }

--- a/pkgs/development/python-modules/ducc0/default.nix
+++ b/pkgs/development/python-modules/ducc0/default.nix
@@ -34,6 +34,11 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "python/test" ];
   pythonImportsCheck = [ "ducc0" ];
 
+  postInstall = ''
+    mkdir -p $out/include
+    cp -r ${src}/src/ducc0 $out/include
+  '';
+
   DUCC0_OPTIMIZATION = "portable-strip";
 
   meta = with lib; {


### PR DESCRIPTION
Version bump. Includes migrating from pybind11 to nanobind as python-cpp glue. Upstream supports both pybind11 and nanobind. We are early adopters in switching to nanobind.

Additionally, I include the sources as well into the resulting package for users who do need the ducc0 C++ sources as dependency (and not only the fully compiled python package).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
