### PR TITLE
etterna: init at 0.74.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1168,9 +1168,11 @@
     githubId = 36565196;
     name = "Alikind System";
 
-    keys = [{
-      fingerprint = "7D31 15DC D912 C15A 2781  F7BB 511C B44B C752 2A89";
-    }];
+    keys = [
+      {
+        fingerprint = "7D31 15DC D912 C15A 2781  F7BB 511C B44B C752 2A89";
+      }
+    ];
   };
   alirezameskin = {
     email = "alireza.meskin@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1162,6 +1162,16 @@
     githubId = 30437811;
     name = "Alex Andrews";
   };
+  alikindsys = {
+    email = "alice@blocovermelho.org";
+    github = "alikindsys";
+    githubId = 36565196;
+    name = "Alikind System";
+
+    keys = [{
+      fingerprint = "7D31 15DC D912 C15A 2781  F7BB 511C B44B C752 2A89";
+    }];
+  };
   alirezameskin = {
     email = "alireza.meskin@gmail.com";
     github = "alirezameskin";

--- a/pkgs/by-name/et/etterna/fix-download-manager.patch
+++ b/pkgs/by-name/et/etterna/fix-download-manager.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Etterna/Singletons/DownloadManager.cpp b/src/Etterna/Singletons/DownloadManager.cpp
+index b42ccd30..3606107d 100644
+--- a/src/Etterna/Singletons/DownloadManager.cpp
++++ b/src/Etterna/Singletons/DownloadManager.cpp
+@@ -6265,7 +6265,10 @@ Download::Install()
+ {
+ 	Core::Platform::requestUserAttention();
+ 	Message* msg;
+-	if (!SongManager::InstallSmzip(m_TempFileName))
++
++	auto path = FILEMAN->ResolvePath(m_TempFileName);
++
++	if (!SongManager::InstallSmzip(path))
+ 		msg = new Message("DownloadFailed");
+ 	else
+ 		msg = new Message("PackDownloaded");

--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  # deps
+  cmake,
+  pkg-config,
+  openssl,
+  libGLU,
+  xorg,
+  alsa-lib,
+  libjack2,
+  libpulseaudio,
+  libogg,
+  sse2neon,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "etterna";
+  version = "0.74.3";
+
+  src = fetchFromGitHub {
+    owner = "etternagame";
+    repo = "etterna";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zzCk6axISswfTAk7rRha5HFzIHQ0AjpAZyAWzH+Cn1s=";
+  };
+
+  patches = [ ./fix-download-manager.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    openssl
+    alsa-lib
+    libjack2
+    libpulseaudio
+    libGLU
+    libogg
+    sse2neon
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libX11
+    xorg.libXext # Needed for DPMS
+    xorg.libXvMC
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "etterna";
+      desktopName = "Etterna";
+      genericName = "Rhythm and dance game";
+      icon = "etterna";
+      tryExec = "etterna";
+      exec = "etterna";
+      categories = [
+        "Application"
+        "Game"
+        "ArcadeGame"
+      ];
+      comment = "A cross-platform rhythm video game.";
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share/etterna}
+    mkdir -p $out/share/applications
+    # copy select necessary game files into virtual fs
+    cp -r /build/source/{Announcers,Assets,BGAnimations,BackgroundEffects,BackgroundTransitions,Data,GameTools,NoteSkins,Scripts,Themes} "$out/share/etterna"
+
+    # copy binary
+    cp /build/source/Etterna $out/bin/.etterna-unwrapped
+
+    # Install the Icon
+    install -Dm644 /build/source/Docs/images/etterna-logo-light.svg "$out/share/icons/hicolor/scalable/apps/etterna.svg"
+
+    # wacky insertion of wrapper directly into phase, so that $out is set
+    cat > $out/bin/etterna << EOF
+    #!${stdenv.shell}
+    export ETTERNA_ROOT_DIR="\$HOME/.local/share/etterna"
+    export ETTERNA_ADDITIONAL_ROOT_DIRS="$out/share/etterna"
+    echo "HOME: \$HOME"
+    echo "PWD: \$(pwd)"
+    echo "ETTERNA_ADDITIONAL_ROOT_DIRS: \$ETTERNA_ADDITIONAL_ROOT_DIRS"
+    exec $out/bin/.etterna-unwrapped "\$@"
+    EOF
+    chmod +x $out/bin/etterna
+    runHook postInstall
+  '';
+
+  cmakeFlags = [ "-D WITH_CRASHPAD=OFF" ];
+
+  meta = {
+    description = "Advanced cross-platform rhythm game focused on keyboard play";
+    homepage = "https://etternaonline.com";
+    changelog = "https://github.com/etternagame/etterna/release/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alikindsys ];
+    mainProgram = "etterna";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages `etterna`. Fixes #352639 and supercedes #353956.

Differences from the existing PR.

- Based on the original build script and only has the external dependencies which are needed for building it. Etterna bundles most of its dependencies and statically links them so I decided not to mess much with it.

- Includes a fix for the bundle downloading feature of the game which I may decide to upstream in the future.
As far as I'm concerned that patch shouldn't affect anything else.

- Includes a `desktopEntry` for easy of launching. 

- It's ready for review

This is a based on a stable release, unlike #353956 which was made before https://github.com/etternagame/etterna/pull/1282 was merged and never updated since. That fix has landed on at least two stable releases (afaik) and the original PR author hasn't [replied for a month](https://github.com/NixOS/nixpkgs/pull/353956#issuecomment-2638838258) which made me create this pull request.

Any feedback on how to make this package definition is highly appreciated since this is my first contribution to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
