### PR TITLE
clang17: fix aarch64-linux build

### DIFF
--- a/pkgs/development/compilers/llvm/17/clang/fix-build-with-gcc-14-on-arm.patch
+++ b/pkgs/development/compilers/llvm/17/clang/fix-build-with-gcc-14-on-arm.patch
@@ -1,0 +1,67 @@
+URL: https://github.com/llvm/llvm-project/pull/78704
+Patch-Source: https://src.fedoraproject.org/rpms/clang17/blob/rawhide/f/0001-Clang-Fix-build-with-GCC-14-on-ARM.patch
+From bd2e848f15c0f25231126eb10cb0ab350717dfc0 Mon Sep 17 00:00:00 2001
+From: Nikita Popov <npopov@redhat.com>
+Date: Fri, 19 Jan 2024 12:09:13 +0100
+Subject: [PATCH] [Clang] Fix build with GCC 14 on ARM
+
+GCC 14 defines `__arm_streaming` as a macro expanding to
+`[[arm::streaming]]`. Due to the nested macro use, this gets
+expanded prior to concatenation.
+
+It doesn't look like C++ has a really clean way to prevent
+macro expansion. The best I have found is to use `EMPTY ## X` where
+`EMPTY` is an empty macro argument, so this is the hack I'm
+implementing here.
+
+Fixes https://github.com/llvm/llvm-project/issues/78691.
+---
+ clang/include/clang/Basic/TokenKinds.def  | 3 ++-
+ clang/include/clang/Basic/TokenKinds.h    | 2 +-
+ clang/utils/TableGen/ClangAttrEmitter.cpp | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/clang/Basic/TokenKinds.def b/clang/include/clang/Basic/TokenKinds.def
+index ef0dad0f2dcd..3add13c079f3 100644
+--- a/include/clang/Basic/TokenKinds.def
++++ b/include/clang/Basic/TokenKinds.def
+@@ -752,8 +752,9 @@ KEYWORD(__builtin_available              , KEYALL)
+ KEYWORD(__builtin_sycl_unique_stable_name, KEYSYCL)
+ 
+ // Keywords defined by Attr.td.
++// The "EMPTY ## X" is used to prevent early macro-expansion of the keyword.
+ #ifndef KEYWORD_ATTRIBUTE
+-#define KEYWORD_ATTRIBUTE(X) KEYWORD(X, KEYALL)
++#define KEYWORD_ATTRIBUTE(X, EMPTY) KEYWORD(EMPTY ## X, KEYALL)
+ #endif
+ #include "clang/Basic/AttrTokenKinds.inc"
+ 
+diff --git a/include/clang/Basic/TokenKinds.h b/clang/include/clang/Basic/TokenKinds.h
+index e4857405bc7f..ff117bd5afc5 100644
+--- a/include/clang/Basic/TokenKinds.h
++++ b/include/clang/Basic/TokenKinds.h
+@@ -109,7 +109,7 @@ bool isPragmaAnnotation(TokenKind K);
+ 
+ inline constexpr bool isRegularKeywordAttribute(TokenKind K) {
+   return (false
+-#define KEYWORD_ATTRIBUTE(X) || (K == tok::kw_##X)
++#define KEYWORD_ATTRIBUTE(X, ...) || (K == tok::kw_##X)
+ #include "clang/Basic/AttrTokenKinds.inc"
+   );
+ }
+diff --git a/utils/TableGen/ClangAttrEmitter.cpp b/clang/utils/TableGen/ClangAttrEmitter.cpp
+index b5813c6abc2b..79db17501b64 100644
+--- a/utils/TableGen/ClangAttrEmitter.cpp
++++ b/utils/TableGen/ClangAttrEmitter.cpp
+@@ -3430,7 +3430,7 @@ void EmitClangAttrTokenKinds(RecordKeeper &Records, raw_ostream &OS) {
+                      "RegularKeyword attributes with arguments are not "
+                      "yet supported");
+         OS << "KEYWORD_ATTRIBUTE("
+-           << S.getSpellingRecord().getValueAsString("Name") << ")\n";
++           << S.getSpellingRecord().getValueAsString("Name") << ", )\n";
+       }
+   OS << "#undef KEYWORD_ATTRIBUTE\n";
+ }
+-- 
+2.43.0
+

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -107,6 +107,10 @@ let
               stripLen = 1;
               hash = "sha256-Vs32kql7N6qtLqc12FtZHURcbenA7+N3E/nRRX3jdig=";
             })
+        # fix build with GCC 14 on aarch64-linux
+        # See https://github.com/llvm/llvm-project/issues/78691
+        ++ lib.optional (lib.versions.major release_version == "17")
+          (getVersionFile "clang/fix-build-with-gcc-14-on-arm.patch")
         ++ lib.optional (lib.versions.major release_version == "18") (fetchpatch {
           name = "tweak-tryCaptureVariable-for-unevaluated-lambdas.patch";
           url = "https://github.com/llvm/llvm-project/commit/3d361b225fe89ce1d8c93639f27d689082bd8dad.patch";

--- a/pkgs/development/compilers/llvm/common/clang/fix-build-with-gcc-14-on-arm.patch
+++ b/pkgs/development/compilers/llvm/common/clang/fix-build-with-gcc-14-on-arm.patch
@@ -1,0 +1,67 @@
+URL: https://github.com/llvm/llvm-project/pull/78704
+Patch-Source: https://src.fedoraproject.org/rpms/clang17/blob/rawhide/f/0001-Clang-Fix-build-with-GCC-14-on-ARM.patch
+From bd2e848f15c0f25231126eb10cb0ab350717dfc0 Mon Sep 17 00:00:00 2001
+From: Nikita Popov <npopov@redhat.com>
+Date: Fri, 19 Jan 2024 12:09:13 +0100
+Subject: [PATCH] [Clang] Fix build with GCC 14 on ARM
+
+GCC 14 defines `__arm_streaming` as a macro expanding to
+`[[arm::streaming]]`. Due to the nested macro use, this gets
+expanded prior to concatenation.
+
+It doesn't look like C++ has a really clean way to prevent
+macro expansion. The best I have found is to use `EMPTY ## X` where
+`EMPTY` is an empty macro argument, so this is the hack I'm
+implementing here.
+
+Fixes https://github.com/llvm/llvm-project/issues/78691.
+---
+ clang/include/clang/Basic/TokenKinds.def  | 3 ++-
+ clang/include/clang/Basic/TokenKinds.h    | 2 +-
+ clang/utils/TableGen/ClangAttrEmitter.cpp | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/clang/Basic/TokenKinds.def b/clang/include/clang/Basic/TokenKinds.def
+index ef0dad0f2dcd..3add13c079f3 100644
+--- a/include/clang/Basic/TokenKinds.def
++++ b/include/clang/Basic/TokenKinds.def
+@@ -752,8 +752,9 @@ KEYWORD(__builtin_available              , KEYALL)
+ KEYWORD(__builtin_sycl_unique_stable_name, KEYSYCL)
+ 
+ // Keywords defined by Attr.td.
++// The "EMPTY ## X" is used to prevent early macro-expansion of the keyword.
+ #ifndef KEYWORD_ATTRIBUTE
+-#define KEYWORD_ATTRIBUTE(X) KEYWORD(X, KEYALL)
++#define KEYWORD_ATTRIBUTE(X, EMPTY) KEYWORD(EMPTY ## X, KEYALL)
+ #endif
+ #include "clang/Basic/AttrTokenKinds.inc"
+ 
+diff --git a/include/clang/Basic/TokenKinds.h b/clang/include/clang/Basic/TokenKinds.h
+index e4857405bc7f..ff117bd5afc5 100644
+--- a/include/clang/Basic/TokenKinds.h
++++ b/include/clang/Basic/TokenKinds.h
+@@ -109,7 +109,7 @@ bool isPragmaAnnotation(TokenKind K);
+ 
+ inline constexpr bool isRegularKeywordAttribute(TokenKind K) {
+   return (false
+-#define KEYWORD_ATTRIBUTE(X) || (K == tok::kw_##X)
++#define KEYWORD_ATTRIBUTE(X, ...) || (K == tok::kw_##X)
+ #include "clang/Basic/AttrTokenKinds.inc"
+   );
+ }
+diff --git a/utils/TableGen/ClangAttrEmitter.cpp b/clang/utils/TableGen/ClangAttrEmitter.cpp
+index b5813c6abc2b..79db17501b64 100644
+--- a/utils/TableGen/ClangAttrEmitter.cpp
++++ b/utils/TableGen/ClangAttrEmitter.cpp
+@@ -3430,7 +3430,7 @@ void EmitClangAttrTokenKinds(RecordKeeper &Records, raw_ostream &OS) {
+                      "RegularKeyword attributes with arguments are not "
+                      "yet supported");
+         OS << "KEYWORD_ATTRIBUTE("
+-           << S.getSpellingRecord().getValueAsString("Name") << ")\n";
++           << S.getSpellingRecord().getValueAsString("Name") << ", )\n";
+       }
+   OS << "#undef KEYWORD_ATTRIBUTE\n";
+ }
+-- 
+2.43.0
+

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -106,6 +106,13 @@ let
                   path = ../12;
                 }
               ];
+              "clang/fix-build-with-gcc-14-on-arm.patch" = [
+                {
+                  after = "17";
+                  before = "18";
+                  path = ../17;
+                }
+              ];
               "lld/add-table-base.patch" = [
                 {
                   after = "16";
@@ -373,12 +380,14 @@ let
             # Crude method to drop polly patches if present, they're not needed for tblgen.
             (p: (!lib.hasInfix "-polly" p))
             tools.libllvm.patches;
+        # Would take tools.libclang.patches, but this introduces a cycle due
+        # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
+        # So copy over only the patches known to be necessary.
         clangPatches = [
-          # Would take tools.libclang.patches, but this introduces a cycle due
-          # to replacements depending on the llvm outpath (e.g. the LLVMgold patch).
-          # So take the only patch known to be necessary.
           (metadata.getVersionFile "clang/gnu-install-dirs.patch")
-        ];
+        ]
+        ++ lib.optional (lib.versions.major metadata.release_version == "17")
+          (metadata.getVersionFile "clang/fix-build-with-gcc-14-on-arm.patch");
       };
 
       libclang = callPackage ./clang {


### PR DESCRIPTION
Fixes the aarch64 build of clang17, which [fails on hydra](https://hydra.nixos.org/job/nixpkgs/trunk/clang_17.aarch64-linux).

Fixes #384508
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
