### PR TITLE
maintainers/scripts/update: Capture stdout in failure logs

### DIFF
--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -17,6 +17,7 @@ Order = Literal["arbitrary", "reverse-topological", "topological"]
 
 class CalledProcessError(Exception):
     process: asyncio.subprocess.Process
+    stdout: bytes | None
     stderr: bytes | None
 
 
@@ -40,6 +41,7 @@ async def check_subprocess_output(*args: str, **kwargs: Any) -> bytes:
     if process.returncode != 0:
         error = CalledProcessError()
         error.process = process
+        error.stdout = stdout
         error.stderr = stderr
 
         raise error
@@ -228,24 +230,23 @@ async def run_update_script(
             f"UPDATE_NIX_ATTR_PATH={package['attrPath']}",
             *update_script_command,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
             cwd=worktree,
         )
-        await merge_changes(merge_lock, package, update_info, temp_dir)
     except KeyboardInterrupt as e:
         eprint("Cancelling…")
         raise asyncio.exceptions.CancelledError()
     except CalledProcessError as e:
         eprint(f" - {package['name']}: ERROR")
-        if e.stderr is not None:
+        if e.stdout is not None:
             eprint()
             eprint(
                 f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------"
             )
             eprint()
-            eprint(e.stderr.decode("utf-8"))
+            eprint(e.stdout.decode("utf-8"))
             with open(f"{package['pname']}.log", "wb") as logfile:
-                logfile.write(e.stderr)
+                logfile.write(e.stdout)
             eprint()
             eprint(
                 f"--- SHOWING ERROR LOG FOR {package['name']} ----------------------"
@@ -255,6 +256,8 @@ async def run_update_script(
             raise UpdateFailedException(
                 f"The update script for {package['name']} failed with exit code {e.process.returncode}"
             )
+    else:
+        await merge_changes(merge_lock, package, update_info, temp_dir)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
For update scripts we pipe stderr to stdout, since this appears to be simpler than vice-versa.  CalledProcessError now includes stdout.

merge_changes is moved out of the try: block.  This will result in a behaviour change.  Errors in merging will end ignore keep-going, and errors will bypass the update-script log handling.

This helps for tools which use stdout heavily for diagnostics (e.g. dotnet/msbuild).

It still requires caching everything in memory, but avoiding that would require temporary files.

We could also keep separate log files for stdout/err, but interleaving them is usually more useful IMO.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
