### PR TITLE
treewide: avoid running dotnet fetch-deps script twice

### DIFF
--- a/pkgs/by-name/av/avalonia/update.bash
+++ b/pkgs/by-name/av/avalonia/update.bash
@@ -4,8 +4,9 @@
 
 set -euo pipefail
 
+export NIXPKGS_ALLOW_INSECURE=1 # uses EOL dotnet-sdk-7
 package="$UPDATE_NIX_ATTR_PATH"
-nix-update "$package"
+nix-update "$package" --src-only
 src=$(nix-build -A "$package".src --no-out-link)
 npmDepsFile=$(nix-instantiate --eval -A "$package".npmDepsFile)
 (

--- a/pkgs/by-name/fs/fsautocomplete/package.nix
+++ b/pkgs/by-name/fs/fsautocomplete/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   dotnetCorePackages,
   testers,
-  _experimental-update-script-combinators,
   nix-update-script,
 }:
 
@@ -38,10 +37,7 @@ buildDotnetModule (finalAttrs: {
 
   passthru = {
     tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
-    updateScript = _experimental-update-script-combinators.sequence [
-      (nix-update-script { })
-      finalAttrs.passthru.fetch-deps
-    ];
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/kr/kryptor/package.nix
+++ b/pkgs/by-name/kr/kryptor/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   dotnetCorePackages,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildDotnetModule rec {
@@ -27,7 +28,7 @@ buildDotnetModule rec {
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
-    updateScript = ./update.sh;
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/kr/kryptor/update.sh
+++ b/pkgs/by-name/kr/kryptor/update.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p bash nix nix-update git cacert
-set -euo pipefail
-
-nix-update kryptor
-$(nix-build . -A kryptor.fetch-deps --no-out-link)

--- a/pkgs/by-name/lu/lumafly/package.nix
+++ b/pkgs/by-name/lu/lumafly/package.nix
@@ -9,7 +9,7 @@
   icoutils,
   copyDesktopItems,
   makeDesktopItem,
-  writeScript,
+  nix-update-script,
 }:
 buildDotnetModule rec {
   pname = "lumafly";
@@ -34,16 +34,7 @@ buildDotnetModule rec {
 
   selfContainedBuild = true;
 
-  passthru.updateScript = writeScript "update-lumafly" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell --pure -i bash -p bash nix nix-update git cacert
-    set -eo pipefail
-
-    prev_version=$(nix eval --raw -f. lumafly.version)
-    nix-update lumafly
-    [[ $(nix eval --raw -f. lumafly.version) == "$prev_version" ]] ||
-      $(nix-build . -A lumafly.fetch-deps --no-out-link)
-  '';
+  passthru.updateScript = nix-update-script { };
 
   runtimeDeps = [
     zlib

--- a/pkgs/by-name/ms/msbuild-structured-log-viewer/package.nix
+++ b/pkgs/by-name/ms/msbuild-structured-log-viewer/package.nix
@@ -10,8 +10,7 @@
   openssl,
   libkrb5,
   makeDesktopItem,
-  writeShellScript,
-  nix-update,
+  nix-update-script,
 }:
 buildDotnetModule (finalAttrs: rec {
   pname = "msbuild-structured-log-viewer";
@@ -73,10 +72,7 @@ buildDotnetModule (finalAttrs: rec {
     categories = [ "Development" ];
   };
 
-  passthru.updateScript = writeShellScript "update-${finalAttrs.pname}" ''
-    ${lib.getExe nix-update}
-    "$(nix-build -A "$UPDATE_NIX_ATTR_PATH.fetch-deps" --no-out-link)"
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Rich interactive log viewer for MSBuild logs";

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -11,6 +11,7 @@
   makeFontsConf,
   runCommand,
   xdg-utils,
+  nix-update-script,
   pname ? "nexusmods-app",
 }:
 let
@@ -181,7 +182,7 @@ buildDotnetModule (finalAttrs: {
           NexusMods.App list-tools
         '';
       };
-    updateScript = ./update.bash;
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/ne/nexusmods-app/update.bash
+++ b/pkgs/by-name/ne/nexusmods-app/update.bash
@@ -1,9 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p nix-update
-#shellcheck shell=bash
-
-set -o errexit -o nounset -o pipefail
-
-package=nexusmods-app
-nix-update "$package"
-"$(nix-build --attr "$package".fetch-deps --no-out-link)"

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -17,6 +17,7 @@
   udev,
   wrapGAppsHook3,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildDotnetModule (finalAttrs: {
@@ -122,7 +123,7 @@ buildDotnetModule (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/otd-daemon";
 
   passthru = {
-    updateScript = ./update.sh;
+    updateScript = nix-update-script { };
     tests = {
       otd-runs = nixosTests.opentabletdriver;
     };

--- a/pkgs/by-name/op/opentabletdriver/update.sh
+++ b/pkgs/by-name/op/opentabletdriver/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p bash nix nix-update git cacert
-set -euo pipefail
-
-prev_version=$(nix eval --raw -f. opentabletdriver.version)
-nix-update opentabletdriver
-[[ $(nix eval --raw -f. opentabletdriver.version) == "$prev_version" ]] ||
-  "$(nix-build . -A opentabletdriver.fetch-deps --no-out-link)"

--- a/pkgs/by-name/ps/ps3-disc-dumper/package.nix
+++ b/pkgs/by-name/ps/ps3-disc-dumper/package.nix
@@ -5,6 +5,7 @@
   zlib,
   openssl,
   dotnetCorePackages,
+  nix-update-script,
 }:
 
 buildDotnetModule rec {
@@ -37,7 +38,7 @@ buildDotnetModule rec {
     openssl
   ];
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Handy utility to make decrypted PS3 disc dumps";

--- a/pkgs/by-name/ps/ps3-disc-dumper/update.sh
+++ b/pkgs/by-name/ps/ps3-disc-dumper/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p bash nix nix-update git cacert
-set -eo pipefail
-
-prev_version=$(nix eval --raw -f. ps3-disc-dumper.version)
-nix-update ps3-disc-dumper
-[[ $(nix eval --raw -f. ps3-disc-dumper.version) == "$prev_version" ]] ||
-  $(nix-build . -A ps3-disc-dumper.fetch-deps --no-out-link)

--- a/pkgs/by-name/to/tone/package.nix
+++ b/pkgs/by-name/to/tone/package.nix
@@ -5,6 +5,7 @@
   ffmpeg-full,
   dotnetCorePackages,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildDotnetModule rec {
@@ -33,7 +34,7 @@ buildDotnetModule rec {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/sandreas/tone";

--- a/pkgs/by-name/to/tone/update.sh
+++ b/pkgs/by-name/to/tone/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p bash nix nix-update git cacert
-set -eo pipefail
-
-prev_version=$(nix eval --raw -f. tone.version)
-nix-update tone
-[[ $(nix eval --raw -f. tone.version) == "$prev_version" ]] ||
-  "$(nix-build . -A tone.fetch-deps --no-out-link)"

--- a/pkgs/by-name/v2/v2rayn/package.nix
+++ b/pkgs/by-name/v2/v2rayn/package.nix
@@ -16,6 +16,7 @@
   bash,
   xorg,
   xdg-utils,
+  nix-update-script,
 }:
 
 buildDotnetModule rec {
@@ -96,7 +97,7 @@ buildDotnetModule rec {
     install -Dm644 v2rayN/v2rayN.Desktop/v2rayN.png $out/share/pixmaps/v2rayn.png
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "GUI client for Windows and Linux, support Xray core and sing-box-core and others";

--- a/pkgs/by-name/v2/v2rayn/update.sh
+++ b/pkgs/by-name/v2/v2rayn/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash nix nix-update
-
-set -eou pipefail
-
-nix-update v2rayn
-
-$(nix-build -A v2rayn.fetch-deps)

--- a/pkgs/by-name/vr/vrcadvert/package.nix
+++ b/pkgs/by-name/vr/vrcadvert/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   lib,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildDotnetModule rec {
@@ -38,7 +39,7 @@ buildDotnetModule rec {
   ];
   versionCheckProgram = "${placeholder "out"}/bin/VrcAdvert";
 
-  passthru.updateScript = ./update.sh;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Advertise your OSC app through OSCQuery";

--- a/pkgs/by-name/vr/vrcadvert/update.sh
+++ b/pkgs/by-name/vr/vrcadvert/update.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p bash nix nix-update git cacert
-set -eo pipefail
-
-prev_version=$(nix eval --raw -f. vrcadvert.version)
-nix-update vrcadvert
-[[ $(nix eval --raw -f. vrcadvert.version) == "$prev_version" ]] ||
-  $(nix-build . -A vrcadvert.fetch-deps --no-out-link)

--- a/pkgs/development/tools/godot/update.sh
+++ b/pkgs/development/tools/godot/update.sh
@@ -9,7 +9,8 @@ attr=$UPDATE_NIX_ATTR_PATH
 prev_version=$UPDATE_NIX_OLD_VERSION
 nix-update "$attr" \
     --version-regex "($versionPrefix\\b.*-stable)" \
-    --override-filename "$2"
+    --override-filename "$2" \
+    --src-only
 [[ $(nix eval --raw -f. "$attr".version) != "$prev_version" ]] || exit 0
 
 "$(nix build --impure --expr "((import ./. {}).$attr.override { withMono = true; }).fetch-deps" --print-out-paths --no-link)"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now that `nix-update-script` also runs the dotnet `fetch-deps` script since v1.10.0, many dotnet packages' update script can be simplified. Keeping `nix-update` and `fetch-deps` in current update scripts would cause to run `fetch-deps` twice, which still works but takes more time to complete. This PR only addresses the cases where this duplicated work would occur. See https://github.com/Mic92/nix-update/pull/320.

~~Depends on https://github.com/NixOS/nixpkgs/pull/388987~~

## Affected packages

These were obtained by `rg -l fetch-deps $(rg -l nix-update)`:
- pkgs/by-name/op/opentabletdriver/update.sh
- pkgs/by-name/ps/ps3-disc-dumper/update.sh
- pkgs/by-name/ne/nexusmods-app/update.bash
- pkgs/by-name/ms/msbuild-structured-log-viewer/package.nix
- pkgs/by-name/lu/lumafly/package.nix
- ~~pkgs/development/tools/build-managers/gradle/default.nix~~ - false positive, unrelated to dotnet
- pkgs/by-name/kr/kryptor/update.sh
- pkgs/by-name/to/tone/update.sh
- pkgs/development/tools/godot/update.sh
- pkgs/by-name/fs/fsautocomplete/package.nix
- pkgs/by-name/v2/v2rayn/update.sh
- pkgs/by-name/av/avalonia/update.bash
- pkgs/by-name/vr/vrcadvert/update.sh

## Testing done

For simple packages that only need a `nix-update-script { }`, I made a branch where I reset the versions to `0.0.0` and ran the update scripts, then check the generated diff.
https://github.com/gepbird/nixpkgs/blob/dotnet-no-duplicate-fetch-deps-test 

```bash
simple_packages=(opentabletdriver ps3-disc-dumper nexusmods-app msbuild-structured-log-viewer lumafly kryptor tone fsautocomplete v2rayn)
for package in $simple_packages; do nix-shell maintainers/scripts/update.nix --argstr package $package --argstr skip-prompt true; done
```

There are 3 other packages:
- `vrcadvert` which needs needs to be manually updated, the current nix code is not compatible with the latest version
- `avalonia` who's update script is also broken on master
- `godot` works similarly to the simple packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
