### PR TITLE
nixos/caddy: secure admin API

### DIFF
--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -69,24 +69,6 @@
             respond "hello world"
           '';
         };
-        specialisation.with-plugins.configuration = {
-          services.caddy = {
-            package = pkgs.caddy.withPlugins {
-              plugins = [ "github.com/caddyserver/replace-response@v0.0.0-20250618171559-80962887e4c6" ];
-              hash = "sha256-kKWXpxEAn23yud8tcgw7FFOaxLjoodZ/cuM1239TRoY=";
-            };
-            configFile = pkgs.writeText "Caddyfile" ''
-              {
-                order replace after encode
-              }
-
-              localhost:80 {
-                respond "hello world"
-                replace world caddy
-              }
-            '';
-          };
-        };
       };
   };
 
@@ -98,7 +80,6 @@
       multipleConfigs = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-configs";
       multipleHostnames = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-hostnames";
       rfc42Config = "${nodes.webserver.system.build.toplevel}/specialisation/rfc42";
-      withPluginsConfig = "${nodes.webserver.system.build.toplevel}/specialisation/with-plugins";
     in
     ''
       url = "http://localhost/example.html"
@@ -141,12 +122,5 @@
           )
           webserver.wait_for_open_port(80)
           webserver.succeed("curl http://localhost | grep hello")
-
-      with subtest("plugins are correctled installed and configurable"):
-          webserver.succeed(
-              "${withPluginsConfig}/bin/switch-to-configuration test >&2"
-          )
-          webserver.wait_for_open_port(80)
-          webserver.succeed("curl http://localhost | grep caddy")
     '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #389016

After this is merged, Caddy's admin API must be configured with `services.caddy.admin`, and `services.caddy.admin` has been made as a prerequisite for `services.caddy.enableReload`.

The reload feature will now be enabled by default transitively through the admin setting to a unix socket at `/var/lib/caddy/admin.sock` if not specified otherwise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
