### PR TITLE
openmpi: fix wrapperData on darwin platform

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -147,7 +147,5 @@ stdenv.mkDerivation (finalAttrs: {
       qbisi
     ];
     platforms = lib.platforms.unix;
-    # Dependency of scalapack for mpiSupport is broken on darwin platform
-    broken = mpiSupport && stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -85,12 +85,11 @@ stdenv.mkDerivation (finalAttrs: {
     SOURCE_DATE_EPOCH = "0";
   };
 
-  outputs =
-    [ "out" ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      "man"
-      "dev"
-    ];
+  outputs = [
+    "out"
+    "man"
+    "dev"
+  ];
 
   buildInputs =
     [
@@ -152,14 +151,16 @@ stdenv.mkDerivation (finalAttrs: {
       # The file names we need to iterate are a combination of ${p}${s}, and there
       # are 7x3 such options. We use lib.mapCartesianProduct to iterate them all.
       fileNamesToIterate = {
-        p = [
-          "mpi"
-          "shmem"
-          "osh"
-        ];
+        p =
+          [
+            "mpi"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            "shmem"
+            "osh"
+          ];
         s =
           [
-            "CC"
             "c++"
             "cxx"
             "cc"
@@ -168,7 +169,8 @@ stdenv.mkDerivation (finalAttrs: {
             "f77"
             "f90"
             "fort"
-          ];
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [ "CC" ];
       };
       wrapperDataSubstitutions =
         {
@@ -176,12 +178,16 @@ stdenv.mkDerivation (finalAttrs: {
           # compiler=_ line that should be replaced by a compiler=#2 string, where
           # #2 is the 2nd value in the list.
           "cc" = [
-            "gcc"
-            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc"
+            # "$CC" is expanded by the executing shell in the substituteInPlace
+            # commands to the name of the compiler ("clang" for Darwin and
+            # "gcc" for Linux)
+            "$CC"
+            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}$CC"
           ];
           "c++" = [
-            "g++"
-            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++"
+            # Same as with $CC
+            "$CXX"
+            "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}$CXX"
           ];
         }
         // lib.optionalAttrs fortranSupport {
@@ -198,8 +204,7 @@ stdenv.mkDerivation (finalAttrs: {
       wrapperDataFileNames = {
         part1 = [
           "mpi"
-          "shmem"
-        ];
+        ] ++ lib.optionals stdenv.hostPlatform.isLinux [ "shmem" ];
         part2 = builtins.attrNames wrapperDataSubstitutions;
       };
     in
@@ -226,12 +231,7 @@ stdenv.mkDerivation (finalAttrs: {
       ${lib.pipe wrapperDataFileNames [
         (lib.mapCartesianProduct (
           { part1, part2 }:
-          # From some reason the Darwin build doesn't include some of these
-          # wrapperDataSubstitutions strings and even some of the files. Hence
-          # we currently don't perform these substitutions on other platforms,
-          # until a Darwin user will care enough about this cross platform
-          # related substitution.
-          lib.optionalString stdenv.hostPlatform.isLinux ''
+          ''
             substituteInPlace "''${!outputDev}/share/openmpi/${part1}${part2}-wrapper-data.txt" \
               --replace-fail \
                 compiler=${lib.elemAt wrapperDataSubstitutions.${part2} 0} \

--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -250,19 +250,16 @@ stdenv.mkDerivation (finalAttrs: {
       done
     '';
 
-  postFixup =
-    lib.optionalString (lib.elem "man" finalAttrs.outputs) ''
-      remove-references-to -t "''${!outputMan}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
-    ''
-    + lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
-      remove-references-to -t "''${!outputDev}" $out/bin/mpirun
-      remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
+  postFixup = ''
+    remove-references-to -t "''${!outputMan}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
+    remove-references-to -t "''${!outputDev}" $out/bin/mpirun
+    remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.library})
 
-      # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
-      wrapProgram "''${!outputDev}/bin/opal_wrapper" \
-        --set OPAL_INCLUDEDIR "''${!outputDev}/include" \
-        --set OPAL_PKGDATADIR "''${!outputDev}/share/openmpi"
-    '';
+    # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
+    wrapProgram "''${!outputDev}/bin/opal_wrapper" \
+      --set OPAL_INCLUDEDIR "''${!outputDev}/include" \
+      --set OPAL_PKGDATADIR "''${!outputDev}/share/openmpi"
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
For darwin platform, one only need to fixup the warpperData file share/openmpi/mpi{cc,c++,fort}-wrapper-data.txt with 
substituting  {$CC,$CXX,gfortran} to the real compiler.

In darwin stdenv, the unfixed mpi{cc,cxx} wrapper is still capable of finding the correct compiler via envrionment CC/CXX and the provided clang packages. 

However,there are two limitiation of current openmpi on darwin platform.
1. if one install openmpi on aarch64-darwin platform via `nix profile intstall nixpkgs#openmpi` and try to compile some code with mpicc/mpicxx, the wrapper will try to find clang in the PATH or use the CC envrioment which is not the desired behavior.
2. even in stdenv, mpif90 cannot find the fortran compiler if gfortran is not in stdenv. e.g. scalapack depend on openmpi but gfortran is not in the buildInputs, it will fail to build on darwin platfrom.

That's the motivation of this pr to fixup warpperData on darwin platform

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
