### PR TITLE
pyroveil: init at 2.0.0

### DIFF
--- a/pkgs/tools/games/pyroveil/default.nix
+++ b/pkgs/tools/games/pyroveil/default.nix
@@ -1,13 +1,4 @@
-{
-    stdenv,
-    cmake,
-    lib,
-    ninja,
-    gcc,
-    git,
-    python311,
-    fetchFromGitHub
-}:
+{ stdenv, cmake, lib, ninja, gcc, git, python311, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "Pyroveil";
@@ -27,13 +18,7 @@ stdenv.mkDerivation {
     };
   });
 
-  nativeBuildInputs = [
-    cmake
-    ninja
-    gcc
-    git
-    python311
-  ];
+  nativeBuildInputs = [ cmake ninja gcc git python311 ];
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 
   postPatch = ''

--- a/pkgs/tools/games/pyroveil/default.nix
+++ b/pkgs/tools/games/pyroveil/default.nix
@@ -1,0 +1,50 @@
+{ 
+    stdenv,
+    cmake,
+    lib,
+    ninja,
+    gcc,
+    git,
+    python311,
+    fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "Pyroveil";
+  # I don't see a version specification anywhere, only in json files.
+  version = "2.0.0";
+  src = (fetchFromGitHub {
+    owner = "HansKristian-Work";
+    repo = "pyroveil";
+    rev = "7fde4d6d0ebc664f33ebc6a42d8c2975bf353bfe";
+    sha256 = "sha256-sKvqcmQsbK8YuCdN2+5NKmyE0Sc8iA45IpYnFRItqiU=";
+    fetchSubmodules = true;
+  }).overrideAttrs (oldAttrs: {
+    env = oldAttrs.env or { } // {
+      GIT_CONFIG_COUNT = 1;
+      GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+      GIT_CONFIG_VALUE_0 = "git@github.com:";
+    };
+  });
+
+  nativeBuildInputs = [ 
+    cmake 
+    ninja 
+    gcc 
+    git 
+    python311  
+  ];
+  
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  postPatch = ''
+    substituteInPlace layer/CMakeLists.txt \
+    --replace "\''${CMAKE_INSTALL_PREFIX}/\''${CMAKE_INSTALL_LIBDIR}" "\''${CMAKE_INSTALL_FULL_LIBDIR}"
+  '';
+
+  meta = {
+    description =
+      "Vulkan layer to replace shaders or roundtrip them to workaround driver bugs";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/tools/games/pyroveil/default.nix
+++ b/pkgs/tools/games/pyroveil/default.nix
@@ -1,4 +1,4 @@
-{ 
+{
     stdenv,
     cmake,
     lib,
@@ -27,12 +27,12 @@ stdenv.mkDerivation {
     };
   });
 
-  nativeBuildInputs = [ 
-    cmake 
-    ninja 
-    gcc 
-    git 
-    python311  
+  nativeBuildInputs = [
+    cmake
+    ninja
+    gcc
+    git
+    python311
   ];
   
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];

--- a/pkgs/tools/games/pyroveil/default.nix
+++ b/pkgs/tools/games/pyroveil/default.nix
@@ -1,24 +1,41 @@
-{ stdenv, cmake, lib, ninja, gcc, git, python311, fetchFromGitHub }:
+{
+  stdenv,
+  cmake,
+  lib,
+  ninja,
+  gcc,
+  git,
+  python311,
+  fetchFromGitHub,
+}:
 
 stdenv.mkDerivation {
   pname = "Pyroveil";
   # I don't see a version specification anywhere, only in json files.
   version = "2.0.0";
-  src = (fetchFromGitHub {
-    owner = "HansKristian-Work";
-    repo = "pyroveil";
-    rev = "7fde4d6d0ebc664f33ebc6a42d8c2975bf353bfe";
-    sha256 = "sha256-sKvqcmQsbK8YuCdN2+5NKmyE0Sc8iA45IpYnFRItqiU=";
-    fetchSubmodules = true;
-  }).overrideAttrs (oldAttrs: {
-    env = oldAttrs.env or { } // {
-      GIT_CONFIG_COUNT = 1;
-      GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
-      GIT_CONFIG_VALUE_0 = "git@github.com:";
-    };
-  });
+  src =
+    (fetchFromGitHub {
+      owner = "HansKristian-Work";
+      repo = "pyroveil";
+      rev = "7fde4d6d0ebc664f33ebc6a42d8c2975bf353bfe";
+      sha256 = "sha256-sKvqcmQsbK8YuCdN2+5NKmyE0Sc8iA45IpYnFRItqiU=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      (oldAttrs: {
+        env = oldAttrs.env or { } // {
+          GIT_CONFIG_COUNT = 1;
+          GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+          GIT_CONFIG_VALUE_0 = "git@github.com:";
+        };
+      });
 
-  nativeBuildInputs = [ cmake ninja gcc git python311 ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+    gcc
+    git
+    python311
+  ];
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 
   postPatch = ''
@@ -27,8 +44,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description =
-      "Vulkan layer to replace shaders or roundtrip them to workaround driver bugs";
+    description = "Vulkan layer to replace shaders or roundtrip them to workaround driver bugs";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/tools/games/pyroveil/default.nix
+++ b/pkgs/tools/games/pyroveil/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation {
     git
     python311
   ];
-  
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 
   postPatch = ''


### PR DESCRIPTION
https://github.com/HansKristian-Work/pyroveil

Pyroveil is a Vulkan layer that can automatically replace shaders or roundtrip them via SPIRV-Cross -> glslang. This can create SPIR-V that is more compatible with NVIDIA drivers in particular.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
