### PR TITLE
tests/lua-5: fix checkPropogatedBuildInputs test; cleanup naming; cleanup lint messages

### DIFF
--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -60,7 +60,7 @@ let
 in
 pkgs.recurseIntoAttrs {
 
-  checkInterpreterPatch =
+  checkInterpreterPath =
     let
       golden_LUA_PATH = golden_LUA_PATHS.${lib.versions.majorMinor lua.version};
     in

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -10,10 +10,10 @@ let
     lua:
     { name, command }:
     pkgs.runCommandLocal "test-${lua.name}-${name}"
-      ({
+      {
         nativeBuildInputs = [ lua ];
         meta.platforms = lua.meta.platforms;
-      })
+      }
       (
         ''
           source ${./assert.sh}
@@ -58,7 +58,7 @@ let
       ";./?.lua;${lua}/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;${lua}/share/lua/5.1/?.lua;${lua}/share/lua/5.1/?/init.lua;";
   };
 in
-pkgs.recurseIntoAttrs ({
+pkgs.recurseIntoAttrs {
 
   checkInterpreterPatch =
     let
@@ -75,12 +75,12 @@ pkgs.recurseIntoAttrs ({
 
   checkWrapping =
     pkgs.runCommandLocal "test-${lua.name}-wrapping"
-      ({
-      })
-      (''
+      {
+      }
+      ''
         grep -- 'LUA_PATH=' ${wrappedHello}/bin/hello
         touch $out
-      '');
+      '';
 
   # checks that lua's setup-hook adds dependencies to LUA_PATH
   # Prevents the following regressions
@@ -90,21 +90,21 @@ pkgs.recurseIntoAttrs ({
   # stdin:1: module 'http.request' not found:
   checkSetupHook =
     pkgs.runCommandLocal "test-${lua.name}-setup-hook"
-      ({
+      {
         nativeBuildInputs = [ lua ];
         buildInputs = [ lua.pkgs.http ];
         meta.platforms = lua.meta.platforms;
-      })
-      (''
+      }
+      ''
         ${lua}/bin/lua -e "require'http.request'"
         touch $out
-      '');
+      '';
 
   checkRelativeImports =
     pkgs.runCommandLocal "test-${lua.name}-relative-imports"
-      ({
-      })
-      (''
+      {
+      }
+      ''
         source ${./assert.sh}
 
         lua_vanilla_package_path="$(${lua}/bin/lua -e "print(package.path)")"
@@ -117,20 +117,18 @@ pkgs.recurseIntoAttrs ({
         assertStringContains "$lua_with_module_package_path" "./?/init.lua"
 
         touch $out
-      '');
+      '';
 
   # Check that a lua package's propagatedBuildInputs end up in LUA_PATH
   checkPropagatedBuildInputs =
     pkgs.runCommandLocal "test-${lua.name}-setup-hook"
-      ({
+      {
         buildInputs = [ lua.pkgs.rest-nvim ];
-      })
+      }
       # `xml2lua` is a propagatedBuildInput of rest-nvim
-      (
-        ''
-          ${lua}/bin/lua -e "require'xml2lua'"
-          touch $out
-        ''
-      );
+      ''
+        ${lua}/bin/lua -e "require'xml2lua'"
+        touch $out
+      '';
 
-})
+}

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -123,12 +123,14 @@ pkgs.recurseIntoAttrs ({
   checkPropagatedBuildInputs =
     pkgs.runCommandLocal "test-${lua.name}-setup-hook"
       ({
-        # lua-curl is a propagatedBuildInput of rest-nvim has
         buildInputs = [ lua.pkgs.rest-nvim ];
       })
-      (''
-        ${lua}/bin/lua -e "require'cURL'"
-        touch $out
-      '');
+      # `xml2lua` is a propagatedBuildInput of rest-nvim
+      (
+        ''
+          ${lua}/bin/lua -e "require'xml2lua'"
+          touch $out
+        ''
+      );
 
 })

--- a/pkgs/development/interpreters/lua-5/tests/default.nix
+++ b/pkgs/development/interpreters/lua-5/tests/default.nix
@@ -73,14 +73,10 @@ pkgs.recurseIntoAttrs {
       '';
     };
 
-  checkWrapping =
-    pkgs.runCommandLocal "test-${lua.name}-wrapping"
-      {
-      }
-      ''
-        grep -- 'LUA_PATH=' ${wrappedHello}/bin/hello
-        touch $out
-      '';
+  checkWrapping = pkgs.runCommandLocal "test-${lua.name}-wrapping" { } ''
+    grep -- 'LUA_PATH=' ${wrappedHello}/bin/hello
+    touch $out
+  '';
 
   # checks that lua's setup-hook adds dependencies to LUA_PATH
   # Prevents the following regressions
@@ -100,24 +96,20 @@ pkgs.recurseIntoAttrs {
         touch $out
       '';
 
-  checkRelativeImports =
-    pkgs.runCommandLocal "test-${lua.name}-relative-imports"
-      {
-      }
-      ''
-        source ${./assert.sh}
+  checkRelativeImports = pkgs.runCommandLocal "test-${lua.name}-relative-imports" { } ''
+    source ${./assert.sh}
 
-        lua_vanilla_package_path="$(${lua}/bin/lua -e "print(package.path)")"
-        lua_with_module_package_path="$(${luaWithModule}/bin/lua -e "print(package.path)")"
+    lua_vanilla_package_path="$(${lua}/bin/lua -e "print(package.path)")"
+    lua_with_module_package_path="$(${luaWithModule}/bin/lua -e "print(package.path)")"
 
-        assertStringContains "$lua_vanilla_package_path" "./?.lua"
-        assertStringContains "$lua_vanilla_package_path" "./?/init.lua"
+    assertStringContains "$lua_vanilla_package_path" "./?.lua"
+    assertStringContains "$lua_vanilla_package_path" "./?/init.lua"
 
-        assertStringContains "$lua_with_module_package_path" "./?.lua"
-        assertStringContains "$lua_with_module_package_path" "./?/init.lua"
+    assertStringContains "$lua_with_module_package_path" "./?.lua"
+    assertStringContains "$lua_with_module_package_path" "./?/init.lua"
 
-        touch $out
-      '';
+    touch $out
+  '';
 
   # Check that a lua package's propagatedBuildInputs end up in LUA_PATH
   checkPropagatedBuildInputs =


### PR DESCRIPTION
Dependencies changed in https://github.com/NixOS/nixpkgs/pull/342196


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
