### PR TITLE
kirsch: init at 0.6.1

### DIFF
--- a/pkgs/by-name/ki/kirsch/package.nix
+++ b/pkgs/by-name/ki/kirsch/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kirsch";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchzip {
     url = "https://github.com/molarmanful/kirsch/releases/download/v${finalAttrs.version}/kirsch-release_v${finalAttrs.version}.zip";
-    hash = "sha256-0wqPFb2pJL94ktGwC7LtY63BDg1XFqKuQeKCAr4Xakc=";
+    hash = "sha256-rytN6FrT2JzwqS2otlg4nXUNCsO84pYtV+LEB8U8ZBE=";
   };
 
   nativeBuildInputs = [ xorg.mkfontscale ];

--- a/pkgs/by-name/ki/kirsch/package.nix
+++ b/pkgs/by-name/ki/kirsch/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kirsch";
-  version = "0.3.4";
+  version = "0.5.0";
 
   src = fetchzip {
     url = "https://github.com/molarmanful/kirsch/releases/download/v${finalAttrs.version}/kirsch-release_v${finalAttrs.version}.zip";
-    hash = "sha256-9B5YJLAZRPs+IuIjUwSG96pbeHL/aWnKUgCeWxVp8j8=";
+    hash = "sha256-0wqPFb2pJL94ktGwC7LtY63BDg1XFqKuQeKCAr4Xakc=";
   };
 
   nativeBuildInputs = [ xorg.mkfontscale ];

--- a/pkgs/by-name/ki/kirsch/package.nix
+++ b/pkgs/by-name/ki/kirsch/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "kirsch";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchzip {
     url = "https://github.com/molarmanful/kirsch/releases/download/v${finalAttrs.version}/kirsch-release_v${finalAttrs.version}.zip";
-    hash = "sha256-rytN6FrT2JzwqS2otlg4nXUNCsO84pYtV+LEB8U8ZBE=";
+    hash = "sha256-6POi3N1JX6FFWHwqOlB3mrkHMYG+TJXz9URarbSPrZw=";
   };
 
   nativeBuildInputs = [ xorg.mkfontscale ];

--- a/pkgs/by-name/ki/kirsch/package.nix
+++ b/pkgs/by-name/ki/kirsch/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  xorg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kirsch";
+  version = "0.3.4";
+
+  src = fetchzip {
+    url = "https://github.com/molarmanful/kirsch/releases/download/v${finalAttrs.version}/kirsch-release_v${finalAttrs.version}.zip";
+    hash = "sha256-9B5YJLAZRPs+IuIjUwSG96pbeHL/aWnKUgCeWxVp8j8=";
+  };
+
+  nativeBuildInputs = [ xorg.mkfontscale ];
+
+  installPhase = ''
+    runHook preInstall
+
+    misc="$out/share/fonts/misc"
+    install -D -m 644 *.{bdf,otb,pcf} -t "$misc"
+    install -D -m 644 *.ttf -t "$out/share/fonts/truetype"
+
+    # create fonts.dir so NixOS xorg module adds to fp
+    mkfontdir "$misc"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Versatile bitmap font with an organic flair";
+    homepage = "https://github.com/molarmanful/kirsch";
+    changelog = "https://github.com/molarmanful/kirsch/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      ejiektpobehuk
+    ];
+  };
+})


### PR DESCRIPTION
Adds [kirsch](https://github.com/molarmanful/kirsch) font - A versatile bitmap font with an organic flair.

closes https://github.com/molarmanful/kirsch/issues/9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
