### PR TITLE
nixos/h2o: enable HTTP/3 via QUIC

### DIFF
--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -351,7 +351,7 @@ in
                 "hydra.example.com" = {
                   tls = {
                     policy = "force";
-                    indentity = [
+                    identity = [
                       {
                         key-file = "/path/to/key";
                         certificate-file = "/path/to/cert";

--- a/nixos/modules/services/web-servers/h2o/default.nix
+++ b/nixos/modules/services/web-servers/h2o/default.nix
@@ -221,10 +221,7 @@ let
                             headerSet ++ [ hsts ];
                       }
                     );
-              in
-              value.settings
-              // headerRecAttrs
-              // {
+
                 listen =
                   let
                     identity =
@@ -233,17 +230,27 @@ let
                         key-file = "${certs.${names.cert}.directory}/key.pem";
                         certificate-file = "${certs.${names.cert}.directory}/fullchain.pem";
                       };
+
+                    baseListen =
+                      {
+                        port = port.TLS;
+                        ssl = (lib.recursiveUpdate tlsRecAttrs value.tls.extraSettings) // {
+                          inherit identity;
+                        };
+                      }
+                      // lib.optionalAttrs (value.host != null) {
+                        host = value.host;
+                      };
+
+                    # QUIC, if used, will duplicate the TLS over TCP directive, but
+                    # append some extra QUIC-related settings
+                    quicListen = lib.optional (value.tls.quic != null) (baseListen // { inherit (value.tls) quic; });
                   in
                   {
-                    port = port.TLS;
-                    ssl = (lib.recursiveUpdate tlsRecAttrs value.tls.extraSettings) // {
-                      inherit identity;
-                    };
-                  }
-                  // lib.optionalAttrs (value.host != null) {
-                    host = value.host;
+                    listen = [ baseListen ] ++ quicListen;
                   };
-              };
+              in
+              value.settings // headerRecAttrs // listen;
           };
     in
     # With a high likelihood of HTTP & ACME challenges being on the same port,

--- a/nixos/modules/services/web-servers/h2o/vhost-options.nix
+++ b/nixos/modules/services/web-servers/h2o/vhost-options.nix
@@ -152,6 +152,25 @@ in
                   '';
             };
             recommendations = tlsRecommendationsOption;
+            quic = mkOption {
+              type = types.nullOr types.attrs;
+              default = null;
+              description = ''
+                Enables HTTP/3 over QUIC on the UDP port for TLS. The attrset
+                provides fine-turning for QUIC behavior, but can be empty. See
+                <https://h2o.examp1e.net/configure/http3_directives.html#quic-attributes>.
+              '';
+              example =
+                literalExpression
+                  # nix
+                  ''
+                    {
+                      amp-limit = 2;
+                      handshake-timeout-rtt-multiplier = 300;
+                      retry = "ON";
+                    }
+                  '';
+            };
             extraSettings = mkOption {
               type = types.attrs;
               default = { };

--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -110,7 +110,6 @@ in
         };
       };
   };
-
   testScript =
     let
       portStrHTTP = builtins.toString port.HTTP;
@@ -122,23 +121,19 @@ in
       server.wait_for_open_port(${portStrHTTP})
       server.wait_for_open_port(${portStrTLS})
 
-      http_hello_world_body = server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
-      assert "${sawatdi_chao_lok}" in http_hello_world_body
+      assert "${sawatdi_chao_lok}" in server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
 
       tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
       assert "http/2 200" in tls_hello_world_head
       assert "server: h2o" in tls_hello_world_head
       assert "content-type: text/x-rst" in tls_hello_world_head
 
-      tls_hello_world_body = server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
-      assert "${sawatdi_chao_lok}" in tls_hello_world_body
+      assert "${sawatdi_chao_lok}" in server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
 
-      tls_hello_world_head_redirected = server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'").lower()
-      assert "redirected" in tls_hello_world_head_redirected
+      assert "redirected" in server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'").lower()
 
       server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
 
-      tls_hello_world_body_redirected = server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
-      assert "${sawatdi_chao_lok}" in tls_hello_world_body_redirected
+      assert "${sawatdi_chao_lok}" in server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
     '';
 }

--- a/nixos/tests/web-servers/h2o/mruby.nix
+++ b/nixos/tests/web-servers/h2o/mruby.nix
@@ -58,10 +58,8 @@ in
       server.wait_for_unit("h2o.service")
       server.wait_for_open_port(${portStr})
 
-      hello_world = server.succeed("curl --fail-with-body http://${domain}:${portStr}/hello_world")
-      assert "${sawatdi_chao_lok}" in hello_world
+      assert "${sawatdi_chao_lok}" in server.succeed("curl --fail-with-body http://${domain}:${portStr}/hello_world")
 
-      file_handler = server.succeed("curl --fail-with-body http://${domain}:${portStr}/file_handler")
-      assert "FILE_HANDLER" in file_handler
+      assert "FILE_HANDLER" in server.succeed("curl --fail-with-body http://${domain}:${portStr}/file_handler")
     '';
 }


### PR DESCRIPTION
This is a bit tricky to configure otherwise. These option allow a users to easily enable [HTTP/3](https://httpwg.org/specs/rfc9114.html) support for an existing virtual host thru a boolean that duplicates the listen port + certs as the TLS which is almost certainly the behavior the user wants.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.