### PR TITLE
ax25-apps: 0.0.8-rc5 -> 0.0.8-rc5-unstable-2021-05-13

### DIFF
--- a/pkgs/by-name/ax/ax25-apps/package.nix
+++ b/pkgs/by-name/ax/ax25-apps/package.nix
@@ -1,25 +1,29 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   libax25,
   ncurses,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ax25-apps";
-  version = "0.0.8-rc5";
+  version = "0.0.8-rc5-unstable-2021-05-13";
 
   buildInputs = [
+    autoreconfHook
     libax25
     ncurses
   ];
 
-  # Due to recent unsolvable administrative domain problems with linux-ax25.org,
-  # the new domain is linux-ax25.in-berlin.de
-  src = fetchurl {
-    url = "https://linux-ax25.in-berlin.de/pub/ax25-apps/ax25-apps-${version}.tar.gz";
-    sha256 = "sha256-MzQOIyy5tbJKmojMrgtOcsaQTFJvs3rqt2hUgholz5Y=";
+  # src from linux-ax25.in-berlin.de remote has been
+  # unreliable, pointing to github mirror from the radiocatalog
+  src = fetchFromGitHub {
+    owner = "radiocatalog";
+    repo = "ax25-apps";
+    rev = "afc4a5faa01a24c4da1d152b901066405f36adb6";
+    hash = "sha256-RLeFndis2OhIkJPLD+YfEUrJdZL33huVzlHq+kGq7dA=";
   };
 
   configureFlags = [

--- a/pkgs/by-name/ax/ax25-apps/package.nix
+++ b/pkgs/by-name/ax/ax25-apps/package.nix
@@ -7,7 +7,7 @@
   ncurses,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ax25-apps";
   version = "0.0.8-rc5-unstable-2021-05-13";
 
@@ -32,11 +32,11 @@ stdenv.mkDerivation rec {
     "--program-transform-name=s@^call$@ax&@;s@^listen$@ax&@"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "AX.25 ham radio applications";
     homepage = "https://linux-ax25.in-berlin.de/wiki/Main_Page";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ sarcasticadmin ];
-    platforms = platforms.linux;
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ sarcasticadmin ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: https://github.com/NixOS/nixpkgs/issues/370906

Relates to: https://github.com/NixOS/nixpkgs/issues/388196

The unreleased version of ax25-apps actually fixed the build errors called out in #370906 back in 2021. There just hasnt been a tag released since 2019.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
