### PR TITLE
formats.lua: init; types.luaInline: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -156,6 +156,7 @@ let
       makeScope makeScopeWithSplicing makeScopeWithSplicing'
       extendMkDerivation;
     inherit (self.derivations) lazyDerivation optionalDrvAttr warnOnInstantiate;
+    inherit (self.generators) mkLuaInline;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset setPrio lowPrio lowPrioSet hiPrio
       hiPrioSet licensesSpdx getLicenseFromSpdxId getLicenseFromSpdxIdOr

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -743,6 +743,8 @@ in rec {
       "nil"
     else if isInt v || isFloat v || isString v || isBool v then
       toJSON v
+    else if isPath v || isDerivation v then
+      toJSON "${v}"
     else if isList v then
       (if v == [ ] then "{}" else
       "{${introSpace}${concatItems (map (value: "${toLua innerArgs value}") v)}${outroSpace}}")
@@ -752,8 +754,6 @@ in rec {
           "(${v.expr})"
         else if v == { } then
           "{}"
-        else if isDerivation v then
-          ''"${toString v}"''
         else
           "{${introSpace}${concatItems (
             mapAttrsToList (key: value: "[${toJSON key}] = ${toLua innerArgs value}") v

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -834,6 +834,15 @@ rec {
         };
       };
 
+    # A value produced by `lib.mkLuaInline`
+    luaInline = mkOptionType {
+      name = "luaInline";
+      description = "inline lua";
+      descriptionClass = "noun";
+      check = x: x._type or null == "lua-inline";
+      merge = mergeEqualOption;
+    };
+
     uniq = unique { message = ""; };
 
     unique = { message }: type: mkOptionType rec {

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -232,6 +232,13 @@ merging is handled.
     definitions cannot be merged. The regular expression is processed
     using `builtins.match`.
 
+### Specialised types {#sec-option-types-specialised}
+
+`types.luaInline`
+
+:   A string wrapped using `lib.mkLuaInline`. Allows embedding lua expressions
+    inline within generated lua. Multiple definitions cannot be merged.
+
 ## Submodule types {#sec-option-types-submodule}
 
 Submodules are detailed in [Submodule](#section-option-types-submodule).

--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -402,6 +402,31 @@ have a predefined type and string generator already declared under
     :   Outputs the given attribute set as an Elixir map, instead of the
         default Elixir keyword list
 
+`pkgs.formats.lua { asBindings ? false, multiline ? true, columnWidth ? 100, indentWidth ? 2, indentUsingTabs ? false }`
+
+:   A function taking an attribute set with values
+
+    `asBindings` (default `false`)
+
+    :   Whether to treat attributes as variable bindings
+
+    `multiline` (default `true`)
+
+    :   Whether to procude a multiline output. The output may still wrap across
+        multiple lines if it would otherwise exceed `columnWidth`.
+
+    `columnWidth` (default `100`)
+
+    :   The column width to use to attempt to wrap lines.
+
+    `indentWidth` (default `2`)
+
+    :   The width of a single indentation level.
+
+    `indentUsingTabs` (default `false`)
+
+    :   Whether the indentation should use tabs instead of spaces.
+
 `pkgs.formats.php { finalVariable }` []{#pkgs-formats-php}
 
 :   A function taking an attribute set with values

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1592,6 +1592,9 @@
   "sec-option-types-string": [
     "index.html#sec-option-types-string"
   ],
+  "sec-option-types-specialised": [
+    "index.html#sec-option-types-specialised"
+  ],
   "sec-option-types-submodule": [
     "index.html#sec-option-types-submodule"
   ],

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -601,6 +601,82 @@ in runBuildTests {
     '';
   };
 
+  luaTable = shouldPass {
+    format = formats.lua { };
+    input = {
+      null = null;
+      false = false;
+      true = true;
+      int = 10;
+      float = 3.141;
+      str = "foo";
+      attrs.foo = null;
+      list = [
+        null
+        null
+      ];
+      path = ./testfile;
+      inline = lib.mkLuaInline "hello('world')";
+    };
+    expected = ''
+      return {
+        ["attrs"] = {
+          ["foo"] = nil,
+        },
+        ["false"] = false,
+        ["float"] = 3.141,
+        ["inline"] = (hello("world")),
+        ["int"] = 10,
+        ["list"] = {
+          nil,
+          nil,
+        },
+        ["null"] = nil,
+        ["path"] = "${./testfile}",
+        ["str"] = "foo",
+        ["true"] = true,
+      }
+    '';
+  };
+
+  luaBindings = shouldPass {
+    format = formats.lua {
+      asBindings = true;
+    };
+    input = {
+      null = null;
+      _false = false;
+      _true = true;
+      int = 10;
+      float = 3.141;
+      str = "foo";
+      attrs.foo = null;
+      list = [
+        null
+        null
+      ];
+      path = ./testfile;
+      inline = lib.mkLuaInline "hello('world')";
+    };
+    expected = ''
+      _false = false
+      _true = true
+      attrs = {
+        ["foo"] = nil,
+      }
+      float = 3.141
+      inline = (hello("world"))
+      int = 10
+      list = {
+        nil,
+        nil,
+      }
+      null = nil
+      path = "${./testfile}"
+      str = "foo"
+    '';
+  };
+
   phpAtoms = shouldPass rec {
     format = formats.php { finalVariable = "config"; };
     input = {


### PR DESCRIPTION
This PR adds a new lua format to pkgs-lib. To support this change, a new `luaInline` type is added to `lib.types` along with some other related changes:

- Added a `lib.generators.mkLuaInline` top-level alias (`lib.mkLuaInline`)
- Added `lib.types.luaInline`
  - With documentation
- Added/fixed path value support in `lib.generators.toLua`
- Added `formats.lua`
  - With documentation
  - And tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] `nix-build ./pkgs/pkgs-lib/tests`
  - [x] `nix-build ./lib/tests/release.nix`
- [ ] [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
