### PR TITLE
xdg-desktop-portal-luminous: init at 0.1.8

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-luminous/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  meson,
+  ninja,
+  libclang,
+  clang,
+  xdg-desktop-portal,
+  slurp,
+  cairo,
+  pango,
+  libxkbcommon,
+  glib,
+  pipewire,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xdg-desktop-portal-luminous";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "waycrate";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-7i6+arKWubziDmy07FocDDiJdOWAszhO7yOOI1iPfds=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-fatlvc+MoAJZGW/5alnDu1PQyK6mnE0aNQAhrMg7Hio=";
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    clang
+    libclang
+  ];
+  buildInputs = [
+    xdg-desktop-portal
+    slurp
+    cairo
+    pango
+    glib
+    pipewire
+    libxkbcommon
+  ];
+
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  configurePhase = ''
+    meson build --prefix=$out --libexecdir=$out/lib --buildtype=release
+  '';
+
+  buildPhase = ''
+    ninja -C build
+  '';
+
+  installPhase = ''
+    ninja -C build install
+  '';
+
+  meta = with lib; {
+    description = "xdg-desktop-portal backend for wlroots based compositors, providing screenshot and screencast";
+    homepage = "https://github.com/waycrate/xdg-desktop-portal-luminous";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ Rishik-Y ];
+  };
+}


### PR DESCRIPTION
## Package Information

- Package name: xdg-desktop-portal-luminous
- Latest released version: 0.1.8
- Current version on the unstable channel: none
- Current version on the stable/release channel: none

An alternative to xdg-desktop-portal-wlr for wlroots compositors. This project is a stand alone binary and does not depend on grim. libwayshot is used as the screencopy backend to enable screenshots.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
