### PR TITLE
quirc: fix on darwin

### DIFF
--- a/pkgs/by-name/qu/quirc/0001-Don-t-build-demos.patch
+++ b/pkgs/by-name/qu/quirc/0001-Don-t-build-demos.patch
@@ -1,8 +1,33 @@
+From 7435b2e12c2004cb0c497ff313288902f2a6f39a Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Fri, 19 Jul 2024 21:53:58 +0200
+Subject: [PATCH] Don't build demos
+
+---
+ Makefile | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
 diff --git a/Makefile b/Makefile
-index 8327b4e..c269291 100644
+index 8327b4e..7901cc5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -99,9 +99,6 @@ install: libquirc.a libquirc.$(LIB_SUFFIX) quirc-demo quirc-scanner
+@@ -45,7 +45,7 @@ DEMO_UTIL_OBJ = \
+ 
+ OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2>&1)
+ OPENCV_LIBS = $(shell pkg-config --libs opencv4)
+-QUIRC_CXXFLAGS = $(QUIRC_CFLAGS) $(OPENCV_CFLAGS) --std=c++17
++QUIRC_CXXFLAGS = $(QUIRC_CFLAGS) --std=c++17
+ 
+ .PHONY: all v4l sdl opencv install uninstall clean
+ 
+@@ -93,15 +93,12 @@ libquirc.$(VERSIONED_LIB_SUFFIX): $(LIB_OBJ)
+ .cxx.o:
+ 	$(CXX) $(QUIRC_CXXFLAGS) -o $@ -c $<
+ 
+-install: libquirc.a libquirc.$(LIB_SUFFIX) quirc-demo quirc-scanner
++install: libquirc.a libquirc.$(LIB_SUFFIX)
+ 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include
+ 	install -o root -g root -m 0644 libquirc.a $(DESTDIR)$(PREFIX)/lib
  	install -o root -g root -m 0755 libquirc.$(VERSIONED_LIB_SUFFIX) \
  		$(DESTDIR)$(PREFIX)/lib
  	cp -d libquirc.$(LIB_SUFFIX) $(DESTDIR)$(PREFIX)/lib
@@ -12,3 +37,6 @@ index 8327b4e..c269291 100644
  
  uninstall:
  	rm -f $(DESTDIR)$(PREFIX)/include/quirc.h
+-- 
+2.42.2
+


### PR DESCRIPTION
According to https://github.com/NixOS/nixpkgs/pull/389124#issuecomment-2722911127, the build is broken on darwin.

This is an attempt to fix it by reverting the change to the patch while keeping the change dropping SDL dep. The old patch does basically the same thing, while unbricking darwin. I do not have darwin builder access, so @GaetanLepage if you could run it throguh that would be appreciated.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
