### PR TITLE
python312Packages.plyara: add pytestCheckHook and source from GitHub

### DIFF
--- a/pkgs/development/python-modules/plyara/default.nix
+++ b/pkgs/development/python-modules/plyara/default.nix
@@ -2,9 +2,15 @@
   lib,
   buildPythonPackage,
   pythonOlder,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   ply,
+
+  pytestCheckHook,
+  pycodestyle,
+  pydocstyle,
+  pyflakes,
+  coverage,
 }:
 
 buildPythonPackage rec {
@@ -14,9 +20,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.10"; # https://github.com/plyara/plyara: "Plyara requires Python 3.10+"
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-zmpb5r3BcveLsQ0uIgQJx2vUaz2p/0PlO76E0e7elwA=";
+  src = fetchFromGitHub {
+    owner = "plyara";
+    repo = "plyara";
+    tag = "v${version}";
+    hash = "sha256-WaQgqx003it+D0AGDxV6aSKO89F2iR9d8L4zvHyd0iQ=";
   };
 
   build-system = [
@@ -31,11 +39,27 @@ buildPythonPackage rec {
     "plyara"
   ];
 
+  nativeCheckInputs = [
+    pytestCheckHook
+    pycodestyle
+    pydocstyle
+    pyflakes
+    coverage
+  ];
+
+  disabledTests = [
+    # touches network
+    "test_third_party_repositories"
+  ];
+
   meta = {
     description = "Parse YARA rules";
-    homepage = "https://pypi.org/project/plyara/";
+    homepage = "https://github.com/plyara/plyara";
     changelog = "https://github.com/plyara/plyara/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ _13621 ];
+    maintainers = with lib.maintainers; [
+      _13621
+      ivyfanchiang
+    ];
   };
 }


### PR DESCRIPTION
Add running pytest checks to plyara python module, requires switching source from PyPI to GitHub

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
