### PR TITLE
various: use libpq instead of postgresql

### DIFF
--- a/pkgs/applications/blockchains/lighthouse/default.nix
+++ b/pkgs/applications/blockchains/lighthouse/default.nix
@@ -7,7 +7,6 @@
 , nix-update-script
 , openssl
 , pkg-config
-, libpq
 , protobuf
 , rustPlatform
 , rust-jemalloc-sys
@@ -117,10 +116,6 @@ rustPlatform.buildRustPackage rec {
     "--skip subnet_service::tests::attestation_service::test_subscribe_same_subnet_several_slots_apart"
     "--skip subnet_service::tests::sync_committee_service::same_subscription_with_lower_until_epoch"
     "--skip subnet_service::tests::sync_committee_service::subscribe_and_unsubscribe"
-  ];
-
-  nativeCheckInputs = [
-    libpq
   ];
 
   passthru = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -210,7 +210,7 @@ in
   poke = addPackageRequires super.poke [ self.poke-mode ];
 
   pq = super.pq.overrideAttrs (old: {
-    buildInputs = old.buildInputs or [ ] ++ [ pkgs.postgresql ];
+    buildInputs = old.buildInputs or [ ] ++ [ pkgs.libpq ];
   });
 
   preview-auto = mkHome super.preview-auto;

--- a/pkgs/by-name/bi/biboumi/package.nix
+++ b/pkgs/by-name/bi/biboumi/package.nix
@@ -14,7 +14,7 @@
   withIDN ? true,
   libidn,
   withPostgreSQL ? false,
-  postgresql,
+  libpq,
   withSQLite ? true,
   sqlite,
   withUDNS ? true,
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       botan2
     ]
     ++ lib.optional withIDN libidn
-    ++ lib.optional withPostgreSQL postgresql
+    ++ lib.optional withPostgreSQL libpq
     ++ lib.optional withSQLite sqlite
     ++ lib.optional withUDNS udns;
 

--- a/pkgs/by-name/gl/glom/package.nix
+++ b/pkgs/by-name/gl/glom/package.nix
@@ -31,7 +31,7 @@
   isocodes,
   gtksourceview,
   gtksourceviewmm,
-  postgresql_15,
+  postgresql,
   gobject-introspection,
   yelp-tools,
   wrapGAppsHook3,
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     isocodes
     gtksourceview
     gtksourceviewmm
-    postgresql_15 # for postgresql utils
+    postgresql # for postgresql utils
   ];
 
   enableParallelBuilding = true;
@@ -128,7 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--with-boost-python=boost_python${lib.versions.major python311.version}${lib.versions.minor python311.version}"
-    "--with-postgres-utils=${lib.getBin postgresql_15}/bin"
+    "--with-postgres-utils=${lib.getBin postgresql}/bin"
   ];
 
   makeFlags = [

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -15,7 +15,7 @@
   libmysqlclient,
   log4cplus,
   openssl,
-  postgresql,
+  libpq,
   python3,
 
   # tests
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
       "--localstatedir=/var"
       "--with-openssl=${lib.getDev openssl}"
     ]
-    ++ lib.optional withPostgres "--with-pgsql=${lib.getDev postgresql}/bin/pg_config"
+    ++ lib.optional withPostgres "--with-pgsql=${lib.getDev libpq}/bin/pg_config"
     ++ lib.optional withMysql "--with-mysql=${lib.getDev libmysqlclient}/bin/mysql_config";
 
   postConfigure = ''

--- a/pkgs/by-name/pg/pg_top/package.nix
+++ b/pkgs/by-name/pg/pg_top/package.nix
@@ -4,7 +4,7 @@
   lib,
   libbsd,
   ncurses,
-  postgresql,
+  libpq,
   stdenv,
 }:
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libbsd
+    libpq
     ncurses
-    postgresql
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -146,7 +146,7 @@ in
   );
   openssl = addToBuildInputs pkgs.openssl;
   plot = addToBuildInputs pkgs.plotutils;
-  postgresql = addToBuildInputsWithPkgConfig pkgs.postgresql;
+  postgresql = addToBuildInputsWithPkgConfig pkgs.libpq;
   rocksdb = addToBuildInputs pkgs.rocksdb_8_3;
   scheme2c-compatibility = addPkgConfig;
   sdl-base =

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -59,7 +59,7 @@ let
       nativeLibs = [ pkgs.mariadb.client ];
     });
     clsql-postgresql = super.clsql-postgresql.overrideLispAttrs (o: {
-      nativeLibs = [ pkgs.postgresql.lib ];
+      nativeLibs = [ pkgs.libpq ];
     });
     clsql-sqlite3 = super.clsql-sqlite3.overrideLispAttrs (o: {
       nativeLibs = [ pkgs.sqlite ];

--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  libpq,
+  postgresql,
   unittestCheckHook,
 }:
 
@@ -22,7 +22,10 @@ buildPythonPackage rec {
 
   unittestFlagsArray = [ "test" ];
 
-  propagatedBuildInputs = [ libpq ];
+  propagatedBuildInputs = [ postgresql ];
+
+  # To find "ecpg"
+  nativeBuildInputs = [ (lib.getDev postgresql) ];
 
   meta = with lib; {
     homepage = "https://github.com/markdrago/pgsanity";

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -335,7 +335,6 @@ let
   };
 
   packagesWithNativeBuildInputs = {
-    adbcpostgresql = [ pkgs.postgresql ];
     adimpro = [ pkgs.imagemagick ];
     animation = [ pkgs.which ];
     Apollonius = with pkgs; [ pkg-config gmp.dev mpfr.dev ];
@@ -484,8 +483,7 @@ let
     RODBC = [ pkgs.libiodbc ];
     rpanel = [ pkgs.tclPackages.bwidget ];
     Rpoppler = [ pkgs.poppler ];
-    RPostgres = with pkgs; [ postgresql ];
-    RPostgreSQL = with pkgs; [ postgresql postgresql ];
+    RPostgreSQL = with pkgs; [ libpq ];
     RProtoBuf = [ pkgs.protobuf ];
     RSclient = [ pkgs.openssl.dev ];
     Rserve = [ pkgs.openssl ];
@@ -614,7 +612,7 @@ let
 
   packagesWithBuildInputs = {
     # sort -t '=' -k 2
-    adbcpostgresql = with pkgs; [ readline.dev zlib.dev openssl.dev libkrb5.dev openpam ];
+    adbcpostgresql = with pkgs; [ readline.dev zlib.dev openssl.dev libkrb5.dev openpam libpq ];
     asciicast = with pkgs; [ xz.dev bzip2.dev zlib.dev icu.dev libdeflate ];
     island = [ pkgs.gsl.dev ];
     svKomodo = [ pkgs.which ];
@@ -646,6 +644,7 @@ let
     RGtk2 = [ pkgs.pkg-config ];
     RProtoBuf = [ pkgs.pkg-config ];
     Rpoppler = [ pkgs.pkg-config ];
+    RPostgres = with pkgs; [ libpq ];
     XML = [ pkgs.pkg-config ];
     apsimx = [ pkgs.which ];
     cairoDevice = [ pkgs.pkg-config ];
@@ -1623,14 +1622,6 @@ let
 
       # consumes a lot of resources in parallel
       enableParallelBuilding = false;
-    });
-
-    RPostgres = old.RPostgres.overrideAttrs (attrs: {
-      preConfigure = ''
-        export INCLUDE_DIR=${pkgs.postgresql}/include
-        export LIB_DIR=${pkgs.postgresql.lib}/lib
-        patchShebangs configure
-        '';
     });
 
     OpenMx = old.OpenMx.overrideAttrs (attrs: {

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -42,7 +42,7 @@ mkDerivation {
     loki
     libmysqlclient
     openssl
-    postgresql
+    postgresql # needs libecpg, which is not available in libpq package
     qscintilla
     qtbase
   ];

--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -7,7 +7,7 @@
   shared-mime-info,
   xz,
   mariadb,
-  postgresql,
+  libpq,
   sqlite,
   backend ? "mysql",
 }:
@@ -32,7 +32,7 @@ mkKdeDerivation {
       "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
     ]
     ++ lib.optionals (backend == "postgres") [
-      "-DPOSTGRES_PATH=${lib.getBin postgresql}/bin"
+      "-DPOSTGRES_PATH=${lib.getBin libpq}/bin"
     ];
 
   extraNativeBuildInputs = [
@@ -47,7 +47,7 @@ mkKdeDerivation {
       xz
     ]
     ++ lib.optionals (backend == "mysql") [ mariadb ]
-    ++ lib.optionals (backend == "postgres") [ postgresql ]
+    ++ lib.optionals (backend == "postgres") [ libpq ]
     ++ lib.optionals (backend == "sqlite") [ sqlite ];
 
   # Hardcoded as a QString, which is UTF-16 so Nix can't pick it up automatically
@@ -60,6 +60,6 @@ mkKdeDerivation {
       echo "${mariadb}" > $out/nix-support/depends
     ''
     + lib.optionalString (backend == "postgres") ''
-      echo "${postgresql}" > $out/nix-support/depends
+      echo "${libpq}" > $out/nix-support/depends
     '';
 }

--- a/pkgs/top-level/pkg-config/pkg-config-data.json
+++ b/pkgs/top-level/pkg-config/pkg-config-data.json
@@ -525,7 +525,7 @@
     },
     "libpq": {
       "attrPath": [
-        "postgresql"
+        "libpq"
       ]
     },
     "libpulse": {


### PR DESCRIPTION
Also fixes a few other users of postgresql/libpq. Split from #388807, because it probably doesn't need to target staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
