### PR TITLE
sbarlua: init at 0-unstable-2024-10-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1403,6 +1403,11 @@
     githubId = 157274630;
     name = "amuckstot30";
   };
+  amusingimpala75 = {
+    github = "amusingimpala75";
+    githubId = 69653100;
+    name = "amusingimpala75";
+  };
   amyipdev = {
     email = "amy@amyip.net";
     github = "amyipdev";

--- a/pkgs/by-name/sb/sbarlua/package.nix
+++ b/pkgs/by-name/sb/sbarlua/package.nix
@@ -1,15 +1,16 @@
 {
   lua54Packages,
   gcc,
-  darwin,
   fetchFromGitHub,
   readline,
   lib,
   ...
 }:
-lua54Packages.buildLuaPackage {
+let
   name = "sbarlua";
-  pname = "sbarlua";
+in lua54Packages.buildLuaPackage {
+  inherit name;
+  pname = name;
   version = "0-unstable-2024-10-12";
 
   src = fetchFromGitHub {
@@ -21,20 +22,16 @@ lua54Packages.buildLuaPackage {
 
   buildInputs = [
     gcc
-    darwin.apple_sdk.frameworks.CoreFoundation
     readline
   ];
 
-  installPhase = ''
-    mkdir -p $out/lib/lua/5.4/
-    cp bin/sketchybar.so $out/lib/lua/5.4
-  '';
+  makeFlags = [ "INSTALL_DIR=$(out)/lib/lua/${lua54Packages.lua.luaversion}" ];
 
-  meta = {
-    description = "Lua bindings for configuring Sketchybar macOS Window Manager";
+  meta = with lib; {
+    description = "Lua bindings for configuring Sketchybar macOS menu bar";
     homepage = "https://github.com/FelixKratz/SbarLua";
-    license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ amusingimpala75 ];
-    platforms = lib.platforms.darwin;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ amusingimpala75 ];
+    platforms = platforms.darwin;
   };
 }

--- a/pkgs/by-name/sb/sbarlua/package.nix
+++ b/pkgs/by-name/sb/sbarlua/package.nix
@@ -8,7 +8,8 @@
 }:
 let
   name = "sbarlua";
-in lua54Packages.buildLuaPackage {
+in
+lua54Packages.buildLuaPackage {
   inherit name;
   pname = name;
   version = "0-unstable-2024-10-12";

--- a/pkgs/by-name/sb/sbarlua/package.nix
+++ b/pkgs/by-name/sb/sbarlua/package.nix
@@ -1,0 +1,40 @@
+{
+  lua54Packages,
+  gcc,
+  darwin,
+  fetchFromGitHub,
+  readline,
+  lib,
+  ...
+}:
+lua54Packages.buildLuaPackage {
+  name = "sbarlua";
+  pname = "sbarlua";
+  version = "0-unstable-2024-10-12";
+
+  src = fetchFromGitHub {
+    owner = "FelixKratz";
+    repo = "SbarLua";
+    rev = "437bd2031da38ccda75827cb7548e7baa4aa9978";
+    sha256 = "sha256-F0UfNxHM389GhiPQ6/GFbeKQq5EvpiqQdvyf7ygzkPg=";
+  };
+
+  buildInputs = [
+    gcc
+    darwin.apple_sdk.frameworks.CoreFoundation
+    readline
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lua/5.4/
+    cp bin/sketchybar.so $out/lib/lua/5.4
+  '';
+
+  meta = {
+    description = "Lua bindings for configuring Sketchybar macOS Window Manager";
+    homepage = "https://github.com/FelixKratz/SbarLua";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ amusingimpala75 ];
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added new package for [sbarlua](https://github.com/FelixKratz/SbarLua), a lua bindings library for the Sketchybar menu bar on macOS.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
