### PR TITLE
logseq: init at 0.10.9-unstable-2025-03-11 

### DIFF
--- a/pkgs/by-name/lo/logseq/electron-forge-disable-signing.patch
+++ b/pkgs/by-name/lo/logseq/electron-forge-disable-signing.patch
@@ -1,0 +1,24 @@
+diff --git a/resources/forge.config.js b/resources/forge.config.js
+index 5a349a2..f967102 100644
+--- a/resources/forge.config.js
++++ b/resources/forge.config.js
+@@ -13,19 +13,6 @@ module.exports = {
+         "schemes": "logseq"
+       }
+     ],
+-    osxSign: {
+-      identity: 'Developer ID Application: Tiansheng Qin',
+-      'hardened-runtime': true,
+-      entitlements: 'entitlements.plist',
+-      'entitlements-inherit': 'entitlements.plist',
+-      'signature-flags': 'library'
+-    },
+-    osxNotarize: {
+-      tool: 'notarytool',
+-      appleId: process.env['APPLE_ID'],
+-      appleIdPassword: process.env['APPLE_ID_PASSWORD'],
+-      teamId: process.env['APPLE_TEAM_ID']
+-    },
+   },
+   makers: [
+     {

--- a/pkgs/by-name/lo/logseq/electron-forge-package-instead-of-make.patch
+++ b/pkgs/by-name/lo/logseq/electron-forge-package-instead-of-make.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/package.json b/resources/package.json
+index 3445cbb..03927d4 100644
+--- a/resources/package.json
++++ b/resources/package.json
+@@ -10,7 +10,7 @@
+   "scripts": {
+     "electron:dev": "electron-forge start",
+     "electron:debug": "electron-forge start --inspect-electron",
+-    "electron:make": "electron-forge make",
++    "electron:make": "electron-forge package",
+     "electron:make-linux-arm64": "electron-forge make --platform=linux --arch=arm64",
+     "electron:make-macos-arm64": "electron-forge make --platform=darwin --arch=arm64",
+     "electron:publish:github": "electron-forge publish",

--- a/pkgs/by-name/lo/logseq/hardcode-git-paths.patch
+++ b/pkgs/by-name/lo/logseq/hardcode-git-paths.patch
@@ -1,0 +1,98 @@
+diff --git a/bb.edn b/bb.edn
+index 76e1ba1..43d2c73 100644
+--- a/bb.edn
++++ b/bb.edn
+@@ -4,8 +4,7 @@
+   {:mvn/version "0.10.0"}
+   logseq/bb-tasks
+   #_{:local/root "../bb-tasks"}
+-  {:git/url "https://github.com/logseq/bb-tasks"
+-   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}
++  {:local/root "@bb_tasks_src@"}
+   logseq/graph-parser
+   {:local/root "deps/graph-parser"}
+   org.clj-commons/digest
+diff --git a/deps.edn b/deps.edn
+index 9fb41e5..2b45436 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -11,8 +11,7 @@
+   cljs-bean/cljs-bean                   {:mvn/version "1.5.0"}
+   prismatic/dommy                       {:mvn/version "1.1.0"}
+   org.clojure/core.match                {:mvn/version "1.0.0"}
+-  com.andrewmcveigh/cljs-time           {:git/url "https://github.com/logseq/cljs-time" ;; fork
+-                                         :sha     "5704fbf48d3478eedcf24d458c8964b3c2fd59a9"}
++  com.andrewmcveigh/cljs-time           {:local/root "@cljs_time_src@"}
+   cljs-drag-n-drop/cljs-drag-n-drop     {:mvn/version "0.1.0"}
+   cljs-http/cljs-http                   {:mvn/version "0.1.46"}
+   org.babashka/sci                      {:mvn/version "0.3.2"}
+diff --git a/deps/common/bb.edn b/deps/common/bb.edn
+index 3188222..1dba8a9 100644
+--- a/deps/common/bb.edn
++++ b/deps/common/bb.edn
+@@ -2,8 +2,7 @@
+  :deps
+  {logseq/bb-tasks
+   #_{:local/root "../../../bb-tasks"}
+-  {:git/url "https://github.com/logseq/bb-tasks"
+-   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
++  {:local/root "@bb_tasks_src@"}}
+ 
+  :pods
+  {clj-kondo/clj-kondo {:version "2023.05.26"}}
+diff --git a/deps/db/bb.edn b/deps/db/bb.edn
+index 2bf0931..e3d5ea8 100644
+--- a/deps/db/bb.edn
++++ b/deps/db/bb.edn
+@@ -3,8 +3,7 @@
+  :deps
+  {logseq/bb-tasks
+   #_{:local/root "../../../bb-tasks"}
+-  {:git/url "https://github.com/logseq/bb-tasks"
+-   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
++  {:local/root "@bb_tasks_src@"}}
+ 
+  :pods
+  {clj-kondo/clj-kondo {:version "2023.05.26"}}
+diff --git a/deps/graph-parser/bb.edn b/deps/graph-parser/bb.edn
+index 5093ff5..9cb7c54 100644
+--- a/deps/graph-parser/bb.edn
++++ b/deps/graph-parser/bb.edn
+@@ -2,8 +2,7 @@
+  :deps
+  {logseq/bb-tasks
+   #_{:local/root "../../../bb-tasks"}
+-  {:git/url "https://github.com/logseq/bb-tasks"
+-   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
++  {:local/root "@bb_tasks_src@"}}
+  
+  :pods
+  {clj-kondo/clj-kondo {:version "2023.05.26"}}
+diff --git a/deps/graph-parser/deps.edn b/deps/graph-parser/deps.edn
+index 4675c30..57abe35 100644
+--- a/deps/graph-parser/deps.edn
++++ b/deps/graph-parser/deps.edn
+@@ -1,8 +1,7 @@
+ {:paths ["src"]
+  :deps
+  ;; External deps should be kept in sync with https://github.com/logseq/nbb-logseq/blob/main/bb.edn
+- {com.andrewmcveigh/cljs-time {:git/url "https://github.com/logseq/cljs-time" ;; fork
+-                               :sha     "5704fbf48d3478eedcf24d458c8964b3c2fd59a9"}
++ {com.andrewmcveigh/cljs-time {:local/root "@cljs_time_src@"}
+   ;; local deps
+   logseq/db                   {:local/root "../db"}
+   logseq/common               {:local/root "../common"}
+diff --git a/deps/publishing/bb.edn b/deps/publishing/bb.edn
+index 878757b..2fce25a 100644
+--- a/deps/publishing/bb.edn
++++ b/deps/publishing/bb.edn
+@@ -2,8 +2,7 @@
+  :deps
+  {logseq/bb-tasks
+   #_{:local/root "../../../bb-tasks"}
+-  {:git/url "https://github.com/logseq/bb-tasks"
+-   :git/sha "70d3edeb287f5cec7192e642549a401f7d6d4263"}}
++  {:local/root "@bb_tasks_src@"}}
+ 
+  :pods
+  {clj-kondo/clj-kondo {:version "2023.05.26"}}

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -1,0 +1,296 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+  fetchYarnDeps,
+  replaceVars,
+  runCommand,
+  writeShellScriptBin,
+
+  copyDesktopItems,
+  cctools,
+  clojure,
+  makeDesktopItem,
+  makeWrapper,
+  nodejs,
+  removeReferencesTo,
+  yarnBuildHook,
+  yarnConfigHook,
+  xcbuild,
+  zip,
+
+  electron,
+  git,
+}:
+
+let
+  # unpack tarball containing electron's headers
+  electron-headers = runCommand "electron-headers" { } ''
+    mkdir -p $out
+    tar -C $out --strip-components=1 -xvf ${electron.headers}
+  '';
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "logseq";
+  version = "0.10.9-unstable-2025-03-11";
+
+  src = fetchFromGitHub {
+    owner = "logseq";
+    repo = "logseq";
+    rev = "ac0a0dae727c46b348d0f1410138d5e49d446692";
+    hash = "sha256-esCB51BeWnni/JFL4yMKcJj5lka2+hLpcvWGify0T2o=";
+  };
+
+  patches = [
+    (replaceVars ./hardcode-git-paths.patch {
+      cljs_time_src = fetchFromGitHub {
+        owner = "logseq";
+        repo = "cljs-time";
+        rev = "5704fbf48d3478eedcf24d458c8964b3c2fd59a9";
+        hash = "sha256-IApL+SEm7AhbTN7J/1KiAKTx7rd53hchRh3jmPQ412g=";
+      };
+      bb_tasks_src = fetchFromGitHub {
+        owner = "logseq";
+        repo = "bb-tasks";
+        rev = "70d3edeb287f5cec7192e642549a401f7d6d4263";
+        hash = "sha256-xVJj5XCkqfaNjnhYZkuqTSJN0ry8UVMaN44r9pxggB0=";
+      };
+    })
+
+    ./electron-forge-package-instead-of-make.patch
+    ./electron-forge-disable-signing.patch
+  ];
+
+  mavenRepo = stdenv.mkDerivation {
+    name = "logseq-${finalAttrs.version}-maven-deps";
+    inherit (finalAttrs) src patches;
+
+    nativeBuildInputs = [ clojure ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME="$(mktemp -d)"
+      mkdir -p "$out"
+
+      # -P       -> resolve all normal deps
+      # -M:alias -> resolve extra-deps of the listed aliases
+      clj -Sdeps "{:mvn/local-repo \"$out\"}" -P -M:cljs
+
+      runHook postBuild
+    '';
+
+    # copied from buildMavenPackage
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      runHook preInstall
+
+      find $out -type f \( \
+        -name \*.lastUpdated \
+        -o -name resolver-status.properties \
+        -o -name _remote.repositories \) \
+        -delete
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+
+    outputHash = "sha256-gcq9zP5AQtpZU7sC9Oq3PkTj6uDo2NSShigkcuglV98=";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+  };
+
+  yarnOfflineCacheRoot = fetchYarnDeps {
+    name = "logseq-${finalAttrs.version}-yarn-deps-root";
+    inherit (finalAttrs) src;
+    hash = "sha256-z4G675kxfpmG2AJlbK5bfeUUgX7jz1ys2FlMNHJqrQ4=";
+  };
+
+  # ./static and ./resources are combined into ./static by the build process
+  # ./static contains the lockfile and ./resources contains everything else
+  yarnOfflineCacheStaticResources = fetchYarnDeps {
+    name = "logseq-${finalAttrs.version}-yarn-deps-static-resources";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/static";
+    hash = "sha256-xuZj2EKHxvkiDPKMLh3ZSvLT54k+buHqg9lRTFv8rNI=";
+  };
+
+  yarnOfflineCacheAmplify = fetchYarnDeps {
+    name = "logseq-${finalAttrs.version}-yarn-deps-amplify";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/packages/amplify";
+    hash = "sha256-IOhSwIf5goXCBDGHCqnsvWLf3EUPqq75xfQg55snIp4=";
+  };
+
+  yarnOfflineCacheTldraw = fetchYarnDeps {
+    name = "logseq-${finalAttrs.version}-yarn-deps-tldraw";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/tldraw";
+    hash = "sha256-CtMl3MPlyO5nWfFhCC1SLb/+1HUM3YfFATAPqJg3rUo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    let
+      clojureWithCache = writeShellScriptBin "clojure" ''
+        exec ${lib.getExe' clojure "clojure"} -Sdeps '{:mvn/local-repo "${finalAttrs.mavenRepo}"}' "$@"
+      '';
+
+      # the build process runs `git describe --long --always --dirty`
+      fakeGit = writeShellScriptBin "git" ''
+        echo "${finalAttrs.src.rev or finalAttrs.version}@nixpkgs"
+      '';
+    in
+    [
+      clojureWithCache
+      copyDesktopItems
+      fakeGit
+      makeWrapper
+      nodejs
+      (nodejs.python.withPackages (ps: [ ps.setuptools ]))
+      removeReferencesTo
+      yarnBuildHook
+      yarnConfigHook
+      zip
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools
+      xcbuild
+    ];
+
+  # we'll run the hook manually multiple times
+  dontYarnInstallDeps = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  postConfigure = ''
+    yarnOfflineCache="$yarnOfflineCacheRoot" yarnConfigHook
+
+    cp resources/package.json static/package.json
+    pushd static
+    yarnOfflineCache="$yarnOfflineCacheStaticResources" yarnConfigHook
+    popd
+
+    pushd packages/amplify
+    yarnOfflineCache="$yarnOfflineCacheAmplify" yarnConfigHook
+    popd
+
+    pushd tldraw
+    cp yarn.lock apps/tldraw-logseq/yarn.lock
+    yarnOfflineCache="$yarnOfflineCacheTldraw" yarnConfigHook
+    pushd apps/tldraw-logseq
+    yarnOfflineCache="$yarnOfflineCacheTldraw" yarnConfigHook
+    popd
+    popd
+
+    # this has to be done after everything is set up, because for some reason
+    # the shebangs somehow get unpatched... I don't know why...
+    patchShebangs node_modules
+    patchShebangs static/node_modules
+    patchShebangs packages/amplify/node_modules
+    patchShebangs tldraw/node_modules
+    patchShebangs tldraw/apps/tldraw-logseq/node_modules
+
+    yarn --offline --cwd tldraw postinstall
+
+    export npm_config_nodedir=${nodejs}
+    pushd packages/amplify
+    npm rebuild --verbose
+    popd
+
+    export npm_config_nodedir=${electron-headers}
+
+    pushd static
+
+    # we want to use our own git, don't try downloading it
+    substituteInPlace node_modules/dugite/package.json \
+      --replace-fail '"postinstall"' '"_postinstall"'
+
+    # this doesn't seem to build with electron-headers
+    rm node_modules/macos-alias/binding.gyp
+
+    # the electron-rebuild command deadlocks for some reason, let's just use normal npm rebuild (since we overrode the nodedir anyways)
+    npm rebuild --verbose
+
+    # remove most references to electron-headers
+    # TODO: track down the remaining references
+    find node_modules -type f \( -name "*.target.mk" -o -name "config.gypi" -o -name "Makefile" \) -delete
+
+    popd
+
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    pushd electron-dist
+    zip -0Xqr ../electron.zip .
+    popd
+
+    rm -r electron-dist
+
+    substituteInPlace static/node_modules/@electron/packager/dist/packager.js \
+      --replace-fail "await this.getElectronZipPath(downloadOpts)" "\"$(pwd)/electron.zip\""
+
+    cp -r static/node_modules resources/node_modules
+  '';
+
+  yarnBuildScript = "release-electron";
+
+  installPhase =
+    ''
+      runHook preInstall
+
+      # remove references to nodejs
+      find static/out/*/resources/app/node_modules -type f -executable -exec remove-references-to -t ${nodejs} '{}' \;
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm644 static/icons/logseq.png "$out/share/icons/hicolor/512x512/apps/logseq.png"
+
+      mkdir -p $out/share/logseq
+      cp -r static/out/*/{locales,resources{,.pak}} $out/share/logseq
+
+      makeWrapper ${lib.getExe electron} $out/bin/logseq \
+          --add-flags $out/share/logseq/resources/app \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+          --set-default LOCAL_GIT_DIRECTORY ${git} \
+          --inherit-argv0
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r static/out/*/Logseq.app $out/Applications
+
+      wrapProgram $out/Applications/Logseq.app/Contents/MacOS/Logseq \
+        --set-default LOCAL_GIT_DIRECTORY ${git}
+
+      makeWrapper $out/Applications/Logseq.app/Contents/MacOS/Logseq $out/bin/logseq
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Logseq";
+      desktopName = "Logseq";
+      exec = "logseq %U";
+      terminal = false;
+      icon = "logseq";
+      startupWMClass = "Logseq";
+      comment = "A privacy-first, open-source platform for knowledge management and collaboration.";
+      mimeTypes = [ "x-scheme-handler/logseq" ];
+      categories = [ "Utility" ];
+    })
+  ];
+
+  meta = {
+    description = "Privacy-first, open-source platform for knowledge management and collaboration";
+    homepage = "https://github.com/logseq/logseq";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    mainProgram = "logseq";
+    platforms = electron.meta.platforms;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -919,7 +919,6 @@ mapAliases {
   lobster-two = throw "'lobster-two' has been renamed to/replaced by 'google-fonts'"; # Converted to throw 2024-10-17
   loc = throw "'loc' has been removed due to lack of upstream maintenance. Consider 'tokei' as an alternative."; # Added 2025-01-25
   loco-cli = loco; # Added 2025-02-24
-  logseq = throw "logseq has been removed, due to lack of maintenance and blocking the Electron 27 removal."; # Added 2025-02-24
   loop = throw "'loop' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   luna-icons = throw "luna-icons has been removed as it was removed upstream"; # Added 2024-10-29
   lv_img_conv = throw "'lv_img_conv' has been removed from nixpkgs as it is broken"; # Added 2024-06-18


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/389011

The original package got removed due to `electron_27` being EOL.

This PR now builds the package from source.
This is good, because we don't have to wait for an actual release to have support for later electron versions.

---

Testing is much appreciated.

### Known minor problems:
- there still are some references to electron-headers in the final closure, but I don't care that much
- `cljs` is not reproducible. this is an upstream issue, we can't do anything about it


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
