### PR TITLE
lyto: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ly/lyto/package.nix
+++ b/pkgs/by-name/ly/lyto/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "lyto";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "eeriemyxi";
+    repo = "lyto";
+    tag = "v${version}";
+    hash = "sha256-XCAM7vo4EcbIxFddggeqABru4epE2jW2YpF++I0mpdU=";
+  };
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    qrcode
+    rich
+    sixel
+    zeroconf
+  ];
+
+  pythonImportsCheck = [
+    "lyto"
+  ];
+
+  meta = {
+    description = "Automatic wireless ADB connection using QR codes";
+    homepage = "https://github.com/eeriemyxi/lyto";
+    changelog = "https://github.com/eeriemyxi/lyto/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ atemu ];
+    mainProgram = "lyto";
+  };
+}

--- a/pkgs/development/python-modules/sixel/default.nix
+++ b/pkgs/development/python-modules/sixel/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "python-sixel";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lubosz";
+    repo = "python-sixel";
+    tag = version;
+    hash = "sha256-ALNdwuZIMS2oWO42LpjgIpAxcQh4Gk35nCwenINLQ64=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    pillow
+  ];
+
+  pythonImportsCheck = [
+    "sixel"
+  ];
+
+  meta = {
+    description = "Display images in the terminal";
+    homepage = "https://github.com/lubosz/python-sixel";
+    changelog = "https://github.com/lubosz/python-sixel/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ atemu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15257,6 +15257,8 @@ self: super: with self; {
 
   six = callPackage ../development/python-modules/six { };
 
+  sixel = callPackage ../development/python-modules/sixel { };
+
   sjcl = callPackage ../development/python-modules/sjcl { };
 
   skein = callPackage ../development/python-modules/skein { };


### PR DESCRIPTION
Both packages are basically just `nix-init`'d but the code does not look obviously wrong to me as someone not very well versed with the current standards of python packaging.

I made the library dependency a python module and the application itself a regular package as the python packaging section recommends.

I tested `lyto` to be working just fine. Sixel didn't work for me with foot but it's claimed to be an experimental feature.

To test this yourself:

1. Connect an android device and your PC to the same network
2. Enable wireless debugging
3. Run `lyto`
4. Scan the QR code with the device in the wireless debugging menu
5. `adb devices` should show the device connected as `device`

You will need `adb` in PATH to do anything with the adb connection, so I didn't add it as an explicit runtime dep.  
You might need avahi configured on your PC to use this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
