### PR TITLE
treefmt: add configuration wrappers

### DIFF
--- a/pkgs/by-name/tr/treefmt/build-config.nix
+++ b/pkgs/by-name/tr/treefmt/build-config.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  formats,
+}:
+module:
+let
+  settingsFormat = formats.toml { };
+  configuration = lib.evalModules {
+    modules = [
+      {
+        _file = ./build-config.nix;
+        freeformType = settingsFormat.type;
+      }
+      {
+        # Wrap user's modules with a default file location
+        _file = "<treefmt.buildConfig args>";
+        imports = lib.toList module;
+      }
+    ];
+  };
+  settingsFile = settingsFormat.generate "treefmt.toml" configuration.config;
+in
+settingsFile.overrideAttrs {
+  passthru = {
+    format = settingsFormat;
+    settings = configuration.config;
+    inherit (configuration) _module options type;
+  };
+}

--- a/pkgs/by-name/tr/treefmt/package.nix
+++ b/pkgs/by-name/tr/treefmt/package.nix
@@ -31,9 +31,10 @@ buildGoModule rec {
     description = "one CLI to format the code tree";
     homepage = "https://github.com/numtide/treefmt";
     license = lib.licenses.mit;
-    maintainers = [
-      lib.maintainers.brianmcgee
-      lib.maintainers.zimbatm
+    maintainers = with lib.maintainers; [
+      brianmcgee
+      MattSturgeon
+      zimbatm
     ];
     mainProgram = "treefmt";
   };

--- a/pkgs/by-name/tr/treefmt/package.nix
+++ b/pkgs/by-name/tr/treefmt/package.nix
@@ -1,6 +1,8 @@
 {
   lib,
   buildGoModule,
+  callPackage,
+  callPackages,
   fetchFromGitHub,
 }:
 buildGoModule rec {
@@ -26,6 +28,38 @@ buildGoModule rec {
     "-X github.com/numtide/treefmt/v2/build.Name=treefmt"
     "-X github.com/numtide/treefmt/v2/build.Version=v${version}"
   ];
+
+  passthru = {
+    /**
+      Wrap treefmt, configured  using structured settings.
+
+      # Type
+
+      ```
+      AttrSet -> Derivation
+      ```
+
+      # Inputs
+
+      - `name`: `String` (default `"treefmt-configured"`)
+      - `settings`: `Module` (default `{ }`)
+      - `runtimeInputs`: `[Derivation]` (default `[ ]`)
+    */
+    withConfig = callPackage ./with-config.nix { };
+
+    /**
+      Build a treefmt config file from structured settings.
+
+      # Type
+
+      ```
+      Module -> Derivation
+      ```
+    */
+    buildConfig = callPackage ./build-config.nix { };
+
+    tests = callPackages ./tests.nix { };
+  };
 
   meta = {
     description = "one CLI to format the code tree";

--- a/pkgs/by-name/tr/treefmt/tests.nix
+++ b/pkgs/by-name/tr/treefmt/tests.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  runCommand,
+  testers,
+  treefmt,
+  nixfmt-rfc-style,
+}:
+let
+  inherit (treefmt) buildConfig withConfig;
+
+  testEqualContents =
+    args:
+    testers.testEqualContents (
+      args
+      // lib.optionalAttrs (builtins.isString args.expected) {
+        expected = builtins.toFile "expected" args.expected;
+      }
+    );
+
+  nixfmtExampleConfig = {
+    on-unmatched = "info";
+    tree-root-file = ".git/index";
+
+    formatter.nixfmt = {
+      command = "nixfmt";
+      includes = [ "*.nix" ];
+    };
+  };
+
+  nixfmtExamplePackage = withConfig {
+    settings = nixfmtExampleConfig;
+    runtimeInputs = [ nixfmt-rfc-style ];
+  };
+in
+{
+  buildConfigEmpty = testEqualContents {
+    assertion = "`buildConfig { }` builds an empty config file";
+    actual = buildConfig { };
+    expected = "";
+  };
+
+  buildConfigExample = testEqualContents {
+    assertion = "`buildConfig` builds the example config";
+    actual = buildConfig nixfmtExampleConfig;
+    expected = ''
+      on-unmatched = "info"
+      tree-root-file = ".git/index"
+      [formatter.nixfmt]
+      command = "nixfmt"
+      includes = ["*.nix"]
+    '';
+  };
+
+  buildConfigModules = testEqualContents {
+    assertion = "`buildConfig` evaluates modules to build a config";
+    actual = buildConfig [
+      nixfmtExampleConfig
+      { tree-root-file = lib.mkForce "overridden"; }
+    ];
+    expected = ''
+      on-unmatched = "info"
+      tree-root-file = "overridden"
+      [formatter.nixfmt]
+      command = "nixfmt"
+      includes = ["*.nix"]
+    '';
+  };
+
+  runNixfmtExample =
+    runCommand "run-nixfmt-example"
+      {
+        nativeBuildInputs = [ nixfmtExamplePackage ];
+        passAsFile = [
+          "input"
+          "expected"
+        ];
+        input = ''
+          {
+            foo="bar";
+            attrs={};
+            list=[];
+          }
+        '';
+        expected = ''
+          {
+            foo = "bar";
+            attrs = { };
+            list = [ ];
+          }
+        '';
+      }
+      ''
+        export XDG_CACHE_HOME=$(mktemp -d)
+        # The example config assumes the tree root has a .git/index file
+        mkdir .git && touch .git/index
+
+        # Copy the input file, then format it using the wrapped treefmt
+        cp $inputPath input.nix
+        treefmt
+
+        # Assert that input.nix now matches expected
+        if diff -u $expectedPath input.nix; then
+          touch $out
+        else
+          echo
+          echo "treefmt did not format input.nix as expected"
+          exit 1
+        fi
+      '';
+}

--- a/pkgs/by-name/tr/treefmt/with-config.nix
+++ b/pkgs/by-name/tr/treefmt/with-config.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  runCommand,
+  treefmt,
+  makeBinaryWrapper,
+}:
+{
+  name ? "treefmt-with-config",
+  settings ? { },
+  runtimeInputs ? [ ],
+}:
+runCommand name
+  {
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    treefmtExe = lib.getExe treefmt;
+    binPath = lib.makeBinPath runtimeInputs;
+    configFile = treefmt.buildConfig {
+      # Wrap user's modules with a default file location
+      _file = "<treefmt.withConfig settings arg>";
+      imports = lib.toList settings;
+    };
+    inherit (treefmt) meta version;
+  }
+  ''
+    mkdir -p $out/bin
+    makeWrapper \
+      $treefmtExe \
+      $out/bin/treefmt \
+      --prefix PATH : "$binPath" \
+      --add-flags "--config-file $configFile"
+  ''


### PR DESCRIPTION
## Summary

This PR adds some functions to the treefmt package that allow users to produce a treefmt config file and/or a wrapped treefmt package from structured settings modules.

- `treefmt.buildConfig` builds a treefmt.toml file using a freeform module
- `treefmt.withConfig` builds a treefmt package wrapped with a config

Also:
- Added myself as a package maintainer
- Added basic tests for the new functions

## Motivation

It is inspired by [treefmt-nix](https://github.com/numtide/treefmt-nix) and the new [nixfmt-tree wrapper package](https://search.nixos.org/packages?channel=unstable&show=nixfmt-tree&type=packages&query=nixfmt-tree) recently added by @infinisil.

Hopefully, the implementation here could be used by the new nixfmt-tree package, ideally simplifying its implementation. To keep this PR's scope minimal, I've not done that here.

## Freeform options module

I also experimented locally with a `settings.nix` module that defined some options & defaults for the treefmt.toml file. I've not included that in this PR to keep the scope minimal. It also sees somewhat pointless to add module options without a clear way to document them; currently the nixpkgs manual does use nixos-render-docs, but it is hard-coded to render only the top-level pkgs `config` options.

<details><summary><strong>Local <code>settings.nix</code> commit</strong></summary>
<p>

```diff
commit f23edc22568005eae80e3a4ca411b4c4cb20af46
Author: Matt Sturgeon <matt@sturgeon.me.uk>
Date:   Wed Mar 5 03:12:47 2025 +0000

    treefmt: add default settings module
    
    Based on the config scheme in treefmt-nix:
    https://github.com/numtide/treefmt-nix/blob/94ae23/module-options.nix

diff --git a/pkgs/by-name/tr/treefmt/build-config.nix b/pkgs/by-name/tr/treefmt/build-config.nix
index 6f8b672d8e54..8a37961f3233 100644
--- a/pkgs/by-name/tr/treefmt/build-config.nix
+++ b/pkgs/by-name/tr/treefmt/build-config.nix
@@ -7,6 +7,8 @@ let
   settingsFormat = formats.toml { };
   configuration = lib.evalModules {
     modules = [
+      # TODO: document the settings options in the nixpkgs manual
+      ./settings.nix
       {
         freeformType = settingsFormat.type;
       }
diff --git a/pkgs/by-name/tr/treefmt/settings.nix b/pkgs/by-name/tr/treefmt/settings.nix
new file mode 100644
index 000000000000..cb8b24f5903e
--- /dev/null
+++ b/pkgs/by-name/tr/treefmt/settings.nix
@@ -0,0 +1,59 @@
+{ lib, config, ... }:
+let
+  inherit (lib) types;
+
+  # Coerce paths and packages into exe strings
+  toExeStr = p: if builtins.isPath p then "${p}" else lib.getExe p;
+  exeType = types.coercedTo (types.either types.package types.path) toExeStr types.str;
+
+  # Type for `formatter.*`
+  formatterType = types.submodule {
+    inherit (config._module) freeformType;
+    options = {
+      command = lib.mkOption {
+        description = "Executable obeying the treefmt formatter spec";
+        type = exeType;
+      };
+      options = lib.mkOption {
+        description = "List of arguments to pass to the command";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+      includes = lib.mkOption {
+        description = "List of files to include for formatting. Supports globbing.";
+        type = types.listOf types.str;
+      };
+      excludes = lib.mkOption {
+        description = "List of files to exclude for formatting. Supports globbing. Takes precedence over the includes.";
+        type = types.listOf types.str;
+        default = [ ];
+      };
+    };
+  };
+in
+{
+  options = {
+    excludes = lib.mkOption {
+      description = "A global list of paths to exclude. Supports glob.";
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "./node_modules/**" ];
+    };
+    on-unmatched = lib.mkOption {
+      description = "Log paths that did not match any formatters at the specified log level.";
+      type = types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+        "fatal"
+      ];
+      default = "warn";
+    };
+    formatter = lib.mkOption {
+      type = types.attrsOf formatterType;
+      default = { };
+      description = "Set of formatters to use";
+    };
+  };
+}
```

</p>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
