### PR TITLE
vimPlugins.YankRing-vim: remove sourceRoot to fix build

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -3861,10 +3861,6 @@ in
     dependencies = [ self.nui-nvim ];
   };
 
-  YankRing-vim = super.YankRing-vim.overrideAttrs {
-    sourceRoot = ".";
-  };
-
   yanky-nvim = super.yanky-nvim.overrideAttrs {
     nvimSkipModule = [
       # Optional telescope integration


### PR DESCRIPTION
This PR fixes the Yanring vim plugin.

I couldn't get this example in home-manager to work: [Yankring Home Manager example](https://github.com/nix-community/home-manager/blob/2f23fa308a7c067e52dfcc30a0758f47043ec176/modules/programs/vim.nix#L71)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



I've tried other plugins and they worked, so the problem was with this one specifically.

I checked the differences between this plugin and the `gitgutter` plugin and I noticed that `gitgutter` derivation places the `plugin` folder on the top level but for `yankring` it is inside a `source` folder, like this:

```
/nix/store/lmw8xzk4ckb2lh83d85aak69mlk35ai4-vimplugin-YankRing.vim-2015-07-29
├── source                       
│  ├── doc   
│  │  └── yankring.txt
│  ├── plugin
│  │  └── yankring.vim 
│  └── README             
└── env-vars  
```

```
/nix/store/km2pc9rkm86b2hjgm0n8nq209gxd6lbs-vimplugin-vim-gitgutter-2024-04-29
├── autoload
│   ├── gitgutter  
│   └── gitgutter.vim       
├── doc                       
│   ├── gitgutter.txt            
│   └── tags            
├── LICENCE                      
├── plugin                    
│   └── gitgutter.vim       
├── README.mkd                   
├── screenshot.png               
└── test                        
    ├── cp932.txt
    ├── fixture_dos_noeol.txt    
    ├── fixture_dos.txt          
    ├── fixture.foo              
    ├── fixture.txt              
    ├── runner.vim          
    ├── test                     
    └── test_gitgutter.vim 
```

I then used `nix repl` to find that the `sourceRoot` property is defined for `yankring` but not for `gitgutter`. After searching a bit through the source code I found that there is an override for `yankring` here https://github.com/NixOS/nixpkgs/blob/c716603a63aca44f39bef1986c13402167450e0a/pkgs/applications/editors/vim/plugins/overrides.nix#L1888C1-L1890C5

Finally, I changed my definition to override the override, and now the plugin works.

```
  programs.vim = {
    enable = true;
    packageConfigurable = pkgs.vim;
    defaultEditor = true;
    plugins = let
      yankring = pkgs.vimPlugins.YankRing-vim.overrideAttrs {
        sourceRoot = "";
      };
    in
      with pkgs.vimPlugins; [
        vim-sensible
        vim-gitgutter
        vim-airline
        yankring
      ];
  };
```

This PR makes this local override unnecessary by fixing the package directly. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
