### PR TITLE
slepc: init at 3.22.2

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -11,6 +11,7 @@
   zlib, # propagated by p4est but required by petsc
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
+  bash,
 
   # Build options
   petsc-optimized ? true,
@@ -99,6 +100,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs ./lib/petsc/bin
+
+    substituteInPlace config/example_template.py \
+      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
   '';
 
   configureFlags =

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -19,6 +19,7 @@
   petsc-precision ? "double",
   mpiSupport ? true,
   withPetsc4py ? false, # petsc python binding
+  withExamples ? false,
   withFullDeps ? false, # full External libraries support
 
   # External libraries options
@@ -164,6 +165,8 @@ stdenv.mkDerivation rec {
   ];
 
   configureScript = "python ./configure";
+
+  installTargets = [ (if withExamples then "install" else "install-lib") ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -207,6 +207,7 @@ stdenv.mkDerivation rec {
     description = "Portable Extensible Toolkit for Scientific computation";
     homepage = "https://petsc.org/release/";
     license = licenses.bsd2;
+    platforms = lib.platforms.unix;
     maintainers = with maintainers; [
       cburstedde
       qbisi

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -21,13 +21,14 @@
   pythonSupport ? false, # petsc python binding
   withExamples ? false,
   withFullDeps ? false, # full External libraries support
+  withCommonDeps ? true, # common External libraries support
 
   # External libraries options
-  withHdf5 ? true,
-  withMetis ? withFullDeps,
-  withParmetis ? false, # parmetis is unfree and should be enabled manualy
-  withPtscotch ? withFullDeps,
+  withHdf5 ? withCommonDeps,
+  withMetis ? withCommonDeps,
   withScalapack ? withFullDeps,
+  withParmetis ? withFullDeps, # parmetis is unfree
+  withPtscotch ? withFullDeps,
   withMumps ? withFullDeps,
   withP4est ? withFullDeps,
 
@@ -41,6 +42,7 @@
   pkg-config,
   p4est,
 }:
+assert withFullDeps -> withCommonDeps;
 
 # This version of PETSc does not support a non-MPI p4est build
 assert withP4est -> (p4est.mpiSupport && mpiSupport);

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -164,8 +164,6 @@ stdenv.mkDerivation rec {
     "fortify3"
   ];
 
-  configureScript = "python ./configure";
-
   installTargets = [ (if withExamples then "install" else "install-lib") ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -177,7 +177,7 @@ stdenv.mkDerivation rec {
   nativeInstallCheckInputs = [ mpiCheckPhaseHook ];
 
   passthru = {
-    inherit mpiSupport;
+    inherit mpiSupport pythonSupport;
   };
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -174,7 +174,28 @@ stdenv.mkDerivation rec {
   # the library is installed and available.
   doInstallCheck = true;
   installCheckTarget = "check_install";
-  nativeInstallCheckInputs = [ mpiCheckPhaseHook ];
+
+  # The PETSC4PY=no flag disables the ex100 test,
+  # which compiles C code to load Python modules for solving a math problem.
+  # This test fails on the Darwin platform but is rarely a common use case for petsc4py.
+  installCheckFlags = lib.optional stdenv.hostPlatform.isDarwin "PETSC4PY=no";
+
+  nativeInstallCheckInputs =
+    [
+      mpiCheckPhaseHook
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.pythonImportsCheckHook
+      python3Packages.unittestCheckHook
+    ];
+
+  unittestFlagsArray = [
+    "-s"
+    "src/binding/petsc4py/test"
+    "-v"
+  ];
+
+  pythonImportsCheck = [ "petsc4py" ];
 
   passthru = {
     inherit mpiSupport pythonSupport;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchzip,
-  cctools,
   gfortran,
   replaceVars,
   python3,
@@ -98,14 +97,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch =
-    ''
-      patchShebangs ./lib/petsc/bin
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace config/install.py \
-        --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
-    '';
+  postPatch = ''
+    patchShebangs ./lib/petsc/bin
+  '';
 
   configureFlags =
     [

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -18,7 +18,7 @@
   petsc-scalar-type ? "real",
   petsc-precision ? "double",
   mpiSupport ? true,
-  withPetsc4py ? false, # petsc python binding
+  pythonSupport ? false, # petsc python binding
   withExamples ? false,
   withFullDeps ? false, # full External libraries support
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
       pkg-config
     ]
     ++ lib.optional mpiSupport mpi
-    ++ lib.optionals withPetsc4py [
+    ++ lib.optionals pythonSupport [
       python3Packages.setuptools
       python3Packages.cython
     ];
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withScalapack scalapack
     ++ lib.optional withMumps mumps_par;
 
-  propagatedBuildInputs = lib.optional withPetsc4py python3Packages.numpy;
+  propagatedBuildInputs = lib.optional pythonSupport python3Packages.numpy;
 
   patches = [
     (replaceVars ./fix-petsc4py-install-prefix.patch {
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
       "--with-precision=${petsc-precision}"
       "--with-mpi=${if mpiSupport then "1" else "0"}"
     ]
-    ++ lib.optional withPetsc4py "--with-petsc4py=1"
+    ++ lib.optional pythonSupport "--with-petsc4py=1"
     ++ lib.optionals mpiSupport [
       "--CC=mpicc"
       "--with-cxx=mpicxx"

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  sowing,
+  python3,
+  python3Packages,
+  arpack-mpi,
+  petsc,
+  mpi,
+  mpiCheckPhaseHook,
+  pythonSupport ? false,
+  withExamples ? false,
+  withArpack ? stdenv.hostPlatform.isLinux,
+}:
+assert petsc.mpiSupport;
+assert pythonSupport -> petsc.pythonSupport;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "slepc";
+  version = "3.22.2";
+
+  src = fetchFromGitLab {
+    owner = "slepc";
+    repo = "slepc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a5DmsA7NAlhrEaS43TYPk7vtDfhXLEP+5sftu2A9Yt4=";
+  };
+
+  postPatch = ''
+    # Fix slepc4py install prefix
+    substituteInPlace config/packages/slepc4py.py \
+      --replace-fail "slepc.prefixdir,'lib'" \
+      "slepc.prefixdir,'${python3.sitePackages}'"
+
+    patchShebangs lib/slepc/bin
+
+    # Use system bfort
+    substituteInPlace config/packages/sowing.py \
+      --replace-fail "bfort = os.path.join(archdir,'bin','bfort')" \
+      "bfort = '${sowing}/bin/bfort'"
+  '';
+
+  # Usually this project is being built as part of a `petsc` build or as part of
+  # other projects, e.g when `petsc` is `./configure`d with
+  # `--download-slepc=1`. This instructs the slepc to be built as a standalone
+  # project.
+  preConfigure = ''
+    export SLEPC_DIR=$PWD
+  '';
+
+  nativeBuildInputs =
+    [
+      python3
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.setuptools
+      python3Packages.cython
+    ];
+
+  configureFlags =
+    lib.optionals withArpack [
+      "--with-arpack=1"
+    ]
+    ++ lib.optionals pythonSupport [
+      "--with-slepc4py=1"
+    ];
+
+  buildInputs =
+    [
+      mpi
+    ]
+    ++ lib.optionals withArpack [
+      arpack-mpi
+    ];
+
+  propagatedBuildInputs = [
+    petsc
+  ];
+
+  enableParallelBuilding = true;
+
+  installTargets = [ (if withExamples then "install" else "install-lib") ];
+
+  nativeInstallCheckInputs =
+    [
+      mpiCheckPhaseHook
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.pythonImportsCheckHook
+      python3Packages.unittestCheckHook
+    ];
+
+  doInstallCheck = true;
+
+  installCheckTarget = [ "check_install" ];
+
+  unittestFlagsArray = [
+    "-s"
+    "src/binding/slepc4py/test"
+    "-v"
+  ];
+
+  pythonImportsCheck = [ "slepc4py" ];
+
+  shellHook = ./setup-hook.sh;
+
+  meta = {
+    description = "Scalable Library for Eigenvalue Problem Computations";
+    homepage = "https://slepc.upv.es";
+    changelog = "https://gitlab.com/slepc/slepc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      bsd2
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+    # Possible error running Fortran src/eps/tests/test7f with 1 MPI process
+    broken = stdenv.hostPlatform.isDarwin && withArpack;
+  };
+})

--- a/pkgs/by-name/sl/slepc/setup-hook.sh
+++ b/pkgs/by-name/sl/slepc/setup-hook.sh
@@ -1,0 +1,1 @@
+export SLEPC_DIR=@out@

--- a/pkgs/by-name/so/sowing/package.nix
+++ b/pkgs/by-name/so/sowing/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  stdenv,
+  fetchFromBitbucket,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sowing";
+  version = "1.1.26.12";
+
+  src = fetchFromBitbucket {
+    owner = "petsc";
+    repo = "pkg-sowing";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ol0xNAnL7ULU1CiGCFZrV37IAV4z1bcWa0f+tuMhQC8=";
+  };
+
+  meta = {
+    description = "Tools for documenting and improving portability";
+    homepage = "https://wgropp.cs.illinois.edu/projects/software/sowing/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ qbisi ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10505,7 +10505,6 @@ self: super: with self; {
     python3 = python;
     python3Packages = self;
     pythonSupport = true;
-    withFullDeps = true;
   });
 
   pex = callPackage ../development/python-modules/pex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10504,7 +10504,7 @@ self: super: with self; {
   petsc4py = toPythonModule (pkgs.petsc.override {
     python3 = python;
     python3Packages = self;
-    withPetsc4py = true;
+    pythonSupport = true;
     withFullDeps = true;
   });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15350,6 +15350,13 @@ self: super: with self; {
 
   sleepyq = callPackage ../development/python-modules/sleepyq { };
 
+  slepc4py = toPythonModule (pkgs.slepc.override {
+    pythonSupport = true;
+    python3 = self.python;
+    python3Packages = self;
+    petsc = petsc4py;
+  });
+
   sleqp = toPythonModule (pkgs.sleqp.override { pythonSupport = true; python3Packages = self; });
 
   slicedimage = callPackage ../development/python-modules/slicedimage { };


### PR DESCRIPTION
Scalable Library for Eigenvalue Problem Computations
Sci-lib depends on petsc and used by many math softwares.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
