### PR TITLE
Fix up PR #388789

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -117,7 +117,7 @@ using lightdm for a user `alice`:
 ## Running X without a display manager  {#sec-x11-startx}
 
 It is possible to avoid a display manager entirely and starting the X server
-manually from a virtual terminal. Add to your configuration
+manually from a virtual terminal. Add to your configuration:
 ```nix
 {
   services.xserver.displayManager.startx = {
@@ -130,7 +130,9 @@ then you can start the X server with the `startx` command.
 
 The second option will generate a base `xinitrc` script that will run your
 window manager and set up the systemd user session.
-You can extend the script using the [extraCommands](#opt-services.xserver.displayManager.startx.extraCommands) for example:
+You can extend the script using the
+[extraCommands](#opt-services.xserver.displayManager.startx.extraCommands)
+option, for example:
 ```nix
 {
   services.xserver.displayManager.startx = {
@@ -146,7 +148,7 @@ You can extend the script using the [extraCommands](#opt-services.xserver.displa
 or, alternatively, you can write your own from scratch in `~/.xinitrc`.
 
 In this case, remember you're responsible for starting the window manager, for
-example
+example:
 ```shell
 sxhkd &
 bspwm &

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -548,6 +548,8 @@
 
 - `services.avahi.ipv6` now defaults to true.
 
+- In the `services.xserver.displayManager.startx` module, two new options [generateScript](#opt-services.xserver.displayManager.startx.generateScript) and [extraCommands](#opt-services.xserver.displayManager.startx.extraCommands) have been added to to declaratively configure the .xinitrc script.
+
 - All services that require a root certificate bundle now use the value of a new read-only option, `security.pki.caBundle`.
 
 - hddfancontrol has been updated to major release 2. See the [migration guide](https://github.com/desbma/hddfancontrol/tree/master?tab=readme-ov-file#migrating-from-v1x), as there are breaking changes.

--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -82,8 +82,8 @@ in
     '';
 
     # Add a sane system-wide xinitrc script
-    environment.etc."X11/xinit/xinitrc".source = lib.mkIf cfg.generateScript (
-      pkgs.writeShellScript "xinitrc" ''
+    environment.etc."X11/xinit/xinitrc" = lib.mkIf cfg.generateScript {
+      source = pkgs.writeShellScript "xinitrc" ''
         ${cfg.extraCommands}
 
         # start user services
@@ -97,8 +97,8 @@ in
         # stop services and all subprocesses
         systemctl --user stop nixos-fake-graphical-session.target
         kill 0
-      ''
-    );
+      '';
+    };
 
     environment.systemPackages = with pkgs; [ xorg.xinit ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1153,7 +1153,7 @@ in {
   systemd-userdbd = handleTest ./systemd-userdbd.nix {};
   systemd-homed = handleTest ./systemd-homed.nix {};
   systemtap = handleTest ./systemtap.nix {};
-  startx = runTest ./startx.nix;
+  startx = import ./startx.nix { inherit pkgs runTest; };
   taler = handleTest ./taler {};
   tandoor-recipes = handleTest ./tandoor-recipes.nix {};
   tandoor-recipes-script-name = handleTest ./tandoor-recipes-script-name.nix {};

--- a/nixos/tests/startx.nix
+++ b/nixos/tests/startx.nix
@@ -1,108 +1,200 @@
-{ lib, ... }:
+{ pkgs, runTest }:
 
 {
-  name = "startx";
-  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      services.getty.autologinUser = "root";
+  declarative = runTest {
+    name = "startx";
+    meta.maintainers = with pkgs.lib.maintainers; [ rnhmjoj ];
 
-      environment.systemPackages = with pkgs; [
-        xdotool
-        catclock
-      ];
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.getty.autologinUser = "root";
 
-      programs.bash.promptInit = "PS1='# '";
+        environment.systemPackages = with pkgs; [
+          xdotool
+          catclock
+        ];
 
-      # startx+bspwm setup
-      services.xserver = {
-        enable = true;
-        windowManager.bspwm = {
+        programs.bash.promptInit = "PS1='# '";
+
+        # startx+bspwm setup
+        services.xserver = {
           enable = true;
-          configFile = pkgs.writeShellScript "bspwrc" ''
-            bspc config border_width 2
-            bspc config window_gap 12
-            bspc rule -a xclock state=floating sticky=on
-          '';
-          sxhkd.configFile = pkgs.writeText "sxhkdrc" ''
-            # open a terminal
-            super + Return
-              urxvtc
-            # quit bspwm
-            super + alt + Escape
-              bspc quit
-          '';
+          windowManager.bspwm = {
+            enable = true;
+            configFile = pkgs.writeShellScript "bspwrc" ''
+              bspc config border_width 2
+              bspc config window_gap 12
+              bspc rule -a xclock state=floating sticky=on
+            '';
+            sxhkd.configFile = pkgs.writeText "sxhkdrc" ''
+              # open a terminal
+              super + Return
+                urxvtc
+              # quit bspwm
+              super + alt + Escape
+                bspc quit
+            '';
+          };
+          displayManager.startx = {
+            enable = true;
+            generateScript = true;
+            extraCommands = ''
+              xrdb -load ~/.Xresources
+              xsetroot -solid '#343d46'
+              xsetroot -cursor_name trek
+              xclock &
+            '';
+          };
         };
-        displayManager.startx = {
-          enable = true;
-          generateScript = true;
-          extraCommands = ''
-            xrdb -load ~/.Xresources
-            xsetroot -solid '#343d46'
-            xsetroot -cursor_name trek
-            xclock &
-          '';
-        };
+
+        # enable some user services
+        security.polkit.enable = true;
+        services.urxvtd.enable = true;
+        programs.xss-lock.enable = true;
       };
 
-      # enable some user services
-      security.polkit.enable = true;
-      services.urxvtd.enable = true;
-      programs.xss-lock.enable = true;
-    };
+    testScript = ''
+      import textwrap
 
-  testScript = ''
-    import textwrap
+      sysu = "env XDG_RUNTIME_DIR=/run/user/0 systemctl --user";
+      prompt = "# "
 
-    sysu = "env XDG_RUNTIME_DIR=/run/user/0 systemctl --user";
-    prompt = "# "
+      with subtest("Wait for the autologin"):
+          machine.wait_until_tty_matches("1", prompt)
 
-    with subtest("Wait for the autologin"):
-        machine.wait_until_tty_matches("1", prompt)
+      with subtest("Setup dotfiles"):
+          machine.execute(textwrap.dedent("""
+            cat <<EOF > ~/.Xresources
+              urxvt*foreground: #9b9081
+              urxvt*background: #181b20
+              urxvt*scrollBar:  false
+              urxvt*title:      myterm
+              urxvt*geometry:   80x240+0+0
+              xclock*geometry:  164x164+24+440
+            EOF
+          """))
 
-    with subtest("Setup dotfiles"):
-        machine.execute(textwrap.dedent("""
-          cat <<EOF > ~/.Xresources
+      with subtest("Can start the X server"):
+          machine.send_chars("startx\n")
+          machine.wait_for_x()
+          machine.wait_for_window("xclock")
+
+      with subtest("Graphical services are running"):
+          machine.succeed(f"{sysu} is-active graphical-session.target")
+          machine.succeed(f"{sysu} is-active urxvtd")
+          machine.succeed(f"{sysu} is-active xss-lock")
+
+      with subtest("Can interact with the WM"):
+          machine.wait_until_succeeds("pgrep sxhkd")
+          machine.wait_until_succeeds("pgrep bspwm")
+          # spawn some terminals
+          machine.send_key("meta_l-ret", delay=0.5)
+          machine.send_key("meta_l-ret", delay=0.5)
+          machine.send_key("meta_l-ret", delay=0.5)
+          # Note: this tests that resources have beeen loaded
+          machine.wait_for_window("myterm")
+          machine.screenshot("screenshot.png")
+
+      with subtest("Can stop the X server"):
+          # kill the WM
+          machine.send_key("meta_l-alt-esc")
+          machine.wait_until_tty_matches("1", prompt)
+
+      with subtest("Graphical session has stopped"):
+          machine.fail(f"{sysu} is-active graphical-session.target")
+          machine.fail(f"{sysu} is-active urxvtd")
+          machine.fail(f"{sysu} is-active xss-lock")
+    '';
+  };
+
+  imperative = runTest {
+    name = "startx-imperative";
+    meta.maintainers = with pkgs.lib.maintainers; [ rnhmjoj ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.getty.autologinUser = "root";
+        programs.bash.promptInit = "PS1='# '";
+
+        # startx+twm setup
+        services.xserver = {
+          enable = true;
+          windowManager.twm.enable = true;
+          displayManager.startx.enable = true;
+          displayManager.startx.generateScript = false;
+        };
+
+        # enable some user services
+        security.polkit.enable = true;
+        services.urxvtd.enable = true;
+        programs.xss-lock.enable = true;
+      };
+
+    testScript = ''
+      import textwrap
+
+      sysu = "env XDG_RUNTIME_DIR=/run/user/0 systemctl --user";
+      prompt = "# "
+
+      with subtest("Wait for the autologin"):
+          machine.wait_until_tty_matches("1", prompt)
+
+      with subtest("Setup dotfiles"):
+          machine.execute(textwrap.dedent("""
+            cat <<EOF > ~/.Xresources
             urxvt*foreground: #9b9081
             urxvt*background: #181b20
             urxvt*scrollBar:  false
             urxvt*title:      myterm
-            urxvt*geometry:   80x240+0+0
-            xclock*geometry:  164x164+24+440
-          EOF
-        """))
+            urxvt*geometry:   20x20+40+40
+            EOF
+            cat <<EOF > ~/.twmrc
+            "Return" = meta : all : f.exec "urxvtc"
+            "Escape" = meta : all : f.quit
+            EOF
+            cat <<EOF > ~/.xinitrc
+            xrdb -load ~/.Xresources
+            xsetroot -solid '#343d46'
+            xsetroot -cursor_name trek
+            # start user services
+            systemctl --user import-environment DISPLAY XDG_SESSION_ID
+            systemctl --user start nixos-fake-graphical-session.target
+            # run the window manager
+            twm
+            # stop services and all subprocesses
+            systemctl --user stop nixos-fake-graphical-session.target
+            EOF
+          """))
 
-    with subtest("Can start the X server"):
-        machine.send_chars("startx\n")
-        machine.wait_for_x()
-        machine.wait_for_window("xclock")
+      with subtest("Can start the X server"):
+          machine.send_chars("startx\n")
+          machine.wait_for_x()
 
-    with subtest("Graphical services are running"):
-        machine.succeed(f"{sysu} is-active graphical-session.target")
-        machine.succeed(f"{sysu} is-active urxvtd")
-        machine.succeed(f"{sysu} is-active xss-lock")
+      with subtest("Graphical services are running"):
+          machine.succeed(f"{sysu} is-active graphical-session.target")
+          machine.succeed(f"{sysu} is-active urxvtd")
+          machine.succeed(f"{sysu} is-active xss-lock")
 
-    with subtest("Can interact with the WM"):
-        machine.wait_until_succeeds("pgrep sxhkd")
-        machine.wait_until_succeeds("pgrep bspwm")
-        # spawn some terminals
-        machine.send_key("meta_l-ret", delay=0.5)
-        machine.send_key("meta_l-ret", delay=0.5)
-        machine.send_key("meta_l-ret", delay=0.5)
-        # Note: this tests that resources have beeen loaded
-        machine.wait_for_window("myterm")
-        machine.screenshot("screenshot.png")
+      with subtest("Can interact with the WM"):
+          machine.wait_until_succeeds("pgrep twm")
+          # spawn a terminal
+          machine.send_key("alt-ret")
+          machine.wait_for_window("myterm")
+          machine.screenshot("screenshot.png")
 
-    with subtest("Can stop the X server"):
-        # kill the WM
-        machine.send_key("meta_l-alt-esc")
-        machine.wait_until_tty_matches("1", prompt)
+      with subtest("Can stop the X server"):
+          # kill the WM
+          machine.send_key("alt-esc")
+          machine.wait_until_tty_matches("1", prompt)
 
-    with subtest("Graphical session has stopped"):
-        machine.fail(f"{sysu} is-active graphical-session.target")
-        machine.fail(f"{sysu} is-active urxvtd")
-        machine.fail(f"{sysu} is-active xss-lock")
-  '';
+      with subtest("Graphical session has stopped"):
+          machine.fail(f"{sysu} is-active graphical-session.target")
+          machine.fail(f"{sysu} is-active urxvtd")
+          machine.fail(f"{sysu} is-active xss-lock")
+    '';
+  };
+
 }


### PR DESCRIPTION
Fix some issues with https://github.com/NixOS/nixpkgs/pull/388789.
Most importantly, the eval error when `generateScript == false` (https://github.com/NixOS/nixpkgs/pull/388789#issuecomment-2715808787).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested via 
  - [x] `nixosTests.startx.imperative`
  - [x] `nixosTests.startx.declarative`

- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc: @gravndal