### PR TITLE
nixos/limine: fix the install script

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -189,7 +189,7 @@ def find_mounted_device(path: str) -> str:
     while not os.path.ismount(path):
         path = os.path.dirname(path)
 
-    devices = [x for x in psutil.disk_partitions(all=True) if x.mountpoint == path]
+    devices = [x for x in psutil.disk_partitions() if x.mountpoint == path]
 
     assert len(devices) == 1
     return devices[0].device
@@ -399,11 +399,12 @@ def main():
 
         if config('forceMbr'):
             limine_deploy_args += '--force-mbr'
-            try:
-                subprocess.run(limine_deploy_args)
-            except:
-                raise Exception(
-                    'Failed to deploy BIOS stage 1 Limine bootloader!\n' +
-                    'You might want to try enabling the `boot.loader.limine.forceMbr` option.')
+
+        try:
+            subprocess.run(limine_deploy_args)
+        except:
+            raise Exception(
+                'Failed to deploy BIOS stage 1 Limine bootloader!\n' +
+                'You might want to try enabling the `boot.loader.limine.forceMbr` option.')
 
 main()


### PR DESCRIPTION
This is a follow-up on #386368, due to a failure in the install script pointed out to me [here](https://github.com/NixOS/nixpkgs/pull/386368#issuecomment-2720430163).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
