### PR TITLE
SDL: replace SDL with SDL_compat

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10403,7 +10403,7 @@ with pkgs;
     autoreconfHook = buildPackages.autoreconfHook269;
   };
 
-  SDL = SDL1;
+  SDL = SDL_compat;
 
   SDL2 = callPackage ../development/libraries/SDL2 {
     inherit (darwin.apple_sdk.frameworks) AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;


### PR DESCRIPTION
**THIS IS NOT YET READY!!**

`SDL` is old and crusty. Some recent work prepared replacement of `SDL` -> `SDL_compat`. `SDL1` can still be used explicitly, if there is reason to do so. However, since #388447 , #388304 , #387357 , and #388253 , it should now be (close to) possible to use `SDL_compat` as a dropin replacement. Thanks also to the work of @marcin-serwin , @K900 , and @pbsds .

This would also benefit from #387419 as that reduces the paths through which SDL is pulled into dependencies. However, this is by far not the only path causing this to be a mass rebuild.

I am happy to be pointed to things breaking by this. @peterhoeg , current maintainer of SDL, said some programs would break with this switch, back in https://github.com/NixOS/nixpkgs/pull/339311#issuecomment-2328073964. other distros made the switch from SDL to SDL_compat a while ago already, with little noticable fallout. Unless there is actual examples of breakages, i am of the opinion to go for it and figure out later. Conditions to do so is this switch not causing any new build failures, ideally - if there are new build failures, something is wrong and this needs touchup.

As to darwin: I found some logic using SDL on darwin and SDL_compat on Linux only. @emilazy thankfully tested dosbox against SDL_compat ([which uses SDL1 on darwin currently](https://github.com/NixOS/nixpkgs/blob/5dcaeaa040c276339d903a9907a40430b5de6a04/pkgs/top-level/all-packages.nix#L1356)) and came to the conclusion it builds and runs. So this change *should* be ok on darwin too.

The rebuild is quite large, which means validating this is hard. However, apart from `directfb -> gst-plugins-bad -> gtk4`, i did an overlay on my main system doing this very switch. So far without any issue. After #387419 is merged, this will be MUCH more reasonable to throw at nixpkgs-review on a community builder.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
