### PR TITLE
lib/strings: add isStorePathPrefix function

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -138,7 +138,7 @@ let
       makeLibraryPath makeIncludePath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs
-      isStorePath isStringLike
+      isStorePath isStorePathPrefix isStringLike
       isValidPosixName toShellVar toShellVars trim trimWith
       escapeRegex escapeURL escapeXML replaceChars lowerChars
       upperChars toLower toUpper toSentenceCase addContextFrom splitString

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -358,7 +358,7 @@ let
     in
     readCommitFromFile "HEAD";
 
-  pathHasContext = builtins.hasContext or (lib.hasPrefix storeDir);
+  pathHasContext = builtins.hasContext or lib.isStorePathPrefix;
 
   canCleanSource = src: src ? _isLibCleanSourceWith || !(pathHasContext (toString src));
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2445,6 +2445,51 @@ rec {
       false;
 
   /**
+    Check whether a value `x` is a store path prefix.
+
+
+    # Inputs
+
+    `x`
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    isStorePath :: a -> bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.isStorePathPrefix` usage example
+
+    ```nix
+    isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11/bin/python"
+    => true
+    isStorePath "/nix/store/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11"
+    => true
+    isStorePath pkgs.python
+    => true
+    isStorePath [] || isStorePath 42 || isStorePath {} || …
+    => false
+    ```
+
+    :::
+  */
+  isStorePathPrefix = x:
+    if isStringLike x then
+      let str = toString x; in
+        # The second branch of this regular expression matches content‐
+        # addressed derivations, which _currently_ do not have a store
+        # directory prefix.
+        # This is a workaround for https://github.com/NixOS/nix/issues/12361
+        # which was needed during the experimental phase of ca-derivations and
+        # should be removed once the issue has been resolved.
+        builtins.match "(${escapeRegex storeDir}|/[0-9a-z]{52})/[^.].*" str != null
+    else
+      false;
+
+  /**
     Parse a string as an int. Does not support parsing of integers with preceding zero due to
     ambiguity between zero-padded and octal numbers. See toIntBase10.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -69,6 +69,7 @@ let
     id
     ifilter0
     isStorePath
+    isStorePathPrefix
     lazyDerivation
     length
     lists
@@ -566,6 +567,49 @@ runTests {
       asPath = true;
       caPath = true;
       caPathAppendix = false;
+      caAsPath = true;
+      otherPath = false;
+      otherVals = {
+        attrset = false;
+        list = false;
+        int = false;
+      };
+    };
+  };
+
+  testIsStorePathPrefix = {
+    expr =
+      let goodPath =
+            "${builtins.storeDir}/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11";
+          goodCAPath = "/1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab";
+      in {
+        storePath = isStorePathPrefix goodPath;
+        storePathDerivation = isStorePathPrefix (import ../.. { system = "x86_64-linux"; }).hello;
+        storePathAppendix = isStorePathPrefix
+          "${goodPath}/bin/python";
+        nonAbsolute = isStorePathPrefix (concatStrings (tail (stringToCharacters goodPath)));
+        asPath = isStorePathPrefix (/. + goodPath);
+        otherPath = isStorePathPrefix "/something/else";
+
+        caPath = isStorePathPrefix goodCAPath;
+        caPathAppendix = isStorePathPrefix
+          "${goodCAPath}/bin/python";
+        caAsPath = isStorePathPrefix (/. + goodCAPath);
+
+        otherVals = {
+          attrset = isStorePathPrefix {};
+          list = isStorePathPrefix [];
+          int = isStorePathPrefix 42;
+        };
+      };
+    expected = {
+      storePath = true;
+      storePathDerivation = true;
+      storePathAppendix = true;
+      nonAbsolute = false;
+      asPath = true;
+      caPath = true;
+      caPathAppendix = true;
       caAsPath = true;
       otherPath = false;
       otherVals = {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -15,6 +15,7 @@ let
     isList
     isString
     isStorePath
+    isStorePathPrefix
     throwIf
     toDerivation
     toList
@@ -605,7 +606,7 @@ rec {
 
         check = x:
           let
-            isInStore = builtins.match "${builtins.storeDir}/[^.].*" (toString x) != null;
+            isInStore = isStorePathPrefix (toString x);
             isAbsolute = builtins.substring 0 1 (toString x) == "/";
             isExpectedType = (
               if inStore == null || inStore then


### PR DESCRIPTION
This introduces a `isStorePathPrefix` function to match paths in the store, including content‐addressed derivations which currently do not have a conventional store path prefix.

This can be used as an alternative to `lib.path.hasStorePathPrefix` (cf. #387304) which requires converting strings to paths.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
