### PR TITLE
xeus-zmq: 1.3.0 -> 3.1.0

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -49,6 +49,18 @@ let
     buildInputs = oldAttrs.buildInputs ++ lib.singleton xtl;
   });
 
+  # Nixpkgs moved to xeus-zmq 3.x, but we need 1.x
+  xeus-zmq_1x = xeus-zmq.overrideAttrs (oldAttrs: {
+    version = "1.3.0";
+
+    src = fetchFromGitHub {
+      owner = "jupyter-xeus";
+      repo = "xeus-zmq";
+      tag = "1.3.0";
+      sha256 = "sha256-CrFb0LDb6akCfFnwMSa4H3D3A8KJx9Kiejw6VeV3IDs=";
+    };
+  });
+
 in
 
 clangStdenv.mkDerivation rec {
@@ -78,7 +90,7 @@ clangStdenv.mkDerivation rec {
     openssl
     pugixml
     xeus_3_2_0
-    xeus-zmq
+    xeus-zmq_1x
     xtl
     zeromq
     zlib

--- a/pkgs/by-name/xe/xeus-zmq/package.nix
+++ b/pkgs/by-name/xe/xeus-zmq/package.nix
@@ -5,6 +5,7 @@
   cmake,
   cppzmq,
   libuuid,
+  nix-update-script,
   nlohmann_json,
   openssl,
   xeus,
@@ -12,15 +13,15 @@
   zeromq,
 }:
 
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "xeus-zmq";
-  version = "1.3.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "jupyter-xeus";
-    repo = "xeus-zmq";
-    rev = "${version}";
-    hash = "sha256-CrFb0LDb6akCfFnwMSa4H3D3A8KJx9Kiejw6VeV3IDs=";
+    repo = finalAttrs.pname;
+    tag = finalAttrs.version;
+    hash = "sha256-ODjgOSQfHb9HWhdiWa0seDx0ElhrhhJRj2RfiMaUQGU=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,6 +37,8 @@ clangStdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ nlohmann_json ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "ZeroMQ-based middleware for xeus";
     homepage = "https://github.com/jupyter-xeus/xeus-zmq";
@@ -43,4 +46,4 @@ clangStdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ thomasjm ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Xeus-zmq is quite out of date. This PR updates xeus-zmq to a newer version compatible with NixOS' (soon-to-be) recent update of xeus.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
