### PR TITLE
svt-av1-psy: 2.3.0 → 2.3.0-B-unstable-2025-02-02; provide update script

### DIFF
--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   nasm,
+  cpuinfo,
   libdovi,
   unstableGitUpdater,
 }:
@@ -21,11 +22,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeBuildType = "Release";
 
-  cmakeFlags = lib.mapAttrsToList lib.cmakeFeature {
-    LIBDOVI_FOUND = lib.boolToString true;
-    # enable when libhdr10plus is available
-    # LIBHDR10PLUS_RS_FOUND = lib.boolToString true;
-  };
+  cmakeFlags =
+    lib.mapAttrsToList
+      (
+        n: v:
+        lib.cmakeOptionType (builtins.typeOf v) n (
+          if builtins.isBool v then lib.boolToString v else toString v
+        )
+      )
+      {
+        USE_EXTERNAL_CPUINFO = true;
+        LIBDOVI_FOUND = true;
+        # enable when libhdr10plus is available
+        # LIBHDR10PLUS_RS_FOUND = true;
+      };
 
   nativeBuildInputs = [
     cmake
@@ -33,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    cpuinfo
     libdovi
   ];
 

--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.3.0";
 
   src = fetchFromGitHub {
-    owner = "gianni-rosato";
+    owner = "psy-ex";
     repo = "svt-av1-psy";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qySrYZDwmoKf7oAQJlBSWInXeOceGSeL2Kc09SJ5Zs0=";
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/gianni-rosato/svt-av1-psy";
+    homepage = "https://github.com/psy-ex/svt-av1-psy";
     description = "Scalable Video Technology AV1 Encoder and Decoder";
 
     longDescription = ''

--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "svt-av1-psy";
-  version = "2.3.0";
+  version = "2.3.0-B-unstable-2025-02-02";
 
   src = fetchFromGitHub {
     owner = "psy-ex";
     repo = "svt-av1-psy";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-qySrYZDwmoKf7oAQJlBSWInXeOceGSeL2Kc09SJ5Zs0=";
+    rev = "ec65071b65ee70078229182ce6e1d0f6a4aa1a47";
+    hash = "sha256-98u7J9tqrnc+MbryjWO2r9iuAy6QjJbbq0/o4xRLzhI=";
   };
 
   cmakeBuildType = "Release";

--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -5,6 +5,7 @@
   cmake,
   nasm,
   libdovi,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,6 +35,11 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libdovi
   ];
+
+  passthru.updateScript = unstableGitUpdater {
+    branch = "master";
+    tagPrefix = "v";
+  };
 
   meta = {
     homepage = "https://github.com/psy-ex/svt-av1-psy";


### PR DESCRIPTION
Release 2.3.0 is a bit outdated.

We could rely on the micro releases, but upstream [recommends to use the `master` branch](https://github.com/psy-ex/svt-av1-psy/blob/master/README.md#other-changes).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
