### PR TITLE
makeBinaryWrapper: generate static executables when isStatic

### DIFF
--- a/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
+++ b/pkgs/by-name/ma/makeBinaryWrapper/make-binary-wrapper.sh
@@ -52,6 +52,7 @@ makeBinaryWrapper() {
         -Wno-overlength-strings \
         -Os \
         -x c \
+        @static@ \
         -o "$wrapper" -
 }
 

--- a/pkgs/by-name/ma/makeBinaryWrapper/package.nix
+++ b/pkgs/by-name/ma/makeBinaryWrapper/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   targetPackages,
   lib,
   makeSetupHook,
@@ -20,6 +21,7 @@ makeSetupHook {
         cc.isClang && !cc.stdenv.hostPlatform.isDarwin
       ) "--ld-path=${cc.targetPrefix}ld"
     }";
+    static = lib.optionalString stdenv.targetPlatform.isStatic "-static";
   };
 
   passthru = {


### PR DESCRIPTION
This seems like a desired change. On FreeBSD, the pkgsStatic stdenv is actually incapable of building dynamic executables, so this is required.

cc @wolfgangwalther, this is the thing that was causing pkgsCross.x86_64-freebsd.pkgsStatic.openssl to break.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
