### PR TITLE
managarr: add DarkAlex and Nindouja as maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17100,6 +17100,12 @@
     name = "Guilhem Saurel";
     keys = [ { fingerprint = "9B1A 7906 5D2F 2B80 6C8A  5A1C 7D2A CDAF 4653 CF28"; } ];
   };
+  nindouja = {
+    email = "nindouja@proton.me";
+    github = "Nindouja";
+    githubId = 5629639;
+    name = "Nindouja";
+  };
   ninjafb = {
     email = "oscar@oronberg.com";
     github = "NinjaFB";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5384,6 +5384,12 @@
     github = "dariof4";
     githubId = 9992814;
   };
+  darkalex = {
+    email = "alex.j.tusa@gmail.com";
+    github = "Dark-Alex-17";
+    githubId = 39523942;
+    name = "Alex Clarke";
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/pkgs/by-name/ma/managarr/package.nix
+++ b/pkgs/by-name/ma/managarr/package.nix
@@ -25,7 +25,11 @@ rustPlatform.buildRustPackage rec {
     description = "TUI and CLI to manage your Servarrs";
     homepage = "https://github.com/Dark-Alex-17/managarr";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.IncredibleLaser ];
+    maintainers = [
+      lib.maintainers.IncredibleLaser
+      lib.maintainers.darkalex
+      lib.maintainers.nindouja
+    ];
     mainProgram = "managarr";
   };
 }


### PR DESCRIPTION
The idea is to add maintainers specifically for the managarr package. So we would be adopting the package I guess.

    * @Dark-Alex-17 is the owner of the package but does not use nixos daily
    * I am myself planing to contribute to that package and try to maintain it up to date on nixpkgs

The package is already in nixpkgs, @Dark-Alex-17 published a new version recently, and before it was auto merged, I was looking into ways to make the bot merge the auto-PR. Adding ourselves to the maintainers list should unlock the power to invoke the auto merge command next time if I'm correct.

*Previously opened as #387723*