### PR TITLE
thunderbird-bin: add 137.0.2 as thunderbird-latest-bin

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/update.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/update.nix
@@ -94,7 +94,7 @@ writeScript "update-${pname}" ''
   }
   EOF
 
-  mv $tmpfile ${channel}_sources.nix
+  mv $tmpfile ${channel}${if versionSuffix == "" then "" else "_${versionSuffix}"}_sources.nix
 
   popd
 ''

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -3,6 +3,7 @@
 # To update `thunderbird-bin`'s `release_sources.nix`, run from the nixpkgs root:
 #
 #     nix-shell maintainers/scripts/update.nix --argstr package pkgs.thunderbird-bin-unwrapped
+#     nix-shell maintainers/scripts/update.nix --argstr package pkgs.thunderbird-esr-bin-unwrapped
 {
   lib,
   stdenv,
@@ -24,6 +25,7 @@
   systemLocale ? config.i18n.defaultLocale or "en_US",
   patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
   generated,
+  versionSuffix ? "",
   applicationName ? "Thunderbird",
 }:
 
@@ -63,8 +65,7 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/${version}/${source.arch}/${source.locale}/thunderbird-${version}.tar.bz2";
-    inherit (source) sha256;
+    inherit (source) url sha256;
   };
 
   nativeBuildInputs = [
@@ -112,12 +113,12 @@ stdenv.mkDerivation {
       curl
       gnupg
       runtimeShell
+      versionSuffix
       ;
     baseName = "thunderbird";
     channel = "release";
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
-    versionSuffix = "esr";
   };
 
   passthru = {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
@@ -1,0 +1,797 @@
+{
+  version = "128.9.2esr";
+  sources = [
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/af/thunderbird-128.9.2esr.tar.bz2";
+      locale = "af";
+      arch = "linux-x86_64";
+      sha256 = "aedc246acba5af959ba0413882aa149a458841ac254d62a1f5dafd3bdd9cc472";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ar/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ar";
+      arch = "linux-x86_64";
+      sha256 = "11fc9a81c124d723fe5cf13b7afd97915fff67ad88a0df3795524fc1895aea9a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ast/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ast";
+      arch = "linux-x86_64";
+      sha256 = "cb8483973123002ae993ecfdccc2c548c8a88eea7a13556bf7b9cc6522710f5b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/be/thunderbird-128.9.2esr.tar.bz2";
+      locale = "be";
+      arch = "linux-x86_64";
+      sha256 = "daf4fe4ff79cf2dd5bb6974d4b96b1023e48fcf858a47a6a2f80c9f94a241bf5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/bg/thunderbird-128.9.2esr.tar.bz2";
+      locale = "bg";
+      arch = "linux-x86_64";
+      sha256 = "1f75adfd5a34d349b7ff3498b74846d7f183dfeffe71c95898edbb1cdd347af5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/br/thunderbird-128.9.2esr.tar.bz2";
+      locale = "br";
+      arch = "linux-x86_64";
+      sha256 = "0099c80187ed38588577025c18a16f4a1f97d34358c1c141253acb8284c0d7b9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ca/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ca";
+      arch = "linux-x86_64";
+      sha256 = "3dd450c1394d0511086fe359397f10ba2286f351a439debdf7243d372dd4e82a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cak/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cak";
+      arch = "linux-x86_64";
+      sha256 = "8be34e4111812242e66e26ce132aa5cfd4207f54c5f6b526177faba1040f7e5b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cs/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cs";
+      arch = "linux-x86_64";
+      sha256 = "56287abaebf7a18f6bb4ccf6b211c3a484fc906ae0a95ff8a57bdb0c0dc610e7";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cy/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cy";
+      arch = "linux-x86_64";
+      sha256 = "b10d11edb5eea9d379ee46e91446d9ad0f4e13c51301fc3c86b1b3b29ce68544";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/da/thunderbird-128.9.2esr.tar.bz2";
+      locale = "da";
+      arch = "linux-x86_64";
+      sha256 = "4c2938e2e5d6f3a87332e2facb917e713dac353d1ea59a28ca8061595fc1ab10";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/de/thunderbird-128.9.2esr.tar.bz2";
+      locale = "de";
+      arch = "linux-x86_64";
+      sha256 = "d4936702e75b71a18d36bc4f4c62a4f5bce75e4704ee9f968f4971466798b372";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/dsb/thunderbird-128.9.2esr.tar.bz2";
+      locale = "dsb";
+      arch = "linux-x86_64";
+      sha256 = "2aa5d5aa83026a49c4eb24f8ae7d918c1c82f1a5e0f3066b7041296479131c13";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/el/thunderbird-128.9.2esr.tar.bz2";
+      locale = "el";
+      arch = "linux-x86_64";
+      sha256 = "27057c8273f6783a7176959ae2fd19f8e2e2416cc29d64c7b64f30e83f091598";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-CA";
+      arch = "linux-x86_64";
+      sha256 = "103162be5b27f412b24174e98bb75e8d467ad49dfcdebefa0c75371da44be009";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-GB";
+      arch = "linux-x86_64";
+      sha256 = "1b2c8555c69f52be42c6857944b02a04b6a91b9e2438dfd376b8215ae5e7ccf6";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-US/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-US";
+      arch = "linux-x86_64";
+      sha256 = "b32a370c7ccf9344493856a508845dd29c904ecbca9c1faa9c788a42a3d2d89f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-AR";
+      arch = "linux-x86_64";
+      sha256 = "d8b3f556e025d488d21d5483b7aa3b5648ddb3fca8fd3260f42e01d272febf35";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-ES";
+      arch = "linux-x86_64";
+      sha256 = "52060be7f02ea93ca75dd3514a791a7231e45ef688bd748f6e06b159ae346cec";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-MX";
+      arch = "linux-x86_64";
+      sha256 = "61e02c8ebbf26f6dbc1714d84a3fb87281a6c0c88ede9a81fc374b873ab886b5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/et/thunderbird-128.9.2esr.tar.bz2";
+      locale = "et";
+      arch = "linux-x86_64";
+      sha256 = "c7b35b9b024c830897429ab8a7c3d0d55d8007ac1afd7bdd5981546772101325";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/eu/thunderbird-128.9.2esr.tar.bz2";
+      locale = "eu";
+      arch = "linux-x86_64";
+      sha256 = "def113bfe9f855a2a4d898c493f84e95e5919ee9ebe46021fd35b8721f2547c8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fi/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fi";
+      arch = "linux-x86_64";
+      sha256 = "7f60dfd652fffc015232ea0b03b4259d38cb553cc0bef83030d8e1695be6938d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fr";
+      arch = "linux-x86_64";
+      sha256 = "e6367e4afb84e73152fc8407001d1442d73356501f208f299d84f41b1ed01e17";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fy-NL";
+      arch = "linux-x86_64";
+      sha256 = "9917344f3a065cad38b00f693971f6d9e86823046d55c7060c9b049086dcf998";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ga-IE";
+      arch = "linux-x86_64";
+      sha256 = "3afc13fdd4e4810e81e26bc54c5a44fe83c2235b65b2833fe1b6706bd2f4b139";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gd/thunderbird-128.9.2esr.tar.bz2";
+      locale = "gd";
+      arch = "linux-x86_64";
+      sha256 = "29d58e819ffc98c494d900b0a799d80f809274d7bb8ed36f36015c6aa4911521";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "gl";
+      arch = "linux-x86_64";
+      sha256 = "0af1c4a750c6f5eafe11f455de8e037228d89fc638de4f69cbc685fb42f9ba1a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/he/thunderbird-128.9.2esr.tar.bz2";
+      locale = "he";
+      arch = "linux-x86_64";
+      sha256 = "fd3c05162bff13f8c0ab73d0be85c08ee75a93f7b2e57361bd224955eb40ec8f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hr";
+      arch = "linux-x86_64";
+      sha256 = "bbc60804dd01dc1b8b8ef7bcf6410401e0e3406e8248783573abc616099ef180";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hsb/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hsb";
+      arch = "linux-x86_64";
+      sha256 = "720a44c20fd9c6bf80d8dcba1f1d3704d222c9dd9ef394e2dff4ed2fe49ba779";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hu/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hu";
+      arch = "linux-x86_64";
+      sha256 = "03391b360918b4fa6a405a5522d82cfb3e68102b6a7ca2bcfbaaf84f1df175ab";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hy-AM";
+      arch = "linux-x86_64";
+      sha256 = "8d88f133d3499eefb1b4b01ee0ecd7c7a7e0dfd261d0662dc8fb449d66b2ceb8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/id/thunderbird-128.9.2esr.tar.bz2";
+      locale = "id";
+      arch = "linux-x86_64";
+      sha256 = "03ba72e400152d8464cfdf8c115833229171fc517cdf7493b5b753744105f5de";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/is/thunderbird-128.9.2esr.tar.bz2";
+      locale = "is";
+      arch = "linux-x86_64";
+      sha256 = "13441515e3dfe06d9748abaebf0b982813550761f824f277dd70d991c06a9cca";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/it/thunderbird-128.9.2esr.tar.bz2";
+      locale = "it";
+      arch = "linux-x86_64";
+      sha256 = "e942ead46e2ca5c82faf0a9c3d98ba1a54f22e21571b938bf0780501e76b2e88";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ja/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ja";
+      arch = "linux-x86_64";
+      sha256 = "5423ab42fdeba564049cb97bfc4dc638cc8c07e34866ec19e16aeede83aaa937";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ka/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ka";
+      arch = "linux-x86_64";
+      sha256 = "e1af08dadc08607a513fddd85a73cfeb31a9b7cdc697936fa623fb2d2191c50c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kab/thunderbird-128.9.2esr.tar.bz2";
+      locale = "kab";
+      arch = "linux-x86_64";
+      sha256 = "b5da89621f22b454c6ce949811ea408f0a960d17a61db3ead0972277766ecfdf";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "kk";
+      arch = "linux-x86_64";
+      sha256 = "62b9e71bfbc61f55a01d993b415eb8f3600180033714001b91642db194ad4c76";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ko/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ko";
+      arch = "linux-x86_64";
+      sha256 = "e6b0bdd3f9c24a1fd703d33acf9087133f7e39281e8ff1ddc9ca402058fe2b5d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lt/thunderbird-128.9.2esr.tar.bz2";
+      locale = "lt";
+      arch = "linux-x86_64";
+      sha256 = "93981c55695e5a1b957b2c26d9a8672b114aa39deb4aed150b90538b0bdde906";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lv/thunderbird-128.9.2esr.tar.bz2";
+      locale = "lv";
+      arch = "linux-x86_64";
+      sha256 = "7062d9bc31ad8e09b9676df1ff3e6e21e56b2531c4e3b02d06451c0ac69b7006";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ms/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ms";
+      arch = "linux-x86_64";
+      sha256 = "95aec53cbe42d9c8690ad8c6d9bb73f9cad3f6d4aa9e8ed505b84c2206f03312";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nb-NO";
+      arch = "linux-x86_64";
+      sha256 = "a016a592f41ebcb4c8fdc9d8cb589f5dd0027aef26799a2be600bb79b296c185";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nl";
+      arch = "linux-x86_64";
+      sha256 = "d8c009cc0add26bd182b26275756cbf5e3d7ce6d10294b573efe850dddaf3112";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nn-NO";
+      arch = "linux-x86_64";
+      sha256 = "b6e578de4e107e989f2339171e8e4076aad9d1e4257691cb5cd29b0971a0f696";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pa-IN";
+      arch = "linux-x86_64";
+      sha256 = "dbdbf3726d9f319348542d6e6a81fc48446b3f25bc856a0efa72b5330350f539";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pl";
+      arch = "linux-x86_64";
+      sha256 = "955113ab1b3c70f1753a00fb16409c3259c30cd406882a5c6432f352e3017758";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pt-BR";
+      arch = "linux-x86_64";
+      sha256 = "36013c7d86f3d6e3a06defe59fc89956ecadbf818f3b4fdf8d9c96db8b9030ca";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pt-PT";
+      arch = "linux-x86_64";
+      sha256 = "7665f711c3f2ce910ec0fec70e88fc80fd11671825381a1f0bdbbba3d21fe641";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/rm/thunderbird-128.9.2esr.tar.bz2";
+      locale = "rm";
+      arch = "linux-x86_64";
+      sha256 = "92b00199c1c2b27567dce33ec4b782eae778baceec8f25cca634a0feb3c26901";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ro/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ro";
+      arch = "linux-x86_64";
+      sha256 = "874f5cd02709478561e005e5ed902c602ce9218ebacc5097816377b58d014e55";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ru/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ru";
+      arch = "linux-x86_64";
+      sha256 = "bc5e5aa0769f6273d1de113c0f8ab92fb93030bc4721ace954ec06d94351838e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sk";
+      arch = "linux-x86_64";
+      sha256 = "0300518b53382b710c4aade4813c8666f89c64a7f9bc4816782141126508bada";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sl";
+      arch = "linux-x86_64";
+      sha256 = "42bc03ec649b3f5a4d774a1ae7c6f7a6900634cbf77507daf94dda8dae0cabbb";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sq/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sq";
+      arch = "linux-x86_64";
+      sha256 = "5c1c03f5d19706f2cc4a24c55305c67a65812dd6e835ca99a9b3d61824fe3afb";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sr";
+      arch = "linux-x86_64";
+      sha256 = "419349e07a5b8b3b0a9dce2f585a4faafec368fbdd16e7a32fb3063a4e5998a3";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sv-SE";
+      arch = "linux-x86_64";
+      sha256 = "093a96a329a4b51fa8d1bfb16b3e9e9b7311f54146dfd9ea62bf0522fbc53987";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/th/thunderbird-128.9.2esr.tar.bz2";
+      locale = "th";
+      arch = "linux-x86_64";
+      sha256 = "a010c2ae76a00fcad6369c3df36cd74debfe32a311d30f7b6181832373420700";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/tr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "tr";
+      arch = "linux-x86_64";
+      sha256 = "943511923a37304493f326e3b1568cfd301f62cf7e88c1e0ef111be55b318cf5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "uk";
+      arch = "linux-x86_64";
+      sha256 = "94f8328389b51c72456808483dc90562b7579cea41cc138f5e03050de861b538";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uz/thunderbird-128.9.2esr.tar.bz2";
+      locale = "uz";
+      arch = "linux-x86_64";
+      sha256 = "ff7d7dc0981ed84b6d87fd2ed54869198e935dea9c78c5fb673ee87e0f8c1cb1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/vi/thunderbird-128.9.2esr.tar.bz2";
+      locale = "vi";
+      arch = "linux-x86_64";
+      sha256 = "b103568da22674e02369b9c90b33fc857f546a00d5ed0399766cc57a1e338b08";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      locale = "zh-CN";
+      arch = "linux-x86_64";
+      sha256 = "e2fe71b1273b956a4266c80ec3a7172fa092b06b7a8073dd86159371e0e94bae";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      locale = "zh-TW";
+      arch = "linux-x86_64";
+      sha256 = "26520d3ae666780db773a2ccd1d0ad0e2b994818d4a7d3cbb8f6ebe270a7d04e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/af/thunderbird-128.9.2esr.tar.bz2";
+      locale = "af";
+      arch = "linux-i686";
+      sha256 = "6d0d4bf4a1b709185609fc7ea910712fee98673f39a057940d627f3f859f5cbe";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ar/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ar";
+      arch = "linux-i686";
+      sha256 = "4380e84b48ac58733aa4bd3eee3ea1189b9bccc8ea452f564668643f713f472f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ast/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ast";
+      arch = "linux-i686";
+      sha256 = "a9e3f8db99044541a5525821bb4da0b6e88e5907e4ae3695ea2a795daa1a0e52";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/be/thunderbird-128.9.2esr.tar.bz2";
+      locale = "be";
+      arch = "linux-i686";
+      sha256 = "140ab2418316724b8bcfe47540fb14b6126f4cde156e98593b3a77fc50d7f3b1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/bg/thunderbird-128.9.2esr.tar.bz2";
+      locale = "bg";
+      arch = "linux-i686";
+      sha256 = "f55043551abf7dd1024ad99b2ace9e4348a4c297fc43de2cb0eb7ed5830ee700";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/br/thunderbird-128.9.2esr.tar.bz2";
+      locale = "br";
+      arch = "linux-i686";
+      sha256 = "1f706bdeae7e3fd1276d0122bfe0b59af59a8fbd7ff29553396e4bb9443430d8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ca/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ca";
+      arch = "linux-i686";
+      sha256 = "594775b8bd1af2480f366636adf44133ae5fb54cb5abf717e84b7ca7f66b860f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cak/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cak";
+      arch = "linux-i686";
+      sha256 = "2fc2d907c0d941c7af74bdd2278bd4ffbca295dfd1547c7e12af44734b25cd07";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cs/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cs";
+      arch = "linux-i686";
+      sha256 = "4685a385d0051d4095c438d732d0a13762e70b92af2b0bcc035560267554c0b6";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cy/thunderbird-128.9.2esr.tar.bz2";
+      locale = "cy";
+      arch = "linux-i686";
+      sha256 = "5aec56a54e6f74527496941cd2ace3bad36f4ef5c35f419d82ca5b042778bb7e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/da/thunderbird-128.9.2esr.tar.bz2";
+      locale = "da";
+      arch = "linux-i686";
+      sha256 = "2247fbc1cb4d2ceea411220901e169bc0957291a4bddfab424bc6792198d2763";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/de/thunderbird-128.9.2esr.tar.bz2";
+      locale = "de";
+      arch = "linux-i686";
+      sha256 = "0d2ae8f5e2da6b286387bed76b6d28d6b0ccf1910d631012742b5c58a0b32aa7";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/dsb/thunderbird-128.9.2esr.tar.bz2";
+      locale = "dsb";
+      arch = "linux-i686";
+      sha256 = "39cb6de6209daa752eb54fe9538f98a099f1430999402ced063c5463455641dd";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/el/thunderbird-128.9.2esr.tar.bz2";
+      locale = "el";
+      arch = "linux-i686";
+      sha256 = "dff84142810c597e18d548feb32d4f5e5595da47b5a6f5cb8b6e96ad8f1e2d8d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-CA";
+      arch = "linux-i686";
+      sha256 = "9e84515f768a865f0308d6ba079a022d796aaf96d3a653a3f21706ddab860ec5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-GB";
+      arch = "linux-i686";
+      sha256 = "982a5e3a60a96ebfe93f4d11327c22a1c7dc07d158f3dd51ff382996c9561b9f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-US/thunderbird-128.9.2esr.tar.bz2";
+      locale = "en-US";
+      arch = "linux-i686";
+      sha256 = "77d58dc23f24d42db2fa7756991a4fd7954d8a8dabafd3ab10e4f95465e908f3";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-AR";
+      arch = "linux-i686";
+      sha256 = "e51db4457a9a1eb30c1e1bf4aeb679e08a529178c7a25a4b6060403ef4822198";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-ES";
+      arch = "linux-i686";
+      sha256 = "1f136f3e70124fcdc8efb8253c85e27c758432646f981c375d758291888ddefa";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      locale = "es-MX";
+      arch = "linux-i686";
+      sha256 = "f017e992b6ddfaeb8871fe93cb1f4f86b0fe9a8a5bf8d05126b0056fa85034bd";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/et/thunderbird-128.9.2esr.tar.bz2";
+      locale = "et";
+      arch = "linux-i686";
+      sha256 = "638d265b2f86aee9fc0343d3f447bcb4aa541a7bca6063e13a5ca242c3dfe1b0";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/eu/thunderbird-128.9.2esr.tar.bz2";
+      locale = "eu";
+      arch = "linux-i686";
+      sha256 = "65bdb8323fd6b8380a619d2fb77194b143a7a1486402357721ba713fa53d4873";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fi/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fi";
+      arch = "linux-i686";
+      sha256 = "089e72e19e9e95f0a80e0b3f889c3dc927ed4689733d3997ab4e07192b7b4613";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fr";
+      arch = "linux-i686";
+      sha256 = "d02f0260abfa7cf6d5de86e862db957e7ab7f058870039dd0f78a6ae76a30fbe";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      locale = "fy-NL";
+      arch = "linux-i686";
+      sha256 = "441520418225cbfe7d52daef87149289c8a2b9e7a348eb527449ae519456b130";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ga-IE";
+      arch = "linux-i686";
+      sha256 = "4954fecffc9134f7ec422db2324b3b202f63b2ee856d5f580528b53adc88d17c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gd/thunderbird-128.9.2esr.tar.bz2";
+      locale = "gd";
+      arch = "linux-i686";
+      sha256 = "2042c5cabadec8d05e8a9339c7927f97c290067431d7e2395136abd44a58850d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "gl";
+      arch = "linux-i686";
+      sha256 = "4c3b9326505fdd233a7f23446ad00798ace67021de3f1a9589f84c616b7cf6b0";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/he/thunderbird-128.9.2esr.tar.bz2";
+      locale = "he";
+      arch = "linux-i686";
+      sha256 = "784a968dcddbcb21770b7c73782b61a7ce181aa2dd91b0b10b18c60547df4f36";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hr";
+      arch = "linux-i686";
+      sha256 = "7a599e61584bd86bd92de1a0939d5bb00b04393291d94d54ab4b3eacd7003399";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hsb/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hsb";
+      arch = "linux-i686";
+      sha256 = "084a1218d9bb4d8ff592848811581c9dcef36129597500efd4f941ac450d204e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hu/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hu";
+      arch = "linux-i686";
+      sha256 = "37510ca117ac9f15bc61a116a3aa55c6da1c6cc5543975cd2449df3e58a27091";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      locale = "hy-AM";
+      arch = "linux-i686";
+      sha256 = "b88b00b8468bff3fb327a32ec505b5b335d03a9b5b5511ee8c28b392d5888f32";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/id/thunderbird-128.9.2esr.tar.bz2";
+      locale = "id";
+      arch = "linux-i686";
+      sha256 = "4767274386cc5aad9e7632d9e0d12bdd093e971b162ce23de1dd489bfc9af2d6";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/is/thunderbird-128.9.2esr.tar.bz2";
+      locale = "is";
+      arch = "linux-i686";
+      sha256 = "b89381d8fb5b73272bb31eb33cd8fe917ec7f3f480d2a6faa252848ad85f2610";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/it/thunderbird-128.9.2esr.tar.bz2";
+      locale = "it";
+      arch = "linux-i686";
+      sha256 = "643d59b59b983dc863ccb3801bcdf64237e8f8d5e5c6a6205cc0aa073b2b329c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ja/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ja";
+      arch = "linux-i686";
+      sha256 = "e8be6e2b502d5d6cf7c6cfb0cb55fb9c59f9559d3f3b2b3c8843501f87723683";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ka/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ka";
+      arch = "linux-i686";
+      sha256 = "71d0d092470f2e8cb70256770830dfa5c474e3597b1f5f72e9b9ec3d2ed4d737";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kab/thunderbird-128.9.2esr.tar.bz2";
+      locale = "kab";
+      arch = "linux-i686";
+      sha256 = "1e010def386dc00e4ba8317c382b2db251109d9245d4f2b6a2c42a212e0be935";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "kk";
+      arch = "linux-i686";
+      sha256 = "cbf76587bc7262b554b83566c63c4bb19a7ecdcd84cbb2585ef7ea11a2a1b8aa";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ko/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ko";
+      arch = "linux-i686";
+      sha256 = "4a12e048ad3e2d366cfb9fa4613cef30bfd346dbd04304ec22d6b93a5a758869";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lt/thunderbird-128.9.2esr.tar.bz2";
+      locale = "lt";
+      arch = "linux-i686";
+      sha256 = "3fb97a63f7a5b6693fdbc8ac4de4b96fc5938586854353febd9f889978df5467";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lv/thunderbird-128.9.2esr.tar.bz2";
+      locale = "lv";
+      arch = "linux-i686";
+      sha256 = "afc25ba8857040b3d72d47ee1a461bfbd7eaf7cf6dd83f98cc979aaf6945740a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ms/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ms";
+      arch = "linux-i686";
+      sha256 = "72210013e9a29c780f9a70a712b1672bdbbfc7ab4b0bc782b3ddd8c0a2bdaca1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nb-NO";
+      arch = "linux-i686";
+      sha256 = "3776faef5142ea86deb03c88fcb31b129a725a87473311b6a0c762306fc3218b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nl";
+      arch = "linux-i686";
+      sha256 = "16342df841db75db99fe595587bc24bf2250dee4f716ebee039317fbfb9ba20d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      locale = "nn-NO";
+      arch = "linux-i686";
+      sha256 = "498a696f70d647dcb9a371c16a18c700007fb4bbda2542ae3d9bcecf28095842";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pa-IN";
+      arch = "linux-i686";
+      sha256 = "d27f7f5aaa16d133fbf03d9b2795e1428974061e3c81af3e3342ee784dc0b787";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pl";
+      arch = "linux-i686";
+      sha256 = "f41281c9747b34ada507eb879194ac87583ee05e329169515e960386ea961545";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pt-BR";
+      arch = "linux-i686";
+      sha256 = "eb7c125afa47911856ea7cb40808e0ad19334b7e1a66276ff85a8b4f56855db4";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      locale = "pt-PT";
+      arch = "linux-i686";
+      sha256 = "3bce587020ea6d5f05510033e8bd1b424e180e0361d5eb2e906de1583783d70c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/rm/thunderbird-128.9.2esr.tar.bz2";
+      locale = "rm";
+      arch = "linux-i686";
+      sha256 = "18404d2a3b10273e3a288782eec15f2ff0bd866ce12f2c1ca70e3ecf9e58809a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ro/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ro";
+      arch = "linux-i686";
+      sha256 = "401fb9524b6dc8f5547fe1e61d7f96a02dee5939950c971790370cea05f65519";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ru/thunderbird-128.9.2esr.tar.bz2";
+      locale = "ru";
+      arch = "linux-i686";
+      sha256 = "b9e3849896c1e65494572a878d3b6209e613215b54b622800509a94a4e873e02";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sk";
+      arch = "linux-i686";
+      sha256 = "abb7bd8ee676c1a5278ed4a71b7399391a3e129b3de68f23569f8fd90fae6347";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sl/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sl";
+      arch = "linux-i686";
+      sha256 = "20f9f46aa8e6d540c15ee526ba8b3541b9261b41034ebc6041fadc13fd25cd79";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sq/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sq";
+      arch = "linux-i686";
+      sha256 = "9acda0361ead5f8574404986954b7787c6500d675339c13e53d07bba807bc16a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sr";
+      arch = "linux-i686";
+      sha256 = "38a482e78a360897336d3437f8fa985b57f8622403da8278791ec9c7dc49e150";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      locale = "sv-SE";
+      arch = "linux-i686";
+      sha256 = "f1e3d53361f5cf0a4ea32d7295089c3003d9fcf0c1b61d2a54e9c9bf9815b085";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/th/thunderbird-128.9.2esr.tar.bz2";
+      locale = "th";
+      arch = "linux-i686";
+      sha256 = "c64c8cd630336e02e5ceb11dbf61eeec11ff9054da653a93e8ad01d1d4d597c5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/tr/thunderbird-128.9.2esr.tar.bz2";
+      locale = "tr";
+      arch = "linux-i686";
+      sha256 = "79c3f55b10d47b3f2979acd5fa35af8c87cd463afd20fb8132ae9488f2aad8e4";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uk/thunderbird-128.9.2esr.tar.bz2";
+      locale = "uk";
+      arch = "linux-i686";
+      sha256 = "b3f77bb30b22064f9f9aa6b236775d4443933e54b23bcb23d52d8a2fa971e7ec";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uz/thunderbird-128.9.2esr.tar.bz2";
+      locale = "uz";
+      arch = "linux-i686";
+      sha256 = "a912700990447fda3b0396493f9971f4a23428af2c9e919f9cc5fd98ab111e50";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/vi/thunderbird-128.9.2esr.tar.bz2";
+      locale = "vi";
+      arch = "linux-i686";
+      sha256 = "807bc4eac07775d49f3c693b58efe5fd6da77c8c7a9a3facf242ee39ff014595";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      locale = "zh-CN";
+      arch = "linux-i686";
+      sha256 = "714a4625f206447255055b266d461d893fa5bae815515f2d3264a2c17da96101";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      locale = "zh-TW";
+      arch = "linux-i686";
+      sha256 = "bc007c2673b5903a9d532081e063194201f163348c5ad1c80c13cd05e55048ba";
+    }
+  ];
+}

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
@@ -1,797 +1,1193 @@
 {
-  version = "128.9.2esr";
+  version = "128.10.0esr";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/af/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/af/thunderbird-128.10.0esr.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "aedc246acba5af959ba0413882aa149a458841ac254d62a1f5dafd3bdd9cc472";
+      sha256 = "857282503e2c867929b387137be486c5cc428968e59a66665eed50eb04d353f2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ar/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ar/thunderbird-128.10.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "11fc9a81c124d723fe5cf13b7afd97915fff67ad88a0df3795524fc1895aea9a";
+      sha256 = "f65c2a73f9eb5b6d990d2f2ea3cbf769a521eb0297bee170bc233713d1baba89";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ast/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ast/thunderbird-128.10.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cb8483973123002ae993ecfdccc2c548c8a88eea7a13556bf7b9cc6522710f5b";
+      sha256 = "1182efca5b9c93ebd05cd7ed47a549c8eb4e2e9d38f2d38740f191881f256c30";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/be/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/be/thunderbird-128.10.0esr.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "daf4fe4ff79cf2dd5bb6974d4b96b1023e48fcf858a47a6a2f80c9f94a241bf5";
+      sha256 = "fb5e8d1f332ec10b38c43ba7690ec749d898c7d1b2a38d9583d0f16c5f0608f3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/bg/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/bg/thunderbird-128.10.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "1f75adfd5a34d349b7ff3498b74846d7f183dfeffe71c95898edbb1cdd347af5";
+      sha256 = "5946dd6688341107bbf7bf99eabe9ffe3686f8a6b64f6d24fd0af8782dbfb883";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/br/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/br/thunderbird-128.10.0esr.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "0099c80187ed38588577025c18a16f4a1f97d34358c1c141253acb8284c0d7b9";
+      sha256 = "cef7fc19a7a3903575a3c2ad8f9bde16880e5a916d921c891137d68390ae07da";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ca/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ca/thunderbird-128.10.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3dd450c1394d0511086fe359397f10ba2286f351a439debdf7243d372dd4e82a";
+      sha256 = "909fe5327d08a3fcaf8845087e5ea210e17e61c7a050793fcc537f38b871bcce";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cak/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cak/thunderbird-128.10.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8be34e4111812242e66e26ce132aa5cfd4207f54c5f6b526177faba1040f7e5b";
+      sha256 = "efeec0a1ac7bebddf841e938ce34b830634a8c542839b8ff1c662b4c2eaa0d16";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cs/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cs/thunderbird-128.10.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "56287abaebf7a18f6bb4ccf6b211c3a484fc906ae0a95ff8a57bdb0c0dc610e7";
+      sha256 = "15403d469bf30379b15e14ec9be44f33507977c6346ed440e361729b7d385af7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cy/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cy/thunderbird-128.10.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b10d11edb5eea9d379ee46e91446d9ad0f4e13c51301fc3c86b1b3b29ce68544";
+      sha256 = "9c36982d3475fa3f03d7a47d102afeecda5567588b4597bd04edd5ca5620d646";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/da/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/da/thunderbird-128.10.0esr.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "4c2938e2e5d6f3a87332e2facb917e713dac353d1ea59a28ca8061595fc1ab10";
+      sha256 = "4bd6f4f660c2ae60ec4d6067ce87d7e841cd00d38f35d1291e95525780613bff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/de/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/de/thunderbird-128.10.0esr.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d4936702e75b71a18d36bc4f4c62a4f5bce75e4704ee9f968f4971466798b372";
+      sha256 = "2dfe11da23805896714d5918ba054d174402758c457d5172241c9c2e38f82cbf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/dsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/dsb/thunderbird-128.10.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2aa5d5aa83026a49c4eb24f8ae7d918c1c82f1a5e0f3066b7041296479131c13";
+      sha256 = "d9777017e578d7ac82e93cf59ba978c4b67dd2d36928f5629fc33f602bf12c7e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/el/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/el/thunderbird-128.10.0esr.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "27057c8273f6783a7176959ae2fd19f8e2e2416cc29d64c7b64f30e83f091598";
+      sha256 = "cacff9ee3ae37c81db51abc99357223664b865315f2776ac36ea443ab9637cef";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-CA/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "103162be5b27f412b24174e98bb75e8d467ad49dfcdebefa0c75371da44be009";
+      sha256 = "c389f71b4b2e944d6d38d5cabd803f67aac885aced035c0c801f2129cbda0afb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-GB/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1b2c8555c69f52be42c6857944b02a04b6a91b9e2438dfd376b8215ae5e7ccf6";
+      sha256 = "7533e0830f276086727c48ae7d94fa0b87332d46baef5276a4351051e49bddf8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-US/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-US/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "b32a370c7ccf9344493856a508845dd29c904ecbca9c1faa9c788a42a3d2d89f";
+      sha256 = "04d28cae6d4286fa5d37b1ba8d0895db216c21175d48ecacc50365c5046a0fff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-AR/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d8b3f556e025d488d21d5483b7aa3b5648ddb3fca8fd3260f42e01d272febf35";
+      sha256 = "24ef9e4a2a9b348eb0b10cfa175d70d0825235e751acb7abe5667a86647b56b7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-ES/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "52060be7f02ea93ca75dd3514a791a7231e45ef688bd748f6e06b159ae346cec";
+      sha256 = "96cc5ed02c6ed6e46e8b7dcd628a564acb987e73849d84fb328b7ef3a9e9cc49";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-MX/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "61e02c8ebbf26f6dbc1714d84a3fb87281a6c0c88ede9a81fc374b873ab886b5";
+      sha256 = "8445c38081b8392b6e2de98982117d3000bf368f6da1e681945193f566b4f01b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/et/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/et/thunderbird-128.10.0esr.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c7b35b9b024c830897429ab8a7c3d0d55d8007ac1afd7bdd5981546772101325";
+      sha256 = "e6fd5134f91507fbfac03c2f859e0d038f506c99d5925fff98c41dd40dd34915";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/eu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/eu/thunderbird-128.10.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "def113bfe9f855a2a4d898c493f84e95e5919ee9ebe46021fd35b8721f2547c8";
+      sha256 = "2c8307a960038bb4edca8406c07a7fa8bc15f6b8d681393996541199470a30a5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fi/thunderbird-128.10.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7f60dfd652fffc015232ea0b03b4259d38cb553cc0bef83030d8e1695be6938d";
+      sha256 = "f71ba700f6271a1998dd093bb251082ddfc59ff885ac67f70f8b50433fc39859";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fr/thunderbird-128.10.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e6367e4afb84e73152fc8407001d1442d73356501f208f299d84f41b1ed01e17";
+      sha256 = "e56a3f73db1e7ae82c2063a663a4f278850fc13c4b6dfba4eefed2062f73b41c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fy-NL/thunderbird-128.10.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9917344f3a065cad38b00f693971f6d9e86823046d55c7060c9b049086dcf998";
+      sha256 = "78032171968489377c7e2cf2ec0715877a2294113523f1dc7f63edaf46471828";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ga-IE/thunderbird-128.10.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3afc13fdd4e4810e81e26bc54c5a44fe83c2235b65b2833fe1b6706bd2f4b139";
+      sha256 = "67691b7d441c918cab3c5cbce5b79e0ef05741f5f90d49e2e4a166e898fbd500";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gd/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/gd/thunderbird-128.10.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "29d58e819ffc98c494d900b0a799d80f809274d7bb8ed36f36015c6aa4911521";
+      sha256 = "26a06b0f88b3b16554fe27a3ff8726699e72d1aa2789e3c53cc0bb92a69413ec";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/gl/thunderbird-128.10.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0af1c4a750c6f5eafe11f455de8e037228d89fc638de4f69cbc685fb42f9ba1a";
+      sha256 = "7575ac6c7be6f3dc82fdcd5005d70eee3e13e1b82d8a79dc1eb7bb7d24c93f78";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/he/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/he/thunderbird-128.10.0esr.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "fd3c05162bff13f8c0ab73d0be85c08ee75a93f7b2e57361bd224955eb40ec8f";
+      sha256 = "e7381bfba44df175372e05cd3efe2e3287389f1324854ab5cc7bb0ed9d081db1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hr/thunderbird-128.10.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bbc60804dd01dc1b8b8ef7bcf6410401e0e3406e8248783573abc616099ef180";
+      sha256 = "f3e1bf2b4929e31b3c4c736a1f685130619e42ff0e215ac838e9cd00a9c61e68";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hsb/thunderbird-128.10.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "720a44c20fd9c6bf80d8dcba1f1d3704d222c9dd9ef394e2dff4ed2fe49ba779";
+      sha256 = "bc9af027c0a67910472adb5e4cdb5b9a24b31659b60bf3c7a6cd4a54f3a73ea8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hu/thunderbird-128.10.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "03391b360918b4fa6a405a5522d82cfb3e68102b6a7ca2bcfbaaf84f1df175ab";
+      sha256 = "80228607792dab475c9cf85932ad84a0c57a12bb87dd7f0748304c06d5a03ce5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hy-AM/thunderbird-128.10.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "8d88f133d3499eefb1b4b01ee0ecd7c7a7e0dfd261d0662dc8fb449d66b2ceb8";
+      sha256 = "bd96c347447840d8d79967cacd8e748edcba01cbec5fb3ac7b4c93d33c6ec094";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/id/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/id/thunderbird-128.10.0esr.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "03ba72e400152d8464cfdf8c115833229171fc517cdf7493b5b753744105f5de";
+      sha256 = "96b51fb41195a83ad216851742c8af4d923aee60dcf5b362e6bdeeea1f5e926b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/is/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/is/thunderbird-128.10.0esr.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "13441515e3dfe06d9748abaebf0b982813550761f824f277dd70d991c06a9cca";
+      sha256 = "f4168470a02f6bbf3e5f05317ff419ebf2b7ced0f653ecb12924094bc20f2151";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/it/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/it/thunderbird-128.10.0esr.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e942ead46e2ca5c82faf0a9c3d98ba1a54f22e21571b938bf0780501e76b2e88";
+      sha256 = "4edb1699a3dfc4fc4ef76d535d69480b5d2a0367e2b2eaddbbf60ba8f3e64d99";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ja/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ja/thunderbird-128.10.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5423ab42fdeba564049cb97bfc4dc638cc8c07e34866ec19e16aeede83aaa937";
+      sha256 = "0c0bfbfcca5c0c20ba5ff9a7d6ff6f640479fba165b054075d4513dd7f5bd00f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ka/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ka/thunderbird-128.10.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e1af08dadc08607a513fddd85a73cfeb31a9b7cdc697936fa623fb2d2191c50c";
+      sha256 = "c76dd2b4569ff8bc75080ced7f1fe6af2c08447ede9d8c6c0b9cb6827dc42ffb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kab/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/kab/thunderbird-128.10.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "b5da89621f22b454c6ce949811ea408f0a960d17a61db3ead0972277766ecfdf";
+      sha256 = "29de0bfc1cec81ff96535e3ab4ab4ff1ceadc72c6b5947abd40ae11dcd7423bb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/kk/thunderbird-128.10.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "62b9e71bfbc61f55a01d993b415eb8f3600180033714001b91642db194ad4c76";
+      sha256 = "42087039b4a255e059659b316a9ed1a7b0a452bd5dc5500e448ebb39cd29f3cb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ko/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ko/thunderbird-128.10.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "e6b0bdd3f9c24a1fd703d33acf9087133f7e39281e8ff1ddc9ca402058fe2b5d";
+      sha256 = "de46b8dab434539a4c5a789d73ea969da0e8427b71423d1fbf6c0de6d1026907";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lt/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/lt/thunderbird-128.10.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "93981c55695e5a1b957b2c26d9a8672b114aa39deb4aed150b90538b0bdde906";
+      sha256 = "413fb6852be1c7ee59a2fef64a7eadd28d043ce42b3f3c3728d1738357279010";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lv/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/lv/thunderbird-128.10.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7062d9bc31ad8e09b9676df1ff3e6e21e56b2531c4e3b02d06451c0ac69b7006";
+      sha256 = "917079f72fd2b99c790cb2f3f8d52096c39681508d0d37db7e2699261fd8d361";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ms/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ms/thunderbird-128.10.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "95aec53cbe42d9c8690ad8c6d9bb73f9cad3f6d4aa9e8ed505b84c2206f03312";
+      sha256 = "b9f4f986c13da6365796c40de7201cfd87447b64176d34f562910eca94ad4996";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nb-NO/thunderbird-128.10.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "a016a592f41ebcb4c8fdc9d8cb589f5dd0027aef26799a2be600bb79b296c185";
+      sha256 = "1c28bc077c84f767aa9d8d7eca42cc240b268453c53663b91d789ded3933b8de";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nl/thunderbird-128.10.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d8c009cc0add26bd182b26275756cbf5e3d7ce6d10294b573efe850dddaf3112";
+      sha256 = "5d5e11a586d7a02b0891594edc36e80db2f8b174e6688c591a6fe3703e98755d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nn-NO/thunderbird-128.10.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b6e578de4e107e989f2339171e8e4076aad9d1e4257691cb5cd29b0971a0f696";
+      sha256 = "9c9773e9e881068521c655523c80fc65d08119b424fe995edb930d669eaaa3ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pa-IN/thunderbird-128.10.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "dbdbf3726d9f319348542d6e6a81fc48446b3f25bc856a0efa72b5330350f539";
+      sha256 = "655eeb22bd08e292aee649c99bf1c9568fba047d97065c4f3f783a7a813aa809";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pl/thunderbird-128.10.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "955113ab1b3c70f1753a00fb16409c3259c30cd406882a5c6432f352e3017758";
+      sha256 = "199a2af3ff6e867df88d5c104bebaf0c1b2143c7b531302258a37f37f8970102";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pt-BR/thunderbird-128.10.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "36013c7d86f3d6e3a06defe59fc89956ecadbf818f3b4fdf8d9c96db8b9030ca";
+      sha256 = "72ca3377228e4ee621a5c0e867f5cf8ec21d1b3347419cbd78c0582a6f3b7226";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pt-PT/thunderbird-128.10.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "7665f711c3f2ce910ec0fec70e88fc80fd11671825381a1f0bdbbba3d21fe641";
+      sha256 = "f5774a5dc875b8af31e59c37f32e355b6b204dcc1228727ec1d999e1f310c08a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/rm/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/rm/thunderbird-128.10.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "92b00199c1c2b27567dce33ec4b782eae778baceec8f25cca634a0feb3c26901";
+      sha256 = "c46b7afc9e8f73d385d868601a99690cf078663cec9c8e92413d8ec076e01f94";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ro/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ro/thunderbird-128.10.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "874f5cd02709478561e005e5ed902c602ce9218ebacc5097816377b58d014e55";
+      sha256 = "f085eecb919959f5496ae205c204619dad529f46c61b718e783760a5a127443e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ru/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ru/thunderbird-128.10.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "bc5e5aa0769f6273d1de113c0f8ab92fb93030bc4721ace954ec06d94351838e";
+      sha256 = "395292e3c38886508140350dc9d75800f5bde25c28c38e40488e291e8cc963b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sk/thunderbird-128.10.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "0300518b53382b710c4aade4813c8666f89c64a7f9bc4816782141126508bada";
+      sha256 = "8c80aec4d51ca07a54401b1f18f41c5fbe618c3b968d68799d8311ca4b0aaf03";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sl/thunderbird-128.10.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "42bc03ec649b3f5a4d774a1ae7c6f7a6900634cbf77507daf94dda8dae0cabbb";
+      sha256 = "f1f16bc225f3e002075da005ca6d8045a81d8dfce898d70aac5f978a40323209";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sq/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sq/thunderbird-128.10.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5c1c03f5d19706f2cc4a24c55305c67a65812dd6e835ca99a9b3d61824fe3afb";
+      sha256 = "dd66306bbbad030532b582c177b706ceee9805ad51123999c3c27bdb5a25e8ce";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sr/thunderbird-128.10.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "419349e07a5b8b3b0a9dce2f585a4faafec368fbdd16e7a32fb3063a4e5998a3";
+      sha256 = "a315196619380a621ffe9d666dbd00210ca84a144aedd599fee702444ce25143";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sv-SE/thunderbird-128.10.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "093a96a329a4b51fa8d1bfb16b3e9e9b7311f54146dfd9ea62bf0522fbc53987";
+      sha256 = "e925948d64771385e546beb69bb4a7f67d0dd61db67bc4b777c42b464c6697e6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/th/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/th/thunderbird-128.10.0esr.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a010c2ae76a00fcad6369c3df36cd74debfe32a311d30f7b6181832373420700";
+      sha256 = "ec7ad345ea2d2f8739b361b9c3fffe49d977938bff7748e060a4a52f044ba3ed";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/tr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/tr/thunderbird-128.10.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "943511923a37304493f326e3b1568cfd301f62cf7e88c1e0ef111be55b318cf5";
+      sha256 = "5e26c74749cbe0bc8ea012fb8014b5eea288c0dcecba2dee525df873248bf597";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/uk/thunderbird-128.10.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "94f8328389b51c72456808483dc90562b7579cea41cc138f5e03050de861b538";
+      sha256 = "b37a1a9a96300e094a0716f4319acda6abb2cd48a9e68b019a0b98c7d11a008a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uz/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/uz/thunderbird-128.10.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ff7d7dc0981ed84b6d87fd2ed54869198e935dea9c78c5fb673ee87e0f8c1cb1";
+      sha256 = "b419a20dcc2963f9ad1826ed2a7507433ba9bd5ac1faf354fd9bc7ce92a7b681";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/vi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/vi/thunderbird-128.10.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b103568da22674e02369b9c90b33fc857f546a00d5ed0399766cc57a1e338b08";
+      sha256 = "b1c13f9c5343823a7c5e98e9801467531ab85c368b27b90a8bcd4d43f11b3edd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/zh-CN/thunderbird-128.10.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e2fe71b1273b956a4266c80ec3a7172fa092b06b7a8073dd86159371e0e94bae";
+      sha256 = "125c0d0dc02f8ce49aff83788bdfa5fba79287e42456169dd51f8281813e8bde";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/zh-TW/thunderbird-128.10.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "26520d3ae666780db773a2ccd1d0ad0e2b994818d4a7d3cbb8f6ebe270a7d04e";
+      sha256 = "b1b7a5ae07bf55d0b80d5142fd85af8d6c9fb270b7f9e6c43800a59b1f40cab2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/af/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/af/thunderbird-128.10.0esr.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "6d0d4bf4a1b709185609fc7ea910712fee98673f39a057940d627f3f859f5cbe";
+      sha256 = "ff991035f96f687b39e355103130d15fbc9f195e94a30f4829337b7ad8444112";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ar/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ar/thunderbird-128.10.0esr.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4380e84b48ac58733aa4bd3eee3ea1189b9bccc8ea452f564668643f713f472f";
+      sha256 = "dda0e89b7a93f9acc90232219ccffb9f5cd62e2cc926acb4594c3c931c965078";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ast/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ast/thunderbird-128.10.0esr.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a9e3f8db99044541a5525821bb4da0b6e88e5907e4ae3695ea2a795daa1a0e52";
+      sha256 = "976922071e429a44a07c9117317c0de37aed07c6aac459713c45d72594d53de9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/be/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/be/thunderbird-128.10.0esr.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "140ab2418316724b8bcfe47540fb14b6126f4cde156e98593b3a77fc50d7f3b1";
+      sha256 = "2834e35f572827392f8f4c05fde6e5d528dcb9e3aeaca9814682bd57f8798116";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/bg/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/bg/thunderbird-128.10.0esr.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f55043551abf7dd1024ad99b2ace9e4348a4c297fc43de2cb0eb7ed5830ee700";
+      sha256 = "2233ee89097b86eca8eaac6652ace0122822ae321b73afd6f7770a2d2b9b18aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/br/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/br/thunderbird-128.10.0esr.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "1f706bdeae7e3fd1276d0122bfe0b59af59a8fbd7ff29553396e4bb9443430d8";
+      sha256 = "6edc20cb551706417f63615da513db332e6840b241f3a7f299ca155b8ba53082";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ca/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ca/thunderbird-128.10.0esr.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "594775b8bd1af2480f366636adf44133ae5fb54cb5abf717e84b7ca7f66b860f";
+      sha256 = "11d95d508d04a4dfeb5cf7fa7b6783aa632d12d5f054c5cb036c5c8e4c77aea1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cak/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cak/thunderbird-128.10.0esr.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "2fc2d907c0d941c7af74bdd2278bd4ffbca295dfd1547c7e12af44734b25cd07";
+      sha256 = "8210634b2156f2d7a8f16fa72fb93e0201060c4f6aec3530c9bca74c86f6a9a5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cs/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cs/thunderbird-128.10.0esr.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "4685a385d0051d4095c438d732d0a13762e70b92af2b0bcc035560267554c0b6";
+      sha256 = "2220fb0a8d27b1fdd836e5c2dfcb119e211f2741f04a48f275b3d1cc53165bb5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cy/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cy/thunderbird-128.10.0esr.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "5aec56a54e6f74527496941cd2ace3bad36f4ef5c35f419d82ca5b042778bb7e";
+      sha256 = "a09c203e506a6e535421d945459aa11553e0c1e9ad6277507361a99b48c65e88";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/da/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/da/thunderbird-128.10.0esr.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "2247fbc1cb4d2ceea411220901e169bc0957291a4bddfab424bc6792198d2763";
+      sha256 = "8ef44025501713220ea38e85a2105cf2817e63bdaa0db025f840da482c0c05fe";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/de/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/de/thunderbird-128.10.0esr.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "0d2ae8f5e2da6b286387bed76b6d28d6b0ccf1910d631012742b5c58a0b32aa7";
+      sha256 = "a74b5e6dde808ce1bd630084bd58ad8dd10fc8944d80dff9f8d225a4593a40db";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/dsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/dsb/thunderbird-128.10.0esr.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "39cb6de6209daa752eb54fe9538f98a099f1430999402ced063c5463455641dd";
+      sha256 = "b52feb7ed9693992fc00257cf2c984a9113177ac30d442d75471af3ba60de64b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/el/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/el/thunderbird-128.10.0esr.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dff84142810c597e18d548feb32d4f5e5595da47b5a6f5cb8b6e96ad8f1e2d8d";
+      sha256 = "b3548609b4bc6b57735b63cd06a0ee8ddb77afaa180ebeae63174a8a00950da4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-CA/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9e84515f768a865f0308d6ba079a022d796aaf96d3a653a3f21706ddab860ec5";
+      sha256 = "33d18c502cbcf78bd63d2f340085c2f60eb7b60e04eb695e69c24ddd42c72fe9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-GB/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "982a5e3a60a96ebfe93f4d11327c22a1c7dc07d158f3dd51ff382996c9561b9f";
+      sha256 = "8ce155991bf4ebc65726656a8349eaee3c8c5fb70f2949b9df73170c04bc0714";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-US/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-US/thunderbird-128.10.0esr.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "77d58dc23f24d42db2fa7756991a4fd7954d8a8dabafd3ab10e4f95465e908f3";
+      sha256 = "1be8a49543eb74101cb6f3f8adf8486d364fbc38bb0a29db93dcb28e6f1eaf89";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-AR/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e51db4457a9a1eb30c1e1bf4aeb679e08a529178c7a25a4b6060403ef4822198";
+      sha256 = "03d1232f34cf044f2a24d5daae731a74d43b538f8d794f30761edfca49ca201a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-ES/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1f136f3e70124fcdc8efb8253c85e27c758432646f981c375d758291888ddefa";
+      sha256 = "0c6e407a3314bf6e7c385dd7fbdbcf7eb4ad66d60afabf1ab2eac69492c90a9a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-MX/thunderbird-128.10.0esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f017e992b6ddfaeb8871fe93cb1f4f86b0fe9a8a5bf8d05126b0056fa85034bd";
+      sha256 = "8aaa9a19b96801f4b1730b5e8a3d647473d893ad43ac1710a27e80f39cd30b7b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/et/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/et/thunderbird-128.10.0esr.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "638d265b2f86aee9fc0343d3f447bcb4aa541a7bca6063e13a5ca242c3dfe1b0";
+      sha256 = "47a4f7f35e7f089a5a0daacf7baa18ed37c3617feb76fbb6eddb648e9539d0d7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/eu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/eu/thunderbird-128.10.0esr.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "65bdb8323fd6b8380a619d2fb77194b143a7a1486402357721ba713fa53d4873";
+      sha256 = "5c803d4a340968111aa94f222d94ba232d2dfb490d57ae854812b36e99dbbfeb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fi/thunderbird-128.10.0esr.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "089e72e19e9e95f0a80e0b3f889c3dc927ed4689733d3997ab4e07192b7b4613";
+      sha256 = "442d7deb0d1189878f217895acad1349e2a7b4cc4fc6c817e624961a2f9b092b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fr/thunderbird-128.10.0esr.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d02f0260abfa7cf6d5de86e862db957e7ab7f058870039dd0f78a6ae76a30fbe";
+      sha256 = "a888b7c00bdaa2eb4df8bd34294eb5cd938c2f68d2e7742f798fd47e942c800e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fy-NL/thunderbird-128.10.0esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "441520418225cbfe7d52daef87149289c8a2b9e7a348eb527449ae519456b130";
+      sha256 = "bcde00737fdf4da0d3bc38a9a888143cf33ddef815c5ee88be266a644f24b4b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ga-IE/thunderbird-128.10.0esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4954fecffc9134f7ec422db2324b3b202f63b2ee856d5f580528b53adc88d17c";
+      sha256 = "8eae62c0a8cccb536d485085c6a610e77391adf9f62c54188b1db1722271fa6d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gd/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/gd/thunderbird-128.10.0esr.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2042c5cabadec8d05e8a9339c7927f97c290067431d7e2395136abd44a58850d";
+      sha256 = "6e9ffce6cabee76803b99392c47fbd6af840c73ecf001fd28839e98a6a658467";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/gl/thunderbird-128.10.0esr.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4c3b9326505fdd233a7f23446ad00798ace67021de3f1a9589f84c616b7cf6b0";
+      sha256 = "655185f0f53bfe21a09d8f484aa33bb0e690ad5baa0e55b1b0d3b5ecd3781631";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/he/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/he/thunderbird-128.10.0esr.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "784a968dcddbcb21770b7c73782b61a7ce181aa2dd91b0b10b18c60547df4f36";
+      sha256 = "4333b6e93320d541f99b62e904d5324d9f370753eafa0e38ee632dbe0e3e1685";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hr/thunderbird-128.10.0esr.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "7a599e61584bd86bd92de1a0939d5bb00b04393291d94d54ab4b3eacd7003399";
+      sha256 = "7d5d76b79acc21fd3badd1b5b7b2416a433506c9af63e702a0db86b5dde61961";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hsb/thunderbird-128.10.0esr.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "084a1218d9bb4d8ff592848811581c9dcef36129597500efd4f941ac450d204e";
+      sha256 = "698f507a3249a9620454eb519a5d22f3f86717e10545b1674c1c7c2fac34f9d4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hu/thunderbird-128.10.0esr.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "37510ca117ac9f15bc61a116a3aa55c6da1c6cc5543975cd2449df3e58a27091";
+      sha256 = "b7b2ccfbe267c6ab9e7f53658633a2f9766287aefa88601139b211e6e391d66a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hy-AM/thunderbird-128.10.0esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b88b00b8468bff3fb327a32ec505b5b335d03a9b5b5511ee8c28b392d5888f32";
+      sha256 = "e317a0367d5f3d8e685ae8b9ee51e15c2c5016a9906db45bd7c869ad4ec0829c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/id/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/id/thunderbird-128.10.0esr.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4767274386cc5aad9e7632d9e0d12bdd093e971b162ce23de1dd489bfc9af2d6";
+      sha256 = "d9dfcb75b9f50d7d9dab47c52879a73b7863235253b0246986421189b154adc4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/is/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/is/thunderbird-128.10.0esr.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "b89381d8fb5b73272bb31eb33cd8fe917ec7f3f480d2a6faa252848ad85f2610";
+      sha256 = "fb3b2f9c82a0fadf5ea85cb7523a2f15bb540dab7bc601d90b7fd6eb852011b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/it/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/it/thunderbird-128.10.0esr.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "643d59b59b983dc863ccb3801bcdf64237e8f8d5e5c6a6205cc0aa073b2b329c";
+      sha256 = "5719d8422de1d249fa53dbe9ba5b07751d062c7f8911cadfc49c61a5f550a66d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ja/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ja/thunderbird-128.10.0esr.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "e8be6e2b502d5d6cf7c6cfb0cb55fb9c59f9559d3f3b2b3c8843501f87723683";
+      sha256 = "eaf4aa599c39a64a8d4bfd357f4660e1d663c8db3be27d729c10037ef48a2334";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ka/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ka/thunderbird-128.10.0esr.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "71d0d092470f2e8cb70256770830dfa5c474e3597b1f5f72e9b9ec3d2ed4d737";
+      sha256 = "1e0c2c0bd1d8f99bbc3fd980bb2e949893e5c85c810e3af08d8d5ced783763a1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kab/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/kab/thunderbird-128.10.0esr.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1e010def386dc00e4ba8317c382b2db251109d9245d4f2b6a2c42a212e0be935";
+      sha256 = "a51daf65157a5588601395fea930a2a4766605d61bffaa1fadc1f357414937fa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/kk/thunderbird-128.10.0esr.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "cbf76587bc7262b554b83566c63c4bb19a7ecdcd84cbb2585ef7ea11a2a1b8aa";
+      sha256 = "9f5d8cf7a99136e5af0dbfd6859536fd4fd647665a73165263efee8f65ec3f7e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ko/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ko/thunderbird-128.10.0esr.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "4a12e048ad3e2d366cfb9fa4613cef30bfd346dbd04304ec22d6b93a5a758869";
+      sha256 = "7e7b9e0f1926cd8c6b2a1cf225e60386873b6b3a2d5de3204a299a2bee22a593";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lt/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/lt/thunderbird-128.10.0esr.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "3fb97a63f7a5b6693fdbc8ac4de4b96fc5938586854353febd9f889978df5467";
+      sha256 = "b15c7e47e949bf077174672d58882856a2b18b4504bc0a63f3b8dafc967f062b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lv/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/lv/thunderbird-128.10.0esr.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "afc25ba8857040b3d72d47ee1a461bfbd7eaf7cf6dd83f98cc979aaf6945740a";
+      sha256 = "bee19390769fd64880b1d31096dc652748dd528f81deba28eeb5b70615a062a8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ms/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ms/thunderbird-128.10.0esr.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "72210013e9a29c780f9a70a712b1672bdbbfc7ab4b0bc782b3ddd8c0a2bdaca1";
+      sha256 = "c008f1fc71ae173c236bdcae25a830efa66f72559ba4bc8d4324a6664bd3d013";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nb-NO/thunderbird-128.10.0esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "3776faef5142ea86deb03c88fcb31b129a725a87473311b6a0c762306fc3218b";
+      sha256 = "f4df94012ef725e4ac5d69f1e5a7ec67dfd48883bc872cd47a428f92179758bd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nl/thunderbird-128.10.0esr.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "16342df841db75db99fe595587bc24bf2250dee4f716ebee039317fbfb9ba20d";
+      sha256 = "fb7ec4da9767576b93b7292d6292447195c9737b4a0face27007e1fbcf0cd5aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nn-NO/thunderbird-128.10.0esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "498a696f70d647dcb9a371c16a18c700007fb4bbda2542ae3d9bcecf28095842";
+      sha256 = "18480e6e5ecbed8fd55ab2747421b88cdd1374557f570669f10dd1ff72085576";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pa-IN/thunderbird-128.10.0esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "d27f7f5aaa16d133fbf03d9b2795e1428974061e3c81af3e3342ee784dc0b787";
+      sha256 = "b2781354f750d0267ae057c8a15b3e9dccd9c9ae6cfbc874e153f4fb759b4da4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pl/thunderbird-128.10.0esr.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f41281c9747b34ada507eb879194ac87583ee05e329169515e960386ea961545";
+      sha256 = "bc45df44d297fd431c6d2e43df0d187302150b1af4d4f275eb35551c4bfb474c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pt-BR/thunderbird-128.10.0esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "eb7c125afa47911856ea7cb40808e0ad19334b7e1a66276ff85a8b4f56855db4";
+      sha256 = "f95eaaf90935edd67334bb712c084a31641133d44ef5b952470164afef50fe45";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pt-PT/thunderbird-128.10.0esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "3bce587020ea6d5f05510033e8bd1b424e180e0361d5eb2e906de1583783d70c";
+      sha256 = "9f98a979c83ea71f1f2377c541c67a369bea29d0bc3058d9ff6d5dde905e9d59";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/rm/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/rm/thunderbird-128.10.0esr.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "18404d2a3b10273e3a288782eec15f2ff0bd866ce12f2c1ca70e3ecf9e58809a";
+      sha256 = "97ff3302535dfd38aa5882af8d8cff3d50a6754dd841d650f6106fc74f0b7438";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ro/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ro/thunderbird-128.10.0esr.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "401fb9524b6dc8f5547fe1e61d7f96a02dee5939950c971790370cea05f65519";
+      sha256 = "7c714cd1b17e92eca91a068a39173cb693476639b68ba9f339f510d08ca685bc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ru/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ru/thunderbird-128.10.0esr.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b9e3849896c1e65494572a878d3b6209e613215b54b622800509a94a4e873e02";
+      sha256 = "123a695a4764e19ce415c29e6d5352c445a105cb8d87916b21cd034a2649185b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sk/thunderbird-128.10.0esr.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "abb7bd8ee676c1a5278ed4a71b7399391a3e129b3de68f23569f8fd90fae6347";
+      sha256 = "119d068c96a7bbd5cfe105b8e38989e949b04e21664a7a1266829daa57763f0e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sl/thunderbird-128.10.0esr.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "20f9f46aa8e6d540c15ee526ba8b3541b9261b41034ebc6041fadc13fd25cd79";
+      sha256 = "6e94f70c01c932655464cca415504054e30b8c0a9ffa2b1ade7b5e67243cfbda";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sq/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sq/thunderbird-128.10.0esr.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9acda0361ead5f8574404986954b7787c6500d675339c13e53d07bba807bc16a";
+      sha256 = "d8a064c2ed903f353a705bc734a4d16c4761abd099c1c20eb211d13f5d94dda7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sr/thunderbird-128.10.0esr.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "38a482e78a360897336d3437f8fa985b57f8622403da8278791ec9c7dc49e150";
+      sha256 = "2e841685380d839f879a26b8ccbb04949f5670f38332e6011c7fce2d7bb7f036";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sv-SE/thunderbird-128.10.0esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "f1e3d53361f5cf0a4ea32d7295089c3003d9fcf0c1b61d2a54e9c9bf9815b085";
+      sha256 = "39c3f998f46758fded9fcffef4f24f03b48ccb61172e6ed71db7a5636b9b6eff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/th/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/th/thunderbird-128.10.0esr.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c64c8cd630336e02e5ceb11dbf61eeec11ff9054da653a93e8ad01d1d4d597c5";
+      sha256 = "90ac6a733e5639a6265808b4e560e900a89065d673179ab9bc7b9df95469d0ae";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/tr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/tr/thunderbird-128.10.0esr.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "79c3f55b10d47b3f2979acd5fa35af8c87cd463afd20fb8132ae9488f2aad8e4";
+      sha256 = "d2f89f9cf312e5653af3925bf883051487bc5769866f6be12157f1983643202f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/uk/thunderbird-128.10.0esr.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b3f77bb30b22064f9f9aa6b236775d4443933e54b23bcb23d52d8a2fa971e7ec";
+      sha256 = "048575c86d22f25e883cd0f65aa66eab26c5d6d6b562ad55eb60b19bb14dfdec";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uz/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/uz/thunderbird-128.10.0esr.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a912700990447fda3b0396493f9971f4a23428af2c9e919f9cc5fd98ab111e50";
+      sha256 = "7fd2cb036ea84171abe02e0619096c2483466f313fc56b45678bfef0200ff37a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/vi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/vi/thunderbird-128.10.0esr.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "807bc4eac07775d49f3c693b58efe5fd6da77c8c7a9a3facf242ee39ff014595";
+      sha256 = "bd69f2da2e23e8db9f9f056316d54be1d1c396a8a7b36d8b6da31c5ecad5b926";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/zh-CN/thunderbird-128.10.0esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "714a4625f206447255055b266d461d893fa5bae815515f2d3264a2c17da96101";
+      sha256 = "9f4ae9e5a002b7a34916740d784f652c867ea0e32bc3a86806f895063533e3db";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/zh-TW/thunderbird-128.10.0esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "bc007c2673b5903a9d532081e063194201f163348c5ad1c80c13cd05e55048ba";
+      sha256 = "b393121d160954913639e44989da42e1f60d3828310df57ba7d67dfae9e3c871";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/af/Thunderbird%20128.10.0esr.dmg";
+      locale = "af";
+      arch = "mac";
+      sha256 = "e11d4a6d9d232acbeeb29498878d02af0e4c677f44a4e278299b87bf0200be6a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ar/Thunderbird%20128.10.0esr.dmg";
+      locale = "ar";
+      arch = "mac";
+      sha256 = "dae7d70a23922d05cf5050d2fccafe137e7a148856a6b544b27dafb9095167f8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ast/Thunderbird%20128.10.0esr.dmg";
+      locale = "ast";
+      arch = "mac";
+      sha256 = "47dc8fb511d0372f9ba2e01bdd6286231676258a9eac43bc909f8a0cb56b6b78";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/be/Thunderbird%20128.10.0esr.dmg";
+      locale = "be";
+      arch = "mac";
+      sha256 = "98acb0839cb639d38bccffb8eed2715c44064ab9d250ed834c73f45b3c3e1cb9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/bg/Thunderbird%20128.10.0esr.dmg";
+      locale = "bg";
+      arch = "mac";
+      sha256 = "1ea24914a33b623991b1698568d093d0a12912bbfeac50212d1a0ab8f50b0c05";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/br/Thunderbird%20128.10.0esr.dmg";
+      locale = "br";
+      arch = "mac";
+      sha256 = "07cf654bc1fc9453d9af96cd8bea0561b39df05cd1c221f9e517f8c941f380b9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ca/Thunderbird%20128.10.0esr.dmg";
+      locale = "ca";
+      arch = "mac";
+      sha256 = "9321a161406268e3d77a27dde9b84ec4d0d03ba4dafb66dc0b75df75911985cb";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cak/Thunderbird%20128.10.0esr.dmg";
+      locale = "cak";
+      arch = "mac";
+      sha256 = "c794090a04b7be0914e08c3b0d6251f95a1290a8f44163513f7e1565f65bbe11";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cs/Thunderbird%20128.10.0esr.dmg";
+      locale = "cs";
+      arch = "mac";
+      sha256 = "cbdb25ef092f89ecd42409869c90329c1abb53f37d7e81911e228f6f46af59b6";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cy/Thunderbird%20128.10.0esr.dmg";
+      locale = "cy";
+      arch = "mac";
+      sha256 = "bb295f6f00102d9ddb4ca4b7d14aebac811d6f575e3ade0e6deaa88d7d9fffac";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/da/Thunderbird%20128.10.0esr.dmg";
+      locale = "da";
+      arch = "mac";
+      sha256 = "6edffdea7e8e2075c7c616a8fd4bc3a9dad2a89322c107480ae34aadcb4c3f69";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/de/Thunderbird%20128.10.0esr.dmg";
+      locale = "de";
+      arch = "mac";
+      sha256 = "f6bf2a01304c31f60813821d7cd2d1d6acfae1409b650b3c5d12b3c43f1a7930";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/dsb/Thunderbird%20128.10.0esr.dmg";
+      locale = "dsb";
+      arch = "mac";
+      sha256 = "527122dd96f80c6428e43000e7266ea85b329aea08d72d0e5738f96a1d4f6c08";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/el/Thunderbird%20128.10.0esr.dmg";
+      locale = "el";
+      arch = "mac";
+      sha256 = "2a04e5c92989ced451b13e6c7b1273e614c7ee7ad93eaa9d77c7f193f3b09809";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-CA/Thunderbird%20128.10.0esr.dmg";
+      locale = "en-CA";
+      arch = "mac";
+      sha256 = "dc01bb4e61a60ed082f55e64d086c09b2b9d2eed38bbd8bb376af17fe9214db5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-GB/Thunderbird%20128.10.0esr.dmg";
+      locale = "en-GB";
+      arch = "mac";
+      sha256 = "f64aba7465d196f8d55c31093b06c9939383fdf8b1f63162f48aacf2547af341";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-US/Thunderbird%20128.10.0esr.dmg";
+      locale = "en-US";
+      arch = "mac";
+      sha256 = "e7402777cc58fea6534c8548244993415fd215b97cad6952a8e3459f90f5810d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-AR/Thunderbird%20128.10.0esr.dmg";
+      locale = "es-AR";
+      arch = "mac";
+      sha256 = "fc6beb6a254559d7b1a20cc0e5abe636ba218a7567d571ccc66c564b5fdc1b71";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-ES/Thunderbird%20128.10.0esr.dmg";
+      locale = "es-ES";
+      arch = "mac";
+      sha256 = "059d77bad5e26477cfb3527c82fbaf5c9524c711e99c08d86badb7658eeeab4e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-MX/Thunderbird%20128.10.0esr.dmg";
+      locale = "es-MX";
+      arch = "mac";
+      sha256 = "ebbeb8cc79023bced82f2429fcc17538ff1f3c77886b8a41f0297543f52bb403";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/et/Thunderbird%20128.10.0esr.dmg";
+      locale = "et";
+      arch = "mac";
+      sha256 = "766a0398e073d912b118c744d6b8af1faa35bf7de3875f3afddd921de11779e2";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/eu/Thunderbird%20128.10.0esr.dmg";
+      locale = "eu";
+      arch = "mac";
+      sha256 = "713f026166781770021952013588aa80be34fc9f974af363f9a8d34dbc9a1a7c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fi/Thunderbird%20128.10.0esr.dmg";
+      locale = "fi";
+      arch = "mac";
+      sha256 = "8f308fb87f9929ac173a7c9213f1c117cb719a260075d97e6573c0171b1da5d5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fr/Thunderbird%20128.10.0esr.dmg";
+      locale = "fr";
+      arch = "mac";
+      sha256 = "91f6788d05d12b37775717a2e6b48a4494b043ef4a0093ccf13fbd41bb4f6a96";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fy-NL/Thunderbird%20128.10.0esr.dmg";
+      locale = "fy-NL";
+      arch = "mac";
+      sha256 = "64e5cd0d29521664dff55590f7b45e1820a518eb01ee4d6caac240fb6eeebd11";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ga-IE/Thunderbird%20128.10.0esr.dmg";
+      locale = "ga-IE";
+      arch = "mac";
+      sha256 = "49d06f924a865fe5451671092f17f804738d8e8bcfb5195b693441c0eb6a88bd";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/gd/Thunderbird%20128.10.0esr.dmg";
+      locale = "gd";
+      arch = "mac";
+      sha256 = "ec9f693a14accb7674638b9239d5a2a7c2026ac0e5f15b830994542bf8dc52b5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/gl/Thunderbird%20128.10.0esr.dmg";
+      locale = "gl";
+      arch = "mac";
+      sha256 = "7aa85c6186f7209df572098678fffb94cc0cd486f39f45af5281469bd8de174a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/he/Thunderbird%20128.10.0esr.dmg";
+      locale = "he";
+      arch = "mac";
+      sha256 = "54ca168d07d80a9fa82d2734538206c3f7e0eed78b81741f4adfe2c5cc1322a7";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hr/Thunderbird%20128.10.0esr.dmg";
+      locale = "hr";
+      arch = "mac";
+      sha256 = "99bb5eeaa30b7e32bd11a721bef44d41d0d14d88999214e99404886f32c7f1f9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hsb/Thunderbird%20128.10.0esr.dmg";
+      locale = "hsb";
+      arch = "mac";
+      sha256 = "af9d4522773d02e0ef7ee14d2bd7820aa2ce43f759f2ef5a74c2ec3e23d8e936";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hu/Thunderbird%20128.10.0esr.dmg";
+      locale = "hu";
+      arch = "mac";
+      sha256 = "80a8d22ad72eed7c312e6246ab76fdeae8dca20d52e2111d0677c131fa75b8b8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hy-AM/Thunderbird%20128.10.0esr.dmg";
+      locale = "hy-AM";
+      arch = "mac";
+      sha256 = "2124196d6ee539ff8ef0033f550029a18dc757bb3c641d0e997eaa6e8fa41a65";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/id/Thunderbird%20128.10.0esr.dmg";
+      locale = "id";
+      arch = "mac";
+      sha256 = "83688c89878513397d5ffd1c8c53b8746f9b7906e565590b9ca6190d28443847";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/is/Thunderbird%20128.10.0esr.dmg";
+      locale = "is";
+      arch = "mac";
+      sha256 = "9b7ff4011adc8ef704ebb8243b1948460b3ae38ca56441e7a027de7710ceaa75";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/it/Thunderbird%20128.10.0esr.dmg";
+      locale = "it";
+      arch = "mac";
+      sha256 = "5b4e5e6d75c70278719186a9464e9ce988e6ad1f28e98e4e200bbcb9772d8d3b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ja-JP-mac/Thunderbird%20128.10.0esr.dmg";
+      locale = "ja-JP-mac";
+      arch = "mac";
+      sha256 = "12f8910af78365ca6527017f4124ca0f0f4c909675a55898e7a093ff0d7b6e0a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ka/Thunderbird%20128.10.0esr.dmg";
+      locale = "ka";
+      arch = "mac";
+      sha256 = "11b4c6aa91bdb0966e93e8e5527c81098f3900a28f0803b5aa899934b6214de1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/kab/Thunderbird%20128.10.0esr.dmg";
+      locale = "kab";
+      arch = "mac";
+      sha256 = "61f105425d800c80f9ff8c4bb27c20a91e95ae7586d019f558b24c7f992bc83b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/kk/Thunderbird%20128.10.0esr.dmg";
+      locale = "kk";
+      arch = "mac";
+      sha256 = "eb2d8514a7191500add449bcb4faef6b6952d1afefd8178aa98c83248ee37282";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ko/Thunderbird%20128.10.0esr.dmg";
+      locale = "ko";
+      arch = "mac";
+      sha256 = "f6855562c14119e5a5a81c2c978eecdfdcf644b22255fc3a3fb9f5e4828faab1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/lt/Thunderbird%20128.10.0esr.dmg";
+      locale = "lt";
+      arch = "mac";
+      sha256 = "e596276341034db477457da788b613131efe59f378b95d72495effbea45bbf75";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/lv/Thunderbird%20128.10.0esr.dmg";
+      locale = "lv";
+      arch = "mac";
+      sha256 = "73c5c1bbd31fbe3853a3636a4b1f39ca736d7c5dfc2113a10d5f202eb1a7a649";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ms/Thunderbird%20128.10.0esr.dmg";
+      locale = "ms";
+      arch = "mac";
+      sha256 = "a885b5b087e36b0f8f4b3846aee2ae9fe2bd7942a382503cb64d609b28741f3d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nb-NO/Thunderbird%20128.10.0esr.dmg";
+      locale = "nb-NO";
+      arch = "mac";
+      sha256 = "a58d895364ed606a572c8b3d553db4951d19110084725c2042c66b12d46d026f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nl/Thunderbird%20128.10.0esr.dmg";
+      locale = "nl";
+      arch = "mac";
+      sha256 = "fc8d052a87038890014d7185417825bca0d75255e72188df1dda7887ed65db2d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nn-NO/Thunderbird%20128.10.0esr.dmg";
+      locale = "nn-NO";
+      arch = "mac";
+      sha256 = "53082cb0e30dae180ea706a4c68f84cf5d9c26b00ae48973d5823481ce5790cb";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pa-IN/Thunderbird%20128.10.0esr.dmg";
+      locale = "pa-IN";
+      arch = "mac";
+      sha256 = "5e0a4f0acf75a37540c344f1d23171d5e25d755e0ed919b2554518300bdce9ac";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pl/Thunderbird%20128.10.0esr.dmg";
+      locale = "pl";
+      arch = "mac";
+      sha256 = "0b204994c027d3ac83827b0f07f2c6525cfef45e7e26af7f5449e8bbd18702b0";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pt-BR/Thunderbird%20128.10.0esr.dmg";
+      locale = "pt-BR";
+      arch = "mac";
+      sha256 = "d1c7b12933bd71b28f24aaa7df88a1828d568b3773ed5ee14be2edbde85cea5c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pt-PT/Thunderbird%20128.10.0esr.dmg";
+      locale = "pt-PT";
+      arch = "mac";
+      sha256 = "03f81c3a9049c11f339472b2eb9f55916e8ff9fe5b5b21679ed005033105807d";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/rm/Thunderbird%20128.10.0esr.dmg";
+      locale = "rm";
+      arch = "mac";
+      sha256 = "75c59efc07f3f34bdab257e0f0c9047694f9419020b6c22378780c422d9e291e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ro/Thunderbird%20128.10.0esr.dmg";
+      locale = "ro";
+      arch = "mac";
+      sha256 = "7dffff8c220907a66985e5d8c5a617094be9f1a030809dd12912f0af9ccc71c8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ru/Thunderbird%20128.10.0esr.dmg";
+      locale = "ru";
+      arch = "mac";
+      sha256 = "1da096f8c0990c5e44c3bfdf4f60a127593a78ece9298830cfe8ddd76001f464";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sk/Thunderbird%20128.10.0esr.dmg";
+      locale = "sk";
+      arch = "mac";
+      sha256 = "6c2b8e2925bb8531f7b76157a044722ebd07edc3c65ee3d7fdd9e3939724b619";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sl/Thunderbird%20128.10.0esr.dmg";
+      locale = "sl";
+      arch = "mac";
+      sha256 = "cc8abcaba5002b56c279e2019ac13766d5ba24f035bf71446a3afcc9eccbd5c9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sq/Thunderbird%20128.10.0esr.dmg";
+      locale = "sq";
+      arch = "mac";
+      sha256 = "477048d3633f85cc0e533e7d30b066814d3a88553a45c2a92ebcf8480a9f4544";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sr/Thunderbird%20128.10.0esr.dmg";
+      locale = "sr";
+      arch = "mac";
+      sha256 = "0c148dcb61d99af28c81bc816abb3851947169985600af7a69f4a85d363aaf1f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sv-SE/Thunderbird%20128.10.0esr.dmg";
+      locale = "sv-SE";
+      arch = "mac";
+      sha256 = "060017afa379d82ad65f8b48a7573d134dd18adb51960cc271458ba9c1406208";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/th/Thunderbird%20128.10.0esr.dmg";
+      locale = "th";
+      arch = "mac";
+      sha256 = "c01b8831299731d5dd6c3b0aca1aa44ae7e8c49e7f949bb1fbadca3341106912";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/tr/Thunderbird%20128.10.0esr.dmg";
+      locale = "tr";
+      arch = "mac";
+      sha256 = "9b7e7d43f56fbc3cf92bd8cf03f119a8a7d9398e7560320e947e99d6ce5a1924";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/uk/Thunderbird%20128.10.0esr.dmg";
+      locale = "uk";
+      arch = "mac";
+      sha256 = "cf46b4d96b61280bb39c5dd5c3ea99d0ab34b7feb913515573b2c8fab5e116bc";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/uz/Thunderbird%20128.10.0esr.dmg";
+      locale = "uz";
+      arch = "mac";
+      sha256 = "ffef659e6962dd70b6b77b9f9a0bc77e922df96a55cc8c1a53ba262f57cc0685";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/vi/Thunderbird%20128.10.0esr.dmg";
+      locale = "vi";
+      arch = "mac";
+      sha256 = "eae5e91866f787e32ff88df412fa0ec137f3531067cfe1886938e91d2a67c0d8";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/zh-CN/Thunderbird%20128.10.0esr.dmg";
+      locale = "zh-CN";
+      arch = "mac";
+      sha256 = "5eb7fd21a86126a7fafcd8c893dbe4ae00c7539fe73298cf7b98450cc58af27c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/zh-TW/Thunderbird%20128.10.0esr.dmg";
+      locale = "zh-TW";
+      arch = "mac";
+      sha256 = "7f3ff91dfe65d5fd044334909d6041e4776440dc550be92995c992c0493d50d1";
     }
   ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,797 +1,797 @@
 {
-  version = "128.9.2esr";
+  version = "137.0.2";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/af/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/af/thunderbird-137.0.2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "aedc246acba5af959ba0413882aa149a458841ac254d62a1f5dafd3bdd9cc472";
+      sha256 = "ae5d7a38a1bb7d7c40ddfa1d0c9805705cf56240f1184618fe93b65894c10600";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ar/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ar/thunderbird-137.0.2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "11fc9a81c124d723fe5cf13b7afd97915fff67ad88a0df3795524fc1895aea9a";
+      sha256 = "e0d3b8c4dec89d23840af72298da9ad6b4d491e506fc2286935a02aeb6986c62";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ast/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ast/thunderbird-137.0.2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cb8483973123002ae993ecfdccc2c548c8a88eea7a13556bf7b9cc6522710f5b";
+      sha256 = "cacb9092f8f7137e17389f2f60803cdda39b4bba2b8a8a369385458381b0a488";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/be/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/be/thunderbird-137.0.2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "daf4fe4ff79cf2dd5bb6974d4b96b1023e48fcf858a47a6a2f80c9f94a241bf5";
+      sha256 = "01e22df0769f9539e117f2a54d47a21e103f8e6caf55a5b3f221994ef1045c32";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/bg/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/bg/thunderbird-137.0.2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "1f75adfd5a34d349b7ff3498b74846d7f183dfeffe71c95898edbb1cdd347af5";
+      sha256 = "9fac89c39c2dc4951abf43a09745f6f5d36eee188c9922d3ef9b66c9847f4626";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/br/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/br/thunderbird-137.0.2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "0099c80187ed38588577025c18a16f4a1f97d34358c1c141253acb8284c0d7b9";
+      sha256 = "28626768b1ef4fd9028d46e2b1b7d1c2b039a2f32814b82892da7d5e46a5b0c4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ca/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ca/thunderbird-137.0.2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "3dd450c1394d0511086fe359397f10ba2286f351a439debdf7243d372dd4e82a";
+      sha256 = "0c750eca6961a4fa50d5a4a9e1de1f1be679196f21781289f2d17c012ac35401";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cak/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cak/thunderbird-137.0.2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8be34e4111812242e66e26ce132aa5cfd4207f54c5f6b526177faba1040f7e5b";
+      sha256 = "e2a501cecc4e172d153cb925e2ef2b4d0ef6f30dd54103076ff3ee44dc35fdd2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cs/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cs/thunderbird-137.0.2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "56287abaebf7a18f6bb4ccf6b211c3a484fc906ae0a95ff8a57bdb0c0dc610e7";
+      sha256 = "0449dcdf3bd206b682a99d79bb8eb95b92f46e1b8977c1da659838f5c433b83f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/cy/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cy/thunderbird-137.0.2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b10d11edb5eea9d379ee46e91446d9ad0f4e13c51301fc3c86b1b3b29ce68544";
+      sha256 = "5180a1bf23a5fab9af458f366a188868792ebbbda024526be551f6a3da545628";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/da/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/da/thunderbird-137.0.2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "4c2938e2e5d6f3a87332e2facb917e713dac353d1ea59a28ca8061595fc1ab10";
+      sha256 = "bacb26b2d47ae51978f177e5e2735c25f0692196fbec0195df0aed0be14c7f90";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/de/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/de/thunderbird-137.0.2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "d4936702e75b71a18d36bc4f4c62a4f5bce75e4704ee9f968f4971466798b372";
+      sha256 = "702d8eac33a01b2de5cecccea98b518ae6e3d7c53fd3aa409cbe6a40200d0042";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/dsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/dsb/thunderbird-137.0.2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2aa5d5aa83026a49c4eb24f8ae7d918c1c82f1a5e0f3066b7041296479131c13";
+      sha256 = "6f044b1734f5e222c3ab1a605cbe7edabf79f3fa3492d4b0d9191c5399dac704";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/el/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/el/thunderbird-137.0.2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "27057c8273f6783a7176959ae2fd19f8e2e2416cc29d64c7b64f30e83f091598";
+      sha256 = "0f30952f82ba4f29a1848e7f65f99c56588558e6cd76a8e991d0ffc092ad3065";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-CA/thunderbird-137.0.2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "103162be5b27f412b24174e98bb75e8d467ad49dfcdebefa0c75371da44be009";
+      sha256 = "4a51f57126732583213bca7b143759e3cfda49d1bdae00dbc83a92084fbd7ba6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-GB/thunderbird-137.0.2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "1b2c8555c69f52be42c6857944b02a04b6a91b9e2438dfd376b8215ae5e7ccf6";
+      sha256 = "b17e9015ca14d60dfe89295dca40d454646b63715773e99362d494c6b6a070d5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/en-US/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-US/thunderbird-137.0.2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "b32a370c7ccf9344493856a508845dd29c904ecbca9c1faa9c788a42a3d2d89f";
+      sha256 = "0ec67084fc238ec3c9c359e705f7e730a7adfe2376b20ad9020b94f8e109a035";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-AR/thunderbird-137.0.2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d8b3f556e025d488d21d5483b7aa3b5648ddb3fca8fd3260f42e01d272febf35";
+      sha256 = "f61de8011dd94e1ec621e2b281c6e5a4b4f36f8b3c9a034ec90220c6c4f6b598";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-ES/thunderbird-137.0.2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "52060be7f02ea93ca75dd3514a791a7231e45ef688bd748f6e06b159ae346cec";
+      sha256 = "9558d3b3cb3da1fec0f267fe0582777884204ac16605bc49717134a16545a147";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-MX/thunderbird-137.0.2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "61e02c8ebbf26f6dbc1714d84a3fb87281a6c0c88ede9a81fc374b873ab886b5";
+      sha256 = "098164af16704687a0e38722e8fac1652b9d7e0f535ed2a7783aae16c3170876";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/et/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/et/thunderbird-137.0.2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c7b35b9b024c830897429ab8a7c3d0d55d8007ac1afd7bdd5981546772101325";
+      sha256 = "6d0976ebf8f66b79d4f21da174217d1610df670761874749461d07ddc4a8747a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/eu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/eu/thunderbird-137.0.2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "def113bfe9f855a2a4d898c493f84e95e5919ee9ebe46021fd35b8721f2547c8";
+      sha256 = "fe2a5302d8ec78d2a26387e866cc5ca79881d7765b1ca8bfe8a5652163460a2c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fi/thunderbird-137.0.2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7f60dfd652fffc015232ea0b03b4259d38cb553cc0bef83030d8e1695be6938d";
+      sha256 = "7908fa449c2cb699c3b33f2f507ca140f0cd9069e79622e2cd2c7a5b670b136a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fr/thunderbird-137.0.2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e6367e4afb84e73152fc8407001d1442d73356501f208f299d84f41b1ed01e17";
+      sha256 = "7502cd60b63f762edff89bec49772463ceafa9193fdd29e3194e14efeba3c600";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fy-NL/thunderbird-137.0.2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9917344f3a065cad38b00f693971f6d9e86823046d55c7060c9b049086dcf998";
+      sha256 = "6c2bf9f223b89ac986d00b6d5ba547e0de45e90a201426d759371e1d50210a00";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ga-IE/thunderbird-137.0.2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3afc13fdd4e4810e81e26bc54c5a44fe83c2235b65b2833fe1b6706bd2f4b139";
+      sha256 = "a4f1c4867865cd488044a14a1bd6b45124ead59c0d5f1f8597da26fb3191cc40";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gd/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/gd/thunderbird-137.0.2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "29d58e819ffc98c494d900b0a799d80f809274d7bb8ed36f36015c6aa4911521";
+      sha256 = "edc9f6ced184e1fe3a3c61b199844d327345be36f5497d7f43fa1b423de494b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/gl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/gl/thunderbird-137.0.2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0af1c4a750c6f5eafe11f455de8e037228d89fc638de4f69cbc685fb42f9ba1a";
+      sha256 = "ad871ab290cc41aaffce75e11c7c1c4148f5ffa1c6417e784146a6f6d6e7fa70";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/he/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/he/thunderbird-137.0.2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "fd3c05162bff13f8c0ab73d0be85c08ee75a93f7b2e57361bd224955eb40ec8f";
+      sha256 = "b826105ef00b6e04397657d8dd0a12410e3dae2dfdfc6562ac69306846b25e26";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hr/thunderbird-137.0.2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "bbc60804dd01dc1b8b8ef7bcf6410401e0e3406e8248783573abc616099ef180";
+      sha256 = "a1ae8628e1073d7aafeb3b2f763c1cd35794e930d71865ebd4acefe825f99792";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hsb/thunderbird-137.0.2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "720a44c20fd9c6bf80d8dcba1f1d3704d222c9dd9ef394e2dff4ed2fe49ba779";
+      sha256 = "22a29aed60af3e22f182cae117a695b87f53ee9862211eb7baaa60c8c97ad408";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hu/thunderbird-137.0.2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "03391b360918b4fa6a405a5522d82cfb3e68102b6a7ca2bcfbaaf84f1df175ab";
+      sha256 = "424122a45fa2f849cdecf1f0f5af4150b71c8c8f2bb2c224ad77c96b6acd77c8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hy-AM/thunderbird-137.0.2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "8d88f133d3499eefb1b4b01ee0ecd7c7a7e0dfd261d0662dc8fb449d66b2ceb8";
+      sha256 = "3848b8abecaa0920ba88f61053fe9281a36721c7a51a96622289d19a7c345815";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/id/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/id/thunderbird-137.0.2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "03ba72e400152d8464cfdf8c115833229171fc517cdf7493b5b753744105f5de";
+      sha256 = "b6fad622eea4625914f8035e40123db1eefe3aeccf1f6d4542d0a7de236746da";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/is/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/is/thunderbird-137.0.2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "13441515e3dfe06d9748abaebf0b982813550761f824f277dd70d991c06a9cca";
+      sha256 = "1667c03203e4494fb2527a1397e82dfcaf9ac3845584eb7b897ff5dcd75a87dc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/it/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/it/thunderbird-137.0.2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e942ead46e2ca5c82faf0a9c3d98ba1a54f22e21571b938bf0780501e76b2e88";
+      sha256 = "688e3a07d08b11cc0bc4eb6de6e329fdbcd31e66d12cfbdaa2d20932edde1ddc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ja/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ja/thunderbird-137.0.2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5423ab42fdeba564049cb97bfc4dc638cc8c07e34866ec19e16aeede83aaa937";
+      sha256 = "67d0c965445fd607c310552bce34eaffa109d15d03ad0e390d2452ab759e55bb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ka/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ka/thunderbird-137.0.2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e1af08dadc08607a513fddd85a73cfeb31a9b7cdc697936fa623fb2d2191c50c";
+      sha256 = "0cc83d519010d5aca0a1088bbc6f9b6670848e15e633e1d1e830690615526719";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kab/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/kab/thunderbird-137.0.2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "b5da89621f22b454c6ce949811ea408f0a960d17a61db3ead0972277766ecfdf";
+      sha256 = "60a7ecbacdbe16f318b97b2f91e252950b4b53c6eb20dc42cedf4f1041d2a8c7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/kk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/kk/thunderbird-137.0.2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "62b9e71bfbc61f55a01d993b415eb8f3600180033714001b91642db194ad4c76";
+      sha256 = "de123dbe631c770989e513f99a12efdc1695f9ec30bdc7c9845b517bb01ebfb1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ko/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ko/thunderbird-137.0.2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "e6b0bdd3f9c24a1fd703d33acf9087133f7e39281e8ff1ddc9ca402058fe2b5d";
+      sha256 = "0ff80afbcf5a12858f4c499f2f804e9df63dc131b6cc63a49b99c08082be20dd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lt/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/lt/thunderbird-137.0.2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "93981c55695e5a1b957b2c26d9a8672b114aa39deb4aed150b90538b0bdde906";
+      sha256 = "daeb3c247d474068717c63de75476fef8bb2350ca7feb812281fdf3fefd13cdf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/lv/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/lv/thunderbird-137.0.2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7062d9bc31ad8e09b9676df1ff3e6e21e56b2531c4e3b02d06451c0ac69b7006";
+      sha256 = "4dd2fa518588b7904ea00b9a6d5e77f347dd3f8ad2429d367c702c2ee0953523";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ms/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ms/thunderbird-137.0.2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "95aec53cbe42d9c8690ad8c6d9bb73f9cad3f6d4aa9e8ed505b84c2206f03312";
+      sha256 = "eed23aff6bd123bbb4dd0c960831382317b94082b910d9283b526dd1282feb5f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nb-NO/thunderbird-137.0.2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "a016a592f41ebcb4c8fdc9d8cb589f5dd0027aef26799a2be600bb79b296c185";
+      sha256 = "5f87f61bfe721ee703df67a46af77ac4db5b580357bd86574b35187fef9d3278";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nl/thunderbird-137.0.2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "d8c009cc0add26bd182b26275756cbf5e3d7ce6d10294b573efe850dddaf3112";
+      sha256 = "7f4843d4659394f64e10629d09c3773b34ee2267a5b6e5cc26a6ae34f0670edc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nn-NO/thunderbird-137.0.2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b6e578de4e107e989f2339171e8e4076aad9d1e4257691cb5cd29b0971a0f696";
+      sha256 = "6a599c1e9d3985754f858895cdb79c87ab5fcba72d8da9d0f75e908771e41230";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pa-IN/thunderbird-137.0.2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "dbdbf3726d9f319348542d6e6a81fc48446b3f25bc856a0efa72b5330350f539";
+      sha256 = "26e79ba7cd9d7e26e8d678fb30da01ed064788bd3d10c29566a558e3e34ab732";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pl/thunderbird-137.0.2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "955113ab1b3c70f1753a00fb16409c3259c30cd406882a5c6432f352e3017758";
+      sha256 = "44e75be88335d1149199e2c461d583f3284dd7b62cbd35776a28e0c51b82df19";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pt-BR/thunderbird-137.0.2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "36013c7d86f3d6e3a06defe59fc89956ecadbf818f3b4fdf8d9c96db8b9030ca";
+      sha256 = "7e0e82870fe8a7d3fd83fd1f88da6a98dafb3401a1ef366432a27ddc8846a6ce";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pt-PT/thunderbird-137.0.2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "7665f711c3f2ce910ec0fec70e88fc80fd11671825381a1f0bdbbba3d21fe641";
+      sha256 = "4b7bfe2966c997371c7b1839137989b1a9688f3c4de16051071920435738ad41";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/rm/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/rm/thunderbird-137.0.2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "92b00199c1c2b27567dce33ec4b782eae778baceec8f25cca634a0feb3c26901";
+      sha256 = "9876da9d04088eba3cafccf37ea571767f799423122a34d25064f56ecce08e2c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ro/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ro/thunderbird-137.0.2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "874f5cd02709478561e005e5ed902c602ce9218ebacc5097816377b58d014e55";
+      sha256 = "a2fffe1150f5909086d148bc2d08c5fa4e5a5559e0b9969f8a47cfa5c000741f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/ru/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ru/thunderbird-137.0.2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "bc5e5aa0769f6273d1de113c0f8ab92fb93030bc4721ace954ec06d94351838e";
+      sha256 = "3aa36619253ac6be7acabed21e3a8a93849f3d026832be8f5b4bd1e893b58bb8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sk/thunderbird-137.0.2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "0300518b53382b710c4aade4813c8666f89c64a7f9bc4816782141126508bada";
+      sha256 = "37ce68e9f2d5f13aac3f4e754dd5d4e9e4024c900813b7ba188878dd870deff4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sl/thunderbird-137.0.2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "42bc03ec649b3f5a4d774a1ae7c6f7a6900634cbf77507daf94dda8dae0cabbb";
+      sha256 = "b486dcbdd0c355bbc6ec52f86e1b7485aff7bf06aeb6e3d26b317d2b0cc6dab6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sq/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sq/thunderbird-137.0.2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "5c1c03f5d19706f2cc4a24c55305c67a65812dd6e835ca99a9b3d61824fe3afb";
+      sha256 = "ac7936bef469ac219b076fa52ac83926b0522ebdcd7d8e6f82def2b5d9386b37";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sr/thunderbird-137.0.2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "419349e07a5b8b3b0a9dce2f585a4faafec368fbdd16e7a32fb3063a4e5998a3";
+      sha256 = "80750d623a49101cbaaf01a1541d6f56322ca98a1b5f116c1c3963c83f1b48d1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sv-SE/thunderbird-137.0.2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "093a96a329a4b51fa8d1bfb16b3e9e9b7311f54146dfd9ea62bf0522fbc53987";
+      sha256 = "57375a51504a94cdc6d91b32593a15153e411e192565de1b87187129bae87944";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/th/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/th/thunderbird-137.0.2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a010c2ae76a00fcad6369c3df36cd74debfe32a311d30f7b6181832373420700";
+      sha256 = "68b1c7c780bced5f8335b598d032355aaa407c0dac79d60163e90faf67a1e27b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/tr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/tr/thunderbird-137.0.2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "943511923a37304493f326e3b1568cfd301f62cf7e88c1e0ef111be55b318cf5";
+      sha256 = "9b2edade61a6a2b1186926a25a93af175c5182915c1ba7b372334b3732e612ea";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/uk/thunderbird-137.0.2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "94f8328389b51c72456808483dc90562b7579cea41cc138f5e03050de861b538";
+      sha256 = "c266db47fbb6a26dbf8858b031407f01387f006292a32957284548b1ae30e7d8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/uz/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/uz/thunderbird-137.0.2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ff7d7dc0981ed84b6d87fd2ed54869198e935dea9c78c5fb673ee87e0f8c1cb1";
+      sha256 = "3d3f9ec9e559d805e4c625b3b58032ee554a88ae7cc9424deaba8e85f64e0308";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/vi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/vi/thunderbird-137.0.2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b103568da22674e02369b9c90b33fc857f546a00d5ed0399766cc57a1e338b08";
+      sha256 = "a370e2206cc020487ced719e9395d4f15ebbbb012cd5cb46d30d8b54e910a238";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/zh-CN/thunderbird-137.0.2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "e2fe71b1273b956a4266c80ec3a7172fa092b06b7a8073dd86159371e0e94bae";
+      sha256 = "5d539f1308df30a6f17bd4b138f9a4ebc1673fef7df47b741ce105b2a06abf8d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-x86_64/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/zh-TW/thunderbird-137.0.2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "26520d3ae666780db773a2ccd1d0ad0e2b994818d4a7d3cbb8f6ebe270a7d04e";
+      sha256 = "9a11f3a2b9db47846e090055da2d5a06a0acb9c67e27edd2c3e60dbb0e312b45";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/af/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/af/thunderbird-137.0.2.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "6d0d4bf4a1b709185609fc7ea910712fee98673f39a057940d627f3f859f5cbe";
+      sha256 = "f0dd8615c7b7a126c67e7a20aeadffb92e6e2b1d9a7d7c2fb2d3836406b82aca";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ar/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ar/thunderbird-137.0.2.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "4380e84b48ac58733aa4bd3eee3ea1189b9bccc8ea452f564668643f713f472f";
+      sha256 = "bdf52baa6e0e726e1c0849d88d0dcaf4e41f71e8002ef405c7fed9d9bcbf33ea";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ast/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ast/thunderbird-137.0.2.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a9e3f8db99044541a5525821bb4da0b6e88e5907e4ae3695ea2a795daa1a0e52";
+      sha256 = "32c46e666cc2118810d2ed51ba30961b2c4b1796c882e13bf1653b9eba87d6b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/be/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/be/thunderbird-137.0.2.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "140ab2418316724b8bcfe47540fb14b6126f4cde156e98593b3a77fc50d7f3b1";
+      sha256 = "75717aae6a3519d75702ce4e85213775d43fd35e4bfe0f2f3d21641e87dbf2c2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/bg/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/bg/thunderbird-137.0.2.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f55043551abf7dd1024ad99b2ace9e4348a4c297fc43de2cb0eb7ed5830ee700";
+      sha256 = "451c308d1ce2af29ac8b84fbc584fd803def2581c01376da61b06b390d1ed158";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/br/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/br/thunderbird-137.0.2.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "1f706bdeae7e3fd1276d0122bfe0b59af59a8fbd7ff29553396e4bb9443430d8";
+      sha256 = "f259ef04d2fb04a82eac78b33684de3fb33de17e2a5b99b6c31b220806a99cb6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ca/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ca/thunderbird-137.0.2.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "594775b8bd1af2480f366636adf44133ae5fb54cb5abf717e84b7ca7f66b860f";
+      sha256 = "e1e473934f1627450df0fe321465c31c966604ef50e49a58b208d2d078cec324";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cak/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cak/thunderbird-137.0.2.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "2fc2d907c0d941c7af74bdd2278bd4ffbca295dfd1547c7e12af44734b25cd07";
+      sha256 = "fc127649b2b9c6089719728f75e7f458bb53ce161e56b45eb17d44d8702ba7c6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cs/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cs/thunderbird-137.0.2.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "4685a385d0051d4095c438d732d0a13762e70b92af2b0bcc035560267554c0b6";
+      sha256 = "bd43d88883d7acc57b99d32e5f66bb81d187eeae5d125d843e2ac6ef1794cc5c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/cy/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cy/thunderbird-137.0.2.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "5aec56a54e6f74527496941cd2ace3bad36f4ef5c35f419d82ca5b042778bb7e";
+      sha256 = "7debf3558a37130cfa86d9cd052f56e8fdccb65f9d12a1bbb17e69343c0755e7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/da/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/da/thunderbird-137.0.2.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "2247fbc1cb4d2ceea411220901e169bc0957291a4bddfab424bc6792198d2763";
+      sha256 = "7cc4dd2befdd63e0a6f56983a60ab06737ca291a3c5f6f2d3bca1f1cc20d848e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/de/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/de/thunderbird-137.0.2.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "0d2ae8f5e2da6b286387bed76b6d28d6b0ccf1910d631012742b5c58a0b32aa7";
+      sha256 = "6413bababe4d376fb985050cf3cdb3b2e8697f9dd40f47dfe3b49bb97d22d139";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/dsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/dsb/thunderbird-137.0.2.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "39cb6de6209daa752eb54fe9538f98a099f1430999402ced063c5463455641dd";
+      sha256 = "af0aec455e9363acd6b040f3883bae4d4083fd94917db0aba7400346f65888f1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/el/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/el/thunderbird-137.0.2.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "dff84142810c597e18d548feb32d4f5e5595da47b5a6f5cb8b6e96ad8f1e2d8d";
+      sha256 = "f7b67c4e5bc22ba384f70d55f668eed3a37f6ae744e5d6c5ffb60abdc0fe9147";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-CA/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-CA/thunderbird-137.0.2.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9e84515f768a865f0308d6ba079a022d796aaf96d3a653a3f21706ddab860ec5";
+      sha256 = "c1c3a77dd2b8ed6a7f99adc9054d8ce18af7d344a60be2d0d3b33ce624447fdf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-GB/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-GB/thunderbird-137.0.2.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "982a5e3a60a96ebfe93f4d11327c22a1c7dc07d158f3dd51ff382996c9561b9f";
+      sha256 = "96271b334294eef59d80f6a9537f431a4ca7edde9de87aec6b33059f3e294403";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/en-US/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-US/thunderbird-137.0.2.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "77d58dc23f24d42db2fa7756991a4fd7954d8a8dabafd3ab10e4f95465e908f3";
+      sha256 = "0940febe5627b2bd3e9bf22fd8a7a50f9df801bde679fe733d15baba8ef503b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-AR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-AR/thunderbird-137.0.2.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e51db4457a9a1eb30c1e1bf4aeb679e08a529178c7a25a4b6060403ef4822198";
+      sha256 = "f2fb8bcc6ae60fcf8ced844c76225291ddfcafbb08153d9dc3054a653a7aa5a1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-ES/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-ES/thunderbird-137.0.2.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "1f136f3e70124fcdc8efb8253c85e27c758432646f981c375d758291888ddefa";
+      sha256 = "436ccaba77d91844f61ee7d6b1f718de8a4d2a33de1c52c143cff8ae96b4e75f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/es-MX/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-MX/thunderbird-137.0.2.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f017e992b6ddfaeb8871fe93cb1f4f86b0fe9a8a5bf8d05126b0056fa85034bd";
+      sha256 = "dd384bad1f9bb4cf2adfc95fba180162938a565fd9b6d7132f96d94b3127b866";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/et/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/et/thunderbird-137.0.2.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "638d265b2f86aee9fc0343d3f447bcb4aa541a7bca6063e13a5ca242c3dfe1b0";
+      sha256 = "cc50c635c43cec81fe74b5cd752639d2eb2f38424420f2a61df96cc58c8757e0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/eu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/eu/thunderbird-137.0.2.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "65bdb8323fd6b8380a619d2fb77194b143a7a1486402357721ba713fa53d4873";
+      sha256 = "8762de548f2349d9a23cfe4e796ecfc3d41c3367de1f0b848c4fbb5a9689e647";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fi/thunderbird-137.0.2.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "089e72e19e9e95f0a80e0b3f889c3dc927ed4689733d3997ab4e07192b7b4613";
+      sha256 = "9371179b70826a5fe250f8d43f8abe40417ed45f2eb09929ece3bb94c8bb1e87";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fr/thunderbird-137.0.2.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "d02f0260abfa7cf6d5de86e862db957e7ab7f058870039dd0f78a6ae76a30fbe";
+      sha256 = "f09541985f41bdaa85bca6e516a6f2d12a6ee53dff8e66104935aacf8ec35d5f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/fy-NL/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fy-NL/thunderbird-137.0.2.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "441520418225cbfe7d52daef87149289c8a2b9e7a348eb527449ae519456b130";
+      sha256 = "e0273c98f2bcd78ac28d3200a6d23fc659902d319c246a1a3bf99dc37ca78530";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ga-IE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ga-IE/thunderbird-137.0.2.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4954fecffc9134f7ec422db2324b3b202f63b2ee856d5f580528b53adc88d17c";
+      sha256 = "6fb9b6c78270951b2e11ced2bfb629bd49ea3382c28503e087780ba4d8a9e76c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gd/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/gd/thunderbird-137.0.2.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2042c5cabadec8d05e8a9339c7927f97c290067431d7e2395136abd44a58850d";
+      sha256 = "148c840a6e1230e19adc9fc4149c45302411a410a2303587b01939920a4c12dd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/gl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/gl/thunderbird-137.0.2.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "4c3b9326505fdd233a7f23446ad00798ace67021de3f1a9589f84c616b7cf6b0";
+      sha256 = "1b118445b22df9edbf62b344574c7de836687fc18581bdbd9950777b27a51e98";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/he/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/he/thunderbird-137.0.2.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "784a968dcddbcb21770b7c73782b61a7ce181aa2dd91b0b10b18c60547df4f36";
+      sha256 = "4aa4cbe802ff22537d8d8cba59ee8c86a5248e6eabea984a91985312df61074d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hr/thunderbird-137.0.2.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "7a599e61584bd86bd92de1a0939d5bb00b04393291d94d54ab4b3eacd7003399";
+      sha256 = "3f58b5033000415df754faed5108e1217ee3012d33c5a551fd0eaeb72787f5aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hsb/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hsb/thunderbird-137.0.2.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "084a1218d9bb4d8ff592848811581c9dcef36129597500efd4f941ac450d204e";
+      sha256 = "8aa886e0525985b0eac3dd4dfe8763747e5d6088f1acba7d10345f64e9f9f866";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hu/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hu/thunderbird-137.0.2.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "37510ca117ac9f15bc61a116a3aa55c6da1c6cc5543975cd2449df3e58a27091";
+      sha256 = "6b07d051705d6505036222f4bb5564591df6d3937699e00ce26d19f91a5fd841";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/hy-AM/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hy-AM/thunderbird-137.0.2.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b88b00b8468bff3fb327a32ec505b5b335d03a9b5b5511ee8c28b392d5888f32";
+      sha256 = "159ae407bb5b5b563b39027f93197f65adc41839c32fa123fba79446bc888e12";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/id/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/id/thunderbird-137.0.2.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4767274386cc5aad9e7632d9e0d12bdd093e971b162ce23de1dd489bfc9af2d6";
+      sha256 = "121cef25930e31fe214b58e533a659c9e658b7534ac434de0d7270bd0f8d5edf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/is/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/is/thunderbird-137.0.2.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "b89381d8fb5b73272bb31eb33cd8fe917ec7f3f480d2a6faa252848ad85f2610";
+      sha256 = "6f1a0ef5f9190fbef44a32e08f3407b9570f525477e23924c2a8dae777a4a7e3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/it/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/it/thunderbird-137.0.2.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "643d59b59b983dc863ccb3801bcdf64237e8f8d5e5c6a6205cc0aa073b2b329c";
+      sha256 = "4461fa1b25a2e6bd5c75ff245fa1944beba603eb5bca220e444eb4d048a44d2e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ja/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ja/thunderbird-137.0.2.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "e8be6e2b502d5d6cf7c6cfb0cb55fb9c59f9559d3f3b2b3c8843501f87723683";
+      sha256 = "e52a165580718dd0ed49f9a8935b0edd47d5beb948c424ae58bef0924c02419a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ka/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ka/thunderbird-137.0.2.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "71d0d092470f2e8cb70256770830dfa5c474e3597b1f5f72e9b9ec3d2ed4d737";
+      sha256 = "e8d7124db5fcd1489b38dc721d7044cde60af8973c02d7b223907ad518c38033";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kab/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/kab/thunderbird-137.0.2.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "1e010def386dc00e4ba8317c382b2db251109d9245d4f2b6a2c42a212e0be935";
+      sha256 = "a846f8dce95859b4a14e3bee8ce17d16b8219fe805115e3640e5d361153e4edd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/kk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/kk/thunderbird-137.0.2.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "cbf76587bc7262b554b83566c63c4bb19a7ecdcd84cbb2585ef7ea11a2a1b8aa";
+      sha256 = "d1ff1117063726859c3ceedd99c7227d5651bee3c7f762c0133cf7718312179c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ko/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ko/thunderbird-137.0.2.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "4a12e048ad3e2d366cfb9fa4613cef30bfd346dbd04304ec22d6b93a5a758869";
+      sha256 = "14a200de5bdfad5b3a0e503bc68a5c33e982e853090a63d90b080c9f07e3372d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lt/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/lt/thunderbird-137.0.2.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "3fb97a63f7a5b6693fdbc8ac4de4b96fc5938586854353febd9f889978df5467";
+      sha256 = "a23e7a7f8ba1f344050639d15099cfc5dae5f7a92ecdad68a566f6107117d9e7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/lv/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/lv/thunderbird-137.0.2.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "afc25ba8857040b3d72d47ee1a461bfbd7eaf7cf6dd83f98cc979aaf6945740a";
+      sha256 = "aef3ab2e7e4ecddbf8660470cac7614842a16d8fa286f1d16ebd2aa6e7e18df9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ms/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ms/thunderbird-137.0.2.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "72210013e9a29c780f9a70a712b1672bdbbfc7ab4b0bc782b3ddd8c0a2bdaca1";
+      sha256 = "cf0bc0cc209c094658b66dbab3968b06f76d3e911f4b369f8a3cbdfcf41b6a97";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nb-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nb-NO/thunderbird-137.0.2.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "3776faef5142ea86deb03c88fcb31b129a725a87473311b6a0c762306fc3218b";
+      sha256 = "bc81cff91e3e5956a84993e653b9d6c733594237234a025adfa02586c55061d7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nl/thunderbird-137.0.2.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "16342df841db75db99fe595587bc24bf2250dee4f716ebee039317fbfb9ba20d";
+      sha256 = "7c5ee0b960014e9bd3f45cedd135f70f0853d449420819392af70d3942afefa3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/nn-NO/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nn-NO/thunderbird-137.0.2.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "498a696f70d647dcb9a371c16a18c700007fb4bbda2542ae3d9bcecf28095842";
+      sha256 = "e4efc803bc2092490205ec76d06f59120fcd9f5c2830789a8b163a5ab6576a80";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pa-IN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pa-IN/thunderbird-137.0.2.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "d27f7f5aaa16d133fbf03d9b2795e1428974061e3c81af3e3342ee784dc0b787";
+      sha256 = "3911687e953ff046df76f7e868877c7c418abbeebe77bd04d91e4b4fb6487e65";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pl/thunderbird-137.0.2.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f41281c9747b34ada507eb879194ac87583ee05e329169515e960386ea961545";
+      sha256 = "9aaf6d5818cc1573d0ddf082824d6dbd44fd2b8cb21b86f74eea576fe1cf0422";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-BR/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pt-BR/thunderbird-137.0.2.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "eb7c125afa47911856ea7cb40808e0ad19334b7e1a66276ff85a8b4f56855db4";
+      sha256 = "9f629d7283bc69eeaa857b775c111ac6a0f1ce5cf9f38fa681e3c2bbd54da3cb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/pt-PT/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pt-PT/thunderbird-137.0.2.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "3bce587020ea6d5f05510033e8bd1b424e180e0361d5eb2e906de1583783d70c";
+      sha256 = "7c9ac18764da4bf253bdd9676f8338dfba29cc41f177829822f94807c9301c74";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/rm/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/rm/thunderbird-137.0.2.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "18404d2a3b10273e3a288782eec15f2ff0bd866ce12f2c1ca70e3ecf9e58809a";
+      sha256 = "680624f5b8f1c385911a93d9f2768c6d79e69c4aec8ce3483d135d041dc15e5a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ro/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ro/thunderbird-137.0.2.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "401fb9524b6dc8f5547fe1e61d7f96a02dee5939950c971790370cea05f65519";
+      sha256 = "205b1795e12c42378f3adf7a6fa836890ff947ff0ce501dc2b9a2583249b9761";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/ru/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ru/thunderbird-137.0.2.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b9e3849896c1e65494572a878d3b6209e613215b54b622800509a94a4e873e02";
+      sha256 = "6063eb8440a86eb46b2b81970c05732330f308643b9d05ab5e7d6c4f125332ba";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sk/thunderbird-137.0.2.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "abb7bd8ee676c1a5278ed4a71b7399391a3e129b3de68f23569f8fd90fae6347";
+      sha256 = "4cff70dac85571595e8e955aff4b9018ba5df967fa4daf3af31c953371e3c9dd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sl/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sl/thunderbird-137.0.2.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "20f9f46aa8e6d540c15ee526ba8b3541b9261b41034ebc6041fadc13fd25cd79";
+      sha256 = "5398642c216335c656459497213ef980578c6891881e5bf6dca4a5603beeb9a8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sq/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sq/thunderbird-137.0.2.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9acda0361ead5f8574404986954b7787c6500d675339c13e53d07bba807bc16a";
+      sha256 = "f7e30919e45e74daf12e2af5b7b36b180bc989cb9fed0c54c8fdd3b939c74c50";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sr/thunderbird-137.0.2.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "38a482e78a360897336d3437f8fa985b57f8622403da8278791ec9c7dc49e150";
+      sha256 = "a4504b464fbd73a133dea56601ccb63470ba23bb03b0409db2946ad629d127cb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/sv-SE/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sv-SE/thunderbird-137.0.2.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "f1e3d53361f5cf0a4ea32d7295089c3003d9fcf0c1b61d2a54e9c9bf9815b085";
+      sha256 = "7363aeb9a55babb603f46e2b0bf5772b026db1df9d9b24393b166f05ee9135fc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/th/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/th/thunderbird-137.0.2.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c64c8cd630336e02e5ceb11dbf61eeec11ff9054da653a93e8ad01d1d4d597c5";
+      sha256 = "6b297c6ddf991939c7c85e2f885ec86c87e1e4991476ad048be607b1588a0594";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/tr/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/tr/thunderbird-137.0.2.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "79c3f55b10d47b3f2979acd5fa35af8c87cd463afd20fb8132ae9488f2aad8e4";
+      sha256 = "906c98176c4326cbf047d168788993ab5376b0cc9a6de0c7dbfe383b2551d7b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uk/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/uk/thunderbird-137.0.2.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "b3f77bb30b22064f9f9aa6b236775d4443933e54b23bcb23d52d8a2fa971e7ec";
+      sha256 = "bdcc09d5443160fef9f19cca15df1806b7765d19e28f8c68bab6857872f5533c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/uz/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/uz/thunderbird-137.0.2.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "a912700990447fda3b0396493f9971f4a23428af2c9e919f9cc5fd98ab111e50";
+      sha256 = "04d3d5110e7112bb427da51f8a49c8574f6108a2f59052fd6ec26465d641b9d9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/vi/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/vi/thunderbird-137.0.2.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "807bc4eac07775d49f3c693b58efe5fd6da77c8c7a9a3facf242ee39ff014595";
+      sha256 = "3209f5b180b436ec906906f4bfc1b8ed5ea844bcb04d5eaca1138e4fadac0481";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-CN/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/zh-CN/thunderbird-137.0.2.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "714a4625f206447255055b266d461d893fa5bae815515f2d3264a2c17da96101";
+      sha256 = "b09bccc90b73c1d6129e6742960eba2997f4af7d6cfb3a34e95636dbc425ad18";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.9.2esr/linux-i686/zh-TW/thunderbird-128.9.2esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/zh-TW/thunderbird-137.0.2.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "bc007c2673b5903a9d532081e063194201f163348c5ad1c80c13cd05e55048ba";
+      sha256 = "7a56de1924681479a56460025cc909abf0f1f66e6cb4ed4f23f6a120a4fb20b4";
     }
   ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,797 +1,1193 @@
 {
-  version = "137.0.2";
+  version = "138.0";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/af/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/af/thunderbird-138.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "ae5d7a38a1bb7d7c40ddfa1d0c9805705cf56240f1184618fe93b65894c10600";
+      sha256 = "64fdf4680b09260c585714cb7d984ce71352a3661e58bb82d38c382a8d0736f0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ar/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ar/thunderbird-138.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "e0d3b8c4dec89d23840af72298da9ad6b4d491e506fc2286935a02aeb6986c62";
+      sha256 = "147e0b42bd95f3077ae92dc81cbe0915c38cc1de2ac9f47255df2cd4d55324a5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ast/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ast/thunderbird-138.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cacb9092f8f7137e17389f2f60803cdda39b4bba2b8a8a369385458381b0a488";
+      sha256 = "f3e172f1490ff3f64b5252ace30fea7a507fa3e89315f8b6fe1764ffb40f4819";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/be/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/be/thunderbird-138.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "01e22df0769f9539e117f2a54d47a21e103f8e6caf55a5b3f221994ef1045c32";
+      sha256 = "534247e30e1eae2a66e58f11b411ca2aa19822caf914d17b5142c40f233992f5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/bg/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/bg/thunderbird-138.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9fac89c39c2dc4951abf43a09745f6f5d36eee188c9922d3ef9b66c9847f4626";
+      sha256 = "65baba48357e2e227f441595e97188c85dc9ebf827248c57757f1d31c0ffafa9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/br/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/br/thunderbird-138.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "28626768b1ef4fd9028d46e2b1b7d1c2b039a2f32814b82892da7d5e46a5b0c4";
+      sha256 = "e5d974d0d9aa282e9dd44c76a7e75d5771df51a2968b2e7c32b85035838358d9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ca/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ca/thunderbird-138.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "0c750eca6961a4fa50d5a4a9e1de1f1be679196f21781289f2d17c012ac35401";
+      sha256 = "cfbbaf729db657c9a4a97392b89a6d1a5f8572c462c5290d650df7a5c09b430e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cak/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/cak/thunderbird-138.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "e2a501cecc4e172d153cb925e2ef2b4d0ef6f30dd54103076ff3ee44dc35fdd2";
+      sha256 = "c577b3aa1755ed4e800b18b404b47efcc796130d1fcec9c4f2b869b571a21de2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cs/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/cs/thunderbird-138.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "0449dcdf3bd206b682a99d79bb8eb95b92f46e1b8977c1da659838f5c433b83f";
+      sha256 = "ce291b64225d038ee205f4479600976a05cd885ac054e6e491ef8243c65b60a3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/cy/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/cy/thunderbird-138.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "5180a1bf23a5fab9af458f366a188868792ebbbda024526be551f6a3da545628";
+      sha256 = "dbfde8e005481a7a85290a4ef488bd857b8fbdbf283397d5ded5e14ff96717d0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/da/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/da/thunderbird-138.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "bacb26b2d47ae51978f177e5e2735c25f0692196fbec0195df0aed0be14c7f90";
+      sha256 = "e3f85cb3d23a3a0967e350b2af7e237e2910d109dc5d60338036439c4cb5b7dc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/de/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/de/thunderbird-138.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "702d8eac33a01b2de5cecccea98b518ae6e3d7c53fd3aa409cbe6a40200d0042";
+      sha256 = "84b267c315db1387743c7a98881301d5b52d86565364b6434dedc332c24dbccb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/dsb/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/dsb/thunderbird-138.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "6f044b1734f5e222c3ab1a605cbe7edabf79f3fa3492d4b0d9191c5399dac704";
+      sha256 = "106e5f40574bda04fea801e5c020feeadcf19d5ac8c84fbb7c01a1a0c10297de";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/el/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/el/thunderbird-138.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "0f30952f82ba4f29a1848e7f65f99c56588558e6cd76a8e991d0ffc092ad3065";
+      sha256 = "c9b05df41578db2be3ac14e51b1ffe8f25f6508920697198f869a2309bc76380";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-CA/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/en-CA/thunderbird-138.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "4a51f57126732583213bca7b143759e3cfda49d1bdae00dbc83a92084fbd7ba6";
+      sha256 = "0f26330e24379f9666cd1a5ca7e7be291df5671ade35d8b8d2a18383f77626aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-GB/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/en-GB/thunderbird-138.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b17e9015ca14d60dfe89295dca40d454646b63715773e99362d494c6b6a070d5";
+      sha256 = "72c61292114fa7dd145e15d31c8e17b655bcd807a3eec75e5d070aae05a468f2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/en-US/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/en-US/thunderbird-138.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0ec67084fc238ec3c9c359e705f7e730a7adfe2376b20ad9020b94f8e109a035";
+      sha256 = "12943e11b8138d63a1fa3bae87b2672d0f49293ef9a636dc2882120dab0b363b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-AR/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/es-AR/thunderbird-138.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f61de8011dd94e1ec621e2b281c6e5a4b4f36f8b3c9a034ec90220c6c4f6b598";
+      sha256 = "c702825a985a59361a90d7de727fd40def2c7fcc516bfbd8fc35355b6cab1b22";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-ES/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/es-ES/thunderbird-138.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "9558d3b3cb3da1fec0f267fe0582777884204ac16605bc49717134a16545a147";
+      sha256 = "c2fc30b5b6ad606ed053c7157d67320205c5bea969dc18b0eb35022bb8caf4fc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/es-MX/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/es-MX/thunderbird-138.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "098164af16704687a0e38722e8fac1652b9d7e0f535ed2a7783aae16c3170876";
+      sha256 = "f373a89c663b1f9e2d06785be2e9b4d0959e25c0ae94241b63411a08b9a152cb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/et/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/et/thunderbird-138.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "6d0976ebf8f66b79d4f21da174217d1610df670761874749461d07ddc4a8747a";
+      sha256 = "7d9ddae2a13ada417c020503babb60746ae086130749b9e6557f63b5dcb27030";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/eu/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/eu/thunderbird-138.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "fe2a5302d8ec78d2a26387e866cc5ca79881d7765b1ca8bfe8a5652163460a2c";
+      sha256 = "a32fa57bcedf635ef313b485bb1bf9fa8def31973cb596742bfedd823b976680";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fi/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/fi/thunderbird-138.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7908fa449c2cb699c3b33f2f507ca140f0cd9069e79622e2cd2c7a5b670b136a";
+      sha256 = "8ff78e521bbc2b5a78fd5feb04b5bcde125aaad28c0fe501dd0ea951ffd19fb4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/fr/thunderbird-138.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "7502cd60b63f762edff89bec49772463ceafa9193fdd29e3194e14efeba3c600";
+      sha256 = "25d06dc1549941d6c20c809cae6787ad9cbf710e1911d770153573d0a225407f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/fy-NL/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/fy-NL/thunderbird-138.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "6c2bf9f223b89ac986d00b6d5ba547e0de45e90a201426d759371e1d50210a00";
+      sha256 = "0e3e0b1430de1b7aa04f026469ab6a63eb04c5908b3ffb8b1e81525197a8dda2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ga-IE/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ga-IE/thunderbird-138.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "a4f1c4867865cd488044a14a1bd6b45124ead59c0d5f1f8597da26fb3191cc40";
+      sha256 = "1d138f305d3a1c844cabdc8622347f8155fbf479440f42cc4d846ee120f0ff72";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/gd/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/gd/thunderbird-138.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "edc9f6ced184e1fe3a3c61b199844d327345be36f5497d7f43fa1b423de494b3";
+      sha256 = "5682890b95452f5f7a77542e2c7960af05891489a397eab8455069a776652097";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/gl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/gl/thunderbird-138.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ad871ab290cc41aaffce75e11c7c1c4148f5ffa1c6417e784146a6f6d6e7fa70";
+      sha256 = "72027c297852f34c82041b0c23fd0a94104e961db126e25221190723eba6c940";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/he/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/he/thunderbird-138.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b826105ef00b6e04397657d8dd0a12410e3dae2dfdfc6562ac69306846b25e26";
+      sha256 = "9f238944fd38c6a9bf219db2b607719e57bdfbc6661c3f07bea22fa4ea75edc1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/hr/thunderbird-138.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "a1ae8628e1073d7aafeb3b2f763c1cd35794e930d71865ebd4acefe825f99792";
+      sha256 = "18f0ebdb3c7bc0b2598a36e4f0644c35e93477c7e5c3dd28e0ca07a9bd32e2ee";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hsb/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/hsb/thunderbird-138.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "22a29aed60af3e22f182cae117a695b87f53ee9862211eb7baaa60c8c97ad408";
+      sha256 = "d59444d9d1fc890e89d0b3ab1943d73946f113dd1b189409e9747e257066b5e9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hu/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/hu/thunderbird-138.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "424122a45fa2f849cdecf1f0f5af4150b71c8c8f2bb2c224ad77c96b6acd77c8";
+      sha256 = "85184f70839dc59abdeead78c153e1d511dbc8abcfff7625d0e1e6640586301d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/hy-AM/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/hy-AM/thunderbird-138.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "3848b8abecaa0920ba88f61053fe9281a36721c7a51a96622289d19a7c345815";
+      sha256 = "d06446fc1bcea84de70e978ecc1eab108044010f6ffe9333bab78ba042e5efcf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/id/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/id/thunderbird-138.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "b6fad622eea4625914f8035e40123db1eefe3aeccf1f6d4542d0a7de236746da";
+      sha256 = "7e804f301cec8614bb4c292c74bd7ed1f953b5dfc9dbe931b0e9ae45e4fdd394";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/is/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/is/thunderbird-138.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1667c03203e4494fb2527a1397e82dfcaf9ac3845584eb7b897ff5dcd75a87dc";
+      sha256 = "f2ecb6052b86cc22561e5e715af4dc7c0cb7bcb5e216c7cea9c1b4f826c74e2b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/it/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/it/thunderbird-138.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "688e3a07d08b11cc0bc4eb6de6e329fdbcd31e66d12cfbdaa2d20932edde1ddc";
+      sha256 = "9e1708df2061c9a8e2604a679a08413bef4aa4917f60140d1f72279f79937be3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ja/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ja/thunderbird-138.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "67d0c965445fd607c310552bce34eaffa109d15d03ad0e390d2452ab759e55bb";
+      sha256 = "c896ed606a4d21a144d7bc680a11990e357247ed134a592e7b6d45934c599f6e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ka/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ka/thunderbird-138.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "0cc83d519010d5aca0a1088bbc6f9b6670848e15e633e1d1e830690615526719";
+      sha256 = "ed9ddf23a6443b1616a7b1023e510dd1b9b7c2a14c9d32e128c46320c8d64997";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/kab/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/kab/thunderbird-138.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "60a7ecbacdbe16f318b97b2f91e252950b4b53c6eb20dc42cedf4f1041d2a8c7";
+      sha256 = "8677110a7251074720e4601ed77fb7565d1b10aff8c0b418e2ccb52fb039d522";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/kk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/kk/thunderbird-138.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "de123dbe631c770989e513f99a12efdc1695f9ec30bdc7c9845b517bb01ebfb1";
+      sha256 = "f8c70f3ca118b79563f5ef7a6897d037952644770e1ad148ee49a3140bba9203";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ko/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ko/thunderbird-138.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "0ff80afbcf5a12858f4c499f2f804e9df63dc131b6cc63a49b99c08082be20dd";
+      sha256 = "58131f12c591ba6ee4adebaeca08bb504e0b8025302be1e8fe7e63780c1516f9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/lt/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/lt/thunderbird-138.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "daeb3c247d474068717c63de75476fef8bb2350ca7feb812281fdf3fefd13cdf";
+      sha256 = "3786e3dd8cdcbee49801ec92001b77c87a70295bab7c11cdb940efdf7fff4f64";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/lv/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/lv/thunderbird-138.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "4dd2fa518588b7904ea00b9a6d5e77f347dd3f8ad2429d367c702c2ee0953523";
+      sha256 = "375ca952b7ba6e57f3bb83ad479d9fd9b193a85d990c8eec6ddae0c9fa7145f1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ms/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ms/thunderbird-138.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "eed23aff6bd123bbb4dd0c960831382317b94082b910d9283b526dd1282feb5f";
+      sha256 = "aba6fe4532c0cf6c731fa9674906644ceaa8f30705050df7c59fcc4c8fa9854b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nb-NO/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/nb-NO/thunderbird-138.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "5f87f61bfe721ee703df67a46af77ac4db5b580357bd86574b35187fef9d3278";
+      sha256 = "58b793833a52ceb8a85fb191c762f71743e6f707741a5b9f1fc2e343d9f0fdf7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/nl/thunderbird-138.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "7f4843d4659394f64e10629d09c3773b34ee2267a5b6e5cc26a6ae34f0670edc";
+      sha256 = "bc9e6c53f71c72c6ed05e11269d790a244ecf2d3733598621934aa6b37e8f6c5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/nn-NO/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/nn-NO/thunderbird-138.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6a599c1e9d3985754f858895cdb79c87ab5fcba72d8da9d0f75e908771e41230";
+      sha256 = "2fdbc111d9c2fc25d4a2ba002d9ea1335d6dc797d66b4a55d9fe0dfbc69e18e9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pa-IN/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/pa-IN/thunderbird-138.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "26e79ba7cd9d7e26e8d678fb30da01ed064788bd3d10c29566a558e3e34ab732";
+      sha256 = "0d39c0853c09e4cf49664e2b9fdad048a9d16fbba8f78d113826d7fb478b49c1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/pl/thunderbird-138.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "44e75be88335d1149199e2c461d583f3284dd7b62cbd35776a28e0c51b82df19";
+      sha256 = "5b55e9f00652b254bd7ae42b449ac029abf957857f0f70e1ace50ca92022d369";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pt-BR/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/pt-BR/thunderbird-138.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "7e0e82870fe8a7d3fd83fd1f88da6a98dafb3401a1ef366432a27ddc8846a6ce";
+      sha256 = "7e45932dc35543e7a4184a2324149b796bde5aeb9d2538b09cb0f78b9b03243f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/pt-PT/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/pt-PT/thunderbird-138.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "4b7bfe2966c997371c7b1839137989b1a9688f3c4de16051071920435738ad41";
+      sha256 = "927faee43fdc595faa2c21db8f99e917e58db0adb3d27f90baab2626aaff6ea6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/rm/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/rm/thunderbird-138.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9876da9d04088eba3cafccf37ea571767f799423122a34d25064f56ecce08e2c";
+      sha256 = "5c3afadcb972ed396f3b681a44d0e12e1fbc19c8156a66ee363db7d3ea7133db";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ro/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ro/thunderbird-138.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "a2fffe1150f5909086d148bc2d08c5fa4e5a5559e0b9969f8a47cfa5c000741f";
+      sha256 = "4e9c66e66ab986ba274d93570a7da8728d1bcd6a8341ba6eca3d557853ecffd9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/ru/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/ru/thunderbird-138.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "3aa36619253ac6be7acabed21e3a8a93849f3d026832be8f5b4bd1e893b58bb8";
+      sha256 = "975e59c3caf443930e1fa9b93793e12857b6120ee5180a88abc1f4dbc66eba7f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/sk/thunderbird-138.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "37ce68e9f2d5f13aac3f4e754dd5d4e9e4024c900813b7ba188878dd870deff4";
+      sha256 = "11f0e51c950dfd37ac0f70d9babed753d489c48976f76b5a89c9efd91027519a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/sl/thunderbird-138.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "b486dcbdd0c355bbc6ec52f86e1b7485aff7bf06aeb6e3d26b317d2b0cc6dab6";
+      sha256 = "2de0bfff86032e3e6908891b5fc3da95f7d5d48e021715d1371536707a86276d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sq/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/sq/thunderbird-138.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "ac7936bef469ac219b076fa52ac83926b0522ebdcd7d8e6f82def2b5d9386b37";
+      sha256 = "2efd01733b459c829cf57063505283f9996d85a94961c254147d4ba3c4de22e5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/sr/thunderbird-138.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "80750d623a49101cbaaf01a1541d6f56322ca98a1b5f116c1c3963c83f1b48d1";
+      sha256 = "6d16c24d500b6f1ba78222388711858230f0eadd32330a5b5867f6dfa534807c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/sv-SE/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/sv-SE/thunderbird-138.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "57375a51504a94cdc6d91b32593a15153e411e192565de1b87187129bae87944";
+      sha256 = "bf7a19ef6e0639705a88130be5bdc20f42f9c776bd61fa091e530e87ef1257a1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/th/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/th/thunderbird-138.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "68b1c7c780bced5f8335b598d032355aaa407c0dac79d60163e90faf67a1e27b";
+      sha256 = "89aa450f310fe33997ed6797df954c7aceae440733e5d13d58bf9e2853dbc895";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/tr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/tr/thunderbird-138.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "9b2edade61a6a2b1186926a25a93af175c5182915c1ba7b372334b3732e612ea";
+      sha256 = "a41b5be5953cd62339a2e7c6d7e5c1a8f5d4a4b4354750d8265518b0656fb2ad";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/uk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/uk/thunderbird-138.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c266db47fbb6a26dbf8858b031407f01387f006292a32957284548b1ae30e7d8";
+      sha256 = "706d4729984f029d5b2c67cf3e2931527280a79819d515b6b6f2939b88913292";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/uz/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/uz/thunderbird-138.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "3d3f9ec9e559d805e4c625b3b58032ee554a88ae7cc9424deaba8e85f64e0308";
+      sha256 = "3c3f6e237ad78024b441647e16a663cd8a83ab5e91523a0c85ad27550f8b3d26";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/vi/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/vi/thunderbird-138.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a370e2206cc020487ced719e9395d4f15ebbbb012cd5cb46d30d8b54e910a238";
+      sha256 = "4e6dc1e8bda5d18861a0428fb98c122383c42fe2eb1413325ab8f2726bc8397c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/zh-CN/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/zh-CN/thunderbird-138.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "5d539f1308df30a6f17bd4b138f9a4ebc1673fef7df47b741ce105b2a06abf8d";
+      sha256 = "81c79e37aab506d2b3f54e2148066de6eb41f081cf576863d7b5c603e20052b5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-x86_64/zh-TW/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-x86_64/zh-TW/thunderbird-138.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "9a11f3a2b9db47846e090055da2d5a06a0acb9c67e27edd2c3e60dbb0e312b45";
+      sha256 = "29325f40d85633b1814391a9691371d44c02d838524155c0783454a6c0deb97d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/af/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/af/thunderbird-138.0.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f0dd8615c7b7a126c67e7a20aeadffb92e6e2b1d9a7d7c2fb2d3836406b82aca";
+      sha256 = "5fd640b861fe40c0f1ae64fad69fb848d7360f8130194559750a5af6937ffea4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ar/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ar/thunderbird-138.0.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "bdf52baa6e0e726e1c0849d88d0dcaf4e41f71e8002ef405c7fed9d9bcbf33ea";
+      sha256 = "3c7188d7574cae5ddcf59a684c4975e8ee46fc3c8d6dca99b4383971aab07b8a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ast/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ast/thunderbird-138.0.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "32c46e666cc2118810d2ed51ba30961b2c4b1796c882e13bf1653b9eba87d6b3";
+      sha256 = "a250d272a83b1f549a899e4f458ee68f8b34656c725ab55c56c958a365d9b34a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/be/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/be/thunderbird-138.0.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "75717aae6a3519d75702ce4e85213775d43fd35e4bfe0f2f3d21641e87dbf2c2";
+      sha256 = "e4b5816de3e650bbb54198c5d3c6464205a76ad01ee062e715a4d145bfc831ff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/bg/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/bg/thunderbird-138.0.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "451c308d1ce2af29ac8b84fbc584fd803def2581c01376da61b06b390d1ed158";
+      sha256 = "96fb1682feb8558a757b1955f9d4472ea8ef04d3b3b0e6de6a0f045aa225a5f2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/br/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/br/thunderbird-138.0.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "f259ef04d2fb04a82eac78b33684de3fb33de17e2a5b99b6c31b220806a99cb6";
+      sha256 = "f51d1cda7e11b8d190dae712344f30d35b35ceeb293c4166fce6fd33fde4d5e6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ca/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ca/thunderbird-138.0.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e1e473934f1627450df0fe321465c31c966604ef50e49a58b208d2d078cec324";
+      sha256 = "dac42c3bcf4ac0a7e64bd2107a3476491b7fb735091bbad629532f5b00a61f83";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cak/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/cak/thunderbird-138.0.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "fc127649b2b9c6089719728f75e7f458bb53ce161e56b45eb17d44d8702ba7c6";
+      sha256 = "bc5ff22837bd969c63981d03004479b741bd063bd6cb19330160ffe9a534ce16";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cs/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/cs/thunderbird-138.0.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "bd43d88883d7acc57b99d32e5f66bb81d187eeae5d125d843e2ac6ef1794cc5c";
+      sha256 = "5b1aa46fcd22a03244f775ff7e9a84403b6dd429ea5b102e643e739e0472d9a3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/cy/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/cy/thunderbird-138.0.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "7debf3558a37130cfa86d9cd052f56e8fdccb65f9d12a1bbb17e69343c0755e7";
+      sha256 = "f5569f6730425e6d27b17022c815bdf9f197438a02041612e0d3cdd4cdc49e5f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/da/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/da/thunderbird-138.0.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7cc4dd2befdd63e0a6f56983a60ab06737ca291a3c5f6f2d3bca1f1cc20d848e";
+      sha256 = "da07b68eecbf81b5a4b3cde8dd90e04f9dc3fb67fe8919e13f2fad5059b978b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/de/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/de/thunderbird-138.0.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "6413bababe4d376fb985050cf3cdb3b2e8697f9dd40f47dfe3b49bb97d22d139";
+      sha256 = "00633551387d1e307f0ea06750d5351a2e6fdf548982240d3576bc082790738b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/dsb/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/dsb/thunderbird-138.0.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "af0aec455e9363acd6b040f3883bae4d4083fd94917db0aba7400346f65888f1";
+      sha256 = "2f679e3ff34ddd4f412cbf65a6cf91b6784bb4b44f44d7cea034587051b000df";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/el/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/el/thunderbird-138.0.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "f7b67c4e5bc22ba384f70d55f668eed3a37f6ae744e5d6c5ffb60abdc0fe9147";
+      sha256 = "ddf321317a2ff559f323278c0445e1b536dd459686f26dfe1bdb24d326affe37";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-CA/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/en-CA/thunderbird-138.0.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c1c3a77dd2b8ed6a7f99adc9054d8ce18af7d344a60be2d0d3b33ce624447fdf";
+      sha256 = "fd08166c30272b77a4fd78adb6b54590d84a9a89b2769d9fcccd6ef78dce9fd6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-GB/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/en-GB/thunderbird-138.0.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "96271b334294eef59d80f6a9537f431a4ca7edde9de87aec6b33059f3e294403";
+      sha256 = "9b64e73ca9720ce39905adcfe02d57882376d1019e654ede02d85be7940b21ef";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/en-US/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/en-US/thunderbird-138.0.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "0940febe5627b2bd3e9bf22fd8a7a50f9df801bde679fe733d15baba8ef503b6";
+      sha256 = "918ab83e535c5d8840ad8e7d982f74e3e65134fc0dac33d25b0cae861cefa6f1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-AR/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/es-AR/thunderbird-138.0.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "f2fb8bcc6ae60fcf8ced844c76225291ddfcafbb08153d9dc3054a653a7aa5a1";
+      sha256 = "1bc0b0837ef69b5f28349f2654abf96d50b332e8f9c92fe07e7a1de6d237fd18";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-ES/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/es-ES/thunderbird-138.0.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "436ccaba77d91844f61ee7d6b1f718de8a4d2a33de1c52c143cff8ae96b4e75f";
+      sha256 = "0fc7a5a2cb635b74e57d1bdd9e21fbbf5ee60a5ad6f0f598ae89b66f2478b1dc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/es-MX/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/es-MX/thunderbird-138.0.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "dd384bad1f9bb4cf2adfc95fba180162938a565fd9b6d7132f96d94b3127b866";
+      sha256 = "aef7510e8fcb4935414ab18d7324222ac82ec55e0cf06bec633abb11e15c470d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/et/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/et/thunderbird-138.0.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cc50c635c43cec81fe74b5cd752639d2eb2f38424420f2a61df96cc58c8757e0";
+      sha256 = "77dcd00eec5b23d2644fc940e48dbd482b55a95c78e493ee15a16ce6954220b8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/eu/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/eu/thunderbird-138.0.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "8762de548f2349d9a23cfe4e796ecfc3d41c3367de1f0b848c4fbb5a9689e647";
+      sha256 = "eb90556f98a24c2535e5669c50e30f2d1da7a89a60a748ed4ef1b90024bf8dbe";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fi/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/fi/thunderbird-138.0.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "9371179b70826a5fe250f8d43f8abe40417ed45f2eb09929ece3bb94c8bb1e87";
+      sha256 = "3e808020a678dab5eb5474b27b1cb1ccf6692e71a4f7857f939e30b3787acfb9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/fr/thunderbird-138.0.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "f09541985f41bdaa85bca6e516a6f2d12a6ee53dff8e66104935aacf8ec35d5f";
+      sha256 = "c36d28bd920b354ced5830e69ff2974e32fb9118788525c19d8f094200ec4486";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/fy-NL/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/fy-NL/thunderbird-138.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "e0273c98f2bcd78ac28d3200a6d23fc659902d319c246a1a3bf99dc37ca78530";
+      sha256 = "7c9b4387c85306c52ca0dacc02462cd490155c2cee4fd13284e65beb6940376f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ga-IE/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ga-IE/thunderbird-138.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "6fb9b6c78270951b2e11ced2bfb629bd49ea3382c28503e087780ba4d8a9e76c";
+      sha256 = "f02540484a879d22efc458adef7b44a2475e6f45336a6aaa480c7b3c78b3d7fe";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/gd/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/gd/thunderbird-138.0.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "148c840a6e1230e19adc9fc4149c45302411a410a2303587b01939920a4c12dd";
+      sha256 = "823f94aa12cd09d8c9f7be552b43fabb28d3a233b85e4fbc363df1892167d719";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/gl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/gl/thunderbird-138.0.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "1b118445b22df9edbf62b344574c7de836687fc18581bdbd9950777b27a51e98";
+      sha256 = "09e5fe5da5fa4183289ef8a29b93c0ccd0b6cc423a265650878c1df3a22792cc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/he/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/he/thunderbird-138.0.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4aa4cbe802ff22537d8d8cba59ee8c86a5248e6eabea984a91985312df61074d";
+      sha256 = "d89180bdd589dc19e1a583dfc08b535b59933eb23c71cf9a929a82d81c8f8e30";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/hr/thunderbird-138.0.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "3f58b5033000415df754faed5108e1217ee3012d33c5a551fd0eaeb72787f5aa";
+      sha256 = "0968b415bd5a80513f2f207794e3a709bb2bdd50664892a1802a9f5d2a0ed12c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hsb/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/hsb/thunderbird-138.0.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8aa886e0525985b0eac3dd4dfe8763747e5d6088f1acba7d10345f64e9f9f866";
+      sha256 = "6ec1068c47441579f318141ae2ec5563de806f12556aeff5e094f82d325117b9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hu/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/hu/thunderbird-138.0.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "6b07d051705d6505036222f4bb5564591df6d3937699e00ce26d19f91a5fd841";
+      sha256 = "26e19104c4d765a36b175a75aa5a38f761f4229f8fdf762d42afed3ee62e194f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/hy-AM/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/hy-AM/thunderbird-138.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "159ae407bb5b5b563b39027f93197f65adc41839c32fa123fba79446bc888e12";
+      sha256 = "e167c02796d5060267a891e6be57b48a7c8db6564511a6d0a4ce6b4994778d4b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/id/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/id/thunderbird-138.0.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "121cef25930e31fe214b58e533a659c9e658b7534ac434de0d7270bd0f8d5edf";
+      sha256 = "2ee9a53a06198993c8d15ab442be3bc2469710e0ac0ed0e3789a45c4871c7e32";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/is/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/is/thunderbird-138.0.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "6f1a0ef5f9190fbef44a32e08f3407b9570f525477e23924c2a8dae777a4a7e3";
+      sha256 = "ce076e50e61fdab1325943ea5d737f5c6735b9d78c6024664bae009444705459";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/it/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/it/thunderbird-138.0.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "4461fa1b25a2e6bd5c75ff245fa1944beba603eb5bca220e444eb4d048a44d2e";
+      sha256 = "81dbbf1b24de5e52bbd2dda13fc9d2eb9acce94ea7d8c23b88cc30dad9eca5e5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ja/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ja/thunderbird-138.0.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "e52a165580718dd0ed49f9a8935b0edd47d5beb948c424ae58bef0924c02419a";
+      sha256 = "229dc4fc326e8bd0b7470309fc542b7b3e6c2d2cfd7e1b0d1b2079efe6be1a4b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ka/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ka/thunderbird-138.0.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e8d7124db5fcd1489b38dc721d7044cde60af8973c02d7b223907ad518c38033";
+      sha256 = "f17830a868e5c6c41697be236890acc0033425f3986df7e8cbd1f4204889c864";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/kab/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/kab/thunderbird-138.0.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a846f8dce95859b4a14e3bee8ce17d16b8219fe805115e3640e5d361153e4edd";
+      sha256 = "3cd470da64cbd00b099bb802ddcd728c0eab42737e516c81e7eef54e52029844";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/kk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/kk/thunderbird-138.0.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "d1ff1117063726859c3ceedd99c7227d5651bee3c7f762c0133cf7718312179c";
+      sha256 = "302c0c136a32aad0806949399c59e98086da6c18f2fcc4cafdc778fd3f12fbe2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ko/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ko/thunderbird-138.0.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "14a200de5bdfad5b3a0e503bc68a5c33e982e853090a63d90b080c9f07e3372d";
+      sha256 = "806b9800c693ced1491c73d41e1e8a862209b6a438c31f191487c74f62d9580a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/lt/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/lt/thunderbird-138.0.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a23e7a7f8ba1f344050639d15099cfc5dae5f7a92ecdad68a566f6107117d9e7";
+      sha256 = "9e5934f03b74b7a689e1c7671f1a2a79eecb1be0d3fb4395ad91c9d037b1423c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/lv/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/lv/thunderbird-138.0.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "aef3ab2e7e4ecddbf8660470cac7614842a16d8fa286f1d16ebd2aa6e7e18df9";
+      sha256 = "057dabbf5ec961784e8bb5e97658751f3259c04e231936ec10f06663dbbc98a8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ms/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ms/thunderbird-138.0.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "cf0bc0cc209c094658b66dbab3968b06f76d3e911f4b369f8a3cbdfcf41b6a97";
+      sha256 = "35111cec8d250f453e3a096a5ea8f72aa53b5bbddfdd5fb6f3109c7092942d30";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nb-NO/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/nb-NO/thunderbird-138.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "bc81cff91e3e5956a84993e653b9d6c733594237234a025adfa02586c55061d7";
+      sha256 = "37fc21db8edbf9d1ca1117e76861e28e7ce93877148edea118be7890df62a29e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/nl/thunderbird-138.0.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "7c5ee0b960014e9bd3f45cedd135f70f0853d449420819392af70d3942afefa3";
+      sha256 = "bb847f5558c1c08cd231eca04324d15c93ed66b3f73e5b5492ab32176117bf0e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/nn-NO/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/nn-NO/thunderbird-138.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e4efc803bc2092490205ec76d06f59120fcd9f5c2830789a8b163a5ab6576a80";
+      sha256 = "587d1363e74e5d39376c14e57c739df4f4c18bd30432571365518f1f81ec6395";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pa-IN/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/pa-IN/thunderbird-138.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "3911687e953ff046df76f7e868877c7c418abbeebe77bd04d91e4b4fb6487e65";
+      sha256 = "4e6124eed380c9cff61714b171540e6b0a22f909bb87c29490a5db6a63875159";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/pl/thunderbird-138.0.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9aaf6d5818cc1573d0ddf082824d6dbd44fd2b8cb21b86f74eea576fe1cf0422";
+      sha256 = "baa3782e2505c4abb2c00ae327bda44969313d48c9fd1f03afb45cb7396fc7e6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pt-BR/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/pt-BR/thunderbird-138.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "9f629d7283bc69eeaa857b775c111ac6a0f1ce5cf9f38fa681e3c2bbd54da3cb";
+      sha256 = "4c9f967e2a1e0bde4183b21a9b23fa42592bcfb2337398f5b048e20588c26335";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/pt-PT/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/pt-PT/thunderbird-138.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "7c9ac18764da4bf253bdd9676f8338dfba29cc41f177829822f94807c9301c74";
+      sha256 = "b4b0fcc4337e6274b3c78248cada7dd27b503a7c6841beed94e10ed55c7cf288";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/rm/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/rm/thunderbird-138.0.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "680624f5b8f1c385911a93d9f2768c6d79e69c4aec8ce3483d135d041dc15e5a";
+      sha256 = "349aeabf51a8d5366e0f5a6ef59d35aee7df7414b010c348af146da24322ad4f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ro/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ro/thunderbird-138.0.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "205b1795e12c42378f3adf7a6fa836890ff947ff0ce501dc2b9a2583249b9761";
+      sha256 = "f766778c5ff05e297bfbe588aa99772c039509838033a73d089594c88f8ebc4e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/ru/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/ru/thunderbird-138.0.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6063eb8440a86eb46b2b81970c05732330f308643b9d05ab5e7d6c4f125332ba";
+      sha256 = "25e3e22525ff012cf847f423cfbaaec1dc0c819936ea23091189ba18930ddfb2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/sk/thunderbird-138.0.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "4cff70dac85571595e8e955aff4b9018ba5df967fa4daf3af31c953371e3c9dd";
+      sha256 = "48392c60e37a32bf233b28c2924a1dc8c98aed44126acbe37bcf3b28f05b23a9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sl/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/sl/thunderbird-138.0.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "5398642c216335c656459497213ef980578c6891881e5bf6dca4a5603beeb9a8";
+      sha256 = "69763d29cf10354acce9abada26a7aed7d0f3c646ddb44426ddab82ff9cc215e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sq/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/sq/thunderbird-138.0.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "f7e30919e45e74daf12e2af5b7b36b180bc989cb9fed0c54c8fdd3b939c74c50";
+      sha256 = "a34bd9eb79e27af57fe4a45c1def3de30b4d0977738667f6c7ddb5aa4eacd8d6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/sr/thunderbird-138.0.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a4504b464fbd73a133dea56601ccb63470ba23bb03b0409db2946ad629d127cb";
+      sha256 = "6ab84bb97034faf916d645e5bcf15eea77ec422848829c3d8f573d00bdc9519e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/sv-SE/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/sv-SE/thunderbird-138.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7363aeb9a55babb603f46e2b0bf5772b026db1df9d9b24393b166f05ee9135fc";
+      sha256 = "b28063b955e22d3aaa51c0eb4b21742ead0ec121ee482247b577cfe6e4ef5ff1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/th/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/th/thunderbird-138.0.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "6b297c6ddf991939c7c85e2f885ec86c87e1e4991476ad048be607b1588a0594";
+      sha256 = "80c07bec145e773a78338a5fcbc1504a1fb697833c624e7d76ead086578e7682";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/tr/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/tr/thunderbird-138.0.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "906c98176c4326cbf047d168788993ab5376b0cc9a6de0c7dbfe383b2551d7b6";
+      sha256 = "40e7d9d8faa12b468cb77300f2c573d43821df83258f12c2c6289c042ee3c948";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/uk/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/uk/thunderbird-138.0.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "bdcc09d5443160fef9f19cca15df1806b7765d19e28f8c68bab6857872f5533c";
+      sha256 = "0d6c27b935b9f179fdeb8cdb285a58b5bbc3e6024e9f94f70b5353578365609d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/uz/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/uz/thunderbird-138.0.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "04d3d5110e7112bb427da51f8a49c8574f6108a2f59052fd6ec26465d641b9d9";
+      sha256 = "0b5dac32806af474c5584232f538707c7b2245dfbb44bf40629e1f17b0ce986b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/vi/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/vi/thunderbird-138.0.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "3209f5b180b436ec906906f4bfc1b8ed5ea844bcb04d5eaca1138e4fadac0481";
+      sha256 = "7ad809af1d163d15dbb1cd96f5fdc608d5ddfffb60c2444b6ac627177b6d164e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/zh-CN/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/zh-CN/thunderbird-138.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b09bccc90b73c1d6129e6742960eba2997f4af7d6cfb3a34e95636dbc425ad18";
+      sha256 = "13fa06c06a1372c8fec99d610c9cbecf290e9a64362924473ce7344c5a176a63";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/137.0.2/linux-i686/zh-TW/thunderbird-137.0.2.tar.xz";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/linux-i686/zh-TW/thunderbird-138.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "7a56de1924681479a56460025cc909abf0f1f66e6cb4ed4f23f6a120a4fb20b4";
+      sha256 = "ed34b77d32e6508867c62ad3952120ed2ca7a3a7ea9c9ea6aa66baf04b7bd3e4";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/af/Thunderbird%20138.0.dmg";
+      locale = "af";
+      arch = "mac";
+      sha256 = "428fb01ad25996a8020869ee76d0582b2ce3bbde2c1b24fa4c94270e1934772a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ar/Thunderbird%20138.0.dmg";
+      locale = "ar";
+      arch = "mac";
+      sha256 = "0a216794cbeb7d408a6f2043c3e0d99caeaefac75d4054c66dc65487ce2faa01";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ast/Thunderbird%20138.0.dmg";
+      locale = "ast";
+      arch = "mac";
+      sha256 = "e55d044c4ccbbeedba636ae62d14cf2a63fbc62a6e4a1506446f5b304abf6147";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/be/Thunderbird%20138.0.dmg";
+      locale = "be";
+      arch = "mac";
+      sha256 = "623eb4a32bef99739c1ce05a05968e0d7f8a8d031c6897289a770f22b4817b12";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/bg/Thunderbird%20138.0.dmg";
+      locale = "bg";
+      arch = "mac";
+      sha256 = "244dc0a1a5f71e6bcae5083e1db304d3a58dbcc8db193704e4a03b0ddade5d94";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/br/Thunderbird%20138.0.dmg";
+      locale = "br";
+      arch = "mac";
+      sha256 = "2a99a91783ed596fd0f5976195687a21a77ececd0f50a66faf3e25e0539d30e5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ca/Thunderbird%20138.0.dmg";
+      locale = "ca";
+      arch = "mac";
+      sha256 = "665a1c451fc35ce5b457a460552475663d19fb1284b09d0e9776be7ec86645f7";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/cak/Thunderbird%20138.0.dmg";
+      locale = "cak";
+      arch = "mac";
+      sha256 = "4aea1a6027f593b3b2518909f4261b16466b95ec8d6031fff52e272f329713a2";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/cs/Thunderbird%20138.0.dmg";
+      locale = "cs";
+      arch = "mac";
+      sha256 = "30dacef8b5e4d6506bc3324ce4d8a4227d771f5b18d939c3d5e38e6f3e6e21c1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/cy/Thunderbird%20138.0.dmg";
+      locale = "cy";
+      arch = "mac";
+      sha256 = "cd7fa6cf4d38845f01f417ecf6e400c8163d578d7799dbf21153b87d99240cdf";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/da/Thunderbird%20138.0.dmg";
+      locale = "da";
+      arch = "mac";
+      sha256 = "ccbf9373ca3df88190ddf1b73641fd2a3e678f4dd56884c36495f2af293e0ae1";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/de/Thunderbird%20138.0.dmg";
+      locale = "de";
+      arch = "mac";
+      sha256 = "226f0d05402a083e45dd8ee3fa6899a653f16e206e525e72907975b8d49d242f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/dsb/Thunderbird%20138.0.dmg";
+      locale = "dsb";
+      arch = "mac";
+      sha256 = "b627cac3ac062a5b65f95e8a7a15d668c504d83c736b9b9b4399c0e8c0f35b53";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/el/Thunderbird%20138.0.dmg";
+      locale = "el";
+      arch = "mac";
+      sha256 = "6eab5d42086a396662ae4d66ce1438d394cdcffcf54c72c9a387c261fd2a7d71";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/en-CA/Thunderbird%20138.0.dmg";
+      locale = "en-CA";
+      arch = "mac";
+      sha256 = "ee1ce2aa2492025445b0375caf7900264c012f54998eb79bdc49e229b66ce3a6";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/en-GB/Thunderbird%20138.0.dmg";
+      locale = "en-GB";
+      arch = "mac";
+      sha256 = "9b00c46d53ad7b70b6416d648157b2c5338ced32af6f2fb498ae17f39cd41014";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/en-US/Thunderbird%20138.0.dmg";
+      locale = "en-US";
+      arch = "mac";
+      sha256 = "494f6f07a0613615fcf13208b2a790b2556dc369057ad2fdf981a26f07ca4e2c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/es-AR/Thunderbird%20138.0.dmg";
+      locale = "es-AR";
+      arch = "mac";
+      sha256 = "1141ee31042d70b4b542cbbd3d50ed46aefc58d976fbefca8ad1a1467caaa1d7";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/es-ES/Thunderbird%20138.0.dmg";
+      locale = "es-ES";
+      arch = "mac";
+      sha256 = "1f2510901b8ccb5bc4967540af7aba1c336982161c390287f8fd62e36c2f0fed";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/es-MX/Thunderbird%20138.0.dmg";
+      locale = "es-MX";
+      arch = "mac";
+      sha256 = "68744eca0fb60c21013679268c4bd7d3177ec5338a2cc3686b10dba4bcf46420";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/et/Thunderbird%20138.0.dmg";
+      locale = "et";
+      arch = "mac";
+      sha256 = "b2e0c14d9d46b962ce49dff060cfc0ba6f4ff5640fdacfd9eb2339468e37944f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/eu/Thunderbird%20138.0.dmg";
+      locale = "eu";
+      arch = "mac";
+      sha256 = "bded7d5524f64dcc4843c1e52f5a8f1a09ac6f4b2a5fd2e26ea54b3c91afb231";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/fi/Thunderbird%20138.0.dmg";
+      locale = "fi";
+      arch = "mac";
+      sha256 = "716d4f05904bb6534e99c3d70b0330d2dc476ae456b4f06afb8a13c9c5d94dad";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/fr/Thunderbird%20138.0.dmg";
+      locale = "fr";
+      arch = "mac";
+      sha256 = "b3d4c166a74324a8f522926c1520f486f4ecd102b5a50fa528696aed58e3733b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/fy-NL/Thunderbird%20138.0.dmg";
+      locale = "fy-NL";
+      arch = "mac";
+      sha256 = "7fbe53aee665667b74e29e252bdc60668b9caf63f71c36a0b288dc3b2beefa07";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ga-IE/Thunderbird%20138.0.dmg";
+      locale = "ga-IE";
+      arch = "mac";
+      sha256 = "121f55b6795a1869243c39b538c66c97dbc0d757a08f8a5fd74de3a8e8894c87";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/gd/Thunderbird%20138.0.dmg";
+      locale = "gd";
+      arch = "mac";
+      sha256 = "1203897cb88811dfcb7c239ae3bec5aab67ebada5566bb0765ffae40a07c1cb3";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/gl/Thunderbird%20138.0.dmg";
+      locale = "gl";
+      arch = "mac";
+      sha256 = "0d8a2b2a234071c31c0db398df48ed9be3f0fea3ea251cff940257411c7a1c2c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/he/Thunderbird%20138.0.dmg";
+      locale = "he";
+      arch = "mac";
+      sha256 = "2cf3797a1b3308aa2e1c6b579f207c4fddd4eb4637ed96714c98b72f7fc288ca";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/hr/Thunderbird%20138.0.dmg";
+      locale = "hr";
+      arch = "mac";
+      sha256 = "a44c849011829e1abc09fdeb6da7005a40bddd9cd0abb8edb15028d8dc6ea676";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/hsb/Thunderbird%20138.0.dmg";
+      locale = "hsb";
+      arch = "mac";
+      sha256 = "da120a0cd7d4d555e8bf2ddc5ad120520bd976caa4baaaea2c63978baa76f2ba";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/hu/Thunderbird%20138.0.dmg";
+      locale = "hu";
+      arch = "mac";
+      sha256 = "e7c62976bd5d9ce518c00175f6ace371cc36df769b1b0bff7daa7ab4d42b2acd";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/hy-AM/Thunderbird%20138.0.dmg";
+      locale = "hy-AM";
+      arch = "mac";
+      sha256 = "425457a3379cbe465b75d0e1d162dfe4d02ed8cdc1c77b2d5715737a63a637d2";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/id/Thunderbird%20138.0.dmg";
+      locale = "id";
+      arch = "mac";
+      sha256 = "6620f4cbea8af2b45fcc8d8b284a13062e335a36be9e51e90b8c96a18d8c27d4";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/is/Thunderbird%20138.0.dmg";
+      locale = "is";
+      arch = "mac";
+      sha256 = "055193aae1d1baac507daa525a9ce9825a4a5d9c7dae9c49b1d48d56132d6236";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/it/Thunderbird%20138.0.dmg";
+      locale = "it";
+      arch = "mac";
+      sha256 = "4d2c9cad745d22f23d45e9719d9ae4540c557ee4ef4b3dae565cbb290ad27730";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ja-JP-mac/Thunderbird%20138.0.dmg";
+      locale = "ja-JP-mac";
+      arch = "mac";
+      sha256 = "202e3310166d964433e615a150860e7a5f1f1eae05fa436de02897cf4189b437";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ka/Thunderbird%20138.0.dmg";
+      locale = "ka";
+      arch = "mac";
+      sha256 = "865ba2cf373babc190326bfc8d2cfaf7772e391f2ff14adaafc89228734a28f2";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/kab/Thunderbird%20138.0.dmg";
+      locale = "kab";
+      arch = "mac";
+      sha256 = "d08f8c1c154c6a3d795c497c6afafd77e3ee3a5b95e2608b80ac714240765428";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/kk/Thunderbird%20138.0.dmg";
+      locale = "kk";
+      arch = "mac";
+      sha256 = "1a1588719ed440f4e3347cc643b48be4accacb45a4f5a4dd432ce58dceb335f9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ko/Thunderbird%20138.0.dmg";
+      locale = "ko";
+      arch = "mac";
+      sha256 = "38acb02de11c9b97787d90a9c1bc68e4c574ca39211bcc9b6a6c615e5f808b5e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/lt/Thunderbird%20138.0.dmg";
+      locale = "lt";
+      arch = "mac";
+      sha256 = "e8dd7b0f472afd13ebc784d2caf4d4680050d563e033c57f3067093d009821a3";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/lv/Thunderbird%20138.0.dmg";
+      locale = "lv";
+      arch = "mac";
+      sha256 = "f2ca22dd2dc17e03e748f99233f5fa60993dcbe6a41079daa3cda3d51d725997";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ms/Thunderbird%20138.0.dmg";
+      locale = "ms";
+      arch = "mac";
+      sha256 = "95c6de9d51e55006cb358666a05f33bb7d24d366c5fdfb9c4775ff12427dd222";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/nb-NO/Thunderbird%20138.0.dmg";
+      locale = "nb-NO";
+      arch = "mac";
+      sha256 = "d98dae7f743b06157e70ecf8ba2088d2c79b19344df00fbe7047b595256a007f";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/nl/Thunderbird%20138.0.dmg";
+      locale = "nl";
+      arch = "mac";
+      sha256 = "f312ad383580908734b6ebac34627f4e73e0c194ba987f5968a38f10d7591fda";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/nn-NO/Thunderbird%20138.0.dmg";
+      locale = "nn-NO";
+      arch = "mac";
+      sha256 = "2d8f05500848c031e5be033064b7a1a574e3aa79e35c9f10bffa45df0fa38da2";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/pa-IN/Thunderbird%20138.0.dmg";
+      locale = "pa-IN";
+      arch = "mac";
+      sha256 = "54b0a1b2212aaf78ef3fdeace924ca684bdc583ca63275fe4655ac90574c66e5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/pl/Thunderbird%20138.0.dmg";
+      locale = "pl";
+      arch = "mac";
+      sha256 = "571a8dc5d94a2ea83daf38aba91f45e45c5c7bff0a9e4f9327790903ccdc8694";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/pt-BR/Thunderbird%20138.0.dmg";
+      locale = "pt-BR";
+      arch = "mac";
+      sha256 = "4038afdddd062b375dfbd5b723715d846e55d3357e4ec17657a77937eda72cb9";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/pt-PT/Thunderbird%20138.0.dmg";
+      locale = "pt-PT";
+      arch = "mac";
+      sha256 = "83b39a56be5c677e03ead579db488f814ceaf1afaef44d9b8830cf39abe3759e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/rm/Thunderbird%20138.0.dmg";
+      locale = "rm";
+      arch = "mac";
+      sha256 = "00db47ceb79d242e4fbb1c26427def58e5a18c442b960d1a4f4bf203cabdae4a";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ro/Thunderbird%20138.0.dmg";
+      locale = "ro";
+      arch = "mac";
+      sha256 = "2b62ebef2266322628d0aca8c7cbc0ffa7c01336ca075dd63a880acf7b4d998b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/ru/Thunderbird%20138.0.dmg";
+      locale = "ru";
+      arch = "mac";
+      sha256 = "8288c373e65f66c6161bf5c60c1df76bbe1609d3fb5fbe875547be979a68b738";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/sk/Thunderbird%20138.0.dmg";
+      locale = "sk";
+      arch = "mac";
+      sha256 = "f31d7b725cafb69e6473ecd94d0cd44655ebf59c6f973dc1dd45d0f4cbcd4e6e";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/sl/Thunderbird%20138.0.dmg";
+      locale = "sl";
+      arch = "mac";
+      sha256 = "c0b07c55e09c71d8881c71d20286ce6dc9632662051f9d8411d07c7b6465becf";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/sq/Thunderbird%20138.0.dmg";
+      locale = "sq";
+      arch = "mac";
+      sha256 = "5ef176b3d49d50b90347ec4c06cf0150327f099bfb75dfe2b4da131107664ca4";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/sr/Thunderbird%20138.0.dmg";
+      locale = "sr";
+      arch = "mac";
+      sha256 = "3dc9f732e49688ac0aa1791f864b0a0421942087edd62ef3c78f313b208bfe1c";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/sv-SE/Thunderbird%20138.0.dmg";
+      locale = "sv-SE";
+      arch = "mac";
+      sha256 = "9befc823bb8288c5cb87eb7e7c6a4ca0611637346de0289a28d58682fd8ff50b";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/th/Thunderbird%20138.0.dmg";
+      locale = "th";
+      arch = "mac";
+      sha256 = "74d1ca327797b16a3011c6cc8df63b002e7881850bdd9f410c2bb9b6a46834ac";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/tr/Thunderbird%20138.0.dmg";
+      locale = "tr";
+      arch = "mac";
+      sha256 = "05508873350826d3107c10e764b97d37e04d6a7ed218ad7f81b84552aada8864";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/uk/Thunderbird%20138.0.dmg";
+      locale = "uk";
+      arch = "mac";
+      sha256 = "e538d57b7cabe86b94fd330509c8b8febfe602ebc585811d041458baffd0c1f5";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/uz/Thunderbird%20138.0.dmg";
+      locale = "uz";
+      arch = "mac";
+      sha256 = "37e639a3ca07c97e39df9b4c1fd16b5963afb67736232cbb2e61c2676717d5fb";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/vi/Thunderbird%20138.0.dmg";
+      locale = "vi";
+      arch = "mac";
+      sha256 = "6bbc6301416212c35d047ae2084504bfa96d95ea5a7de0dd60cfb5b7899458ee";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/zh-CN/Thunderbird%20138.0.dmg";
+      locale = "zh-CN";
+      arch = "mac";
+      sha256 = "b3417dedd953611404b4aa77ed6c114c025ec9f2047a29a73b96f10944533487";
+    }
+    {
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/138.0/mac/zh-TW/Thunderbird%20138.0.dmg";
+      locale = "zh-TW";
+      arch = "mac";
+      sha256 = "36e3e7cd2b8cbe17c27f876b21f7769c410a4a38418127a93a177316943ef919";
     }
   ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16086,11 +16086,21 @@ with pkgs;
   thunderbird-128-unwrapped = thunderbirdPackages.thunderbird-128;
   thunderbird-128 = wrapThunderbird thunderbirdPackages.thunderbird-128 { };
 
-  thunderbird-bin = wrapThunderbird thunderbird-bin-unwrapped {
+  thunderbird-bin = thunderbird-latest-bin;
+  thunderbird-latest-bin = wrapThunderbird thunderbird-latest-bin-unwrapped {
     pname = "thunderbird-bin";
   };
-  thunderbird-bin-unwrapped = callPackage ../applications/networking/mailreaders/thunderbird-bin {
-    generated = import ../applications/networking/mailreaders/thunderbird-bin/release_sources.nix;
+  thunderbird-latest-bin-unwrapped =
+    callPackage ../applications/networking/mailreaders/thunderbird-bin
+      {
+        generated = import ../applications/networking/mailreaders/thunderbird-bin/release_sources.nix;
+      };
+  thunderbird-esr-bin = wrapThunderbird thunderbird-esr-bin-unwrapped {
+    pname = "thunderbird-esr-bin";
+  };
+  thunderbird-esr-bin-unwrapped = callPackage ../applications/networking/mailreaders/thunderbird-bin {
+    generated = import ../applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix;
+    versionSuffix = "esr";
   };
 
   timbreid = callPackage ../applications/audio/pd-plugins/timbreid {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds `thunderbird-latest-bin` that is non-ESR version of Thunderbird.

See also #389819:

> The official Thunderbird website now recommends the latest release by default.
>
> See https://www.thunderbird.net/en-US/download/

When this PR is merged, I will backport it to the stable but set `thunderbird-bin = thunderbird-esr-bin`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
