### PR TITLE
postgresqlTestHook: shutdown on failure

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -251,6 +251,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /maintainers/scripts/kde @K900 @NickCao @SuperSandro2000 @ttuegel
 
 # PostgreSQL and related stuff
+/pkgs/by-name/po/postgresqlTestHook @NixOS/postgres
 /pkgs/by-name/ps/psqlodbc @NixOS/postgres
 /pkgs/servers/sql/postgresql @NixOS/postgres
 /pkgs/development/tools/rust/cargo-pgrx @NixOS/postgres

--- a/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
+++ b/pkgs/by-name/po/postgresqlTestHook/postgresql-test-hook.sh
@@ -1,5 +1,5 @@
-preCheckHooks+=('postgresqlStart')
-postCheckHooks+=('postgresqlStop')
+preCheckHooks+=(postgresqlStart)
+postCheckHooks+=(postgresqlStop)
 
 
 postgresqlStart() {
@@ -69,6 +69,7 @@ EOF
 
   echo 'starting postgresql'
   eval "${postgresqlStartCommands:-pg_ctl start}"
+  failureHooks+=(postgresqlStop)
 
   echo 'setting up postgresql'
   eval "$postgresqlTestSetupCommands"
@@ -80,4 +81,5 @@ EOF
 postgresqlStop() {
   echo 'stopping postgresql'
   pg_ctl stop
+  failureHooks=("${failureHooks[@]/postgresqlStop}")
 }

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -7,10 +7,9 @@
   postgresql,
   postgresqlBuildExtension,
   runtimeShell,
-  stdenv,
 }:
 
-postgresqlBuildExtension (finalAttrs: {
+postgresqlBuildExtension {
   pname = "postgresql_anonymizer";
 
   inherit (pg-dump-anon) version src;
@@ -32,4 +31,4 @@ postgresqlBuildExtension (finalAttrs: {
   meta = lib.getAttrs [ "homepage" "teams" "license" ] pg-dump-anon.meta // {
     description = "Extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database";
   };
-})
+}

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -5,7 +5,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 let

--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -7,7 +7,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -4,7 +4,6 @@
   postgresql,
   postgresqlBuildExtension,
   protobufc,
-  stdenv,
 }:
 
 postgresqlBuildExtension {

--- a/pkgs/servers/sql/postgresql/ext/hypopg.nix
+++ b/pkgs/servers/sql/postgresql/ext/hypopg.nix
@@ -4,7 +4,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
+++ b/pkgs/servers/sql/postgresql/ext/jsonb_deep_sum.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension {

--- a/pkgs/servers/sql/postgresql/ext/lantern.nix
+++ b/pkgs/servers/sql/postgresql/ext/lantern.nix
@@ -6,7 +6,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg-semver.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg-semver.nix
@@ -4,7 +4,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  testers,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 let

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_libversion.nix
@@ -6,7 +6,6 @@
   pkg-config,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_net.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_net.nix
@@ -4,7 +4,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -5,7 +5,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
   testers,
 }:
 

--- a/pkgs/servers/sql/postgresql/ext/pg_roaringbitmap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_roaringbitmap.nix
@@ -3,8 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  postgresqlTestHook,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 with {

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -4,7 +4,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension {

--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -5,7 +5,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pg_topn.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_topn.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension rec {

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -5,7 +5,6 @@
   openssl,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 let

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -5,7 +5,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
   unstableGitUpdater,
 }:
 

--- a/pkgs/servers/sql/postgresql/ext/pgmq.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgmq.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -6,7 +6,6 @@
   pkg-config,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
   xxHash,
 }:
 

--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -6,7 +6,6 @@
   perl,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pgsodium.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsodium.nix
@@ -6,7 +6,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
@@ -4,7 +4,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -45,7 +45,6 @@ postgresqlBuildExtension (finalAttrs: {
       SELECT * FROM finish();
       ROLLBACK;
     '';
-    failureHook = "postgresqlStop";
     checkPhase = ''
       runHook preCheck
       psql -a -v ON_ERROR_STOP=1 -f $sqlPath

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
@@ -4,7 +4,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -8,7 +8,6 @@
   postgresqlTestExtension,
   R,
   rPackages,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/pltcl.nix
+++ b/pkgs/servers/sql/postgresql/ext/pltcl.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlTestExtension,
-  tcl,
   tclPackages,
 }:
 

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -92,7 +92,6 @@ postgresqlBuildExtension (finalAttrs: {
   ];
 
   postgresqlTestUserOptions = "LOGIN SUPERUSER";
-  failureHook = "postgresqlStop";
 
   # postgis config directory assumes /include /lib from the same root for json-c library
   env.NIX_LDFLAGS = "-L${lib.getLib json_c}/lib";

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -6,7 +6,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/rum.nix
+++ b/pkgs/servers/sql/postgresql/ext/rum.nix
@@ -4,7 +4,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/smlar.nix
+++ b/pkgs/servers/sql/postgresql/ext/smlar.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension {

--- a/pkgs/servers/sql/postgresql/ext/system_stats.nix
+++ b/pkgs/servers/sql/postgresql/ext/system_stats.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 postgresqlBuildExtension (finalAttrs: {
   pname = "system_stats";

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -4,8 +4,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
-  unstableGitUpdater,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
+++ b/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
@@ -3,7 +3,6 @@
   lib,
   postgresql,
   postgresqlBuildExtension,
-  stdenv,
 }:
 
 postgresqlBuildExtension (finalAttrs: {

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -7,7 +7,6 @@
   postgresql,
   postgresqlBuildExtension,
   postgresqlTestExtension,
-  stdenv,
 
   enableUnfree ? true,
 }:

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -5,7 +5,6 @@ let
     {
       stdenv,
       fetchFromGitHub,
-      fetchpatch,
       fetchurl,
       lib,
       replaceVars,

--- a/pkgs/servers/sql/postgresql/postgresqlTestExtension.nix
+++ b/pkgs/servers/sql/postgresql/postgresqlTestExtension.nix
@@ -21,7 +21,6 @@ stdenvNoCC.mkDerivation (
       postgresqlTestHook
       (postgresql.withPackages (ps: [ finalPackage ] ++ (map (p: ps."${p}") withPackages)))
     ];
-    failureHook = "postgresqlStop";
     postgresqlTestUserOptions = "LOGIN SUPERUSER";
     passAsFile = [ "sql" ];
     sql =


### PR DESCRIPTION
~~This improves postgresqlTestHook in two aspects:~~
- ~~One is, that postgresql doesn't need to be added manually to every
nativeCheckInputs list anymore.~~
- ~~The other is, that all those tests now run with a specially pinned
PostgreSQL version, which can be updated independently via staging.~~

~~This allows us to ship updates to PostgreSQL faster by going to master
directly. In the normal case, the latest version and the test version
evaluate to the exact same derivation, so no duplicate builds. Only
while a minor update for the test version is going through staging, the
two versions differ temporarily.~~

Change of plans: Only some small improvements to `postgresqlTestHook` left.

## Things done

Hopefully the number of rebuilds is low enough for master :thinking: 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
