### PR TITLE
cargoSetupHook: set cargo target linker via env

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-build-hook.sh
@@ -38,7 +38,7 @@ cargoBuildHook() {
     concatTo flagsArray cargoBuildFlags
 
     echoCmd 'cargoBuildHook flags' "${flagsArray[@]}"
-    @setEnv@ cargo build "${flagsArray[@]}"
+    cargo build "${flagsArray[@]}"
 
     if [ -n "${buildAndTestSubdir-}" ]; then
         popd

--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -37,7 +37,7 @@ cargoCheckHook() {
     concatTo flagsArray cargoTestFlags checkFlags checkFlagsArray
 
     echoCmd 'cargoCheckHook flags' "${flagsArray[@]}"
-    @setEnv@ cargo test "${flagsArray[@]}"
+    cargo test "${flagsArray[@]}"
 
     if [[ -n "${buildAndTestSubdir-}" ]]; then
         popd

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -36,6 +36,8 @@ cargoSetupPostUnpackHook() {
     @cargoConfig@
 EOF
 
+    export CARGO_TARGET_@cargoEnvVarTarget@_LINKER=@cargoTargetLinker@
+
     echo "Finished cargoSetupPostUnpackHook"
 }
 

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -102,12 +102,14 @@
         # inputs do not cause us to find the wrong `diff`.
         diff = "${lib.getBin diffutils}/bin/diff";
 
+        inherit (stdenv.targetPlatform.rust) cargoEnvVarTarget;
+
+        cargoTargetLinker = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc";
+
         cargoConfig =
-          lib.optionalString (stdenv.hostPlatform.config != stdenv.targetPlatform.config) ''
-            [target."${stdenv.targetPlatform.rust.rustcTarget}"]
-            "linker" = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
+          # TODO: set host linker via environment variable instead (like the target linker above),
+          #       because .cargo/config.toml is overridden by some projects
           ''
-          + ''
             [target."${stdenv.hostPlatform.rust.rustcTarget}"]
             "linker" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
             "rustflags" = [ "-C", "target-feature=${
@@ -118,6 +120,7 @@
       passthru.tests =
         {
           test = tests.rust-hooks.cargoSetupHook;
+          invalid-config = tests.rust-hooks.cargoSetupHook-invalid-config;
         }
         // lib.optionalAttrs (stdenv.isLinux) {
           testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -27,8 +27,6 @@
       name = "cargo-build-hook.sh";
       substitutions = {
         inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
-
       };
       passthru.tests =
         {
@@ -46,7 +44,6 @@
       name = "cargo-check-hook.sh";
       substitutions = {
         inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
       };
       passthru.tests =
         {
@@ -139,8 +136,6 @@
       ];
       substitutions = {
         inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
-
       };
     } ./maturin-build-hook.sh
   ) { };

--- a/pkgs/build-support/rust/hooks/maturin-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/maturin-build-hook.sh
@@ -31,7 +31,7 @@ maturinBuildHook() {
     concatTo flagsArray maturinBuildFlags
 
     echoCmd 'maturinBuildHook flags' "${flagsArray[@]}"
-    @setEnv@ maturin build "${flagsArray[@]}"
+    maturin build "${flagsArray[@]}"
 
     if [ -n "${buildAndTestSubdir-}" ]; then
         popd


### PR DESCRIPTION
- **Revert "rust: re add setEnv to cargo build hooks"**
- **cargoSetupHook: set cargo target linker via env**

This fixes a couple of builds which ship an invalid linker config via their .cargo/config.toml
    
Permanent fix for https://github.com/NixOS/nixpkgs/pull/387733
    
Replaces https://github.com/NixOS/nixpkgs/pull/386191

Why: see my comment https://github.com/NixOS/nixpkgs/pull/386191#issuecomment-2716350836

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
