### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "5757bbb8bd7c0630a0cc4bb19c47e588db30b97c",
-  "sha256": "0px0lr7ad2zrws400507c9w5nnaffz9mp9hqssm64icdm6f6h0fz"
+  "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+  "sha256": "0qg99zj0gb0pc6sjlkmwhk1c1xz14qxmk6gamgfmcxpsfdp5vn72"
 }


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/363585, but now including the nixfmt update from https://github.com/NixOS/nixpkgs/pull/387047. Needed for https://github.com/NixOS/nixpkgs/pull/380990 to use the latest nixfmt version.

Ran `ci/update-pinned-nixpkgs.sh`, which updated it to the version from this nixpkgs-unstable Hydra eval: https://hydra.nixos.org/eval/1813168#tabs-inputs

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
