### PR TITLE
pkgsStatic.dtc: use upstream patch

### DIFF
--- a/pkgs/by-name/dt/dtc/package.nix
+++ b/pkgs/by-name/dt/dtc/package.nix
@@ -25,11 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (fetchpatch2 {
-      # https://github.com/dgibson/dtc/pull/141
-      url = "https://github.com/dgibson/dtc/commit/56a7d0cb3be5f2f7604bc42299e24d13a39c72d8.patch";
-      hash = "sha256-GmAyk/K2OolH/Z8SsgwCcq3/GOlFuSpnVPr7jsy8Cs0=";
-    })
+    # backport of https://github.com/dgibson/dtc/pull/141
+    # to 1.7.2, to drop in 1.8.
+    ./static.patch
     # backport fix for SWIG 4.3
     (fetchpatch2 {
       url = "https://github.com/dgibson/dtc/commit/9a969f3b70b07bbf1c9df44a38d7f8d1d3a6e2a5.patch";
@@ -65,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonAutoFeatures = "auto";
   mesonFlags = [
-    (lib.mesonBool "static-build" stdenv.hostPlatform.isStatic)
     (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
   ];
 

--- a/pkgs/by-name/dt/dtc/static.patch
+++ b/pkgs/by-name/dt/dtc/static.patch
@@ -1,0 +1,150 @@
+commit a881a5b110d2f23a11924604bff64ab3c2755bc6
+Author: Brandon Maier <brandon.maier@gmail.com>
+Date:   Thu Mar 6 20:30:47 2025 -0600
+
+    meson: support building libfdt without static library
+    
+    Some packaging systems like NixOS don't support compiling static
+    libraries. However libfdt's meson.build uses `both_library()` which
+    forces the build to always compile shared and static libraries. Removing
+    `both_library()` will make packaging easier.
+    
+    libfdt uses `both_libraries()` to support the 'static-build' option.
+    But we do not need the 'static-build' option as Meson can natively
+    build static using
+    
+    > meson setup builddir/ -Dc_link_args='-static' --prefer-static --default-library=static
+    
+    So drop 'static-build' and then replace `both_libraries()` with
+    `library()`.
+    
+    Signed-off-by: Brandon Maier <brandon.maier@gmail.com>
+    Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+
+diff --git a/libfdt/meson.build b/libfdt/meson.build
+index bf8343f..c2f4bd6 100644
+--- a/libfdt/meson.build
++++ b/libfdt/meson.build
+@@ -26,7 +26,7 @@ else
+ endif
+ 
+ link_args += version_script
+-libfdt = both_libraries(
++libfdt = library(
+   'fdt', sources,
+   version: meson.project_version(),
+   link_args: link_args,
+@@ -34,17 +34,11 @@ libfdt = both_libraries(
+   install: true,
+ )
+ 
+-if static_build
+-  link_with = libfdt.get_static_lib()
+-else
+-  link_with = libfdt.get_shared_lib()
+-endif
+-
+ libfdt_inc = include_directories('.')
+ 
+ libfdt_dep = declare_dependency(
+   include_directories: libfdt_inc,
+-  link_with: link_with,
++  link_with: libfdt,
+ )
+ 
+ install_headers(
+diff --git a/meson.build b/meson.build
+index 310699f..603ffaa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,7 +1,7 @@
+ project('dtc', 'c',
+   version: files('VERSION.txt'),
+   license: ['GPL2+', 'BSD-2'],
+-  default_options: 'werror=true',
++  default_options: ['werror=true', 'default_library=both'],
+   meson_version: '>=0.57.0'
+ )
+ 
+@@ -27,16 +27,8 @@ add_project_arguments(
+   language: 'c'
+ )
+ 
+-if get_option('static-build')
+-  static_build = true
+-  extra_link_args = ['-static']
+-else
+-  static_build = false
+-  extra_link_args = []
+-endif
+-
+ yamltree = 'yamltree.c'
+-yaml = dependency('yaml-0.1', version: '>=0.2.3', required: get_option('yaml'), static: static_build)
++yaml = dependency('yaml-0.1', version: '>=0.2.3', required: get_option('yaml'))
+ if not yaml.found()
+   add_project_arguments('-DNO_YAML', language: 'c')
+   yamltree = []
+@@ -92,7 +84,6 @@ if get_option('tools')
+       ],
+       dependencies: util_dep,
+       install: true,
+-      link_args: extra_link_args,
+     )
+   endif
+ 
+@@ -113,11 +104,10 @@ if get_option('tools')
+     ],
+     dependencies: [util_dep, yaml],
+     install: true,
+-    link_args: extra_link_args,
+   )
+ 
+   foreach e: ['fdtdump', 'fdtget', 'fdtput', 'fdtoverlay']
+-    dtc_tools += executable(e, files(e + '.c'), dependencies: util_dep, install: true, link_args: extra_link_args)
++    dtc_tools += executable(e, files(e + '.c'), dependencies: util_dep, install: true)
+   endforeach
+ 
+   install_data(
+diff --git a/meson_options.txt b/meson_options.txt
+index 36f391a..62b31b3 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -8,7 +8,5 @@ option('valgrind', type: 'feature', value: 'auto',
+        description: 'Valgrind support')
+ option('python', type: 'feature', value: 'auto',
+        description: 'Build pylibfdt Python library')
+-option('static-build', type: 'boolean', value: false,
+-       description: 'Build static binaries')
+ option('tests', type: 'boolean', value: true,
+        description: 'Build tests')
+diff --git a/tests/meson.build b/tests/meson.build
+index 9cf6e3d..baed174 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -96,22 +96,20 @@ tests += [
+   'truncated_string',
+ ]
+ 
++test_deps = [testutil_dep, util_dep, libfdt_dep]
++
+ dl = cc.find_library('dl', required: false)
+-if dl.found() and not static_build
++if dl.found()
+   tests += [
+     'asm_tree_dump',
+     'value-labels',
+   ]
+-endif
+-
+-test_deps = [testutil_dep, util_dep, libfdt_dep]
+-if not static_build
+   test_deps += [dl]
+ endif
+ 
+ tests_exe = []
+ foreach t: tests
+-  tests_exe += executable(t, files(t + '.c'), dependencies: test_deps, link_args: extra_link_args)
++  tests_exe += executable(t, files(t + '.c'), dependencies: test_deps)
+ endforeach
+ 
+ run_tests = find_program('run_tests.sh')


### PR DESCRIPTION
This changes the patch to the version that got merged in https://github.com/dgibson/dtc/pull/141

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
