### PR TITLE
qbittorrent-enhanced: add support for tracker whitelist

### DIFF
--- a/pkgs/by-name/qb/qbittorrent-enhanced/package.nix
+++ b/pkgs/by-name/qb/qbittorrent-enhanced/package.nix
@@ -1,8 +1,9 @@
 {
-  lib,
+  clientWhitelist ? true,
   fetchFromGitHub,
-  qbittorrent,
   guiSupport ? true,
+  lib,
+  qbittorrent,
 }:
 
 (qbittorrent.override { inherit guiSupport; }).overrideAttrs (old: rec {
@@ -15,6 +16,13 @@
     rev = "release-${version}";
     hash = "sha256-qYGDPEg4BZZgHschgFjp23EnmaBtmM+UNoC2Lympt/g=";
   };
+
+  postUnpack = lib.optionalString clientWhitelist ''
+    #Use default qBittorrent user agent for tracker whitelist
+    substituteInPlace source/src/base/bittorrent/sessionimpl.cpp --replace-fail "qBittorrent Enhanced" "qBittorrent"
+    substituteInPlace source/src/base/net/dnsupdater.cpp --replace-fail "qBittorrent Enhanced" "qBittorrent"
+    substituteInPlace source/src/base/version.h.in --replace-fail "QBT_VERSION_BUILD 10" "QBT_VERSION_BUILD 0"
+  '';
 
   meta = old.meta // {
     description = "Unofficial enhanced version of qBittorrent, a BitTorrent client";


### PR DESCRIPTION
Trackers that have torrent client list use whitelist instead of blacklist, so qbittorrent-enhanced automatically gets blocked because it's user agent has been modified from the official qbittorrent one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
