### PR TITLE
hdr10plus: init at 2.1.3

### DIFF
--- a/pkgs/by-name/hd/hdr10plus/package.nix
+++ b/pkgs/by-name/hd/hdr10plus/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  rust,
+  rustPlatform,
+  hdr10plus_tool,
+  cargo-c,
+  fontconfig,
+}:
+
+let
+  inherit (lib) optionals concatStringsSep;
+  inherit (rust.envVars) setEnv;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "hdr10plus";
+  version = "2.1.3";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  inherit (hdr10plus_tool)
+    src
+    useFetchCargoVendor
+    cargoDeps
+    cargoHash
+    ;
+
+  nativeBuildInputs = [ cargo-c ];
+  buildInputs = [ fontconfig ];
+
+  cargoCFlags = [
+    "--package=hdr10plus"
+    "--frozen"
+    "--prefix=${placeholder "out"}"
+    "--includedir=${placeholder "dev"}/include"
+    "--pkgconfigdir=${placeholder "dev"}/lib/pkgconfig"
+    "--target=${stdenv.hostPlatform.rust.rustcTarget}"
+  ];
+
+  # mirror Cargo flags
+  cargoCBuildFlags =
+    optionals (finalAttrs.cargoBuildType != "debug") [
+      "--profile=${finalAttrs.cargoBuildType}"
+    ]
+    ++ optionals (finalAttrs.cargoBuildNoDefaultFeatures) [
+      "--no-default-features"
+    ]
+    ++ optionals (finalAttrs.cargoBuildFeatures != [ ]) [
+      "--features=${concatStringsSep "," finalAttrs.cargoBuildFeatures}"
+    ];
+
+  cargoCTestFlags =
+    optionals (finalAttrs.cargoCheckType != "debug") [
+      "--profile=${finalAttrs.cargoCheckType}"
+    ]
+    ++ optionals (finalAttrs.cargoCheckNoDefaultFeatures) [
+      "--no-default-features"
+    ]
+    ++ optionals (finalAttrs.cargoCheckFeatures != [ ]) [
+      "--features=${concatStringsSep "," finalAttrs.cargoCheckFeatures}"
+    ];
+
+  configurePhase = ''
+    # let stdenv handle stripping
+    export "CARGO_PROFILE_''${cargoBuildType@U}_STRIP"=false
+
+    prependToVar cargoCFlags -j "$NIX_BUILD_CORES"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ${setEnv} cargo cbuild "''${cargoCFlags[@]}" "''${cargoCBuildFlags[@]}"
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${setEnv} cargo ctest "''${cargoCFlags[@]}" "''${cargoCTestFlags[@]}"
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${setEnv} cargo cinstall "''${cargoCFlags[@]}" "''${cargoCBuildFlags[@]}"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    inherit hdr10plus_tool;
+  };
+
+  meta = {
+    description = "Library to work with HDR10+ in HEVC files";
+    homepage = "https://github.com/quietvoid/hdr10plus_tool";
+    changelog = "https://github.com/quietvoid/hdr10plus_tool/releases/tag/${hdr10plus_tool.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mvs ];
+    pkgConfigModules = [ "hdr10plus-rs" ];
+  };
+})

--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -6,6 +6,7 @@
   nasm,
   cpuinfo,
   libdovi,
+  hdr10plus,
   unstableGitUpdater,
 }:
 
@@ -33,8 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
       {
         USE_EXTERNAL_CPUINFO = true;
         LIBDOVI_FOUND = true;
-        # enable when libhdr10plus is available
-        # LIBHDR10PLUS_RS_FOUND = true;
+        LIBHDR10PLUS_RS_FOUND = true;
       };
 
   nativeBuildInputs = [
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cpuinfo
     libdovi
+    hdr10plus
   ];
 
   passthru.updateScript = unstableGitUpdater {


### PR DESCRIPTION
This adds the C bindings of [hdr10plus](https://github.com/quietvoid/hdr10plus_tool/tree/main/hdr10plus).

I considered simply adding new outputs to the existing `hdr10plus_tool` package, the C bindings however require different Cargo features and I fear that building them together would pollute the build environment without any added benefit.

The second commit enables automatic updating of the library version whenever `hdr10plus_tool` is updated.

The third commit enables use of the library in `svt-av1-psy`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
