### PR TITLE
gcc: fix inconsistency in isCross condition

### DIFF
--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -26,8 +26,8 @@ let
             inherit majorMinorVersion;
             reproducibleBuild = true;
             profiledCompiler = false;
-            libcCross = if stdenv.targetPlatform != stdenv.buildPlatform then args.libcCross else null;
-            threadsCross = if stdenv.targetPlatform != stdenv.buildPlatform then threadsCross else { };
+            libcCross = if ! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then args.libcCross else null;
+            threadsCross = if ! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then threadsCross else { };
             isl = if stdenv.hostPlatform.isDarwin then null else isl_0_20;
             # do not allow version skew when cross-building gcc
             #
@@ -49,7 +49,7 @@ let
             # cross-case.
             stdenv =
               if
-                (stdenv.targetPlatform != stdenv.buildPlatform || stdenv.hostPlatform != stdenv.targetPlatform)
+                ((! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform) || (! lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform))
                 && stdenv.cc.isGNU
               then
                 pkgs."gcc${majorVersion}Stdenv"

--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -26,8 +26,10 @@ let
             inherit majorMinorVersion;
             reproducibleBuild = true;
             profiledCompiler = false;
-            libcCross = if ! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then args.libcCross else null;
-            threadsCross = if ! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then threadsCross else { };
+            libcCross =
+              if !lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then args.libcCross else null;
+            threadsCross =
+              if !lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then threadsCross else { };
             isl = if stdenv.hostPlatform.isDarwin then null else isl_0_20;
             # do not allow version skew when cross-building gcc
             #
@@ -49,7 +51,10 @@ let
             # cross-case.
             stdenv =
               if
-                ((! lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform) || (! lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform))
+                (
+                  (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform)
+                  || (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
+                )
                 && stdenv.cc.isGNU
               then
                 pkgs."gcc${majorVersion}Stdenv"

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -7,7 +7,7 @@
 
 let
   forceLibgccToBuildCrtStuff = import ./libgcc-buildstuff.nix { inherit lib stdenv; };
-  isCross = with stdenv; targetPlatform != hostPlatform;
+  isCross = ! lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform;
 in
 
 # We don't support multilib and cross at the same time

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -7,7 +7,7 @@
 
 let
   forceLibgccToBuildCrtStuff = import ./libgcc-buildstuff.nix { inherit lib stdenv; };
-  isCross = with stdenv; targetPlatform.config != hostPlatform.config;
+  isCross = with stdenv; targetPlatform != hostPlatform;
 in
 
 # We don't support multilib and cross at the same time

--- a/pkgs/development/compilers/gcc/common/checksum.nix
+++ b/pkgs/development/compilers/gcc/common/checksum.nix
@@ -9,7 +9,7 @@
 
 let
   enableChecksum =
-    (with stdenv; buildPlatform == hostPlatform && hostPlatform == targetPlatform)
+    (with stdenv; lib.systems.equals buildPlatform hostPlatform && lib.systems.equals hostPlatform targetPlatform)
     && langC
     && langCC
     && !stdenv.hostPlatform.isDarwin;

--- a/pkgs/development/compilers/gcc/common/checksum.nix
+++ b/pkgs/development/compilers/gcc/common/checksum.nix
@@ -9,7 +9,10 @@
 
 let
   enableChecksum =
-    (with stdenv; lib.systems.equals buildPlatform hostPlatform && lib.systems.equals hostPlatform targetPlatform)
+    (
+      with stdenv;
+      lib.systems.equals buildPlatform hostPlatform && lib.systems.equals hostPlatform targetPlatform
+    )
     && langC
     && langCC
     && !stdenv.hostPlatform.isDarwin;

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -23,7 +23,7 @@
 , langObjCpp
 , langJit
 , langRust ? false
-, disableBootstrap ? stdenv.targetPlatform != stdenv.hostPlatform
+, disableBootstrap ? (! lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
 }:
 
 assert !enablePlugin -> disableGdbPlugin;
@@ -45,10 +45,10 @@ let
   # See https://github.com/NixOS/nixpkgs/pull/209870#issuecomment-1500550903
   disableBootstrap' = disableBootstrap && !langFortran && !langGo;
 
-  crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
-  crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
+  crossMingw = (! lib.systems.equals targetPlatform hostPlatform) && targetPlatform.isMinGW;
+  crossDarwin = (! lib.systems.equals targetPlatform hostPlatform) && targetPlatform.libc == "libSystem";
 
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
+  targetPrefix = lib.optionalString (! lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform)
                   "${stdenv.targetPlatform.config}-";
 
   crossConfigureFlags =
@@ -201,16 +201,16 @@ let
 
     # Ada options, gcc can't build the runtime library for a cross compiler
     ++ lib.optional langAda
-      (if hostPlatform == targetPlatform
+      (if lib.systems.equals hostPlatform targetPlatform
        then "--enable-libada"
        else "--disable-libada")
 
     ++ import ../common/platform-flags.nix { inherit (stdenv)  targetPlatform; inherit lib; }
-    ++ lib.optionals (targetPlatform != hostPlatform) crossConfigureFlags
+    ++ lib.optionals (! lib.systems.equals targetPlatform hostPlatform) crossConfigureFlags
     ++ lib.optional disableBootstrap' "--disable-bootstrap"
 
     # Platform-specific flags
-    ++ lib.optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
+    ++ lib.optional (lib.systems.equals targetPlatform hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
     ++ lib.optional targetPlatform.isNetBSD "--disable-libssp" # Provided by libc.
     ++ lib.optionals hostPlatform.isSunOS [
       "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
@@ -220,7 +220,7 @@ let
     ++ lib.optional (targetPlatform.libc == "musl")
       # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
       "--disable-libmpx"
-    ++ lib.optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
+    ++ lib.optionals (lib.systems.equals targetPlatform hostPlatform && targetPlatform.libc == "musl") [
       "--disable-libsanitizer"
       "--disable-symvers"
       "libat_cv_have_ifunc=no"

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -55,12 +55,12 @@ in
   # same for all gcc's
   depsBuildTarget =
     (
-      if hostPlatform == buildPlatform then
+      if lib.systems.equals hostPlatform buildPlatform then
         [
           targetPackages.stdenv.cc.bintools # newly-built gcc will be used
         ]
       else
-        assert targetPlatform == hostPlatform;
+        assert lib.systems.equals targetPlatform hostPlatform;
         [
           # build != host == target
           stdenv.cc

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -19,7 +19,7 @@ in
     let
       mkFlags =
         dep: langD:
-        lib.optionals (targetPlatform != hostPlatform && dep != null && !langD) (
+        lib.optionals ((! lib.systems.equals targetPlatform hostPlatform) && dep != null && !langD) (
           [
             "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
           ]
@@ -35,7 +35,7 @@ in
     let
       mkFlags =
         dep:
-        lib.optionals (targetPlatform != hostPlatform && dep != null) (
+        lib.optionals ((! lib.systems.equals targetPlatform hostPlatform) && dep != null) (
           [
             "-Wl,-L${lib.getLib dep}${dep.libdir or "/lib"}"
           ]

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -19,7 +19,7 @@ in
     let
       mkFlags =
         dep: langD:
-        lib.optionals ((! lib.systems.equals targetPlatform hostPlatform) && dep != null && !langD) (
+        lib.optionals ((!lib.systems.equals targetPlatform hostPlatform) && dep != null && !langD) (
           [
             "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
           ]
@@ -35,7 +35,7 @@ in
     let
       mkFlags =
         dep:
-        lib.optionals ((! lib.systems.equals targetPlatform hostPlatform) && dep != null) (
+        lib.optionals ((!lib.systems.equals targetPlatform hostPlatform) && dep != null) (
           [
             "-Wl,-L${lib.getLib dep}${dep.libdir or "/lib"}"
           ]

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -25,7 +25,11 @@ lib.pipe drv
         pkg.overrideAttrs (
           previousAttrs:
           lib.optionalAttrs
-            ((! lib.systems.equals targetPlatform  hostPlatform) && (enableShared || targetPlatform.isMinGW) && withoutTargetLibc)
+            (
+              (!lib.systems.equals targetPlatform hostPlatform)
+              && (enableShared || targetPlatform.isMinGW)
+              && withoutTargetLibc
+            )
             {
               makeFlags = [
                 "all-gcc"
@@ -46,7 +50,8 @@ lib.pipe drv
 
         (
           let
-            targetPlatformSlash = if lib.systems.equals hostPlatform targetPlatform then "" else "${targetPlatform.config}/";
+            targetPlatformSlash =
+              if lib.systems.equals hostPlatform targetPlatform then "" else "${targetPlatform.config}/";
 
             # If we are building a cross-compiler and the target libc provided
             # to us at build time has a libgcc, use that instead of building a

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -25,7 +25,7 @@ lib.pipe drv
         pkg.overrideAttrs (
           previousAttrs:
           lib.optionalAttrs
-            (targetPlatform != hostPlatform && (enableShared || targetPlatform.isMinGW) && withoutTargetLibc)
+            ((! lib.systems.equals targetPlatform  hostPlatform) && (enableShared || targetPlatform.isMinGW) && withoutTargetLibc)
             {
               makeFlags = [
                 "all-gcc"
@@ -46,7 +46,7 @@ lib.pipe drv
 
         (
           let
-            targetPlatformSlash = if hostPlatform == targetPlatform then "" else "${targetPlatform.config}/";
+            targetPlatformSlash = if lib.systems.equals hostPlatform targetPlatform then "" else "${targetPlatform.config}/";
 
             # If we are building a cross-compiler and the target libc provided
             # to us at build time has a libgcc, use that instead of building a
@@ -55,7 +55,7 @@ lib.pipe drv
             useLibgccFromTargetLibc = libcCross != null && libcCross ? passthru.libgcc;
 
             enableLibGccOutput =
-              (!stdenv.targetPlatform.isWindows || (with stdenv; targetPlatform == hostPlatform))
+              (!stdenv.targetPlatform.isWindows || (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform))
               && !langJit
               && !stdenv.hostPlatform.isDarwin
               && enableShared

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -35,7 +35,13 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # meet that need: it runs on the hostPlatform.
 +
   lib.optionalString
-    (langFortran && (with stdenv; (! lib.systems.equals buildPlatform hostPlatform) && (lib.systems.equals hostPlatform targetPlatform)))
+    (
+      langFortran
+      && (
+        with stdenv;
+        (!lib.systems.equals buildPlatform hostPlatform) && (lib.systems.equals hostPlatform targetPlatform)
+      )
+    )
     ''
       export GFORTRAN_FOR_TARGET=${pkgsBuildTarget.gfortran}/bin/${stdenv.targetPlatform.config}-gfortran
     ''
@@ -52,7 +58,8 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # actually different we need to convince the configure script that it
 # is in fact building a cross compiler although it doesn't believe it.
 +
-  lib.optionalString (targetPlatform.config == hostPlatform.config && (! lib.systems.equals targetPlatform hostPlatform))
+  lib.optionalString
+    (targetPlatform.config == hostPlatform.config && (!lib.systems.equals targetPlatform hostPlatform))
     ''
       substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
     ''
@@ -65,12 +72,14 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 +
   lib.optionalString
     (
-      (! lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && targetPlatform.config == hostPlatform.config
+      (!lib.systems.equals targetPlatform hostPlatform)
+      && withoutTargetLibc
+      && targetPlatform.config == hostPlatform.config
     )
     ''
       export inhibit_libc=true
     ''
 
-+ lib.optionalString ((! lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared) (
-  import ./libgcc-buildstuff.nix { inherit lib stdenv; }
-)
++ lib.optionalString (
+  (!lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared
+) (import ./libgcc-buildstuff.nix { inherit lib stdenv; })

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -35,7 +35,7 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # meet that need: it runs on the hostPlatform.
 +
   lib.optionalString
-    (langFortran && (with stdenv; buildPlatform != hostPlatform && hostPlatform == targetPlatform))
+    (langFortran && (with stdenv; (! lib.systems.equals buildPlatform hostPlatform) && (lib.systems.equals hostPlatform targetPlatform)))
     ''
       export GFORTRAN_FOR_TARGET=${pkgsBuildTarget.gfortran}/bin/${stdenv.targetPlatform.config}-gfortran
     ''
@@ -52,7 +52,7 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # actually different we need to convince the configure script that it
 # is in fact building a cross compiler although it doesn't believe it.
 +
-  lib.optionalString (targetPlatform.config == hostPlatform.config && targetPlatform != hostPlatform)
+  lib.optionalString (targetPlatform.config == hostPlatform.config && (! lib.systems.equals targetPlatform hostPlatform))
     ''
       substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
     ''
@@ -60,17 +60,17 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # Normally (for host != target case) --without-headers automatically
 # enables 'inhibit_libc=true' in gcc's gcc/configure.ac. But case of
 # gcc->clang or dynamic->static "cross"-compilation manages to evade it: there
-# hostPlatform != targetPlatform, hostPlatform.config == targetPlatform.config.
+# ! lib.systems.equals hostPlatform targetPlatform, hostPlatform.config == targetPlatform.config.
 # We explicitly inhibit libc headers use in this case as well.
 +
   lib.optionalString
     (
-      targetPlatform != hostPlatform && withoutTargetLibc && targetPlatform.config == hostPlatform.config
+      (! lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && targetPlatform.config == hostPlatform.config
     )
     ''
       export inhibit_libc=true
     ''
 
-+ lib.optionalString (targetPlatform != hostPlatform && withoutTargetLibc && enableShared) (
++ lib.optionalString ((! lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared) (
   import ./libgcc-buildstuff.nix { inherit lib stdenv; }
 )

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -21,7 +21,7 @@
 , libucontext ? null
 , gnat-bootstrap ? null
 , enableMultilib ? false
-, enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enablePlugin ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform) # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -77,14 +77,14 @@ let
     disableBootstrap = atLeast11 && !stdenv.hostPlatform.isDarwin && (atLeast12 -> !profiledCompiler);
 
     inherit (stdenv) buildPlatform hostPlatform targetPlatform;
-    targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
+    targetConfig = if (! lib.systems.equals targetPlatform hostPlatform) then targetPlatform.config else null;
 
     patches = callFile ./patches {};
 
     /* Cross-gcc settings (build == host != target) */
-    crossMingw = targetPlatform != hostPlatform && targetPlatform.isMinGW;
+    crossMingw = (! lib.systems.equals targetPlatform hostPlatform) && targetPlatform.isMinGW;
     stageNameAddon = optionalString withoutTargetLibc "-nolibc";
-    crossNameAddon = optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}${stageNameAddon}-";
+    crossNameAddon = optionalString (! lib.systems.equals targetPlatform hostPlatform) "${targetPlatform.config}${stageNameAddon}-";
 
     callFile = callPackageWith {
       # lets
@@ -244,7 +244,7 @@ pipe ((callFile ./common/builder.nix {}) ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
+    optionalString ((! lib.systems.equals targetPlatform hostPlatform) || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       (let
@@ -296,11 +296,11 @@ pipe ((callFile ./common/builder.nix {}) ({
     if atLeast11
     then let target =
                optionalString (profiledCompiler) "profiled" +
-               optionalString (targetPlatform == hostPlatform && hostPlatform == buildPlatform && !disableBootstrap) "bootstrap";
+               optionalString ((lib.systems.equals targetPlatform hostPlatform) && (lib.systems.equals hostPlatform buildPlatform) && !disableBootstrap) "bootstrap";
          in optional (target != "") target
     else
       optional
-        (targetPlatform == hostPlatform && hostPlatform == buildPlatform)
+        ((lib.systems.equals targetPlatform hostPlatform) && (lib.systems.equals hostPlatform buildPlatform))
         (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   inherit (callFile ./common/strip-attributes.nix { })
@@ -328,11 +328,11 @@ pipe ((callFile ./common/builder.nix {}) ({
     # compiler (after the specs for the cross-gcc are created). Having
     # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
 
-    CPATH = optionals (targetPlatform == hostPlatform) (makeSearchPathOutput "dev" "include" ([]
+    CPATH = optionals (lib.systems.equals targetPlatform hostPlatform) (makeSearchPathOutput "dev" "include" ([]
       ++ optional (zlib != null) zlib
     ));
 
-    LIBRARY_PATH = optionals (targetPlatform == hostPlatform) (makeLibraryPath (
+    LIBRARY_PATH = optionals (lib.systems.equals targetPlatform hostPlatform) (makeLibraryPath (
       optional (zlib != null) zlib
     ));
 
@@ -342,7 +342,7 @@ pipe ((callFile ./common/builder.nix {}) ({
       EXTRA_FLAGS_FOR_TARGET
       EXTRA_LDFLAGS_FOR_TARGET
       ;
-  } // optionalAttrs (!atLeast12 && stdenv.cc.isClang && targetPlatform != hostPlatform) {
+  } // optionalAttrs (!atLeast12 && stdenv.cc.isClang && (! lib.systems.equals targetPlatform hostPlatform)) {
     NIX_CFLAGS_COMPILE = "-Wno-register";
   });
 
@@ -376,7 +376,7 @@ pipe ((callFile ./common/builder.nix {}) ({
   } // optionalAttrs (!atLeast11) {
     badPlatforms = [ "aarch64-darwin" ];
   } // optionalAttrs is10 {
-    badPlatforms = if targetPlatform != hostPlatform then [ "aarch64-darwin" ] else [ ];
+    badPlatforms = if (! lib.systems.equals targetPlatform hostPlatform) then [ "aarch64-darwin" ] else [ ];
   };
 } // optionalAttrs (!atLeast10 && stdenv.targetPlatform.isDarwin) {
   # GCC <10 requires default cctools `strip` instead of `llvm-strip` used by Darwin bintools.

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -45,8 +45,8 @@ let
   canApplyIainsDarwinPatches =
     stdenv.hostPlatform.isDarwin
     && stdenv.hostPlatform.isAarch64
-    && buildPlatform == hostPlatform
-    && hostPlatform == targetPlatform;
+    && (lib.systems.equals buildPlatform hostPlatform)
+    && (lib.systems.equals hostPlatform targetPlatform);
 
   inherit (lib) optionals optional;
 in
@@ -62,7 +62,7 @@ in
 
 [ ]
 ++ optional (!atLeast12) ./fix-bug-80431.patch
-++ optional (targetPlatform != hostPlatform) ./libstdc++-target.patch
+++ optional (! lib.systems.equals targetPlatform hostPlatform) ./libstdc++-target.patch
 ++ optionals (noSysDirs) (
   [ (if atLeast12 then ./gcc-12-no-sys-dirs.patch else ./no-sys-dirs.patch) ]
   ++ (
@@ -255,7 +255,7 @@ in
 
 ++ optional (langAda && (is9 || is10)) ./gnat-cflags.patch
 ++
-  optional (is10 && buildPlatform.system == "aarch64-darwin" && targetPlatform != buildPlatform)
+  optional (is10 && buildPlatform.system == "aarch64-darwin" && (! lib.systems.equals targetPlatform buildPlatform))
     (fetchpatch {
       url = "https://raw.githubusercontent.com/richard-vd/musl-cross-make/5e9e87f06fc3220e102c29d3413fbbffa456fcd6/patches/gcc-${version}/0008-darwin-aarch64-self-host-driver.patch";
       sha256 = "sha256-XtykrPd5h/tsnjY1wGjzSOJ+AyyNLsfnjuOZ5Ryq9vA=";

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -62,7 +62,7 @@ in
 
 [ ]
 ++ optional (!atLeast12) ./fix-bug-80431.patch
-++ optional (! lib.systems.equals targetPlatform hostPlatform) ./libstdc++-target.patch
+++ optional (!lib.systems.equals targetPlatform hostPlatform) ./libstdc++-target.patch
 ++ optionals (noSysDirs) (
   [ (if atLeast12 then ./gcc-12-no-sys-dirs.patch else ./no-sys-dirs.patch) ]
   ++ (
@@ -255,7 +255,12 @@ in
 
 ++ optional (langAda && (is9 || is10)) ./gnat-cflags.patch
 ++
-  optional (is10 && buildPlatform.system == "aarch64-darwin" && (! lib.systems.equals targetPlatform buildPlatform))
+  optional
+    (
+      is10
+      && buildPlatform.system == "aarch64-darwin"
+      && (!lib.systems.equals targetPlatform buildPlatform)
+    )
     (fetchpatch {
       url = "https://raw.githubusercontent.com/richard-vd/musl-cross-make/5e9e87f06fc3220e102c29d3413fbbffa456fcd6/patches/gcc-${version}/0008-darwin-aarch64-self-host-driver.patch";
       sha256 = "sha256-XtykrPd5h/tsnjY1wGjzSOJ+AyyNLsfnjuOZ5Ryq9vA=";


### PR DESCRIPTION
In libgcc.nix, `targetPlatformSlash` is set by checking if hostPlatform == targetPlatform. In default.nix, `targetConfig` (which is also going to be part of the path) is also set by checking if hostPlatform == targetPlatform.

However, in common.nix, the recently added `isCross` is set by checking if hostPlatform.config == targetPlatform.config. This means that for platforms like '-nolibc' the paths in common.nix are not set up correctly for libgcc.nix to find and move libgcc_s.so .

Changing isCross to also check hostPlatform == targetPlatform fixes this issue.

Followup to https://github.com/NixOS/nixpkgs/pull/380325 .
Fixes https://github.com/NixOS/nixpkgs/issues/383914#issuecomment-2715859493 .


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
