### PR TITLE
arpack-mpi: fix test failure on aarch64-linux platfrom

### DIFF
--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -2,7 +2,7 @@
 , gfortran, blas, lapack, eigen
 , useMpi ? false
 , mpi
-, openssh
+, mpiCheckPhaseHook
 , igraph
 , useAccel ? false #use Accelerate framework on darwin
 }:
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     blas lapack
   ]) ++ lib.optional useMpi mpi;
 
-  nativeCheckInputs = lib.optional useMpi openssh;
+  nativeCheckInputs = lib.optional useMpi mpiCheckPhaseHook;
   checkInputs =
     # work around for `ld: file not found: @rpath/libquadmath.0.dylib`
     # which occurs due to an mpi test linking with `-flat_namespace`

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
   # a couple tests fail when run in parallel
   doCheck = true;
   enableParallelChecking = false;
-  __darwinAllowLocalNetworking = true;
 
   env = lib.optionalAttrs useAccel {
     # Without these flags some tests will fail / segfault when using Accelerate


### PR DESCRIPTION
mpi based tests use mpiCheckPhaseHook now

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
