### PR TITLE
nixos/xpad-noone: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -79,6 +79,8 @@
 
 - [Yggdrasil-Jumper](https://github.com/one-d-wide/yggdrasil-jumper) is an independent project that aims to transparently reduce latency of a connection over Yggdrasil network, utilizing NAT traversal to automatically bypass intermediary nodes.
 
+- [xpad-noone](https://github.com/medusalix/xpad-noone) is the original upstream xpad driver from the Linux kernel with support for Xbox One controllers removed， especially useful for people who want to use an XBox One controller under the xone driver and an Xbox 360 controller under the xpad driver at the same time. Available as [hardware.xpad-noone](options.html#hardware.xpad-noone).
+
 - [uMurmur](https://umurmur.net), minimalistic Mumble server primarily targeted to run on embedded computers. Available as [services.umurmur](options.html#opt-services.umurmur).
 
 - [Zenoh](https://zenoh.io/), a pub/sub/query protocol with low overhead. The Zenoh router daemon is available as [services.zenohd](options.html#opt-services.zenohd.enable)

--- a/nixos/modules/hardware/xpad-noone.nix
+++ b/nixos/modules/hardware/xpad-noone.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.hardware.xpad-noone;
+in
+{
+  options.hardware.xpad-noone = {
+    enable = lib.mkEnableOption "The Xpad driver from the Linux kernel with support for Xbox One controllers removed";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot = {
+      blacklistedKernelModules = [ "xpad" ];
+      extraModulePackages = with config.boot.kernelPackages; [ xpad-noone ];
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ Cryolitia ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -122,6 +122,7 @@
   ./hardware/wooting.nix
   ./hardware/xone.nix
   ./hardware/xpadneo.nix
+  ./hardware/xpad-noone.nix
   ./i18n/input-method/default.nix
   ./i18n/input-method/fcitx5.nix
   ./i18n/input-method/hime.nix

--- a/pkgs/os-specific/linux/xpad-noone/default.nix
+++ b/pkgs/os-specific/linux/xpad-noone/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "xpad-noone";
+  version = "0-unstable-2024-01-10";
+
+  src = fetchFromGitHub {
+    owner = "medusalix";
+    repo = finalAttr.pname;
+    rev = "c3d1610";
+    hash = "sha256-jDRyvbU9GsnM1ARTuwnoD7ZXlfBxne13UpSKRo7HHSY=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "/lib/modules/\$(shell uname -r)/build" "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install *.ko -Dm444 -t $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/xpad-noone
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/medusalix/xpad-noone";
+    description = "Xpad driver from the Linux kernel with support for Xbox One controllers removed";
+    license = with lib.licenses; [
+      gpl2Only
+    ];
+    maintainers = with lib.maintainers; [ Cryolitia ];
+    platforms = lib.platforms.linux;
+    broken = kernel.kernelOlder "5.15";
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -637,6 +637,8 @@ in {
 
     tsme-test = callPackage ../os-specific/linux/tsme-test { };
 
+    xpad-noone = callPackage ../os-specific/linux/xpad-noone { };
+
   } // lib.optionalAttrs config.allowAliases {
     zfs = throw "linuxPackages.zfs has been removed, use zfs_* instead, or linuxPackages.\${pkgs.zfs.kernelModuleAttribute}"; # added 2025-01-23
     zfs_2_1 = throw "zfs_2_1 has been removed"; # added 2024-12-25;


### PR DESCRIPTION
Introduce `xpad-noone`: https://github.com/medusalix/xpad-noone

While enabling `hardware.xone`, the default driver `xpad` will be disabled to prevent conflict, but `xone` only provides the driver of Xbox One controller but not Xbox 360 controller. The `xpad-noone` drives only Xbox 360 controller, so can be used safety with `xone`.

The idea is previously mentioned in https://github.com/NixOS/nixpkgs/pull/161008#issuecomment-1046311934 by @hpfr 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
