### PR TITLE
quirc: drop SDL dependency

### DIFF
--- a/pkgs/by-name/qu/quirc/0001-Don-t-build-demos.patch
+++ b/pkgs/by-name/qu/quirc/0001-Don-t-build-demos.patch
@@ -1,33 +1,8 @@
-From 7435b2e12c2004cb0c497ff313288902f2a6f39a Mon Sep 17 00:00:00 2001
-From: toonn <toonn@toonn.io>
-Date: Fri, 19 Jul 2024 21:53:58 +0200
-Subject: [PATCH] Don't build demos
-
----
- Makefile | 7 ++-----
- 1 file changed, 2 insertions(+), 5 deletions(-)
-
 diff --git a/Makefile b/Makefile
-index 8327b4e..7901cc5 100644
+index 8327b4e..c269291 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -45,7 +45,7 @@ DEMO_UTIL_OBJ = \
- 
- OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2>&1)
- OPENCV_LIBS = $(shell pkg-config --libs opencv4)
--QUIRC_CXXFLAGS = $(QUIRC_CFLAGS) $(OPENCV_CFLAGS) --std=c++17
-+QUIRC_CXXFLAGS = $(QUIRC_CFLAGS) --std=c++17
- 
- .PHONY: all v4l sdl opencv install uninstall clean
- 
-@@ -93,15 +93,12 @@ libquirc.$(VERSIONED_LIB_SUFFIX): $(LIB_OBJ)
- .cxx.o:
- 	$(CXX) $(QUIRC_CXXFLAGS) -o $@ -c $<
- 
--install: libquirc.a libquirc.$(LIB_SUFFIX) quirc-demo quirc-scanner
-+install: libquirc.a libquirc.$(LIB_SUFFIX)
- 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include
- 	install -o root -g root -m 0644 libquirc.a $(DESTDIR)$(PREFIX)/lib
+@@ -99,9 +99,6 @@ install: libquirc.a libquirc.$(LIB_SUFFIX) quirc-demo quirc-scanner
  	install -o root -g root -m 0755 libquirc.$(VERSIONED_LIB_SUFFIX) \
  		$(DESTDIR)$(PREFIX)/lib
  	cp -d libquirc.$(LIB_SUFFIX) $(DESTDIR)$(PREFIX)/lib
@@ -37,6 +12,3 @@ index 8327b4e..7901cc5 100644
  
  uninstall:
  	rm -f $(DESTDIR)$(PREFIX)/include/quirc.h
--- 
-2.42.2
-

--- a/pkgs/by-name/qu/quirc/package.nix
+++ b/pkgs/by-name/qu/quirc/package.nix
@@ -3,12 +3,8 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
-  SDL_gfx,
-  SDL,
   libjpeg,
   libpng,
-  opencv,
-  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,40 +22,37 @@ stdenv.mkDerivation (finalAttrs: {
     # use correct pkg-config / ar / ranlib for cross
     # don't try to change ownership
     substituteInPlace Makefile \
-      --replace-fail "pkg-config " "${stdenv.cc.targetPrefix}pkg-config " \
       --replace-fail "ar " "${stdenv.cc.targetPrefix}ar " \
       --replace-fail "ranlib " "${stdenv.cc.targetPrefix}ranlib " \
       --replace-fail "-o root" "" \
       --replace-fail "-g root" ""
   '';
 
-  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    SDL
-    SDL_gfx
     libjpeg
     libpng
-    opencv
   ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
-  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev SDL}/include/SDL -I${SDL_gfx}/include/SDL";
+  makeFlags = [
+    "PREFIX=$(out)"
+    "SDL_CFLAGS="
+    "SDL_LIBS="
+    "-o inspect"
+    "-o quirc-demo"
+  ];
 
-  patches =
-    [
-      (fetchpatch2 {
-        url = "https://github.com/dlbeer/quirc/commit/2c350d8aaf37246e538a2c93b2cce8c78600d2fc.patch?full_index=1";
-        hash = "sha256-ZTcy/EoOBoyOjtXjmT+J/JcbX8lxGKmbWer23lymbWo=";
-      })
-      (fetchpatch2 {
-        url = "https://github.com/dlbeer/quirc/commit/257c6c94d99960819ecabf72199e5822f60a3bc5.patch?full_index=1";
-        hash = "sha256-WLQK7vy34VmgJzppTnRjAcZoSGWVaXQSaGq9An8W0rw=";
-      })
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
-      # Disable building of linux-only demos on non-linux systems
-      ./0001-Don-t-build-demos.patch
-    ];
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/dlbeer/quirc/commit/2c350d8aaf37246e538a2c93b2cce8c78600d2fc.patch?full_index=1";
+      hash = "sha256-ZTcy/EoOBoyOjtXjmT+J/JcbX8lxGKmbWer23lymbWo=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/dlbeer/quirc/commit/257c6c94d99960819ecabf72199e5822f60a3bc5.patch?full_index=1";
+      hash = "sha256-WLQK7vy34VmgJzppTnRjAcZoSGWVaXQSaGq9An8W0rw=";
+    })
+    # Disable building of Demos to not pull in unwanted dependencies
+    ./0001-Don-t-build-demos.patch
+  ];
 
   preInstall = ''
     mkdir -p "$out"/{bin,lib,include}


### PR DESCRIPTION
the `quirc` package depends on SDL for some demos and a test of those demos.
See [upstream readme (demo)](https://github.com/dlbeer/quirc/blob/fd13bfbf4f58b0a966b2fdfd634b96faaf3f34d2/README.md?plain=1#L33-L40) and [upstream readme (test)](https://github.com/dlbeer/quirc/blob/fd13bfbf4f58b0a966b2fdfd634b96faaf3f34d2/README.md?plain=1#L66-L72)

We already conditionally patched out the demos because they don't seem to build on darwin. It makes sense to provide a minimal package with basically only the lib output. The minimal package can get away without SDL dependencies pulled in to ffmpeg. ffmpeg is a core package, reducing the size of the derivation as well as reducing potentially vulnerable dependencies is a good thing.

I have *not* tested the impact of this. `ffmpeg-full` still builds and no longer lists SDL1 as a dependency through quirc (it lists it through libvisual until #388447 hits repos). Putting this here mostly to track. I am not sure how to actually use and test this plugin through ffmpeg. Help is appreciated. But seeing as darwin didn't provide the demos anyways and still builds ffmpeg, this really should be fine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
