### PR TITLE
Revert "linux: simplify toolchain selection"

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -46,7 +46,8 @@ sub runConfig {
     # required to get clang LTO working, among other things.
     my $pid = open2(\*IN, \*OUT,
                     "make -C $ENV{SRC} O=$buildRoot config"
-                    . " SHELL=bash ARCH=$ENV{ARCH} CROSS_COMPILE=$ENV{CROSS_COMPILE}"
+                    . " SHELL=bash ARCH=$ENV{ARCH} CC=$ENV{CC} HOSTCC=$ENV{HOSTCC} HOSTCXX=$ENV{HOSTCXX}"
+                    . " LD=$ENV{LD} NM=$ENV{NM} AR=$ENV{AR} OBJCOPY=$ENV{OBJCOPY}"
                     . " $makeFlags");
 
     # Parse the output, look for questions and then send an

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -172,18 +172,34 @@ let
 
     buildPhase = ''
       export buildRoot="''${buildRoot:-build}"
+      export HOSTCC=$CC_FOR_BUILD
+      export HOSTCXX=$CXX_FOR_BUILD
+      export HOSTAR=$AR_FOR_BUILD
+      export HOSTLD=$LD_FOR_BUILD
+
+      # Absolute paths for tools avoid any PATH-clobbering issues.
+      export CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc
+      export LD=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld
+      export AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar
+      export NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm
+      export STRIP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}strip
+      export OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy
+      export OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump
+      export READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf
 
       # Get a basic config file for later refinement with $generateConfig.
       make $makeFlags \
           -C . O="$buildRoot" $kernelBaseConfig \
-          ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
+          ARCH=$kernelArch \
+          HOSTCC=$HOSTCC HOSTCXX=$HOSTCXX HOSTAR=$HOSTAR HOSTLD=$HOSTLD \
+          CC=$CC OBJCOPY=$OBJCOPY OBJDUMP=$OBJDUMP READELF=$READELF \
+          LD=$LD AR=$AR NM=$NM STRIP=$STRIP \
           $makeFlags
 
       # Create the config file.
       echo "generating kernel configuration..."
       ln -s "$kernelConfigPath" "$buildRoot/kernel-config"
-      DEBUG=1 ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
-        KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
+      DEBUG=1 ARCH=$kernelArch KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
         PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
         perl -w $generateConfig
     '';

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -428,14 +428,25 @@ let
 
   # Absolute paths for compilers avoid any PATH-clobbering issues.
   commonMakeFlags = [
+    "O=$(buildRoot)"
+    "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+    "LD=${if stdenv.isx86_64 && stdenv.cc.bintools.isLLVM
+          then
+            # The wrapper for ld.lld breaks linking the kernel. We use the unwrapped linker as workaround. See:
+            # https://github.com/NixOS/nixpkgs/issues/321667
+            stdenv.cc.bintools.bintools
+          else stdenv.cc}/bin/${stdenv.cc.targetPrefix}ld"
+    "AR=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}ar"
+    "NM=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}nm"
+    "STRIP=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
+    "OBJCOPY=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objcopy"
+    "OBJDUMP=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}objdump"
+    "READELF=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}readelf"
+    "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
+    "HOSTLD=${buildPackages.stdenv.cc.bintools}/bin/${buildPackages.stdenv.cc.targetPrefix}ld"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-  ] ++ lib.optionals (stdenv.isx86_64 && stdenv.cc.bintools.isLLVM) [
-    # The wrapper for ld.lld breaks linking the kernel. We use the
-    # unwrapped linker as workaround. See:
-    #
-    # https://github.com/NixOS/nixpkgs/issues/321667
-    "LD=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ld"
   ] ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [])
     ++ extraMakeFlags;
 in


### PR DESCRIPTION
This reverts commit 70cc251554d883130ae1a94ffd3508c2d521db6a.

The reverted commit actually pulls in GCC for kernel builds in pkgsLLVM again. *sigh* Let's accept defeat here and specify everything manually again. This is a partial revert of apparently broken improvements in #344665.

An easy way to test this is:

```
build -j2 -A pkgsLLVM.linux_latest.configfile && grep CC_IS result
```

This should always say CLANG and _not_ GCC.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
