### PR TITLE
paru: correct shell completion file names

### DIFF
--- a/pkgs/by-name/pa/paru/package.nix
+++ b/pkgs/by-name/pa/paru/package.nix
@@ -53,9 +53,9 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     installManPage man/paru.8 man/paru.conf.5
-    installShellCompletion --bash completions/bash
-    installShellCompletion --fish completions/fish
-    installShellCompletion --zsh completions/zsh
+    installShellCompletion --name paru.bash --bash completions/bash
+    installShellCompletion --name paru.fish --fish completions/fish
+    installShellCompletion --name _paru --zsh completions/zsh
     cp -r locale "$out/share/"
   '';
 


### PR DESCRIPTION
Previously the package was installing shell completion files that did not have the binary name in their file name and therefore the completions were not being picked up by my shell (`zsh`). I think the issue stems from the way that  `installShellCompletion` determines the target completion file name when left without a static name. I have changed it to use static names for the completion files so they will actually be picked up by the completion systems. I merely copied the configuration used in the [PKGBUILD on the AUR (lines 45-47)](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=paru#n45).

I copied this package then made these same changes in my [home-manager flake](https://git.curtisjones.ca/nixos/home-manager) and `zsh` was then able to properly pick up completions for `paru`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
