### PR TITLE
castget: 2.0.1 -> 2.0.1-unstable-2025-01-25; unbreak

### DIFF
--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -1,27 +1,32 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
 
   # native
+  autoreconfHook,
   glibcLocales,
   pkg-config,
-  ronn,
 
   # host
   curl,
   glib,
   id3lib,
   libxml2,
+  taglib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "castget";
-  version = "2.0.1";
+  # Using unstable version since it doesn't require `ronn`, see:
+  # https://github.com/mlj/castget/commit/e97b179227b4fc7e2e2bc5a373933624c0467daa
+  version = "2.0.1-unstable-2025-01-25";
 
-  src = fetchurl {
-    url = "http://savannah.nongnu.org/download/castget/castget-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-Q4tffsfjGkXtN1ZjD+RH9CAVrNpT7AkgL0hihya16HU=";
+  src = fetchFromGitHub {
+    owner = "mlj";
+    repo = "castget";
+    rev = "e97b179227b4fc7e2e2bc5a373933624c0467daa";
+    hash = "sha256-3t/N8JO36wjHuzIdWNstRWphC/ZR6KkZX0l9yKarS7c=";
   };
 
   # without this, the build fails because of an encoding issue with the manual page.
@@ -37,12 +42,13 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     id3lib
     libxml2
+    taglib
   ];
   nativeBuildInputs = [
+    autoreconfHook
     # See comment on locale above
     glibcLocales
     pkg-config
-    ronn
   ];
 
   meta = {

--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     ronn
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Simple, command-line based RSS enclosure downloader";
     mainProgram = "castget";
     longDescription = ''
@@ -53,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
       primarily intended for automatic, unattended downloading of podcasts.
     '';
     homepage = "https://castget.johndal.com/";
-    maintainers = with maintainers; [ doronbehar ];
-    license = licenses.gpl2;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
       primarily intended for automatic, unattended downloading of podcasts.
     '';
     homepage = "https://castget.johndal.com/";
+    changelog = "https://github.com/mlj/castget/blob/${finalAttrs.version}/CHANGES.md";
     maintainers = with lib.maintainers; [ doronbehar ];
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -2,13 +2,17 @@
   lib,
   stdenv,
   fetchurl,
+
+  # native
+  glibcLocales,
   pkg-config,
-  glib,
   ronn,
+
+  # host
   curl,
+  glib,
   id3lib,
   libxml2,
-  glibcLocales,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,16 +33,16 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [
-    glib
     curl
+    glib
     id3lib
     libxml2
   ];
   nativeBuildInputs = [
-    ronn
     # See comment on locale above
     glibcLocales
     pkg-config
+    ronn
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
