### PR TITLE
 chromaprint: add checks

### DIFF
--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase =
     let
       exampleAudio = fetchurl {
-        # Sourced from https://archive.org/details/Dvorak_Symphony_9/01.Adagio-Allegro_Molto.mp3
         name = "Dvorak_Symphony_9_1.mp3";
         url = "https://archive.org/download/Dvorak_Symphony_9/01.Adagio-Allegro_Molto.mp3";
         hash = "sha256-I+Ve3/OpL+3Joc928F8M21LhCH2eQfRtaJVx9mNOLW0=";

--- a/pkgs/by-name/ch/chromaprint/package.nix
+++ b/pkgs/by-name/ch/chromaprint/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   fetchpatch2,
+  fetchurl,
   cmake,
   ninja,
   ffmpeg-headless,
@@ -76,8 +77,30 @@ stdenv.mkDerivation (finalAttrs: {
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 
+  doCheck = true;
+  checkPhase =
+    let
+      exampleAudio = fetchurl {
+        # Sourced from https://archive.org/details/Dvorak_Symphony_9/01.Adagio-Allegro_Molto.mp3
+        name = "Dvorak_Symphony_9_1.mp3";
+        url = "https://archive.org/download/Dvorak_Symphony_9/01.Adagio-Allegro_Molto.mp3";
+        hash = "sha256-I+Ve3/OpL+3Joc928F8M21LhCH2eQfRtaJVx9mNOLW0=";
+        meta.license = lib.licenses.publicDomain;
+      };
+
+      # sha256 because actual output of fpcalc is quite long
+      expectedHash = "c47ae40e02caf798ff5ab4d91ff00cfdca8f6786c581662436941d3e000c9aac";
+    in
+    ''
+      runHook preCheck
+      tests/all_tests
+      ${lib.optionalString withTools "diff -u <(src/cmd/fpcalc ${exampleAudio} | sha256sum | cut -c-64) <(echo '${expectedHash}')"}
+      runHook postCheck
+    '';
+
   meta =
     {
+      changelog = "https://github.com/acoustid/chromaprint/releases/tag/v${finalAttrs.version}";
       homepage = "https://acoustid.org/chromaprint";
       description = "AcoustID audio fingerprinting library";
       license = lib.licenses.lgpl21Plus;


### PR DESCRIPTION
chromaprint is an audio fingerprinting library. As such, it makes sense to assure fingerprints do not change.
This enables the upstream checks, which check the library bindings.
This also calculates a fingerprint on some example audio. The example audio used in [NixOS VM tests](https://github.com/NixOS/nixpkgs/blob/4e4716308d124aef78b3ed7d00e5e5798638a4d7/nixos/tests/mpd.nix#L4-L11) apparently has a dead source url, so i took the liberty of using a public domain track from https://archive.org in the hopes that stays around for longer.

This works (chromaprint builds and passes tests), but i did not yet test on darwin. Tests might need to be disabled there, not sure. Ofborg will know.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
