### PR TITLE
nixos-{rebuild; install}: rework logic; use `system.nix`

### DIFF
--- a/pkgs/by-name/ni/nixos-install/nixos-install.8
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.8
@@ -33,9 +33,19 @@
 .Sh DESCRIPTION
 This command installs NixOS in the file system mounted on
 .Pa /mnt Ns
-, based on the NixOS configuration specified in
-.Pa /mnt/etc/nixos/configuration.nix Ns
-\&. It performs the following steps:
+, or defined through the
+.Fl -root
+option, based on the NixOS configuration specified in
+.Pa /mnt/etc/nixos/system.nix Ns
+,
+.Pa /mnt/etc/nixos/configuration.nix
+or specified through the
+.Fl -file Ns
+,
+.Fl -attr Ns
+or
+.Fl -flake Ns
+options. It performs the following steps:
 .
 .Bl -enum
 .It
@@ -114,7 +124,7 @@ output named
 \&.
 .
 .It Fl -file Ar path , Fl f Ar path
-Enable and build the NixOS system from the specified file. The file must
+Build the NixOS system from the specified file. The file must
 evaluate to an attribute set, and it must contain a valid NixOS configuration
 at attribute
 .Va attrPath Ns
@@ -127,17 +137,19 @@ function in nixpkgs or importing and calling
 from nixpkgs. If specified without
 .Fl -attr
 option, builds the configuration from the top-level
-attribute of the file.
+attribute set of the file.
 .
 .It Fl -attr Ar attrPath , Fl A Ar attrPath
-Enable and build the NixOS system from nix file and use the specified attribute
+Build the NixOS system from nix file and use the specified attribute
 path from file specified by the
 .Fl -file
 option. If specified without
 .Fl -file
-option, uses
-.Va [root] Ns Pa /etc/nixos/default.nix Ns
-\&.
+option, it tires to find
+.Pa system.nix
+in
+.Va root Ns Pa /etc/nixos Ns
+, in current directory and iteratively in parent directories.
 .
 .It Fl -channel Ar channel
 If this option is provided, do not copy the current

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -66,20 +66,24 @@
 .
 .Sh DESCRIPTION
 This command updates the system so that it corresponds to the
-configuration specified in
-.Pa /etc/nixos/configuration.nix Ns
+configuration specified in one of
+.Pa /etc/nixos/flake.nix Ns
 ,
-.Pa /etc/nixos/flake.nix
-or the file and attribute specified by the
-.Fl -file
-and/or
-.Fl -attr
+.Pa /etc/nixos/system.nix Ns
+,
+.Pa /etc/nixos/configuration.nix
+or specified through the
+.Fl -file Ns
+,
+.Fl -attr Ns
+or
+.Fl -flake
 options. Thus, every time you modify the configuration or any other NixOS
 module, you must run
 .Nm
 to make the changes take effect. It builds the new system in
 .Pa /nix/store Ns
-, runs its activation script, and stop and (re)starts any system services if
+, runs its activation script, stops and (re)starts any system services if
 needed. Please note that user services need to be started manually as they
 aren't detected by the activation script at the moment.
 .
@@ -422,7 +426,7 @@ nixos-rebuild commands in parallel, but may also prevent the remote
 from working properly.
 .
 .It Fl -file Ar path , Fl f Ar path
-Enable and build the NixOS system from the specified file. The file must
+Build the NixOS system from the specified file. The file must
 evaluate to an attribute set, and it must contain a valid NixOS configuration
 at attribute
 .Va attrPath Ns
@@ -435,17 +439,19 @@ function in nixpkgs or importing and calling
 from nixpkgs. If specified without
 .Fl -attr
 option, builds the configuration from the top-level
-attribute of the file.
+attribute set of the file.
 .
 .It Fl -attr Ar attrPath , Fl A Ar attrPath
-Enable and build the NixOS system from nix file and use the specified attribute
+Build the NixOS system from nix file and use the specified attribute
 path from file specified by the
 .Fl -file
 option. If specified without
 .Fl -file
-option, uses
-.Pa default.nix
-in current directory.
+option, it tries to find
+.Pa system.nix
+in
+.Pa /etc/nixos Ns
+, in current directory and iteratively in parent directories.
 .
 .It Fl -flake Va flake-uri Ns Op Va #name
 Build the NixOS system from the specified flake. It defaults to the directory

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -35,10 +35,11 @@ targetHost=
 useSudo=
 noSSHTTY=
 verboseScript=
-noFlake=
 attr=
-buildFile=default.nix
-buildingAttribute=1
+buildFile=
+# keys: module, by-attrset, flake
+declare -A requestedBuildMethods
+declare -A blacklistedBuildMethods
 installBootloader=
 json=
 
@@ -68,8 +69,12 @@ while [ "$#" -gt 0 ]; do
             log "$0: '$i' requires an argument"
             exit 1
         fi
-        buildFile="$1"
-        buildingAttribute=
+        if [ -f "$1" ]; then
+            buildFile="$1"
+        else
+            buildFile="${1%/}/default.nix"
+        fi
+        requestedBuildMethods["by-attrset"]=1
         shift 1
         ;;
       --attr|-A)
@@ -78,7 +83,7 @@ while [ "$#" -gt 0 ]; do
             exit 1
         fi
         attr="$1"
-        buildingAttribute=
+        requestedBuildMethods["by-attrset"]=1
         shift 1
         ;;
       --install-grub)
@@ -178,10 +183,17 @@ while [ "$#" -gt 0 ]; do
         ;;
       --flake)
         flake="$1"
+        requestedBuildMethods["flake"]=1
         shift 1
         ;;
       --no-flake)
-        noFlake=1
+        blacklistedBuildMethods["flake"]=1
+        ;;
+      --no-by-attrset)
+        blacklistedBuildMethods["by-attrset"]=1
+        ;;
+      --no-module)
+        blacklistedBuildMethods["module"]=1
         ;;
       --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)
         lockFlags+=("$i")
@@ -316,7 +328,7 @@ nixBuild() {
             esac
         done
 
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             instArgs+=("$buildFile")
         fi
 
@@ -396,16 +408,106 @@ if [[ "$action" = switch || "$action" = boot || "$action" = test ]]; then
     canRun=1
 fi
 
-# Verify that user is not trying to use attribute building and flake
-# at the same time
-if [[ -z $buildingAttribute && -n $flake ]]; then
-    log "error: '--flake' cannot be used with '--file' or '--attr'"
+# Finds a specific file in a directory or its parents
+findInParents() {
+    local dir=$1
+    local filename=$2
+    while [[ ! -f "$dir/$filename" ]] && [[ "$dir" != / ]]; do
+        dir=$(dirname "$dir")
+    done
+    if [[ -f "$dir/$filename" ]]; then
+        echo "$dir/$filename"
+    else
+        return 1
+    fi
+}
+
+# remove blacklisted build methods from requested build methods
+for blacklistedMethod in "${!blacklistedBuildMethods[@]}"; do
+    logVerbose "blacklisting build method: $blacklistedMethod"
+    unset requestedBuildMethods["$blacklistedMethod"]
+done
+
+# If user requested multiple build methods, abort
+if [[ ${#requestedBuildMethods[@]} -gt 1 ]]; then
+    log "error: multiple build methods requested: ${requestedBuildMethods[@]}"
+    exit 1
+fi
+
+findFlake() {
+    # - Hardcoded resolved symlink /etc/nixos/flake.nix
+    if [[ -e /etc/nixos/flake.nix ]]; then
+        resolvedFlake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
+        flake=$resolvedFlake
+        return 0
+    fi
+    return 1
+}
+
+findByAttrset() {
+    # - From nixos-system in nix path
+    # - From default.nix up from the current directory
+    # - Hardcoded to /etc/nixos/default.nix
+    if resolvedBuildFile="$(runCmd nix-instantiate --find-file nixos-system 2>/dev/null)"; then
+        buildFile=$resolvedBuildFile
+        return 0
+    elif resolvedBuildFile="$(findInParents "$PWD" default.nix)"; then
+        buildFile=$resolvedBuildFile
+        return 0
+    elif [[ -f "/etc/nixos/default.nix" ]]; then
+        buildFile="/etc/nixos/default.nix"
+        return 0
+    fi
+    return 1
+}
+
+findModule() {
+    # - From NIXOS_CONFIG environment variable
+    # - From nixos-config in nix path
+    if [[ -n $NIXOS_CONFIG ]]; then
+        return 0
+    elif resolvedNixosConfig="$(runCmd nix-instantiate --find-file nixos-config 2>/dev/null)"; then
+        NIXOS_CONFIG=$resolvedNixosConfig
+        return 0
+    fi
+    return 1
+}
+
+# If user didn't request a specific build method, try to find one
+if [[ ${#requestedBuildMethods[@]} -eq 0 ]]; then
+    logVerbose "No build method explicitly requested"
+    if [[ -z "${blacklistedBuildMethods["flake"]}" ]] && findFlake; then
+        requestedBuildMethods["flake"]=1
+        logVerbose "Found flake '$flake'"
+    elif [[ -z "${blacklistedBuildMethods["by-attrset"]}" ]] && findByAttrset; then
+        requestedBuildMethods["by-attrset"]=1
+        logVerbose "Found by-attrset '$buildFile'"
+    elif [[ -z "${blacklistedBuildMethods["module"]}" ]] && findModule; then
+        requestedBuildMethods["module"]=1
+        logVerbose "Found module '$NIXOS_CONFIG'"
+    else
+        log "error: no build method found"
+        exit 1
+    fi
+fi
+
+# find configuration files if not already found
+if [[ -n "${requestedBuildMethods["flake"]}" && -z $flake ]]; then
+    findFlake
+elif [[ -n "${requestedBuildMethods["by-attrset"]}" && -z $buildFile ]]; then
+    findByAttrset
+elif [[ -n "${requestedBuildMethods["module"]}" && -z $NIXOS_CONFIG ]]; then
+    findModule
+fi
+
+if [[ -n "${requestedBuildMethods["by-attrset"]}" && -n $attr && -z $buildFile ]]; then
+    log "error: '--attr' cannot be used without '--file', a 'nixos-system' entry in 'NIX_PATH', or '/etc/nixos/default.nix' existing"
     exit 1
 fi
 
 # If ‘--upgrade’ or `--upgrade-all` is given,
 # run ‘nix-channel --update nixos’.
-if [[ -n $upgrade && -z $_NIXOS_REBUILD_REEXEC && -z $flake ]]; then
+if [[ -z "${requestedBuildMethods["flake"]}" && -n $upgrade && -z $_NIXOS_REBUILD_REEXEC ]]; then
     # If --upgrade-all is passed, or there are other channels that
     # contain a file called ".update-on-nixos-rebuild", update them as
     # well. Also upgrade the nixos channel.
@@ -434,12 +536,6 @@ if [ -z "$_NIXOS_REBUILD_REEXEC" ]; then
     export PATH=@nix@/bin:$PATH
 fi
 
-# Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
-# actual flake.
-if [[ -z $flake && -e /etc/nixos/flake.nix && -z $noFlake ]]; then
-    flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
-fi
-
 tmpDir=$(mktemp -t -d nixos-rebuild.XXXXXX)
 
 if [[ ${#tmpDir} -ge 60 ]]; then
@@ -461,7 +557,7 @@ SSHOPTS="$NIX_SSHOPTS -o ControlMaster=auto -o ControlPath=$tmpDir/ssh-%n -o Con
 
 # For convenience, use the hostname as the default configuration to
 # build from the flake.
-if [[ -n $flake ]]; then
+if [[ -n "${requestedBuildMethods["flake"]}" ]]; then
     if [[ $flake =~ ^(.*)\#([^\#\"]*)$ ]]; then
        flake="${BASH_REMATCH[1]}"
        flakeAttr="${BASH_REMATCH[2]}"
@@ -485,14 +581,14 @@ fi
 
 # Re-execute nixos-rebuild from the Nixpkgs tree.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast ]]; then
-    if [[ -z $buildingAttribute ]]; then
+    if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
         p=$(runCmd nix-build --no-out-link "$buildFile" -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
         SHOULD_REEXEC=1
-    elif [[ -z $flake ]]; then
+    elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
         if p=$(runCmd nix-build --no-out-link --expr 'with import <nixpkgs/nixos> {}; config.system.build.nixos-rebuild' "${extraBuildFlags[@]}"); then
             SHOULD_REEXEC=1
         fi
-    else
+    else # flake
         runCmd nix "${flakeFlags[@]}" build --out-link "${tmpDir}/nixos-rebuild" "$flake#$flakeAttr.config.system.build.nixos-rebuild" "${extraBuildFlags[@]}" "${lockFlags[@]}"
         if p=$(readlink -e "${tmpDir}/nixos-rebuild"); then
             SHOULD_REEXEC=1
@@ -510,16 +606,16 @@ fi
 
 # Find configuration.nix and open editor instead of building.
 if [ "$action" = edit ]; then
-    if [[ -z $buildingAttribute ]]; then
+    if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
         log "error: '--file' and '--attr' are not supported with 'edit'"
         exit 1
-    elif [[ -z $flake ]]; then
+    elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
         NIXOS_CONFIG=${NIXOS_CONFIG:-$(runCmd nix-instantiate --find-file nixos-config)}
         if [[ -d $NIXOS_CONFIG ]]; then
             NIXOS_CONFIG=$NIXOS_CONFIG/default.nix
         fi
         runCmd exec ${EDITOR:-nano} "$NIXOS_CONFIG"
-    else
+    else # flake
         runCmd exec nix "${flakeFlags[@]}" edit "${lockFlags[@]}" -- "$flake#$flakeAttr"
     fi
     exit 1
@@ -556,7 +652,7 @@ prebuiltNix() {
 getNixDrv() {
     nixDrv=
 
-    if [[ -z $buildingAttribute ]]; then
+    if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
         if nixDrv="$(runCmd nix-instantiate "$buildFile" --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
@@ -604,7 +700,7 @@ getVersion() {
 }
 
 
-if [[ -n $buildNix && -z $flake ]]; then
+if [[ -n $buildNix && -z "${requestedBuildMethods["flake"]}" ]]; then
     log "building Nix..."
     getNixDrv
     if [ -a "$nixDrv" ]; then
@@ -623,7 +719,7 @@ fi
 
 # Update the version suffix if we're building from Git (so that
 # nixos-version shows something useful).
-if [[ -n $canRun && -z $flake ]]; then
+if [[ -n $canRun && -z "${requestedBuildMethods["flake"]}" ]]; then
     if nixpkgs=$(runCmd nix-instantiate --find-file nixpkgs "${extraBuildFlags[@]}"); then
         suffix=$(getVersion "$nixpkgs" || true)
         if [ -n "$suffix" ]; then
@@ -641,11 +737,11 @@ if [ "$action" = repl ]; then
     # This is a very end user command, implemented using sub-optimal means.
     # You should feel free to improve its behavior, as well as resolve tech
     # debt in "breaking" ways. Humans adapt quite well.
-    if [[ -z $buildingAttribute ]]; then
+    if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
         exec nix repl --file "$buildFile" "$attr" "${extraBuildFlags[@]}"
-    elif [[ -z $flake ]]; then
+    elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
         exec nix repl --file '<nixpkgs/nixos>' "${extraBuildFlags[@]}"
-    else
+    else # flake
         if [[ -n "${lockFlags[0]}" ]]; then
             # nix repl itself does not support locking flags
             log "nixos-rebuild repl does not support locking flags yet"
@@ -795,41 +891,41 @@ fi
 if [ -z "$rollback" ]; then
     log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
-        else
+        else # flake
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
         copyToTarget "$pathToConfig"
         targetHostSudoCmd nix-env -p "$profile" --set "$pathToConfig"
     elif [[ "$action" = test || "$action" = build || "$action" = dry-build || "$action" = dry-activate ]]; then
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
-        else
+        else # flake
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.toplevel" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     elif [ "$action" = build-vm ]; then
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
-        else
+        else # flake
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.vm" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"
-        else
+        else # flake
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     elif [ "$action" = build-image ]; then
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             variants="$(
                 runCmd nix-instantiate --eval --strict --json --expr \
                 "let
@@ -838,13 +934,13 @@ if [ -z "$rollback" ]; then
                 in builtins.attrNames set.${attr:+$attr.}config.system.build.images" \
                 "${extraBuildFlags[@]}"
             )"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             variants="$(
                 runCmd nix-instantiate --eval --strict --json --expr \
                 "with import <nixpkgs/nixos> {}; builtins.attrNames config.system.build.images" \
                 "${extraBuildFlags[@]}"
             )"
-        else
+        else # flake
             variants="$(
                 runCmd nix "${flakeFlags[@]}" eval --json \
                 "$flake#$flakeAttr.config.system.build.images" \
@@ -857,7 +953,7 @@ if [ -z "$rollback" ]; then
             exit 1
         fi
 
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             imageName="$(
                 runCmd nix-instantiate --eval --strict --json --expr \
                 "let
@@ -867,14 +963,14 @@ if [ -z "$rollback" ]; then
                 "${extraBuildFlags[@]}" \
                 | jq -r .
             )"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             imageName="$(
                 runCmd nix-instantiate --eval --strict --json --expr \
                 "with import <nixpkgs/nixos> {}; config.system.build.images.$imageVariant.passthru.filePath" \
                 "${extraBuildFlags[@]}" \
                 | jq -r .
             )"
-        else
+        else # flake
             imageName="$(
                 runCmd nix "${flakeFlags[@]}" eval --raw \
                 "$flake#$flakeAttr.config.system.build.images.$imageVariant.passthru.filePath" \
@@ -882,11 +978,11 @@ if [ -z "$rollback" ]; then
             )"
         fi
 
-        if [[ -z $buildingAttribute ]]; then
+        if [[ -n "${requestedBuildMethods["by-attrset"]}" ]]; then
             pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.images.${imageVariant}" "${extraBuildFlags[@]}")"
-        elif [[ -z $flake ]]; then
+        elif [[ -n "${requestedBuildMethods["module"]}" ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A config.system.build.images.${imageVariant} -k "${extraBuildFlags[@]}")"
-        else
+        else # flake
             pathToConfig="$(nixFlakeBuild "$flake#$flakeAttr.config.system.build.images.${imageVariant}" "${extraBuildFlags[@]}" "${lockFlags[@]}")"
         fi
     else

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -486,7 +486,7 @@ fi
 # Re-execute nixos-rebuild from the Nixpkgs tree.
 if [[ -z $_NIXOS_REBUILD_REEXEC && -n $canRun && -z $fast ]]; then
     if [[ -z $buildingAttribute ]]; then
-        p=$(runCmd nix-build --no-out-link $buildFile -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
+        p=$(runCmd nix-build --no-out-link "$buildFile" -A "${attr:+$attr.}config.system.build.nixos-rebuild" "${extraBuildFlags[@]}")
         SHOULD_REEXEC=1
     elif [[ -z $flake ]]; then
         if p=$(runCmd nix-build --no-out-link --expr 'with import <nixpkgs/nixos> {}; config.system.build.nixos-rebuild' "${extraBuildFlags[@]}"); then
@@ -557,7 +557,7 @@ getNixDrv() {
     nixDrv=
 
     if [[ -z $buildingAttribute ]]; then
-        if nixDrv="$(runCmd nix-instantiate $buildFile --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
+        if nixDrv="$(runCmd nix-instantiate "$buildFile" --add-root "$tmpDir/nix.drv" --indirect -A ${attr:+$attr.}config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then return; fi
     if nixDrv="$(runCmd nix-instantiate '<nixpkgs>' --add-root "$tmpDir/nix.drv" --indirect -A nix "${extraBuildFlags[@]}")"; then return; fi
@@ -642,7 +642,7 @@ if [ "$action" = repl ]; then
     # You should feel free to improve its behavior, as well as resolve tech
     # debt in "breaking" ways. Humans adapt quite well.
     if [[ -z $buildingAttribute ]]; then
-        exec nix repl --file $buildFile $attr "${extraBuildFlags[@]}"
+        exec nix repl --file "$buildFile" "$attr" "${extraBuildFlags[@]}"
     elif [[ -z $flake ]]; then
         exec nix repl --file '<nixpkgs/nixos>' "${extraBuildFlags[@]}"
     else
@@ -796,7 +796,7 @@ if [ -z "$rollback" ]; then
     log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
         if [[ -z $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
         else
@@ -806,7 +806,7 @@ if [ -z "$rollback" ]; then
         targetHostSudoCmd nix-env -p "$profile" --set "$pathToConfig"
     elif [[ "$action" = test || "$action" = build || "$action" = dry-build || "$action" = dry-activate ]]; then
         if [[ -z $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.toplevel" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A system -k "${extraBuildFlags[@]}")"
         else
@@ -814,7 +814,7 @@ if [ -z "$rollback" ]; then
         fi
     elif [ "$action" = build-vm ]; then
         if [[ -z $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vm" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vm -k "${extraBuildFlags[@]}")"
         else
@@ -822,7 +822,7 @@ if [ -z "$rollback" ]; then
         fi
     elif [ "$action" = build-vm-with-bootloader ]; then
         if [[ -z $buildingAttribute ]]; then
-            pathToConfig="$(nixBuild $buildFile -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
+            pathToConfig="$(nixBuild "$buildFile" -A "${attr:+$attr.}config.system.build.vmWithBootLoader" "${extraBuildFlags[@]}")"
         elif [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' -A vmWithBootLoader -k "${extraBuildFlags[@]}")"
         else


### PR DESCRIPTION
previously flake and buildingFile variables were used to deduce which method to use this originally came to that, because flake variable was used to check if script is building flake or module

after introduction of buildingFile variable, some parts got messy,
checking if building flake was with -z $flake, checking if building module was with -n $flake, and checking if building by attrset was with -n $buildingFile

using single variable to check which build method to use between two is fine, but when more methods are added, in my opinion it's better to use associative array

resolves issues pointed in https://github.com/NixOS/nixpkgs/pull/333788

> Previously, `nixos-rebuild -A foo` would build the `default.nix` in the current directory, while `nixos-rebuild` without `-A` would not use file-based building at all.
>
> This difference compared to what `nix-build` would do is confusing. Furthermore, using `default.nix` is not great, because there's many of those files all around, and they're almost never for NixOS.

issue for by-attrset build method quoted above is resolved in the following way:

- use `nixos-system` entry in nix path
- deprecate `default.nix` and warn about it
- use `system.nix` 

supercedes https://github.com/NixOS/nixpkgs/pull/333788

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
