### PR TITLE
Revert "vscode-extensions.ms-python.python: 2025.2.0 -> 2024.15.2024091301"

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-python.python/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.python/default.nix
@@ -21,8 +21,8 @@ vscode-utils.buildVscodeMarketplaceExtension rec {
   mktplcRef = {
     name = "python";
     publisher = "ms-python";
-    version = "2024.15.2024091301";
-    hash = "sha256-MB8Vq2rjO37yW3Zh+f8ek/yz0qT+ZYHn/JnF5ZA6CXQ=";
+    version = "2025.2.0";
+    hash = "sha256-f573A/7s8jVfH1f3ZYZSTftrfBs6iyMWewhorX4Z0Nc=";
   };
 
   buildInputs = [ icu ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#389525.
Downgrade, no idea how ryantm picked this up.