### PR TITLE
roboto: 2.138 -> 3.011, switch to variable version

### DIFF
--- a/pkgs/by-name/ro/roboto/package.nix
+++ b/pkgs/by-name/ro/roboto/package.nix
@@ -2,52 +2,37 @@
   lib,
   stdenvNoCC,
   fetchzip,
-  python3Packages,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "roboto";
-  version = "2.138";
+  version = "3.011";
 
   src = fetchzip {
-    url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
+    url = "https://github.com/googlefonts/roboto-3-classic/releases/download/v${finalAttrs.version}/Roboto_v${finalAttrs.version}.zip";
     stripRoot = false;
-    hash = "sha256-ue3PUZinBpcYgSho1Zrw1KHl7gc/GlN1GhWFk6g5QXE=";
+    hash = "sha256-Ko5x4zn/bhrFLuYktaAsqsWUsIOMfnxK8rZ4UiqK8ds=";
   };
-
-  nativeBuildInputs = [
-    python3Packages.fonttools
-  ];
 
   installPhase = ''
     runHook preInstall
 
-    # The RobotoCondensed fonts have a usWidthClass value of 5, which is
-    # incorrect. It should be 3.
-    # See the corresponding issue at https://github.com/googlefonts/roboto-3-classic/issues/130
-    for file in RobotoCondensed*; do
-      fontname=$(echo $file | sed 's/\.ttf//')
-      ttx -v -o $fontname.xml $file
-      substituteInPlace $fontname.xml \
-        --replace-fail "<usWidthClass value=\"5\"/>" "<usWidthClass value=\"3\"/>"
-      ttx --no-recalc-timestamp $fontname.xml -o $fontname.ttf
-    done
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 unhinted/static/*.ttf -t $out/share/fonts/truetype
 
     runHook postInstall
   '';
 
   meta = {
-    homepage = "https://github.com/google/roboto";
-    description = "Roboto family of fonts";
+    homepage = "https://github.com/googlefonts/roboto-3-classic";
+    description = "This is a variable version of Roboto intended to be a 1:1 match with the official non-variable release from Google";
     longDescription = ''
-      Google’s signature family of fonts, the default font on Android and
-      Chrome OS, and the recommended font for Google’s visual language,
-      Material Design.
+      This is not an official Google project, but was enabled with generous
+      funding by Google Fonts, who contracted Type Network. The Roboto family of
+      instances contained 6 weights and two widths of normal, along with italic
+      of the regular width.
     '';
-    license = lib.licenses.asl20;
+    license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.romildo ];
   };
-}
+})


### PR DESCRIPTION
The old repository (https://github.com/google/roboto) has been archived by Google.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
