### PR TITLE
ISSUE_TEMPLATE: avoid using maintainer usernames as headings (part 2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -102,6 +102,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -116,6 +116,7 @@ body:
         If this issue is related to the Darwin packaging architecture as a whole, or is related to the core Darwin frameworks, consider mentioning the `@NixOS/darwin-core` team.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -106,6 +106,7 @@ body:
         If in doubt, check `git blame` for whoever last touched the module, or check the associated package's maintainers. Please add the mentions above the `---` characters.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -109,6 +109,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/09_documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/09_documentation_request.yml
@@ -48,6 +48,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)

--- a/.github/ISSUE_TEMPLATE/10_unreproducible_package.yml
+++ b/.github/ISSUE_TEMPLATE/10_unreproducible_package.yml
@@ -121,6 +121,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
       value: |
 
+
         ---
 
         **Note for maintainers:** Please tag this issue in your pull request description. (i.e. `Resolves #ISSUE`.)


### PR DESCRIPTION
Continued from #387825

## Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).