### PR TITLE
adrs: fix src hash

### DIFF
--- a/pkgs/by-name/ad/adrs/package.nix
+++ b/pkgs/by-name/ad/adrs/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     owner = "joshrotenberg";
     repo = "adrs";
     rev = "v${version}";
-    hash = "sha256-BnbI5QsrnyEQFpTWqOPrbZnVa7J3vaByO9fnKd5t64o=";
+    hash = "sha256-C9Kg7xY3Q0xsd2DlUcc3OM+/hyzmwz55oi6Ul3K7zkM=";
   };
 
   useFetchCargoVendor = true;


### PR DESCRIPTION
The hash is marked as incorrect when trying to build adrs 0.3.0. The build succeeds when replacing the rev with
9ffcadfcc7c014b158e7ad54374172cb0dd6df53
which is the same rev as the tag.

Updated the src hash so the build succeeds again.

@ryantm for visibility since the last update was made with @r-ryantm. What is more peculiar is that the update was made on Feb 9, 2025, 4:32 PM PST, but the tag was created on Feb 10, 2025, 8:14 AM PST.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
