### PR TITLE
bash: Make it possible to set alternative LS_COLORS

### DIFF
--- a/nixos/modules/programs/bash/ls-colors.nix
+++ b/nixos/modules/programs/bash/ls-colors.nix
@@ -13,11 +13,17 @@ in
     programs.bash.enableLsColors = lib.mkEnableOption "extra colors in directory listings" // {
       default = true;
     };
+    programs.bash.lsColorsFile = lib.mkOption {
+      type = lib.types.path;
+      default = "";
+      example = lib.literalExpression "\${pkgs.dircolors-solarized}/ansi-dark";
+      description = "Alternative colorscheme for ls colors";
+    };
   };
 
   config = lib.mkIf enable {
     programs.bash.promptPluginInit = ''
-      eval "$(${pkgs.coreutils}/bin/dircolors -b)"
+      eval "$(${pkgs.coreutils}/bin/dircolors -b ${config.programs.bash.lsColorsFile})"
     '';
   };
 }

--- a/pkgs/by-name/di/dircolors-solarized/package.nix
+++ b/pkgs/by-name/di/dircolors-solarized/package.nix
@@ -1,0 +1,39 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "dircolors-solarized";
+  version = "0-unstable-2025-02-03";
+
+  src = fetchFromGitHub {
+    owner = "seebi";
+    repo = "dircolors-solarized";
+    rev = "52bfa164e4388ee232f6a9235f62e8482e1f1767";
+    hash = "sha256-+2t9OsyD9QkamsFbgmgehBrfszBQmv1Y0C94T4g16GI=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    for f in dircolors.*; do
+      install -Dm644 $f $out/''${f#dircolors.}
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Repository of themes for GNU, supporting Solarized color scheme";
+    homepage = "https://github.com/seebi/dircolors-solarized";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ polyfloyd ];
+  };
+}


### PR DESCRIPTION
This change makes it possible to set an alternative color scheme for `ls` through dircolors.

It works by introducing the `programs.bash.lsColorsFile` attr which is set to a file containing the colors in the respective format.

I included the dircolors-solarized package that I use myself.

An example configuration.nix entry looks like:
```
  programs.bash = {
    enableLsColors = true;
    lsColorsFile = "${pkgs.dircolors-solarized}/ansi-dark";
  };
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
