### PR TITLE
graphite-cli: remove diegs from maintainers

### DIFF
--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -44,6 +44,6 @@ buildNpmPackage rec {
     homepage = "https://graphite.dev/docs/graphite-cli";
     license = lib.licenses.unfree; # no license specified
     mainProgram = "gt";
-    maintainers = with lib.maintainers; [ diegs ];
+    maintainers = with lib.maintainers; [];
   };
 }

--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -44,6 +44,6 @@ buildNpmPackage rec {
     homepage = "https://graphite.dev/docs/graphite-cli";
     license = lib.licenses.unfree; # no license specified
     mainProgram = "gt";
-    maintainers = with lib.maintainers; [];
+    maintainers = with lib.maintainers; [ ];
   };
 }


### PR DESCRIPTION
I no longer use this package and cannot easily test it or maintain it (non-free and requires subscription service).