### PR TITLE
add script to update vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
+++ b/pkgs/applications/editors/vscode/extensions/update_installed_exts.sh
@@ -40,7 +40,15 @@ function get_vsixpkg() {
     URL="https://$1.gallery.vsassets.io/_apis/public/gallery/publisher/$1/extension/$2/latest/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
 
     # Quietly but delicately curl down the file, blowing up at the first sign of trouble.
-    curl --silent --show-error --retry 3 --fail -X GET -o "$EXTTMP/$N.zip" "$URL"
+    curl --silent --show-error --retry 3 --fail -X GET -o "$EXTTMP/$N.zip" "$URL" || {
+        if (($? > 128))
+        then exit $?
+        fi
+        cat >&2 <<EOF
+unable to download $N
+EOF
+        return
+}
     # Unpack the file we need to stdout then pull out the version
     VER=$(jq -r '.version' <(unzip -qc "$EXTTMP/$N.zip" "extension/package.json"))
     # Calculate the hash
@@ -73,7 +81,7 @@ if [ -z "$CODE" ]; then
 fi
 
 # Try to be a good citizen and clean up after ourselves if we're killed.
-trap clean_up SIGINT
+trap clean_up EXIT
 
 # Begin the printing of the nix expression that will house the list of extensions.
 printf '{ extensions = [\n'

--- a/pkgs/applications/editors/vscode/extensions/write_updates_installed_exts.py
+++ b/pkgs/applications/editors/vscode/extensions/write_updates_installed_exts.py
@@ -1,0 +1,36 @@
+# I am not putting a nix-shell shebang here because I can't be bothered to figure out how to put a Python package into it
+
+from json import loads
+from sys import stderr
+from regex import MULTILINE, subn
+import fileinput
+
+if __name__ == "__main__":
+    with open("./default.nix", "r") as file:
+        contents = file.read()
+
+    for line in fileinput.input(encoding="utf-8"):
+        match loads(line):
+            case {"name": name, "publisher": publisher, "version": version, "hash": hash}:
+                pass  # only for assignment
+            case _:
+                raise RuntimeError
+
+        pattern = fr"""(?<="?{publisher}"?\."?{name}"?\s*=\s*buildVscodeMarketplaceExtension\s*{{\s*mktplcRef\s*=\s*){{[^{{}}]*}}(?=;)"""
+
+        replacement = f"""{{
+          publisher = "{publisher}";
+          name = "{name}";
+          version = "{version}";
+          hash = "{hash}";
+        }}"""  # indentation here is somewhat important!
+
+        contents, subcount = subn(pattern, replacement, contents, MULTILINE)
+
+        assert subcount <= 1
+        if subcount == 0:
+            print(f"failed to find match for {line}", file=stderr)
+
+    with open("./default.nix", "w") as file:
+        file.write(contents)
+


### PR DESCRIPTION
- **vscode/extensions/update_installed_exts.sh: log on download failure instead of early exit**
- **vscode/extensions/update_installed_exts.sh: add json output format**
- **vscode/extensions: add script to write new versions from update_installed_exts.sh**

Obsoletes #388747.

Could use some polish, or comments. But it works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
