### PR TITLE
Refactor nixos/bash prompt using bash function

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -89,12 +89,14 @@ in
 
             PROMPT_COLOR="1;31m"
             ((UID)) && PROMPT_COLOR="1;32m"
-            if [ -n "$INSIDE_EMACS" ]; then
-              # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
-              PS1="\n\[\033[$PROMPT_COLOR\][\u@\h:\w]\\$\[\033[0m\] "
-            else
-              PS1="\n\[\033[$PROMPT_COLOR\][\[\e]0;\u@\h: \w\a\]\u@\h:\w]\\$\[\033[0m\] "
+
+            # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
+            if [ ! -n "$INSIDE_EMACS" ]; then
+              local TITLE="\[\e]0;\u@\h: \w\a\]"
             fi
+
+            PS1="\n\[\033[$PROMPT_COLOR\][$TITLE\u@\h:\w]\\$\[\033[0m\] "
+
             if test "$TERM" = "xterm"; then
               PS1="\[\033]2;\h:\u:\w\007\]$PS1"
             fi

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -87,7 +87,7 @@ in
               return
             fi
 
-            PROMPT_COLOR="1;31m"
+            local PROMPT_COLOR="1;31m"
             ((UID)) && PROMPT_COLOR="1;32m"
 
             # Emacs term mode doesn't support xterm title escape sequence (\e]0;)

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -82,7 +82,11 @@ in
       promptInit = lib.mkOption {
         default = ''
           # Provide a nice prompt if the terminal supports it.
-          if [ "$TERM" != "dumb" ] || [ -n "$INSIDE_EMACS" ]; then
+          set_prompt() {
+            if [ "$TERM" == "dumb" ] && [ ! -n "$INSIDE_EMACS" ]; then
+              return
+            fi
+
             PROMPT_COLOR="1;31m"
             ((UID)) && PROMPT_COLOR="1;32m"
             if [ -n "$INSIDE_EMACS" ]; then
@@ -94,7 +98,9 @@ in
             if test "$TERM" = "xterm"; then
               PS1="\[\033]2;\h:\u:\w\007\]$PS1"
             fi
-          fi
+          }
+
+          set_prompt
         '';
         description = ''
           Shell script code used to initialise the bash prompt.

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -91,8 +91,9 @@ in
             ((UID)) && PROMPT_COLOR="1;32m"
 
             # Emacs term mode doesn't support xterm title escape sequence (\e]0;)
+            local TITLE=""
             if [ ! -n "$INSIDE_EMACS" ]; then
-              local TITLE="\[\e]0;\u@\h: \w\a\]"
+              TITLE="\[\e]0;\u@\h: \w\a\]"
             fi
 
             PS1="\n\[\033[$PROMPT_COLOR\][$TITLE\u@\h:\w]\\$\[\033[0m\] "


### PR DESCRIPTION
It simplifies the flow of logic and makes it easier to understand.
it also makes it trivial to reset the prompt to this one by just calling this function.  this helps for newcomers to linux when they are experimenting with customising prompt.

i was using this value (though read from a `.sh` file) in my `programs.bash.promptInit` for 6 months, and it (seems) to work well with the default gnome terminal emulator and also the `Alt-F2` terminals. 

however, i have not tested it anywhere else nor tested it in this form (i.e. making changes to the underlying implementation itself)

[programs.bash.promptInit]: https://search.nixos.org/options?query=bash&show=programs.bash.promptInit "NixOS Search - Options - bash"
[nixos/modules/programs/bash/bash.nix]: https://github.com/goyalyashpal/nixpkgs/blob/master/nixos/modules/programs/bash/bash.nix "nixpkgs/nixos/modules/programs/bash/bash.nix at master · goyalyashpal/nixpkgs"

.
* destination: [programs.bash.promptInit]
* files: [nixos/modules/programs/bash/bash.nix]



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
