### PR TITLE
Fix FreeBSD native stdenv again

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -235,6 +235,10 @@ def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: list
     except ELFError:
         return []
 
+    # these platforms are packaged in nixpkgs with ld.so in a separate derivation
+    # than libc.so and friends. keep_libc is mandatory.
+    keep_libc |= file_osabi in ('ELFOSABI_FREEBSD', 'ELFOSABI_OPENBSD')
+
     rpath = []
     if file_is_dynamic_executable:
         print("setting interpreter of", path)

--- a/pkgs/by-name/gd/gdbm/freebsd-patch-src-lock-c.patch
+++ b/pkgs/by-name/gd/gdbm/freebsd-patch-src-lock-c.patch
@@ -1,0 +1,37 @@
+https://github.com/freebsd/freebsd-ports/blob/e198aef78afa4fd78ddc62fb5d0f7caa1b076bb0/databases/gdbm/files/patch-src_lock.c
+
+--- a/src/lock.c.orig	2025-03-06 16:24:09 UTC
++++ b/src/lock.c
+@@ -73,15 +73,10 @@ try_lock_flock (GDBM_FILE dbf, int nb)
+     {
+       return TRY_LOCK_OK;
+     }
+-  else if (errno == EWOULDBLOCK)
++  else if (errno == EWOULDBLOCK || errno == EINTR)
+     {
+       return TRY_LOCK_FAIL;
+     }
+-  else if (errno == EINTR)
+-    {
+-      errno = ETIME;
+-      return TRY_LOCK_FAIL;
+-    }
+ #endif
+   return TRY_LOCK_NEXT;
+ }
+@@ -116,7 +111,6 @@ try_lock_lockf (GDBM_FILE dbf, int nb)
+       switch (errno)
+ 	{
+ 	case EINTR:
+-	  errno = ETIME;
+ 	case EACCES:
+ 	case EAGAIN:
+ 	case EDEADLK:
+@@ -162,7 +156,6 @@ try_lock_fcntl (GDBM_FILE dbf, int nb)
+   switch (errno)
+     {
+     case EINTR:
+-      errno = ETIME;
+     case EACCES:
+     case EAGAIN:
+     case EDEADLK:

--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  fetchpatch,
   stdenv,
   testers,
   updateAutotoolsGnuConfigScriptsHook,
@@ -15,12 +16,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0C2zxZJu2Hf4gXuBzR+S9T73TKjG21Q/u6AnGzTzk+w=";
   };
 
-  patches = [
-    # Remove on next release.
-    ./upstream-darwin-clock-nanosleep-fix.patch
-    ./upstream-lockwait-test-fixes.patch
-    ./upstream-musl-ssize_t-fix.patch
-  ];
+  patches =
+    [
+      # Remove on next release.
+      ./upstream-darwin-clock-nanosleep-fix.patch
+      ./upstream-lockwait-test-fixes.patch
+      ./upstream-musl-ssize_t-fix.patch
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+      ./freebsd-patch-src-lock-c.patch
+    ];
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
           # the filesystem does not necessarily have hardlink capabilities
           "libarchive/test/test_write_disk_hardlink.c"
           # access-time-related tests flakey on some systems
+          "libarchive/test/test_read_disk_directory_traversals.c"
           "cpio/test/test_option_a.c"
           "cpio/test/test_option_t.c"
         ]

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -134,6 +134,8 @@ stdenv.mkDerivation (finalAttrs: {
           # EOPNOTSUPP when performed in jailed build env
           "tcp_reuseport"
           "udp_reuseport"
+          # jailed build env does not have a hostname
+          "gethostname"
           # Fails when built on non-nix FreeBSD
           # https://github.com/libuv/libuv/issues/4606
           "fs_event_watch_delete_dir"
@@ -142,6 +144,8 @@ stdenv.mkDerivation (finalAttrs: {
     in
     lib.optionalString (finalAttrs.finalPackage.doCheck) ''
       sed '/${tdRegexp}/d' -i test/test-list.h
+      # https://github.com/libuv/libuv/issues/4794
+      substituteInPlace Makefile.am --replace-fail -lutil "-lutil -lm"
     '';
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -526,6 +526,8 @@ stdenv.mkDerivation (
         optionalString stdenv.hostPlatform.isFreeBSD ''
           rm test/tools/llvm-libtool-darwin/L-and-l.test
           rm test/ExecutionEngine/Interpreter/intrinsics.ll
+          # Fails in sandbox
+          substituteInPlace unittests/Support/LockFileManagerTest.cpp --replace-fail "Basic" "DISABLED_Basic"
         ''
       + ''
         patchShebangs test/BugPoint/compile-custom.ll.py

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -7,6 +7,7 @@
   ninja,
   patches ? [ ],
   python3,
+  updateAutotoolsGnuConfigScriptsHook,
   release_version,
   runCommand,
   src ? null,
@@ -76,6 +77,10 @@ let
       cmake
       ninja
       python3
+
+      # while this is not an autotools build, it still includes a config.guess
+      # this is needed until scripts are updated to not use /usr/bin/uname on FreeBSD native
+      updateAutotoolsGnuConfigScriptsHook
     ];
 
     cmakeFlags = [

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcMinimal.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcMinimal.nix
@@ -6,6 +6,7 @@
   byacc,
   gencat,
   csu,
+  i18n,
   extraSrc ? [ ],
 }:
 
@@ -32,6 +33,7 @@ mkDerivation {
     "etc/group"
     "etc/master.passwd"
     "etc/shells"
+    "include/paths.h"
   ] ++ extraSrc;
 
   outputs = [
@@ -54,8 +56,13 @@ mkDerivation {
   ];
 
   # this target is only used in the rtld-elf derivation. build it there instead.
+  #
+  # WE SHOULD REALLY BE REPLACING /usr/lib/i18n WITH THE libiconvModules DERIVATION
+  # but this causes some awful dependency loops which basically collapse the entire libc derivation
+  # instead, set the PATH_I18NMODULE environment variable whenever possible
   postPatch = ''
     sed -E -i -e '/BUILD_NOSSP_PIC_ARCHIVE=/d' $BSDSRCDIR/lib/libc/Makefile
+    substituteInPlace $BSDSRCDIR/include/paths.h --replace '/usr/share/i18n' '${i18n}/share/i18n'
   '';
 
   preBuild = ''

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -96,6 +96,7 @@ let
           "bin/clang"
           "bin/clang++"
           "bin/cpp"
+          "lib/clang"
         ];
         # SYNCME: this version number must be synced with the one in make-bootstrap-tools.nix
         version = "18";

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -62,6 +62,9 @@ let
         name = attrs.name or (builtins.baseNameOf (builtins.elemAt attrs.paths 0));
         src = bootstrapArchive;
         builder = "${bootstrapArchive}/bin/bash";
+        # this script will prefer to link files instead of copying them.
+        # this prevents clang in particular, but possibly others, from calling readlink(argv[0])
+        # and obtaining dependencies, ld(1) in particular, from there instead of $PATH.
         args = [ ./linkBootstrap.sh ];
         PATH = "${bootstrapArchive}/bin";
         paths = attrs.paths;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -442,7 +442,7 @@ let
             inherit (prevStage.freebsd) libc;
             inherit (prevStage) gnugrep coreutils expand-response-params;
             runtimeShell = shell;
-            bintools = prevStage.binutils-unwrapped;
+            bintools = (prevStage.llvmPackages or { }).bintools-unwrapped or prevStage.binutils-unwrapped;
             propagateDoc = false;
             nativeTools = false;
             nativeLibc = false;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -449,11 +449,15 @@ let
           };
         };
         overrides = overrides prevStage;
-        preHook = ''
-          export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
-          export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
-          export PATH_LOCALE=${prevStage.freebsd.localesReal or prevStage.freebsd.locales}/share/locale
-        '';
+        preHook =
+          ''
+            export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
+            export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+            export PATH_LOCALE=${prevStage.freebsd.localesReal or prevStage.freebsd.locales}/share/locale
+          ''
+          + lib.optionalString (prevStage.freebsd ? libiconvModules) ''
+            export PATH_I18NMODULE=${prevStage.freebsd.libiconvModules}/lib/i18n
+          '';
       };
     in
     {

--- a/pkgs/stdenv/freebsd/linkBootstrap.sh
+++ b/pkgs/stdenv/freebsd/linkBootstrap.sh
@@ -6,5 +6,9 @@ for path in $paths; do
         exit 1
     fi
     mkdir -p $out/$(dirname $path)
-    ln -s $src/$path $out/$path
+    if [[ -d $src/$path ]]; then
+        ln -s $src/$path $out/$path
+    else
+        cp -RL $src/$path $out/$path
+    fi
 done

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
         sed -i -E 's:[[:space:]]test-sigsegv-catch-stackoverflow[12]\$\(EXEEXT\)::g' gnulib-tests/Makefile.in
         sed -i -E 's:[[:space:]]test-sigaction\$\(EXEEXT\)::g' gnulib-tests/Makefile.in
       ''
+    else if stdenv.hostPlatform.isFreeBSD then
+      ''
+        sed -i -E 's:test-time::g' gnulib-tests/Makefile.in
+      ''
     else
       null;
 

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   ed,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -13,6 +14,13 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/patch/patch-${version}.tar.xz";
     hash = "sha256-+Hzuae7CtPy/YKOWsDCtaqNBXxkqpffuhMrV4R9/WuM=";
   };
+
+  # This test is filesystem-dependent - observed failing on ZFS
+  postPatch = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
+    sed -E -i -e '/bad-filenames/d' tests/Makefile.am
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_strnlen_working=yes"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -243,6 +243,9 @@ with pkgs;
       auto-patchelf
       bintools
     ];
+    substitutions = {
+      hostPlatform = stdenv.hostPlatform.config;
+    };
   } ../build-support/setup-hooks/auto-patchelf.sh;
 
   appimageTools = callPackage ../build-support/appimage { };


### PR DESCRIPTION
Hey gamers it's ya gal Audrey here with another episode of "we need some CI on this derivation". This episode's sponsor is the nix-community builders, who generously offered to set me up with a machine to make sure this build stays building!

Most of these changes are fallout from splitting freebsd.libc into freebsd.libcMinimal + several other derivations. The rest are simply the march of time, rot and let rot.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-freebsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
