### PR TITLE
treewide: remove gebner from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8474,12 +8474,6 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
-  gebner = {
-    email = "gebner@gebner.org";
-    github = "gebner";
-    githubId = 313929;
-    name = "Gabriel Ebner";
-  };
   geluk = {
     email = "johan+nix@geluk.io";
     github = "geluk";

--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -48,7 +48,7 @@ in
     meta = with lib; {
       homepage = "http://abcde.einval.com/wiki/";
       license = licenses.gpl2Plus;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ ];
       description = "Command-line audio CD ripper";
       longDescription = ''
         abcde is a front-end command-line utility (actually, a shell

--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -178,7 +178,6 @@ mkDerivation rec {
     maintainers = with lib.maintainers; [
       bjornfor
       raskin
-      gebner
     ];
     mainProgram = "openscad";
   };

--- a/pkgs/applications/misc/coolreader/default.nix
+++ b/pkgs/applications/misc/coolreader/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
     description = "Cross platform open source e-book reader";
     mainProgram = "cr3";
     license = licenses.gpl2Plus; # see https://github.com/buggins/coolreader/issues/80
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -91,7 +91,6 @@ mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       abbradar
-      gebner
     ];
   };
 }

--- a/pkgs/applications/misc/cura/plugins.nix
+++ b/pkgs/applications/misc/cura/plugins.nix
@@ -35,7 +35,7 @@ let
         description = "Enables printing directly to OctoPrint and monitoring the process";
         homepage = "https://github.com/fieldOfView/Cura-OctoPrintPlugin";
         license = licenses.agpl3Plus;
-        maintainers = with maintainers; [ gebner ];
+        maintainers = with maintainers; [ ];
       };
     };
 
@@ -74,7 +74,7 @@ let
         description = "Cura plugin for HID mice such as 3Dconnexion spacemouse";
         homepage = "https://github.com/smartavionics/RawMouse";
         license = licenses.agpl3Plus;
-        maintainers = with maintainers; [ gebner ];
+        maintainers = with maintainers; [ ];
       };
     };
 

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       abbradar
-      gebner
     ];
     mainProgram = "CuraEngine";
   };

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ darwin;
     mainProgram = "goldendict";
     maintainers = with maintainers; [
-      gebner
       astsmtl
       sikmir
     ];

--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -96,7 +96,6 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [
       iblech
-      gebner
     ];
   };
 }

--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -143,7 +143,6 @@ stdenv.mkDerivation rec {
       "aarch64-linux"
     ];
     maintainers = with maintainers; [
-      gebner
       linsui
     ];
   };

--- a/pkgs/applications/science/logic/eprover/default.nix
+++ b/pkgs/applications/science/logic/eprover/default.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = with maintainers; [
       raskin
-      gebner
     ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/logic/glucose/default.nix
+++ b/pkgs/applications/science/logic/glucose/default.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.labri.fr/perso/lsimon/research/glucose/";
     license = if enableUnfree then licenses.unfreeRedistributable else licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/science/logic/vampire/default.nix
+++ b/pkgs/applications/science/logic/vampire/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation rec {
     mainProgram = "vampire";
     platforms = platforms.unix;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/applications/science/logic/verit/default.nix
+++ b/pkgs/applications/science/logic/verit/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     homepage = "https://verit.loria.fr/";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = [ maintainers.gebner ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/applications/science/math/speedcrunch/default.nix
+++ b/pkgs/applications/science/math/speedcrunch/default.nix
@@ -42,7 +42,6 @@ mkDerivation rec {
       full keyboard-friendly and more than 15 built-in math function.
     '';
     maintainers = with maintainers; [
-      gebner
       j0hax
     ];
     inherit (qtbase.meta) platforms;

--- a/pkgs/by-name/as/aspino/package.nix
+++ b/pkgs/by-name/as/aspino/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "SAT/PseudoBoolean/MaxSat/ASP solver using glucose";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     license = licenses.asl20;
     homepage = "https://alviano.net/software/maxino/";

--- a/pkgs/by-name/au/automaticcomponenttoolkit/package.nix
+++ b/pkgs/by-name/au/automaticcomponenttoolkit/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     mainProgram = "act";
     homepage = "https://github.com/Autodesk/AutomaticComponentToolkit";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ca/calculix-ccx/package.nix
+++ b/pkgs/by-name/ca/calculix-ccx/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     description = "Three-dimensional structural finite element program";
     mainProgram = "ccx";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High-level, retained-mode toolkit for effective 3D graphics development";
     mainProgram = "coin-config";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 })

--- a/pkgs/by-name/cv/cvc4/package.nix
+++ b/pkgs/by-name/cv/cvc4/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       vbgl
       thoughtpolice
-      gebner
     ];
   };
 }

--- a/pkgs/by-name/el/elan/package.nix
+++ b/pkgs/by-name/el/elan/package.nix
@@ -89,7 +89,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     mainProgram = "elan";
   };
 }

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -202,7 +202,7 @@ freecad-utils.makeCustomizable (stdenv.mkDerivation (finalAttrs: {
       right at home with FreeCAD.
     '';
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ gebner srounce ];
+    maintainers = with lib.maintainers; [ srounce ];
     platforms = lib.platforms.linux;
   };
 }))

--- a/pkgs/by-name/ip/ipaexfont/package.nix
+++ b/pkgs/by-name/ip/ipaexfont/package.nix
@@ -32,6 +32,6 @@ stdenvNoCC.mkDerivation {
     '';
     homepage = "https://moji.or.jp/ipafont/";
     license = licenses.ipa;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ip/iprover/package.nix
+++ b/pkgs/by-name/ip/iprover/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.cs.man.ac.uk/~korovink/iprover/";
     maintainers = with maintainers; [
       raskin
-      gebner
     ];
     platforms = platforms.linux;
     license = licenses.gpl3;

--- a/pkgs/by-name/kh/khal/package.nix
+++ b/pkgs/by-name/kh/khal/package.nix
@@ -120,6 +120,6 @@ python.pkgs.buildPythonApplication rec {
     homepage = "https://lostpackets.de/khal/";
     changelog = "https://github.com/pimutils/khal/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/le/lean/package.nix
+++ b/pkgs/by-name/le/lean/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       thoughtpolice
-      gebner
     ];
   };
 }

--- a/pkgs/by-name/le/lean2/package.nix
+++ b/pkgs/by-name/le/lean2/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       thoughtpolice
-      gebner
     ];
     broken = stdenv.hostPlatform.isAarch64;
     mainProgram = "lean";

--- a/pkgs/by-name/li/lib3mf/package.nix
+++ b/pkgs/by-name/li/lib3mf/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
     description = "Reference implementation of the 3D Manufacturing Format file standard";
     homepage = "https://3mf.io/";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/li/libde265/package.nix
+++ b/pkgs/by-name/li/libde265/package.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     mainProgram = "dec265";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
   };
 })

--- a/pkgs/by-name/li/libeb/package.nix
+++ b/pkgs/by-name/li/libeb/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       the EB, EBG, EBXA, EBXA-C, S-EBXA and EPWING formats.
     '';
     license = licenses.bsd3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/by-name/li/libheif/package.nix
+++ b/pkgs/by-name/li/libheif/package.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
     description = "ISO/IEC 23008-12:2017 HEIF image file format decoder and encoder";
     license = lib.licenses.lgpl3Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/li/libqalculate/package.nix
+++ b/pkgs/by-name/li/libqalculate/package.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://qalculate.github.io";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      gebner
       doronbehar
       alyaeanyx
     ];

--- a/pkgs/by-name/ma/marlin-calc/package.nix
+++ b/pkgs/by-name/ma/marlin-calc/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/eyal0/Marlin";
     description = "Marlin 3D printer timing simulator";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/marlin-calc.x86_64-darwin
     mainProgram = "marlin-calc";

--- a/pkgs/by-name/me/metis-prover/package.nix
+++ b/pkgs/by-name/me/metis-prover/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     mainProgram = "metis";
     homepage = "https://www.gilith.com/research/metis/";
     license = licenses.mit;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/mi/minisat/package.nix
+++ b/pkgs/by-name/mi/minisat/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Compact and readable SAT solver";
     maintainers = with maintainers; [
-      gebner
       raskin
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/zlib-ng/minizip-ng";
     license = licenses.zlib;
     maintainers = with maintainers; [
-      gebner
       ris
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/mj/mjpg-streamer/package.nix
+++ b/pkgs/by-name/mj/mjpg-streamer/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     description = "Takes JPGs from Linux-UVC compatible webcams, filesystem or other input plugins and streams them as M-JPEG via HTTP to webbrowsers, VLC and other software";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     mainProgram = "mjpg_streamer";
   };
 }

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -106,7 +106,6 @@ buildBazelPackage rec {
     license = licenses.free;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      gebner
       ericsagnes
       pineapplehunter
     ];

--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -268,7 +268,6 @@ let
             license = licenses.agpl3Only;
             maintainers = with maintainers; [
               abbradar
-              gebner
               WhittlesJr
               gador
             ];

--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -111,7 +111,7 @@ in
       description = "Plugin for slicing via Cura Legacy from within OctoPrint";
       homepage = "https://github.com/OctoPrint/OctoPrint-CuraEngineLegacy";
       license = licenses.agpl3Only;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ ];
     };
   };
 
@@ -384,7 +384,7 @@ in
       description = "Better print time estimation for OctoPrint";
       homepage = "https://github.com/eyal0/OctoPrint-PrintTimeGenius";
       license = licenses.agpl3Only;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ ];
     };
   };
 
@@ -433,7 +433,7 @@ in
       description = "OctoPrint plugin to control ATX/AUX power supply";
       homepage = "https://github.com/kantlivelong/OctoPrint-PSUControl";
       license = licenses.agpl3Only;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ ];
     };
   };
 
@@ -589,7 +589,7 @@ in
       description = "Touch friendly interface for a small TFT module or phone for OctoPrint";
       homepage = "https://github.com/BillyBlaze/OctoPrint-TouchUI";
       license = licenses.agpl3Only;
-      maintainers = with maintainers; [ gebner ];
+      maintainers = with maintainers; [ ];
     };
   };
 

--- a/pkgs/by-name/op/open-wbo/package.nix
+++ b/pkgs/by-name/op/open-wbo/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
     description = "State-of-the-art MaxSAT and Pseudo-Boolean solver";
     mainProgram = "open-wbo";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     license = licenses.mit;
     homepage = "http://sat.inesc-id.pt/open-wbo/";

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;  # essentially...
     # The special exception defined in the file OCCT_LGPL_EXCEPTION.txt
     # are basically about making the license a little less share-alike.
-    maintainers = with maintainers; [ amiloradovsky gebner ];
+    maintainers = with maintainers; [ amiloradovsky ];
     platforms = platforms.all;
   };
 

--- a/pkgs/by-name/pr/procmail/package.nix
+++ b/pkgs/by-name/pr/procmail/package.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/BuGlessRB/procmail/";
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/pu/pubs/package.nix
+++ b/pkgs/by-name/pu/pubs/package.nix
@@ -78,7 +78,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/pubs/pubs/blob/v${version}/changelog.md";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [
-      gebner
       dotlambda
     ];
   };

--- a/pkgs/by-name/qa/qalculate-gtk/package.nix
+++ b/pkgs/by-name/qa/qalculate-gtk/package.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Ultimate desktop calculator";
     homepage = "http://qalculate.github.io";
     maintainers = with maintainers; [
-      gebner
       doronbehar
       alyaeanyx
       aleksana

--- a/pkgs/by-name/si/simp_le/package.nix
+++ b/pkgs/by-name/si/simp_le/package.nix
@@ -72,7 +72,6 @@ python.pkgs.buildPythonApplication rec {
     description = "Simple Let's Encrypt client";
     license = licenses.gpl3;
     maintainers = with maintainers; [
-      gebner
       makefu
     ];
     platforms = platforms.linux;

--- a/pkgs/by-name/sp/spnavcfg/package.nix
+++ b/pkgs/by-name/sp/spnavcfg/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Interactive configuration GUI for space navigator input devices";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     mainProgram = "spnavcfg";
   };
 })

--- a/pkgs/by-name/sp/spooles/package.nix
+++ b/pkgs/by-name/sp/spooles/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.netlib.org/linalg/spooles/";
     description = "Library for solving sparse real and complex linear systems of equations";
     license = licenses.publicDomain;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/te/tegaki-zinnia-japanese/package.nix
+++ b/pkgs/by-name/te/tegaki-zinnia-japanese/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     homepage = "http://tegaki.org/";
     license = licenses.lgpl21;
     platforms = platforms.unix;
-    maintainers = [ maintainers.gebner ];
+    maintainers = [ ];
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/by-name/tp/tptp/package.nix
+++ b/pkgs/by-name/tp/tptp/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
     description = "Thousands of problems for theorem provers and tools";
     maintainers = with maintainers; [
       raskin
-      gebner
     ];
     # 6.3 GiB of data. Installation is unpacking and editing a few files.
     # No sense in letting Hydra build it.

--- a/pkgs/by-name/ui/uivonim/package.nix
+++ b/pkgs/by-name/ui/uivonim/package.nix
@@ -37,7 +37,7 @@ buildNpmPackage rec {
   meta = with lib; {
     homepage = "https://github.com/smolck/uivonim";
     description = "Cross-platform GUI for neovim based on electron";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
     license = licenses.agpl3Only;
     mainProgram = "uivonim";

--- a/pkgs/by-name/vi/vieb/package.nix
+++ b/pkgs/by-name/vi/vieb/package.nix
@@ -71,7 +71,6 @@ buildNpmPackage rec {
     description = "Vim Inspired Electron Browser";
     mainProgram = "vieb";
     maintainers = with maintainers; [
-      gebner
       tejing
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/zi/zinnia/package.nix
+++ b/pkgs/by-name/zi/zinnia/package.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
     homepage = "http://taku910.github.io/zinnia/";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = [ maintainers.gebner ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -84,9 +84,7 @@ stdenv.mkDerivation {
     homepage = "https://www.fstar-lang.org";
     changelog = "https://github.com/FStarLang/FStar/raw/v${version}/CHANGES.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [
-      gebner
-    ];
+    maintainers = with maintainers; [ ];
     mainProgram = "fstar.exe";
     platforms = with platforms; darwin ++ linux;
   };

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -279,8 +279,6 @@ package-maintainers:
     - total
     - turtle
     - typed-spreadsheet
-  gebner:
-    - wstunnel
   gridaphobe:
     - located-base
   iblech:

--- a/pkgs/development/libraries/embree/default.nix
+++ b/pkgs/development/libraries/embree/default.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     homepage = "https://embree.github.io/";
     maintainers = with maintainers; [
       hodapp
-      gebner
     ];
     license = licenses.asl20;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/soqt/default.nix
+++ b/pkgs/development/libraries/soqt/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/coin3d/soqt";
     license = licenses.bsd3;
     description = "Glue between Coin high-level 3D visualization library and Qt";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -38,6 +38,6 @@ buildDunePackage rec {
     description = "Various signed and unsigned integers for OCaml";
     homepage = "https://github.com/andrenth/ocaml-stdint";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.gebner ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/cachelib/default.nix
+++ b/pkgs/development/python-modules/cachelib/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pallets/cachelib";
     description = "Collection of cache libraries in the same API interface";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -46,7 +46,6 @@ buildPythonPackage rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       abbradar
-      gebner
     ];
   };
 }

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     maintainers = with maintainers; [
       abbradar
       orivej
-      gebner
     ];
   };
 }

--- a/pkgs/development/python-modules/mathlibtools/default.nix
+++ b/pkgs/development/python-modules/mathlibtools/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/leanprover-community/mathlib-tools";
     changelog = "https://github.com/leanprover-community/mathlib-tools/raw/v${version}/CHANGELOG.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/piccata/default.nix
+++ b/pkgs/development/python-modules/piccata/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Simple CoAP (RFC7252) toolkit";
     homepage = "https://github.com/NordicSemiconductor/piccata";
     license = licenses.mit;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/coin3d/pivy/";
     description = "Python binding for Coin";
     license = licenses.bsd0;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pure-eval/default.nix
+++ b/pkgs/development/python-modules/pure-eval/default.nix
@@ -34,6 +34,6 @@ buildPythonPackage rec {
     description = "Safely evaluate AST nodes without side effects";
     homepage = "https://github.com/alexmojaki/pure_eval";
     license = licenses.mit;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyfakefs/default.nix
+++ b/pkgs/development/python-modules/pyfakefs/default.nix
@@ -56,6 +56,6 @@ buildPythonPackage rec {
     homepage = "https://pyfakefs.org/";
     changelog = "https://github.com/jmcgeheeiv/pyfakefs/blob/v${version}/CHANGES.md";
     license = licenses.asl20;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyside2-tools/default.nix
+++ b/pkgs/development/python-modules/pyside2-tools/default.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation {
     description = "PySide2 development tools";
     license = licenses.gpl2;
     homepage = "https://wiki.qt.io/Qt_for_Python";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     description = "LGPL-licensed Python bindings for Qt";
     license = licenses.lgpl21;
     homepage = "https://wiki.qt.io/Qt_for_Python";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
     changelog = "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-${finalAttrs.version}?h=v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     description = "Interface to the OpenThread Network Co-Processor (NCP)";
     homepage = "https://github.com/openthread/pyspinel";
     license = licenses.asl20;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pythonocc-core/default.nix
+++ b/pkgs/development/python-modules/pythonocc-core/default.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/tpaviot/pythonocc-core/releases/tag/${version}";
     license = licenses.lgpl3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/sentry-sdk/1.nix
+++ b/pkgs/development/python-modules/sentry-sdk/1.nix
@@ -130,7 +130,6 @@ buildPythonPackage rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [
       fab
-      gebner
     ];
   };
 }

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation {
       lgpl21
     ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -69,7 +69,7 @@ stdenv'.mkDerivation (finalAttrs: {
     ];
     homepage = "https://wiki.qt.io/Qt_for_Python";
     changelog = "https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-${finalAttrs.version}?h=v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/python-modules/shippai/default.nix
+++ b/pkgs/development/python-modules/shippai/default.nix
@@ -19,6 +19,6 @@ buildPythonPackage rec {
     description = "Use Rust failures as Python exceptions";
     homepage = "https://github.com/untitaker/shippai";
     license = licenses.mit;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/spyder-ide/spyder-kernels/releases";
     changelog = "https://github.com/spyder-ide/spyder-kernels/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -145,7 +145,7 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/spyder-ide/spyder/releases";
     changelog = "https://github.com/spyder-ide/spyder/blob/master/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gebner ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     mainProgram = "trimesh";
     maintainers = with lib.maintainers; [
-      gebner
       pbsds
     ];
   };

--- a/pkgs/development/python-modules/uranium/default.nix
+++ b/pkgs/development/python-modules/uranium/default.nix
@@ -61,7 +61,6 @@ buildPythonPackage rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       abbradar
-      gebner
     ];
   };
 }

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     mainProgram = "tokei";
   };
 }

--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -42,7 +42,7 @@ mkDerivation rec {
     homepage = "https://github.com/KDE/heaptrack";
     license = licenses.lgpl21Plus;
     mainProgram = "heaptrack_gui";
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     description = "DIGImend graphics tablet drivers for the Linux kernel";
     homepage = "https://digimend.github.io/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/mail/opensmtpd/extras.nix
+++ b/pkgs/servers/mail/opensmtpd/extras.nix
@@ -107,7 +107,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      gebner
       ekleog
     ];
   };

--- a/pkgs/servers/pulseaudio/hsphfpd.nix
+++ b/pkgs/servers/pulseaudio/hsphfpd.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
     description = "Bluetooth HSP/HFP daemon";
     homepage = "https://github.com/pali/hsphfpd-prototype";
     license = licenses.artistic1;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/archivers/pax/default.nix
+++ b/pkgs/tools/archivers/pax/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "POSIX standard archive tool from MirBSD";
     homepage = "https://www.mirbsd.org/pax.htm";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ gebner ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      gebner
       ericsagnes
     ];
   };


### PR DESCRIPTION
@gebner has been an amazing maintainer, but appears to have moved on: the last commit on nixpkgs appears to have been in Feb 2023, and they have not been responding to pings (e.g. https://github.com/NixOS/nixpkgs/issues/347764).

They also approved https://github.com/NixOS/nixpkgs/pull/337292 before, but that PR had some additional changes and was closed without merging.

This PR is in no way intended to diminish Gabriel's accomplishments, and they're welcome to just say so if they'd prefer this PR not to be merged. Also, even if it's merged, of course they're always welcome to return to activity and be added back. The intent of this PR is to give more realistic expectations around the maintainership of these packages, and to invite others to step up for maintainership if they rely on those packages.

This seems in line with https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
