### PR TITLE
Fix khelpcenter manpages

### DIFF
--- a/pkgs/kde/gear/khelpcenter/default.nix
+++ b/pkgs/kde/gear/khelpcenter/default.nix
@@ -5,6 +5,7 @@
   xapian,
   man-db,
   python3,
+  kio-extras,
 }:
 mkKdeDerivation {
   pname = "khelpcenter";
@@ -13,6 +14,7 @@ mkKdeDerivation {
     qtwebengine
     xapian
     python3
+    kio-extras
   ];
   patches = [
     (replaceVars ./use_nix_paths_for_mansearch_utilities.patch {

--- a/pkgs/kde/gear/khelpcenter/default.nix
+++ b/pkgs/kde/gear/khelpcenter/default.nix
@@ -1,7 +1,10 @@
 {
   mkKdeDerivation,
+  replaceVars,
   qtwebengine,
   xapian,
+  man-db,
+  python3,
 }:
 mkKdeDerivation {
   pname = "khelpcenter";
@@ -9,6 +12,12 @@ mkKdeDerivation {
   extraBuildInputs = [
     qtwebengine
     xapian
+    python3
+  ];
+  patches = [
+    (replaceVars ./use_nix_paths_for_mansearch_utilities.patch {
+      inherit man-db;
+    })
   ];
   meta.mainProgram = "khelpcenter";
 }

--- a/pkgs/kde/gear/khelpcenter/use_nix_paths_for_mansearch_utilities.patch
+++ b/pkgs/kde/gear/khelpcenter/use_nix_paths_for_mansearch_utilities.patch
@@ -1,0 +1,23 @@
+diff --git a/searchhandlers/khc_mansearch.py b/searchhandlers/khc_mansearch.py
+index ce61ed9c..a8c4c653 100755
+--- a/searchhandlers/khc_mansearch.py
++++ b/searchhandlers/khc_mansearch.py
+@@ -32,15 +32,15 @@ def main():
+     # If the query is a single word, perhaps it is the literal name of the
+     # command, or a prefix, or a substring
+     if not ' ' in words:
+-        results_prefix = subprocess.run(['whatis', '-w', words + '*'], capture_output=True, text=True)
++        results_prefix = subprocess.run(['@man-db@/bin/whatis', '-w', words + '*'], capture_output=True, text=True)
+         if results_prefix.returncode == 0:
+             command_results += results_prefix.stdout
+-        results_substring = subprocess.run(['whatis', '-w', '*' + words + '*'], capture_output=True, text=True)
++        results_substring = subprocess.run(['@man-db@/bin/whatis', '-w', '*' + words + '*'], capture_output=True, text=True)
+         if results_substring.returncode == 0:
+             command_results += results_substring.stdout
+ 
+     # Build the apropos command line
+-    apropos = ['apropos', '-L', args.lang]
++    apropos = ['@man-db@/bin/apropos', '-L', args.lang]
+     if args.method == 'and':
+         apropos.append('--and')
+     apropos.extend(words.split(' '))

--- a/pkgs/kde/gear/kio-extras/add-nixos-man-db-config-path.patch
+++ b/pkgs/kde/gear/kio-extras/add-nixos-man-db-config-path.patch
@@ -1,0 +1,13 @@
+diff --git a/man/kio_man.cpp b/man/kio_man.cpp
+index a2fb6dbf5..cb6f373bc 100644
+--- a/man/kio_man.cpp
++++ b/man/kio_man.cpp
+@@ -868,6 +868,8 @@ void MANProtocol::constructPath(QStringList &constr_path, QStringList constr_cat
+         mc.setFileName("/etc/manpath.config"); // SuSE, Debian
+     if (!mc.exists())
+         mc.setFileName("/etc/man.config"); // Mandrake
++    if (!mc.exists())
++        mc.setFileName("/run/current-system/etc/man_db.conf"); // NixOS
+ 
+     if (mc.open(QIODevice::ReadOnly)) {
+         QTextStream is(&mc);

--- a/pkgs/kde/gear/kio-extras/default.nix
+++ b/pkgs/kde/gear/kio-extras/default.nix
@@ -19,6 +19,10 @@
 mkKdeDerivation {
   pname = "kio-extras";
 
+  patches = [
+    # An upstream merge request is pending for this https://invent.kde.org/network/kio-extras/-/merge_requests/422
+    ./add-nixos-man-db-config-path.patch
+  ];
   extraNativeBuildInputs = [
     pkg-config
     gperf


### PR DESCRIPTION
This fixes 2 issues on NixOS with KDE's documentation viewer, khelpcenter:
* It was giving no results trying to search manpages due to a Python script referring to non-nix paths.
* It was giving blank pages trying to view manpages due to its backend `kio-extras` not knowing where to find the man-db config file.

Additionally a little conversion of paths that look suspicious but doesn't break on my system, see the commits for details.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
