### PR TITLE
yo: mark broken

### DIFF
--- a/pkgs/by-name/yo/yo/package.nix
+++ b/pkgs/by-name/yo/yo/package.nix
@@ -20,6 +20,7 @@ buildNpmPackage rec {
   dontNpmBuild = true;
 
   meta = {
+    broken = true; # Cannot find package 'slash'
     description = "CLI tool for running Yeoman generators";
     homepage = "https://github.com/yeoman/yo";
     license = lib.licenses.bsd2;


### PR DESCRIPTION
Running yo fails with

    Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'slash' imported from /nix/store/4mxgc9v3bhdy40g0yi0ly24gzijn4pk8-yo-5.1.0/lib/node_modules/yo/node_modules/@yeoman/conflicter/dist/yo-resolve.js
        at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
        at packageResolve (node:internal/modules/esm/resolve:768:81)
        at moduleResolve (node:internal/modules/esm/resolve:854:18)
        at defaultResolve (node:internal/modules/esm/resolve:984:11)
        at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
        at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
        at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
        at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
        at ModuleJob._link (node:internal/modules/esm/module_job:135:49)

See https://github.com/NixOS/nixpkgs/issues/367282.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
