### PR TITLE
liblsl, python3.pkgs.pylsl: minor fixes

### DIFF
--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +16,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-nmu7Kxk4U5sGO8Od9JR4id4V4mjeibj4AHjUYhpGPeo=";
   };
+  passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/by-name/li/liblsl/package.nix
+++ b/pkgs/by-name/li/liblsl/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/sccn/liblsl/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ abcsds ];
-    mainProgram = "liblsl";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/python-modules/pylsl/default.nix
+++ b/pkgs/development/python-modules/pylsl/default.nix
@@ -47,6 +47,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/labstreaminglayer/pylsl";
     license = licenses.mit;
     maintainers = with maintainers; [ abcsds ];
-    mainProgram = "pylsl";
   };
 }


### PR DESCRIPTION
- `liblsl`, `python3.pkgs.pylsl`: remove `meta.mainProgram`
  [`mainProgram`] must be the name of a program the derivation ships under `bin/`, see [`lib.getExe`] ;
- `liblsl`: add `updateScript`, to help @r-ryantm keep this up-to-date
  `pylsl` shouldn't need an update script, as Repology presumably gets up-to-date versions from PyPI.

[`mainProgram`]: https://nixos.org/manual/nixpkgs/unstable/#var-meta-mainProgram
[`lib.getExe`]: https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.meta.getExe

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
