### PR TITLE
uwsgi: remove python2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -268,6 +268,8 @@
 
 - `isd` was updated from 0.2.0 to 0.5.1, the new version may crash with a previously generated config, try moving or deleting `~/.config/isd/schema.json`.
 
+- `uwsgi` no longer supports Python 2 plugins.
+
 - `asusd` has been upgraded to version 6 which supports multiple aura devices. To account for this, the single `auraConfig` configuration option has been replaced with `auraConfigs` which is an attribute set of config options per each device. The config files may also be now specified as either source files or text strings; to account for this you will need to specify that `text` is used for your existing configs, e.g.:
   ```diff
   -services.asusd.asusdConfig = '''file contents'''

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -33,19 +33,8 @@ let
           c.plugins or cfg.plugins;
       plugins = unique plugins';
 
-      hasPython = v: filter (n: n == "python${v}") plugins != [ ];
-      hasPython2 = hasPython "2";
-      hasPython3 = hasPython "3";
-
-      python =
-        if hasPython2 && hasPython3 then
-          throw "`plugins` attribute in uWSGI configuration shouldn't contain both python2 and python3"
-        else if hasPython2 then
-          cfg.package.python2
-        else if hasPython3 then
-          cfg.package.python3
-        else
-          null;
+      hasPython3 = filter (n: n == "python3") plugins != [ ];
+      python = if hasPython3 then cfg.package.python3 else null;
 
       pythonEnv = python.withPackages (c.pythonPackages or (self: [ ]));
 

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -8,7 +8,7 @@
   libxcrypt,
   expat,
   zlib,
-  # plugins: list of strings, eg. [ "python2" "python3" ]
+  # plugins: list of strings, eg. [ "python3" ]
   plugins ? [ ],
   pam,
   withPAM ? stdenv.hostPlatform.isLinux,
@@ -16,7 +16,6 @@
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   libcap,
   withCap ? stdenv.hostPlatform.isLinux,
-  python2,
   python3,
   ncurses,
   ruby,
@@ -31,25 +30,20 @@ let
     apxs2Support = false;
   };
 
-  pythonPlugin =
-    pkg:
-    lib.nameValuePair "python${if pkg.isPy2 then "2" else "3"}" {
-      interpreter = pkg.pythonOnBuildForHost.interpreter;
+  available = lib.listToAttrs [
+    (lib.nameValuePair "python3" {
+      interpreter = python3.pythonOnBuildForHost.interpreter;
       path = "plugins/python";
       inputs = [
-        pkg
+        python3
         ncurses
       ];
       install = ''
-        install -Dm644 uwsgidecorators.py $out/${pkg.sitePackages}/uwsgidecorators.py
-        ${pkg.pythonOnBuildForHost.executable} -m compileall $out/${pkg.sitePackages}/
-        ${pkg.pythonOnBuildForHost.executable} -O -m compileall $out/${pkg.sitePackages}/
+        install -Dm644 uwsgidecorators.py $out/${python3.sitePackages}/uwsgidecorators.py
+        ${python3.pythonOnBuildForHost.executable} -m compileall $out/${python3.sitePackages}/
+        ${python3.pythonOnBuildForHost.executable} -O -m compileall $out/${python3.sitePackages}/
       '';
-    };
-
-  available = lib.listToAttrs [
-    (pythonPlugin python2)
-    (pythonPlugin python3)
+    })
     (lib.nameValuePair "rack" {
       path = "plugins/rack";
       inputs = [ ruby ];
@@ -91,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "unbit";
     repo = "uwsgi";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-/7Z9lq7JiGBrTpmtbIEqpMg7nw9SVm8ypmzd1/p6xgU=";
   };
 
@@ -128,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
   UWSGI_INCLUDES = lib.optionalString withCap "${libcap.dev}/include";
 
   passthru = {
-    inherit python2 python3;
+    inherit python3;
     tests.uwsgi = nixosTests.uwsgi;
   };
 


### PR DESCRIPTION
Currently trying to see how well nixpkgs can survive without python2, as it refuses to eval without `NIXPKGS_ALLOW_INSECURE=1`.

When such a change leads to 0 rebuilds (nixpkgs-review shows the same), it should be a simple merge?
Or must PRs that handle insecure / broken packages be reviewed differently?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've been trying to see how well nixpkgs can survive without python2.
With 
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
