### PR TITLE
grafana-alloy: 1.7.1 -> 1.7.4

### DIFF
--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -17,17 +17,17 @@
 
 buildGoModule rec {
   pname = "grafana-alloy";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "alloy";
     tag = "v${version}";
-    hash = "sha256-t1YDYQ+0RKHYaL/oE9XGjV7/g28rHO9avL6/CTfMHeE=";
+    hash = "sha256-P97kT14oVvi4IZIfzGfC0ZIuX50EOnFeYyq4F9ZEAg4=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-d9uWbZ+5YSnB3yqL/YZ0ld+8soO3oGb8gttzj3Q7MXs=";
+  vendorHash = "sha256-S6U9wVsNTpqeniQ7Nmg6ImLDHBHxZk2hVMkzANVApB8=";
 
   nativeBuildInputs = [
     fixup-yarn-lock

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -17,13 +17,13 @@
 
 buildGoModule rec {
   pname = "grafana-alloy";
-  version = "1.7.3";
+  version = "1.7.4";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "alloy";
     tag = "v${version}";
-    hash = "sha256-m8QJ0UWotPIa4wQ1JUzFFV4BtFuhh4Y+j2WWi2yE3ik=";
+    hash = "sha256-vMNh7tvRYGJRRWcLePBbNlUU2qVNtKhOSwsfB1dWWRA=";
   };
 
   proxyVendor = true;

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -17,17 +17,17 @@
 
 buildGoModule rec {
   pname = "grafana-alloy";
-  version = "1.7.2";
+  version = "1.7.3";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "alloy";
     tag = "v${version}";
-    hash = "sha256-P97kT14oVvi4IZIfzGfC0ZIuX50EOnFeYyq4F9ZEAg4=";
+    hash = "sha256-m8QJ0UWotPIa4wQ1JUzFFV4BtFuhh4Y+j2WWi2yE3ik=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-S6U9wVsNTpqeniQ7Nmg6ImLDHBHxZk2hVMkzANVApB8=";
+  vendorHash = "sha256-rZcqCcb++A8HYLVcGVWQ61fEXAqF0GXbTze/GGsF5bA=";
 
   nativeBuildInputs = [
     fixup-yarn-lock


### PR DESCRIPTION
https://github.com/grafana/alloy/releases/tag/v1.7.2
https://github.com/grafana/alloy/releases/tag/v1.7.3

diff: https://github.com/grafana/alloy/compare/v1.7.1...v1.7.2
diff: https://github.com/grafana/alloy/compare/v1.7.2...v1.7.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
