### PR TITLE
zettlr update 3.2.0 -> 3.4.3

### DIFF
--- a/pkgs/applications/misc/zettlr/default.nix
+++ b/pkgs/applications/misc/zettlr/default.nix
@@ -2,7 +2,7 @@
 
 builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
   zettlr = {
-    version = "3.2.0";
-    hash = "sha256-gttDGWFJ/VmOyqgOSKnCqqPtNTKJd1fmDpa0ZAX3xc8=";
+    version = "3.4.3";
+    hash = "sha256-Xb9zszbkHWAaIcu74EGQH0PVbuXIZXH/dja1F1Hkx1c=";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates the zettlr package from 3.2.0 to 3.4.3, I did this update because zettlr's 3.2.0 mermaid dependency is outdated and the new version supports a much richer syntax. I built the application locally and started it without any issues following this [guide](https://nixos.wiki/wiki/Update_a_package)  

i did not use sandboxing (I use a flake based install and I dont have `/etc/nix/nix.conf`so I'm not sure where I'm supposed to put the `sandbox=true` expression or how it would affect my system at large...) 

I did test on my nixos install with the following commands

```bash
$ nix store prefetch-file https://github.com/Zettlr/Zettlr/releases/download/v3.4.3/Zettlr-3.4.3-x86_64.appimage
Downloaded 'https://github.com/Zettlr/Zettlr/releases/download/v3.4.3/Zettlr-3.4.3-x86_64.appimage' to '/nix/store/827b3jiq0hqfdir9mvdfvnhib7m9ifza-Zettlr-3.4.3-x86_64.appimage' (hash 'sha256-Xb9zszbkHWAaIcu74EGQH
0PVbuXIZXH/dja1F1Hkx1c=').
$ nix-build -A zettlr
[...]
building '/nix/store/9yq7mxsvd8pn19jj27k1mikxh51qyb7m-zettlr-3.4.3-fhsenv-rootfs.drv'...
structuredAttrs is enabled
Warning: Schema ?org.gnome.system.locale? has path ?/system/locale/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
Warning: Schema ?org.gnome.system.proxy? has path ?/system/proxy/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
Warning: Schema ?org.gnome.system.proxy.http? has path ?/system/proxy/http/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
Warning: Schema ?org.gnome.system.proxy.https? has path ?/system/proxy/https/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
Warning: Schema ?org.gnome.system.proxy.ftp? has path ?/system/proxy/ftp/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
Warning: Schema ?org.gnome.system.proxy.socks? has path ?/system/proxy/socks/?.  Paths starting with ?/apps/?, ?/desktop/? or ?/system/? are deprecated.
building '/nix/store/11fi8550d8bf1cmig3l8vb20aj0hrpwz-zettlr-3.4.3-bwrap.drv'...
building '/nix/store/728z1s1kggqxn88fbc9q22w8zqwifirj-zettlr-3.4.3.drv'...
/nix/store/6pcgm49cgdkgy33v9b2pns1m57g0hy00-zettlr-3.4.3
$ nix-env -f . -iA zettlr
installing 'zettlr-3.4.3'
building '/nix/store/3aqmgq67bfm7hffb33jm22gq2nxbiqm5-user-environment.drv'...
$ zettlr
```

using the new version, my more complex mermaid flowchart renders correctly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
