### PR TITLE
home-assistant-custom-components.sleep_as_android: init at 2.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3181,6 +3181,12 @@
     githubId = 77934086;
     keys = [ { fingerprint = "4CA3 48F6 8FE1 1777 8EDA 3860 B9A2 C1B0 25EC 2C55"; } ];
   };
+  blenderfreaky = {
+    name = "blenderfreaky";
+    email = "nix@blenderfreaky.de";
+    github = "blenderfreaky";
+    githubId = 14351657;
+  };
   blinry = {
     name = "blinry";
     email = "mail@blinry.org";

--- a/pkgs/servers/home-assistant/custom-components/sleep_as_android/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/sleep_as_android/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  pyhaversion,
+  nix-update-script,
+  # Test dependencies
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+  aiohttp-cors,
+  paho-mqtt,
+}:
+let
+  version = "2.3.2";
+in
+buildHomeAssistantComponent {
+  owner = "IATkachenko";
+  domain = "sleep_as_android";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "IATkachenko";
+    repo = "HA-SleepAsAndroid";
+    tag = "v${version}";
+    hash = "sha256-aJKjHZcRdmiXJdtWRY4fv5oxCHTDIVpvZEwhIE9ISv8=";
+  };
+
+  dependencies = [
+    pyhaversion
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-homeassistant-custom-component
+    aiohttp-cors
+    paho-mqtt
+  ];
+
+  pytestFlagsArray = [
+    # Fixes `AttributeError: 'async_generator' object has no attribute 'data'`
+    #  See https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/158
+    "--asyncio-mode=auto"
+  ];
+
+  disabledTests = [
+    # Broken on upstream, see https://github.com/IATkachenko/HA-SleepAsAndroid/issues/85
+    #  AttributeError: module 'homeassistant.data_entry_flow' has no attribute 'RESULT_TYPE_FORM'
+    "test_successful_config_flow"
+    "test_options_flow"
+
+    # Likely fails due to --asyncio-mode=auto
+    #  TypeError: object MagicMock can't be used in 'await' expression
+    "test_async_setup_entry"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Sleep As Android integration for Home Assistant";
+    homepage = "https://github.com/IATkachenko/HA-SleepAsAndroid";
+    changelog = "https://github.com/IATkachenko/HA-SleepAsAndroid/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ blenderfreaky ];
+  };
+}


### PR DESCRIPTION
Adds Sleep as Android integration to Home Assistant custom components.

Have been using this successfully for around a month now, so functionality seems solid.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
