### PR TITLE
nexusmods-app: 0.7.3 -> 0.8.2

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -48,7 +48,7 @@
 
 ### NexusMods.App upgraded {#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded}
 
-- `nexusmods-app` has been upgraded from version 0.6.3 to 0.7.3.
+- `nexusmods-app` has been upgraded from version 0.6.3 to 0.8.2.
 
   - Before upgrading, you **must reset all app state** (mods, games, settings, etc). NexusMods.App will crash if any state from a version older than 0.7.0 is still present.
 

--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -31,8 +31,8 @@
   },
   {
     "pname": "Avalonia",
-    "version": "11.2.2",
-    "hash": "sha256-lYWqgjYOyh4pg+TdkgqeFhi8OMI1p9IOvSntVXo5zvE="
+    "version": "11.2.4",
+    "hash": "sha256-CcdWUxqd43A4KeY1K4T5M6R1M0zuwdwyd5Qh/BAlNT4="
   },
   {
     "pname": "Avalonia.Angle.Windows.Natives",
@@ -51,43 +51,43 @@
   },
   {
     "pname": "Avalonia.BuildServices",
-    "version": "0.0.29",
-    "hash": "sha256-WPHRMNowRnYSCh88DWNBCltWsLPyOfzXGzBqLYE7tRY="
+    "version": "0.0.31",
+    "hash": "sha256-wgtodGf644CsUZEBIpFKcUjYHTbnu7mZmlr8uHIxeKA="
   },
   {
     "pname": "Avalonia.Controls.ColorPicker",
-    "version": "11.2.2",
-    "hash": "sha256-Mmp7Mjy9Y6uvkfjE8KLWoJWcVZHiJwqmhQupsxYRExo="
+    "version": "11.2.4",
+    "hash": "sha256-21Wfb4p0dCevw8Iu/Fchngt1teAnBaxEWgiUpFkerTo="
   },
   {
     "pname": "Avalonia.Controls.DataGrid",
-    "version": "11.2.2",
-    "hash": "sha256-RbkISZEp55N9dtqvPp0Ej2/wpU/YzI4wgJjBCJnIGl4="
+    "version": "11.2.4",
+    "hash": "sha256-fqQBKzHcL0CwuOQ90Gp+UUZZP9OQ9U6H41bvikxQJpo="
   },
   {
     "pname": "Avalonia.Controls.TreeDataGrid",
-    "version": "11.1.0",
-    "hash": "sha256-WU0vs7a3BTQQiJn+fBhs+o+iKt5aukIVjpfH5LyyWwc="
+    "version": "11.1.1",
+    "hash": "sha256-pEh7qGLhkirOW81xqy8iRMmFpOgdyTFpWpUHrkHgmcM="
   },
   {
     "pname": "Avalonia.Desktop",
-    "version": "11.2.2",
-    "hash": "sha256-ucd2SH0CAjwE5TSgwhhzYZqMD1zuTlR7qLQDl3mYGvg="
+    "version": "11.2.4",
+    "hash": "sha256-WKTOx7RNSb0fOMg5Za4j+u9DwKXDqVzHwQCEXSm7TFo="
   },
   {
     "pname": "Avalonia.Diagnostics",
-    "version": "11.2.2",
-    "hash": "sha256-aOji+/TYSP0l3dpn62bvWMdce2YkYi5xzRPC3nS6ZGc="
+    "version": "11.2.4",
+    "hash": "sha256-MUSfRXeJ1bstO2rTqWWCQyVq2EpjM5b5bxe0KxVAEU4="
   },
   {
     "pname": "Avalonia.FreeDesktop",
-    "version": "11.2.2",
-    "hash": "sha256-c/u6TX1Hl2h8B5xe7Zo1AJ6cR5BazI19NRnw56a36y0="
+    "version": "11.2.4",
+    "hash": "sha256-lw8YFXR/pn0awFvFW+OhjZ2LbHonL6zwqLIz+pQp+Sk="
   },
   {
     "pname": "Avalonia.Headless",
-    "version": "11.2.2",
-    "hash": "sha256-XGKYwxFAdrOWq2HgFY42+8wS03t2bHGNuajwKC4mLHc="
+    "version": "11.2.4",
+    "hash": "sha256-3XvLm+pu+s3gXJVyn8dl8teQX4ikNn+dvKXb18Owsn8="
   },
   {
     "pname": "Avalonia.Labs.Panels",
@@ -96,13 +96,13 @@
   },
   {
     "pname": "Avalonia.Native",
-    "version": "11.2.2",
-    "hash": "sha256-2Scuc+OCtfLChDYCi4feCh9XUrgJpbVaek3xRnpOGDE="
+    "version": "11.2.4",
+    "hash": "sha256-MvxivGjYerXcr70JpWe9CCXO6MU9QQgCkmZfjZCFdJM="
   },
   {
     "pname": "Avalonia.ReactiveUI",
-    "version": "11.2.2",
-    "hash": "sha256-Rr/wmmS47korAK0nAplpWCWrS1O9YZZD6i+efR7btN0="
+    "version": "11.2.4",
+    "hash": "sha256-LqwLUDCIbJowol6BNTTsK7a7KjcLLbCM3y3KKvuHRGw="
   },
   {
     "pname": "Avalonia.Remote.Protocol",
@@ -111,8 +111,8 @@
   },
   {
     "pname": "Avalonia.Remote.Protocol",
-    "version": "11.2.2",
-    "hash": "sha256-lMb3VvHXQGxn0dyEGkzKXxFocvPJUaNnOpRJpHF9ORU="
+    "version": "11.2.4",
+    "hash": "sha256-mKQVqtzxnZu6p64ZxIHXKSIw3AxAFjhmrxCc5/1VXfc="
   },
   {
     "pname": "Avalonia.Skia",
@@ -126,8 +126,8 @@
   },
   {
     "pname": "Avalonia.Skia",
-    "version": "11.2.2",
-    "hash": "sha256-YmOT+r4OfyOyg8epho6bVaEW2HImEfsZ5rNqhWIY5Fk="
+    "version": "11.2.4",
+    "hash": "sha256-82UQGuCl5hN5kdA3Uz7hptpNnG1EPlSB6k/a6XPSuXI="
   },
   {
     "pname": "Avalonia.Svg.Skia",
@@ -136,23 +136,23 @@
   },
   {
     "pname": "Avalonia.Themes.Fluent",
-    "version": "11.2.2",
-    "hash": "sha256-+wBsbMAMDMRkZN/t94qwQgyew8eCY2RBreoTCgs3KJU="
+    "version": "11.2.4",
+    "hash": "sha256-CPun/JWFCVoGxgMA510/gMP2ZB9aZJ9Bk8yuNjwo738="
   },
   {
     "pname": "Avalonia.Themes.Simple",
-    "version": "11.2.2",
-    "hash": "sha256-HXkfpUuTN8hSBMXCCGW78+2GC5w3VdTUp1qm7HvUZPI="
+    "version": "11.2.4",
+    "hash": "sha256-rnF2/bzN8AuOFlsuekOxlu+uLI7n1kIAmC36FFXMKak="
   },
   {
     "pname": "Avalonia.Win32",
-    "version": "11.2.2",
-    "hash": "sha256-pouvlprL9VeEi1dG5zR6nFj+I/4CIjH1rHbV3N9/FHg="
+    "version": "11.2.4",
+    "hash": "sha256-LJSKiLbdof8qouQhN7pY1RkMOb09IiAu/nrJFR2OybY="
   },
   {
     "pname": "Avalonia.X11",
-    "version": "11.2.2",
-    "hash": "sha256-86EIfm1zEvKleliP58xAs7KGxP/n7x2m8ca8C9W1XqA="
+    "version": "11.2.4",
+    "hash": "sha256-qty8D2/HlZz/7MiEhuagjlKlooDoW3fow5yJY5oX4Uk="
   },
   {
     "pname": "AvaloniaEdit.TextMate",
@@ -275,6 +275,11 @@
     "hash": "sha256-3pyiJeWRwfaT7p1ArsoR13aI78Jo13aHOEw3BelTS9g="
   },
   {
+    "pname": "DynamicData",
+    "version": "9.1.2",
+    "hash": "sha256-rDbtd7Fw/rhq6s9G4p/rltZ3EIR5r1RcMXsAEe7nZjw="
+  },
+  {
     "pname": "EmptyFiles",
     "version": "8.5.0",
     "hash": "sha256-mLraPiJa1JiXOWQ17GUp8MWuBNrIjcYYjItQRfMjP8s="
@@ -306,8 +311,8 @@
   },
   {
     "pname": "FluentAssertions",
-    "version": "6.12.2",
-    "hash": "sha256-yvbnZapTF610zG8YhMOESn0iXudX4xVCdoSKVo6eu+w="
+    "version": "7.1.0",
+    "hash": "sha256-AHHBQ5l7RCnjitxNE2aElBkdlg3BCcN9z+r9QrM+GeA="
   },
   {
     "pname": "FluentAssertions.Analyzers",
@@ -356,58 +361,58 @@
   },
   {
     "pname": "GameFinder",
-    "version": "4.4.0",
-    "hash": "sha256-MaVW4qgbZgsoyIq8cLQLNJnZe2M7wsKAIE+ICxRNyzg="
+    "version": "4.5.0",
+    "hash": "sha256-n9LaGrFy4kHTeXfk5HQbnZli1rzIaw0kWx4bXjUuFm8="
   },
   {
     "pname": "GameFinder.Common",
-    "version": "4.4.0",
-    "hash": "sha256-7tk84DGPBM2M8KvuTnDm4hLVmLUMd8GSLDFhsjl7Ra0="
+    "version": "4.5.0",
+    "hash": "sha256-2HHwusG2DqMSfgH3eD07afvLTmRsUSOcPc6yIuHcMks="
   },
   {
     "pname": "GameFinder.Launcher.Heroic",
-    "version": "4.4.0",
-    "hash": "sha256-/fp62b11/TXEMsrZzafHbbZYmU9pGgr7qVE2iUCVJik="
+    "version": "4.5.0",
+    "hash": "sha256-N9wQl4kTPcQC0ulqPm5OugCVeBUEstVLyG87/dwu1Fg="
   },
   {
     "pname": "GameFinder.RegistryUtils",
-    "version": "4.4.0",
-    "hash": "sha256-6Yk3A88xSWO7wr+1bJQtH6D2DRzQ0AOb8HkmSb34MPk="
+    "version": "4.5.0",
+    "hash": "sha256-n6ZmjyUlAp75mVIYi0R4ncQX7hqLAvsgapMf58Mr3Jo="
   },
   {
     "pname": "GameFinder.StoreHandlers.EADesktop",
-    "version": "4.4.0",
-    "hash": "sha256-k2tUCIxnKEdIZtaqATpJLoHh6p0mgLIB1UzBWoEcDec="
+    "version": "4.5.0",
+    "hash": "sha256-JUt5STjbESpaFmvDeGM0yQqgQziD4Or5FxBPwW4XMJE="
   },
   {
     "pname": "GameFinder.StoreHandlers.EGS",
-    "version": "4.4.0",
-    "hash": "sha256-7zxg064pFoHOYOa2kibtC1kpYgXRpbFh1Z9EatEcSNE="
+    "version": "4.5.0",
+    "hash": "sha256-O8rFUroxJHQoX0UFK4xmV637Qz+bm5Xk/SCIbhRDZQA="
   },
   {
     "pname": "GameFinder.StoreHandlers.GOG",
-    "version": "4.4.0",
-    "hash": "sha256-8LWj1MaEKhukBXs0ZIt5pt5z1H1i3VuoJONqqH6gNvY="
+    "version": "4.5.0",
+    "hash": "sha256-EyX15gumoPf4hyZ4Q8YFfyQfD1dj6J2RmilcGnkf7NE="
   },
   {
     "pname": "GameFinder.StoreHandlers.Origin",
-    "version": "4.4.0",
-    "hash": "sha256-TP9KYLDIZxFn3+N58zwjBPrL5COl2HxEpfr550OsUrM="
+    "version": "4.5.0",
+    "hash": "sha256-N2TS31L6hzJKn4LsW7g31v2LRsCjKyjVdOH6Kum7vWE="
   },
   {
     "pname": "GameFinder.StoreHandlers.Steam",
-    "version": "4.4.0",
-    "hash": "sha256-D6ABxneqdc+467RvYMs8qULyYHNTs7I0GsmXBIpiZMM="
+    "version": "4.5.0",
+    "hash": "sha256-IjdnksYT1EApOxYix6eInBAE2khwOyTbK11hjNqXZT8="
   },
   {
     "pname": "GameFinder.StoreHandlers.Xbox",
-    "version": "4.4.0",
-    "hash": "sha256-xLZJ4J79ptEjPduwdY8E288UJRQ92JnHSjkJc6Ubt+4="
+    "version": "4.5.0",
+    "hash": "sha256-CmiTBT2T3pC3GzqxUr6T2hQNDp9gmxrRPDkFOzNC3Yo="
   },
   {
     "pname": "GameFinder.Wine",
-    "version": "4.4.0",
-    "hash": "sha256-lmGF+gzipCBIu/c4wR2Qgqq6/5Dd4ZhqlxUuCRX7pmY="
+    "version": "4.5.0",
+    "hash": "sha256-QARwwZNoHOEnSnHZXeqoGj9R0uK+hMXte9Hc38vZlAI="
   },
   {
     "pname": "Gee.External.Capstone",
@@ -438,6 +443,11 @@
     "pname": "Grpc.Net.Common",
     "version": "2.52.0",
     "hash": "sha256-XoY+jt+JIt6SzvCjUSXKKa9Q8Bu5UrNJv2z1hCBKDrY="
+  },
+  {
+    "pname": "Halgari.Jamarino.IntervalTree",
+    "version": "1.0.0-alpha",
+    "hash": "sha256-EyVYjSpQ3g+N6knSmQzS2j7ueoowZOHxjYX93lSRQns="
   },
   {
     "pname": "HarfBuzzSharp",
@@ -511,8 +521,8 @@
   },
   {
     "pname": "HtmlAgilityPack",
-    "version": "1.11.70",
-    "hash": "sha256-V/SI2N1+jNkwjSQRd2Y/XVVhdOKvSNz3/NeIFE9V3wY="
+    "version": "1.11.71",
+    "hash": "sha256-ddNrIXTfiu8gwrUs/5xYDjpD0sOth90kut6qCgxGUSE="
   },
   {
     "pname": "Humanizer",
@@ -780,11 +790,6 @@
     "hash": "sha256-idb2hvuDlxl83x0yttGHnTgEQmwLLdUT7QfMeGDXVJE="
   },
   {
-    "pname": "Jamarino.IntervalTree",
-    "version": "1.2.2",
-    "hash": "sha256-L8vFWl+1OUviHB+TOkw7Po0+IBLnJMZ1fnvqcYQOuRQ="
-  },
-  {
     "pname": "JetBrains.Annotations",
     "version": "2024.3.0",
     "hash": "sha256-BQYhE7JDJ9Bw588KyWzOvQFvQTiRa0K9maVkI9lZgBc="
@@ -838,6 +843,11 @@
     "pname": "Magick.NET.Core",
     "version": "14.0.0",
     "hash": "sha256-mwh8d7qmM7m6IbnLSPNq8ZMcD24/1ypM3Gdf6GZm0ao="
+  },
+  {
+    "pname": "Markdig",
+    "version": "0.38.0",
+    "hash": "sha256-5DuDlj+TCDJWP8oJM2WU48ps3HFuUg5P28O/SPcjwGk="
   },
   {
     "pname": "Markdown.Avalonia.Tight",
@@ -1168,11 +1178,6 @@
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
     "version": "8.0.0",
     "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.1",
-    "hash": "sha256-lzTYLpRDAi3wW9uRrkTNJtMmaYdtGJJHdBLbUKu60PM="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
@@ -1555,6 +1560,11 @@
     "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
   },
   {
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "6.0.0",
+    "hash": "sha256-N9EVZbl5w1VnMywGXyaVWzT9lh84iaJ3aD48hIBk1zA="
+  },
+  {
     "pname": "Nerdbank.FullDuplexStream",
     "version": "1.1.12",
     "hash": "sha256-PZwy+qQ8nOdH5gRRQ24go2yh+YmZQhziwbyWC+1qoJc="
@@ -1626,18 +1636,18 @@
   },
   {
     "pname": "NexusMods.MnemonicDB",
-    "version": "0.9.98",
-    "hash": "sha256-1B1PBH/iUuLOPsUo5WAsSAkDGWQBTlY8sk/sAiugpB0="
+    "version": "0.9.114",
+    "hash": "sha256-VE1SEKwsS+XAi12l+0jYOQDG1zYSI1t9wKDjXMMyyng="
   },
   {
     "pname": "NexusMods.MnemonicDB.Abstractions",
-    "version": "0.9.98",
-    "hash": "sha256-rZ9UP6BcxYPlHKqyGj0G5q+woEjvpRS/jg69UY4aWDE="
+    "version": "0.9.114",
+    "hash": "sha256-6nNJkQp5FhO29oKnwSvP3Qw6/Zab3RwB3F7WkS6mDBY="
   },
   {
     "pname": "NexusMods.MnemonicDB.SourceGenerator",
-    "version": "0.9.98",
-    "hash": "sha256-jP07gJZQ9ZT9DXyWIQOlgmZx0onqiUe3w2JiN55NA94="
+    "version": "0.9.114",
+    "hash": "sha256-vMGecXrBoDgWFk1VyMqsENEVpWuGVaPULjJ4azZThRE="
   },
   {
     "pname": "NexusMods.Paths",
@@ -1718,6 +1728,11 @@
     "pname": "NuGet.Resolver",
     "version": "6.3.4",
     "hash": "sha256-rXYXgdJMtwne3skk4jMgqyZlwh3QCTX9hIHvvXafxUM="
+  },
+  {
+    "pname": "NuGet.Versioning",
+    "version": "6.12.1",
+    "hash": "sha256-f/ejCuzCAwKs4N4Ec6yf2RovrhBT0nj0hRDP+03/Iy4="
   },
   {
     "pname": "NuGet.Versioning",
@@ -2436,8 +2451,8 @@
   },
   {
     "pname": "System.Configuration.ConfigurationManager",
-    "version": "4.4.0",
-    "hash": "sha256-+8wGYllXnIxRzy9dLhZFB88GoPj8ivYXS0KUfcivT8I="
+    "version": "6.0.0",
+    "hash": "sha256-fPV668Cfi+8pNWrvGAarF4fewdPVEDwlJWvJk0y+Cms="
   },
   {
     "pname": "System.Console",
@@ -2498,6 +2513,11 @@
     "pname": "System.Diagnostics.Tracing",
     "version": "4.3.0",
     "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
+  },
+  {
+    "pname": "System.Drawing.Common",
+    "version": "6.0.0",
+    "hash": "sha256-/9EaAbEeOjELRSMZaImS1O8FmUe8j4WuFUw1VOrPyAo="
   },
   {
     "pname": "System.Dynamic.Runtime",
@@ -2866,13 +2886,13 @@
   },
   {
     "pname": "System.Security.AccessControl",
-    "version": "4.5.0",
-    "hash": "sha256-AFsKPb/nTk2/mqH/PYpaoI8PLsiKKimaXf+7Mb5VfPM="
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
   },
   {
     "pname": "System.Security.AccessControl",
-    "version": "5.0.0",
-    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+    "version": "6.0.0",
+    "hash": "sha256-qOyWEBbNr3EjyS+etFG8/zMbuPjA+O+di717JP9Cxyg="
   },
   {
     "pname": "System.Security.Claims",
@@ -2925,6 +2945,11 @@
     "hash": "sha256-Ri53QmFX8I8UH0x4PikQ1ZA07ZSnBUXStd5rBfGWFOE="
   },
   {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "6.0.0",
+    "hash": "sha256-Wi9I9NbZlpQDXgS7Kl06RIFxY/9674S7hKiYw5EabRY="
+  },
+  {
     "pname": "System.Security.Cryptography.X509Certificates",
     "version": "4.3.0",
     "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
@@ -2933,6 +2958,11 @@
     "pname": "System.Security.Permissions",
     "version": "4.5.0",
     "hash": "sha256-Fa6dX6Gyse1A/RBoin8cVaHQePbfBvp6jjWxUXPhXKQ="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "6.0.0",
+    "hash": "sha256-/MMvtFWGN/vOQfjXdOhet1gsnMgh6lh5DCHimVsnVEs="
   },
   {
     "pname": "System.Security.Principal",
@@ -2948,11 +2978,6 @@
     "pname": "System.Security.Principal.Windows",
     "version": "4.4.0",
     "hash": "sha256-lwNBM33EW45j6o8bM4hKWirEUZCvep0VYFchc50JOYc="
-  },
-  {
-    "pname": "System.Security.Principal.Windows",
-    "version": "4.5.0",
-    "hash": "sha256-BkUYNguz0e4NJp1kkW7aJBn3dyH9STwB5N8XqnlCsmY="
   },
   {
     "pname": "System.Security.Principal.Windows",
@@ -3068,6 +3093,11 @@
     "pname": "System.Threading.Timer",
     "version": "4.3.0",
     "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
+  },
+  {
+    "pname": "System.Windows.Extensions",
+    "version": "6.0.0",
+    "hash": "sha256-N+qg1E6FDJ9A9L50wmVt3xPQV8ZxlG1xeXgFuxO+yfM="
   },
   {
     "pname": "System.Xml.ReaderWriter",
@@ -3278,6 +3308,11 @@
     "pname": "Xunit.SkippableFact",
     "version": "1.4.13",
     "hash": "sha256-pLtx0/2oTKYO1Y1Vg3k/Eli2OWHT5uorGdBp2uXvFfw="
+  },
+  {
+    "pname": "YamlDotNet",
+    "version": "16.3.0",
+    "hash": "sha256-4Gi8wSQ8Rsi/3+LyegJr//A83nxn2fN8LN1wvSSp39Q="
   },
   {
     "pname": "ZstdSharp.Port",

--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -501,23 +501,23 @@
   },
   {
     "pname": "HotChocolate.Language.SyntaxTree",
-    "version": "14.1.0",
-    "hash": "sha256-4cRFDfLW+A0378BZ0wzPrc7FOiuTdCtlA4gyitSrhiI="
+    "version": "15.0.3",
+    "hash": "sha256-PXlle10Q2Yuhcip1WhY922G5ObD4yRwYyPyUqci7Z7A="
   },
   {
     "pname": "HotChocolate.Transport.Abstractions",
-    "version": "14.1.0",
-    "hash": "sha256-i8i4ovnxHcFRrnU/a3U01izWEa+OsOjxgLDRq7wo1vs="
+    "version": "15.0.3",
+    "hash": "sha256-uRSetnfWOwar73WO/wplsHexCzpbZf6xYxVBLWaIwLo="
   },
   {
     "pname": "HotChocolate.Transport.Http",
-    "version": "14.1.0",
-    "hash": "sha256-e5VoAtmieIhNvhtGMnmPXqYAZE9SrXlfyJmDKF7LBJo="
+    "version": "15.0.3",
+    "hash": "sha256-9SkFbGb/uYmIGPDT1LnF3m42c8sEeCZBv4OuClMEU6w="
   },
   {
     "pname": "HotChocolate.Utilities",
-    "version": "14.1.0",
-    "hash": "sha256-KIYlc1jDG1BT6gZGZoei6ypHXZo9I3dN4zM/NpDWJuI="
+    "version": "15.0.3",
+    "hash": "sha256-9y7iNQqv1wrkuGZ3ovXkQQ+seSB4bZwexfmlneoeEAg="
   },
   {
     "pname": "HtmlAgilityPack",
@@ -888,11 +888,6 @@
     "pname": "Microsoft.AspNet.WebApi.Client",
     "version": "6.0.0",
     "hash": "sha256-lNL5C4W7/p8homWooO/3ZKDZQ2M0FUTDixJwqWBPVbo="
-  },
-  {
-    "pname": "Microsoft.AspNetCore.WebUtilities",
-    "version": "8.0.0",
-    "hash": "sha256-e4wqTJUgPfq6CfRwuXTw32K9vB+hOpSLxSZDpzv23Yg="
   },
   {
     "pname": "Microsoft.AspNetCore.WebUtilities",
@@ -1271,11 +1266,6 @@
   },
   {
     "pname": "Microsoft.Extensions.Http",
-    "version": "8.0.0",
-    "hash": "sha256-UgljypOLld1lL7k7h1noazNzvyEHIJw+r+6uGzucFSY="
-  },
-  {
-    "pname": "Microsoft.Extensions.Http",
     "version": "9.0.0",
     "hash": "sha256-MsStH3oUfyBbcSEoxm+rfxFBKI/rtB5PZrSGvtDjVe0="
   },
@@ -1383,11 +1373,6 @@
     "pname": "Microsoft.Extensions.Logging.EventSource",
     "version": "9.0.0",
     "hash": "sha256-pplZskMsR3gGbs3I0wycGsvIMPIpfWFJpOsR9GkiYRw="
-  },
-  {
-    "pname": "Microsoft.Extensions.ObjectPool",
-    "version": "8.0.0",
-    "hash": "sha256-FxFr5GC0y6vnp5YD2A2vISXYizAz3k/QyrH7sBXP5kg="
   },
   {
     "pname": "Microsoft.Extensions.ObjectPool",
@@ -2251,28 +2236,28 @@
   },
   {
     "pname": "StrawberryShake.Core",
-    "version": "14.1.0",
-    "hash": "sha256-h1Ozv0vdR2UvHIw3JqoBNKPVuD1S31aui7IQ8i8hcnE="
+    "version": "15.0.3",
+    "hash": "sha256-bAqmB6l6r1GAAm6w0BcUdwGlktU/FAeB3vPiENmOaKg="
   },
   {
     "pname": "StrawberryShake.Resources",
-    "version": "14.1.0",
-    "hash": "sha256-6uOb5V7UeHM9OKUTJ4p8/YwvI16LcrC12tPhSAw3U0Q="
+    "version": "15.0.3",
+    "hash": "sha256-m50HKpBrcQkrJxlRAfg2RNobMbv9yw3jakDz7Hp/sn8="
   },
   {
     "pname": "StrawberryShake.Server",
-    "version": "14.1.0",
-    "hash": "sha256-6K6TnX8YL0Dbt8wTv9FmBlbSo+UfaucHi9a5CqWCjoY="
+    "version": "15.0.3",
+    "hash": "sha256-Tdl27WUE0pA+SXZetKjPPcQxM6rxzf1Cnjz6Jw/XZaM="
   },
   {
     "pname": "StrawberryShake.Transport.Http",
-    "version": "14.1.0",
-    "hash": "sha256-Pa2vACAYMgLrAxiZUR7PxBvPY9wrclQRYGZod/VMG5Q="
+    "version": "15.0.3",
+    "hash": "sha256-UmB5tTEwB0JImx/LDb+ihCao4YxsT3XvHJpuUDBMODc="
   },
   {
     "pname": "StrawberryShake.Transport.WebSockets",
-    "version": "14.1.0",
-    "hash": "sha256-Hqp6GSxMcYorg5v8ns24DNfUDwYGY3urg0FKPleD86I="
+    "version": "15.0.3",
+    "hash": "sha256-Nz70BHgzDzxIRzIjKgx6Vx1T+K/UKoPkG6wP/yNKVYs="
   },
   {
     "pname": "Svg.Custom",
@@ -2608,6 +2593,11 @@
     "pname": "System.IO.Pipelines",
     "version": "8.0.0",
     "hash": "sha256-LdpB1s4vQzsOODaxiKstLks57X9DTD5D6cPx8DE1wwE="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "9.0.0",
+    "hash": "sha256-vb0NrPjfEao3kfZ0tavp2J/29XnsQTJgXv3/qaAwwz0="
   },
   {
     "pname": "System.Linq",

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -8,8 +8,6 @@
   fetchgit,
   imagemagick,
   lib,
-  makeFontsConf,
-  runCommand,
   xdg-utils,
   nix-update-script,
   pname ? "nexusmods-app",
@@ -146,44 +144,7 @@ buildDotnetModule (finalAttrs: {
       "NexusMods.Games.FOMOD.Tests.FomodXmlInstallerTests.InstallsFilesSimple_UsingRar"
     ];
 
-  passthru = {
-    tests =
-      let
-        runTest =
-          name: script:
-          runCommand "${pname}-test-${name}"
-            {
-              nativeBuildInputs = [ finalAttrs.finalPackage ];
-              FONTCONFIG_FILE = makeFontsConf {
-                fontDirectories = [ ];
-              };
-            }
-            ''
-              export XDG_DATA_HOME="$PWD/data"
-              export XDG_STATE_HOME="$PWD/state"
-              export XDG_CACHE_HOME="$PWD/cache"
-              mkdir -p "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
-              # TODO: on error, print $XDG_STATE_HOME/NexusMods.App/Logs/nexusmods.app.main.current.log
-              ${script}
-              touch $out
-            '';
-      in
-      {
-        serve = runTest "serve" ''
-          NexusMods.App
-        '';
-        help = runTest "help" ''
-          NexusMods.App --help
-        '';
-        associate-nxm = runTest "associate-nxm" ''
-          NexusMods.App associate-nxm
-        '';
-        list-tools = runTest "list-tools" ''
-          NexusMods.App list-tools
-        '';
-      };
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     mainProgram = "NexusMods.App";

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -59,18 +59,18 @@ buildDotnetModule (finalAttrs: {
   nugetDeps = ./deps.json;
   mapNuGetDependencies = true;
 
-  # TODO: remove .NET 8; StrawberryShake currently needs it
-  dotnet-sdk =
-    with dotnetCorePackages;
-    combinePackages [
-      sdk_9_0
-      runtime_8_0
-    ];
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
   dotnet-runtime = dotnetCorePackages.runtime_9_0;
 
   postPatch = ''
     # for some reason these tests fail (intermittently?) with a zero timestamp
     touch tests/NexusMods.UI.Tests/WorkspaceSystem/*.verified.png
+
+    # Bump StrawberryShake so we can drop .NET 8
+    # See https://github.com/Nexus-Mods/NexusMods.App/pull/2830
+    substituteInPlace Directory.Packages.props \
+      --replace-fail 'Include="StrawberryShake.Server" Version="14.1.0"' \
+                     'Include="StrawberryShake.Server" Version="15.0.3"'
   '';
 
   makeWrapperArgs = [

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -24,12 +24,12 @@ let
 in
 buildDotnetModule (finalAttrs: {
   inherit pname;
-  version = "0.7.3";
+  version = "0.8.2";
 
   src = fetchgit {
     url = "https://github.com/Nexus-Mods/NexusMods.App.git";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-p3MTxuLR/mkVrL+hwW2R13/eVHWWulZPRh9OsuHq9kU=";
+    hash = "sha256-qRo+s1Wf6WXR1kFqvGA6n+Bsp6qTzpK8/W9fuiaA+Yo=";
     fetchSubmodules = true;
     fetchLFS = true;
   };
@@ -131,14 +131,16 @@ buildDotnetModule (finalAttrs: {
 
   disabledTests =
     [
-      "NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_RemoteImage"
-      "NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_ImageStoredFile"
+      # Fails attempting to download game hashes DB from github:
+      # HttpRequestException : Resource temporarily unavailable (github.com:443)
+      "NexusMods.DataModel.SchemaVersions.Tests.LegacyDatabaseSupportTests.TestDatabase"
+      "NexusMods.DataModel.SchemaVersions.Tests.MigrationSpecificTests.TestsFor_0001_ConvertTimestamps.OldTimestampsAreInRange"
+      "NexusMods.DataModel.SchemaVersions.Tests.MigrationSpecificTests.TestsFor_0003_FixDuplicates.No_Duplicates"
+      "NexusMods.DataModel.SchemaVersions.Tests.MigrationSpecificTests.TestsFor_0004_RemoveGameFiles.Test"
 
-      # Fails in ofborg with VerifyException tests/Games/NexusMods.Games.StardewValley.Tests
-      "NexusMods.Games.StardewValley.Tests.StardewValleyInstallersTests.CanInstallMod"
-
-      # Fails with: Expected a <System.ArgumentException> to be thrown, but no exception was thrown.
-      "NexusMods.Networking.ModUpdates.Tests.PerFeedCacheUpdaterTests.Constructor_WithItemsFromDifferentGames_ShouldThrowArgumentException_InDebug"
+      # Fails attempting to fetch SMAPI version data from github:
+      # https://github.com/erri120/smapi-versions/raw/main/data/game-smapi-versions.json
+      "NexusMods.Games.StardewValley.Tests.SMAPIGameVersionDiagnosticEmitterTests.Test_TryGetLastSupportedSMAPIVersion"
     ]
     ++ lib.optionals (!_7zz.meta.unfree) [
       "NexusMods.Games.FOMOD.Tests.FomodXmlInstallerTests.InstallsFilesSimple_UsingRar"


### PR DESCRIPTION
- Bump version: 0.7.3 -> 0.8.2
- [Upstream changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.8.2)
- [Previous update PR](https://github.com/NixOS/nixpkgs/pull/379226)

Also:
- Bumped StrawberryShake (as per [upstream's PR](https://github.com/Nexus-Mods/NexusMods.App/pull/2830)),
  allowing us to drop .net 8 runtime and _only_ build with .net 9
- Re-enabled tests that no longer fail and/or no longer exist
- Disabled 5 tests that now require network access
- Double checked the `InstallsFilesSimple_UsingRar` test still exists
- Removed the package's passthru tests. See [comment below](https://github.com/NixOS/nixpkgs/pull/388999#issuecomment-2717612791).

At first I thought the newly failing tests should've been covered by `RequiresNetworking`, [however](https://github.com/Nexus-Mods/NexusMods.App/pull/1222#issuecomment-2060687094):
> The `RequiresNetworking` trait isn't very descriptive, but we're using this for tests that talk to the Nexus Mods API. A better name for the trait would be "RequiresNexusModsAPIKey".

## Notes for end-users

> [!TIP]
> When upgrading from version 0.7.0 or newer, it _should_ be safe to upgrade **without** resetting/uninstalling.

> [!NOTE]
> All games except Stardew Valley have been moved behind the "Unsupported Games" flag in Settings. If you were modding Cyberpunk, Baldur's Gate 3 or Mount & Blade II:Bannerlord in a previous release, you will need to enable this option to continue managing your mods.

> [!CAUTION]
> When upgrading from a **version older than 0.7.0**, you will need a fresh start.
> If you have configuration leftover from an old version, the updated app will crash.
>
> See upstream's guide on [how to uninstall the app](https://nexus-mods.github.io/NexusMods.App/users/Uninstall).

<details><summary>Resetting tips</summary>
<p>

You can reset all modded games and wipe your nexusmods-app config using:
```
NexusMods.App uninstall-app
```
- This should be done **before** updating the app.
- **Be careful**: There's no way to recover a wiped config!

If you've run the appimage version from upstream, or a pre-0.6 nixpkgs version, you may also need to remove old desktop entries to avoid other issues:
```
rm ~/.local/share/applications/com.nexusmods.app.desktop
```

</p>
</details>

> [!CAUTION]
> Known issues are listed on the [changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.8.2), but include:
> * The sort order for some columns does not work as expected.
> * The game version is not checked when adding a collection meaning you can install outdated mods without being warned. 
> * The table header sorting and collapsible section states are not saved and reset each time the view is loaded.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Updated existing a release notes entry
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
