### PR TITLE
python3Packages.docrepr: init at 0.2.0

### DIFF
--- a/pkgs/development/python-modules/docrepr/default.nix
+++ b/pkgs/development/python-modules/docrepr/default.nix
@@ -1,0 +1,64 @@
+{
+  buildPythonPackage,
+  # fetchFromGitHub,
+  fetchPypi,
+  fetchpatch,
+  lib,
+
+  # Build dependencies
+  setuptools,
+
+  # Runtime dependencies
+  docutils,
+  jinja2,
+  sphinx,
+
+  # Test dependencies
+  ipython,
+  matplotlib,
+  numpy,
+  pillow,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "docrepr";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-OtYuzaoLerkNzZwpq8mMrn1h0JM58YOW1MpbirQci5A=";
+  };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/spyder-ide/docrepr/compare/3fcb6430d9f5da8f547a30d08a36244ab31bc65c..a1afbd6c260530a07e92fdc19e72792c9d1dc38c.patch";
+      hash = "sha256-jwh48txPUxyx3AmaCyd7H3DP578ETYPt6zBpxtWcosg=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+  dependencies = [
+    docutils
+    jinja2
+    sphinx
+  ];
+
+  nativeCheckInputs = [
+    ipython
+    matplotlib
+    numpy
+    pillow
+    pytest-asyncio
+    pytestCheckHook
+  ];
+  pythonImportsCheck = [ "docrepr.sphinxify" ];
+
+  meta = {
+    changelog = "https://github.com/spyder-ide/docrepr/releases/tag/${version}";
+    homepage = "https://github.com/spyder-ide/docrepr";
+    description = "Renders Python docstrings to rich HTML";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -22,6 +22,7 @@
   typing-extensions,
 
   # Optional dependencies
+  docrepr,
   ipykernel,
   ipyparallel,
   ipywidgets,
@@ -69,6 +70,7 @@ buildPythonPackage rec {
     ++ lib.optionals (pythonOlder "3.12") [ typing-extensions ];
 
   optional-dependencies = {
+    docrepr = [ docrepr ];
     kernel = [ ipykernel ];
     nbconvert = [ nbconvert ];
     nbformat = [ nbformat ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3886,6 +3886,8 @@ self: super: with self; {
 
   docrep = callPackage ../development/python-modules/docrep { };
 
+  docrepr = callPackage ../development/python-modules/docrepr { };
+
   docutils = callPackage ../development/python-modules/docutils { };
 
   docx2python = callPackage ../development/python-modules/docx2python { };


### PR DESCRIPTION
I went to the trouble of packaging `docrepr` before realizing that I don't need it. So I decided to publish my result in case somebody needs it in the future. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
