### PR TITLE
mpvScripts.buildLua: fix `runtime-dependencies` option

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -76,20 +76,17 @@ lib.makeOverridable (
           runHook postInstall
         '';
 
-        passthru =
-          {
-            inherit scriptName;
-          }
-          // lib.optionalAttrs (runtime-dependencies != [ ]) {
-            extraWrapperArgs =
-              [
-                "--prefix"
-                "PATH"
-                ":"
-              ]
-              ++ (map lib.makeBinPath runtime-dependencies)
-              ++ args.passthru.extraWrapperArgs or [ ];
-          };
+        passthru = {
+          inherit scriptName;
+          extraWrapperArgs =
+            lib.optionals (runtime-dependencies != [ ]) [
+              "--prefix"
+              "PATH"
+              ":"
+              (lib.makeBinPath runtime-dependencies)
+            ] ++ args.passthru.extraWrapperArgs or [ ];
+        };
+
         meta =
           {
             platforms = lib.platforms.all;


### PR DESCRIPTION
Fix bugs introduced by e2596ac22d4211b3c070f9e518d7b4dc087edc9b in `mpvScripts.buildLua`:
- type error noticed by @FliegendeWurst;
- logic error in the interaction between `passthru.extraWrapperArgs` and `runtime-dependencies`.


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
