### PR TITLE
firebase-tools: 13.32.0 -> 13.34.0

### DIFF
--- a/pkgs/by-name/fi/firebase-tools/package.nix
+++ b/pkgs/by-name/fi/firebase-tools/package.nix
@@ -9,16 +9,16 @@
 }:
 buildNpmPackage rec {
   pname = "firebase-tools";
-  version = "13.32.0";
+  version = "13.34.0";
 
   src = fetchFromGitHub {
     owner = "firebase";
     repo = "firebase-tools";
     tag = "v${version}";
-    hash = "sha256-KImt8se4pf/W1XAV8PprYmJRWQqMIAH9FVCEFSV/3Ys=";
+    hash = "sha256-2Zyg7D0/JYQ/PSYsoOIa/aSjGibySP+XZNWpT+dct8k=";
   };
 
-  npmDepsHash = "sha256-/EWfXiITSV1r4zVvnHk+9U7MpcUlp7/MNUBJWRw3wRk=";
+  npmDepsHash = "sha256-3JaafJIfqhS7c8krdXwARufuVV/PG4emvbVv8H3gy8Q=";
 
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json

--- a/pkgs/by-name/fi/firebase-tools/package.nix
+++ b/pkgs/by-name/fi/firebase-tools/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   python3,
   xcbuild,
+  nix-update-script,
 }:
 buildNpmPackage rec {
   pname = "firebase-tools";
@@ -34,6 +35,8 @@ buildNpmPackage rec {
   env = {
     PUPPETEER_SKIP_DOWNLOAD = true;
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/firebase/firebase-tools/blob/v${version}/CHANGELOG.md";


### PR DESCRIPTION
Done: Updateed to latest, added standard passthru update script.

## [v13.34.0](https://github.com/firebase/firebase-tools/releases/tag/v13.34.0)

* Fix webframeworks deployments when using site in firebase.json. (https://github.com/firebase/firebase-tools/pull/8295)
* Add support for brownfield project onboard dataconnect:sql:setup. (https://github.com/firebase/firebase-tools/pull/8150)
* Update the Firebase Data Connect local toolkit to v1.8.5, which includes the following changes: (https://github.com/firebase/firebase-tools/pull/8310)
  * Fix the Int and Int64 scalars to correctly validate the int32 and int64 ranges, respectively.
  * Fix the generated web SDK so that pnpm properly uses the link functionality.

## [ v13.33.0](https://github.com/firebase/firebase-tools/tree/v13.33.0)

https://github.com/firebase/firebase-tools/commit/ea45544ed06052d7ccefdf65befaab6a25f7f4d7
* Fixed issue where apps:init fails to detect the output directory when it was run in a directory where app was the only module.
* Set LOG_EXECUTION_ID=true by default for Cloud Functions (2nd gen) to improve debugging by displaying execution IDs in logs. (https://github.com/firebase/firebase-tools/pull/8276)
* Fix bug where function deployment no-oped for functions in bad state. (https://github.com/firebase/firebase-tools/pull/8289)
* Updated the Firebase Data Connect local toolkit to v1.8.4 which includes the following changes: (https://github.com/firebase/firebase-tools/pull/8290)
React hooks for mutations without args no longer require undefined to be passed when calling mutate.
  * Fixed import resolution when moduleResolution is set to bundler.
  * React code generation will now generate a README explaining how to use generated query and mutation hook functions.
  * Fixed an issue where React developers have to pass in an empty object even when all fields are optional.
  * Fixed an issue where FirebaseError wasn't being passed into UseMutationOptions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
