### PR TITLE
magic-wormhole: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -3,23 +3,24 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   setuptools,
+  versioneer,
 
   # dependencies
-  spake2,
-  pynacl,
-  six,
   attrs,
-  twisted,
   autobahn,
   automat,
-  tqdm,
   click,
+  cryptography,
   humanize,
   iterable-io,
+  pynacl,
+  qrcode,
+  spake2,
+  tqdm,
+  twisted,
   txtorcon,
   zipstream-ng,
 
@@ -36,25 +37,16 @@
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.17.0";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole";
     tag = version;
-    hash = "sha256-BxPF4iQ91wLBagdvQ/Y89VIZBkMxFiEHnK+BU55Bwr4=";
+    hash = "sha256-FQ7m6hkJcFZaE+ptDALq/gijn/RcAM1Zvzi2+xpoXBU=";
   };
 
-  patches = [
-    # TODO: drop patch for magic-wormhole > 0.17.0
-    # fix test for twisted 24.10.0 (https://github.com/magic-wormhole/magic-wormhole/pull/554)
-    (fetchpatch {
-      name = "fix-twisted-24.10.0.patch";
-      url = "https://github.com/magic-wormhole/magic-wormhole/commit/d7353cad6fe9d43620a0de33a634f395757d2e5c.patch";
-      hash = "sha256-mvgVFW3Fa2I8/39ron0bYYsJNm2r97jnLFCfhtHSIP0=";
-    })
-  ];
   postPatch =
     # enable tests by fixing the location of the wormhole binary
     ''
@@ -67,7 +59,10 @@ buildPythonPackage rec {
       sed -i -e "s|'ifconfig'|'${nettools}/bin/ifconfig'|" src/wormhole/ipaddrs.py
     '';
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    versioneer
+  ];
 
   dependencies =
     [
@@ -75,10 +70,11 @@ buildPythonPackage rec {
       autobahn
       automat
       click
+      cryptography
       humanize
       iterable-io
       pynacl
-      six
+      qrcode
       spake2
       tqdm
       twisted


### PR DESCRIPTION
## Description of changes

https://github.com/magic-wormhole/magic-wormhole/blob/refs/tags/0.18.0/NEWS.md
https://github.com/magic-wormhole/magic-wormhole/compare/refs/tags/0.17.0...refs/tags/0.18.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 10 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python312Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python312Packages.magic-wormhole.dist)</li>
    <li>python313Packages.magic-wormhole</li>
    <li>python313Packages.magic-wormhole.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc