### PR TITLE
python3.pkgs.pysls: Fix build

### DIFF
--- a/pkgs/development/python-modules/pylsl/default.nix
+++ b/pkgs/development/python-modules/pylsl/default.nix
@@ -3,6 +3,7 @@
   liblsl,
   fetchFromGitHub,
   buildPythonPackage,
+  stdenv,
   numpy,
   setuptools,
   setuptools-scm,
@@ -23,7 +24,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pylsl/lib/__init__.py \
-      --replace "def find_liblsl_libraries(verbose=False):" "$(echo -e "def find_liblsl_libraries(verbose=False):\n    yield '${liblsl}/lib/liblsl.so'")"
+      --replace "def find_liblsl_libraries(verbose=False):" "$(echo -e "def find_liblsl_libraries(verbose=False):\n    yield '${liblsl}/lib/liblsl.${
+        if stdenv.hostPlatform.isDarwin then "dylib" else "so"
+      }'")"
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/pylsl/default.nix
+++ b/pkgs/development/python-modules/pylsl/default.nix
@@ -3,7 +3,9 @@
   liblsl,
   fetchFromGitHub,
   buildPythonPackage,
+  numpy,
   setuptools,
+  setuptools-scm,
   wheel,
 }:
 
@@ -20,16 +22,20 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace pylsl/pylsl.py \
+    substituteInPlace src/pylsl/lib/__init__.py \
       --replace "def find_liblsl_libraries(verbose=False):" "$(echo -e "def find_liblsl_libraries(verbose=False):\n    yield '${liblsl}/lib/liblsl.so'")"
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
+    setuptools-scm
     wheel
   ];
 
-  buildImputs = [ liblsl ];
+  dependencies = [
+    liblsl
+    numpy
+  ];
 
   pythonImportsCheck = [ "pylsl" ];
 


### PR DESCRIPTION
Fix the build of `python3.pkgs.pysls`, which was broken by #375144

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
