### PR TITLE
firewalld: repackage

### DIFF
--- a/pkgs/by-name/fi/firewalld/add-config-path-env-var.patch
+++ b/pkgs/by-name/fi/firewalld/add-config-path-env-var.patch
@@ -1,0 +1,12 @@
+--- a/src/firewall/config/__init__.py.in
++++ b/src/firewall/config/__init__.py.in
+@@ -80,7 +80,8 @@
+     FIREWALLD_POLICIES = path + "/policies"
+ 
+ 
+-set_default_config_paths("/usr/lib/firewalld")
++import os
++set_default_config_paths(os.environ.get("NIX_FIREWALLD_CONFIG_PATH", "/usr/lib/firewalld"))
+ 
+ FIREWALLD_LOGFILE = "/var/log/firewalld"
+ 

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -110,6 +110,10 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
+  postInstall = lib.optionalString (!withGui) ''
+    rm $out/bin/firewall-{applet,config}
+  '';
+
   dontWrapGApps = true;
 
   preFixup = lib.optionalString withGui ''

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -69,41 +69,38 @@ stdenv.mkDerivation rec {
         --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
     '';
 
-  nativeBuildInputs =
-    [
-      autoconf
-      automake
-      docbook_xml_dtd_42
-      docbook-xsl-nons
-      glib
-      intltool
-      ipset
-      iptables
-      kmod
-      libxml2
-      libxslt
-      pkg-config
-      python3
-      python3.pkgs.wrapPython
-      sysctl
-    ]
-    ++ lib.optionals withGui [
-      gobject-introspection
-      wrapGAppsNoGuiHook
-    ];
+  nativeBuildInputs = [
+    autoconf
+    automake
+    docbook_xml_dtd_42
+    docbook-xsl-nons
+    glib
+    intltool
+    ipset
+    iptables
+    kmod
+    libxml2
+    libxslt
+    pkg-config
+    python3
+    python3.pkgs.wrapPython
+    sysctl
+    wrapGAppsNoGuiHook
+  ];
 
   buildInputs =
     [
       glib
+      gobject-introspection
       ipset
       iptables
       kmod
+      pythonPath
       sysctl
     ]
     ++ lib.optionals withGui [
       gtk3
       libnotify
-      pythonPath
     ];
 
   preConfigure = ''
@@ -116,7 +113,7 @@ stdenv.mkDerivation rec {
 
   dontWrapGApps = true;
 
-  preFixup = lib.optionalString withGui ''
+  preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -107,10 +107,12 @@ stdenv.mkDerivation rec {
     wrapPythonProgramsIn "$out/share/firewalld/testsuite/python" "$out ${pythonPath}"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Firewall daemon with D-Bus interface";
-    homepage = "https://github.com/firewalld/firewalld";
-    license = licenses.gpl2Plus;
-    maintainers = [ ];
+    homepage = "https://firewalld.org";
+    downloadPage = "https://github.com/firewalld/firewalld/releases";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ prince213 ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -21,6 +21,7 @@
   networkmanagerapplet,
   pkg-config,
   python3,
+  qt6,
   sysctl,
   wrapGAppsNoGuiHook,
   withGui ? false,
@@ -72,24 +73,28 @@ stdenv.mkDerivation rec {
         --replace-fail "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
     '';
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-    docbook_xml_dtd_42
-    docbook-xsl-nons
-    glib
-    intltool
-    ipset
-    iptables
-    kmod
-    libxml2
-    libxslt
-    pkg-config
-    python3
-    python3.pkgs.wrapPython
-    sysctl
-    wrapGAppsNoGuiHook
-  ];
+  nativeBuildInputs =
+    [
+      autoconf
+      automake
+      docbook_xml_dtd_42
+      docbook-xsl-nons
+      glib
+      intltool
+      ipset
+      iptables
+      kmod
+      libxml2
+      libxslt
+      pkg-config
+      python3
+      python3.pkgs.wrapPython
+      sysctl
+      wrapGAppsNoGuiHook
+    ]
+    ++ lib.optionals withGui [
+      qt6.wrapQtAppsHook
+    ];
 
   buildInputs =
     [
@@ -105,6 +110,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withGui [
       gtk3
       libnotify
+      qt6.qtbase
     ];
 
   preConfigure = ''
@@ -116,10 +122,15 @@ stdenv.mkDerivation rec {
   '';
 
   dontWrapGApps = true;
+  dontWrapQtApps = true;
 
-  preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
+  preFixup =
+    ''
+      makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    ''
+    + lib.optionalString withGui ''
+      makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+    '';
 
   postFixup = ''
     chmod +x $out/share/firewalld/*.py $out/share/firewalld/testsuite/python/*.py $out/share/firewalld/testsuite/{,integration/}testsuite

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -83,15 +83,11 @@ stdenv.mkDerivation rec {
       docbook-xsl-nons
       glib
       intltool
-      ipset
-      iptables
-      kmod
       libxml2
       libxslt
       pkg-config
       python3
       python3.pkgs.wrapPython
-      sysctl
       wrapGAppsNoGuiHook
     ]
     ++ lib.optionals withGui [
@@ -118,6 +114,20 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     ./autogen.sh
   '';
+
+  ac_cv_path_MODPROBE = lib.getExe' kmod "modprobe";
+  ac_cv_path_RMMOD = lib.getExe' kmod "rmmod";
+  ac_cv_path_SYSCTL = lib.getExe' sysctl "sysctl";
+
+  configureFlags = [
+    "--with-iptables=${lib.getExe' iptables "iptables"}"
+    "--with-iptables-restore=${lib.getExe' iptables "iptables-restore"}"
+    "--with-ip6tables=${lib.getExe' iptables "ip6tables"}"
+    "--with-ip6tables-restore=${lib.getExe' iptables "ip6tables-restore"}"
+    "--with-ebtables=${lib.getExe' iptables "ebtables"}"
+    "--with-ebtables-restore=${lib.getExe' iptables "ebtables-restore"}"
+    "--with-ipset=${lib.getExe' ipset "ipset"}"
+  ];
 
   postInstall =
     ''

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -118,9 +118,13 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  postInstall = lib.optionalString (!withGui) ''
-    rm $out/bin/firewall-{applet,config}
-  '';
+  postInstall =
+    ''
+      rm -r $out/share/firewalld/testsuite
+    ''
+    + lib.optionalString (!withGui) ''
+      rm $out/bin/firewall-{applet,config}
+    '';
 
   dontWrapGApps = true;
   dontWrapQtApps = true;
@@ -134,10 +138,9 @@ stdenv.mkDerivation rec {
     '';
 
   postFixup = ''
-    chmod +x $out/share/firewalld/*.py $out/share/firewalld/testsuite/python/*.py $out/share/firewalld/testsuite/{,integration/}testsuite
-    patchShebangs --host $out/share/firewalld/testsuite/{,integration/}testsuite $out/share/firewalld/*.py
+    chmod +x $out/share/firewalld/*.py
+    patchShebangs --host $out/share/firewalld/*.py
     wrapPythonProgramsIn "$out/bin" "$out ${pythonPath}"
-    wrapPythonProgramsIn "$out/share/firewalld/testsuite/python" "$out ${pythonPath}"
   '';
 
   meta = {

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./respect-xml-catalog-files-var.patch
+    ./specify-localedir.patch
   ];
 
   postPatch =

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoreconfHook,
+  autoconf,
+  automake,
   bash,
   docbook_xml_dtd_42,
   docbook-xsl-nons,
@@ -67,7 +68,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [
-      autoreconfHook
+      autoconf
+      automake
       docbook_xml_dtd_42
       docbook-xsl-nons
       glib
@@ -93,6 +95,10 @@ stdenv.mkDerivation rec {
       libnotify
       pythonPath
     ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
 
   dontWrapGApps = true;
 

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -4,19 +4,22 @@
   fetchFromGitHub,
   autoconf,
   automake,
-  bash,
   docbook_xml_dtd_42,
   docbook-xsl-nons,
   glib,
   gobject-introspection,
   gtk3,
   intltool,
+  ipset,
+  iptables,
+  kmod,
   libnotify,
   libxml2,
   libxslt,
   networkmanagerapplet,
   pkg-config,
   python3,
+  sysctl,
   wrapGAppsNoGuiHook,
   withGui ? false,
 }:
@@ -74,11 +77,15 @@ stdenv.mkDerivation rec {
       docbook-xsl-nons
       glib
       intltool
+      ipset
+      iptables
+      kmod
       libxml2
       libxslt
       pkg-config
       python3
       python3.pkgs.wrapPython
+      sysctl
     ]
     ++ lib.optionals withGui [
       gobject-introspection
@@ -87,8 +94,11 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      bash
       glib
+      ipset
+      iptables
+      kmod
+      sysctl
     ]
     ++ lib.optionals withGui [
       gtk3

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -34,8 +34,7 @@ let
       pygobject3
     ]
     ++ lib.optionals withGui [
-      pyqt5
-      pyqt5-sip
+      pyqt6
     ]
   );
 in

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -57,12 +57,13 @@ stdenv.mkDerivation rec {
 
   postPatch =
     ''
-      substituteInPlace src/firewall/config/__init__.py.in \
-        --replace-fail /usr "$out"
+      substituteInPlace config/xmlschema/check.sh \
+        --replace-fail /usr/bin/ ""
 
-      for file in config/firewall-{applet,config}.desktop.in; do
-        substituteInPlace $file \
-          --replace "/usr/bin/" "$out/bin/"
+      for file in src/{firewall-offline-cmd.in,firewall/config/__init__.py.in} \
+        config/firewall-{applet,config}.desktop.in; do
+          substituteInPlace $file \
+            --replace-fail /usr "$out"
       done
     ''
     + lib.optionalString withGui ''

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -12,10 +12,12 @@
   intltool,
   ipset,
   iptables,
+  kdePackages,
   kmod,
   libnotify,
   libxml2,
   libxslt,
+  networkmanager,
   networkmanagerapplet,
   pkg-config,
   python3,
@@ -56,7 +58,7 @@ stdenv.mkDerivation rec {
   postPatch =
     ''
       substituteInPlace src/firewall/config/__init__.py.in \
-        --replace "/usr/share" "$out/share"
+        --replace-fail /usr "$out"
 
       for file in config/firewall-{applet,config}.desktop.in; do
         substituteInPlace $file \
@@ -65,7 +67,8 @@ stdenv.mkDerivation rec {
     ''
     + lib.optionalString withGui ''
       substituteInPlace src/firewall-applet.in \
-        --replace "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
+        --replace-fail "/usr/bin/systemsettings" "${kdePackages.systemsettings}/bin/systemsettings" \
+        --replace-fail "/usr/bin/nm-connection-editor" "${networkmanagerapplet}/bin/nm-connection-editor"
     '';
 
   nativeBuildInputs = [
@@ -94,6 +97,7 @@ stdenv.mkDerivation rec {
       ipset
       iptables
       kmod
+      networkmanager
       pythonPath
       sysctl
     ]

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./add-config-path-env-var.patch
     ./respect-xml-catalog-files-var.patch
     ./specify-localedir.patch
   ];

--- a/pkgs/by-name/fi/firewalld/specify-localedir.patch
+++ b/pkgs/by-name/fi/firewalld/specify-localedir.patch
@@ -1,0 +1,12 @@
+--- a/src/firewall/config/__init__.py.in
++++ b/src/firewall/config/__init__.py.in
+@@ -19,6 +19,9 @@
+ DOMAIN = "firewalld"
+ import gettext
+ 
++locale.bindtextdomain(DOMAIN, "/usr/share/locale")
++gettext.bindtextdomain(DOMAIN, "/usr/share/locale")
++
+ gettext.install(domain=DOMAIN)
+ 
+ from . import dbus  # noqa: F401


### PR DESCRIPTION
This PR fixes the firewalld package, which will pave the way for my upcoming PR adding nixos modules.
It now works as expected.

Related: https://git.sr.ht/~prince213/firewalld-nix
Related: #165882.

Closes #293778.
Closes #369440.
Closes #371129.

To test the changes, build firewalld and firewalld-gui locally and run executables in bin, observe that they run without errors in aforementioned issues/PRs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
