### PR TITLE
nixos/slskd: remove useless inotify watches

### DIFF
--- a/nixos/modules/services/web-apps/slskd.nix
+++ b/nixos/modules/services/web-apps/slskd.nix
@@ -282,6 +282,7 @@ in {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
+        Environment = ["DOTNET_USE_POLLING_FILE_WATCHER=1"];
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
         StateDirectory = "slskd";  # Creates /var/lib/slskd and manages permissions
         ExecStart = "${cfg.package}/bin/slskd --app-dir /var/lib/slskd --config ${configurationYaml}";


### PR DESCRIPTION
Closes #389397

This is a temporary fix for an upstream bug that does a useless inotify watch of the whole nix store 😨

@melvyn2

I'd like to backport this PR, but I don't know how.

Cheers!