### PR TITLE
another-redis-desktop-manager: init at 1.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11649,6 +11649,12 @@
     githubId = 3170771;
     name = "Jo Vandeginste";
   };
+  joyanhui = {
+    email = "leiyanhui@gmail.com";
+    github = "joyanhui";
+    githubId = 40133116;
+    name = "Lei Yanhui";
+  };
   jpagex = {
     name = "Jérémy Pagé";
     email = "contact@jeremypage.me";

--- a/pkgs/by-name/an/another-redis-desktop-manager/package.nix
+++ b/pkgs/by-name/an/another-redis-desktop-manager/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  libxshmfence,
+}:
+let
+  pname = "another-redis-desktop-manager";
+  version = "1.7.1";
+  src =
+    fetchurl
+      {
+        x86_64-linux = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-linux-${version}-x86_64.AppImage";
+          hash = "sha256-XuS4jsbhUproYUE2tncT43R6ErYB9WTg6d7s16OOxFQ=";
+        };
+        aarch64-linux = {
+          url = "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v${version}/Another-Redis-Desktop-Manager-linux-${version}-arm64.AppImage";
+          hash = "sha256-0WXWl0UAQBqJlvt2MNpNHuqmEAlIlvY0FfHXu4LKkcY=";
+        };
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.system}");
+  meta = {
+    description = "Faster, better and more stable redis desktop manager";
+    longDescription = ''
+      Faster, better, more stable Redis Desktop (GUI) management client, compatible with Windows, Mac, Linux, superior performance, easy to load massive key values.
+      Supports Sentinel, clustering, ssh channels, ssl authentication, stream, subscribe, tree view, command line, and dark mode; A variety of formatting methods, and even the ability to customize formatting scripts,
+    '';
+    homepage = "https://github.com/qishibo/AnotherRedisDesktopManager";
+    changelog = "https://github.com/qishibo/AnotherRedisDesktopManager?tab=readme-ov-file#feature-log";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      joyanhui
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "another-redis-desktop-manager";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+  extraPkgs = pkgs: [
+    libxshmfence
+  ];
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    install -Dm644 ${appimageContents}/usr/share/icons/hicolor/0x0/apps/another-redis-desktop-manager.png $out/share/icons/hicolor/0x0/apps/another-redis-desktop-manager.png
+    cat > $out/share/applications/another-redis-desktop-manager.desktop  << EOF
+    [Desktop Entry]
+    Name=Another Redis Desktop Manager
+    Exec=another-redis-desktop-manager
+    Terminal=false
+    Type=Application
+    Icon=$out/share/icons/hicolor/0x0/apps/another-redis-desktop-manager.png
+    StartupWMClass=Another Redis Desktop Manager
+    X-AppImage-Version=${version}
+    Comment=A faster, better and more stable redis desktop manager.
+    Categories=Utility;
+    EOF
+  '';
+}


### PR DESCRIPTION
Adds the Another Redis Desktop Manager package at version 1.7.1 and appoints @joyanhui as a maintainer of this package.

Another Redis Desktop Manager provides functionalities comparable to RedisInsight, with enhanced user-friendly features specifically for managing JSON and other formatted string keys.

For more information, please visit: https://github.com/qishibo/AnotherRedisDesktopManager

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

There is solely one icon file included in the official package; therefore, the method of using 'cat>' is employed to generate the desktop file.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
