### PR TITLE
[Backport release-24.11] Thunderbird: 133.0 -> 136.0; 128.7.1esr -> 128.8.0esr

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -93,8 +93,8 @@ rec {
   thunderbird-esr = thunderbird-128;
 
   thunderbird-128 = common {
-    version = "128.7.1esr";
-    sha512 = "3f84e1f1a83379da1f154b66dbb5f941d04548ad017aab32aa9520f4315edb524e3754ac1fe9a7ae27f7aa33e2881c6783f11ccc53cda713f107760b7d880667";
+    version = "128.8.0esr";
+    sha512 = "a6ccdf5a067a1f908246885b22a1dadc66f4667d4ac74d1c1867c88a70b194c508e8d9e139f357ebc1d344f032fdc9b75c365fe49937d2463d7bd61b85ef86d1";
 
     updateScript = callPackage ./update.nix {
       attrPath = "thunderbirdPackages.thunderbird-128";

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -81,8 +81,8 @@ rec {
   thunderbird = thunderbird-esr;
 
   thunderbird-latest = common {
-    version = "133.0";
-    sha512 = "8cf8973964cabdc7fafe83d1dfd4f9fbfd340638b1f3d396a98059c00650549b0f4a7bfc486a294b2966136266d4524d6c825a6ee344cd753ac2f7ab412cbc96";
+    version = "136.0";
+    sha512 = "37c94258b49a7e87b24b4cffaa6eae81698356ddc3f0f49ea675b885dea2c56a3ca758dac2ddb2720beaf2f34faa15a9ab9b5eda0b352c0c8f14167c01838714";
 
     updateScript = callPackage ./update.nix {
       attrPath = "thunderbirdPackages.thunderbird-latest";


### PR DESCRIPTION
Backporting https://github.com/NixOS/nixpkgs/pull/388975
(some trivial conflicts, auto-resolved by my git)

https://www.thunderbird.net/en-US/thunderbird/134.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2025-04/
    
    Fixes: CVE-2024-50336, CVE-2025-0237, CVE-2025-0238, CVE-2025-0239,
           CVE-2025-0240, CVE-2025-0241, CVE-2025-0242, CVE-2025-0243,
           CVE-2025-0247
    
https://www.thunderbird.net/en-US/thunderbird/135.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2025-11/
    
    Fixes: CVE-2025-1009, CVE-2025-1010, CVE-2025-1018, CVE-2025-1011,
           CVE-2205-1012, CVE-2025-1019, CVE-2025-1013, CVE-2025-1014,
           CVE-2025-0510, CVE-2025-1015, CVE-2025-1016, CVE-2025-1017,
           CVE-2025-1020,
    
https://www.thunderbird.net/en-US/thunderbird/136.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2025-17/
    
    Fixes: CVE-2025-26696, CVE-2025-26695, CVE-2025-1930, CVE-2025-1931,
           CVE-2025-1932, CVE-2025-1933, CVE-2025-1934, CVE-2025-1942,
           CVE-2025-1935, CVE-2025-1936, CVE-2025-1937, CVE-2025-1938,
           CVE-2025-1943



https://www.thunderbird.net/en-US/thunderbird/128.8.0esr/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2025-18/
    
    Fixes: CVE-2025-26696, CVE-2025-26695, CVE-2024-43097, CVE-2025-1930,
           CVE-2025-1931, CVE-2025-1932, CVE-2025-1933, CVE-2025-1934,
           CVE-2025-1935, CVE-2025-1936, CVE-2025-1937, CVE-2025-1938

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
