### PR TITLE
sofa: init at 24.12.00

### DIFF
--- a/pkgs/by-name/so/sofa/package.nix
+++ b/pkgs/by-name/so/sofa/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+  fetchpatch,
+
+  # propagatedNativeBuildInputs
+  cmake,
+  qt6Packages,
+
+  # propagatedBuildInputs
+  boost,
+  cxxopts,
+  eigen,
+  glew,
+  gtest,
+  libGL,
+  metis,
+  tinyxml-2,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sofa";
+  version = "24.12.00";
+
+  src = fetchFromGitHub {
+    owner = "sofa-framework";
+    repo = "sofa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LeFIM1RJjA2ynimjE8XngOQ8gR7BgqqTZBbDp0KXxs0=";
+  };
+
+  patches = [
+    # Include missing header for setw / setfill.
+    # ref. https://github.com/sofa-framework/sofa/pull/5279
+    # This was merged upstream and can be removed in next version
+    (fetchpatch {
+      url = "https://github.com/sofa-framework/sofa/commit/700b6cdd94fe24a51b2a7014fb0fc83e6abe1fbc.patch";
+      hash = "sha256-czc1u03USQt18d7cMPmXYguBhSb5JOJLplPvoixp+3w=";
+    })
+  ];
+
+  propagatedNativeBuildInputs = [
+    cmake
+    qt6Packages.wrapQtAppsHook
+  ];
+  propagatedBuildInputs = [
+    boost
+    cxxopts
+    eigen
+    glew
+    gtest
+    qt6Packages.libqglviewer
+    qt6Packages.qtbase
+    libGL
+    metis
+    tinyxml-2
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SOFA_ALLOW_FETCH_DEPENDENCIES" false)
+  ];
+
+  doCheck = true;
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install_name_tool -change \
+      $out/lib/libSceneChecking.${finalAttrs.version}.dylib \
+      $out/plugins/SceneChecking/lib/libSceneChecking.${finalAttrs.version}.dylib \
+      $out/bin/.runSofa-${finalAttrs.version}-wrapped
+  '';
+
+  meta = {
+    description = "Real-time multi-physics simulation with an emphasis on medical simulation";
+    homepage = "https://github.com/sofa-framework/sofa/";
+    changelog = "https://github.com/sofa-framework/sofa/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "runSofa";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
Add SOFA : https://www.sofa-framework.org/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
