### PR TITLE
freebsd.{geom,libgeom,libbsdxml}: split outputs and improve docs

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/geom.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/geom.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   libgeom,
   libufs,
@@ -16,6 +17,12 @@ let
       # geli isn't okay with just libcrypt, it wants files in here
       "sys/crypto/sha2"
       "sys/opencrypto"
+    ];
+
+    outputs = [
+      "out"
+      "man"
+      "debug"
     ];
 
     # libgeom needs sbuf and bsdxml but linker doesn't know that
@@ -37,8 +44,19 @@ mkDerivation {
     "lib/Makefile.inc"
     "lib/geom"
   ];
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
 
   GEOM_CLASS_DIR = "${libs}/lib";
+
+  # link in man pages from libs
+  postInstall = ''
+    mkdir -p $man/share/man/man8
+    ln -s ${lib.getMan libs}/share/man/man8/*.8* $man/share/man/man8/
+  '';
 
   buildInputs = [ libgeom ];
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libbsdxml.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libbsdxml.nix
@@ -3,4 +3,8 @@ mkDerivation {
   path = "lib/libexpat";
   extraPaths = [ "contrib/expat" ];
   buildInputs = [ ];
+  outputs = [
+    "out"
+    "debug"
+  ];
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libgeom.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libgeom.nix
@@ -5,6 +5,13 @@
 }:
 mkDerivation {
   path = "lib/libgeom";
+
+  outputs = [
+    "out"
+    "man"
+    "debug"
+  ];
+
   buildInputs = [
     libbsdxml
     libsbuf


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
