### PR TITLE
 python3Packages.wandb: 0.19.6 -> 0.19.8; update dependencies

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -32,6 +32,7 @@
   setproctitle,
   setuptools,
   pythonOlder,
+  eval-type-backport,
   typing-extensions,
 
   # tests
@@ -191,6 +192,9 @@ buildPythonPackage rec {
       setproctitle
       # setuptools is necessary since pkg_resources is required at runtime.
       setuptools
+    ]
+    ++ lib.optionals (pythonOlder "3.10") [
+      eval-type-backport
     ]
     ++ lib.optionals (pythonOlder "3.12") [
       typing-extensions

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -76,12 +76,12 @@
 }:
 
 let
-  version = "0.19.6";
+  version = "0.19.8";
   src = fetchFromGitHub {
     owner = "wandb";
     repo = "wandb";
     tag = "v${version}";
-    hash = "sha256-snyr0IlE4otk1ctWUrJEFAmHYsXe+k6qULCaO3aW0e4=";
+    hash = "sha256-hveMyGeu9RhdtWMbV/4GQ4KUNfjSt0CKyW7Yx8QtlLM=";
   };
 
   gpu-stats = rustPlatform.buildRustPackage {

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -25,6 +25,7 @@
   platformdirs,
   protobuf,
   psutil,
+  pydantic,
   pyyaml,
   requests,
   sentry-sdk_2,
@@ -56,7 +57,6 @@
   parameterized,
   pillow,
   plotly,
-  pydantic,
   pyfakefs,
   pyte,
   pytest-asyncio,
@@ -184,6 +184,7 @@ buildPythonPackage rec {
       platformdirs
       protobuf
       psutil
+      pydantic
       pyyaml
       requests
       sentry-sdk_2
@@ -220,7 +221,6 @@ buildPythonPackage rec {
     parameterized
     pillow
     plotly
-    pydantic
     pyfakefs
     pyte
     pytest-asyncio


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`pydantic` is now a [dependency](https://github.com/wandb/wandb/blob/d85536576997c476ed048a640e4cfd118feb0b26/pyproject.toml#L32), which causes errors if built with `doCheck = false`. While I was looking at `pyproject.toml`, I also noticed [`eval_type_backport`](https://github.com/wandb/wandb/blob/d85536576997c476ed048a640e4cfd118feb0b26/pyproject.toml#L33) was added for `python_version < '3.10'`.

Changelogs: 
- https://github.com/wandb/wandb/releases/tag/v0.19.7
- https://github.com/wandb/wandb/releases/tag/v0.19.8

Supersedes https://github.com/NixOS/nixpkgs/pull/386522, https://github.com/NixOS/nixpkgs/pull/387449.

Hard for me to run `nixpkgs-review`, sorry.

cc @samuela @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
