### PR TITLE
emacs: bump elisp pkgs

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -85,6 +85,17 @@ in
   # fixed in https://git.savannah.gnu.org/cgit/emacs/elpa.git/commit/?h=externals/dbus-codegen&id=cfc46758c6252a602eea3dbc179f8094ea2a1a85
   dbus-codegen = ignoreCompilationErrorIfOlder super.dbus-codegen "0.1.0.20201127.221326"; # elisp error
 
+  debbugs = super.debbugs.overrideAttrs (old: {
+    preInstall =
+      old.preInstall or ""
+      + "\n"
+      + ''
+        tmp_src_dir=$(mktemp -d)
+        tar --extract --verbose --file $src --directory $tmp_src_dir --strip-components 1
+        EMACSLOADPATH=$tmp_src_dir/test:$EMACSLOADPATH
+      '';
+  });
+
   ebdb = super.ebdb.overrideAttrs (
     finalAttrs: previousAttrs:
     let

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.0.0.20250205.220528";
+      version = "1.0.0.20250226.200747";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.0.0.20250205.220528.tar";
-        sha256 = "0ds8kifvc3557xvb1vas7ivc4kn8wkjaqqj5h3azbh1bcbdj1xnp";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.0.0.20250226.200747.tar";
+        sha256 = "1h07lgxrrr3838hnl2zzdfm4gj7d6gbdsmnzdbmnzz8h65pk1x93";
       };
       packageRequires = [ ];
       meta = {
@@ -74,10 +74,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.8pre0.20241225.10347";
+      version = "0.8pre0.20250223.175841";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20241225.10347.tar";
-        sha256 = "0c6rivd7qvrd02pvryffr2h6y0lyp9z0zrvdk2rygxz6l5pq0g9x";
+        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20250223.175841.tar";
+        sha256 = "0hmv2wvbs006lwc7r9bz9pf7i40dbklqllkrwdigbxbi2cn8xya8";
       };
       packageRequires = [ persist ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.8.0.20250207.132239";
+      version = "14.0.9.0.20250312.215110";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.8.0.20250207.132239.tar";
-        sha256 = "07x57jz5hpgky62h3rljrxbfcv850qfbm0nkny2bjg7cjhm97ih7";
+        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250312.215110.tar";
+        sha256 = "1xphcw0p1q9snk420l9x9xy02lgjxdm4m7d3vynwkb3lcwz9hi3s";
       };
       packageRequires = [ ];
       meta = {
@@ -548,10 +548,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.1.0.20250201.220645";
+      version = "0.1.1.0.20250211.151603";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.1.0.20250201.220645.tar";
-        sha256 = "05rf750b9isjmwp9ys0g17njmd0428fqdl6sa8wakn286gpx2910";
+        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.1.1.0.20250211.151603.tar";
+        sha256 = "1qirlk0wjrhxxy0k01mr2cx3dzp16ns3047j2a3mpfhq83413w43";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -654,10 +654,10 @@
     elpaBuild {
       pname = "autorevert-tail-truncate";
       ename = "autorevert-tail-truncate";
-      version = "1.0.0.0.20250208.61538";
+      version = "1.0.1.0.20250209.105211";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/autorevert-tail-truncate-1.0.0.0.20250208.61538.tar";
-        sha256 = "1m00rr3mnv79vbczs7dg0fvqz1l0zyrbsqqz54gaqyl6r27hlwfl";
+        url = "https://elpa.gnu.org/devel/autorevert-tail-truncate-1.0.1.0.20250209.105211.tar";
+        sha256 = "07nlbvlassaj0rcph1kwf2h9bxdkfk3s77q300aj6kp0k73a17rd";
       };
       packageRequires = [ ];
       meta = {
@@ -761,10 +761,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.3.0.20241101.92331";
+      version = "0.1.4.0.20250312.213251";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.3.0.20241101.92331.tar";
-        sha256 = "0fnkzb4m0ank7892cjqjzxdjf1amjnpfbm3wh0g5j3xf44g8hk44";
+        url = "https://elpa.gnu.org/devel/bicep-ts-mode-0.1.4.0.20250312.213251.tar";
+        sha256 = "10vzdld0776gsmjg0wfk731vvwlaw7zf0zhccw0crf7hr5rhhfhg";
       };
       packageRequires = [ ];
       meta = {
@@ -782,10 +782,10 @@
     elpaBuild {
       pname = "bind-key";
       ename = "bind-key";
-      version = "2.4.1.0.20250101.73917";
+      version = "2.4.1.0.20250227.73309";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250101.73917.tar";
-        sha256 = "0a1q6lwkky92f2fhmzlsj58cf9ywhzi2c0lhf2f6zk0ka4nz4yjz";
+        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250227.73309.tar";
+        sha256 = "13ps20qb6ajnhn5qcaf4jncbn25q2iqji8r7f3mflp58h3m8gajm";
       };
       packageRequires = [ ];
       meta = {
@@ -804,10 +804,10 @@
     elpaBuild {
       pname = "blist";
       ename = "blist";
-      version = "0.4.0.20250207.24413";
+      version = "0.6.0.20250210.24138";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/blist-0.4.0.20250207.24413.tar";
-        sha256 = "1raw8rvj3kghf4hpcz13c1jk8kpgjr9jlpq3y08aqh1k1y2y01w1";
+        url = "https://elpa.gnu.org/devel/blist-0.6.0.20250210.24138.tar";
+        sha256 = "1rf4y81i7jmgqdma1i5gvr767mi2z7qpil4w9sak7graqj79vzn6";
       };
       packageRequires = [ ilist ];
       meta = {
@@ -1105,10 +1105,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "1.9.0.20250128.81944";
+      version = "2.0.0.20250311.165029";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-1.9.0.20250128.81944.tar";
-        sha256 = "1yccij3mv2lvf047d8qayafczfpvjj1pxg3b7hqbfmhlmk35jkj5";
+        url = "https://elpa.gnu.org/devel/cape-2.0.0.20250311.165029.tar";
+        sha256 = "1birjf3znacrv82vx8y346xhmzy4ssrd9hmdwp0jjin440lfd7wc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1318,10 +1318,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.1.0.0.20250208.162726";
+      version = "1.2.3.0.20250310.213131";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.1.0.0.20250208.162726.tar";
-        sha256 = "1qdwl82shxgnds6131zlyhqgg0h2szqwj376pfvk450gmvmnk7g9";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.3.0.20250310.213131.tar";
+        sha256 = "1k457wzqbyps7wrhk7klpa06jnw9mbf00g2cp52l76911hcmfwbj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1386,10 +1386,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20250114.210922";
+      version = "1.0.2.0.20250228.25856";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250114.210922.tar";
-        sha256 = "12h08awsmmf166ls5y49jv51273lyhvifpxk08r8vwy546jv2q5b";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250228.25856.tar";
+        sha256 = "0bjl3i1vxqxinj396f22072z7xpzd9j7cd0mp55v8sa9kb1riiq3";
       };
       packageRequires = [ ];
       meta = {
@@ -1482,14 +1482,35 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.0.2.0.0.20250128.131847";
+      version = "30.0.2.0.0.20250308.104508";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.0.2.0.0.20250128.131847.tar";
-        sha256 = "0r50ky5jrsza2pc3fv7k04wrsqd59fxlqgp4dbmjssndpjgyb7ga";
+        url = "https://elpa.gnu.org/devel/compat-30.0.2.0.0.20250308.104508.tar";
+        sha256 = "1rri9hknrzkm51vq9m6ji6w6zrdglvr3k3345lwd5vl79lfqhv5c";
       };
       packageRequires = [ seq ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/compat.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  cond-star = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cond-star";
+      ename = "cond-star";
+      version = "1.0.0.20250310.74521";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20250310.74521.tar";
+        sha256 = "1j7s227aih10np8j74b880lgk8v3g35dgpph23bzkqzrybl3w0z6";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/cond-star.html";
         license = lib.licenses.free;
       };
     }
@@ -1525,10 +1546,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.0.0.20250207.161222";
+      version = "2.1.0.20250311.165829";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.0.0.20250207.161222.tar";
-        sha256 = "150xaqhpz3awimsnpclky6gpn84j9fw3vsjhzwqqlpp5v3spb0kc";
+        url = "https://elpa.gnu.org/devel/consult-2.1.0.20250311.165829.tar";
+        sha256 = "1j5xz5985dgwkcvw44arxndjyylbzmcz51j8rq48hdb5206jpgfj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1573,10 +1594,10 @@
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.4.1.0.20250202.52435";
+      version = "0.5.0.0.20250219.74017";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-hoogle-0.4.1.0.20250202.52435.tar";
-        sha256 = "1nlf2icdy8b5jkqp33m0izf40z7h9nbsfcb4wx36db3dn4ajjb7p";
+        url = "https://elpa.gnu.org/devel/consult-hoogle-0.5.0.0.20250219.74017.tar";
+        sha256 = "0k0xqnwg75cm284niyfmcnmdx3qbnslr1ssz5hz0yca99bz8sypx";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1595,10 +1616,10 @@
     elpaBuild {
       pname = "consult-recoll";
       ename = "consult-recoll";
-      version = "1.0.0.0.20250205.171239";
+      version = "1.0.0.0.20250223.210510";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-recoll-1.0.0.0.20250205.171239.tar";
-        sha256 = "1mpvf601nyb8wz0brcxs2dvzf87s66wg83k9q6c605brnkg23cyb";
+        url = "https://elpa.gnu.org/devel/consult-recoll-1.0.0.0.20250223.210510.tar";
+        sha256 = "1aivy3imjpkm5rbvcygyj8a42hmpkkld852jf4lkb42s4ifpf3i7";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1638,10 +1659,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "1.7.0.20250128.82142";
+      version = "1.7.0.20250219.165655";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-1.7.0.20250128.82142.tar";
-        sha256 = "17wih4xrba4ilx8jkdm5f1l47ihmvg30wzycfzb67h60hqb6gb97";
+        url = "https://elpa.gnu.org/devel/corfu-1.7.0.20250219.165655.tar";
+        sha256 = "0xk3sqba3aii619rv7rjm5pvzaj3mvirk4hv7yijr1cd3qp7jghf";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1683,10 +1704,10 @@
     elpaBuild {
       pname = "counsel";
       ename = "counsel";
-      version = "0.14.2.0.20240520.132838";
+      version = "0.15.0.0.20250304.94445";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/counsel-0.14.2.0.20240520.132838.tar";
-        sha256 = "1xpvkyljahcjf84f4b40ivax1i06vyyyhlj3v7x0g90qjl6ba2cr";
+        url = "https://elpa.gnu.org/devel/counsel-0.15.0.0.20250304.94445.tar";
+        sha256 = "051nbhrhq92h64cwmjavcljyxy99qn1j4awjlsrf75023r5j3ii3";
       };
       packageRequires = [
         ivy
@@ -1813,10 +1834,10 @@
     elpaBuild {
       pname = "csv-mode";
       ename = "csv-mode";
-      version = "1.27.0.20240816.74202";
+      version = "1.27.0.20250307.75451";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/csv-mode-1.27.0.20240816.74202.tar";
-        sha256 = "1j6iqjp9k14i3d9n9dnk3m4wpixkflq8dlr6mapbgvd2kksmgigp";
+        url = "https://elpa.gnu.org/devel/csv-mode-1.27.0.20250307.75451.tar";
+        sha256 = "089z16kqm12zs7wrs46hskmz3mc1jqx00mzilaap197xq9hqkc3m";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -1867,6 +1888,27 @@
       };
     }
   ) { };
+  cus-abbrev = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cus-abbrev";
+      ename = "cus-abbrev";
+      version = "0.1.0.20250307.190425";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/cus-abbrev-0.1.0.20250307.190425.tar";
+        sha256 = "1xjfdxr2yy7s5xq0732bczczm6c9ypkr1jlyl2jg240p51gg4kp8";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/cus-abbrev.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   cycle-quotes = callPackage (
     {
       elpaBuild,
@@ -1898,10 +1940,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.22.0.0.20250202.141832";
+      version = "0.23.0.0.20250310.201518";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.22.0.0.20250202.141832.tar";
-        sha256 = "0z4c30v13z51hcpvbr2w18fj73f2rgvvjwwb0yn7vn0xrvlgsyap";
+        url = "https://elpa.gnu.org/devel/dape-0.23.0.0.20250310.201518.tar";
+        sha256 = "1g8nq6bhzh7kg8gw8f45lj5a6x25965qfyrzyzaapif0ndxfvpxc";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1941,10 +1983,10 @@
     elpaBuild {
       pname = "dash";
       ename = "dash";
-      version = "2.19.1.0.20240510.132708";
+      version = "2.20.0.0.20250312.130713";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dash-2.19.1.0.20240510.132708.tar";
-        sha256 = "1m16w781gzsjim087jj8n42kn1lrvkplsigbsx0l7fd6hqagyl2k";
+        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20250312.130713.tar";
+        sha256 = "0kdmc5axls8lhpbzzvab3c49kdagh3630jyrd0xmrdwf4pxim7ns";
       };
       packageRequires = [ ];
       meta = {
@@ -1985,10 +2027,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.43.0.20250208.110220";
+      version = "0.44.0.20250311.94450";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.43.0.20250208.110220.tar";
-        sha256 = "1hwvdlx9gwm52vc3yddd58iwa1m69lr6wclwcc848ic8ag001zk2";
+        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250311.94450.tar";
+        sha256 = "0w1mhj8byz2msn02h0kb95z3y9f4dimb5by03lhr3llpy3ar26hg";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2032,10 +2074,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "3.1.0.0.20250205.61207";
+      version = "3.1.0.0.20250311.152457";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20250205.61207.tar";
-        sha256 = "0196s2jy08cf7pbysxlxzfziysm7sq87xkr19z1dxbd4284ad9qk";
+        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20250311.152457.tar";
+        sha256 = "1xvkfzqqnm27dml3l8ldnprwwkh5gkm39rmasvzin89z74aywq2j";
       };
       packageRequires = [ ];
       meta = {
@@ -2062,6 +2104,28 @@
       packageRequires = [ denote ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/denote-menu.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  denote-search = callPackage (
+    {
+      denote,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "denote-search";
+      ename = "denote-search";
+      version = "1.0.3.0.20250302.121931";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/denote-search-1.0.3.0.20250302.121931.tar";
+        sha256 = "1di64988dwldzfhbnc12y5czmrfc531lrq5glbny659fz73qimxx";
+      };
+      packageRequires = [ denote ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/denote-search.html";
         license = lib.licenses.free;
       };
     }
@@ -2194,10 +2258,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20241205.233841";
+      version = "1.10.0.0.20250223.232014";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20241205.233841.tar";
-        sha256 = "1a1ndnf6w7j0k85k1rzdi8r0m4fj78lafzsf9dl4s3dj11lqrphh";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250223.232014.tar";
+        sha256 = "1bcjrkqilzpc116af3gxz8gwb2p7vz57i2bcv7xz8mbsz8yqma8r";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2321,10 +2385,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.3.0.0.20250205.94505";
+      version = "0.4.0.0.20250305.70339";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.3.0.0.20250205.94505.tar";
-        sha256 = "1z9wg3z3kgmx3xv300r61ss5af23zs4cmhjn3xl7acn7ym6mpg33";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.4.0.0.20250305.70339.tar";
+        sha256 = "1xq6qwp90qqacnnr4h0fc66inhn2pf37s8zhi26df8amxpxb7cim";
       };
       packageRequires = [ ];
       meta = {
@@ -2650,10 +2714,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241223.0.20250119.74354";
+      version = "20250216.0.20250305.175133";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20241223.0.20250119.74354.tar";
-        sha256 = "0ijzgj03qkjyyy1m4191q3d69y3sf8cd426ivpl2ww38l1iyhy8a";
+        url = "https://elpa.gnu.org/devel/eev-20250216.0.20250305.175133.tar";
+        sha256 = "0xx9s43wix06agbwbvdsc3fqxc16q2jj5slyljz0nw9kw4h9lngs";
       };
       packageRequires = [ ];
       meta = {
@@ -2671,10 +2735,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.9.0.0.20250208.100006";
+      version = "1.9.0.0.20250220.64933";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20250208.100006.tar";
-        sha256 = "0wns13m6cqxjh4kp8kmz3x0yicf4a48mbn962bdm3vgwy1wlhhyp";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20250220.64933.tar";
+        sha256 = "0iq4lc8r1y255r3vphay9fjcphgv176hdp4a4gbwj2xrldsqwwvi";
       };
       packageRequires = [ ];
       meta = {
@@ -2699,10 +2763,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20250208.134208";
+      version = "1.18.0.20250308.53648";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250208.134208.tar";
-        sha256 = "0sqm6z9phbdhy6f4dzcbk5w44j4kpxnk3hgd0y233v0nhxz80ahs";
+        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250308.53648.tar";
+        sha256 = "0km41xslg9d1gv6dl7kldzg4aw8fg797nnbr45m91ywgj2cxiicl";
       };
       packageRequires = [
         eldoc
@@ -2730,10 +2794,10 @@
     elpaBuild {
       pname = "el-search";
       ename = "el-search";
-      version = "1.12.6.1.0.20221221.75346";
+      version = "1.12.6.1.0.20250307.74553";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/el-search-1.12.6.1.0.20221221.75346.tar";
-        sha256 = "12500xc7aln09kzf3kn6xq7xnphbqzmyz20h0sgpf8f1rvlh2h33";
+        url = "https://elpa.gnu.org/devel/el-search-1.12.6.1.0.20250307.74553.tar";
+        sha256 = "053bzm8gz336krhivkp6sb6gbl7788mp8zx3xsfdwxdxrib72hf8";
       };
       packageRequires = [
         cl-print
@@ -2754,10 +2818,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.15.0.0.20250201.35652";
+      version = "1.15.0.0.20250304.14245";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.15.0.0.20250201.35652.tar";
-        sha256 = "1y2if2f1azw92qxlv5hxyjlhs95ysghwb7xxa5vl5wsn4drgc5pz";
+        url = "https://elpa.gnu.org/devel/eldoc-1.15.0.0.20250304.14245.tar";
+        sha256 = "1spns425l79zjc2p0xvs8i3g6ap30l8fi1shb8gdbfn5blkb1phz";
       };
       packageRequires = [ ];
       meta = {
@@ -2826,10 +2890,10 @@
     elpaBuild {
       pname = "elisp-benchmarks";
       ename = "elisp-benchmarks";
-      version = "1.16.0.20250106.93952";
+      version = "1.16.0.20250215.101900";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/elisp-benchmarks-1.16.0.20250106.93952.tar";
-        sha256 = "1xsdl4bnwhryf7a36is97qycjlsh25x1lmldsvk8jz1incipiyny";
+        url = "https://elpa.gnu.org/devel/elisp-benchmarks-1.16.0.20250215.101900.tar";
+        sha256 = "1qcr6sss94hy5c79b8n78950y1ybdc8rwxd6sj1q7xb9m9rgwls1";
       };
       packageRequires = [ ];
       meta = {
@@ -2845,21 +2909,21 @@
       fetchurl,
       lib,
       llm,
-      spinner,
+      plz,
       transient,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.13.7.0.20250208.110313";
+      version = "1.5.4.0.20250312.193157";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-0.13.7.0.20250208.110313.tar";
-        sha256 = "0mglzqh4pjwzjqrrpkrg8296c32nv0ja778nmb27r6zdig9ss5zj";
+        url = "https://elpa.gnu.org/devel/ellama-1.5.4.0.20250312.193157.tar";
+        sha256 = "0sqfkv552ibcyfi8q69xxlfghi46908xk7fb6qhz5c7i0d933r96";
       };
       packageRequires = [
         compat
         llm
-        spinner
+        plz
         transient
       ];
       meta = {
@@ -3076,10 +3140,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20250207.202136";
+      version = "5.6.1snapshot0.20250312.13833";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250207.202136.tar";
-        sha256 = "1qdbq8yx10cfvids88vmvi3q8481fvypfpdx5490b4sbjkpsryqr";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250312.13833.tar";
+        sha256 = "03352zza9zmv5paha806yj4pbv0p9pmbnr2b574a7xlw6qn5kzn0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3398,10 +3462,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.3.7.0.20250117.105815";
+      version = "1.3.7.0.20250225.2515";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20250117.105815.tar";
-        sha256 = "0ya7pdm1npa80prrcbfwk2k9rf8sgyphfmghvwqc6w4svwh4kf2m";
+        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20250225.2515.tar";
+        sha256 = "0n7ffwfgz6s3rkl1fw0zzaqknzm93xr7vpc92h3grfjgrkl7526a";
       };
       packageRequires = [
         eldoc
@@ -3465,10 +3529,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "2.1.0.0.20250125.104950";
+      version = "3.0.0.0.20250220.111012";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-2.1.0.0.20250125.104950.tar";
-        sha256 = "1jaz58gci7d8wgxmjwgg3qwhh1m6rnphbfvmrr0g6hr741vif65r";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.0.0.20250220.111012.tar";
+        sha256 = "122a5hapm0jk43gd7sn1qsv9nz9b55rhff9irnqmv78f0wxxy3sy";
       };
       packageRequires = [ ];
       meta = {
@@ -3696,6 +3760,27 @@
       };
     }
   ) { };
+  gnome-dark-style = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "gnome-dark-style";
+      ename = "gnome-dark-style";
+      version = "0.2.2.0.20250309.73232";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/gnome-dark-style-0.2.2.0.20250309.73232.tar";
+        sha256 = "09bplrzfik4hqg041a0992nd64wnr208sr37dd013n992gwj7gqn";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/gnome-dark-style.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   gnorb = callPackage (
     {
       cl-lib ? null,
@@ -3914,10 +3999,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.6.0.20250106.183831";
+      version = "0.12.6.0.20250304.171535";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20250106.183831.tar";
-        sha256 = "1x10m46azmsvndi40vn3am3pjj8p90dkg9gnyh2v9wzzavdbb26j";
+        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20250304.171535.tar";
+        sha256 = "0maqbx42xg1zbijdbs354iqxclzkfi0pdy5zjyi1n9pwxgxmc7vd";
       };
       packageRequires = [
         compat
@@ -4048,10 +4133,10 @@
     elpaBuild {
       pname = "hiddenquote";
       ename = "hiddenquote";
-      version = "1.2.0.20231107.184113";
+      version = "1.2.0.20250305.95113";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hiddenquote-1.2.0.20231107.184113.tar";
-        sha256 = "0iy7mxqhph4kmp4a96r141f4dpk5vwiydx9i9gx5c13zzwvy2y7r";
+        url = "https://elpa.gnu.org/devel/hiddenquote-1.2.0.20250305.95113.tar";
+        sha256 = "114gvcz1p3s9ksnl2ljjv0h1ncn3ad0pfi1wnga9ab07h7l46jn5";
       };
       packageRequires = [ ];
       meta = {
@@ -4154,10 +4239,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250208.215943";
+      version = "9.0.2pre0.20250305.163914";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250208.215943.tar";
-        sha256 = "1bqc2zvch5aldyjy6ncsyvw034rhxrpk9r27qrq706n3n3b140b8";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250305.163914.tar";
+        sha256 = "1w7kql8q62h5fm496bdp6gq7j6f6lbp3bz1h1g3vb7qplbx4mkys";
       };
       packageRequires = [ ];
       meta = {
@@ -4218,10 +4303,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.2.0.20250201.115728";
+      version = "0.8.2.0.20250306.142956";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.8.2.0.20250201.115728.tar";
-        sha256 = "1xp9lhk1yz842b3z6j181ziql99b0pj1wy7nnpjlqxnga0pcf8z9";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.8.2.0.20250306.142956.tar";
+        sha256 = "1j2a8jixv1k52dmh57id1l4b70rz79hl3gaydmk6pzpdri38msd5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4324,10 +4409,10 @@
     elpaBuild {
       pname = "ivy";
       ename = "ivy";
-      version = "0.14.2.0.20240829.172705";
+      version = "0.15.0.0.20250225.83943";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-0.14.2.0.20240829.172705.tar";
-        sha256 = "0rsgrrzy33gpm8h0w0zk7al5awj14rvxlklgb7v2jllsd6z6c9gx";
+        url = "https://elpa.gnu.org/devel/ivy-0.15.0.0.20250225.83943.tar";
+        sha256 = "1h26hx2cvw73nlaryrqhdmxsyagqzcy9iiiglxihq4sp302kcqar";
       };
       packageRequires = [ ];
       meta = {
@@ -4347,10 +4432,10 @@
     elpaBuild {
       pname = "ivy-avy";
       ename = "ivy-avy";
-      version = "0.14.2.0.20240214.214218";
+      version = "0.15.0.0.20250225.84011";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-avy-0.14.2.0.20240214.214218.tar";
-        sha256 = "1i3hrc5pb30qkzzpiza0mff97132b04sglg39mg0ad05hl3sq5dc";
+        url = "https://elpa.gnu.org/devel/ivy-avy-0.15.0.0.20250225.84011.tar";
+        sha256 = "0c4azhg0p6b3gbcnmi6v7g4x0x2zkfs1qv0c9nbqpr5cjh0x0bgk";
       };
       packageRequires = [
         avy
@@ -4395,10 +4480,10 @@
     elpaBuild {
       pname = "ivy-hydra";
       ename = "ivy-hydra";
-      version = "0.14.2.0.20240214.214337";
+      version = "0.15.0.0.20250225.84034";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-hydra-0.14.2.0.20240214.214337.tar";
-        sha256 = "1paqprwizhavr1kfijfbr0my3ncmw94821d3c9qj1fnjkp3nfj4x";
+        url = "https://elpa.gnu.org/devel/ivy-hydra-0.15.0.0.20250225.84034.tar";
+        sha256 = "0ammfla2zvzzy4cy80ki8404qij3766gnwmqjjd4ld102jn606m8";
       };
       packageRequires = [
         hydra
@@ -4531,10 +4616,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "1.12.0.20250207.140139";
+      version = "2.0.0.20250311.165730";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-1.12.0.20250207.140139.tar";
-        sha256 = "0lankxybmh4d7vkyaadrm53ph4w165mnjmfmr8kfnsy7k16hqc41";
+        url = "https://elpa.gnu.org/devel/jinx-2.0.0.20250311.165730.tar";
+        sha256 = "0fv0lkqlpsl8fxhsxw772bl83ram252wn6zjvj0ngy99zrh6cvjp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4596,10 +4681,10 @@
     elpaBuild {
       pname = "json-mode";
       ename = "json-mode";
-      version = "0.2.0.20221221.80401";
+      version = "0.2.0.20250307.75711";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/json-mode-0.2.0.20221221.80401.tar";
-        sha256 = "0hr0dqnz3c9bc78k3nnwrhwqhgyjq1qpnjfa7wd9bsla3gfp88hk";
+        url = "https://elpa.gnu.org/devel/json-mode-0.2.0.20250307.75711.tar";
+        sha256 = "06554pl40d8cgnabcxvixsdn904z28zsl579w6y64cqjf3da4qx3";
       };
       packageRequires = [ ];
       meta = {
@@ -4617,10 +4702,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25.0.20250128.110421";
+      version = "1.0.25.0.20250225.2515";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250128.110421.tar";
-        sha256 = "0i4bz6s85ci2nm5inkgv2f5kifhbb6lmxcr33d2gllg0hl1xvy9g";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250225.2515.tar";
+        sha256 = "1zfgpyrlbydnqwim4zrh9xbj37g8yqbwdz9ci0r90d1s4h6nyzgv";
       };
       packageRequires = [ ];
       meta = {
@@ -4660,10 +4745,10 @@
     elpaBuild {
       pname = "kind-icon";
       ename = "kind-icon";
-      version = "0.2.2.0.20240717.130344";
+      version = "0.2.2.0.20250311.112658";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kind-icon-0.2.2.0.20240717.130344.tar";
-        sha256 = "1rp4fx1ygwaz4sd26xkp3iz008dwg430dx7xzdba0prycdc9kh7f";
+        url = "https://elpa.gnu.org/devel/kind-icon-0.2.2.0.20250311.112658.tar";
+        sha256 = "07lnpxq6g8rlc0mbnbwya8jjp2d42xixwm1knz57ab0lm7vcbmap";
       };
       packageRequires = [ svg-lib ];
       meta = {
@@ -4724,10 +4809,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.3.0.20250121.152631";
+      version = "0.4.3.0.20250211.173738";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.4.3.0.20250121.152631.tar";
-        sha256 = "0l2nji86pkdswj8x5a5cdyqqdmh8rmlv5bm4a38zdi84kw22wfm0";
+        url = "https://elpa.gnu.org/devel/kubed-0.4.3.0.20250211.173738.tar";
+        sha256 = "0fwlhq9l4bcfscyfch83vkxnp14dv24qalrhxrjffh06h3lw96zm";
       };
       packageRequires = [ ];
       meta = {
@@ -4982,10 +5067,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.23.0.0.20250208.202943";
+      version = "0.24.1.0.20250309.220649";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.23.0.0.20250208.202943.tar";
-        sha256 = "0mxrhq3vch02asbj7v4xfmi8n953byy5bc1s3g9nwb75cjlvrcvz";
+        url = "https://elpa.gnu.org/devel/llm-0.24.1.0.20250309.220649.tar";
+        sha256 = "005b28kl669mzjbns83z5nd0hkq46v8608py1db4vn30941jjc1a";
       };
       packageRequires = [
         plz
@@ -5518,10 +5603,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.6.0.0.20250208.95815";
+      version = "4.6.0.0.20250220.64729";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20250208.95815.tar";
-        sha256 = "1sg46vcysbffqjq0wcrsv7z80qv39yw6nl4clsga4il8wkph5n21";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20250220.64729.tar";
+        sha256 = "1gr24821rbfj6jb4qnzka5445jq0k11k30a1xr8xjvy6kq62knqc";
       };
       packageRequires = [ ];
       meta = {
@@ -6099,10 +6184,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20250202.170245";
+      version = "9.8pre0.20250312.181832";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250202.170245.tar";
-        sha256 = "13ipl0crx6n896084shax8i2j6cp7xc1x1acpvarjfwk7cix6s04";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250312.181832.tar";
+        sha256 = "1bp5a6h7f458awla2ywhjj2wjbwj4bqkz891xsfirsj5801bc72i";
       };
       packageRequires = [ ];
       meta = {
@@ -6121,10 +6206,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20241203.194117";
+      version = "1.1.0.20250309.165914";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20241203.194117.tar";
-        sha256 = "03mbak4dv1z49j3sa3v97vmk82b4s5j5fhnwxdy7qqkf7v06jrha";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250309.165914.tar";
+        sha256 = "1nx4b15g7zai76587phi3dy19adywmhmaan2jg62vl11mij2z08b";
       };
       packageRequires = [ org ];
       meta = {
@@ -6155,6 +6240,32 @@
       ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/org-edna.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  org-gnosis = callPackage (
+    {
+      compat,
+      elpaBuild,
+      emacsql,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "org-gnosis";
+      ename = "org-gnosis";
+      version = "0.0.9.0.20250226.154732";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.0.9.0.20250226.154732.tar";
+        sha256 = "1yk5fp4l3q1ycgbgmgn9biy3na22ssvx15j76k6almx50cgcngyp";
+      };
+      packageRequires = [
+        compat
+        emacsql
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/org-gnosis.html";
         license = lib.licenses.free;
       };
     }
@@ -6191,10 +6302,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.6.0.20250115.104225";
+      version = "1.7.0.20250311.170125";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.6.0.20250115.104225.tar";
-        sha256 = "10cqfivrva3g4arl1r4ckh9my71qrdajsn3xgnncz4w2inr6g5rz";
+        url = "https://elpa.gnu.org/devel/org-modern-1.7.0.20250311.170125.tar";
+        sha256 = "0xijjr2y15ghjicflmsq3l5ir2laz6pvsfcr0p7jziiz0ax97fx9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6368,10 +6479,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.6.0.20250128.82432";
+      version = "1.6.0.20250301.161304";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.6.0.20250128.82432.tar";
-        sha256 = "1gci9ig7f5vdznf0syj6s08ifz1m8m9a60r777pb94z8y7h9zn7f";
+        url = "https://elpa.gnu.org/devel/osm-1.6.0.20250301.161304.tar";
+        sha256 = "14d10amng3xij0wnj29iz480rsv6z8hkn6ynnh13lfc9kaf5bhh0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6440,6 +6551,27 @@
       packageRequires = [ async ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/paced.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  package-x = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "package-x";
+      ename = "package-x";
+      version = "1.0.0.20250212.211602";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/package-x-1.0.0.20250212.211602.tar";
+        sha256 = "0plkkpdf9apjhr60n4j7idbg5brmx3hndfg2lq8d00si6gr5c73b";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/package-x.html";
         license = lib.licenses.free;
       };
     }
@@ -6552,6 +6684,7 @@
   ) { };
   persist = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -6559,12 +6692,12 @@
     elpaBuild {
       pname = "persist";
       ename = "persist";
-      version = "0.6.1.0.20240801.14323";
+      version = "0.6.1.0.20250213.95218";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/persist-0.6.1.0.20240801.14323.tar";
-        sha256 = "05y2a66a9gzs2xn4skb7ralidfk01z49ac3hf51sznrlri3wikng";
+        url = "https://elpa.gnu.org/devel/persist-0.6.1.0.20250213.95218.tar";
+        sha256 = "0rvd38k3hzz70dcn3xpmcilkp7vmq32gdic349184548b220jypm";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/persist.html";
         license = lib.licenses.free;
@@ -6602,10 +6735,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.49.0.20240424.65247";
+      version = "0.4.50.0.20250303.193108";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/phps-mode-0.4.49.0.20240424.65247.tar";
-        sha256 = "03xz1ig3zsbwixa4hkh7g9ihjxlw2jmzydqldkvjsyv1yhyyf2j4";
+        url = "https://elpa.gnu.org/devel/phps-mode-0.4.50.0.20250303.193108.tar";
+        sha256 = "1a7251cn5jiq6322ffs7bzz3bqyfdap2skwb0s1kwxn0zhq1hjcz";
       };
       packageRequires = [ ];
       meta = {
@@ -6666,10 +6799,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.2pre0.20241227.143348";
+      version = "0.1.3pre0.20250228.134816";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.2pre0.20241227.143348.tar";
-        sha256 = "010s4kfx3apdhh9z4r9d2c44arf90nbn8r1j9j3gjhpimsdjhbgq";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.3pre0.20250228.134816.tar";
+        sha256 = "08dasdzl53rnb29jl023vmcqs0xall1ra2dfpzqsjjzc1a1lz08y";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -6688,10 +6821,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.3pre0.20241106.190902";
+      version = "0.2.4pre0.20250228.133501";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.3pre0.20241106.190902.tar";
-        sha256 = "1yx1yqqqps6cj1bwr0dq9n850jr0vh6nph85rw4b70qy6g63k473";
+        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.4pre0.20250228.133501.tar";
+        sha256 = "1m38fzbcmvqh8nwxsb2wic549af8wicpqxsd18d5631z04910ryb";
       };
       packageRequires = [ plz ];
       meta = {
@@ -6815,10 +6948,10 @@
     elpaBuild {
       pname = "popper";
       ename = "popper";
-      version = "0.4.6.0.20241130.171037";
+      version = "0.4.8.0.20250222.131836";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/popper-0.4.6.0.20241130.171037.tar";
-        sha256 = "1gypxgkzaf422pdv9v2rfj010mbvb0qcw3hl3aw99qd7w1ndrd9k";
+        url = "https://elpa.gnu.org/devel/popper-0.4.8.0.20250222.131836.tar";
+        sha256 = "03h7i6z8zm1najw5vz9kflf6l35vlkcb6gkqp9g94q1r6j8s7bl2";
       };
       packageRequires = [ ];
       meta = {
@@ -6836,10 +6969,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.4.4.0.20241202.131153";
+      version = "1.4.4.0.20250211.11057";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/posframe-1.4.4.0.20241202.131153.tar";
-        sha256 = "1rlzgl2bjc46g261m513dgl52n2vq0xlfmfpdm1qrdww06jjklg6";
+        url = "https://elpa.gnu.org/devel/posframe-1.4.4.0.20250211.11057.tar";
+        sha256 = "18vmjb0qx39danlvq0r4k2crqvb8xkfrpfj5xk7yxwj7al92q390";
       };
       packageRequires = [ ];
       meta = {
@@ -6944,10 +7077,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20250104.95952";
+      version = "0.11.1.0.20250311.202651";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250104.95952.tar";
-        sha256 = "1qdffp243idkgmswqyhz0fyq120f0xx5ay31y65zfgwxbrcb35cf";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250311.202651.tar";
+        sha256 = "12d3v449rk70l71i1hyfy9fkvqv82y4gadcdwn9n4hdgqzknj598";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7030,10 +7163,10 @@
     elpaBuild {
       pname = "pyim";
       ename = "pyim";
-      version = "5.3.4.0.20240508.25615";
+      version = "5.3.4.0.20250225.70943";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pyim-5.3.4.0.20240508.25615.tar";
-        sha256 = "0p079girx795fvqswdjh8l5mwdyndanfcsvb1qvj2klq063y1vv5";
+        url = "https://elpa.gnu.org/devel/pyim-5.3.4.0.20250225.70943.tar";
+        sha256 = "07549ppwkx8xr71a4xdkxwhg9ilmnmxmqac83klcpzscm9gasyh3";
       };
       packageRequires = [
         async
@@ -7072,19 +7205,23 @@
       compat,
       elpaBuild,
       fetchurl,
+      flymake ? null,
       lib,
+      project,
       seq,
     }:
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.28.0.20250204.222800";
+      version = "0.30.0.20250311.1541";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.28.0.20250204.222800.tar";
-        sha256 = "0ljnj4k793i53z9hgg148443x3q2yvmfp8f8kgjc0p0kz95d7m6m";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20250311.1541.tar";
+        sha256 = "0mx17q36rjf2ax1vy0pm79ya35ys5wg0n97flk98x4w1l5wggx6w";
       };
       packageRequires = [
         compat
+        flymake
+        project
         seq
       ];
       meta = {
@@ -7485,10 +7622,10 @@
     elpaBuild {
       pname = "register-list";
       ename = "register-list";
-      version = "0.1.0.20221212.230034";
+      version = "0.1.0.20250213.102055";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/register-list-0.1.0.20221212.230034.tar";
-        sha256 = "02qc5ll26br1smx5d0ci3wm0s4hdj8sw72xdapn5bql5509n75dx";
+        url = "https://elpa.gnu.org/devel/register-list-0.1.0.20250213.102055.tar";
+        sha256 = "1q0lcj1ranylqawvi9y0c6rc87bl7g6bdwd08hpnsjh3jzyzmvqk";
       };
       packageRequires = [ ];
       meta = {
@@ -7507,10 +7644,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.1.0.20241229.210640";
+      version = "2.1.0.20250224.150638";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/relint-2.1.0.20241229.210640.tar";
-        sha256 = "1gx1rq17qvq73cl8921mx6w24nq9nvaa1w1blhl4r3n4wb7j96cw";
+        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250224.150638.tar";
+        sha256 = "06fn5lm4w7ypjrndlc8kl2lvvipiv4ik9hh8rvaa5h0vhkw1y947";
       };
       packageRequires = [ xr ];
       meta = {
@@ -7874,10 +8011,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.2.1.0.20250125.80419";
+      version = "0.2.1.0.20250303.51849";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-0.2.1.0.20250125.80419.tar";
-        sha256 = "0h5bh6wqqx8v8bxjnilrcz7764di5cgycwrs5vm93zmhkkxdfx1p";
+        url = "https://elpa.gnu.org/devel/show-font-0.2.1.0.20250303.51849.tar";
+        sha256 = "1nbgvb5id2jfjpics0fxmkc6mj343ry1ww6n8l1glk8nchskqx78";
       };
       packageRequires = [ ];
       meta = {
@@ -8087,10 +8224,10 @@
     elpaBuild {
       pname = "soap-client";
       ename = "soap-client";
-      version = "3.2.3.0.20250101.73917";
+      version = "3.2.3.0.20250226.15703";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20250101.73917.tar";
-        sha256 = "0y2zzf5c1yfxx2wrr2ixymk2brp3x73qlxsnjkbmlb6hvjzqp704";
+        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20250226.15703.tar";
+        sha256 = "0nnksnwhx9fhj3lrc8s1l2c075xgpcfz5hmdk253835n0wzfz3n5";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -8347,10 +8484,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0.0.20250208.100140";
+      version = "2.2.0.0.20250216.155518";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250208.100140.tar";
-        sha256 = "1g79nlv3csgd4qprv6gfb4pijlpcsypz24lij40szf53y325p7vl";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250216.155518.tar";
+        sha256 = "0dvshs7zshi1s7rgrhrn4igi96y76gybhmwq337sigjm76fh37i2";
       };
       packageRequires = [ ];
       meta = {
@@ -8497,10 +8634,10 @@
     elpaBuild {
       pname = "swiper";
       ename = "swiper";
-      version = "0.14.2.0.20240829.172807";
+      version = "0.15.0.0.20250225.84058";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/swiper-0.14.2.0.20240829.172807.tar";
-        sha256 = "0hv9dmn5gbbnx2yx7x91p20is41h7l7s4qk1y805kp6r5lknz2b3";
+        url = "https://elpa.gnu.org/devel/swiper-0.15.0.0.20250225.84058.tar";
+        sha256 = "1j0ys0q804w7yghxvs5mw6qbi8f7vw34fp1ng09ds1ylpsxfsxfa";
       };
       packageRequires = [ ivy ];
       meta = {
@@ -8937,10 +9074,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.2.0.20250205.202103";
+      version = "1.4.0.20250312.1734";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/track-changes-1.2.0.20250205.202103.tar";
-        sha256 = "1hiaphb20cng08b806w68a24fy00yfpp2kpmwn1aw5xywxkqsgi7";
+        url = "https://elpa.gnu.org/devel/track-changes-1.4.0.20250312.1734.tar";
+        sha256 = "003cp1sz74nj92dbvcm4gzsr546v5l38ifi76371lv3j5wxjfgsi";
       };
       packageRequires = [ ];
       meta = {
@@ -8958,10 +9095,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.1.0.20250130.82356";
+      version = "2.7.2.2.0.20250227.73653";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.7.2.1.0.20250130.82356.tar";
-        sha256 = "1p59jfn0kjs4q3cgfgb16bnbpss3bzcicvs6lhi3r4w7z24gind5";
+        url = "https://elpa.gnu.org/devel/tramp-2.7.2.2.0.20250227.73653.tar";
+        sha256 = "19iaj5dzxqjw413j4fawgsi3fia73d28c3v2iy5la9xaxrqxwig5";
       };
       packageRequires = [ ];
       meta = {
@@ -9044,10 +9181,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.4.0.20250201.131431";
+      version = "0.8.5.0.20250306.191617";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.8.4.0.20250201.131431.tar";
-        sha256 = "1micgh8w9x0x95wis581f5p3mbhmiq5q3mg8rz1fn3xnjjiqr8a3";
+        url = "https://elpa.gnu.org/devel/transient-0.8.5.0.20250306.191617.tar";
+        sha256 = "1yjq58925f4f13ln7i2hzmyknhswmgpwh1n5dc8bnk7pbfnkzcq3";
       };
       packageRequires = [
         compat
@@ -9068,10 +9205,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "1.0.0.20220410.130412";
+      version = "1.1.0.20250225.93512";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-cycles-1.0.0.20220410.130412.tar";
-        sha256 = "1rmgmlbjig866gr5jr89mv8ikvpf0p0pcgpa236nmiw3j6jsywa8";
+        url = "https://elpa.gnu.org/devel/transient-cycles-1.1.0.20250225.93512.tar";
+        sha256 = "1j6w8zy39h744wps9dgc05l7zrk7pg6vwx91rh7kvzrj6m8hmwds";
       };
       packageRequires = [ ];
       meta = {
@@ -9267,10 +9404,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.5.2snapshot0.20241024.210047";
+      version = "0.5.2snapshot0.20250304.194036";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.5.2snapshot0.20241024.210047.tar";
-        sha256 = "0m12x3mrryc0czihavx8kc48df6404bi534dicnjia2v9xv574jv";
+        url = "https://elpa.gnu.org/devel/urgrep-0.5.2snapshot0.20250304.194036.tar";
+        sha256 = "0hcskhl9qs9rajv1kxna1xqfkhil5w5mdiyrj0swh7mcaw63fwr1";
       };
       packageRequires = [
         compat
@@ -9362,10 +9499,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20250111.74423";
+      version = "2.4.6.0.20250302.30748";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250111.74423.tar";
-        sha256 = "1zrw1i9pm6pgmv48p8abk0a45nvj59pa361zkvgmlnpb1nhciv39";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250302.30748.tar";
+        sha256 = "0hd0ii901jr7l0f3yl1kmnplnsj34lbcs7c71ndlkfg2qzgys6kj";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9452,10 +9589,10 @@
     elpaBuild {
       pname = "vc-got";
       ename = "vc-got";
-      version = "1.2.0.20230129.104658";
+      version = "1.2.0.20250223.143804";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-got-1.2.0.20230129.104658.tar";
-        sha256 = "0dwigmr1rm8a80ngx25jrqlgnbdj51db6avmyg3v7avhkyg5x455";
+        url = "https://elpa.gnu.org/devel/vc-got-1.2.0.20250223.143804.tar";
+        sha256 = "18rph07s97jhnfc13kpfma82i7y5nkj9z697xxqxzzz8ijnqncnw";
       };
       packageRequires = [ ];
       meta = {
@@ -9580,10 +9717,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "1.11.0.20250203.105541";
+      version = "2.0.0.20250311.165544";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-1.11.0.20250203.105541.tar";
-        sha256 = "14mykwn0wypd6h5s6l175q8ibsvqc6mnrnws6plmqzlpghir1ipk";
+        url = "https://elpa.gnu.org/devel/vertico-2.0.0.20250311.165544.tar";
+        sha256 = "1vw6qjrbsymx18kpn47p89ni7gpnwb0zs7prbzzpn1p370bb578r";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9603,10 +9740,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.8.0.0.20250120.15236";
+      version = "0.8.0.0.20250211.11642";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-posframe-0.8.0.0.20250120.15236.tar";
-        sha256 = "18zcjyb2m3my6inwg6p0x77236vijyppqb1ka89zfbr8cwwvcxqp";
+        url = "https://elpa.gnu.org/devel/vertico-posframe-0.8.0.0.20250211.11642.tar";
+        sha256 = "0l9s2r9s8gm2xyaz8alik7m3qy4jjg6mdpbdrgd5n9bp6jk85kz5";
       };
       packageRequires = [
         posframe
@@ -9882,10 +10019,10 @@
     elpaBuild {
       pname = "window-tool-bar";
       ename = "window-tool-bar";
-      version = "0.3.0.20250208.111330";
+      version = "0.3.0.20250313.50858";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/window-tool-bar-0.3.0.20250208.111330.tar";
-        sha256 = "1xg1jkb08hw0a1q9rfd3fvdkwmcd04syzj9lihlyww2am8ki286v";
+        url = "https://elpa.gnu.org/devel/window-tool-bar-0.3.0.20250313.50858.tar";
+        sha256 = "00cvxm8qgfck1ydc3089c4p707wmqb2x0z2nc8xjzb38p4khw0pr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10125,10 +10262,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.1.0.20241229.210720";
+      version = "2.1.0.20250224.150416";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xr-2.1.0.20241229.210720.tar";
-        sha256 = "0p7v5pl1rynhki6rx0fsxm3jnch3lspw59v9mxz86ir1w03913mm";
+        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250224.150416.tar";
+        sha256 = "0ndfsnma1h3h6kbaymaa7cckdsk92zbi822zarliwvwg9qf1qmnw";
       };
       packageRequires = [ ];
       meta = {
@@ -10146,10 +10283,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20250101.73917";
+      version = "1.7.0.0.20250304.63233";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250101.73917.tar";
-        sha256 = "057s32ps07cnzny7zv1zp794nhwvi11zfwjbbzql38pryqrjijp4";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250304.63233.tar";
+        sha256 = "0zkawnpgh60nqn5nz1vp4w6klw37v3ay5vyp5dsjz7bz4f3vcnvd";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.8";
+      version = "14.0.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-14.0.8.tar";
-        sha256 = "0bcjkbwhbkmm0r7pbh44j7vw9b39g2iw1jgw4sq54qp7387j6lmy";
+        url = "https://elpa.gnu.org/packages/auctex-14.0.9.tar";
+        sha256 = "1mhzrqln0fjj9nn04dhgzpcyv2wzysz4l85wmp4fw620jksf8j7n";
       };
       packageRequires = [ ];
       meta = {
@@ -527,10 +527,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.1.tar";
-        sha256 = "1mni58ckvcs33jnp78y39pg6rfnm4908iz6g7l7d9y8hbjwin4xm";
+        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.1.1.tar";
+        sha256 = "0wag5iq3bgk3sazlc4a0g67l4517kv4khidkiwrrgv1b1nq0kcrl";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -633,10 +633,10 @@
     elpaBuild {
       pname = "autorevert-tail-truncate";
       ename = "autorevert-tail-truncate";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/autorevert-tail-truncate-1.0.0.tar";
-        sha256 = "0p8gbcgmra4av4c0sbrazfb56vp564m2cyjrspkmsjlzwgl3634r";
+        url = "https://elpa.gnu.org/packages/autorevert-tail-truncate-1.0.1.tar";
+        sha256 = "1g7bqd617vmanjf3s1c4adsj5zhvsxrzib2pkj508fs5hbyyi1wi";
       };
       packageRequires = [ ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "bicep-ts-mode";
       ename = "bicep-ts-mode";
-      version = "0.1.3";
+      version = "0.1.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/bicep-ts-mode-0.1.3.tar";
-        sha256 = "02377gsdnfvvydjw014p2y6y74nd5zfh1ghq5l9ayq0ilvv8fmx7";
+        url = "https://elpa.gnu.org/packages/bicep-ts-mode-0.1.4.tar";
+        sha256 = "0jf6zbmmwyjrl6wrcc99ahbv0xqbfr9zdzayi7racbflsyflxnb7";
       };
       packageRequires = [ ];
       meta = {
@@ -783,10 +783,10 @@
     elpaBuild {
       pname = "blist";
       ename = "blist";
-      version = "0.4";
+      version = "0.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/blist-0.4.tar";
-        sha256 = "0k1h6rmyphqsgznk53hc1xbbnj2h2n2jknlb8vjxlv01z83s32wy";
+        url = "https://elpa.gnu.org/packages/blist-0.6.tar";
+        sha256 = "1r7pnbz4vdwbnga271d03i5dy1hvnxbf17q5bcrn05vwxlf8g83m";
       };
       packageRequires = [ ilist ];
       meta = {
@@ -1084,10 +1084,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "1.9";
+      version = "2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-1.9.tar";
-        sha256 = "0g9zv5fi86ky6jjqzqxn8hd4xkfdl6fp4cqpn91zn5sp35dbvrvv";
+        url = "https://elpa.gnu.org/packages/cape-2.0.tar";
+        sha256 = "0llcvbqbr296niag7z60kqxpahcv1809734j7d9vnwpl3kgcxg9v";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1298,10 +1298,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.1.0";
+      version = "1.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/colorful-mode-1.1.0.tar";
-        sha256 = "1rq9jsa6imj6bw8s63sg7v6xc1zgrr4afrm4pydl280ly6cmp5bv";
+        url = "https://elpa.gnu.org/packages/colorful-mode-1.2.3.tar";
+        sha256 = "0y8bsmb27lxa87a9q9vk36dx914dl07np3bkyn019p2ak73wakgk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1474,6 +1474,27 @@
       };
     }
   ) { };
+  cond-star = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "cond-star";
+      ename = "cond-star";
+      version = "1.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/cond-star-1.0.tar";
+        sha256 = "1r8wfb7g6dknpnqvsszrcdpc695srk0f8s85zi0d93k1iyl3yi2q";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/cond-star.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   constants = callPackage (
     {
       elpaBuild,
@@ -1505,10 +1526,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.0.tar";
-        sha256 = "14xwd5i27km3kqv8xny1mjb9h1y5m55d51hh7l9zyc603080fry0";
+        url = "https://elpa.gnu.org/packages/consult-2.1.tar";
+        sha256 = "0w88gpgkqjmllypckrkc54gm42yjsfjp4mj9q9pii8qir49sh8ls";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1553,10 +1574,10 @@
     elpaBuild {
       pname = "consult-hoogle";
       ename = "consult-hoogle";
-      version = "0.4.1";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-hoogle-0.4.1.tar";
-        sha256 = "18gb1ggj184c7v2fbykyqj49cxcid8gnds2ab0r13mm1ad2q6xdi";
+        url = "https://elpa.gnu.org/packages/consult-hoogle-0.5.0.tar";
+        sha256 = "183mms98c5ajr2z60qwpl2b8b466dqz6nd84vvpqdzvxr9qkw14n";
       };
       packageRequires = [ consult ];
       meta = {
@@ -1663,10 +1684,10 @@
     elpaBuild {
       pname = "counsel";
       ename = "counsel";
-      version = "0.14.2";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/counsel-0.14.2.tar";
-        sha256 = "10jajfl2vhqj2awy991kqrf1hcsj8nkvn760cbxjsm2lhzvqqhj3";
+        url = "https://elpa.gnu.org/packages/counsel-0.15.0.tar";
+        sha256 = "1mw13iw7ygnigjarcfg7lazrdwk7l17clxs2igf75kdkk4l4jgb4";
       };
       packageRequires = [
         ivy
@@ -1878,10 +1899,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.22.0";
+      version = "0.23.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.22.0.tar";
-        sha256 = "06sfhh4sn9ddmf83h3a7hcx6ghinrigl5s7a2pa3c0abfg3jjbsb";
+        url = "https://elpa.gnu.org/packages/dape-0.23.0.tar";
+        sha256 = "0y6snj9cwn1f754bn2smyf8ggjihws7a0rxb3b5s8dsvdkgz5hzy";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1921,10 +1942,10 @@
     elpaBuild {
       pname = "dash";
       ename = "dash";
-      version = "2.19.1";
+      version = "2.20.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dash-2.19.1.tar";
-        sha256 = "1c7yibfikkwlip8zh4kiamh3kljil3hyl250g8fkxpdyhljjdk6m";
+        url = "https://elpa.gnu.org/packages/dash-2.20.0.tar";
+        sha256 = "1ckcsfksvwcknbp39v5p4yyl5h6a8xz0iljx7wb20igq0l4lpy18";
       };
       packageRequires = [ ];
       meta = {
@@ -1965,10 +1986,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.43";
+      version = "0.44";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/debbugs-0.43.tar";
-        sha256 = "1jzdr7bp48incg1bdnq4s1ldnyp6hncz0mydy0bizk3c68chsls5";
+        url = "https://elpa.gnu.org/packages/debbugs-0.44.tar";
+        sha256 = "02kb24rscbhs4w6xknf5d6l1cicy99b0004hr20pkki6faapzpx2";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2042,6 +2063,28 @@
       packageRequires = [ denote ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/denote-menu.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  denote-search = callPackage (
+    {
+      denote,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "denote-search";
+      ename = "denote-search";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/denote-search-1.0.3.tar";
+        sha256 = "1537c5xr7gvsvwn7khjs03z4g6js03mwwz9i5rwnmksajhkyfiv7";
+      };
+      packageRequires = [ denote ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/denote-search.html";
         license = lib.licenses.free;
       };
     }
@@ -2296,10 +2339,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.3.0";
+      version = "0.4.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dired-preview-0.3.0.tar";
-        sha256 = "0cfwpdh70a7n37nkwqqnjfjb6nc8mfkcry3dl95xj2wj70bavsf8";
+        url = "https://elpa.gnu.org/packages/dired-preview-0.4.0.tar";
+        sha256 = "1ns0vgg0rmx823rcd4c18xxg6kjj22lklv74bhxf7cj6h50r4z7l";
       };
       packageRequires = [ ];
       meta = {
@@ -2625,10 +2668,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241223";
+      version = "20250216";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20241223.tar";
-        sha256 = "0rp7b3sfh94zyah303sk43mfdbzcz6p20dqarkzbsgin3n77ara8";
+        url = "https://elpa.gnu.org/packages/eev-20250216.tar";
+        sha256 = "07bxywrcb8w379nzn8yi307lafb3b7qv8r362mx9vv0w8fmv8r6b";
       };
       packageRequires = [ ];
       meta = {
@@ -2824,21 +2867,21 @@
       fetchurl,
       lib,
       llm,
-      spinner,
+      plz,
       transient,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.13.7";
+      version = "1.5.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-0.13.7.tar";
-        sha256 = "1nlav89rb1xdrjj4kb9pvz3wjvlvwyz7h11fm098g8s81r703hcx";
+        url = "https://elpa.gnu.org/packages/ellama-1.5.4.tar";
+        sha256 = "0kf25znwzc9mdy2adhramzcr30y9f8qa1q9s0swbsa4ilja7ks7w";
       };
       packageRequires = [
         compat
         llm
-        spinner
+        plz
         transient
       ];
       meta = {
@@ -3442,10 +3485,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "2.1.0";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/fontaine-2.1.0.tar";
-        sha256 = "10wywr7h4li99zxw3mzmy44rnkvii8rwri23b7vkacvhv3z8sfrf";
+        url = "https://elpa.gnu.org/packages/fontaine-3.0.0.tar";
+        sha256 = "1v2gwry755m3gj6gxrxgcbvw39sdgrmazpw09nkayrvx9ar5fszw";
       };
       packageRequires = [ ];
       meta = {
@@ -3669,6 +3712,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/gnome-c-style.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  gnome-dark-style = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "gnome-dark-style";
+      ename = "gnome-dark-style";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/gnome-dark-style-0.2.2.tar";
+        sha256 = "1vf0ka0xg8mvaq3s3b8rgsdv77q7qd73k9mqfvyk7ywhxj7zdb9i";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/gnome-dark-style.html";
         license = lib.licenses.free;
       };
     }
@@ -4305,10 +4369,10 @@
     elpaBuild {
       pname = "ivy";
       ename = "ivy";
-      version = "0.14.2";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ivy-0.14.2.tar";
-        sha256 = "1h9gfkkcw9nfw85m0mh08qfmi2y0jkvdk54qx0iy5p04ysmhs6k1";
+        url = "https://elpa.gnu.org/packages/ivy-0.15.0.tar";
+        sha256 = "13kikgvrhi2b6dg0py4n51kc881dv7bll71iaxq1bjlzdwvsn20h";
       };
       packageRequires = [ ];
       meta = {
@@ -4328,10 +4392,10 @@
     elpaBuild {
       pname = "ivy-avy";
       ename = "ivy-avy";
-      version = "0.14.2";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ivy-avy-0.14.2.tar";
-        sha256 = "12s5z3h8bpa6vdk7f54i2dy18hd3p782pq3x6mkclkvlxijv7d11";
+        url = "https://elpa.gnu.org/packages/ivy-avy-0.15.0.tar";
+        sha256 = "0xqykxvsm7q81744qj4w7ma83v6s9a4wx4flywqch4dn7liaiqwj";
       };
       packageRequires = [
         avy
@@ -4376,10 +4440,10 @@
     elpaBuild {
       pname = "ivy-hydra";
       ename = "ivy-hydra";
-      version = "0.14.2";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ivy-hydra-0.14.2.tar";
-        sha256 = "1p08rpj3ac2rwjcqbzkq9r5pmc1d9ci7s9bl0qv5cj5r8wpl69mx";
+        url = "https://elpa.gnu.org/packages/ivy-hydra-0.15.0.tar";
+        sha256 = "1crznifig71l6h4zjsr39d2w02blw7vla1vafv0yhhj6ryd4030g";
       };
       packageRequires = [
         hydra
@@ -4512,10 +4576,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "1.12";
+      version = "2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-1.12.tar";
-        sha256 = "0hy79bdzzbn45yqyfx4ybg742n5ci1ivazm67g4jhyd43vdfd8gf";
+        url = "https://elpa.gnu.org/packages/jinx-2.0.tar";
+        sha256 = "1haix1q4rfz18m4bblp4k4gqjd9jbwg9j9zl411b8s2ga268pdkk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4963,10 +5027,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.23.0";
+      version = "0.24.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.23.0.tar";
-        sha256 = "0a277fvi28xxjkr0884pdq23alk6rs3m42vs75r5ivv6ggznjzz9";
+        url = "https://elpa.gnu.org/packages/llm-0.24.1.tar";
+        sha256 = "1vy62pg8hdakw0zbyl1fb8bvbhl2w36z683gbhjb71ikl3bqnav8";
       };
       packageRequires = [
         plz
@@ -6075,10 +6139,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.21";
+      version = "9.7.25";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.21.tar";
-        sha256 = "0g2zwzidf4wzw0f120445a5j2297l9xgjbr0szhacspkfrxgjxg5";
+        url = "https://elpa.gnu.org/packages/org-9.7.25.tar";
+        sha256 = "0isa5mqsmnyw874kh980kal4r45h6qdzizg186lvczmhdqir85bm";
       };
       packageRequires = [ ];
       meta = {
@@ -6135,6 +6199,32 @@
       };
     }
   ) { };
+  org-gnosis = callPackage (
+    {
+      compat,
+      elpaBuild,
+      emacsql,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "org-gnosis";
+      ename = "org-gnosis";
+      version = "0.0.9";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/org-gnosis-0.0.9.tar";
+        sha256 = "1p0qpvxwjvbmzf8npsyirpgi7ykd7ai14m758zp1rlwz03qyx2m4";
+      };
+      packageRequires = [
+        compat
+        emacsql
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/org-gnosis.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   org-jami-bot = callPackage (
     {
       elpaBuild,
@@ -6167,10 +6257,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.6";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.6.tar";
-        sha256 = "1fmmblqs6v52690fvky3xq48m5a3xh8xrl7j8pqw6hc06igm4m5q";
+        url = "https://elpa.gnu.org/packages/org-modern-1.7.tar";
+        sha256 = "0f1i28x7a9m69xjl3n4bb91pjxm21xw1byhqilyw524y8s22j3wm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6420,6 +6510,27 @@
       };
     }
   ) { };
+  package-x = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "package-x";
+      ename = "package-x";
+      version = "1.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/package-x-1.0.tar";
+        sha256 = "1wzwpqy992qv4jizx6fv6r1aw46gjzk49f4vv178bmshz03vndrx";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/package-x.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   parsec = callPackage (
     {
       cl-lib ? null,
@@ -6578,10 +6689,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.49";
+      version = "0.4.50";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/phps-mode-0.4.49.tar";
-        sha256 = "1zxzv6h2075s0ldwr9izfy3sxrrg3x5y5vilnlgnwd7prcq8qa8y";
+        url = "https://elpa.gnu.org/packages/phps-mode-0.4.50.tar";
+        sha256 = "1dyxqkyik6cxmqnwmxlxd1v42jcnkh0hl1qqm65nhvmf3ksq59kh";
       };
       packageRequires = [ ];
       meta = {
@@ -6642,10 +6753,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.1";
+      version = "0.1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/plz-event-source-0.1.1.tar";
-        sha256 = "0mraza6r8p6rwmsmgz7kkllhwi6spz8jzkk458jlgqxilm0jajib";
+        url = "https://elpa.gnu.org/packages/plz-event-source-0.1.2.tar";
+        sha256 = "1gq0w6pkg58066gwc58y3j0w2hbfzmy1r62j02jfiqjb5am1gfjk";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -6664,10 +6775,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.2";
+      version = "0.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.2.tar";
-        sha256 = "0m1hm2myc5pqax8kkz910wn3443pxdsav7rcf7bcqnim4l0ismvn";
+        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.3.tar";
+        sha256 = "1qb0zag7isnl9hx71jma5yk6rinfdbscmlgwg2489067vshf9x7b";
       };
       packageRequires = [ plz ];
       meta = {
@@ -6770,10 +6881,10 @@
     elpaBuild {
       pname = "popper";
       ename = "popper";
-      version = "0.4.6";
+      version = "0.4.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/popper-0.4.6.tar";
-        sha256 = "0xwy4p9g0lfd4ybamsl5gsppmx79yv16s4lh095x5y5qfmgcvq2c";
+        url = "https://elpa.gnu.org/packages/popper-0.4.8.tar";
+        sha256 = "1i667qablblr8s614j1p6zfyqkwci56fpycb8hbxap6fpirgmv9x";
       };
       packageRequires = [ ];
       meta = {
@@ -7003,20 +7114,28 @@
   ) { };
   python = callPackage (
     {
-      cl-lib ? null,
+      compat,
       elpaBuild,
       fetchurl,
+      flymake ? null,
       lib,
+      project,
+      seq,
     }:
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.28";
+      version = "0.30";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/python-0.28.tar";
-        sha256 = "042jhg87bnc750wwjwvp32ici3pyswx1pza2qz014ykdqqnsx0aq";
+        url = "https://elpa.gnu.org/packages/python-0.30.tar";
+        sha256 = "1m8jmjkf5cgw0jr5j4ca525kllaf1ailx5mg2z4xzvqwxkzwhwxd";
       };
-      packageRequires = [ cl-lib ];
+      packageRequires = [
+        compat
+        flymake
+        project
+        seq
+      ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/python.html";
         license = lib.licenses.free;
@@ -8384,10 +8503,10 @@
     elpaBuild {
       pname = "swiper";
       ename = "swiper";
-      version = "0.14.2";
+      version = "0.15.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/swiper-0.14.2.tar";
-        sha256 = "1rzp78ix19ddm7fx7p4i5iybd5lw244kqvf3nrafz3r7q6hi8yds";
+        url = "https://elpa.gnu.org/packages/swiper-0.15.0.tar";
+        sha256 = "16vznhb8zqzqvg3i2pkwfani2h19dm08aj7qv334mlyj97rv1ppn";
       };
       packageRequires = [ ivy ];
       meta = {
@@ -8800,10 +8919,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.2";
+      version = "1.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/track-changes-1.2.tar";
-        sha256 = "0al6a1xjs6p2pn6z976pnmfqz2x5xcz99b5gkdzz90ywbn7018m4";
+        url = "https://elpa.gnu.org/packages/track-changes-1.4.tar";
+        sha256 = "0ygc53dm144ld4f7ig1fh1z345gnkrin7q108kj9d4dhgp8f2381";
       };
       packageRequires = [ ];
       meta = {
@@ -8821,10 +8940,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.1";
+      version = "2.7.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.7.2.1.tar";
-        sha256 = "17178jpn05bpy1cmxf27kdmrabcgcghslr7ri49dqm3sqydk4fmm";
+        url = "https://elpa.gnu.org/packages/tramp-2.7.2.2.tar";
+        sha256 = "0nq441hdr9akpdklplnf4hcza4jgj4vq2718mvf2iznbqqs4b33k";
       };
       packageRequires = [ ];
       meta = {
@@ -8907,10 +9026,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.4";
+      version = "0.8.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.8.4.tar";
-        sha256 = "1dc636j9194i9pfj4rxxfy33f5rwsqp5qkf1c7a06yazblvgaqxi";
+        url = "https://elpa.gnu.org/packages/transient-0.8.5.tar";
+        sha256 = "0ydxddlf9aniindgi135rj3c1d1ar5qi5kwh1qkdff9124d6f0kh";
       };
       packageRequires = [
         compat
@@ -8931,10 +9050,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "1.0";
+      version = "1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-cycles-1.0.tar";
-        sha256 = "0s6cxagqxj4i3qf4kx8mdrihciz3v6ga7zw19jcv896rdhx75bx5";
+        url = "https://elpa.gnu.org/packages/transient-cycles-1.1.tar";
+        sha256 = "0y19kns3xfppyhriyapam3m134yvm9idylmsj12s9g9zva0sal45";
       };
       packageRequires = [ ];
       meta = {
@@ -9442,10 +9561,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "1.11";
+      version = "2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-1.11.tar";
-        sha256 = "0wfx0hrjkdhqqgi954npam6nv505bnq76jc18sxcca6dilzjzwnf";
+        url = "https://elpa.gnu.org/packages/vertico-2.0.tar";
+        sha256 = "1x34vsrr812wlawb5wy5aq81467xsjxjz0zsjsxq121d4pzam4z3";
       };
       packageRequires = [ compat ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
@@ -21,6 +21,9 @@ melpaBuild {
 
   files = ''(:defaults "msg")'';
 
+  # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76573
+  ignoreCompilationError = true;
+
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1633,6 +1633,8 @@ let
         # missing optional dependencies
         suggest = addPackageRequires super.suggest [ self.shut-up ];
 
+        sx = ignoreCompilationError super.sx; # elisp error
+
         symex = ignoreCompilationError super.symex; # elisp error
 
         term-alert = mkHome super.term-alert;

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1574,6 +1574,8 @@ let
 
         shadchen = ignoreCompilationError super.shadchen; # elisp error
 
+        shampoo = ignoreCompilationError super.shampoo; # elisp error
+
         # missing optional dependencies and one of them (mew) is not on any ELPA
         shimbun = ignoreCompilationError (
           addPackageRequires super.shimbun [

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1535,6 +1535,10 @@ let
 
         rpm-spec-mode = ignoreCompilationError super.rpm-spec-mode; # elisp error
 
+        # missing optional dependencies
+        # https://github.com/emacs-rustic/rustic/pull/93
+        rustic = addPackageRequires super.rustic [ self.flycheck ];
+
         # https://github.com/emacsfodder/emacs-theme-sakura/issues/1
         sakura-theme = addPackageRequiresIfOlder super.sakura-theme [ self.autothemer ] "20240921.1028";
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1425,6 +1425,9 @@ let
 
         org-special-block-extras = ignoreCompilationError super.org-special-block-extras; # elisp error
 
+        # https://github.com/ichernyshovvv/org-timeblock/issues/65
+        org-timeblock = markBroken super.org-timeblock;
+
         org-trello = ignoreCompilationError super.org-trello; # elisp error
 
         # Requires xwidgets compiled into emacs, so mark this package

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1317,6 +1317,8 @@ let
           }
         );
 
+        keystore-mode = ignoreCompilationError super.keystore-mode; # elisp error
+
         kite = ignoreCompilationError super.kite; # elisp error
 
         # missing optional dependencies

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -918,6 +918,8 @@ let
           }
         );
 
+        clojure-quick-repls = ignoreCompilationError super.clojure-quick-repls; # elisp error
+
         # https://github.com/atilaneves/cmake-ide/issues/176
         cmake-ide = addPackageRequires super.cmake-ide [ self.dash ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1334,6 +1334,8 @@ let
         # missing optional dependencies
         lispy = addPackageRequires (mkHome super.lispy) [ self.indium ];
 
+        lsp-origami = ignoreCompilationError super.lsp-origami; # elisp error
+
         # missing optional dependencies
         magik-mode = addPackageRequires super.magik-mode [
           self.auto-complete

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -923,21 +923,24 @@ let
 
         code-review = ignoreCompilationError super.code-review; # elisp error
 
-        codesearch = super.codesearch.overrideAttrs (
-          finalAttrs: previousAttrs: {
-            patches =
-              if lib.versionOlder finalAttrs.version "20240827.805" then
-                previousAttrs.patches or [ ]
-                ++ [
-                  (pkgs.fetchpatch {
-                    name = "remove-unused-dash.patch";
-                    url = "https://github.com/abingham/emacs-codesearch/commit/bd24a152ab6ea9f69443ae8e5b7351bb2f990fb6.patch";
-                    hash = "sha256-cCHY8Ak2fHuuhymjSF7w2MLPDJa84mBUdKg27mB9yto=";
-                  })
-                ]
-              else
-                previousAttrs.patches or null;
-          }
+        # elisp error
+        codesearch = ignoreCompilationError (
+          super.codesearch.overrideAttrs (
+            finalAttrs: previousAttrs: {
+              patches =
+                if lib.versionOlder finalAttrs.version "20240827.805" then
+                  previousAttrs.patches or [ ]
+                  ++ [
+                    (pkgs.fetchpatch {
+                      name = "remove-unused-dash.patch";
+                      url = "https://github.com/abingham/emacs-codesearch/commit/bd24a152ab6ea9f69443ae8e5b7351bb2f990fb6.patch";
+                      hash = "sha256-cCHY8Ak2fHuuhymjSF7w2MLPDJa84mBUdKg27mB9yto=";
+                    })
+                  ]
+                else
+                  previousAttrs.patches or null;
+            }
+          )
         );
 
         # https://github.com/hying-caritas/comint-intercept/issues/2

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1270,6 +1270,11 @@ let
         # https://github.com/duelinmarkers/insfactor.el/issues/7
         insfactor = addPackageRequires super.insfactor [ self.cider ];
 
+        iregister = super.iregister.overrideAttrs (old: {
+          recipe = "";
+          files = ''(:defaults (:exclude ".bump-version.el"))'';
+        });
+
         # https://github.com/wandersoncferreira/ivy-clojuredocs/issues/5
         ivy-clojuredocs = addPackageRequires super.ivy-clojuredocs [ self.parseedn ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1079,6 +1079,10 @@ let
         emms-player-simple-mpv = ignoreCompilationError super.emms-player-simple-mpv;
         emms-player-mpv-jp-radios = ignoreCompilationError super.emms-player-mpv-jp-radios;
 
+        # missing optional dependencies
+        # https://github.com/isamert/empv.el/pull/96
+        empv = addPackageRequires super.empv [ self.hydra ];
+
         enotify = ignoreCompilationError super.enotify; # elisp error
 
         # https://github.com/leathekd/ercn/issues/6

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1505,6 +1505,8 @@ let
         # https://github.com/colonelpanic8/org-project-capture/issues/66
         org-projectile-helm = addPackageRequires super.org-projectile-helm [ self.helm-org ];
 
+        origami-predef = ignoreCompilationError super.origami-predef; # elisp error
+
         # https://github.com/DarwinAwardWinner/mac-pseudo-daemon/issues/9
         osx-pseudo-daemon = addPackageRequiresIfOlder super.osx-pseudo-daemon [ self.mac-pseudo-daemon ] "20240922.2024";
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -852,6 +852,8 @@ let
           }
         );
 
+        brainfuck-mode = ignoreCompilationError super.brainfuck-mode; # elisp error
+
         bts = ignoreCompilationError super.bts; # elisp error
 
         bts-github = ignoreCompilationError super.bts-github; # elisp error

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1659,6 +1659,8 @@ let
 
         weibo = ignoreCompilationError super.weibo; # elisp error
 
+        workgroups2 = ignoreCompilationError super.workgroups2; # elisp error
+
         xenops = mkHome super.xenops;
 
         # missing optional dependencies

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1284,6 +1284,8 @@ let
         # TODO report to upstream
         jack-connect = addPackageRequires super.jack-connect [ self.dash ];
 
+        javap-mode = ignoreCompilationError super.javap-mode; # elisp error
+
         jdee = ignoreCompilationError super.jdee; # elisp error
 
         # https://github.com/fred-o/jekyll-modes/issues/6

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -972,6 +972,9 @@ let
         # needs network during compilation
         consult-gh-forge = ignoreCompilationError (buildWithGit super.consult-gh-forge);
 
+        # needs network during compilation
+        consult-gh-with-pr-review = ignoreCompilationError super.consult-gh-with-pr-review;
+
         counsel-gtags = ignoreCompilationError super.counsel-gtags; # elisp error
 
         # https://github.com/fuxialexander/counsel-notmuch/issues/3

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -93,10 +93,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.2.3.0.20241017.150805";
+      version = "2.3.0.0.20250306.133745";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.2.3.0.20241017.150805.tar";
-        sha256 = "19m3xg2yhf9gxyvp3n143dkyb6r592b2bv7sxcj4g8fhm7qlj6jc";
+        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.3.0.0.20250306.133745.tar";
+        sha256 = "14p1yaxzns3zmi0d799fn76pca3d0ayl5v73bdssr0fq6rq04q5a";
       };
       packageRequires = [ ];
       meta = {
@@ -263,10 +263,10 @@
     elpaBuild {
       pname = "base32";
       ename = "base32";
-      version = "1.0.0.20240227.184114";
+      version = "1.0.0.20250312.191912";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/base32-1.0.0.20240227.184114.tar";
-        sha256 = "0nxxymnxy9sd12w1kfj8n86zbhxf40mi12nmb3q0wigg2nynl31k";
+        url = "https://elpa.nongnu.org/nongnu-devel/base32-1.0.0.20250312.191912.tar";
+        sha256 = "1aglwd9mm2c53nqm7j6hrh02mag9gg5x5yc25jmaajqy9qrbh54n";
       };
       packageRequires = [ ];
       meta = {
@@ -305,10 +305,10 @@
     elpaBuild {
       pname = "beancount";
       ename = "beancount";
-      version = "0.9.0.20240908.163924";
+      version = "0.9.0.20250220.225133";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.20240908.163924.tar";
-        sha256 = "0iqshz6xamnhx4m5phr5zrfmai61l41f44hmyiqvwqg6spyf6nzi";
+        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.20250220.225133.tar";
+        sha256 = "0apibxpakk6014fr6w3kmxcdfyk61baqib8aibx6920q7zj8yxv4";
       };
       packageRequires = [ ];
       meta = {
@@ -347,10 +347,10 @@
     elpaBuild {
       pname = "bind-map";
       ename = "bind-map";
-      version = "1.1.2.0.20240308.155008";
+      version = "1.1.2.0.20250308.71029";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bind-map-1.1.2.0.20240308.155008.tar";
-        sha256 = "1vrn55667x38qqcaqy8f9p1l5f79j551qjw4m01k5ndan1ybbs8p";
+        url = "https://elpa.nongnu.org/nongnu-devel/bind-map-1.1.2.0.20250308.71029.tar";
+        sha256 = "0z0dzlxj011nggzgzk5g4dwc1c2z78264pggj8li0h15216yq3ll";
       };
       packageRequires = [ ];
       meta = {
@@ -453,10 +453,10 @@
     elpaBuild {
       pname = "buttercup";
       ename = "buttercup";
-      version = "1.36.0.20240904.231112";
+      version = "1.37.0.20250216.231504";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.36.0.20240904.231112.tar";
-        sha256 = "1kshwvzszv5jpjf3j5rpwas0zs60xprk0v30w58822vh13swcqrc";
+        url = "https://elpa.nongnu.org/nongnu-devel/buttercup-1.37.0.20250216.231504.tar";
+        sha256 = "01x2b82kbb2pcn2m75yfrfcjc1dg6qcqyc1d6abnhwvgdxfxv7yf";
       };
       packageRequires = [ ];
       meta = {
@@ -495,10 +495,10 @@
     elpaBuild {
       pname = "caml";
       ename = "caml";
-      version = "4.10snapshot0.20231010.232819";
+      version = "4.10snapshot0.20250227.123439";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.10snapshot0.20231010.232819.tar";
-        sha256 = "0dw5429dy1m4jj0khs58fc8cisky8yd9m58ckhjx5qf1k1bm0hji";
+        url = "https://elpa.nongnu.org/nongnu-devel/caml-4.10snapshot0.20250227.123439.tar";
+        sha256 = "1bg8vf7sh6f7s7jghfyqhb5da38kr8f3bbizzy7xfim2jy1i4ci7";
       };
       packageRequires = [ ];
       meta = {
@@ -544,10 +544,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.17.0snapshot0.20250130.80122";
+      version = "1.18.0snapshot0.20250305.132250";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.17.0snapshot0.20250130.80122.tar";
-        sha256 = "1k3vrnml83vlfjq3qindaii2laj8m0zcifvp97hm8ibfsdz2qmbg";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.18.0snapshot0.20250305.132250.tar";
+        sha256 = "09a7kin91dmhhbyzvlalijiyjnzal2mqjcqbmrzq6nm1lswdrzvx";
       };
       packageRequires = [
         clojure-mode
@@ -594,10 +594,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.2.2.0.20241104.213550";
+      version = "0.2.4snapshot0.20250310.123844";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.2.2.0.20241104.213550.tar";
-        sha256 = "0b37iccwh8l6z0q3ls3ysfy7pjp8q52kbiw4lipjgljg0lmj5lsv";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.2.4snapshot0.20250310.123844.tar";
+        sha256 = "0nnw6bwcca9nxwhg3a1m25c8n2s4x6frkmi1j7x0dlxiy5hj8ddb";
       };
       packageRequires = [ ];
       meta = {
@@ -688,10 +688,10 @@
     elpaBuild {
       pname = "crux";
       ename = "crux";
-      version = "0.5.0.0.20240401.113645";
+      version = "0.6.0snapshot0.20250212.201746";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.5.0.0.20240401.113645.tar";
-        sha256 = "12pk351yrj850rg1yd9spxwrhkjlllgxbpbpfs829vnbpnvxlp6f";
+        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0snapshot0.20250212.201746.tar";
+        sha256 = "1apz9kfs416l9r47wkbw1a6wpysxn1fvyywpkfwfb4r7j9dlmsdm";
       };
       packageRequires = [ ];
       meta = {
@@ -710,10 +710,10 @@
     elpaBuild {
       pname = "csv2ledger";
       ename = "csv2ledger";
-      version = "1.5.4.0.20241109.230511";
+      version = "1.5.4.0.20250204.233740";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20241109.230511.tar";
-        sha256 = "1ank47lk4qgmbgr7qb9fgkramc7qngs93rq0rnlvkdh2fm198ywj";
+        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20250204.233740.tar";
+        sha256 = "1rx1k7fzlnlxn8crjm21qnq57g5p31zlk6z6zf883sakc2jwal7f";
       };
       packageRequires = [ csv-mode ];
       meta = {
@@ -795,10 +795,10 @@
     elpaBuild {
       pname = "dart-mode";
       ename = "dart-mode";
-      version = "1.0.7.0.20240925.1934";
+      version = "1.0.7.0.20250224.120240";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20240925.1934.tar";
-        sha256 = "0pzhvlbfdk0adj4by21knbpvkj99dzclhixad2cdyfvqgw3j1xkk";
+        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250224.120240.tar";
+        sha256 = "0jc4snbk62fi2ksnca8cp7m3jc7xr0yaap9p9hjjv72h1hnnl1rl";
       };
       packageRequires = [ ];
       meta = {
@@ -902,10 +902,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20250208.231709";
+      version = "0.2.0.20250224.222628";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250208.231709.tar";
-        sha256 = "0cpnac241jsz5zrwyhyrx6m9qk09bcc1c9xphh9ss0y04rkmdghn";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250224.222628.tar";
+        sha256 = "03qqmcn0lni4sb0vz25sjspq64f1b2a0nkvy7bfyifsjn8an1kqs";
       };
       packageRequires = [ ];
       meta = {
@@ -919,17 +919,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      transient,
     }:
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.0.53.0.20250206.25042";
+      version = "2.2.7.0.20250312.165153";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.0.53.0.20250206.25042.tar";
-        sha256 = "0nvwss3ckcqnfmq8mk3zxrbvg5d71h4zxbf2x7hlgd79izmyqpkb";
+        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.2.7.0.20250312.165153.tar";
+        sha256 = "1k6y9simcqfszyq5s0vb41s6pjmr9pd3djbnjdk5vvqhqyphig21";
       };
-      packageRequires = [ transient ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/dirvish.html";
         license = lib.licenses.free;
@@ -966,10 +965,10 @@
     elpaBuild {
       pname = "dockerfile-mode";
       ename = "dockerfile-mode";
-      version = "1.7.0.20240914.114946";
+      version = "1.9.0.20250225.102722";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dockerfile-mode-1.7.0.20240914.114946.tar";
-        sha256 = "1v7yv221p844249m75ip41p0khn2gas7hfv8b0np3g78pzdai4mw";
+        url = "https://elpa.nongnu.org/nongnu-devel/dockerfile-mode-1.9.0.20250225.102722.tar";
+        sha256 = "1mmylgvlmx7cdppfsi28hnf2s3v6qnpk5ii2r2qjbyj7vnbnk97g";
       };
       packageRequires = [ ];
       meta = {
@@ -1094,10 +1093,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20241027.181535";
+      version = "0.11.0.0.20250219.152840";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20241027.181535.tar";
-        sha256 = "17vx1rf8dnyfkj1c7cv2zw9kvrc9cllm3wr4r0wik31xrkw7zpdj";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250219.152840.tar";
+        sha256 = "1dhb67w0hjh59hbkscw7xs4l5sizdip0xif2s11yx1nxzk86aw8w";
       };
       packageRequires = [ ];
       meta = {
@@ -1115,10 +1114,10 @@
     elpaBuild {
       pname = "eglot-inactive-regions";
       ename = "eglot-inactive-regions";
-      version = "0.6.3.0.20241217.45248";
+      version = "0.6.3.0.20250313.74527";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/eglot-inactive-regions-0.6.3.0.20241217.45248.tar";
-        sha256 = "1kf84wzfdysskmxjv45c1vdp5vpg7issk92gvcvrw59afsv25cza";
+        url = "https://elpa.nongnu.org/nongnu-devel/eglot-inactive-regions-0.6.3.0.20250313.74527.tar";
+        sha256 = "1vrrngpbfi9gbkx9bn2fqznr8wg8m9msdj438nsysl8175ai0c1d";
       };
       packageRequires = [ ];
       meta = {
@@ -1178,10 +1177,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.4.0.20241022.162545";
+      version = "3.6.5.0.20250306.150410";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.4.0.20241022.162545.tar";
-        sha256 = "070njpzhspzgpry9wy69l76kmfdwzy8c5nx32kr0isx7b6qzvb5v";
+        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.5.0.20250306.150410.tar";
+        sha256 = "1ah1vsbigz7ip7iz7f53w0bnmwf7dhfzyn1dx1dkfp4lkpr8gc7g";
       };
       packageRequires = [ ];
       meta = {
@@ -1199,10 +1198,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.1.0.0.20241201.155153";
+      version = "4.2.0.0.20250301.163737";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.1.0.0.20241201.155153.tar";
-        sha256 = "10sqyqba0jsf1w6i7x77vxgj13wjzr3k9bcpzmzxhqgprakndixy";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.2.0.0.20250301.163737.tar";
+        sha256 = "1rzxgfykrckxw6sbgw71dd99s8rnz0jjjpddsf8rsy7ialjzw4w4";
       };
       packageRequires = [ ];
       meta = {
@@ -1244,10 +1243,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20250121.180033";
+      version = "1.15.0.0.20250302.65539";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250121.180033.tar";
-        sha256 = "1c1dd14l9hjjgqzi872bni27q8z4q6sxd2sxfrj0x13gppa3jcnv";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20250302.65539.tar";
+        sha256 = "0xvdcvqimz2vk6hibip8cgn6jxgibxial6awl46vxq4b8g6bbply";
       };
       packageRequires = [
         cl-lib
@@ -1695,10 +1694,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0snapshot0.20250201.75945";
+      version = "35.0snapshot0.20250226.154115";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20250201.75945.tar";
-        sha256 = "1sd7ayqw1jv86yy84jvw708kzxmx1js754yx7l4ijp76dgb7pwsm";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20250226.154115.tar";
+        sha256 = "1sxlipzvh0sr057zydh1pqdnx6ginh0yrfycbv1ps3bwvpc7g8a5";
       };
       packageRequires = [ ];
       meta = {
@@ -1788,10 +1787,10 @@
     elpaBuild {
       pname = "focus";
       ename = "focus";
-      version = "1.0.1.0.20241029.150652";
+      version = "1.0.1.0.20250311.185538";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/focus-1.0.1.0.20241029.150652.tar";
-        sha256 = "08ryv68xfvlgbsyq80r9bycj4d9dbdz0v7ipdgjxnxfkp3di2s01";
+        url = "https://elpa.nongnu.org/nongnu-devel/focus-1.0.1.0.20250311.185538.tar";
+        sha256 = "1n5ph519fl0snfi2xvj7zhby2bscjlw7gfxjcs1acwhvn3ywwchd";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -1985,10 +1984,10 @@
     elpaBuild {
       pname = "geiser-gauche";
       ename = "geiser-gauche";
-      version = "0.0.2.0.20220503.170006";
+      version = "0.0.2.0.20250311.73546";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-gauche-0.0.2.0.20220503.170006.tar";
-        sha256 = "159wlbsv6wr0wpp4y0a5y2dm7bk4rpzkvc7phl9ry3a60r10h8yc";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-gauche-0.0.2.0.20250311.73546.tar";
+        sha256 = "1fw2fxbzl2mjvm2pj7fzdqlz3l76j8xd76kz0719vb7m6fnf1kwg";
       };
       packageRequires = [ geiser ];
       meta = {
@@ -2263,10 +2262,10 @@
     elpaBuild {
       pname = "go-mode";
       ename = "go-mode";
-      version = "1.6.0.0.20240630.202407";
+      version = "1.6.0.0.20250311.20239";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/go-mode-1.6.0.0.20240630.202407.tar";
-        sha256 = "0l99vsah7j79pfz0wnvpw4c7i9fw3miipfi7givgxanjrnyra859";
+        url = "https://elpa.nongnu.org/nongnu-devel/go-mode-1.6.0.0.20250311.20239.tar";
+        sha256 = "1viwxqbp6jdhbmapjgcgrjyrzn4m2r68b5vb0814y3w4gi55rzgq";
       };
       packageRequires = [ ];
       meta = {
@@ -2349,10 +2348,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.7.0.20250208.194452";
+      version = "0.9.7.0.20250312.185844";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.7.0.20250208.194452.tar";
-        sha256 = "0j2czjinfzpp0ra3c1l9gkhhw65k9kgjbkgqkdf9a1f0szxsjlck";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.7.0.20250312.185844.tar";
+        sha256 = "16jrv9aw5h40vfwhv2wmlgngbzgbi68pianx6flfx6fzmlsdxpww";
       };
       packageRequires = [
         compat
@@ -2480,10 +2479,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20250205.144004";
+      version = "17.5.0.20250305.134904";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250205.144004.tar";
-        sha256 = "1p3dgr8zyv3ir34x9nbgbz67bpb491kd45haplvk8c32xddli8c3";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250305.134904.tar";
+        sha256 = "10pn6b4hml8wzzliynlag1fr7lnc526gzbfqbhs3kzh6qx5rf8zn";
       };
       packageRequires = [ ];
       meta = {
@@ -2546,10 +2545,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.0.20250208.103323";
+      version = "4.0.2.0.20250228.64018";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.0.20250208.103323.tar";
-        sha256 = "0gs5n6qfhq6b8mgqfmiaqaziw4p5r4w22m9fcj2dxvp3vm2nrk5m";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.2.0.20250228.64018.tar";
+        sha256 = "1mjgc22vp68wk1klq7f5i74pqr5wmwb53cc81n04zi6jynv2rimm";
       };
       packageRequires = [
         helm-core
@@ -2571,10 +2570,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.0.20250208.103323";
+      version = "4.0.2.0.20250228.64018";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.0.20250208.103323.tar";
-        sha256 = "14h1kh1ng6dfhgg062civsh0r6gsnsaw48h5h1b726ypdd5lgh4c";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.2.0.20250228.64018.tar";
+        sha256 = "1i7f8n4gk7fppxdlylm1hwp8ab2dqpg9h30ppv46nzp6bp0fywyw";
       };
       packageRequires = [ async ];
       meta = {
@@ -2592,10 +2591,10 @@
     elpaBuild {
       pname = "hideshowvis";
       ename = "hideshowvis";
-      version = "0.8.0.20240529.112833";
+      version = "0.8.0.20250225.175051";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hideshowvis-0.8.0.20240529.112833.tar";
-        sha256 = "0wb1i3p79wf39svgbvdjlhivbyankm4xklf1r63i5vlaxz5fc6di";
+        url = "https://elpa.nongnu.org/nongnu-devel/hideshowvis-0.8.0.20250225.175051.tar";
+        sha256 = "1f0p5ir99n5m41habjkhy2c2nj7infianp6zy0d6i8493gxcxay4";
       };
       packageRequires = [ ];
       meta = {
@@ -2849,10 +2848,10 @@
     elpaBuild {
       pname = "inf-ruby";
       ename = "inf-ruby";
-      version = "2.8.1.0.20241220.25141";
+      version = "2.9.0.0.20250212.2927";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.8.1.0.20241220.25141.tar";
-        sha256 = "0z3vbdb1df0vwjm2lk6bk11c0afg8w6p5n2x8q4wgmwqyp3h3gb2";
+        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.9.0.0.20250212.2927.tar";
+        sha256 = "0hnwrybc89fdpkn3l1ff4x3vf5c2d6rgjjxbwyikk67b6p405zm7";
       };
       packageRequires = [ ];
       meta = {
@@ -2870,10 +2869,10 @@
     elpaBuild {
       pname = "inkpot-theme";
       ename = "inkpot-theme";
-      version = "0.1.0.20240610.140611";
+      version = "0.1.0.20250303.103930";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inkpot-theme-0.1.0.20240610.140611.tar";
-        sha256 = "1291cwg6vk9y8an6a1pfbv05g2yqcswwry25c9ingsyb4ql0pr6k";
+        url = "https://elpa.nongnu.org/nongnu-devel/inkpot-theme-0.1.0.20250303.103930.tar";
+        sha256 = "02lkb9yl83bkad0jj6im6yhv160fsk0zf02zi9y9fzqx4p4qrn1g";
       };
       packageRequires = [ ];
       meta = {
@@ -3002,10 +3001,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.1.0.20240805.132239";
+      version = "1.4.2.0.20250301.164536";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.1.0.20240805.132239.tar";
-        sha256 = "1afmj52zcr8sdh2ijw0xhxv5p713mw85f4q9rizrpbcx3pw0xmbj";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.2.0.20250301.164536.tar";
+        sha256 = "1zipc2baxzx5ima0r34q9d8v9bfw3a41hv2423gbx8036ndq3h2g";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3045,10 +3044,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "0.6.0.0.20250201.130026";
+      version = "0.6.1.0.20250312.142844";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-0.6.0.0.20250201.130026.tar";
-        sha256 = "09z94xb9hm4769fsw91aiw2lp1lv3siqa6gk3ik77591bzbax2l0";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-0.6.1.0.20250312.142844.tar";
+        sha256 = "099m6knzf6rh4r9x6f285mimg8i7znrays1bsi1y22hvik5mmgl2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3069,10 +3068,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.2snapshot0.20250203.195605";
+      version = "0.19.3snapshot0.20250306.133154";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.2snapshot0.20250203.195605.tar";
-        sha256 = "16mr8ki4xg2yqday18x3a3fcbj8krcmwrj09xww43c8rhkixnk4k";
+        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.3snapshot0.20250306.133154.tar";
+        sha256 = "0lkjp8y7f3npvbd63c2n7jfplp63qschbpq0ngqjs7q6254yfk9i";
       };
       packageRequires = [
         compat
@@ -3098,10 +3097,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0.0.20250208.155652";
+      version = "0.14.0.0.20250306.20614";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250208.155652.tar";
-        sha256 = "0sg2kkggg8sb5dmydglka6g84ljlj393yv5vbz51ysjc74cfvcxz";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250306.20614.tar";
+        sha256 = "0vggsncnj7fbc307sa78pl6aszzn7644mrhsa8q24syp9xn1xwrz";
       };
       packageRequires = [
         compat
@@ -3171,10 +3170,10 @@
     elpaBuild {
       pname = "lua-mode";
       ename = "lua-mode";
-      version = "20221027.0.20231023.94721";
+      version = "20221027.0.20250310.115056";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/lua-mode-20221027.0.20231023.94721.tar";
-        sha256 = "1zlllyj2w8am1fv3iia8yrqhwsk2pi9kkw8ml6qc2lamfa09y65p";
+        url = "https://elpa.nongnu.org/nongnu-devel/lua-mode-20221027.0.20250310.115056.tar";
+        sha256 = "0k1cgb6ld0bgy0bzir2v743ddxp15ng95j0k4sgcdzj5cyzj46kj";
       };
       packageRequires = [ ];
       meta = {
@@ -3224,10 +3223,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.0.0.20250204.133404";
+      version = "4.3.1.0.20250312.143226";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.3.0.0.20250204.133404.tar";
-        sha256 = "1bj6sqb54lzdnk31lwxmgzgwgy5j55i29z8ad5m9sxjxxzlg700m";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.3.1.0.20250312.143226.tar";
+        sha256 = "0mba1qf1z6dsbhrzl7d4rz8f6xbqqlwrxa16dbi9gl5ibaf4kx0p";
       };
       packageRequires = [
         compat
@@ -3255,10 +3254,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.0.0.20250204.133404";
+      version = "4.3.1.0.20250312.143226";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.3.0.0.20250204.133404.tar";
-        sha256 = "1c7zmjpvqqgybmws7wr7bh1nhp26r3v3mr7a7yhdhaij1xwxjjj2";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.3.1.0.20250312.143226.tar";
+        sha256 = "1s9dz5bayf852bdmd656zdzsch5w2jj687hnbpbmb2zbj050r45g";
       };
       packageRequires = [
         compat
@@ -3280,10 +3279,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.7alpha0.20250115.165803";
+      version = "2.8alpha0.20250310.105434";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.7alpha0.20250115.165803.tar";
-        sha256 = "1hmqfd4azc62qhfialnc2c6c97d9wp2mh16dahb6sgkl5axsr9rp";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250310.105434.tar";
+        sha256 = "1hs8kaw22r9fskh6pwchv1343k3phcfk1a1zdk41wvvc622pl11m";
       };
       packageRequires = [ ];
       meta = {
@@ -3304,10 +3303,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.1.9.0.20250204.190250";
+      version = "1.1.12.0.20250305.210452";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.1.9.0.20250204.190250.tar";
-        sha256 = "1gw9gihf6wsgzaj4waf10blj9gm1iipfmrxawr7idsv4i91crrky";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.1.12.0.20250305.210452.tar";
+        sha256 = "1dnii6hwxjbprm9cskah40vk41hgnbnvxnjykf8hssf2d5g1qsg3";
       };
       packageRequires = [
         persist
@@ -3380,10 +3379,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20250201.191149";
+      version = "1.5.0.0.20250216.181716";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250201.191149.tar";
-        sha256 = "0vvss5l1j1wa6brwlsskdgq11j4vr36i5cl2sfdzafiza4qbh56l";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250216.181716.tar";
+        sha256 = "0cmn4v9xzw42k98i17mbzh0vd2llw4cf79di2camgkc8gf07g01r";
       };
       packageRequires = [ ];
       meta = {
@@ -3478,6 +3477,7 @@
   ) { };
   multiple-cursors = callPackage (
     {
+      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
@@ -3485,12 +3485,12 @@
     elpaBuild {
       pname = "multiple-cursors";
       ename = "multiple-cursors";
-      version = "1.4.0.0.20241202.163103";
+      version = "1.5.0.0.20250210.181349";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.4.0.0.20241202.163103.tar";
-        sha256 = "018f3fpv0ganvhcwykpb2rfw41nqlkj87dx1zfzkf7s9011grkfv";
+        url = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors-1.5.0.0.20250210.181349.tar";
+        sha256 = "072vlw8cb1f1mbzlx68lg8yrmyc7ca2f2iyxmvjy5nn3lx7v6lkd";
       };
-      packageRequires = [ ];
+      packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/multiple-cursors.html";
         license = lib.licenses.free;
@@ -3639,10 +3639,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.6.0.20250112.165818";
+      version = "0.6.0.20250227.181559";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20250112.165818.tar";
-        sha256 = "0n7jdhrfv8w26k09nzbsry57pfak1wwv33axrpl683k3m90r1xv5";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20250227.181559.tar";
+        sha256 = "15cc87skz34cw9zrg055jmqnjqpbwl06mfvqblzg3x5irjgghkfi";
       };
       packageRequires = [ org ];
       meta = {
@@ -3689,10 +3689,10 @@
     elpaBuild {
       pname = "org-journal";
       ename = "org-journal";
-      version = "2.2.0.0.20240225.201950";
+      version = "2.2.0.0.20250306.142904";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-journal-2.2.0.0.20240225.201950.tar";
-        sha256 = "013yyxalngcl55z0z23qgjz0gwgjp5px0hd2ykibflw2vlqkl97p";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-journal-2.2.0.0.20250306.142904.tar";
+        sha256 = "1bknrir6g0zw24plizf5gdaa76navb5p913l83zba64m67mi0bwg";
       };
       packageRequires = [ org ];
       meta = {
@@ -3825,10 +3825,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.0.0.20240808.194549";
+      version = "2.0.1.0.20250301.233925";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.0.0.20240808.194549.tar";
-        sha256 = "14ql24z977myihyn5hv4ivayzfpj580dhr7rgwwb6yqzj8j1bz4l";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.1.0.20250301.233925.tar";
+        sha256 = "0adppm61dn3cfkgdyc5ik42z0byvyc2dkwhjdzvw66nnl3fjb3ch";
       };
       packageRequires = [
         compat
@@ -3872,10 +3872,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.24.0.20250108.140733";
+      version = "0.25.0.20250307.91203";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.24.0.20250108.140733.tar";
-        sha256 = "1d6axrq2ymfxybzsk9xg4001cqkj4kkxpdj5fwfx28nf82f594cm";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.25.0.20250307.91203.tar";
+        sha256 = "11yx2k7bsyi4ql8jhyz36s0pcxr0d6ssnnv7w128qfy9k0bklnr7";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -3915,10 +3915,10 @@
     elpaBuild {
       pname = "page-break-lines";
       ename = "page-break-lines";
-      version = "0.15.0.20241107.72714";
+      version = "0.15.0.20250218.160727";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20241107.72714.tar";
-        sha256 = "0661kz0f8rippn1pi0jdzxa000vvakqv0s4y5f7f6vg41vhcna54";
+        url = "https://elpa.nongnu.org/nongnu-devel/page-break-lines-0.15.0.20250218.160727.tar";
+        sha256 = "0w6kcvqckjn4x6m5za73s4snn4pwpn0syf1mzjkqrzrx00sjcq3z";
       };
       packageRequires = [ ];
       meta = {
@@ -4004,10 +4004,10 @@
     elpaBuild {
       pname = "pcmpl-args";
       ename = "pcmpl-args";
-      version = "0.1.3.0.20220510.145627";
+      version = "0.1.3.0.20250216.224206";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pcmpl-args-0.1.3.0.20220510.145627.tar";
-        sha256 = "1j1imsxbmpbxwywpl399panwgh071f9bpz3s4yf0mzcb4slpyxsq";
+        url = "https://elpa.nongnu.org/nongnu-devel/pcmpl-args-0.1.3.0.20250216.224206.tar";
+        sha256 = "11alsr3b2liinvsvh5nd2nkkqd08pvrpkbla2xnfmbr4i2rg93r7";
       };
       packageRequires = [ ];
       meta = {
@@ -4072,10 +4072,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20250109.210315";
+      version = "1.26.1.0.20250224.145951";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250109.210315.tar";
-        sha256 = "09vm0fxpnbbzd9x2n26jnc23h8fzz86ci2bv1fqx4b2lij39bh82";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250224.145951.tar";
+        sha256 = "0fcfm286x9q8cgqagw4d1n512g2g0bcllwyn2b591fam9nfzx800";
       };
       packageRequires = [ ];
       meta = {
@@ -4114,10 +4114,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20250101.4328";
+      version = "0.5.9.0.20250224.15605";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250101.4328.tar";
-        sha256 = "0qgkwd0kbkifkpfv0gznd4n81xhf62q9s0bd0831yp1mkxd9y03x";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250224.15605.tar";
+        sha256 = "11l0k9lrh7jhjshag9mclq5qa8vmll98vqf08837svlgpf0nwc4z";
       };
       packageRequires = [ ];
       meta = {
@@ -4135,10 +4135,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.0snapshot0.20250209.60525";
+      version = "2.9.1.0.20250312.165928";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.0snapshot0.20250209.60525.tar";
-        sha256 = "00x2xilxzgckv8i0bjq8zpwm6l7j8ac55hld7vf4iyzv100jhf9g";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250312.165928.tar";
+        sha256 = "0wqgzph6vkgq55h5669l0rxqjxz7chbzrrjxb16r6pisxnw4b2dd";
       };
       packageRequires = [ ];
       meta = {
@@ -4199,14 +4199,35 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250205.162816";
+      version = "1.0.20250212.102351";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250205.162816.tar";
-        sha256 = "1cq7yl4g7s4gvzfqfkxnx0k507xws5d8iy1lnawwclw7gsc4y9hk";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250212.102351.tar";
+        sha256 = "1byfpwv7nk4ncqd1cx3qphs37xllmw8mx9gdxd86l66qr1hyp22j";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/racket-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  radio = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "radio";
+      ename = "radio";
+      version = "0.4.1.0.20250305.101402";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/radio-0.4.1.0.20250305.101402.tar";
+        sha256 = "0l71sgr2a3xpmq3s6ilzk89psjl2zymc15v2la3zd0iw1xbd97x6";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/radio.html";
         license = lib.licenses.free;
       };
     }
@@ -4304,10 +4325,10 @@
     elpaBuild {
       pname = "request";
       ename = "request";
-      version = "0.3.3.0.20230126.231738";
+      version = "0.3.3.0.20250219.185201";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/request-0.3.3.0.20230126.231738.tar";
-        sha256 = "1fsyi1g65am1ln72hmxi216g95l29v9xdx9hrhky7i3j96fflnf6";
+        url = "https://elpa.nongnu.org/nongnu-devel/request-0.3.3.0.20250219.185201.tar";
+        sha256 = "0r2rzkgfw8ka31v7hyrsymnra3v40g2sdwvz7s34fgxx9fkryihb";
       };
       packageRequires = [ ];
       meta = {
@@ -4367,10 +4388,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20241112.43839";
+      version = "1.0.6.0.20250225.10231";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20241112.43839.tar";
-        sha256 = "1jmby08vp18qr2cx3k6skw9mar7vb7wr5ph9q2g95wx8836g6mbp";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250225.10231.tar";
+        sha256 = "1j25kqpwrg898zgs21vad5zzh6i54g48lxgzc2rb8wmifd2zd792";
       };
       packageRequires = [ ];
       meta = {
@@ -4542,10 +4563,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250203.182938";
+      version = "2.31snapshot0.20250310.203219";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250203.182938.tar";
-        sha256 = "179h8fk5hkdcbq4w9gdcqc8gs4pafl5kdy3818vsmvgvfy6rvzq6";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250310.203219.tar";
+        sha256 = "0f9j1phl36xnjh4g1263nkfqnjc79jrk1c0yqawykhljal87xyka";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4606,10 +4627,10 @@
     elpaBuild {
       pname = "solarized-theme";
       ename = "solarized-theme";
-      version = "2.0.4.0.20250204.123251";
+      version = "2.0.4.0.20250222.142943";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.0.4.0.20250204.123251.tar";
-        sha256 = "1vhzxz5nlx59kmxscf1jxwkb3bsjp0h0yk2dr777inyi5dqpi8gl";
+        url = "https://elpa.nongnu.org/nongnu-devel/solarized-theme-2.0.4.0.20250222.142943.tar";
+        sha256 = "0m8wxvm9a501w4pfc1an4i99h0wv6hpfk1yizh8yjw0y3y8fz606";
       };
       packageRequires = [ ];
       meta = {
@@ -4873,6 +4894,27 @@
       };
     }
   ) { };
+  teco = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "teco";
+      ename = "teco";
+      version = "9.0.20200801.144333";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/teco-9.0.20200801.144333.tar";
+        sha256 = "0j3wzsyr28qf8pcb73nim54rmw00p45gfh2s6dnlvpfbcg96r83v";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/teco.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   telephone-line = callPackage (
     {
       cl-generic,
@@ -4974,10 +5016,10 @@
     elpaBuild {
       pname = "totp-auth";
       ename = "totp-auth";
-      version = "1.0.0.20240227.184114";
+      version = "1.0.0.20250312.200047";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/totp-auth-1.0.0.20240227.184114.tar";
-        sha256 = "1yqvn30qc1vdhshcss4znzily08rbv77mf8hrhmy5zayq4n23nca";
+        url = "https://elpa.nongnu.org/nongnu-devel/totp-auth-1.0.0.20250312.200047.tar";
+        sha256 = "1qi0svqdbk389kzlm4i7ghrrp01nc87vvqzjgynd56bw5nalibcr";
       };
       packageRequires = [ base32 ];
       meta = {
@@ -5017,10 +5059,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.1.0.0.20250118.220609";
+      version = "0.2.1.0.20250305.214142";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.1.0.0.20250118.220609.tar";
-        sha256 = "02fr515bjn6l9pn54gqx3v1vp88fh5i0l03gaqfwja0kmfvyf9k1";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250305.214142.tar";
+        sha256 = "1h3ymlcimrvgm62k2w05xf53fk8n80n3pxz9f4lm6nwpjn8ns8ll";
       };
       packageRequires = [ ];
       meta = {
@@ -5060,10 +5102,10 @@
     elpaBuild {
       pname = "tuareg";
       ename = "tuareg";
-      version = "3.0.2snapshot0.20231009.174342";
+      version = "3.0.2snapshot0.20250227.215734";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.2snapshot0.20231009.174342.tar";
-        sha256 = "10ijh4h8srm810b74jb0bqb8zxca91bsbhlb85fyyscbsvhms2f1";
+        url = "https://elpa.nongnu.org/nongnu-devel/tuareg-3.0.2snapshot0.20250227.215734.tar";
+        sha256 = "1ngkjn7dr2k61w5vv8qjgjj8wwc9674px7w1hc8539f7nplf7i71";
       };
       packageRequires = [ caml ];
       meta = {
@@ -5089,6 +5131,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/typescript-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  typst-ts-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "typst-ts-mode";
+      ename = "typst-ts-mode";
+      version = "0.11.0.0.20250221.91757";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.11.0.0.20250221.91757.tar";
+        sha256 = "0829ah70ib1q0va6f18xlbh13laa1cn196i8xa3jji4ljmcxkfyj";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -5207,10 +5270,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.6.3.0.20241109.231059";
+      version = "2.6.3.0.20250204.233635";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20241109.231059.tar";
-        sha256 = "1k6ih7fw0xmbm6m249cdinyx8g5k3gpdglla8242w64bqrxxcpr8";
+        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20250204.233635.tar";
+        sha256 = "0516ccjk21bkfdv24mp59xb9pdzc4hwnz4cfyfg0xnrd1kiihggq";
       };
       packageRequires = [ ];
       meta = {
@@ -5454,10 +5517,10 @@
     elpaBuild {
       pname = "ws-butler";
       ename = "ws-butler";
-      version = "0.7.0.20241107.1911";
+      version = "1.3.0.20250310.20542";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-0.7.0.20241107.1911.tar";
-        sha256 = "1571dns6zdvdqvz5mnca207jpbijm9aiaf6x4iy69w91hszsdda0";
+        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-1.3.0.20250310.20542.tar";
+        sha256 = "1np6n8n54awwbcny84l3k53416a4xa7gl6420296k7f9r588ngw0";
       };
       packageRequires = [ ];
       meta = {
@@ -5475,10 +5538,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.9.20250205172500.0.20250205.172824";
+      version = "26.10.20250308091402.0.20250308.122854";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.9.20250205172500.0.20250205.172824.tar";
-        sha256 = "0229g7p910515dysr0pv4cxgzk2nmcc4yx1f7vdz78qqppfv7qfa";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.10.20250308091402.0.20250308.122854.tar";
+        sha256 = "0c0afwkjp8p445qs2rfg7n9gs842bq46di95q10ab9s8qcg4j7d8";
       };
       packageRequires = [ ];
       meta = {
@@ -5561,10 +5624,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20241207.222105";
+      version = "1.0.0.20250225.95035";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20241207.222105.tar";
-        sha256 = "1nd9cnnwqrxizfzqdx3a4l9wj5sdr6gg42fss9dngbd22spa3kkb";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250225.95035.tar";
+        sha256 = "1cmf2vg50lhbkcq5wrzgcc8h5idwdywg42dnizv3dbsvv4h5kcpl";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5582,10 +5645,10 @@
     elpaBuild {
       pname = "zenburn-theme";
       ename = "zenburn-theme";
-      version = "2.9.0snapshot0.20240926.61928";
+      version = "2.9.0snapshot0.20250213.141810";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.9.0snapshot0.20240926.61928.tar";
-        sha256 = "029ip7ar11vif0c7qazsizp8600z7j0yznwl3j6wywpi6dzx4sii";
+        url = "https://elpa.nongnu.org/nongnu-devel/zenburn-theme-2.9.0snapshot0.20250213.141810.tar";
+        sha256 = "165sy1df0cil2m63nnsxnmvvp7v2yh31lxzpdbzz6vwx6br4nl84";
       };
       packageRequires = [ ];
       meta = {
@@ -5604,10 +5667,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20241104.162434";
+      version = "0.0.8.0.20250305.223352";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20241104.162434.tar";
-        sha256 = "01g51mvsg578hcnr8kbda8pbgy7yrk57p9djy3bn1rp4vwjh2f46";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250305.223352.tar";
+        sha256 = "1hdmvsnfvqb0ngx3kzv7855c9bmn30bk2zc4nizh98abdh1gk02g";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -93,10 +93,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.2.3";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/annotate-2.2.3.tar";
-        sha256 = "1x0v51rbnyzwvjwp4xwsd2a4xisid65zgww6yk0bb81421i54ps3";
+        url = "https://elpa.nongnu.org/nongnu/annotate-2.3.0.tar";
+        sha256 = "0l5pw9z4i1mlf346dg7brha37jmlrq6pyvjdj2mxhdfs6nzddaba";
       };
       packageRequires = [ ];
       meta = {
@@ -453,10 +453,10 @@
     elpaBuild {
       pname = "buttercup";
       ename = "buttercup";
-      version = "1.36";
+      version = "1.37";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/buttercup-1.36.tar";
-        sha256 = "1glcsigj1s796xr9wps6a5mzrdl5qlfvmsnsa2yp5cwhkb9h1f50";
+        url = "https://elpa.nongnu.org/nongnu/buttercup-1.37.tar";
+        sha256 = "1r6q2ngqc0bnkkajhv5n9hw7njhmzf22192chl974vqm7x2vzn7v";
       };
       packageRequires = [ ];
       meta = {
@@ -544,10 +544,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.16.1";
+      version = "1.17.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.16.1.tar";
-        sha256 = "12nzhxy614fbmck7k7yy5yfknvmrsafc06vysc7c6ya6q4mmb91x";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.17.1.tar";
+        sha256 = "0h708n6yz4v50843rp5wan9g35zd4f91nia5lryzmdqskah1yrcg";
       };
       packageRequires = [
         clojure-mode
@@ -594,10 +594,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.2.2";
+      version = "0.2.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.2.2.tar";
-        sha256 = "14s3gawx2lazzd5ziz2plhl6k1qik8gfjka7fijgxb55ls9bvgrp";
+        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.2.3.tar";
+        sha256 = "1gk48s87cryr3xvrjw9l0mv3yb1w6h4xg8zn2wnz5qnrw8cdb1wv";
       };
       packageRequires = [ ];
       meta = {
@@ -942,17 +942,16 @@
       elpaBuild,
       fetchurl,
       lib,
-      transient,
     }:
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.0.53";
+      version = "2.2.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dirvish-2.0.53.tar";
-        sha256 = "02ji38zsb7lw43s919a8xfxcz2fl5cdrs3rk99cfqyvc4c1lywql";
+        url = "https://elpa.nongnu.org/nongnu/dirvish-2.2.7.tar";
+        sha256 = "1739ghnd6rig5rc0538l9xhm02ag79b33d26mhhrii60q42zkpqg";
       };
-      packageRequires = [ transient ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/dirvish.html";
         license = lib.licenses.free;
@@ -989,10 +988,10 @@
     elpaBuild {
       pname = "dockerfile-mode";
       ename = "dockerfile-mode";
-      version = "1.7";
+      version = "1.9";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dockerfile-mode-1.7.tar";
-        sha256 = "1rpgjhbb2vzz6fqcqksvx27a1mj8p3bgmjh00433qd8g7hghc9v7";
+        url = "https://elpa.nongnu.org/nongnu/dockerfile-mode-1.9.tar";
+        sha256 = "11cdwb3l0fkzx8xgcf9xi6mi7q86jf9vfhagpc076qxwwjz0vgp7";
       };
       packageRequires = [ ];
       meta = {
@@ -1202,10 +1201,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.4";
+      version = "3.6.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.4.tar";
-        sha256 = "0f6hsw50a36jyp1ikawcdj9yn3isks03ax47x8vflmayydndir4g";
+        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.5.tar";
+        sha256 = "0ab6m1c32j3rp577v8qb4k542fjgpvvkcgjvzfcc56fwb9d6xfy0";
       };
       packageRequires = [ ];
       meta = {
@@ -1223,10 +1222,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.1.0";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.1.0.tar";
-        sha256 = "1nf7piakf1v23bnqdyivp4l9vq6xyzjxrgxaswncmvzqxb4qvhyx";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.2.0.tar";
+        sha256 = "03nxfdbha7apar6qhjg57pa4cawjjwswlkci2wm9044wps87734c";
       };
       packageRequires = [ ];
       meta = {
@@ -2562,10 +2561,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.tar";
-        sha256 = "1nvdadphkqizrpd92wp9n8dhbqp7dh7m4vhpxf9m18hqwrwsbm0v";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.2.tar";
+        sha256 = "1gp0gfd5xr2nxis6ss41v5izh5cbgj9j2z2swkfjg0dqngfzl3xs";
       };
       packageRequires = [
         helm-core
@@ -2587,10 +2586,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.tar";
-        sha256 = "043pavv01m7frhdvfnp3f1xfbs1xjv43p1xs96yg75gyg1cigfd5";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.2.tar";
+        sha256 = "1mgc89k12lwivj453q3frcwzwag10wngy13jz6jxdl7135gsmywd";
       };
       packageRequires = [ async ];
       meta = {
@@ -2865,10 +2864,10 @@
     elpaBuild {
       pname = "inf-ruby";
       ename = "inf-ruby";
-      version = "2.8.1";
+      version = "2.9.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/inf-ruby-2.8.1.tar";
-        sha256 = "1iisxgrw7lkrcl86mj3s3578qxnx1cn615swsmnch2ilwjqdrdza";
+        url = "https://elpa.nongnu.org/nongnu/inf-ruby-2.9.0.tar";
+        sha256 = "0q6vfll2s1wc1fkmjdqsfws51j6x13knr96k94z2mjnjclv4qgcj";
       };
       packageRequires = [ ];
       meta = {
@@ -3018,10 +3017,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.1";
+      version = "1.4.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.1.tar";
-        sha256 = "0xpdz6fqvmx6ha20c957r4psz393r0ag7ml971x21v035r3gfx8r";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.2.tar";
+        sha256 = "0lmqqpqib7gz12m9ckappf3rw8n8x0nridmsf4c48vbn2jh607hy";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3061,10 +3060,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "0.6.0";
+      version = "0.6.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-0.6.0.tar";
-        sha256 = "14rfpi40rhn906s4glj565v1b1kd7fa668sq7b7hh83pq47iylyr";
+        url = "https://elpa.nongnu.org/nongnu/llama-0.6.1.tar";
+        sha256 = "0ri0pql710v6yrsnl5hv7xqax6ap1whk4xip9xx732a59fws60cg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3085,10 +3084,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.1";
+      version = "0.19.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/logview-0.19.1.tar";
-        sha256 = "0gg393ygrqyghmaa0ykml9dfkxj13bh5pw82hiahmngy5lrygb26";
+        url = "https://elpa.nongnu.org/nongnu/logview-0.19.2.tar";
+        sha256 = "0jcc726fh6lq9x6hhl9cm4i98irf5z3pz1lchkwwy21jippxwj2i";
       };
       packageRequires = [
         compat
@@ -3240,10 +3239,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.0";
+      version = "4.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.3.0.tar";
-        sha256 = "0s9i6pn7j36yvd6nhrnkj7amrgywv02bxhxyg2ac56gsf9bwgqas";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.3.1.tar";
+        sha256 = "1wac8k466pmq79qvh70k7hfr1c5pyh2ignjsh4df46n08y2c67ys";
       };
       packageRequires = [
         compat
@@ -3271,10 +3270,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.0";
+      version = "4.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.3.0.tar";
-        sha256 = "0f6axq5iqfwlbzllzvqd6yk3p8l7ny624qlmnidrynij53rycy0n";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.3.1.tar";
+        sha256 = "0rkr6lw1m4mc695k4pqpsfc5fnbp94pgl7j6y6c5f96d4dzvcx24";
       };
       packageRequires = [
         compat
@@ -3296,10 +3295,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.6";
+      version = "2.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/markdown-mode-2.6.tar";
-        sha256 = "15s8snzfvzzfk7wfizz5r8aksywq7s9h6xbb2y5dqjkpqg951va2";
+        url = "https://elpa.nongnu.org/nongnu/markdown-mode-2.7.tar";
+        sha256 = "156pi0g3i390irdn0751k75k8dp1d20yafk7343hxysgkdip84pb";
       };
       packageRequires = [ ];
       meta = {
@@ -3320,10 +3319,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.1.9";
+      version = "1.1.12";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-1.1.9.tar";
-        sha256 = "01csrqkbjch7cxvmsp8lp3ipaijsqbr230nmk0ss2q19rkmh4sc9";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-1.1.12.tar";
+        sha256 = "1yad0f5qbz3q0h3g4ckmzjha6y1ql954h0p19ibi8rl1kqb6f574";
       };
       packageRequires = [
         persist
@@ -3501,6 +3500,7 @@
   ) { };
   multiple-cursors = callPackage (
     {
+      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
@@ -3508,12 +3508,12 @@
     elpaBuild {
       pname = "multiple-cursors";
       ename = "multiple-cursors";
-      version = "1.4.0";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/multiple-cursors-1.4.0.tar";
-        sha256 = "0452wrbwg8hyvsri99h71g04dll5w65na265pp9whphq6l06ikrx";
+        url = "https://elpa.nongnu.org/nongnu/multiple-cursors-1.5.0.tar";
+        sha256 = "05nvanam57mwa1rajnjrp9j9j23bmr5za90yp56jb6rsi8mphzbx";
       };
-      packageRequires = [ ];
+      packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/multiple-cursors.html";
         license = lib.licenses.free;
@@ -3848,10 +3848,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.0.tar";
-        sha256 = "16i702ziy5z9zrmgz55bky0nar2hy55mkllswf7pgk8x4aihlda0";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.1.tar";
+        sha256 = "0fisk3gkqlkndkv185xffxn75msd26wsv77m0m0a25fr6xlvn2hn";
       };
       packageRequires = [
         compat
@@ -3895,10 +3895,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.24";
+      version = "0.25";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/package-lint-0.24.tar";
-        sha256 = "1cdm86vyi3whq2gmb3dfkzir6hx2pf5m0yxg8pfj7ja31jfi4r25";
+        url = "https://elpa.nongnu.org/nongnu/package-lint-0.25.tar";
+        sha256 = "0nagz2ynqg0vlh8sz1ss0g78j1qi3ni1x74gzbnk3i67wwkrld8k";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4158,10 +4158,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.8.0";
+      version = "2.9.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/projectile-2.8.0.tar";
-        sha256 = "05llvm3xw3dbjdnfhy2kk6z3pysrsc9f6i7dm4glw5j1k7vig306";
+        url = "https://elpa.nongnu.org/nongnu/projectile-2.9.1.tar";
+        sha256 = "07icp9baa7jkyqnz4b1sxl1dg88y5vzzhiwyfb12q349flbkkkb1";
       };
       packageRequires = [ ];
       meta = {
@@ -4222,14 +4222,35 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250205.162816";
+      version = "1.0.20250212.102351";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250205.162816.tar";
-        sha256 = "0mzm7qd89z6y5ivc7qfsahmlhamxr9rpxzm9arbx2hbnqlhj1il5";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250212.102351.tar";
+        sha256 = "14c7y8n562x7dy03078db4xxvyvvxb5kkw9vgg1296xrcpj7mls2";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/racket-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  radio = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "radio";
+      ename = "radio";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/radio-0.4.1.tar";
+        sha256 = "049j72m7f3a2naffpp8q4q0qrgqw0mnw5paqwabig417mwzzhqqr";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/radio.html";
         license = lib.licenses.free;
       };
     }
@@ -4913,6 +4934,27 @@
       };
     }
   ) { };
+  teco = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "teco";
+      ename = "teco";
+      version = "9";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/teco-9.tar";
+        sha256 = "1c794lb22pbqc3dsaadjp0jn50j1c6wrx1b2xq1pp39yja49qvpp";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/teco.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   telephone-line = callPackage (
     {
       cl-generic,
@@ -5048,6 +5090,27 @@
       };
     }
   ) { };
+  treesit-fold = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "treesit-fold";
+      ename = "treesit-fold";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/treesit-fold-0.2.1.tar";
+        sha256 = "1dxrp6rd6bp90h7yhkr61jf83w7ivryk2ln6hdyl6lirfk7d4h43";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/treesit-fold.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   treeview = callPackage (
     {
       elpaBuild,
@@ -5108,6 +5171,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/typescript-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  typst-ts-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "typst-ts-mode";
+      ename = "typst-ts-mode";
+      version = "0.11.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.11.0.tar";
+        sha256 = "0waf2m5cypfpcbb5g39xf9z5ik84wx83178d8s4npspw1zfhmbh3";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/typst-ts-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -5447,10 +5531,10 @@
     elpaBuild {
       pname = "ws-butler";
       ename = "ws-butler";
-      version = "0.7";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/ws-butler-0.7.tar";
-        sha256 = "1rwkwcb4079czdsccldzq4kjrl25y53k4zy2n7026cd7hxxvc959";
+        url = "https://elpa.nongnu.org/nongnu/ws-butler-1.3.tar";
+        sha256 = "14q19rvps5jcshyls3aa55pxmqbbkhhbdlchnl7ybxwkvvmig9zh";
       };
       packageRequires = [ ];
       meta = {
@@ -5468,10 +5552,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.9.20250205172500";
+      version = "26.10.20250308091402";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.9.20250205172500.tar";
-        sha256 = "1la0chy12vbm4wcmgc6iwbmbn9zaiz8xfpp1c11lp3dsv1w5gfj3";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.10.20250308091402.tar";
+        sha256 = "1rni5rjz7m4lxjcxhn2h4cds4d67hbd6c8hf731n6ygygarhjp9p";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1235,14 +1235,14 @@
   "repo": "eliascotto/accent",
   "unstable": {
    "version": [
-    20240130,
-    1109
+    20250210,
+    906
    ],
    "deps": [
     "popup"
    ],
-   "commit": "9b02a73f3a73cc4aef73c1f2c54a2b6168b0d301",
-   "sha256": "1hdyhrjgvmdzj4yiwz9bl37a2smrak40a5a1cmqlm9328lvhsam8"
+   "commit": "d613700dc4159692f5c30dc5f241c9de41bbb1dc",
+   "sha256": "0chvcjc77s4dvvci4fd5kp7h7l56hgi9ra31p1azns6bvgm52jiq"
   }
  },
  {
@@ -1734,11 +1734,11 @@
   "repo": "brownts/ada-ts-mode",
   "unstable": {
    "version": [
-    20250130,
-    146
+    20250309,
+    1743
    ],
-   "commit": "3b5bb777dc3d3d0f2be66d24a8cd663e6863db97",
-   "sha256": "021jhfxvnl72mdl6cjyzynvn5df0mpya7025wnmjaf45dl29kk1c"
+   "commit": "d0c1c124b236b402b884188948cb1f3502ef8779",
+   "sha256": "0ilyhvg6ik98rsl9yim8jb3nkfwi8yh9i6nh5wprbmqrmmk63dr6"
   }
  },
  {
@@ -2072,20 +2072,20 @@
   "repo": "anticomputer/age.el",
   "unstable": {
    "version": [
-    20240410,
-    433
+    20250228,
+    521
    ],
-   "commit": "890c467ebc27538507c54a03afd2f7260630d7f5",
-   "sha256": "0777nvrvswv81g0rkclm7r2ai1xfjf380lhg8lidd060dkp71ic1"
+   "commit": "05ad63306bdac3a58f3a3b23adfd94c8d573f9f2",
+   "sha256": "014zdv86qsi48yyy6z40ix514ssixw39jd34sj5wsxbngm03w14l"
   },
   "stable": {
    "version": [
     0,
     1,
-    5
+    7
    ],
-   "commit": "890c467ebc27538507c54a03afd2f7260630d7f5",
-   "sha256": "0777nvrvswv81g0rkclm7r2ai1xfjf380lhg8lidd060dkp71ic1"
+   "commit": "05ad63306bdac3a58f3a3b23adfd94c8d573f9f2",
+   "sha256": "014zdv86qsi48yyy6z40ix514ssixw39jd34sj5wsxbngm03w14l"
   }
  },
  {
@@ -2244,6 +2244,21 @@
    ],
    "commit": "45bf75f17752c8e8dd4c8a4531c0aa419cdccb84",
    "sha256": "03xypgq6vy7819r42g23kgn7p775bc0v9blzhi0zp5c61p4cw8v3"
+  }
+ },
+ {
+  "ename": "aidermacs",
+  "commit": "145b2843183e9db03ac1dbd90747e82b2a58e89a",
+  "sha256": "0k03mwk84g2jv54ldb4fjjr4jk4cmdbvnv5r52h1dfg09rm3sbns",
+  "fetcher": "github",
+  "repo": "MatthewZMD/aidermacs",
+  "unstable": {
+   "version": [
+    20250313,
+    353
+   ],
+   "commit": "58b3fc29f5046c195951a6315651fa0fc14511ae",
+   "sha256": "1w0c4sxi1q7lfdpsy7dk20xwchx4aypgxl4ygq58s459qhclaiyz"
   }
  },
  {
@@ -2907,6 +2922,21 @@
   }
  },
  {
+  "ename": "amber-glow-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "0mrs42zih9x22lf6hjanh5xhw59mf5ivn4dqajdrngb7wvlm4c63",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250305,
+    936
+   ],
+   "commit": "43afeb68b3ba0394f8cc925ebb90e9a6620b4b28",
+   "sha256": "17cc82qdsq0y2ypq4vx91ywhvdcmmrlg0csnvk05k64769xw9kvh"
+  }
+ },
+ {
   "ename": "amd-mode",
   "commit": "e4d6e9935e4935c9de769c7bf1c1b6dd256e10da",
   "sha256": "17ry6vm5xlmdfs0mykdyn05cik38yswq5axdgn8hxrvvb6f58d06",
@@ -3087,8 +3117,8 @@
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20231123,
-    1806
+    20250310,
+    1512
    ],
    "deps": [
     "dash",
@@ -3096,8 +3126,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "92a6295622df7fae563d6b599e2dc8640e940ddf",
-   "sha256": "0x5srah4w3vrn5wqzfy02dfxmxyi0hfvlk7nq3h2dshz6q6x7b9z"
+   "commit": "28b3e0088ac7113390aa006bf277c8aa14e561a2",
+   "sha256": "068rf93nwymajj6l43rbfd0aslyjqp3bswsqkbf0yip87f9vc24h"
   },
   "stable": {
    "version": [
@@ -3307,11 +3337,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20250118,
-    856
+    20250308,
+    1011
    ],
-   "commit": "65b64b3c492aabae1289fff63120187b535a30ab",
-   "sha256": "1fgccmk1p91za13mahiz1fh6bb1b1shxhpm9zyrjmg7x73ihhjcn"
+   "commit": "ce90bc242753f798efc99a360e641b3184d687bb",
+   "sha256": "09pcym4fr29v6c9790fq3gnc5ky28wjg048x8jfqn8msd5hz6r19"
   }
  },
  {
@@ -3422,11 +3452,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20241017,
-    1508
+    20250306,
+    1337
    ],
-   "commit": "c5a41ce5ac861e3fcd95669eb68c886ce702d39b",
-   "sha256": "1pqgqr3mq3iw8k6gi72kb328wi3i5mc0c5y5ca48cj9qndwslv37"
+   "commit": "f29c91db0b0d4e4be0013bfa7222797b2114d2a9",
+   "sha256": "154v0bljcg2s188sbnnxm56pv3pjzgg51akxjca62s0swqzqh96b"
   },
   "stable": {
    "version": [
@@ -3544,28 +3574,28 @@
   "repo": "emacs-ansible/emacs-ansible",
   "unstable": {
    "version": [
-    20250208,
-    241
+    20250222,
+    1816
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "4601ff31f56af19c71e86fcc7a2d52b7c17e8abd",
-   "sha256": "001w2fqr5sajy3wpjzqp239hfc6dlbg2hhgz51sjq3a5lmh3cq5l"
+   "commit": "8474bd186ba0fd56ce86524869083947628eed08",
+   "sha256": "189mqb5sayhll5dr005b675rcswdb6jy4k6bjspx3cxgfbakk6h8"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "a005c70be00de6b8d45b51807fe1e049dd945fb3",
-   "sha256": "1i9fymfw8s05s3cy4rbldd6pya6y7gpaqcjcrkcyd96y5awb0w34"
+   "commit": "8474bd186ba0fd56ce86524869083947628eed08",
+   "sha256": "189mqb5sayhll5dr005b675rcswdb6jy4k6bjspx3cxgfbakk6h8"
   }
  },
  {
@@ -3841,19 +3871,19 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20250207,
-    2227
+    20250308,
+    1920
    ],
-   "commit": "ba333e7ddce49fcbb34b7ad6e37ed880a90e4f4d",
-   "sha256": "08kmf0dm420f7k81q5jj1i2p15p481z0gg01lq07w4hq1nw6a0kk"
+   "commit": "2c8e8229cbe26c7fd264c2ffe3fbeb9435dad3ae",
+   "sha256": "1g69iiigcscfsa858apk3r7zc6wvjmrqli5n6v6j6fg293gg2696"
   },
   "stable": {
    "version": [
     4,
-    3
+    4
    ],
-   "commit": "543f6d651d11322f26665f017f051fbcfc21ceb0",
-   "sha256": "0pw16nh2pbb33fkwk2wmr73x6z405w2acsjfli77j2j9vg4nxh52"
+   "commit": "d8ccc0ba0f127c11df39e79313a17bcb740359c0",
+   "sha256": "1dqx5wjmaxxl3xdj0kh2q157d4x9ygfwn4fschcw9vwm5jrcph51"
   }
  },
  {
@@ -4128,11 +4158,11 @@
   "repo": "motform/arduino-cli-mode",
   "unstable": {
    "version": [
-    20250207,
-    1753
+    20250303,
+    1649
    ],
-   "commit": "de4721f11a82d33539f2552ce8942ed5158485c1",
-   "sha256": "1zfkr5v3d17sqp39b0dl39rmmqgjw1rv6vr0nix6mqsldc0hcl6d"
+   "commit": "4286110c98abb4f9d8397207735736dcf05475d7",
+   "sha256": "05vgrsms110qb027bkfx8hkc4cx2rhfrqii44w252spk8zjkcfnm"
   }
  },
  {
@@ -4451,20 +4481,20 @@
   "repo": "Sorixelle/astro-ts-mode",
   "unstable": {
    "version": [
-    20241230,
-    256
+    20250308,
+    2341
    ],
-   "commit": "23b21a067709091681d1d9986e48aae2758b8614",
-   "sha256": "0a952mhgc46pklf3pffyddn8fvp1dfzc6kl9c4a62nrmg5s1ahh4"
+   "commit": "886d692378d0da2071e710c1e6db02e5b2e0dd30",
+   "sha256": "07qdklcw6sfqw9d7yw32qylwaj8w4is6cfm59idhbcgwjlayw08c"
   },
   "stable": {
    "version": [
     3,
     0,
-    0
+    1
    ],
-   "commit": "23b21a067709091681d1d9986e48aae2758b8614",
-   "sha256": "0a952mhgc46pklf3pffyddn8fvp1dfzc6kl9c4a62nrmg5s1ahh4"
+   "commit": "886d692378d0da2071e710c1e6db02e5b2e0dd30",
+   "sha256": "07qdklcw6sfqw9d7yw32qylwaj8w4is6cfm59idhbcgwjlayw08c"
   }
  },
  {
@@ -5159,20 +5189,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250101,
-    1410
+    20250301,
+    1627
    ],
-   "commit": "f25aaf8f1e3c38c481aabcf08b7b31280b78a9ae",
-   "sha256": "0cd42xigvw7fy2qy5kn0xlc97sp03w8ja6qjs2y22h29xva6fwsl"
+   "commit": "5304e2f8a69ed9610b2392b846471f43b28b773b",
+   "sha256": "1mclnf6ichsjdnjd1b6bg4vqhhjpy6y3458khnxvr1fpn67h6iny"
   },
   "stable": {
    "version": [
     2,
     0,
-    4
+    5
    ],
-   "commit": "f25aaf8f1e3c38c481aabcf08b7b31280b78a9ae",
-   "sha256": "0cd42xigvw7fy2qy5kn0xlc97sp03w8ja6qjs2y22h29xva6fwsl"
+   "commit": "5304e2f8a69ed9610b2392b846471f43b28b773b",
+   "sha256": "1mclnf6ichsjdnjd1b6bg4vqhhjpy6y3458khnxvr1fpn67h6iny"
   }
  },
  {
@@ -6780,11 +6810,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20241215,
-    126
+    20250223,
+    119
    ],
-   "commit": "1d48474c3c07521276f4e7d73317a654997b4381",
-   "sha256": "07zzn261hvckmvsrwxajlkwdwrihr3wz06149hvsibplkfj0rpga"
+   "commit": "9f7188e0b26424d3259cd27bd65e4204303f86ce",
+   "sha256": "0srnw6dv9sw1s7q62ng8dfqyn5s4ml1mcy25pzh761m3kizv6mvn"
   },
   "stable": {
    "version": [
@@ -7399,11 +7429,11 @@
   "repo": "dholm/benchmark-init-el",
   "unstable": {
    "version": [
-    20240320,
-    1342
+    20250313,
+    1200
    ],
-   "commit": "2b34432d79fa0aae8abc3db72db1cb79a28c00b2",
-   "sha256": "1slw10mp9lkfy04qgv7ly76rww2rs3yijq6sjx4jwswd4b46bmsg"
+   "commit": "6507caa3c4cb2a6c9b85c771c5e9e5aeb7d745bc",
+   "sha256": "0ylfqr1ddkgvd2i57q46cpq2709iynji8m8vxhyg7dygmjijm1f2"
   },
   "stable": {
    "version": [
@@ -7466,6 +7496,21 @@
    ],
    "commit": "409836f2cf4883826600de42519ee9cffeb48a11",
    "sha256": "174nfiigbzjkzfjxsp1p4gafqqvw5hlvkfwd3qnb10xwribhvkxz"
+  }
+ },
+ {
+  "ename": "berry-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "00xidbi6fr4kk4kgvimhbjnmh2ggy2b39a2pv0k1cd07sinphkbm",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250224,
+    923
+   ],
+   "commit": "ae9a0c318c371ed70ec568f3a618d47124817fe7",
+   "sha256": "10pkpv4i1xv2cv9ma3mnavrm3xvffa5nwxa66nrzvvrkvcjbpg82"
   }
  },
  {
@@ -7877,26 +7922,26 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20240831,
-    2208
+    20250301,
+    1629
    ],
    "deps": [
     "compat"
    ],
-   "commit": "04c3e44eb10303b81c47c1d333df1fa23a224963",
-   "sha256": "1a5mdr3g0kwjz3891cg6v3b3lc5v0b0rgwp4b39qncry3l4k5yjg"
+   "commit": "530eb666ebafb985c3ab227a0fcc4b580373af91",
+   "sha256": "0gsjw3mjj88ggb18ypqfq2h8xbsiddr3gnjb2pnpha7jyl3v5sj5"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "04c3e44eb10303b81c47c1d333df1fa23a224963",
-   "sha256": "1a5mdr3g0kwjz3891cg6v3b3lc5v0b0rgwp4b39qncry3l4k5yjg"
+   "commit": "530eb666ebafb985c3ab227a0fcc4b580373af91",
+   "sha256": "0gsjw3mjj88ggb18ypqfq2h8xbsiddr3gnjb2pnpha7jyl3v5sj5"
   }
  },
  {
@@ -7921,6 +7966,25 @@
    ],
    "commit": "773a6dde790c4a240e643a9071e4c7bce09d40de",
    "sha256": "11dirb13hblfa95hqqshrsjri4d4qzcq5qhhnd4xqajdchr62758"
+  }
+ },
+ {
+  "ename": "bilibili",
+  "commit": "f381364657c5ba1cb8b9651016e1bd437ea00b99",
+  "sha256": "08yc9d57yj0jxvabjdjm9kxhnjxghwd0pl5dn6z194pz0x9hsjfs",
+  "fetcher": "github",
+  "repo": "lorniu/bilibili.el",
+  "unstable": {
+   "version": [
+    20250312,
+    743
+   ],
+   "deps": [
+    "mpvi",
+    "org"
+   ],
+   "commit": "7b4c735e9f69d9d67b9cc772452991a71069bd9f",
+   "sha256": "02xzlswpgiqmn7yb0k05jicg6n3r0wji12xl12g92nni4yjr923x"
   }
  },
  {
@@ -8016,11 +8080,11 @@
   "repo": "justbur/emacs-bind-map",
   "unstable": {
    "version": [
-    20240308,
-    2050
+    20250308,
+    1210
    ],
-   "commit": "d7b0e42b78f708669ec368ebbd1f503094ceee22",
-   "sha256": "0g449iyndsdmhpk4j8zrl9smkjww3vhrvv2v4d6108q1wcg1p7v7"
+   "commit": "f23cfc13222a39e686d28a83ff83e9901d8908b2",
+   "sha256": "1a05nxm0iadvqy3wlz58f7c4g0lvip3n8dwkn1fr14dyl1vssgar"
   },
   "stable": {
    "version": [
@@ -8490,11 +8554,11 @@
   "repo": "Sodaware/blitzmax-mode",
   "unstable": {
    "version": [
-    20211128,
-    2028
+    20250221,
+    1408
    ],
-   "commit": "080d66c80f8350f3981bb97bc45c91b683cafdc0",
-   "sha256": "1y406ghis7zs148rcp6fyq10hh1kw87zrqw9bprhfjpc051rcw46"
+   "commit": "adf6444ca4cea047b5532495e9692ed044224ea4",
+   "sha256": "06xg1iij7p1q28zsi6f3az8dfdj8lyhdcdssd8n35bc408l3ps0q"
   },
   "stable": {
    "version": [
@@ -8871,8 +8935,8 @@
   "repo": "boogie-org/boogie-friends",
   "unstable": {
    "version": [
-    20221115,
-    658
+    20250310,
+    1610
    ],
    "deps": [
     "cl-lib",
@@ -8881,8 +8945,8 @@
     "flycheck",
     "yasnippet"
    ],
-   "commit": "5b32e4859823ed7f5e70fd5d2eac5d813a8e3e51",
-   "sha256": "1gihjkxnq4mqlcgjhmfbf4i7v7zyqy01ls2ac10pa5k1db2g1nbc"
+   "commit": "54905dab2944e7e808aa9445727646d7a3855174",
+   "sha256": "1lkdhwmdkfwmlywblxk23m4170cqcah49xy5xdl9kc5dsi9lm66g"
   }
  },
  {
@@ -8893,11 +8957,11 @@
   "repo": "akirak/bookmark-frecency.el",
   "unstable": {
    "version": [
-    20231126,
-    1320
+    20250220,
+    1407
    ],
-   "commit": "b969969865eae11b84bd3b0bc54cc5cacdcefaa8",
-   "sha256": "03wnbb5ibbr68iy0vlhl49078bj72vj9zx2q7l50b6yvkn5g1ymf"
+   "commit": "c0a4dae3ff23a548538716cbd2ad533680dc7e9e",
+   "sha256": "0igarshhk7pilx57c07ykhvikn3mzppp2bsjbgkkgxiwmzlsbs8j"
   }
  },
  {
@@ -8908,11 +8972,11 @@
   "repo": "ideasman42/emacs-bookmark-in-project",
   "unstable": {
    "version": [
-    20240421,
-    322
+    20250303,
+    1040
    ],
-   "commit": "369161f257921747c3b540eac7bc8eb4aa8186b9",
-   "sha256": "0346ljcb6b31y4wh5gikb7lpjpn4sqisk7frbdxqcp5yy15i1pmf"
+   "commit": "02fb655301b446c94c994c37c44055adc24f162a",
+   "sha256": "14ml1q0n1yh69xrbqfh7pzbmd06kzfvsfbp51p3sq2m9qh4wljyg"
   }
  },
  {
@@ -8980,28 +9044,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20241201,
-    1406
+    20250301,
+    2325
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "497e1c02555852ee92d1c0ec70839e9ed93a02b8",
-   "sha256": "0vsazlnl3fa5i71cn74wk4pf4wakmx5navpfmf5f6aj475f1yk0s"
+   "commit": "581e11718985bc80df66d34beff6b2d08a9abff8",
+   "sha256": "0vh2mc73jb8brvnq5yanhl0nmn1h8qnl8p0ynhr4bicp1b7gi117"
   },
   "stable": {
    "version": [
     4,
     1,
-    2
+    3
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "497e1c02555852ee92d1c0ec70839e9ed93a02b8",
-   "sha256": "0vsazlnl3fa5i71cn74wk4pf4wakmx5navpfmf5f6aj475f1yk0s"
+   "commit": "581e11718985bc80df66d34beff6b2d08a9abff8",
+   "sha256": "0vh2mc73jb8brvnq5yanhl0nmn1h8qnl8p0ynhr4bicp1b7gi117"
   }
  },
  {
@@ -9185,6 +9249,21 @@
   }
  },
  {
+  "ename": "bray",
+  "commit": "5c115943955e175ca4892583a1e9a7e99394dd6a",
+  "sha256": "1dhws7xpwfss99qfz49imq4jflq5p31j314xdny0hkiv3x2jhrcy",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-bray",
+  "unstable": {
+   "version": [
+    20250225,
+    2239
+   ],
+   "commit": "99488037cf61cfa6e6694d6a0d9725d23c15add5",
+   "sha256": "1d23c9vy51jcp5gbssjsr4zwfcwvlz26mb4z8qrczbjaxjhq1m0f"
+  }
+ },
+ {
   "ename": "brazilian-holidays",
   "commit": "111f2736e864e7cc8be6beb00eebb62f4d614e8c",
   "sha256": "1akqv0xd03vq46s8rzpk2hmjvy676dgnivaq8n5myagjkj9bmw3r",
@@ -9231,25 +9310,25 @@
   "url": "https://bitbucket.org/MikeWoolley/brf-mode",
   "unstable": {
    "version": [
-    20250114,
-    1134
+    20250301,
+    1142
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "a6ea410920b19f1ec39aa270ee25591747654944",
-   "sha256": "1qlg8x70wfc5n4m1z1126280682ckgw613nplcslc6n4m8g2zkn1"
+   "commit": "4751ce5c76f53d4e3e6a658461651a4f3ce35045",
+   "sha256": "0k80aiw80618js19sqxky10fc7h501gr4j8279v3x636yr6a5lfb"
   },
   "stable": {
    "version": [
     2,
-    2
+    4
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "a6ea410920b19f1ec39aa270ee25591747654944",
-   "sha256": "1qlg8x70wfc5n4m1z1126280682ckgw613nplcslc6n4m8g2zkn1"
+   "commit": "4751ce5c76f53d4e3e6a658461651a4f3ce35045",
+   "sha256": "0k80aiw80618js19sqxky10fc7h501gr4j8279v3x636yr6a5lfb"
   }
  },
  {
@@ -9696,14 +9775,14 @@
   "repo": "swflint/buffer-sets",
   "unstable": {
    "version": [
-    20230319,
-    1822
+    20250226,
+    2053
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "951e894ef96d533324f7f24c2a0def45ae89d558",
-   "sha256": "10gfrcz2b0fcwl6m6i0a8ffybrjn7vgg1c3c4i43wjqn1vxs1jzy"
+   "commit": "8d67ed8c9ea182abdcf457e0c247ab44675def9e",
+   "sha256": "07rjf3j44kpgcizx0cmdhccbyf0dd9pxv7i6zic2vlq1jvhj9mci"
   },
   "stable": {
    "version": [
@@ -9726,20 +9805,20 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20250121,
-    2019
+    20250226,
+    1609
    ],
-   "commit": "418178cf2578287e424a7d37d59d62b4f4fb8414",
-   "sha256": "12vz3vrbrnvw90lv471872yqhcwrk8h02d139slgz23rd8dm2xxg"
+   "commit": "c426fe97b0d994e8a028dc9070880d8dfcd94ac7",
+   "sha256": "1bz4kxkxgc5095ask59sm5648i05d8p3cdr84yfzvd4qyxhxzj6h"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
-   "commit": "8ea821806e58d9e5b7818c3ad2f5bcb51aa1a7ab",
-   "sha256": "1p15vad5yndf89x519a49pliqal5vws8dq8cjr7yvyca0sqkb2y2"
+   "commit": "0856afa78d415ec1124ab792a844a97b7d7a2f47",
+   "sha256": "0gmka4xikri5830g0qcn686bhn1w69nzsaf2siz5v7d6lq2k7mj4"
   }
  },
  {
@@ -10222,19 +10301,19 @@
   "repo": "jorgenschaefer/emacs-buttercup",
   "unstable": {
    "version": [
-    20240904,
-    2311
+    20250216,
+    2315
    ],
-   "commit": "bf01a33f8bc2d3664121d3b20f7496e67ce55e6a",
-   "sha256": "1xa8nlvjhwq0ryz8n3f7i671zm5qfbvr7qs75m7d52rmv60zkajc"
+   "commit": "c467c659b2c5b7029e20909331e072d7301af1d5",
+   "sha256": "0gkw1lmy8ynralrs4xwqsd06ww09xk5yqjdgw4r5c0zhp5dxn4ky"
   },
   "stable": {
    "version": [
     1,
-    36
+    37
    ],
-   "commit": "bf01a33f8bc2d3664121d3b20f7496e67ce55e6a",
-   "sha256": "1xa8nlvjhwq0ryz8n3f7i671zm5qfbvr7qs75m7d52rmv60zkajc"
+   "commit": "c467c659b2c5b7029e20909331e072d7301af1d5",
+   "sha256": "0gkw1lmy8ynralrs4xwqsd06ww09xk5yqjdgw4r5c0zhp5dxn4ky"
   }
  },
  {
@@ -10379,6 +10458,21 @@
    ],
    "commit": "c214093c36864d6208fcb9e6a72413ed17ed5d60",
    "sha256": "10k90r4ckkkdjn9pqcbfyp6ynvrd5k0ngqcn5d0v1qvkn6jifxjx"
+  }
+ },
+ {
+  "ename": "c2-mode",
+  "commit": "5ffcd74d50f0d3a64ad24b1d32dc1b05af3a106c",
+  "sha256": "1yag46kh3h6z0fg4a879kz1614yk0l70r6mihgccbg28w3h3879g",
+  "fetcher": "github",
+  "repo": "easimonenko/c2-mode",
+  "unstable": {
+   "version": [
+    20250303,
+    956
+   ],
+   "commit": "e3cc3a94f88d98e5a1b9086a4ad480009040a1ed",
+   "sha256": "10cwys01kpi9jl1ih9nrqnqnjq7yn25d2jychwdvwdwzww1rshsv"
   }
  },
  {
@@ -10752,8 +10846,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20240714,
-    642
+    20250224,
+    323
    ],
    "deps": [
     "dash",
@@ -10763,8 +10857,8 @@
     "s",
     "transient"
    ],
-   "commit": "bb9cfb5e5f9c2bb45386c1a9d1273a7832f8c28b",
-   "sha256": "0hmcmwmcv951v9bl8cr1cij6pkak84b9frr7h4aiydw6jpb0lcaa"
+   "commit": "77b9c491511c7f6f3a37d688097a035b7dc6d794",
+   "sha256": "0pvczjgnpnqznb8jnmzw0vpmcmk3s1kpxp3vi99klmmrm8ns06zm"
   },
   "stable": {
    "version": [
@@ -10817,6 +10911,30 @@
    ],
    "commit": "0bbe292b1b9c7ba1d8a65ed5e475f6a53f5f9f27",
    "sha256": "0kckjs7yg8d04nir5z3f00k05272kgma98794g0ycgfn1vrck0h0"
+  }
+ },
+ {
+  "ename": "calle24",
+  "commit": "c32623c445004f48313f1b33061f42f38bb87070",
+  "sha256": "0dxk3a1hyigbq4g1xcsh1jq3jv1vykza3yxq2v4lys9zhr9cy575",
+  "fetcher": "github",
+  "repo": "kickingvegas/calle24",
+  "unstable": {
+   "version": [
+    20250311,
+    1548
+   ],
+   "commit": "aa0e41ea586b0b8a836b267d4e2bfb62e66e8561",
+   "sha256": "0fc46ia1gri7q9y90c09vqspm5dfqab6alf7b0aam1fjrggawjsj"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    6
+   ],
+   "commit": "aa0e41ea586b0b8a836b267d4e2bfb62e66e8561",
+   "sha256": "0fc46ia1gri7q9y90c09vqspm5dfqab6alf7b0aam1fjrggawjsj"
   }
  },
  {
@@ -10873,11 +10991,11 @@
   "repo": "ocaml/caml-mode",
   "unstable": {
    "version": [
-    20231011,
-    328
+    20250227,
+    1734
    ],
-   "commit": "47defafa2b08fb680e89bfee9cb9ce82bd9e3bcf",
-   "sha256": "0y0d6pq9jd5slih1n0n1235b178xvs2d0q05wm6qwg0xpkc1x3c2"
+   "commit": "744333dc4c4bd8b93e037efa8f7362b0903b96a2",
+   "sha256": "1mg7d0gyshfhqjipbhy3gy905i60wmwi0ql24jx40mhy911nkj7r"
   },
   "stable": {
    "version": [
@@ -10930,25 +11048,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20250128,
-    819
+    20250311,
+    1650
    ],
    "deps": [
     "compat"
    ],
-   "commit": "118db73710466ab03708e7511f4bff7827057000",
-   "sha256": "0pcgxv011z0gl0g38yh2dr09sx17pwpbvydz2dzvm730k9lbyikh"
+   "commit": "2e86b6deed2844fc1345ff01bc92c3a849a33778",
+   "sha256": "0wm0y982zrfzzbdizpvr39c55bhp9y7l7w1sp8ps1b4ijbmgd0r9"
   },
   "stable": {
    "version": [
-    1,
-    9
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "118db73710466ab03708e7511f4bff7827057000",
-   "sha256": "0pcgxv011z0gl0g38yh2dr09sx17pwpbvydz2dzvm730k9lbyikh"
+   "commit": "2e86b6deed2844fc1345ff01bc92c3a849a33778",
+   "sha256": "0wm0y982zrfzzbdizpvr39c55bhp9y7l7w1sp8ps1b4ijbmgd0r9"
   }
  },
  {
@@ -11258,26 +11376,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250204,
-    1934
+    20250312,
+    2328
    ],
    "deps": [
     "transient"
    ],
-   "commit": "0ba181cbef1abdd45f9504c62f71212d64113e77",
-   "sha256": "0cvz98zqmrzbyjx4azc100bpa6f0cxgwyj4ky0932kjl89h6kwh2"
+   "commit": "ea0d69f5fd0aeb3530a7fcbd2e356123f4fdbc59",
+   "sha256": "14kb874xnl2fxzyqbp1r2pl8m1jp0mbcp5pq82ywx9nk4n69p3mv"
   },
   "stable": {
    "version": [
     2,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "0ba181cbef1abdd45f9504c62f71212d64113e77",
-   "sha256": "0cvz98zqmrzbyjx4azc100bpa6f0cxgwyj4ky0932kjl89h6kwh2"
+   "commit": "ea0d69f5fd0aeb3530a7fcbd2e356123f4fdbc59",
+   "sha256": "14kb874xnl2fxzyqbp1r2pl8m1jp0mbcp5pq82ywx9nk4n69p3mv"
   }
  },
  {
@@ -11410,11 +11528,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20250204,
-    2016
+    20250309,
+    2135
    ],
-   "commit": "8d14c1968580f9aa66a84929fc8a9daf1e1e2b90",
-   "sha256": "1vl0ws6gmm26j1f98myzkhy7m1fzyxpaspdv7f5hsilmlx7mk35h"
+   "commit": "44ceeef71057a674c512d1b4bf87fefff114f5f6",
+   "sha256": "17sfp3pks111dx8zr00c8qr2mzc53vjm8626dfawdfan1fxr0wf6"
   },
   "stable": {
    "version": [
@@ -11523,15 +11641,15 @@
   "repo": "emacs-lsp/emacs-ccls",
   "unstable": {
    "version": [
-    20240331,
-    2132
+    20250301,
+    131
    ],
    "deps": [
     "dash",
     "lsp-mode"
    ],
-   "commit": "9c91aad768d5c401295c79f341c5296b69b29490",
-   "sha256": "0m4q3zs6sr12avh9wr800wxr8lps7k0nzbgf4nckmzsavqb6csrh"
+   "commit": "28c7930c89c48a8f8e0ff5a62734f587f54e52be",
+   "sha256": "19x4y73va3gvxjl6j783vdzrcfa9fc4qv6lk91qqs3i9g3avahc3"
   }
  },
  {
@@ -11646,16 +11764,16 @@
   "repo": "ardumont/emacs-celery",
   "unstable": {
    "version": [
-    20170225,
-    924
+    20250221,
+    1903
    ],
    "deps": [
-    "dash-functional",
+    "dash",
     "deferred",
     "s"
    ],
-   "commit": "b3378dd81e5a717432123fb13d70201da5dc841a",
-   "sha256": "0xm9dhcw7p60rckq9i4aqpv050n2244yi8w5rvqlqb2i4pnkb0fh"
+   "commit": "c689a47176d09a99382a4daecbe42ded94d4d649",
+   "sha256": "1g6zqmwz5h71lyn4w68m8i3s3p7amrckx0547yx667nhivvs6266"
   },
   "stable": {
    "version": [
@@ -11866,14 +11984,14 @@
   "repo": "fourier/cff",
   "unstable": {
    "version": [
-    20160118,
-    2018
+    20250209,
+    2316
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b6ab2a28e64ef06f281ec74cfe3114e450644dfa",
-   "sha256": "019vqjmq6hb2f5lddqy0ya5q0fd47xix29cashlchz0r034rc32r"
+   "commit": "ebb2c9c24cae43283221219e95dac0ab43925a0f",
+   "sha256": "1mjn9bbvkw794ararnkqi57r3v5diiscw65i2j53wj1bmp3dxcqh"
   }
  },
  {
@@ -11899,7 +12017,7 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250202,
+    20250209,
     904
    ],
    "deps": [
@@ -11907,8 +12025,8 @@
     "s",
     "yaml-mode"
    ],
-   "commit": "fb15f876722350c87bf4fc5cc26e16aa4d1bf2c7",
-   "sha256": "0pr92p7sw8lh4glawbw97dzvfq7s8jsq0ylqjmc1xl3jws6aniy4"
+   "commit": "a7d9a4914ed71ca4e79de37f11176b9fb253b846",
+   "sha256": "1yr4b206sckqqwpqz9h70i9hfpqhlirhkyzixah8zzm3z3nrg3yd"
   },
   "stable": {
    "version": [
@@ -11998,20 +12116,20 @@
   "repo": "GrammarSoft/cg3",
   "unstable": {
    "version": [
-    20250130,
-    1433
+    20250311,
+    1539
    ],
-   "commit": "9f3d75193e0a5988e51a901644356f4bec618d7f",
-   "sha256": "08jbqkii2vndy82lairij95qylhf7nz55z3d39z58iavqp42dsih"
+   "commit": "51c6f82d7cc686aec96587abd2eabe1b5c1ed9e1",
+   "sha256": "07jh0nirsij9v311nmff5yzcs2hq9izri7abrrml5k0kk115nnpp"
   },
   "stable": {
    "version": [
     1,
-    4,
-    6
+    5,
+    0
    ],
-   "commit": "c22f5572c0946b0d21f4d489308ea0ce9f305ea0",
-   "sha256": "0lz98f5lic1wlbwdj8j85kgsjrsbbmy61q9cqn2bjki272bcfzjf"
+   "commit": "51c6f82d7cc686aec96587abd2eabe1b5c1ed9e1",
+   "sha256": "07jh0nirsij9v311nmff5yzcs2hq9izri7abrrml5k0kk115nnpp"
   }
  },
  {
@@ -12172,26 +12290,26 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20250207,
-    926
+    20250311,
+    2144
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "be81dd78fd1a6e7f0e50a0e7d67c0542d47783a8",
-   "sha256": "1lb6bg3wr3p3l03p3imrk8f6fp5mnvqbgd6aafb9vzfqp81xqgly"
+   "commit": "fcc18a1534dfdb91e2a11e09b45ae14dc9dd50f3",
+   "sha256": "04af1f7pkk970x2vrv46x4ipgpyy3hh6v82kxc4gndg0gs78i04y"
   },
   "stable": {
    "version": [
     2,
-    12,
-    2
+    16,
+    1
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "99db92a3ba19872280249321198c2f6eb1af3e73",
-   "sha256": "1wvfqgzhhqq2n0nvx5cqbn74bh79pzxmhlss4fxdx487y86rs8w7"
+   "commit": "50745e34082283f2a3a65a3f314629b29c1a883f",
+   "sha256": "1xq4hfr3m5sgi9wrr3nrp6fsnnw8d044gz0y50d4h46cvq8c6f2g"
   }
  },
  {
@@ -12202,15 +12320,15 @@
   "repo": "kimim/chatu",
   "unstable": {
    "version": [
-    20250114,
-    505
+    20250301,
+    319
    ],
    "deps": [
     "org",
     "plantuml-mode"
    ],
-   "commit": "607ab3d96c948e37f27f6268ce6f5266188566d3",
-   "sha256": "0pdzqvs7w295nlsyd1d50q8kwflbzccvmkyx2abwkqyasbanf00m"
+   "commit": "b666b53e5a13f722833f856a76b0ce996c1b2bcd",
+   "sha256": "0b50fqfch1c0s5prg7kq2d2xaa6vgrcscd1danc6l1vaa65wq58a"
   }
  },
  {
@@ -12857,8 +12975,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250116,
-    1758
+    20250313,
+    1410
    ],
    "deps": [
     "clojure-mode",
@@ -12869,13 +12987,13 @@
     "spinner",
     "transient"
    ],
-   "commit": "c0e7f2526d7b5ed67c723c4fbf3ce5391f4f5123",
-   "sha256": "1rcgs8r5vyli0040s2sj1qg28fcmlhxhyv90yskgnjyfpzs1qann"
+   "commit": "e125d3eaef7718b6975f12b94f7b4ffa4bd20b58",
+   "sha256": "0lchm6i4zym3swx8hkznnlbxziqn66x9bdkz2dxclrldmw7pf5ks"
   },
   "stable": {
    "version": [
     1,
-    16,
+    17,
     1
    ],
    "deps": [
@@ -12887,8 +13005,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "588c5790f0c09f5c09076885e11a73eaef70c262",
-   "sha256": "1k0zdi5zpv730gkym98amfp00xpk1hkry231v98iiw1khp345lsm"
+   "commit": "d2f34b60e5c5e569d4b7f4f79b36893f5c4dfa20",
+   "sha256": "02lilk85a7h9wxxvxr6k69p12wslbl9xp3jkcbdn11078fwhif6j"
   }
  },
  {
@@ -13067,20 +13185,20 @@
   "repo": "guidoschmidt/circadian.el",
   "unstable": {
    "version": [
-    20240603,
-    935
+    20250222,
+    1158
    ],
-   "commit": "76464419f69e9758bc5a76b2420c9648ddf93dba",
-   "sha256": "1blpk69ba2dira5av3ad854h4xkxxl5f47mkbjbgmzjlqihv8q3p"
+   "commit": "73fa3fd8b63af04bab877209397e42b83fbb9534",
+   "sha256": "0kxa8hky56xmg8szii23yai0w8zfh3ql7mazn9ff77aa8lx6mplm"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "76464419f69e9758bc5a76b2420c9648ddf93dba",
-   "sha256": "1blpk69ba2dira5av3ad854h4xkxxl5f47mkbjbgmzjlqihv8q3p"
+   "commit": "73fa3fd8b63af04bab877209397e42b83fbb9534",
+   "sha256": "0kxa8hky56xmg8szii23yai0w8zfh3ql7mazn9ff77aa8lx6mplm"
   }
  },
  {
@@ -13203,16 +13321,16 @@
   "repo": "pprevos/citar-denote",
   "unstable": {
    "version": [
-    20250202,
-    854
+    20250225,
+    927
    ],
    "deps": [
     "citar",
     "dash",
     "denote"
    ],
-   "commit": "47f1ed2fbdd6ce88e65dd5ec77e984dfa4f72d49",
-   "sha256": "1lb8gy9gf4jdq5mfbkdmv4gwg1rw6h5vk3zn4mhly9p39baq69dv"
+   "commit": "ee33058fbce47b9874af6928b202223e6b12700b",
+   "sha256": "1l9dss6j7pwm625ggn0r6qqpxwwfsdrh5ngn9vibglvz2yi507wx"
   },
   "stable": {
    "version": [
@@ -13478,14 +13596,14 @@
   "repo": "emacsmirror/clang-format",
   "unstable": {
    "version": [
-    20241019,
-    2151
+    20250223,
+    1620
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f01d16be89a4421169c421d25cfdddb3ad62460f",
-   "sha256": "0f53sbr970spyl9k4mnh03y6kc3gxzh77b70s04bw8sda5sb980b"
+   "commit": "a099177b5cd5060597d454e4c1ffdc96b92ba985",
+   "sha256": "0csnqcnr8y25yb1p07vk53q8hxl11qmf2596cx8axjnaymaiv05d"
   }
  },
  {
@@ -13547,15 +13665,15 @@
   "repo": "mzacho/claudia",
   "unstable": {
    "version": [
-    20241216,
-    2112
+    20250309,
+    2334
    ],
    "deps": [
     "markdown-mode",
     "uuidgen"
    ],
-   "commit": "6905b1c734d18578537ae97a63a65a896ba341f1",
-   "sha256": "08f1h1dfy3ks3y7shqvj198s150lcja98lm9170cdgjj910akvjc"
+   "commit": "d33d36a2682682a8f85bcdff3f4fe668c83c2cba",
+   "sha256": "1q79hz71vjjzhfghfqr9r7rhx18f70zxy34l52562v4p91qx5y8w"
   }
  },
  {
@@ -14329,20 +14447,20 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20241104,
-    2135
+    20250310,
+    1233
    ],
-   "commit": "3ca382c3ccf2ad560d0974229ec88963e82d2fe7",
-   "sha256": "194sw4fb9845sysn23dv64c7qwj4kfz02hzdij05wn01xkjscgph"
+   "commit": "b165c6e8d6040e8701f1e3798c1b33f8549b823f",
+   "sha256": "1xi610rz8n2brp61mwg25rzd12p8hacba8ykl3vx86gkfx4xxf8b"
   },
   "stable": {
    "version": [
     0,
     2,
-    2
+    3
    ],
-   "commit": "a923aa83a61751a588ed3afc133d45898995762e",
-   "sha256": "15aisl4pzdgi5nqpjxllq053fj9011liz53ph9kqvl7mzspffgaj"
+   "commit": "9662b6caa86b67b51aa883b35e21645233ca6f68",
+   "sha256": "01gmv0cm0rirf91qwbbmy78ygmxrcn4swaack8bc2gdaybh2msnf"
   }
  },
  {
@@ -14388,28 +14506,28 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20250126,
-    1747
+    20250301,
+    2221
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "d925b8c9c1c724b49d7af7806b7ec1d71209d6e3",
-   "sha256": "1x5nwbmwvgl96f7grhh60472m0d6jiykls0f52c1ff03b2dhplax"
+   "commit": "dc7924c1d206483a2555a98470c96fadf419f32d",
+   "sha256": "1gmad6gszy7imx3sq6s1sdkhgpmylp0c11p85ilz553cxyzv4n2r"
   },
   "stable": {
    "version": [
     2,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "d925b8c9c1c724b49d7af7806b7ec1d71209d6e3",
-   "sha256": "1x5nwbmwvgl96f7grhh60472m0d6jiykls0f52c1ff03b2dhplax"
+   "commit": "dc7924c1d206483a2555a98470c96fadf419f32d",
+   "sha256": "1gmad6gszy7imx3sq6s1sdkhgpmylp0c11p85ilz553cxyzv4n2r"
   }
  },
  {
@@ -14582,20 +14700,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20250114,
-    1444
+    20250304,
+    1338
    ],
-   "commit": "72e27a48566e4b3becefc1a16aeba550c32c4128",
-   "sha256": "027g3i2dvbss7q46kya9r653bnxj46lraf7ikc7j6wxyw7m8jkmh"
+   "commit": "bf8f4d4639407e01bb7e827eb7b6d1fc44fabb52",
+   "sha256": "1ds3d9bf1732zcbiv9l29zm9hmwhcqhkfr1p9jbxb6mm3q719afh"
   },
   "stable": {
    "version": [
     3,
     31,
-    5
+    6
    ],
-   "commit": "9fe70fd76412f41ab2bec24ba42b081b48691961",
-   "sha256": "08zbwcc39jcgl99na8118vvj4728yaq453nmbx8agbf09h71f4na"
+   "commit": "859ca5c4d7396a011a462878179bc173e1283731",
+   "sha256": "1jkp72my1nql39z06ma2ydi78h4rzxca0kakbvyp5b22dadcm37q"
   }
  },
  {
@@ -14783,8 +14901,8 @@
   "repo": "ag91/code-compass",
   "unstable": {
    "version": [
-    20241211,
-    24
+    20250227,
+    1124
    ],
    "deps": [
     "async",
@@ -14792,8 +14910,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "76c5732de8746ea61d4d0cf9dad00b3c35874807",
-   "sha256": "0lv37n19gd433zf5y9i0v4f4g8pzy5ls4xfnaz27kqhsp7abbd1p"
+   "commit": "6b741978c83f0359c7e555ab78708eed6ced8486",
+   "sha256": "0g8bw01jpp488y95m14nbizq0acx9grqhk34g37lwn8imshl9hi6"
   }
  },
  {
@@ -15240,11 +15358,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20241028,
-    1458
+    20250306,
+    1440
    ],
-   "commit": "2548eb47dcf09ce433f48f5d027890ef259dabe7",
-   "sha256": "1xj1k23mj78wnpvgndfd9lisfm8ax67dps3gbvfzdm38sp4wkkq5"
+   "commit": "5e3ed508e2c0a9a6d9af700212dd7ce96a356da6",
+   "sha256": "1v4h94swwkvryafv35y77w24aa0wgwqlyjx3228smhxkqn3j8v84"
   },
   "stable": {
    "version": [
@@ -15547,11 +15665,11 @@
   "stable": {
    "version": [
     1,
-    3,
-    1
+    5,
+    0
    ],
-   "commit": "69415caa1a381063d3e794912dfe88f672854ab0",
-   "sha256": "05ypgsdrgqj8105bvd17jn7w633y3ysbr5sgz33m7kj1ca7sl9ga"
+   "commit": "6ab75d0a690f0080e9b97c730aac817d04144cd0",
+   "sha256": "0v90x1s839bwsprfg9c246x8i52rybjpi59pcyj1aj198wwf8a35"
   }
  },
  {
@@ -15728,11 +15846,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20250114,
-    2109
+    20250228,
+    258
    ],
-   "commit": "9a81d0cca268d35d5e18d7d4e2277a9e57887dd8",
-   "sha256": "1lilh252wv2fq11y5jav6i8lss76isj63vsgm3i4lsz841lgz3qw"
+   "commit": "8d599ebc8a9aca27c0a6157aeb31c5b7f05ed0a3",
+   "sha256": "0k1k1rzqi6gc2iirlcg8nw1alv1hs8qf72a1wqcifmkx1ajb7d8i"
   },
   "stable": {
    "version": [
@@ -17186,15 +17304,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20191222,
-    920
+    20250218,
+    2303
    ],
    "deps": [
     "company",
     "rtags"
    ],
-   "commit": "595055b5316a7c92ba1d638f324f98842a0f41a5",
-   "sha256": "17zmcp6ynbgpvp5hwlnfw7n5vq07c9qgv8vbs156wjs9p6x36qpl"
+   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
+   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
   },
   "stable": {
    "version": [
@@ -17658,11 +17776,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20250204,
-    1654
+    20250313,
+    16
    ],
-   "commit": "71f6cae711c943354dea34d35b435f84f6607129",
-   "sha256": "1vy4bhjw2f9b2s194nz4bcmlhbibfhhn7dj7n0fk53ky03xs54cn"
+   "commit": "ec2d0beb0668d66de29510980f8112230757a0a6",
+   "sha256": "108sh6j845pmpj5s6k04z55ylrp6p0jfb70lfbq62bzp5nm2z3xz"
   },
   "stable": {
    "version": [
@@ -17794,8 +17912,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20241222,
-    1158
+    20250224,
+    1232
    ],
    "deps": [
     "eldoc",
@@ -17803,8 +17921,8 @@
     "plz",
     "seq"
    ],
-   "commit": "862d3508e31f5d3ee0142414717d229e30bac477",
-   "sha256": "10qpqglv2vd1cnpd08nvhqhrdllnak5d6dqb0nnm1cq7fzkwyj16"
+   "commit": "228f562f0a7aa5edbb56ed8da6b6844fd013436e",
+   "sha256": "0wvd08mz4y0wj1b0gmw7093d8krmx5w520q4x52yn5cn4vr6bbwm"
   },
   "stable": {
    "version": [
@@ -18142,25 +18260,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20250207,
-    1612
+    20250311,
+    1658
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c74ae6149172e3429b844c22d67e02b01abea1e4",
-   "sha256": "0fxcprca5p0ld95828mw49fz90cg127yal7nbdhk2gk133k3l1fa"
+   "commit": "d557305b730f7666d46bc3eb04c87cfcc493a8e5",
+   "sha256": "1d04j6psx05cbnsmc78rqnzg1zpcnqd9m1830d276n1jpfszmh10"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "03fa8f6b7482eab1dee85d32ab604f0b7312cf82",
-   "sha256": "0dvj5l6y3s292p0hi66l43g5ykbrvi1glh71n8slkayg76c8jqfp"
+   "commit": "d557305b730f7666d46bc3eb04c87cfcc493a8e5",
+   "sha256": "1d04j6psx05cbnsmc78rqnzg1zpcnqd9m1830d276n1jpfszmh10"
   }
  },
  {
@@ -18299,14 +18417,14 @@
   "repo": "karthink/consult-dir",
   "unstable": {
    "version": [
-    20241114,
-    454
+    20250313,
+    359
    ],
    "deps": [
     "consult"
    ],
-   "commit": "26fd5516511747ecefe98ef8e4592e330d99e6ae",
-   "sha256": "1sl6cwsj7jnylv4idjmcfs2z2i17a5b3aqb93q00hkbmqig94gam"
+   "commit": "4532b8d215d16b0159691ce4dee693e72d71e0ff",
+   "sha256": "1yv6sssg8fddi9g44c7x026z7ajgzsc351lvf7sp79il0hqjg0nm"
   },
   "stable": {
    "version": [
@@ -18329,21 +18447,21 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20250110,
-    1808
+    20250216,
+    2144
    ],
    "deps": [
     "consult",
     "eglot",
     "project"
    ],
-   "commit": "2bc816be057a2ece99d4bf014ade14ae7d758b07",
-   "sha256": "020k7yrf4c0zw9gpyq2mn421dm3c7ccfzqw1dpl20k8xqsabjm52"
+   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
+   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
@@ -18351,8 +18469,8 @@
     "eglot",
     "project"
    ],
-   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
-   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
+   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
+   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
   }
  },
  {
@@ -18363,28 +18481,28 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20250101,
-    2155
+    20250216,
+    2144
    ],
    "deps": [
     "consult-eglot",
     "embark-consult"
    ],
-   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
-   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
+   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
+   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
     "consult-eglot",
     "embark-consult"
    ],
-   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
-   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
+   "commit": "b71499f4b93bfea4e2005564c25c5bb0f9e73199",
+   "sha256": "1xx5g4z4l0kanf2mh3f798gw8ydfzbx15wfyqrnhwhiljz796xis"
   }
  },
  {
@@ -18444,29 +18562,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250202,
-    2110
+    20250310,
+    350
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "f2a4498d0a5aa9e03adc406c5013f9318385e57c",
-   "sha256": "0yv22iggcvjdvpv16sqblbcp761ksn2gf78zh0x1lss03vgivfap"
+   "commit": "e21b9e44c6d241a9a3afc6c45b3e7c37a543a744",
+   "sha256": "1qxk12ia5p8qhmvxdy6zz5kb2cz2gmcmn3mg8gz3s823zx0fj4j0"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "987b6705f6a7e866afc18974b0eae4d20b3b1004",
-   "sha256": "19gfgs3xc9dlf9zsdvjsf7am16gp38rw812l0z035fny3avbpxzw"
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
   }
  },
  {
@@ -18477,28 +18595,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250201,
-    1318
+    20250309,
+    2223
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "8a5c7ea1e732b01634c5f3533f72c002135c3421",
-   "sha256": "19cby16vmq3bj6m3s4mjrl65vdwjbhxjww0s9b2dg9fsfy70dlbx"
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
+    "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "987b6705f6a7e866afc18974b0eae4d20b3b1004",
-   "sha256": "19gfgs3xc9dlf9zsdvjsf7am16gp38rw812l0z035fny3avbpxzw"
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
   }
  },
  {
@@ -18509,29 +18628,62 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250202,
-    1941
+    20250309,
+    2223
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "2b3d90783583ef44006aea9552314e0b5ab2e47a",
-   "sha256": "1q7n6z2rw31jszn7nq1i68c6h0qiavygf7r94izvkrpywdy65m7w"
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "987b6705f6a7e866afc18974b0eae4d20b3b1004",
-   "sha256": "19gfgs3xc9dlf9zsdvjsf7am16gp38rw812l0z035fny3avbpxzw"
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+  }
+ },
+ {
+  "ename": "consult-gh-with-pr-review",
+  "commit": "be490ed8922d6f45c7a0fe9fc880b4e97e7e3d3b",
+  "sha256": "1b5fyd1lx09wgawdp4pg4w5zzk1rp7z6db0qlky8vq11ybkj5ay6",
+  "fetcher": "github",
+  "repo": "armindarvish/consult-gh",
+  "unstable": {
+   "version": [
+    20250309,
+    2223
+   ],
+   "deps": [
+    "consult",
+    "consult-gh",
+    "pr-review"
+   ],
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+  },
+  "stable": {
+   "version": [
+    2,
+    3
+   ],
+   "deps": [
+    "consult",
+    "consult-gh",
+    "pr-review"
+   ],
+   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
+   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
   }
  },
  {
@@ -18572,14 +18724,14 @@
   "repo": "ghosty141/consult-git-log-grep",
   "unstable": {
    "version": [
-    20250116,
-    1919
+    20250307,
+    1159
    ],
    "deps": [
     "consult"
    ],
-   "commit": "2dbedc0efc90c8a0311c9f2244596fe1ee3eddd4",
-   "sha256": "02d3pvri15lff7v51sgnsg5mlc6pcf1mwn9l085qy8mksviykyl9"
+   "commit": "e85627bb950f6c4ae296a2623d55e8e659e29ba8",
+   "sha256": "0xw4nvv5smy77l7d4gxr7qwm98qqv73mmszcgalm5wki88x1g3br"
   }
  },
  {
@@ -18842,26 +18994,26 @@
   "repo": "titus.pinta/consult-tex",
   "unstable": {
    "version": [
-    20240808,
-    1300
+    20250306,
+    1724
    ],
    "deps": [
     "consult"
    ],
-   "commit": "9df92b31a8e7ef253667229a4e05153ea13346de",
-   "sha256": "0ipabvybhfk6zzv4q7vvlcpvhr7pxs4shwbvj3bxwr76303ajxvi"
+   "commit": "546e4b16a3f98fa1d4d440acb158b8fa5147a14c",
+   "sha256": "02laqiwbp5p3ajp7c3jnkbbcl1aqn7vj63y1afam15gx69m57xf2"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
     "consult"
    ],
-   "commit": "675755e106f9e64e2c1fd3cf05a43275c09497da",
-   "sha256": "18kz99lmfqr7hm3n3xkp51hi6fibyj2ry6abpl897rl4ky9rabr9"
+   "commit": "14aa968056923fe6b0f96f637405e9d0b8e23020",
+   "sha256": "02laqiwbp5p3ajp7c3jnkbbcl1aqn7vj63y1afam15gx69m57xf2"
   }
  },
  {
@@ -18904,26 +19056,26 @@
   "repo": "chmouel/consult-vc-modified-files",
   "unstable": {
    "version": [
-    20241216,
-    928
+    20250307,
+    905
    ],
    "deps": [
     "consult"
    ],
-   "commit": "06387842bceb47887f6c07b148220a4e256d7eed",
-   "sha256": "1bxq6fny01a0a4gq5xzlrj6jg73pxdyp2fl89jzp5kh9h0kg3h0w"
+   "commit": "99d98f6220685aaa42ab1a9d4baf34560095645b",
+   "sha256": "1wyz6w92gldxp9bxrq8f8s27pb9jdslaadhra9gn7wg2ql6s8idk"
   },
   "stable": {
    "version": [
     0,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "consult"
    ],
-   "commit": "06387842bceb47887f6c07b148220a4e256d7eed",
-   "sha256": "1bxq6fny01a0a4gq5xzlrj6jg73pxdyp2fl89jzp5kh9h0kg3h0w"
+   "commit": "e73aa635cfe454e62bbaca0fd8bbdc0a30946ee6",
+   "sha256": "07v2lw5r7s1p5s7iviw4l1pa7da96f0q642max77wmlay29v70k5"
   }
  },
  {
@@ -19081,8 +19233,8 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20250105,
-    1949
+    20250223,
+    139
    ],
    "deps": [
     "dash",
@@ -19091,8 +19243,8 @@
     "jsonrpc",
     "s"
    ],
-   "commit": "be6c274562e150e4acf5253968d1b434c40d368b",
-   "sha256": "1m9ramdjdph2girqa6jssapmd6y4qr5fnqrvjns85k7b3z74b2a1"
+   "commit": "7d105d708a23d16cdfd5240500be8bb02f95a46e",
+   "sha256": "1gc8rnyl60wlxdhqi1a96mq0wfgpnfziyihpvcy9bmnx14s34ch1"
   }
  },
  {
@@ -19103,34 +19255,38 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250205,
-    1106
+    20250313,
+    822
    ],
    "deps": [
-    "chatgpt-shell",
     "magit",
     "markdown-mode",
     "org",
+    "polymode",
     "request",
     "shell-maker",
     "transient"
    ],
-   "commit": "a3a9f13506f6bb8105c625bbd731e6c0e741eec2",
-   "sha256": "0igjhnz9447c0x3431l1f5k142v3bqcm5wzjppbhdx7gqf9i1cs6"
+   "commit": "0337869a7d19171133198453985009655a846f75",
+   "sha256": "1qmaqqwr38d0br5prc2wrq9qcdwwx09v5312ip7ln1lgzd9a1b18"
   },
   "stable": {
    "version": [
-    1,
     2,
-    0
+    0,
+    1
    ],
    "deps": [
-    "chatgpt-shell",
+    "magit",
     "markdown-mode",
-    "request"
+    "org",
+    "polymode",
+    "request",
+    "shell-maker",
+    "transient"
    ],
-   "commit": "e8235960cc568bf2026e8c4206b4e43a7a9b9c02",
-   "sha256": "1p5jm19awr9azjjjwk8ywckl1riv5g1j221azwhsak24zb5y8l0i"
+   "commit": "965ea54ec28d47ee8219831c93b1131ae51d8c06",
+   "sha256": "1zxp69p4c32wbh2sdd6779xsfk4zbygqsrr4vmq2cbkhxjw8s07c"
   }
  },
  {
@@ -19460,28 +19616,28 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250109,
-    1116
+    20250304,
+    939
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "2c3f20a4dcdde0942dd6901c503936a74246f546",
-   "sha256": "05k3h16sqxk3a3knpk2vk549m8828l68x03ww7hvgiwljy284h5a"
+   "commit": "db61f55bc281c28beb723ef17cfe74f59580d2f4",
+   "sha256": "0ypbjjmr1lyyq5azlbx03rpbkhpc1fl4fbm6m2zbv48bzyr49hn5"
   },
   "stable": {
    "version": [
     0,
-    14,
-    2
+    15,
+    0
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "8c30f4cab5948aa8d942a3b2bbf5fb6a94d9441d",
-   "sha256": "1iqj27pc2iivmwfh329v0d9g0z1y0whlnamrl7g2bi374h41m368"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   }
  },
  {
@@ -20348,17 +20504,17 @@
  },
  {
   "ename": "crc",
-  "commit": "28cbd69b950ff176f82da0bacaadebbe1ef12348",
-  "sha256": "03d93i4a8yl4igsdds2d51gj69nvq4q9kldqhqa9c4d2mjgzwcbl",
+  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
+  "sha256": "067ms2sy3ls1b9067gap5ks322l1akzz7yi4krw69fydanzqgw6b",
   "fetcher": "codeberg",
-  "repo": "WammKD/Emacs-CRC",
+  "repo": "Jaft/Emacs-CRC",
   "unstable": {
    "version": [
-    20250113,
-    556
+    20250303,
+    119
    ],
-   "commit": "0947fdc098d8f110910d4d9066b873d440bc78af",
-   "sha256": "0ydfvi29m3815cngk7m6abqlml7zrvqr3yr7178ql3hgmpb04dzy"
+   "commit": "568bd5e0fddfbf430c295da33a17f6ed99484188",
+   "sha256": "15k1h9j57687jxq2sfx6w7zj0l2pp421dvpj4ys1d4wd7f6hh1w7"
   },
   "stable": {
    "version": [
@@ -20366,8 +20522,8 @@
     1,
     2
    ],
-   "commit": "0947fdc098d8f110910d4d9066b873d440bc78af",
-   "sha256": "0ydfvi29m3815cngk7m6abqlml7zrvqr3yr7178ql3hgmpb04dzy"
+   "commit": "568bd5e0fddfbf430c295da33a17f6ed99484188",
+   "sha256": "15k1h9j57687jxq2sfx6w7zj0l2pp421dvpj4ys1d4wd7f6hh1w7"
   }
  },
  {
@@ -20605,11 +20761,11 @@
   "repo": "bbatsov/crux",
   "unstable": {
    "version": [
-    20240401,
-    1136
+    20250212,
+    2017
    ],
-   "commit": "6ed75a69f542fb7feab6b8f182caf0924b3fb510",
-   "sha256": "09lybi0bld14bdfvbji5cxrwrwflcvfnkdk618yybv1zphxmj2nx"
+   "commit": "c83c54d3d746e83861bcb22b0309c66a2d4db17f",
+   "sha256": "0g8ph4brjsczfzmg0inzm4b1fwvbx0hgakczwnzxmkg1ssd1gigm"
   },
   "stable": {
    "version": [
@@ -20734,8 +20890,8 @@
   "repo": "hlolli/csound-mode",
   "unstable": {
    "version": [
-    20240823,
-    857
+    20250310,
+    1026
    ],
    "deps": [
     "dash",
@@ -20743,8 +20899,8 @@
     "multi",
     "shut-up"
    ],
-   "commit": "34e208ba29bf5a8679a07607d29951f7657676e1",
-   "sha256": "17rrgmby1dhl1j0a42bh3x5i06jn4lz5ipmxq2ysdpypivlrarkn"
+   "commit": "4a6aa20ad919f088d65b903814453bd56266cf77",
+   "sha256": "18q4jpj6fnry67m6z3y5kk70hhk8db5l7wjwylhwmh362c3hzp30"
   },
   "stable": {
    "version": [
@@ -20875,15 +21031,15 @@
   "repo": "neeasade/ct.el",
   "unstable": {
    "version": [
-    20250205,
-    1258
+    20250221,
+    2339
    ],
    "deps": [
     "dash",
     "hsluv"
    ],
-   "commit": "5dce87360e5a8c22e2ffde970ff4189cd7fa4138",
-   "sha256": "0czzbbnwmbpzcrf6m0wcqxj3nsc7vk5bb9x157gcwrip68g7gzyn"
+   "commit": "e3d082136e06c0ec777ab032bec5a785239f412b",
+   "sha256": "06gs6r2b8ldhjaigdbp9dnspbikajkkqarwif8y7q8mwiv63m6ib"
   }
  },
  {
@@ -20997,11 +21153,11 @@
   "repo": "maurooaranda/ctune",
   "unstable": {
    "version": [
-    20210205,
-    1428
+    20250310,
+    2034
    ],
-   "commit": "3f7abc6e74d4e5954b476ba9a1dc652f96b10c05",
-   "sha256": "1lcgkh0hhgx4rvc84kgbg3sczqp53gz6859c30hq1agn1zhbwrvy"
+   "commit": "7c26d7af3cd0d6cf4f94deb7f2bf3cf8ed8a1f11",
+   "sha256": "14xzyrijix1w7g8z014y9b3hdhw2mm60168crlnkagpdw7j0rq92"
   },
   "stable": {
    "version": [
@@ -21779,11 +21935,11 @@
   "repo": "rails-to-cosmos/danneskjold-theme",
   "unstable": {
    "version": [
-    20241114,
-    749
+    20250302,
+    1553
    ],
-   "commit": "96c000887d5bf7be17ff315c939bb7c8c962b86a",
-   "sha256": "1vbb5s5vl08lx0rjvn4a0czhnfdndn70vsk68kzfbchycpd3m7pp"
+   "commit": "597cdf9135ce6cced22e46f81598723f11dbdcc5",
+   "sha256": "1zlhch5hhkgvzqn2d3ji6asxxi9gljj68l91xplrfdvg4ydy9lvn"
   }
  },
  {
@@ -21835,8 +21991,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20250131,
-    1624
+    20250228,
+    2153
    ],
    "deps": [
     "bui",
@@ -21849,8 +22005,8 @@
     "posframe",
     "s"
    ],
-   "commit": "2a5524bef1528945311dd8557b18c53d6e95fa3d",
-   "sha256": "1xsl621bax8g4aq4m890b31f4mpsh9nywxazqxnlki52mv6a4m5d"
+   "commit": "56e92dd86b526c191275cf7813208baad14e0c5d",
+   "sha256": "1qmkxymzyg4rzv9by5z4s3bxpgg2h0szk4632nbm8khq09pkjcjx"
   },
   "stable": {
    "version": [
@@ -22107,20 +22263,20 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20240510,
-    1327
+    20250312,
+    1307
    ],
-   "commit": "1de9dcb83eacfb162b6d9a118a4770b1281bcd84",
-   "sha256": "1nkz7m2yllvin3aynnp1wldjzasah9rv4nlydcxxh5qx4ws3dpka"
+   "commit": "fcb5d831fc08a43f984242c7509870f30983c27c",
+   "sha256": "092kf61bi6dwl42yng69g3y55ni8afycqbpaqx9wzf8frx9myg6m"
   },
   "stable": {
    "version": [
     2,
-    19,
-    1
+    20,
+    0
    ],
-   "commit": "39d067b9fbb2db65fc7a6938bfb21489ad990cb4",
-   "sha256": "0z6f8y1m9amhg427iz1d4xcyr6n0kj5w7kmiz134p320ixsdnzd8"
+   "commit": "fcb5d831fc08a43f984242c7509870f30983c27c",
+   "sha256": "092kf61bi6dwl42yng69g3y55ni8afycqbpaqx9wzf8frx9myg6m"
   }
  },
  {
@@ -22180,26 +22336,26 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20210826,
-    1149
+    20250312,
+    1307
    ],
    "deps": [
     "dash"
    ],
-   "commit": "39d067b9fbb2db65fc7a6938bfb21489ad990cb4",
-   "sha256": "0z6f8y1m9amhg427iz1d4xcyr6n0kj5w7kmiz134p320ixsdnzd8"
+   "commit": "fcb5d831fc08a43f984242c7509870f30983c27c",
+   "sha256": "092kf61bi6dwl42yng69g3y55ni8afycqbpaqx9wzf8frx9myg6m"
   },
   "stable": {
    "version": [
     2,
-    19,
-    1
+    20,
+    0
    ],
    "deps": [
     "dash"
    ],
-   "commit": "39d067b9fbb2db65fc7a6938bfb21489ad990cb4",
-   "sha256": "0z6f8y1m9amhg427iz1d4xcyr6n0kj5w7kmiz134p320ixsdnzd8"
+   "commit": "fcb5d831fc08a43f984242c7509870f30983c27c",
+   "sha256": "092kf61bi6dwl42yng69g3y55ni8afycqbpaqx9wzf8frx9myg6m"
   }
  },
  {
@@ -22210,11 +22366,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20250110,
-    2013
+    20250227,
+    121
    ],
-   "commit": "7b7846689845078cb5604508c5075e28e2160efe",
-   "sha256": "1pm3sgf52s7sb0kz4g72nssr8dl3q1ppwbkiiwlqd3b3vj5y2zjp"
+   "commit": "9616e5b5e793c3d8228a8fccf7b9ef7ace365005",
+   "sha256": "0pwjya3s83krx61rfdbqkc0jlsiv9g1fgk3d1wz7ll23rlqgnsi0"
   },
   "stable": {
    "version": [
@@ -22253,14 +22409,14 @@
   "repo": "emacs-dashboard/dashboard-ls",
   "unstable": {
    "version": [
-    20250101,
-    845
+    20250226,
+    929
    ],
    "deps": [
     "dashboard"
    ],
-   "commit": "4eea843e5b7dcc4fe23eaf67b163ed7b13b56613",
-   "sha256": "089w0sxxyarbsm7hcnw5yvrh6vyj3yc0ymvcnks9slw3ia3svxl9"
+   "commit": "68ecc61d7302ccb71b0197096e8c9d80a03ad9b5",
+   "sha256": "15cryscf3x5f55hcvh28kqnblkvdvkhzbj9f62hj2wj2ka61r1bg"
   },
   "stable": {
    "version": [
@@ -22564,11 +22720,20 @@
   "repo": "earneson/emacs-ddate",
   "unstable": {
    "version": [
-    20221031,
-    1611
+    20250306,
+    1709
    ],
-   "commit": "31576a62792743c614e362688b3752b7a959814e",
-   "sha256": "0p2an6mqqshprr8yh9j5r71nasfr50ankg04d8z4jzz4yjigarx0"
+   "commit": "ec3de36ae7bcf71829f03a5063ee9912fcca40bc",
+   "sha256": "08sdhj4gs66dxv5fqpbp3vwm21rasw2qz0853056h19jiqkzz3a1"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "ec3de36ae7bcf71829f03a5063ee9912fcca40bc",
+   "sha256": "08sdhj4gs66dxv5fqpbp3vwm21rasw2qz0853056h19jiqkzz3a1"
   }
  },
  {
@@ -23213,6 +23378,24 @@
   }
  },
  {
+  "ename": "denote-agenda",
+  "commit": "3686fce3ff5df1992672405377209d9189b928cc",
+  "sha256": "1551nhy869f0cqzq6ax72fpxp6kg7vhr4wh6lv97n9ylbpj5vsxl",
+  "fetcher": "sourcehut",
+  "repo": "swflint/denote-agenda",
+  "unstable": {
+   "version": [
+    20250302,
+    2012
+   ],
+   "deps": [
+    "denote"
+   ],
+   "commit": "ad03c7f4778552f9aa42ed5eadac067f2fe8a6d0",
+   "sha256": "1884gwzzz3k2abr4x7j0p5r258njv7q57mlw1im2h4a4danmzjcg"
+  }
+ },
+ {
   "ename": "denote-citar-sections",
   "commit": "9ba5d6796e1c2564f2fb49b6a020ab4f7aa90968",
   "sha256": "00dskskj3gyqcm75akhply0c77z97g3yzx2fr6kvd0mmyc39qi7b",
@@ -23241,15 +23424,15 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20250202,
-    924
+    20250215,
+    2059
    ],
    "deps": [
     "dash",
     "denote"
    ],
-   "commit": "4dbc3441c9d6ae340aabc1e80ae9c86ca781d72e",
-   "sha256": "0jmldsizqiq5ldwk16j98dmyvn65wi6c37gkvljb40aj5gpbm83l"
+   "commit": "3f1678efe3470332bf9395cb07e15b928fb29d05",
+   "sha256": "118wrgfpmk36hm1vfpdfn7andm8r1zbl0cgc0cvwfyigzr1av7v1"
   },
   "stable": {
    "version": [
@@ -23262,6 +23445,42 @@
    ],
    "commit": "d2c1f94b6560d802755b010fcd4438068ddaa12f",
    "sha256": "0773691jxyv039y407c8dppkky41b3icacavddcv9m8v481763b7"
+  }
+ },
+ {
+  "ename": "denote-journal-capture",
+  "commit": "4f1924c03798e91d149e3320ecfcc3fe7428bba5",
+  "sha256": "1221bxdjfd0r4w0m0ila90psqz85g4ab25czr2pfiyj6ka7gyckh",
+  "fetcher": "sourcehut",
+  "repo": "swflint/denote-journal-capture",
+  "unstable": {
+   "version": [
+    20250302,
+    2013
+   ],
+   "deps": [
+    "denote"
+   ],
+   "commit": "6c2c81fff472de81b8e7ba9bccf26788f257ffa6",
+   "sha256": "0kxcdgs2rs0r7a3sahkkg6i00ggiky9lmjjmxjy3picpmjlsm1mc"
+  }
+ },
+ {
+  "ename": "denote-project-notes",
+  "commit": "96fbee4ad0cc8eefeefdf79c0c924d260c1f2dc7",
+  "sha256": "0xlk585a59dq5prcw1z3ym8yygymyl7nv0kfmpr13nfgkcivisia",
+  "fetcher": "sourcehut",
+  "repo": "swflint/denote-project-notes",
+  "unstable": {
+   "version": [
+    20250304,
+    2322
+   ],
+   "deps": [
+    "denote"
+   ],
+   "commit": "f7426374454f43b2846675c72224722422677023",
+   "sha256": "15divkv2b9ypndyb1j6a6aqkfhwqca6yjmsyrrjhm04qjky465n0"
   }
  },
  {
@@ -23759,11 +23978,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20250208,
-    2317
+    20250224,
+    2226
    ],
-   "commit": "463efc61b44bb34f34e44a1cb028f5f69ac1bed4",
-   "sha256": "1sbcmpgvd1c1qvv8iq7w2mvk00ndx2dzhsmkwmcfiwk75bb17hnv"
+   "commit": "c2a402967b4043e104a431ab72c55477805ad2cb",
+   "sha256": "1sh9lwnwngdlhzg4zv728f3qmi5l7a6mnjf62ml4k8rlx0lcvww7"
   }
  },
  {
@@ -23789,14 +24008,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20241205,
-    2338
+    20250223,
+    2320
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "65a5de16e21c87b7c12a78a63fc3b57e07c03c86",
-   "sha256": "19ildcyyhakf7v1ycmk6srrsfxrj70mk6cs8m690wkxmh80fzgbj"
+   "commit": "685e99135001da13caecdff71acea1ee20bed373",
+   "sha256": "0wifczw882r4hl03yvc8m7b9fp06vccffsqji1lfiv4c3szli873"
   },
   "stable": {
    "version": [
@@ -23912,16 +24131,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250109,
-    923
+    20250219,
+    1602
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "ffa3a0ac75ed2533f4814bf7bbd3ec022c6f1eaa",
-   "sha256": "0q56834wh5vxnclj7ywc5p4vg11gp6l2x5lvc176p9q149s98950"
+   "commit": "ddc460e2c7da8b0c8308163edbd8a0a6428c891e",
+   "sha256": "0xczmm39g62275dnlf6jjc5icfwi1gssszabm2j8x1z2k5gf6qkn"
   }
  },
  {
@@ -24897,14 +25116,14 @@
   "repo": "xuhdev/dired-quick-sort",
   "unstable": {
    "version": [
-    20250101,
-    2131
+    20250212,
+    2155
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "68faa3abf52023edead271422a7ac76c0fd5c4e7",
-   "sha256": "1d4fxcf5dwq80p8jcxbvl4sd2g4kb8rlx9kvchwr8bg6wb237zir"
+   "commit": "611acc82919e99ac37ce504934f5e8c605ad7efa",
+   "sha256": "176zr0qcagfcmiqx5hg3vzbw41xfdmc8ws0sr6drc00izl8kj5jp"
   },
   "stable": {
    "version": [
@@ -24979,11 +25198,11 @@
   "repo": "vifon/dired-rifle.el",
   "unstable": {
    "version": [
-    20210316,
-    1452
+    20250307,
+    130
    ],
-   "commit": "cc1af692bbac651f5e5111d9ab1c0805989d65e5",
-   "sha256": "08csqjpwlqln2yk5by9zwh6jsl5kn33jy240d7a1py1d892b7xy8"
+   "commit": "4bc28f2892cf586cde0a200e350b17218dc556c4",
+   "sha256": "1973skckm43qxmzxf4ddbsdnsdm02pda3v3m3mjhr1z0hpr30blh"
   }
  },
  {
@@ -25079,15 +25298,15 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20241205,
-    259
+    20250212,
+    629
    ],
    "deps": [
     "compat",
     "dired-subtree"
    ],
-   "commit": "dd758094849a05c742868e8a9e57f47f7ec4d07a",
-   "sha256": "1kpg220q4hghdjcxmg87w09yr4z03f9knpf0zxs3wz4ggbllgh5g"
+   "commit": "3bc8927ed4d14a017eefc75d5af65022343e2ac1",
+   "sha256": "0vdx5sm7kg2xwvndhjsmixfwlsj45gz0wi5a670pr25268f47mp4"
   },
   "stable": {
    "version": [
@@ -25428,26 +25647,20 @@
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20250209,
-    1504
+    20250312,
+    1651
    ],
-   "deps": [
-    "transient"
-   ],
-   "commit": "2eb0118681dd65836bfa7e3442f5ed152615b533",
-   "sha256": "0c207mz2naqhdcl93wjy958akv2yqlmxqripgvqlawzbaqaf5qjy"
+   "commit": "a8e3a4ddcfe07dce284acb6276515bb813a57e14",
+   "sha256": "13y066sj6ax8czlfp6vy2da310q988vij933wvw31frihwd2v200"
   },
   "stable": {
    "version": [
     2,
-    0,
-    53
+    2,
+    7
    ],
-   "deps": [
-    "transient"
-   ],
-   "commit": "c535e2147171be5506f4ff34e862bacbfb3de768",
-   "sha256": "1nmp5ci4dvcpih6phfhk66s98lf8b49qd35ymy29kqkf5v4cnwga"
+   "commit": "a8e3a4ddcfe07dce284acb6276515bb813a57e14",
+   "sha256": "13y066sj6ax8czlfp6vy2da310q988vij933wvw31frihwd2v200"
   }
  },
  {
@@ -25481,19 +25694,19 @@
   "repo": "jart/disaster",
   "unstable": {
    "version": [
-    20240822,
-    708
+    20250302,
+    1549
    ],
-   "commit": "b20f8e1ef96167a7beed5eb4fc6ef72488bd3662",
-   "sha256": "15qi8szd1cggvy7qjd0z9aryw1qgps7hx97shvz03jakg8ik13fv"
+   "commit": "5b7f7b06ecffa474535afb34cca3e348c59de71d",
+   "sha256": "0xjicvdy5m14g6h1iaswcm202l51kdj7fyyfj6xq5xhf4jnkkq55"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "50232ae95dd3dd149a82fc1b136c191c9ba9f0f4",
-   "sha256": "16ypwbr5yhah4yr0lzj6qwkb720sw1q11cklzbsml6vralbfy0gm"
+   "commit": "5b7f7b06ecffa474535afb34cca3e348c59de71d",
+   "sha256": "0xjicvdy5m14g6h1iaswcm202l51kdj7fyyfj6xq5xhf4jnkkq55"
   }
  },
  {
@@ -25701,26 +25914,26 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20241226,
-    2043
+    20250309,
+    2015
    ],
    "deps": [
     "transient"
    ],
-   "commit": "1062f228a62ec87fe4c40e46bae098117b412790",
-   "sha256": "15qj84l3dwh4zbg890jkk48fpiiy7mr1i0ixk7zcs6hjl1p8as70"
+   "commit": "35a5794fd1cbca11d6070e30a2344f97042e7343",
+   "sha256": "06vhsf997jdprh9y2z5lhz73fxl1mq99z6767lmmyavm2hxbxscp"
   },
   "stable": {
    "version": [
-    1,
-    3,
-    1
+    2,
+    0,
+    0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "bbe8f5cb9a2b5ef7482d3a109c81d6622c55677a",
-   "sha256": "03wf14vilnysj9szcffsadhw86p68v3083dv98d99c8axm51n6hz"
+   "commit": "d665f9f72f3736f3059db55496966b9c4b343d25",
+   "sha256": "0550bfqbprbr9s36xgyrwdg2mrry28j5cbd7fms980ixn6a4vcx5"
   }
  },
  {
@@ -26345,11 +26558,11 @@
   "repo": "spotify/dockerfile-mode",
   "unstable": {
    "version": [
-    20240914,
-    1549
+    20250225,
+    1527
    ],
-   "commit": "4d893bd2da15833ce056332e6c972d5d93e78f04",
-   "sha256": "1cdcdzmw4i1i73q0dgjpk4wmwkr71wijz642l2g5l36cik5whk41"
+   "commit": "7ce17e054eca4d56ca8bc1e4a6a0dbf58efd8d52",
+   "sha256": "1ilnfv57d2rinf0np3i675gfdv8n6iv8vlls92m6d45yahykqacw"
   },
   "stable": {
    "version": [
@@ -26602,16 +26815,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20241225,
-    206
+    20250313,
+    703
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "9d6f0f9635ae722b6bd943a76e996f54443e373f",
-   "sha256": "1704ikj93j9wvf4gc7dvmbsrhnvjiyd8r2j5i1m4m63f2536gvby"
+   "commit": "ec27cdb3cf1fec1db63c752b3654c9de28e22089",
+   "sha256": "0rl1z12749zzvibp0l80q38mw854zzff4yycgmhci8pr5avjwk63"
   },
   "stable": {
    "version": [
@@ -26655,14 +26868,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20250112,
-    1812
+    20250225,
+    429
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e506a8724156da3b1e62cb8136265e9705549d04",
-   "sha256": "1nq535423ap74qad58q06s3hhngqq763j8rvawv1iz837fym9s07"
+   "commit": "88126db5e63d816533d0372cb99246b842cac74e",
+   "sha256": "1wrl83iczlzdnig4gmpw5g7c54h2j4lpdgm8yxkb8dnp9ksv806v"
   },
   "stable": {
    "version": [
@@ -27334,16 +27547,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20240625,
-    224
+    20250310,
+    2014
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "cd65a743370ac7b1a12e9ef0a7371b285a2597fb",
-   "sha256": "1ly7xsfliyw38hqh862p6m37mxl460k4zq1fy3xs0jz9q3ak84iq"
+   "commit": "737267a6139a988369cb95ecd365b2db95e05db0",
+   "sha256": "1mr06xiqqrknalg7a1xp1kgc4m9pm23sanhq1s3pzsqr6zz1p0zi"
   },
   "stable": {
    "version": [
@@ -27569,11 +27782,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20250131,
-    1520
+    20250218,
+    1720
    ],
-   "commit": "d1e35b09ac7ad0fc7571083248f8d54a40250883",
-   "sha256": "1lf0r4bhjb8w8pa7j22pyf56qhiwz7lfs7mbxmh5ly3kd7a2bsad"
+   "commit": "4b077432a94873e5f505c8f569743cfd984eebb1",
+   "sha256": "031icdbca6f9j453h07hwmxl0jc4i370lpn2y6lcqhqv4fw5c1lz"
   },
   "stable": {
    "version": [
@@ -28082,11 +28295,11 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20250131,
-    627
+    20250226,
+    2354
    ],
-   "commit": "50b70ff0e67bbdbdbf9c37570956c5c47bf50bc2",
-   "sha256": "1gnpn48bj85as7a5c0aasjrhij5wdx3rnl7fhh00kwq8d1s7a40h"
+   "commit": "8d831ff25d085634e288b35d4774f8c4a48a4d76",
+   "sha256": "03hafc1q3gfk6pcx4ijrrzk1isljc4jka67wx5gv6h7hgwvkwxh7"
   },
   "stable": {
    "version": [
@@ -28348,14 +28561,14 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250207,
-    127
+    20250308,
+    2208
    ],
    "deps": [
     "f"
    ],
-   "commit": "bf955796138c155e7ecf62acbde465c3908f1691",
-   "sha256": "038gm369i790c8qyfifs5db2cm1g8vvxglbck16bxvmwvk2w4f6v"
+   "commit": "0e7ce6d69945cfc4a0cbbc758048dc3d50ddda71",
+   "sha256": "1gsd5a9kmmgbkcjyqqvapdgydn2399jgvyl0zng1irl19pkrjjg3"
   },
   "stable": {
    "version": [
@@ -28443,15 +28656,15 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250122,
-    1155
+    20250222,
+    1322
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "afe85e3d048ec602ededc24d241b4d8bd459ea99",
-   "sha256": "0b2ybyjnw8ig7vjw4x7c1dsvj7d56b7a8nmli7nbsp5ncz6w7jpp"
+   "commit": "aa54f33ee2b1205e651da1153014c128d82f1659",
+   "sha256": "028b6dpwaidjfc6h79wlfqggxdc4adng72amgsgm0hik70a604v0"
   },
   "stable": {
    "version": [
@@ -29018,11 +29231,11 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20241027,
-    1815
+    20250219,
+    1528
    ],
-   "commit": "24f5b2b1cd4e37adc245fb59f7edeb6872a707a4",
-   "sha256": "1yh5pz34aldn75z6vpfmc93jklvd7fd8azvwcq1d7cl352jf5i5r"
+   "commit": "1a9942746cf5b10daae8962f380b5f2a459086f3",
+   "sha256": "0l875294xqzaz2qv14jcqqx39jd08ibz0npfjg6rvnggzdm2f2jv"
   },
   "stable": {
    "version": [
@@ -29184,8 +29397,8 @@
   "repo": "sebastiw/edts",
   "unstable": {
    "version": [
-    20241202,
-    25
+    20250214,
+    2310
    ],
    "deps": [
     "auto-complete",
@@ -29196,8 +29409,8 @@
     "popup",
     "s"
    ],
-   "commit": "d38f538c8e3fb285fb3c66b87eb68eba4ed074c3",
-   "sha256": "00yzvgvriak3ykgr13hvsvb51gai4p2m2wijjrrs3m5bzrsg0qkm"
+   "commit": "5481bcbe61f2843fbb939daac5a32e59b9acfd69",
+   "sha256": "18cnch0l3xrh39f42302ff4357qk02jyvwpjfpd602grm205m3gv"
   },
   "stable": {
    "version": [
@@ -29651,11 +29864,11 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20250106,
-    2030
+    20250215,
+    2014
    ],
-   "commit": "0e41fa0315b2e499dd0947cdda05d9a2e1aa2203",
-   "sha256": "0pjp51di1jv7ziq4sf0q526jjjizvrd8xw5qlzjd2pz7gsz754rc"
+   "commit": "6e697ad705f792f63667b28a23d0e188dff14178",
+   "sha256": "0vgr9vxjm6zp468qw2zr7pgl91xrckhdvkp9syv2gqqa5c6kp2dr"
   },
   "stable": {
    "version": [
@@ -29690,8 +29903,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20230827,
-    325
+    20250307,
+    1731
    ],
    "deps": [
     "anaphora",
@@ -29702,8 +29915,8 @@
     "websocket",
     "with-editor"
    ],
-   "commit": "ac92eb92eac35a9542485969487e43f5318825a1",
-   "sha256": "1yypv9gi3f3bjy7qgy21r7p0iff9wxq4cjjvr1ynf15c0hkdydiz"
+   "commit": "271136654631d42105164163fff3d8ceec4c5e40",
+   "sha256": "08yjlikjxybha49fw6if3ms9dj2v2sbhyyc0k4d5afiq360bwr9r"
   }
  },
  {
@@ -29788,15 +30001,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20250128,
-    1448
+    20250313,
+    436
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "8aabfa6201e2590bc47e908721ad05e3716d9add",
-   "sha256": "00brvkxyzjvyns2x35hb4xccmcp1bccx0y67zqvamrmwv6f2p04h"
+   "commit": "eb79cc31ec6ee93ef1db97868b6e2d7593321441",
+   "sha256": "0mp97z5bnz5wnk7pgd432k828wypwiwlv7fwkr21wwrr0181jpr9"
   },
   "stable": {
    "version": [
@@ -29975,26 +30188,20 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20250131,
-    953
+    20250313,
+    1138
    ],
-   "deps": [
-    "compat"
-   ],
-   "commit": "aa852eaf10b5a9b1618d4c3447b15606b88da4c8",
-   "sha256": "0mj92dsd169ij2g3vmq626vdh5aqc9zbc43yjip7dl1qy4lh34sk"
+   "commit": "33ee1713e1219e4f86c7817cb5491e7532750afa",
+   "sha256": "0n7gh9awd3fhr0hnwdbk0wsqx8sl01pyaks2jpvzcr532al2mn7b"
   },
   "stable": {
    "version": [
-    0,
-    3,
-    23
+    2,
+    2,
+    3
    ],
-   "deps": [
-    "compat"
-   ],
-   "commit": "aa852eaf10b5a9b1618d4c3447b15606b88da4c8",
-   "sha256": "0mj92dsd169ij2g3vmq626vdh5aqc9zbc43yjip7dl1qy4lh34sk"
+   "commit": "33ee1713e1219e4f86c7817cb5491e7532750afa",
+   "sha256": "0n7gh9awd3fhr0hnwdbk0wsqx8sl01pyaks2jpvzcr532al2mn7b"
   }
  },
  {
@@ -30335,11 +30542,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20250121,
-    305
+    20250304,
+    1743
    ],
-   "commit": "fbcce82150a02f5c8cdb00293e45c17006c208c2",
-   "sha256": "1x8hyhqxxg6zli32biq5ifw6rhjcabwzdaj3jbzvzjdqdgb8crwv"
+   "commit": "deeb22f84378b382f09e78f1718bc4c39a3582b8",
+   "sha256": "1w9258vdl994l786vmhzx2xm8mb9rvc9v0fl12qib5fvfgk51d15"
   }
  },
  {
@@ -30399,11 +30606,11 @@
   "repo": "emacs-eldev/eldev",
   "unstable": {
    "version": [
-    20241217,
-    1230
+    20250312,
+    1010
    ],
-   "commit": "42f80c129264ab666e3ff589ee3bbc8f6c51a637",
-   "sha256": "0p00m7v1vsf4rs1w19ahy27lvf0wbrc5lh1243fyh74xllmg0kyi"
+   "commit": "0d001f26a7e50e46b342a84eccf92940649bd5fe",
+   "sha256": "0h1a0k9fljxvll5q71ki74lf5vgdrjbr3js81wyrjshcasn1nwfa"
   },
   "stable": {
    "version": [
@@ -30911,16 +31118,15 @@
   "repo": "remyhonig/elfeed-org",
   "unstable": {
    "version": [
-    20231009,
-    1125
+    20250219,
+    950
    ],
    "deps": [
-    "cl-lib",
     "elfeed",
     "org"
    ],
-   "commit": "fe59a96969bd321f5f9ec7317a4bc80943b94c86",
-   "sha256": "1ag0864vgvwdz3kmk5sj5hq25l7v7pqn33iyhhsd897wgqcmr2dk"
+   "commit": "1197cf29f6604e572ec604874a8f50b58081176a",
+   "sha256": "0giwnzlqk2s5hb6fs8a0l4dxcmn2fvkngpj1fayzwj0qnvds1kri"
   }
  },
  {
@@ -30963,26 +31169,26 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20240711,
-    433
+    20250217,
+    337
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "c2be8c12d4c1e7027409d4a1b7876da68f3c167c",
-   "sha256": "0kmg3pciqihs8r5xja3pv48gzkn3vs6y6ij0dlmzmavymfp7hq5z"
+   "commit": "5ab2382d54baa4ee54b2fc54d7de54ec6e488c74",
+   "sha256": "16dsv9nqc71hpdxcy8xspy6ji32q8j38ikq57kxrvkysv2zsjzy6"
   },
   "stable": {
    "version": [
     1,
     2,
-    8
+    9
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "c2be8c12d4c1e7027409d4a1b7876da68f3c167c",
-   "sha256": "0kmg3pciqihs8r5xja3pv48gzkn3vs6y6ij0dlmzmavymfp7hq5z"
+   "commit": "5ab2382d54baa4ee54b2fc54d7de54ec6e488c74",
+   "sha256": "16dsv9nqc71hpdxcy8xspy6ji32q8j38ikq57kxrvkysv2zsjzy6"
   }
  },
  {
@@ -31201,11 +31407,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20240801,
-    1325
+    20250224,
+    2229
    ],
-   "commit": "43a44dcbd17adf3b235de93e748321c7076f1c3c",
-   "sha256": "1c03qssa74jrsszcsvz1whj5md5vcdximxg8yfyq0s3spld8bs2n"
+   "commit": "5d6d843d2a94aa462c32456e2ec751ce5ca3cab0",
+   "sha256": "16062wbkxfg39q2c5v2j64vymx9sxvhzkpmrlajgrgas6jxyacc6"
   }
  },
  {
@@ -31515,32 +31721,32 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20250209,
-    1407
+    20250312,
+    1931
    ],
    "deps": [
     "compat",
     "llm",
-    "spinner",
+    "plz",
     "transient"
    ],
-   "commit": "e037bbd213a0441c1aa37a72a4c9cb7039df38ef",
-   "sha256": "01bzcd8sk26rkz3aj9v1dxp9p0wjvivvl9xxxj0hlzar79w5ayki"
+   "commit": "a97cfc250998efadfc728a1021770294d150d77f",
+   "sha256": "1lcrfnb9fbc6nb14hjc0v24cq309vd7wsin80gy9v97y22bdmpnv"
   },
   "stable": {
    "version": [
-    0,
-    13,
-    9
+    1,
+    5,
+    4
    ],
    "deps": [
     "compat",
     "llm",
-    "spinner",
+    "plz",
     "transient"
    ],
-   "commit": "e037bbd213a0441c1aa37a72a4c9cb7039df38ef",
-   "sha256": "01bzcd8sk26rkz3aj9v1dxp9p0wjvivvl9xxxj0hlzar79w5ayki"
+   "commit": "a97cfc250998efadfc728a1021770294d150d77f",
+   "sha256": "1lcrfnb9fbc6nb14hjc0v24cq309vd7wsin80gy9v97y22bdmpnv"
   }
  },
  {
@@ -31900,11 +32106,11 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20241022,
-    1625
+    20250306,
+    1504
    ],
-   "commit": "a1c5fbf16b528fb67d087437d44d66e9edc99664",
-   "sha256": "0pkgk7608w31kvdjid54xfrc5zrbrzwi98wrglwl07s429xlbai2"
+   "commit": "972a069f240f071a79da23c98d3519df45bb5851",
+   "sha256": "0jv3v8pbncrnniz7wphp7gzlp9vbc2ib8psn2bhil2jhc2s6kj59"
   },
   "stable": {
    "version": [
@@ -32282,28 +32488,30 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20250112,
-    1452
+    20250301,
+    1701
    ],
    "deps": [
     "compat",
-    "llama"
+    "llama",
+    "seq"
    ],
-   "commit": "9dcfcaa2bb3ff01fdf6ca18a8e768433d070b9d6",
-   "sha256": "1linxzr0mkjz7zmvjddrkr628v2vqhhbqv2m5cpbzm1rscqk7fim"
+   "commit": "ff70b824c17193af6e66f748573d5120a3527377",
+   "sha256": "00savh3hgr1m14h84hnjfp8k1j38b7wmv9bwkchnzzrcy291azhx"
   },
   "stable": {
    "version": [
     2,
-    1,
-    0
+    2,
+    1
    ],
    "deps": [
     "compat",
-    "llama"
+    "llama",
+    "seq"
    ],
-   "commit": "9dcfcaa2bb3ff01fdf6ca18a8e768433d070b9d6",
-   "sha256": "1linxzr0mkjz7zmvjddrkr628v2vqhhbqv2m5cpbzm1rscqk7fim"
+   "commit": "ff70b824c17193af6e66f748573d5120a3527377",
+   "sha256": "00savh3hgr1m14h84hnjfp8k1j38b7wmv9bwkchnzzrcy291azhx"
   }
  },
  {
@@ -32314,14 +32522,14 @@
   "repo": "lanceberge/elysium",
   "unstable": {
    "version": [
-    20250119,
-    2338
+    20250216,
+    2328
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "98476a2b7165dc31a9e25c4528db70efecf57f1e",
-   "sha256": "05vzqj8cpnyxda122bcd4ihz635ikg4ggj87pj51sj2lszpwngyf"
+   "commit": "21276b513f009f291594ba072f5e5fbf9c14d2d8",
+   "sha256": "0marbjrg3nfdzgpqv1n0151b00kdbvcp2v67b9fwdqhwxm9hmi1b"
   },
   "stable": {
    "version": [
@@ -32398,20 +32606,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20241201,
-    1551
+    20250301,
+    1637
    ],
-   "commit": "d6529f010a0573630122b826230e72157ab8fa88",
-   "sha256": "1wp6sx6nwjvn1laxgsm5pciilq59sigk85l1iwlchhi5i94ma29z"
+   "commit": "f111b0acc79eadeeb3c6c1332d943f11fd6932ff",
+   "sha256": "08zc3x6cgbn2x67xajz8rnika3bhd86yb6h77q8wg1dxyh1ib2m9"
   },
   "stable": {
    "version": [
     4,
-    1,
+    2,
     0
    ],
-   "commit": "d6529f010a0573630122b826230e72157ab8fa88",
-   "sha256": "1wp6sx6nwjvn1laxgsm5pciilq59sigk85l1iwlchhi5i94ma29z"
+   "commit": "f111b0acc79eadeeb3c6c1332d943f11fd6932ff",
+   "sha256": "08zc3x6cgbn2x67xajz8rnika3bhd86yb6h77q8wg1dxyh1ib2m9"
   }
  },
  {
@@ -32642,6 +32850,21 @@
   }
  },
  {
+  "ename": "ember-twilight-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "07v58l7a6nzl0wvvwljvnj9qipfjkqmv6gxs6fd8g84k33w8rs0d",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250224,
+    923
+   ],
+   "commit": "ae9a0c318c371ed70ec568f3a618d47124817fe7",
+   "sha256": "10pkpv4i1xv2cv9ma3mnavrm3xvffa5nwxa66nrzvvrkvcjbpg82"
+  }
+ },
+ {
   "ename": "ember-yasnippets",
   "commit": "6c37a13d56e9a0a4e7e2c11349ed87610a0f6b2c",
   "sha256": "1jwkzcqcpy7ykdjhsqmg8ds6qyl4jglyjbgg7v301x068dsxkja6",
@@ -32756,16 +32979,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20250204,
-    2022
+    20250313,
+    1342
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "5e9922f2a45fc4b869bd4947540903ea15acfeb2",
-   "sha256": "004riskycjkj9c305yf0rkfkkbl95rwsxp6jpcb2ivaw5kn2ai5p"
+   "commit": "3286ac88bf2c306bd66431205eb80ca3bff3e7ef",
+   "sha256": "0gczgnkvls5dr69zh9qcdh4m2f5zqgdx8y6z35cdv3lcbrvc4vkh"
   },
   "stable": {
    "version": [
@@ -33167,15 +33390,15 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250124,
-    1233
+    20250225,
+    1652
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "a27c9d29bde03ee6ce7f9a84e449c50066566087",
-   "sha256": "043xckqwvfn8gay1a21rs24pd8k6c9apjk66mhmlsb57mc6mnmld"
+   "commit": "4c660fe44f7ea562896924ce9de28cd37ef15a38",
+   "sha256": "1lb2fcry04rcdyviacfp9s9rz7nsxskyr00md59cm6zflrv6wrgv"
   },
   "stable": {
    "version": [
@@ -33676,8 +33899,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20250205,
-    1933
+    20250302,
+    4
    ],
    "deps": [
     "closql",
@@ -33685,14 +33908,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "dad7206206f9d329695b5559a601591a2037709f",
-   "sha256": "18n5w378mx863dbsg7p64n613bp36swdmjl5ff3jdfrjirx78vr6"
+   "commit": "553550bf285af0f168ce8b58483d70ceb3dee73f",
+   "sha256": "1a6zw1z318ip4vnqfgv99b2knbm3qq6ji7spqq9g5w3lls40aqvx"
   },
   "stable": {
    "version": [
     4,
     0,
-    3
+    5
    ],
    "deps": [
     "closql",
@@ -33700,8 +33923,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "d28ce2f7d57c2f082506d25e653b68673daf33c2",
-   "sha256": "0zdlymx44jgrzm68cnh636mpdazihqiakf5m3v1c2rhvh6cb6yg6"
+   "commit": "553550bf285af0f168ce8b58483d70ceb3dee73f",
+   "sha256": "1a6zw1z318ip4vnqfgv99b2knbm3qq6ji7spqq9g5w3lls40aqvx"
   }
  },
  {
@@ -33712,30 +33935,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20240821,
-    2319
+    20250302,
+    21
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "58d5f2b6b6f68a22510cf4301dadf2ec4b5ffcaa",
-   "sha256": "0kbflck869lbwh9l97231jxpypmx0fm7vlxafqfyf69vpsiib5xh"
+   "commit": "ad41118a3fed2b4312a0b3266ffa029996523aa4",
+   "sha256": "1mkd0677mr21cyksv681nfvysc0r6xcc60h0pvr2mrlag97m50nh"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    2
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "58d5f2b6b6f68a22510cf4301dadf2ec4b5ffcaa",
-   "sha256": "0kbflck869lbwh9l97231jxpypmx0fm7vlxafqfyf69vpsiib5xh"
+   "commit": "ad41118a3fed2b4312a0b3266ffa029996523aa4",
+   "sha256": "1mkd0677mr21cyksv681nfvysc0r6xcc60h0pvr2mrlag97m50nh"
   }
  },
  {
@@ -34402,11 +34625,39 @@
   "stable": {
    "version": [
     27,
-    2,
+    3
+   ],
+   "commit": "05737d130706c7189a8e6750d9c2252d2cc7987e",
+   "sha256": "1g5nhsq26gknz8705k9lk0vgmlwkimzzw90vx1wqswkdm7crsgv5"
+  }
+ },
+ {
+  "ename": "erlang-ts",
+  "commit": "3faacc9ffe6cdf85f2492022d0823bc1c3a048ef",
+  "sha256": "1bq7ym7v85nv49f4m4hnsgas0816bbr6h1dddwz8dnws495y65h4",
+  "fetcher": "github",
+  "repo": "erlang/emacs-erlang-ts",
+  "unstable": {
+   "version": [
+    20250202,
+    1841
+   ],
+   "deps": [
+    "erlang"
+   ],
+   "commit": "eb579dd55fbb2cf721290939e7b3a50be19c0305",
+   "sha256": "055gmrlx30jm9wzgbkqpf0z9bsmaqgywxxnw41w7ia00wwfwh562"
+  },
+  "stable": {
+   "version": [
+    0,
     2
    ],
-   "commit": "8a4e04e9c48d94ef1216b0426fa71ccfdd78f7d3",
-   "sha256": "0y287gvbl0zw7i2j27pp0lkcn8q408qv3fmxw669wm14q0q83yak"
+   "deps": [
+    "erlang"
+   ],
+   "commit": "eb579dd55fbb2cf721290939e7b3a50be19c0305",
+   "sha256": "055gmrlx30jm9wzgbkqpf0z9bsmaqgywxxnw41w7ia00wwfwh562"
   }
  },
  {
@@ -34846,14 +35097,14 @@
   "repo": "SqrtMinusOne/eshell-atuin",
   "unstable": {
    "version": [
-    20240519,
-    2200
+    20250301,
+    833
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b8bff27bbd7d4e7c28770d6f88d8ebcb1b965a9e",
-   "sha256": "0rqjljiwb1j345a4y2md44dbk6qpicz02cbzrbpfbi0a937y0222"
+   "commit": "1ac4895529546839985c7f57c9858644f7be1e6a",
+   "sha256": "0zf62qdmqw7y7s1dg3d35abr9jaymyqfbrv4bplkrry2wwk0m4gx"
   }
  },
  {
@@ -35068,10 +35319,10 @@
  },
  {
   "ename": "eshell-prompt-extras",
-  "commit": "cdd1f8002636bf02c7a3d3d0a075758972eaf228",
-  "sha256": "1k0cig7chdm349bp6rz9z105njs9bxicnpkcm4v0nrnk59ynj2h6",
+  "commit": "02892d9ff96c5b0061619e7bd864fe65ae34fba8",
+  "sha256": "0a6kk345v4z7rrh4qnhbvqwgkg9cq1nhijh66cdlmk073pkcv6y8",
   "fetcher": "github",
-  "repo": "zwild/eshell-prompt-extras",
+  "repo": "suzzvv/eshell-prompt-extras",
   "unstable": {
    "version": [
     20231019,
@@ -36083,26 +36334,26 @@
   "repo": "daedsidog/evedel",
   "unstable": {
    "version": [
-    20241215,
-    2233
+    20250303,
+    1213
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "d1c7d008fce74bc738231e18064708b2f0d4d710",
-   "sha256": "1p0ncycwh4y6fn8pwxniizmn7h4qlgn2ljsaa8ijbpm5rgydx9cq"
+   "commit": "d979801f5f496ff20aebf4c3343bffcd0e0d3a0b",
+   "sha256": "0y6q45rzs7sl6gjpvxd8kgg550my2jjg4kmvhj63kvvhxrixv4p3"
   },
   "stable": {
    "version": [
     0,
     4,
-    16
+    20
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "bea64bd0475d1c2a4a84b9533740ae03712d0d6f",
-   "sha256": "0qz1x1zah1zm51pf2qh2vr9c96d2d2w5z4izb9djmaqrw112gara"
+   "commit": "86e124da13b7d05b57a750c43bbebbec1874973c",
+   "sha256": "1i7ybd91cc8zdm245nkqnm73irwhbqqb7jj19v8zvf5908nkxzlc"
   }
  },
  {
@@ -36113,11 +36364,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20250204,
-    2341
+    20250309,
+    138
    ],
-   "commit": "473aa509a3d4135d5b2bebe978476a3d96779072",
-   "sha256": "0b58gsz32r3srbcr5jjqm2b9bhdnvfqy8xzgglvqjiy5cs489vpb"
+   "commit": "9e551dbfb8aea093628ee4f62ba9836c9c437192",
+   "sha256": "10bqnk1sg2adrynp0qvpnbypr7n26hlynw8s8nhwj7ns62104fd5"
   },
   "stable": {
    "version": [
@@ -36160,16 +36411,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20250121,
-    1800
+    20250302,
+    655
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "c222ce1ea6fbefaed08308c061371ebdf01b078f",
-   "sha256": "1idsjcycw0s1v7ixj5202fa63ld3axxn4lh7p45wz9yh3wk5vs3v"
+   "commit": "ac620beace5f28fbf40cd69765975bf6e915c01c",
+   "sha256": "1shn64qa3ygxzag657096jijpk4fg246qvc9db1d5648qmfya6fd"
   },
   "stable": {
    "version": [
@@ -36362,15 +36613,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20250124,
-    1436
+    20250219,
+    1559
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "7ab9179591bc2f9474f480f52ec8dc44cf0a05f1",
-   "sha256": "0409lx529lml1g2jz7wl0vw6n5x0wnpmj7ir2vcp7msjgz89ji8g"
+   "commit": "cb850ff0d11f644dbd133428cff57e82e655ecd7",
+   "sha256": "1gqzqwnclg2nh9dnicc9adlzsfpn93r97gnz7ghxir36rl4b8ihd"
   },
   "stable": {
    "version": [
@@ -38765,16 +39016,16 @@
   "repo": "walseb/exwm-firefox-evil",
   "unstable": {
    "version": [
-    20231026,
-    309
+    20250311,
+    952
    ],
    "deps": [
     "evil",
     "exwm",
     "exwm-firefox-core"
    ],
-   "commit": "ec9e14eca25aea9b7c7169be23843898f46696e7",
-   "sha256": "1fbxll1ylkrkk6jm4mwcdvpix23dxvfsgl2zs10lr823ndydk1b6"
+   "commit": "c87d601de9bad4d3cbf41c69281073b465a66769",
+   "sha256": "1466l5v3a7gmx95sjhnyc9ph4jcik18zblyki6mx9v46p82niahm"
   }
  },
  {
@@ -38829,14 +39080,14 @@
   "repo": "SqrtMinusOne/exwm-modeline",
   "unstable": {
    "version": [
-    20231225,
-    2340
+    20250222,
+    1334
    ],
    "deps": [
     "exwm"
    ],
-   "commit": "f72e65818f90c754edb8d0dcff47e8248a7f0a56",
-   "sha256": "1qwxhkp5phbnzfijxlg7ldr68wpny4y07khhlbik3s6bn6829afh"
+   "commit": "c933baccb8535a81ebae06a5dc4245b801c47f06",
+   "sha256": "19csnf2qgkwy8gpdn1bx5fifw4ibjw3kbjhsabhjbr3j529p5v45"
   },
   "stable": {
    "version": [
@@ -39759,11 +40010,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20241223,
-    2116
+    20250312,
+    1613
    ],
-   "commit": "3632cc77de3ba350297b46bea9ccc3e41e4c1def",
-   "sha256": "0bgkg8zi4555j9pn1ccjqpf2v3idp7p99mxn6amhv65jxvcwmj02"
+   "commit": "ec185c3ca05703fa6734dfb8934c352f34d54572",
+   "sha256": "1k7pc5ax83ryaphkq36620ddbnr0k70ria6mnbf9ac5y658rq6kj"
   },
   "stable": {
    "version": [
@@ -40265,8 +40516,8 @@
   "repo": "LaurenceWarne/finito.el",
   "unstable": {
    "version": [
-    20241109,
-    1535
+    20250209,
+    1956
    ],
    "deps": [
     "async",
@@ -40277,8 +40528,8 @@
     "s",
     "transient"
    ],
-   "commit": "d5b48c426e4f236127ff256a16be0299c743271f",
-   "sha256": "1bggi8jj5dqhmd71ld4cqr81w8v5f1q1y07chjp96bwrpchbngkf"
+   "commit": "7dc99cc22053038777bdff06d34db323047976bb",
+   "sha256": "1v30q9vm6lz8gkipi1s5b0w40yprsw34bif6bjrpcjh8hzq6kcyk"
   },
   "stable": {
    "version": [
@@ -40901,17 +41152,17 @@
  },
  {
   "ename": "flexoki-themes",
-  "commit": "a7328b13097d6dcbf0e2ad6cc530ce03625e926f",
-  "sha256": "1ikim26d8w4k8p8264wwrzcl335x11dd79g0yndbbzh4sd6d9d9f",
-  "fetcher": "github",
+  "commit": "45e87fc1fc52dc3d7df148a4b5adf306cbda63ce",
+  "sha256": "0b80irz1xg41n1sf6zclrrjf9cj2x607qwali9mrqg3v753laqyx",
+  "fetcher": "codeberg",
   "repo": "crmsnbleyd/flexoki-emacs-theme",
   "unstable": {
    "version": [
-    20250114,
-    959
+    20250228,
+    1934
    ],
-   "commit": "a777d2377a3d80af625c701d182c396316c0338d",
-   "sha256": "0sdnq0xhwy91zbyazdshjc3izkccq782ivvn7dmx5js0nzj6xqj7"
+   "commit": "4ca5d80bc4f33b5ace8950f0c00069539835fab4",
+   "sha256": "0yka5ry44cfdwgfbl2bwix3pfnrvziyq9bza64j21f5f3kjwdmw2"
   }
  },
  {
@@ -41223,11 +41474,11 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20250201,
-    759
+    20250226,
+    1541
    ],
-   "commit": "af1e8ca7257298dd6c51ed4424c09283b4fedb7a",
-   "sha256": "1r5w7b4v4vk0b5dw07yz9mq27ngz4m55yl4a7ih7s252a9kca4dk"
+   "commit": "b9db1379dcc3e59238dc1fdd7db368c66e8734ba",
+   "sha256": "1ny1lqmh55bwfgsrgr5rg13gbgqp5rdw5sx72hz1nx2vfcwcklvl"
   },
   "stable": {
    "version": [
@@ -41867,14 +42118,14 @@
   "repo": "flycheck/flycheck-deno",
   "unstable": {
    "version": [
-    20250101,
-    902
+    20250226,
+    2238
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "47671457b649b2de422cd56f7b3950aabc015c1f",
-   "sha256": "1rsjyilrj3sm1giy1g0g3kzd4g65k3x4rsykfg291cr815fa7fai"
+   "commit": "d59b0cceb81b776a7143d7e25e06f7c3e71aa56f",
+   "sha256": "08gakqkigqzwg9884606z03jq3p3ccar1ad5xyapbfhmk5v0bqh5"
   },
   "stable": {
    "version": [
@@ -41933,15 +42184,15 @@
   "repo": "atilaneves/flycheck-dmd-dub",
   "unstable": {
    "version": [
-    20210412,
-    1608
+    20250304,
+    1432
    ],
    "deps": [
     "f",
     "flycheck"
    ],
-   "commit": "818bfed45ac8597b6ad568c71eb9428138a125c8",
-   "sha256": "19xgj1z1b6m30syq2ps99v1gk76prmvh27nqj83nbqz57nqa0vjb"
+   "commit": "c1bf54b7eca8951a38ce9f6ae12e07a011f03eb5",
+   "sha256": "1i4vdci0bnpsj5vidjd25wya748krzq0v6k3p3pgz7fq9hmrzjqn"
   },
   "stable": {
    "version": [
@@ -42019,14 +42270,14 @@
   "repo": "flycheck/flycheck-eask",
   "unstable": {
    "version": [
-    20250101,
-    901
+    20250226,
+    939
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "f93e5dd30aa9f7c612823760867c2f361fde6631",
-   "sha256": "0zfck269hjax9hs1y46gy6b4dg2ymhlh583az3pad99mjhdfyl2m"
+   "commit": "8a7f847466935b5937e93f5ccbd4711812d962a3",
+   "sha256": "1rrrwr36m6ppscj6fjpsyfm8zkjmhg6asnbm26gsj1x0ln1k19xg"
   },
   "stable": {
    "version": [
@@ -42244,14 +42495,14 @@
   "repo": "weijiangan/flycheck-golangci-lint",
   "unstable": {
    "version": [
-    20240329,
-    1647
+    20250211,
+    1910
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "91c59b128aa6f719069cfb3e5df77588691a3e14",
-   "sha256": "1qw3g0vaj0nf6kf0ga0hayyv099g27s7pa472760fwx2v857vns6"
+   "commit": "424ba1b3a13f5548c440b7a25822932ad4b51cd6",
+   "sha256": "1a58anq6vzhwl0z45rrm1y28fl8qh2yhmi6zd8kc9jmsavp4019w"
   }
  },
  {
@@ -42292,14 +42543,14 @@
   "repo": "flycheck/flycheck-google-cpplint",
   "unstable": {
    "version": [
-    20250101,
-    901
+    20250226,
+    2239
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "9b2f8eeb46874cbb0c34caaa91ac3cdc3d0d6f56",
-   "sha256": "1zrphyisppbvga44pz1pp6zhcn3jdxzb37d62w7plbb56ydrf8fd"
+   "commit": "bba4b07ef39fe2c1d404584c0a561e4e0c5dc90d",
+   "sha256": "095qgwj7146a5arnckajrmp0yqzmxas3bjvq2hqns8qlg381l7y0"
   },
   "stable": {
    "version": [
@@ -42369,16 +42620,16 @@
   "repo": "emacs-grammarly/flycheck-grammarly",
   "unstable": {
    "version": [
-    20250101,
-    849
+    20250226,
+    2244
    ],
    "deps": [
     "flycheck",
     "grammarly",
     "s"
    ],
-   "commit": "3cb1853bcdf62856604a081c0d88ae09d69f1601",
-   "sha256": "0rsinzcwa767hib01hl36p9b6c5swfv45fhbq7dvv6g0zm0hkhrw"
+   "commit": "34ee0901e1de05b0c60208293c8beb9a4587e5c7",
+   "sha256": "11iir8bqrv1f1hl8prfm6dm30jql89sbby5vvzkcqgyfzwvrh60j"
   },
   "stable": {
    "version": [
@@ -43604,8 +43855,8 @@
   "repo": "flycheck/flycheck-rust",
   "unstable": {
    "version": [
-    20250101,
-    902
+    20250226,
+    2240
    ],
    "deps": [
     "dash",
@@ -43613,8 +43864,8 @@
     "let-alist",
     "seq"
    ],
-   "commit": "d499471ec433a62898a95ce76561964e3d015ce5",
-   "sha256": "09vjwk1k0z3lrl2z1hdf59v9cc2k3sac3vy3s6gcf4az9kvq38zh"
+   "commit": "2b544bab19b987bfb41d5d88801b89e29bdf69c7",
+   "sha256": "1kdvq7cdnx6pm8yjm1zyyyg9xj20y3lshcash4bpdmfiswki6y08"
   },
   "stable": {
    "version": [
@@ -45334,14 +45585,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20241214,
-    532
+    20250217,
+    2352
    ],
    "deps": [
     "project"
    ],
-   "commit": "b877f47eb9da608a40cc1bc25826d2176494bf6d",
-   "sha256": "0wpcwvnvldm99i0wbvsbxm8bz9acsis8ihp7wp1xd185p8k5cilw"
+   "commit": "7921f331defb1c6e071b4b56d9c61c4c8a7de572",
+   "sha256": "13fy1pyi2kxjh8f499njpqsj0mf1khh3lzdxsyk9vw34c22263s5"
   }
  },
  {
@@ -46040,20 +46291,20 @@
   "repo": "Lindydancer/font-lock-studio",
   "unstable": {
    "version": [
-    20250104,
-    1653
+    20250309,
+    1523
    ],
-   "commit": "fb932d8eb7d305ee4dcc6f29bb5e56cfb3fe9104",
-   "sha256": "0ssa62qm3zv0l9adz0bpi4iaixbi788ihh1qy5n41h6jzcjig4k4"
+   "commit": "12d542b939610367d99051655c76fd2b970fd0e4",
+   "sha256": "0gjr02kww4a0a4x30pj6lls2wdj25vi14ay4pl4fgc2h98yli3c8"
   },
   "stable": {
    "version": [
     0,
     0,
-    9
+    10
    ],
-   "commit": "fb932d8eb7d305ee4dcc6f29bb5e56cfb3fe9104",
-   "sha256": "0ssa62qm3zv0l9adz0bpi4iaixbi788ihh1qy5n41h6jzcjig4k4"
+   "commit": "12d542b939610367d99051655c76fd2b970fd0e4",
+   "sha256": "0gjr02kww4a0a4x30pj6lls2wdj25vi14ay4pl4fgc2h98yli3c8"
   }
  },
  {
@@ -46285,8 +46536,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20250205,
-    1920
+    20250301,
+    2353
    ],
    "deps": [
     "closql",
@@ -46301,14 +46552,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "add7868aaf7b8538f086d3a007c412419d08ead9",
-   "sha256": "0q0w6jv5aq5fc9ii710z32961vg1rmsrr750p9gg9qvqk82csm3g"
+   "commit": "1c904090dfdcd201d9170997052c43846ddce149",
+   "sha256": "1ps1xwpxhb9vn6bf0wxy8bdba72f973spys0xw1k686swczrb225"
   },
   "stable": {
    "version": [
     0,
     4,
-    7
+    8
    ],
    "deps": [
     "closql",
@@ -46323,8 +46574,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "33e240d360b8e3950e9c8b7024e3e763465c0c13",
-   "sha256": "1576ic28h5nanab092r2w7id66jv2wf3vw8fkhsbvm6fi4l6g4vg"
+   "commit": "1c904090dfdcd201d9170997052c43846ddce149",
+   "sha256": "1ps1xwpxhb9vn6bf0wxy8bdba72f973spys0xw1k686swczrb225"
   }
  },
  {
@@ -46706,26 +46957,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20240805,
-    1314
+    20250301,
+    1639
    ],
    "deps": [
     "compat"
    ],
-   "commit": "050ef28e4007a608f12bbd476ccc52d19854f13d",
-   "sha256": "07wl86qamd3hrgybq29gmm1x0xc25qm3b95bj92ywh61wm173n1d"
+   "commit": "2b0dab1dc1ed9a5e6f706d08538372c30fd2a5cd",
+   "sha256": "0xz98cy7h99v084ym2ghrhjy3r4sad9ibz4kxa8pmj8243mlzb7r"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "050ef28e4007a608f12bbd476ccc52d19854f13d",
-   "sha256": "07wl86qamd3hrgybq29gmm1x0xc25qm3b95bj92ywh61wm173n1d"
+   "commit": "2b0dab1dc1ed9a5e6f706d08538372c30fd2a5cd",
+   "sha256": "0xz98cy7h99v084ym2ghrhjy3r4sad9ibz4kxa8pmj8243mlzb7r"
   }
  },
  {
@@ -47401,15 +47652,15 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20241120,
-    854
+    20250311,
+    1518
    ],
    "deps": [
     "cl-lib",
     "reformatter"
    ],
-   "commit": "a9cb4ee550d1ae14a7274d4e0c9bb6a2dff17c5a",
-   "sha256": "0kl8xcg5lp26cx5r8ikprzw2py7d0s4gibfkn525fnx94fdqcswr"
+   "commit": "ac363a47f6b24b9af5b817fb7bd94c16ebd46c3d",
+   "sha256": "0hxa894dxwm5zls9vi0ly1n4d62w620kzbh22dyilk0wh3zjfhr1"
   }
  },
  {
@@ -47762,11 +48013,11 @@
   "repo": "pastor/gdb-x",
   "unstable": {
    "version": [
-    20240814,
-    2137
+    20250213,
+    2057
    ],
-   "commit": "55dd7a427a83a9abd5719cd2920ab7d2c94ba558",
-   "sha256": "1fncmi0ciz0fwf97li554kfvbpkqv5vwy0aafin9vcc63aawwi2y"
+   "commit": "9db6e02cc101f21fea778879a4420bfe1af91096",
+   "sha256": "08ibkm959kdqay92q662px38baz9avmq7dszpr1pvs2nzfwbf272"
   }
  },
  {
@@ -48025,14 +48276,14 @@
   "repo": "emacs-geiser/gauche",
   "unstable": {
    "version": [
-    20220503,
-    1700
+    20250311,
+    735
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "8ff743f6416f00751e24aef8b9791501a40f5421",
-   "sha256": "1ppracwfl1snq0ifdlyxpdlv7fbn3pbxm1hd1ihgqivii5nbya9r"
+   "commit": "9eb8b35f0c3bf44ae7990be707591ed8498b6fa3",
+   "sha256": "0ahhd7092bm76981hgid4dn60xpgl0vrw35h8d7y08wpr9kswsch"
   },
   "stable": {
    "version": [
@@ -48602,28 +48853,28 @@
   "repo": "anticomputer/gh-notify",
   "unstable": {
    "version": [
-    20240411,
-    2031
+    20250215,
+    2257
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "bcd30f1804d6e1bf0201a16486d094a3817636b6",
-   "sha256": "0spwcby1ag91wf9k3waydfav5wf37na80vayxf3kgcss2dpixz7n"
+   "commit": "eb14b84d10d23be80a1e48f3d74c4f8ff144adf8",
+   "sha256": "0a170rdh80c33spkss97sbhp6bwr76hdslig893h9gr874kbk6z2"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "forge",
     "magit"
    ],
-   "commit": "364cc30f619321b98dc6772ca50c87fa14350a50",
-   "sha256": "1bi1jqw3fxzc4q2vxf1pjph0f2ahdzlpfpan83hn404h6hl46ldn"
+   "commit": "eb14b84d10d23be80a1e48f3d74c4f8ff144adf8",
+   "sha256": "0a170rdh80c33spkss97sbhp6bwr76hdslig893h9gr874kbk6z2"
   }
  },
  {
@@ -48741,8 +48992,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20250204,
-    1422
+    20250301,
+    1641
    ],
    "deps": [
     "compat",
@@ -48750,14 +49001,14 @@
     "llama",
     "treepy"
    ],
-   "commit": "077e339bd714a0b8cafcb4ce2b9ec684b0509022",
-   "sha256": "0fh6yyj0ya77sg65q8akqllvyracwgpp5cx8dr6pv5fp860c2w0d"
+   "commit": "af663777c47a3dce64b2144b4409587b35521e47",
+   "sha256": "1bd8lnhv50brfxqwyk7jmgrig0cahkam7ggwaifaz8vb8m456yar"
   },
   "stable": {
    "version": [
     4,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -48765,8 +49016,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "c5003950b5efd065a20983546a12ffcd079b4a93",
-   "sha256": "05jmljhf9g191rsjkrsirjr7qkm02yfprd43dq79nbflz7z615ss"
+   "commit": "af663777c47a3dce64b2144b4409587b35521e47",
+   "sha256": "1bd8lnhv50brfxqwyk7jmgrig0cahkam7ggwaifaz8vb8m456yar"
   }
  },
  {
@@ -49102,15 +49353,15 @@
   "repo": "eki3z/git-cliff.el",
   "unstable": {
    "version": [
-    20250123,
-    1912
+    20250216,
+    2216
    ],
    "deps": [
-    "dash",
+    "llama",
     "transient"
    ],
-   "commit": "936095b416edecd999a013e3cc0aab9a6050bdde",
-   "sha256": "0cwaqq597dw8zgmd06kxlcbvgvhz4g5xxdi8lknj4dxh7a5av3qp"
+   "commit": "e33246132ecf5bc5b7ef4156921deb6558f95289",
+   "sha256": "08nd5z42ckqcm11mapwh95sa424g2hc46x6mq5l8034na69qa7c4"
   },
   "stable": {
    "version": [
@@ -49414,11 +49665,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20241208,
-    1850
+    20250214,
+    1240
    ],
-   "commit": "40f7b1674d2c703199ff2f82b464f17aa6f61b4b",
-   "sha256": "0cqc76pqqdhv7fgfsfyq8ych184gbmyvfh0h7a2zyh5wl2p7kb0i"
+   "commit": "8d0f98cf36f6b9c31285329b054ae77f9a3d9b33",
+   "sha256": "013rh88pk6g4iqp0l1ihxn8dhljnjkz8jqdkvvp0vin57p8rj0w6"
   },
   "stable": {
    "version": [
@@ -50333,11 +50584,11 @@
   "repo": "gleam-lang/gleam-mode",
   "unstable": {
    "version": [
-    20250209,
-    426
+    20250223,
+    1619
    ],
-   "commit": "8656c4080dd2bb7dd6d6167953d6463d090509b0",
-   "sha256": "09649yp39qdipvkw430mcilc9lpdg1bbbjgjgr4g9w5q9ma277fj"
+   "commit": "75b5b1a2eede31969a94322f117b0c82036ff40b",
+   "sha256": "1225g79kajzicbgswlvygf03ap6kq3l6wc2mpand2qb564vbhld4"
   }
  },
  {
@@ -51279,11 +51530,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20240620,
-    1948
+    20250311,
+    156
    ],
-   "commit": "636d36e37a0d2b6adb2e12d802ff4794ccbba336",
-   "sha256": "0n8qx85ijrijq8wdmmlga69v47vq0kw0njjkvmvibv05hi8g2q2h"
+   "commit": "58b0c3dfc87f5ae4137ea498dc0e03adc9eeb751",
+   "sha256": "01db618lfkqwf7ps9hi9k2s1v6p7vgj901p04kn5vdcrs3b7cxny"
   },
   "stable": {
    "version": [
@@ -51520,20 +51771,20 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20240802,
-    131
+    20250304,
+    814
    ],
-   "commit": "424682b94df9efb3dd59e396677b45e4a67b7723",
-   "sha256": "0cyg3wbxxhyp268w4sidbdi0jdig1a7614mnvd8jl91vryinjf55"
+   "commit": "55efeac0f99f8eff3f9017e62229212e4876f09b",
+   "sha256": "1zk91s2p2sa9v40zyshn54wbpjfn2g5prxad4zzwqncm0dlcjpab"
   },
   "stable": {
    "version": [
     3,
     0,
-    7
+    9
    ],
-   "commit": "334efbddd3d421ec294002fca166fbd6b0152e2e",
-   "sha256": "0603iq1vjbm44sl7qrmkdfcqzzc703h1g5hdcswpj7pi0w7fxb4s"
+   "commit": "9ffbcddb5dbc3be37afc7d5f16206512004f6ef0",
+   "sha256": "1j5knkb8h0wpr6pzvrb6kvisjkm4kkd7jzad6h566sn0si2x9y5g"
   }
  },
  {
@@ -52167,7 +52418,7 @@
   "stable": {
    "version": [
     0,
-    48,
+    49,
     0
    ],
    "deps": [
@@ -52176,8 +52427,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "648bbc7f926ca0708e4231f6ab6eb07e1e9a2043",
-   "sha256": "001h6rx6sfysd7gmp8p6hp0rcz7gda4s7y71p5h3nics301n925c"
+   "commit": "bd808e86d9a22201072ed0aac198372b8abd95b4",
+   "sha256": "1w2b3kcjligpp4k5fvl8jyrx7n6ddv8ck99hhh09j31gnikd5nvl"
   }
  },
  {
@@ -52260,11 +52511,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250112,
-    2218
+    20250301,
+    2043
    ],
-   "commit": "781c08949d95b49a4342c5cb6035e2ae2732040b",
-   "sha256": "0bykdilh3ykh8xsagjh6gwywihrfql444ya1r63lbak2vamxvvx6"
+   "commit": "32e234f5243e25fd13ddfad6c8a533072b7a20b8",
+   "sha256": "1v321yq9bsxazlvmvvd33g8h33na2fdc5fjrjp4qwq0pb1w1i3z4"
   }
  },
  {
@@ -52307,11 +52558,11 @@
   "repo": "antonhibl/gptai",
   "unstable": {
    "version": [
-    20230530,
-    1853
+    20250220,
+    1735
    ],
-   "commit": "e7b8b91b425986868e8bc0edcac384ba47d4d4b7",
-   "sha256": "0qp051vz0jpb2db3724vrv7g2hrpvrsqyvq1zzpxf3360pqfsjhc"
+   "commit": "446b3a3f8a4f2412c969189a1f64aed099582094",
+   "sha256": "19x6xzvjns2hv74nkyym0nc30ipbv5ryfdsc5c30354lvi7vw029"
   },
   "stable": {
    "version": [
@@ -52331,15 +52582,15 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20250209,
-    344
+    20250313,
+    158
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "2dd3e317bf4af82cddfa1d1b127c04c17589c878",
-   "sha256": "13c88f2j03fdwhyl19j9r6lvgczb31v0q0nn79vhhsxw9bp22xzh"
+   "commit": "10e77396bc78e05c922b04a344818bc8ab72d665",
+   "sha256": "1cgm6lqn0yn18cisrgn5cllc6kwx63bawzyqxq5hky7mmrvqfd25"
   },
   "stable": {
    "version": [
@@ -52353,6 +52604,54 @@
    ],
    "commit": "5a5cddb93d610bd59ec52a070b0f89a9ec842152",
    "sha256": "15ny2d04ci04swmxikkyb7lsjr51gvxpr2cj02gwx88bidx34md2"
+  }
+ },
+ {
+  "ename": "gptel-aibo",
+  "commit": "f39652c0893bc70d06c0a87a1e086d63f1a6bb83",
+  "sha256": "0msvkanch75rpwbbxkkacaqn7fpraycvnw9ih8l5s3x5q71jhikz",
+  "fetcher": "github",
+  "repo": "dolmens/gptel-aibo",
+  "unstable": {
+   "version": [
+    20250311,
+    545
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "a8b1550812da3606613b054b05f9458b98067a00",
+   "sha256": "1kw1imwj7ca63d8aszp6rwlj0kih6rv43rbrbsf8r6nifnws5rg7"
+  }
+ },
+ {
+  "ename": "gptel-fn-complete",
+  "commit": "e32759c156c2dfac7f35ada096fec7dc06e5c34a",
+  "sha256": "1pp833bsfsv791j3nhggdbrwfwgvyjl5n2a99pqp43dnrhk2lmib",
+  "fetcher": "github",
+  "repo": "mwolson/gptel-fn-complete",
+  "unstable": {
+   "version": [
+    20250313,
+    222
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "fc17166bb0e3ef03dabf9b1550284dc3f441dc0f",
+   "sha256": "0cwlnlwpncysy6qd66j6q1wyqk5r7rgrwjwg66n9s72qfmminbl5"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    1
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "1a28af9c6c37db8a92937316fe43042ef01a1186",
+   "sha256": "18760brg0p4hwphg0wr3hwcv91jizy519fiawr56gv22xvq225sr"
   }
  },
  {
@@ -52826,15 +53125,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20250106,
-    1838
+    20250304,
+    1715
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "6db9710e60f3d7bd85ab6c3e95bf9f9ab208b2a9",
-   "sha256": "1d3a6bma7inv1sqbg9pfqh8zv9y7akf5v5swl407l44snj9gis5x"
+   "commit": "7d47cf845e0f6116b0748f05c903db6d0b94e495",
+   "sha256": "19j8fbxyylq5h8w9q6w3vwkqncdm8ljhbwfnw3r92hxmbq9w02si"
   }
  },
  {
@@ -52983,20 +53282,20 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20250123,
-    1407
+    20250307,
+    1011
    ],
-   "commit": "008a8bb829045113848f504269221fbb76180cab",
-   "sha256": "0injp6mxb6cyngf61nlg7vdim36brlplcpaijbyf6c4x0dfy8cy2"
+   "commit": "e90e3b47d8fcbb7625106e1ea840519a58c2c39c",
+   "sha256": "04ybyxv2ps7bydb89shhfwhdayhr0kbyzwjxf3a6chmymdvny4wh"
   },
   "stable": {
    "version": [
     2,
-    3,
-    3
+    4,
+    0
    ],
-   "commit": "378de9609614448ca29e2add91f2d0059f963d8c",
-   "sha256": "0valpvbklqzc48f9m1rysjh24323cykpz39dk6avx6vj3y70lnaq"
+   "commit": "ffce7f78ebe48645b93fa162038ac7f678ffd618",
+   "sha256": "1lndn60xgamxfmca623frqfqv6dvzrmqzw5x805px58838nfdrhd"
   }
  },
  {
@@ -53447,8 +53746,8 @@
   "url": "https://git.savannah.gnu.org/git/guix/emacs-guix.git",
   "unstable": {
    "version": [
-    20231206,
-    2147
+    20250309,
+    2106
    ],
    "deps": [
     "bui",
@@ -53457,8 +53756,8 @@
     "geiser",
     "magit-popup"
    ],
-   "commit": "455272c5cc72ed4ba5bad13c669f024f51479a58",
-   "sha256": "1ihrd7f92p9xidh1mbjk1piykzg46xypnzf1rlxxsymmddlq4jpn"
+   "commit": "287fc4fbea0c90efca01af8fd0d64748903253cf",
+   "sha256": "09dxbl2r8f2l6axqpmfh620mnbs37j9wnaz89pq8hhh7fmfz8xff"
   }
  },
  {
@@ -53638,14 +53937,14 @@
   "repo": "hhvm/hack-mode",
   "unstable": {
    "version": [
-    20240905,
-    2225
+    20250304,
+    640
    ],
    "deps": [
     "s"
    ],
-   "commit": "343e45f2a616c726f20ba099f3f98a1a01cec405",
-   "sha256": "0yd6l86m84qdbnm6cpqrv0xlsvfbhfrgjjns5f209js8i0wysjvs"
+   "commit": "0addbff8b61cfd75b81961507a1646c4acd316ba",
+   "sha256": "047b1a0lffa3lh7wsaycf9qkasj1zp1zsa52m8477bgkhvkf010y"
   },
   "stable": {
    "version": [
@@ -54228,11 +54527,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20250205,
-    1440
+    20250305,
+    1349
    ],
-   "commit": "495fb9688e12ed1bf945b4876f124ee38b84c039",
-   "sha256": "15yqaq6jblrj47h1fj11lmz05glgg40r5am6ynggwjipghchl817"
+   "commit": "2ada981f2447039c070441d37d28cd32cc2906ca",
+   "sha256": "1194n50xq85y9ymbv4npi3b47zra0fdr6f5hxgp12s07rnh4gf33"
   },
   "stable": {
    "version": [
@@ -54345,6 +54644,30 @@
    ],
    "commit": "f1099c6296fc9575675e281402b89854739114bb",
    "sha256": "1a6almgsh93jzi5h59mmrlwcz805j3fnr8vrcfxnirxpr39159sq"
+  }
+ },
+ {
+  "ename": "hatty",
+  "commit": "5adbdc5c65d8932df718afcda842d64f9182971e",
+  "sha256": "1abzpw6l36yaz0fysbx15il8khbi3x34r87n03akdhkpb1zycnpy",
+  "fetcher": "github",
+  "repo": "ErikPrantare/hatty.el",
+  "unstable": {
+   "version": [
+    20250227,
+    2326
+   ],
+   "commit": "dd95986529fa90e47eaadeedd671986c5ab15aa7",
+   "sha256": "0gs6gbgaxr1p7j4gqnzx5lq3krnn6nxlmgwfp5d5i8fdkg1c1ka7"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "25fcffa9fcc96ef44fbfa7583873deda6a1dda81",
+   "sha256": "12klhmsqpvbb3arbq8wc1nbhgq218ickvjy9p8j7w3pymiyvkgv0"
   }
  },
  {
@@ -54547,27 +54870,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250208,
-    1033
+    20250228,
+    640
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "80d5c9e68f7ce162967f0818ea8c9abb7d24594f",
-   "sha256": "1s4svjfw1x302s0hybby4y0rspdxx92drh8l7y1zhygdzsjb7bj5"
+   "commit": "c0b70dbc2697ff361d9d5bb99e11c654317aa00d",
+   "sha256": "07z3zrdyifsdp91rf0akzxbzxd8ny3rxz49b5j53kppl8l3shxg0"
   },
   "stable": {
    "version": [
     4,
-    0
+    0,
+    2
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "e0d028081f1f24da8e649f6ea3ecea42216d4632",
-   "sha256": "0il5npxw8wrpbwd8nyf9q9yxxd5plh3zl45m04w0wj4lpz9sqz7w"
+   "commit": "af3a6a3d842c350b469a735b31ee00bd22fedcc9",
+   "sha256": "0l9p6yiv8w9s0rpa4fyrp9gw1dgwpyr9fmkhs53bhc6v9x7br8ix"
   }
  },
  {
@@ -55436,25 +55760,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250203,
-    533
+    20250227,
+    1917
    ],
    "deps": [
     "async"
    ],
-   "commit": "23fd81de2ad895dec73b8f6a332483b64c4c6396",
-   "sha256": "1c23k43kgzavkl66bjq0l8sjpdyf29b4wh31a9dqk8dkxg99i4bs"
+   "commit": "04104d2add4806130cdeb3c915e9c09fb1de1046",
+   "sha256": "0z5v1nbq55hbcjca3p5gq0jpg20jkml08jvdssbk908jxzcgpyfm"
   },
   "stable": {
    "version": [
     4,
-    0
+    0,
+    2
    ],
    "deps": [
     "async"
    ],
-   "commit": "e0d028081f1f24da8e649f6ea3ecea42216d4632",
-   "sha256": "0il5npxw8wrpbwd8nyf9q9yxxd5plh3zl45m04w0wj4lpz9sqz7w"
+   "commit": "af3a6a3d842c350b469a735b31ee00bd22fedcc9",
+   "sha256": "0l9p6yiv8w9s0rpa4fyrp9gw1dgwpyr9fmkhs53bhc6v9x7br8ix"
   }
  },
  {
@@ -55618,14 +55943,14 @@
   "repo": "emacs-helm/helm-dictionary",
   "unstable": {
    "version": [
-    20241222,
-    651
+    20250227,
+    1635
    ],
    "deps": [
     "helm"
    ],
-   "commit": "6114ef3171cad09c74ac0028db58fb479f3c5d21",
-   "sha256": "07pnzpr67fxam2qih6b3miyb84g27b8m4m37z1mdk4297qr060a5"
+   "commit": "725cc0df42ad57a7902c330065d9e8ee1216791c",
+   "sha256": "1ipia68s5x1ny6w99g56hfcnhphlz7zh7bhmrrjyv3aflr7d3170"
   }
  },
  {
@@ -56971,14 +57296,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250127,
-    2041
+    20250227,
+    1652
    ],
    "deps": [
     "helm"
    ],
-   "commit": "d6d061704f375f809a2ee7644149a28e8770b35f",
-   "sha256": "0jyq2jb9j10n9pqfh2vzpzw0v7hcjgzg3rvw95vakwq7iznj04cv"
+   "commit": "640cc6ccd8720462ac949d75de9bc99883830d92",
+   "sha256": "19wxmnq7l42kwqdrfvb861z5llm50rz3dbxlckqlmz1cggdzicv3"
   },
   "stable": {
    "version": [
@@ -57373,14 +57698,14 @@
   "repo": "emacs-helm/helm-org",
   "unstable": {
    "version": [
-    20240922,
-    603
+    20250227,
+    1650
    ],
    "deps": [
     "helm"
    ],
-   "commit": "9b7d5d4fd18180b2009a0f2b908c84d5363e41f3",
-   "sha256": "0h776y4vzxg1jpgd1c4nps33ywnxpn6iw10z34amxnv9mvxmip20"
+   "commit": "22d60952f8017e154c53b03087619eb269e12339",
+   "sha256": "1wb8666gkx24lwhc2p6zfgf8brsg5dkj1ivq8mf5jqxyqzlflj46"
   },
   "stable": {
    "version": [
@@ -57829,16 +58154,16 @@
   "repo": "bbatsov/helm-projectile",
   "unstable": {
    "version": [
-    20250207,
-    2201
+    20250218,
+    1525
    ],
    "deps": [
     "cl-lib",
     "helm",
     "projectile"
    ],
-   "commit": "8bfd2c58085036dd5dcdffa8283e6fcdc689a358",
-   "sha256": "08pdfkm43sqiyfsmqz0q617qrklw7qlag1lq05pipg501zh4p1k3"
+   "commit": "041076e35a6663302a91a0fa672f847c7d64bf29",
+   "sha256": "1yhdc6h72crnlp46hbvs20c0fc9r1x7896z7rbp1z0i0hphsrs86"
   },
   "stable": {
    "version": [
@@ -58235,15 +58560,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20191222,
-    920
+    20250218,
+    2303
    ],
    "deps": [
     "helm",
     "rtags"
    ],
-   "commit": "595055b5316a7c92ba1d638f324f98842a0f41a5",
-   "sha256": "17zmcp6ynbgpvp5hwlnfw7n5vq07c9qgv8vbs156wjs9p6x36qpl"
+   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
+   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
   },
   "stable": {
    "version": [
@@ -59241,8 +59566,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20250131,
-    1645
+    20250227,
+    1527
    ],
    "deps": [
     "dash",
@@ -59250,8 +59575,8 @@
     "f",
     "s"
    ],
-   "commit": "34328c639ed7aad371a3f57209acad2a5bb66401",
-   "sha256": "127q15nnqzwa5a6rwlcg7srcrqdibs3ivzvdf7cw51sxgr11cwzb"
+   "commit": "3794389ef685b6a59b3a487d0492c3add3c42c2f",
+   "sha256": "0343h1zrr2cfnfzcqazsrv6c9cs7c8q7cq5pzj9hjka5yw5n8v7r"
   },
   "stable": {
    "version": [
@@ -60398,26 +60723,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20250105,
-    1956
+    20250301,
+    1643
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fb692ec0923bcd98eaa8760127921aca61db8e1e",
-   "sha256": "0py936brc7kwggzcxi8mdndpgphzrxdd3ig9hbjlccs9ihwq3hi4"
+   "commit": "0ce21c329b686802121df45bf4ae15ae201137bf",
+   "sha256": "0yhy29khisj8cr359d6f2x2zyfjcvvhyyg0kkkvifzqnzkkaa9v0"
   },
   "stable": {
    "version": [
     3,
     8,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fb692ec0923bcd98eaa8760127921aca61db8e1e",
-   "sha256": "0py936brc7kwggzcxi8mdndpgphzrxdd3ig9hbjlccs9ihwq3hi4"
+   "commit": "0ce21c329b686802121df45bf4ae15ae201137bf",
+   "sha256": "0yhy29khisj8cr359d6f2x2zyfjcvvhyyg0kkkvifzqnzkkaa9v0"
   }
  },
  {
@@ -60800,14 +61125,14 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20250202,
-    1244
+    20250313,
+    1131
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "83e41a06994b92598eeefe78a23ba794b5474924",
-   "sha256": "1k3nldh00z1vzjrr8x733mfj1zx6n880gzm997cgrrr10vwap6zr"
+   "commit": "347228032d436bd72ec22616ca7cf8f52f32ed17",
+   "sha256": "122yrlmlndlf3kn60fdlclc0g7ic9ma3kn4lk94w9zx9filbsfza"
   },
   "stable": {
    "version": [
@@ -61427,11 +61752,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20250208,
-    2159
+    20250313,
+    1508
    ],
-   "commit": "c3ff71d9ce31a333470ab8d73fe13ab84ad8af66",
-   "sha256": "1b199h2j0yl6a30dyakqs97723wskxzwq2qvjnidgv2s713f63jf"
+   "commit": "f6f319eb4012d6eaaec83bc0351d0bb4d5fd699a",
+   "sha256": "0rgkq2v28dwkzd0ycbr2mdx9svgkvmwzjalp6c2c052dqh7pxv06"
   },
   "stable": {
    "version": [
@@ -61600,20 +61925,20 @@
   "repo": "precompute/hyperstitional-themes",
   "unstable": {
    "version": [
-    20240528,
-    2016
+    20250303,
+    1837
    ],
-   "commit": "e87e4ca39384c75398c64c920bf4cbc253f6740b",
-   "sha256": "0026mlsank67q32sxhjmis9jhsd267gm1v5b7bdw8sm5mh96yx9g"
+   "commit": "998d7fea95a4f8071a806c497fb70619dcd900ac",
+   "sha256": "12w84nbxnkiqldcky47hz0c63n48qic1y1kypaj8cccc8309x88v"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    4
    ],
-   "commit": "e87e4ca39384c75398c64c920bf4cbc253f6740b",
-   "sha256": "0026mlsank67q32sxhjmis9jhsd267gm1v5b7bdw8sm5mh96yx9g"
+   "commit": "998d7fea95a4f8071a806c497fb70619dcd900ac",
+   "sha256": "12w84nbxnkiqldcky47hz0c63n48qic1y1kypaj8cccc8309x88v"
   }
  },
  {
@@ -62649,28 +62974,28 @@
   "repo": "KarimAziev/igist",
   "unstable": {
    "version": [
-    20241108,
-    1947
+    20250313,
+    1020
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "13193a29544dc50a442a1a336e5d82c50f6663c0",
-   "sha256": "1pznh051rpwzpydgxw2j8ky36iqb5azb50p0zz0azrf134k8dcav"
+   "commit": "bf7e7abea93e6d16853f7714a98406dc34964f88",
+   "sha256": "0nssjv0mfxy34mbfv3c4bnszbc4ryqqs9pclbyg3spplfpvbxy97"
   },
   "stable": {
    "version": [
     1,
-    6,
-    4
+    7,
+    0
    ],
    "deps": [
     "ghub",
     "transient"
    ],
-   "commit": "13193a29544dc50a442a1a336e5d82c50f6663c0",
-   "sha256": "1pznh051rpwzpydgxw2j8ky36iqb5azb50p0zz0azrf134k8dcav"
+   "commit": "c0d50e690bdc42efcc49fb2daa1fa76684f972b6",
+   "sha256": "1h9nnrw0ilj9s8c2ad5wdvhjsl53bl3j4f39kl4clr58xb68ww3l"
   }
  },
  {
@@ -63322,11 +63647,11 @@
   "repo": "jcs-elpa/indent-control",
   "unstable": {
    "version": [
-    20250101,
-    1009
+    20250211,
+    48
    ],
-   "commit": "6b55986999f230760389a4dcd5d784121305de24",
-   "sha256": "0q3yzsbjjxc6wxbp240l2nyk5vz72s3jihb1va4h0g2ccw4fxk7j"
+   "commit": "d8fcfff53abfb47cc806c99ebb7b151e9fff4811",
+   "sha256": "0jlg10g31bjj3szlgzkfr000rw421if7bpg0r2pva25nb3saqxh8"
   },
   "stable": {
    "version": [
@@ -63631,20 +63956,20 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20241220,
-    251
+    20250212,
+    29
    ],
-   "commit": "dad78a13f162200a0f6720fe40e0726525424bba",
-   "sha256": "16bgk4hxnisiv18cnkyjym36yijmig9jln9bglnbvqbvhp2f86b5"
+   "commit": "b8076aad10dfb0ba1e3a8b0d39c2b370dbe96ab0",
+   "sha256": "1ah4hfy17x4ikrg3q555q7qfmz021wmfm5v11l1id3aqfqira599"
   },
   "stable": {
    "version": [
     2,
-    8,
-    1
+    9,
+    0
    ],
-   "commit": "8116b3b8336819a9838dd73e6926b5ba6d57c05e",
-   "sha256": "043ml560z69rlgw60w7m03r6cdwp8gfi1zs38qykg2yi98l6gg3x"
+   "commit": "b8076aad10dfb0ba1e3a8b0d39c2b370dbe96ab0",
+   "sha256": "1ah4hfy17x4ikrg3q555q7qfmz021wmfm5v11l1id3aqfqira599"
   }
  },
  {
@@ -63901,11 +64226,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20250121,
-    2019
+    20250312,
+    1941
    ],
-   "commit": "8f03a8f6ca8c980e7d90c6ea4cb308fd6ea3e24a",
-   "sha256": "0fkg75zm2mbdn7pv51m8vzcqmyf0g0pkb0cchzra22f8sycgbplv"
+   "commit": "8052a12c07cfdb8d344d35d4fbc0936dda495986",
+   "sha256": "0s5mrzmayciac8nk3fi83y62w1hc0iapzxw6v2dw6cx177sp8rnx"
   },
   "stable": {
    "version": [
@@ -63994,14 +64319,14 @@
   "repo": "emacs-jp/init-loader",
   "unstable": {
    "version": [
-    20240401,
-    103
+    20250313,
+    47
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4ed535f887eb7ac72aedf282b7e4f5a2f7cb7582",
-   "sha256": "1q3fkds0cl9q7z3w2jqqisyblq09whcf2087h0wzl64zwg8ikz07"
+   "commit": "1837769c872b6453c7c02490f50a6eb322156c2c",
+   "sha256": "0fpc6c47blpyi9j3w3x3jc9rqq333pi4ryj0zzgxsf7sgl5vzw12"
   },
   "stable": {
    "version": [
@@ -64091,11 +64416,11 @@
   "repo": "ideasman42/emacs-theme-inkpot",
   "unstable": {
    "version": [
-    20240610,
-    1406
+    20250303,
+    1039
    ],
-   "commit": "259272084f8ead2453f83f526ed95061f879d464",
-   "sha256": "08lnbvnn56hkm78sxs7k5h8wy4v0c2aynq41bqjr3p2j19hkxssr"
+   "commit": "a10b26fbee33dc8533a6688df51c540683f39134",
+   "sha256": "1xfls2bxb8rvslmwsyk6cnskqin5pq8qph2sp9c60qcxgk0islnq"
   }
  },
  {
@@ -64916,20 +65241,20 @@
  },
  {
   "ename": "iso-639",
-  "commit": "00248ba809ef61d5f233ee47db785b7d4702c52d",
-  "sha256": "1qg2z7sp7h5g648i29bgnnal0byjh3jrzgslp59vsw4br6y9lsnr",
+  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
+  "sha256": "1kg4229aw00651p86mfxd7hmdq29vg5srb633xa50caz6zn169y2",
   "fetcher": "codeberg",
-  "repo": "WammKD/emacs-iso-639",
+  "repo": "Jaft/emacs-iso-639",
   "unstable": {
    "version": [
-    20250130,
-    957
+    20250303,
+    214
    ],
    "deps": [
     "levenshtein"
    ],
-   "commit": "39b5fa1a51bae99d852a64f1a7423afc33e46ced",
-   "sha256": "1g0lxi4vvmwcwvhhshvf5gv1vp9dzi87293bdxsw1vxdpv9gh8w6"
+   "commit": "63e0788175da46c55562919c7fe7c4e43546752d",
+   "sha256": "1i07vi7lqvzfvnxlhx1bfh56b4csj8a9c2r8w3i6zl9vlvj2ryrv"
   },
   "stable": {
    "version": [
@@ -64940,8 +65265,8 @@
    "deps": [
     "levenshtein"
    ],
-   "commit": "99ebb7281bf5be6e2b2779e67abc7da886055400",
-   "sha256": "0yq7fdsj56c16vncnms2vlb2sljfjm25844p4l3fd7wffb3yfj6i"
+   "commit": "63e0788175da46c55562919c7fe7c4e43546752d",
+   "sha256": "1i07vi7lqvzfvnxlhx1bfh56b4csj8a9c2r8w3i6zl9vlvj2ryrv"
   }
  },
  {
@@ -65039,10 +65364,10 @@
   "stable": {
    "version": [
     2,
-    1
+    2
    ],
-   "commit": "4b5b33244a029a81679951bcf8bcda71012ed1c8",
-   "sha256": "09wypwp0fcj5m3gmh0ipkv6fqlad20iyb2g3952iz5yjdhapva9k"
+   "commit": "60a30589d5bea2b50ccab32a1b3e1388d38ecdb2",
+   "sha256": "09g2sa364g1s25q9a3d9kn6xs78rgpn6w2axkkd0qviakr290ilz"
   }
  },
  {
@@ -65108,20 +65433,20 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250109,
-    1452
+    20250224,
+    2125
    ],
-   "commit": "abb9e1e5649bcd078a2a75bcb27abb42311b4f86",
-   "sha256": "15h0sfng2w7rxm90kr4gfwcq9n9z7dkxak4ix7nsd3m0n6am51wy"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   },
   "stable": {
    "version": [
     0,
-    14,
-    2
+    15,
+    0
    ],
-   "commit": "8c30f4cab5948aa8d942a3b2bbf5fb6a94d9441d",
-   "sha256": "1iqj27pc2iivmwfh329v0d9g0z1y0whlnamrl7g2bi374h41m368"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   }
  },
  {
@@ -65132,28 +65457,28 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20240214,
-    2118
+    20250224,
+    2125
    ],
    "deps": [
     "avy",
     "ivy"
    ],
-   "commit": "749ac1235a7948011cb0caddd4c31037e3314614",
-   "sha256": "0d598jxdrxjlszaikh27v7j2zdndisfqzb384d94siw4rwzfj4zr"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   },
   "stable": {
    "version": [
     0,
-    14,
-    2
+    15,
+    0
    ],
    "deps": [
     "avy",
     "ivy"
    ],
-   "commit": "8c30f4cab5948aa8d942a3b2bbf5fb6a94d9441d",
-   "sha256": "1iqj27pc2iivmwfh329v0d9g0z1y0whlnamrl7g2bi374h41m368"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   }
  },
  {
@@ -65279,8 +65604,8 @@
   "repo": "s-kostyaev/ivy-erlang-complete",
   "unstable": {
    "version": [
-    20211019,
-    447
+    20250210,
+    1738
    ],
    "deps": [
     "async",
@@ -65288,8 +65613,8 @@
     "erlang",
     "ivy"
    ],
-   "commit": "6913f6ef7c942a5a2c42bc17635d09c91353e7ca",
-   "sha256": "0i06332ycky68ccnyay4c277nl227r0hvbrflswbj4g1rybfdd3q"
+   "commit": "88bbfab802a58f157c1ff7886324eb4056b451c8",
+   "sha256": "0czc4v2w6vf0w2b6sr9vipb3ldklsklbdsr11j8xhn00fi9kxxkv"
   },
   "stable": {
    "version": [
@@ -65499,28 +65824,28 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20240214,
-    2118
+    20250224,
+    2125
    ],
    "deps": [
     "hydra",
     "ivy"
    ],
-   "commit": "749ac1235a7948011cb0caddd4c31037e3314614",
-   "sha256": "0d598jxdrxjlszaikh27v7j2zdndisfqzb384d94siw4rwzfj4zr"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   },
   "stable": {
    "version": [
     0,
-    14,
-    2
+    15,
+    0
    ],
    "deps": [
     "hydra",
     "ivy"
    ],
-   "commit": "8c30f4cab5948aa8d942a3b2bbf5fb6a94d9441d",
-   "sha256": "1iqj27pc2iivmwfh329v0d9g0z1y0whlnamrl7g2bi374h41m368"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   }
  },
  {
@@ -65781,15 +66106,15 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20191222,
-    920
+    20250218,
+    2303
    ],
    "deps": [
     "ivy",
     "rtags"
    ],
-   "commit": "595055b5316a7c92ba1d638f324f98842a0f41a5",
-   "sha256": "17zmcp6ynbgpvp5hwlnfw7n5vq07c9qgv8vbs156wjs9p6x36qpl"
+   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
+   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
   },
   "stable": {
    "version": [
@@ -66049,15 +66374,28 @@
   "repo": "emacs-jabber/emacs-jabber",
   "unstable": {
    "version": [
-    20240624,
-    528
+    20250310,
+    305
    ],
    "deps": [
     "fsm",
     "srv"
    ],
-   "commit": "e766d84b81d5df6abc30fcbbb94f7c8640ea54e2",
-   "sha256": "0b6msdyvhjr4v4j8hl6kmcjks88iq001w1fhjgfvg8ii9n77n6xn"
+   "commit": "30c023b6b54601594d347956cc2918e7841e5ed4",
+   "sha256": "0ain52p79sxll0bnsb4llfp1h4pqcqx3l6im4ibia06lg2aiqhpv"
+  },
+  "stable": {
+   "version": [
+    0,
+    9,
+    0
+   ],
+   "deps": [
+    "fsm",
+    "srv"
+   ],
+   "commit": "30c023b6b54601594d347956cc2918e7841e5ed4",
+   "sha256": "0ain52p79sxll0bnsb4llfp1h4pqcqx3l6im4ibia06lg2aiqhpv"
   }
  },
  {
@@ -66846,25 +67184,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20250207,
-    1401
+    20250311,
+    1657
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e1a5a8921e42cd4ae7cb0dba95fe968d04359ee0",
-   "sha256": "05n1354w733170wgv2m2r3516a7cax5k0k2z9gc66z16pmacwici"
+   "commit": "9c778357ffaac972c86f4acd39d70c547abcaf46",
+   "sha256": "1xmhfrxbyw9yqxa845m90rikm6zg3fdhsb74i3qg6pgm5fiwpj1f"
   },
   "stable": {
    "version": [
-    1,
-    12
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2144d03f7bcc3f461b4e67f913dfc0055e4ad7e2",
-   "sha256": "1cxnxwbxfq29793r6f8pvvw2mb9mj7pa7g7z5k46abplkq65ds3g"
+   "commit": "9c778357ffaac972c86f4acd39d70c547abcaf46",
+   "sha256": "1xmhfrxbyw9yqxa845m90rikm6zg3fdhsb74i3qg6pgm5fiwpj1f"
   }
  },
  {
@@ -67142,11 +67480,11 @@
   "repo": "nverno/jq-ts-mode",
   "unstable": {
    "version": [
-    20240305,
-    1511
+    20250223,
+    1411
    ],
-   "commit": "9e6a2aab79a973e1200b8e4b5e6f1762b29b0dec",
-   "sha256": "082sfn63as6sfsf13ziplyag7nglyc3baf2fk0hwz37y54ada35y"
+   "commit": "3ac689c3c38be9117076de0bcc15510e369016c9",
+   "sha256": "0klza1vdbwxjrxpvbl53g1www3giz2fqv8fh6lw0ks32j4vwbrks"
   }
  },
  {
@@ -67428,8 +67766,8 @@
   "repo": "js-emacs/js2-refactor.el",
   "unstable": {
    "version": [
-    20210306,
-    2003
+    20250210,
+    1811
    ],
    "deps": [
     "dash",
@@ -67438,13 +67776,13 @@
     "s",
     "yasnippet"
    ],
-   "commit": "1372f8449c620d6209173ac12bcb7ac4ce6a3651",
-   "sha256": "0m7gpfn7kls371kajlvbmf77vf7bqj948my8hv864mmgpyff50g0"
+   "commit": "e1177c728ae52a5e67157fb18ee1409d8e95386a",
+   "sha256": "1axkiyxlkmgwa59jqkwwqldcp52xf9vnkid8r1v9b3qa6pgcszm1"
   },
   "stable": {
    "version": [
     0,
-    9,
+    10,
     0
    ],
    "deps": [
@@ -67454,8 +67792,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "089c7800e3e7b0a89ee2392037ac07851bcee298",
-   "sha256": "1iwblf5i7k1i1ax9pjv7n8zv9q157krirdn0gwcib6dwza2i30jp"
+   "commit": "e1177c728ae52a5e67157fb18ee1409d8e95386a",
+   "sha256": "1axkiyxlkmgwa59jqkwwqldcp52xf9vnkid8r1v9b3qa6pgcszm1"
   }
  },
  {
@@ -67928,20 +68266,20 @@
   "repo": "llemaitre19/jtsx",
   "unstable": {
    "version": [
-    20250102,
-    812
+    20250307,
+    2319
    ],
-   "commit": "8043e8339debd66d6d3591c82d8bc8437a1021bd",
-   "sha256": "0n2l1hs8grb7m7mg3vr06r2jibxaaxriv0lkfpzh09x5m8hh6q8r"
+   "commit": "4cf3bbbd3b7ca3687494169699140d39b1843d8b",
+   "sha256": "0m3drmx57mzqahjjxfb7vwz753hhdg45akcpyfaj92miljqds3v8"
   },
   "stable": {
    "version": [
     0,
-    5,
-    1
+    6,
+    0
    ],
-   "commit": "e81259a7584619ce3266a2d532f674ef45ee4274",
-   "sha256": "0z8z41hy4ssyyb4skzzysayw72jc441bffhbw1mgmgpjr7412b94"
+   "commit": "4cf3bbbd3b7ca3687494169699140d39b1843d8b",
+   "sha256": "0m3drmx57mzqahjjxfb7vwz753hhdg45akcpyfaj92miljqds3v8"
   }
  },
  {
@@ -68041,8 +68379,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20241216,
-    2010
+    20250310,
+    1739
    ],
    "deps": [
     "dash",
@@ -68051,14 +68389,14 @@
     "s",
     "spinner"
    ],
-   "commit": "e2b08f37b89a39e90e9e7e4f22faa0540a9efb2e",
-   "sha256": "0v7kx6drjzsrbzsc9qnfbq6w6hp0aqyxmrrvxxb1zn5lfka5z61d"
+   "commit": "cacf52e4c8db76706e6aa336d38746d15a2b6fe2",
+   "sha256": "07057mydg5smbq82xyhiybjmnidca1kp62m7zmgshakshxx1kwwh"
   },
   "stable": {
    "version": [
     1,
     3,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -68067,8 +68405,8 @@
     "s",
     "spinner"
    ],
-   "commit": "cd08e6edcd8bf5e3b44cb4deb7117e37d7e2061a",
-   "sha256": "0h5lwc2hsk4rc82idhf9qj9553v7x76wmy9x2z1h60pdd93ilcyr"
+   "commit": "4a0adf835dc650adcbec51bd0792ef53efbad65b",
+   "sha256": "1jphpyhg52c2gm8dkz42s3nsyb4b1bg9n4vx8qncn1flclczkgcz"
   }
  },
  {
@@ -69189,26 +69527,26 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20240805,
-    1322
+    20250301,
+    1645
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c44618d2867fc2410e5061fef2a805e974198cf2",
-   "sha256": "02h6dq1hq2k3x1gqcx5lafsl94wqq63jx1avf91dc6r0s6byb0sm"
+   "commit": "df329db48c22a3905d540c4240ac65c7b45f51dd",
+   "sha256": "130jfvy3pr3syqk6xaz910nignja32bzfnx342rr927jwa1vprfm"
   },
   "stable": {
    "version": [
     1,
     4,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c44618d2867fc2410e5061fef2a805e974198cf2",
-   "sha256": "02h6dq1hq2k3x1gqcx5lafsl94wqq63jx1avf91dc6r0s6byb0sm"
+   "commit": "df329db48c22a3905d540c4240ac65c7b45f51dd",
+   "sha256": "130jfvy3pr3syqk6xaz910nignja32bzfnx342rr927jwa1vprfm"
   }
  },
  {
@@ -69484,20 +69822,20 @@
   "repo": "hperrey/khalel",
   "unstable": {
    "version": [
-    20240527,
-    527
+    20250225,
+    1846
    ],
-   "commit": "14ef50352394cd1d62b80bc17ab14f4f801f47cd",
-   "sha256": "017hw2mr810r7hxs8jvnf590n6van8w29ibryz9dwxszrij21gd7"
+   "commit": "c4548265ee5947a4fc391ae615c6fb31c2e8dacd",
+   "sha256": "1j3j1rlnz8mj4xa53biq8n2x8rrfg725vn4svh5aany8i2mrl5p5"
   },
   "stable": {
    "version": [
     0,
     1,
-    12
+    13
    ],
-   "commit": "14ef50352394cd1d62b80bc17ab14f4f801f47cd",
-   "sha256": "017hw2mr810r7hxs8jvnf590n6van8w29ibryz9dwxszrij21gd7"
+   "commit": "c4548265ee5947a4fc391ae615c6fb31c2e8dacd",
+   "sha256": "1j3j1rlnz8mj4xa53biq8n2x8rrfg725vn4svh5aany8i2mrl5p5"
   }
  },
  {
@@ -69538,28 +69876,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250207,
-    50
+    20250218,
+    1324
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "ff6cb80c84a690cc589d9f16c1fb9fe2ad22bf7d",
-   "sha256": "1zdfg22n8b7s6401hfr7aww5kqiiadrvplgf7qbya1s723y8vmxg"
+   "commit": "0016fe06c96c9e09e6d411a9d3219d290bd34757",
+   "sha256": "02rfmh0mazixzf6i777zpz188c42p79ql74jd72y9gnf9c361b1x"
   },
   "stable": {
    "version": [
     1,
     36,
-    4
+    6
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "ff6cb80c84a690cc589d9f16c1fb9fe2ad22bf7d",
-   "sha256": "1zdfg22n8b7s6401hfr7aww5kqiiadrvplgf7qbya1s723y8vmxg"
+   "commit": "0016fe06c96c9e09e6d411a9d3219d290bd34757",
+   "sha256": "02rfmh0mazixzf6i777zpz188c42p79ql74jd72y9gnf9c361b1x"
   }
  },
  {
@@ -69787,25 +70125,40 @@
  },
  {
   "ename": "kixtart-mode",
-  "commit": "672cfc166209b6c2ffcb0e549fd2416be7212a5a",
-  "sha256": "079bw4lgxbmk65rrfyy8givs8j5wsyhpcjjw915ifkg577gj87qp",
-  "fetcher": "github",
-  "repo": "ryrun/kixtart-mode",
+  "commit": "699f4d019b5b462f0386986776e5063cbfea3965",
+  "sha256": "0iqk3xbx6hqpyqwq5wlqxdx18c0q3g4fgngb0mfg958jilgiaigj",
+  "fetcher": "sourcehut",
+  "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20150611,
-    1604
+    20250310,
+    2020
    ],
-   "commit": "1c2356797e7b766bbaaa2b341176a8b10499cd79",
-   "sha256": "1ld3ccg8q7hmjrj60rxvmmfy4dpm2lvlshjqdf9ifgjzp221g4vb"
+   "deps": [
+    "eldoc"
+   ],
+   "commit": "8a02eb6cbd99815b33352796a2a756a5d75edcae",
+   "sha256": "056g26j74cdjmmdz80cyd12fwmqnmsrg6jj94w8wfa1l8aksp9gb"
+  },
+  "stable": {
+   "version": [
+    1,
+    4,
+    2
+   ],
+   "deps": [
+    "eldoc"
+   ],
+   "commit": "8a02eb6cbd99815b33352796a2a756a5d75edcae",
+   "sha256": "056g26j74cdjmmdz80cyd12fwmqnmsrg6jj94w8wfa1l8aksp9gb"
   }
  },
  {
   "ename": "kkp",
-  "commit": "dcae17bc6cc208122587fb2edaaedde2bc30a89c",
-  "sha256": "1izg1ga1djshr7vmkk0pxsywgyz64dcc7abnraianwb7005lsxgb",
+  "commit": "eea0f2ba4951667d78a7d90d81cd591783a66bdf",
+  "sha256": "03bq53x553j8m3x33nvq067qxajvy3sl5223x1h939x6gmkdyd0k",
   "fetcher": "github",
-  "repo": "benjaminor/kkp",
+  "repo": "benotn/kkp",
   "unstable": {
    "version": [
     20250206,
@@ -69820,32 +70173,32 @@
  },
  {
   "ename": "klere-theme",
-  "commit": "962f7c87d0630399ea388f25ec5792fa2f2b4489",
-  "sha256": "05s3l0zzh9wrfi2mpw1krddqnqgzixgd7dmfcz7jnj2pda09j7bf",
+  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
+  "sha256": "1kxhdaw2mn4vkdxyx0zdhzy0p7axwg0ayi125pmfbv18y1ypdh6q",
   "fetcher": "codeberg",
-  "repo": "WammKD/emacs-klere-theme",
+  "repo": "Jaft/emacs-klere-theme",
   "unstable": {
    "version": [
-    20250131,
-    317
+    20250225,
+    2027
    ],
-   "commit": "01c8ffa5bdce2a2ea39dfdf92ab86721f9d7b55c",
-   "sha256": "02xga3b5xm7rdr06f1fxlwznjzkm15vysykl9v6v32c4ck5q4msz"
+   "commit": "4a8e28002b3cd6acd67886aab01d59b21b659dda",
+   "sha256": "0hq4dnm7aaq39b8kcps3frv4l1xb6qr61cjs0nrfj54sdwnrz2xx"
   }
  },
  {
   "ename": "klondike",
-  "commit": "07468c723e34a5c25e315a07649a0af2d62ae6ab",
-  "sha256": "0fa28w572cq5jf4n9sgs0bb9r5q2s1c0khgrwhgbkmzil42mlbh4",
+  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
+  "sha256": "0g0x1p6mn57fknj1knk2gn325lkchz93jyycfybbg025s1wi0zw0",
   "fetcher": "codeberg",
-  "repo": "WammKD/Emacs-Klondike",
+  "repo": "Jaft/Emacs-Klondike",
   "unstable": {
    "version": [
-    20250130,
-    113
+    20250301,
+    2336
    ],
-   "commit": "24cd355c0ab7281e9a884cf373774aeb7d0a4d3f",
-   "sha256": "0522jnscy2sfzm3pb9qf989rlky39855cang6nsvzwzp020wbqcq"
+   "commit": "891cc54c1d9411f7848a4bba34811370ae19960e",
+   "sha256": "0vp4lqn591famh28ghrlilnbxixwpfysn2g1jfc8qvv583ffsgjx"
   },
   "stable": {
    "version": [
@@ -69853,8 +70206,8 @@
     2,
     0
    ],
-   "commit": "77b0bcfe99ee2c67c95d1a3efd2fbfcad556ca3e",
-   "sha256": "03km9ykj8clyw9phjm3g9mmshzp5z61kd796ixjf91cb67rfjnjs"
+   "commit": "50315bbb341f74e0ecc23e66757bbfa4a8cacb50",
+   "sha256": "07ydsghdd0vvnm0pyah7zkrk41n25cqgmvv1lgzckkrzyp5m2f54"
   }
  },
  {
@@ -70245,8 +70598,8 @@
   "repo": "kubernetes-el/kubernetes-el",
   "unstable": {
    "version": [
-    20221229,
-    1519
+    20250310,
+    1057
    ],
    "deps": [
     "dash",
@@ -70257,8 +70610,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "099004511670c7fd52a619c5758047bb3172ba36",
-   "sha256": "113c490gp69pkq9rnw5s7vfkr8pw14q7lv205gwx8awg129frnpn"
+   "commit": "c8a2cceaf328213faa5fc00af758ba395488384d",
+   "sha256": "1m8avcjy64qlqrd0qrz8ffbhzn723icshf010isqm99r5404d2ja"
   },
   "stable": {
    "version": [
@@ -70470,8 +70823,8 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20250121,
-    1920
+    20250213,
+    1900
    ],
    "deps": [
     "async-await",
@@ -70482,8 +70835,8 @@
     "request",
     "s"
    ],
-   "commit": "17614c9becbb4d52075ccb5bac66ea51895e9e3a",
-   "sha256": "0wfjbk679r8qj5lng8wg3d3b6ss9w5979chihzk62z5lbn5g9pf6"
+   "commit": "7c92f7934face10b696da45c2459f085a40eb867",
+   "sha256": "1x5l4l486615w77ac4dh95af9x8yhivd5z557c2j053avx2728c4"
   },
   "stable": {
    "version": [
@@ -70590,16 +70943,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20250125,
-    1144
+    20250220,
+    1613
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "20749ec0c9e9ff2135dcc474f53c7bb78bff7c8e",
-   "sha256": "1q2ms06g2y47kqjhmf3zrb9wpb1imnk6hlkysl7gl3glxhkakdbf"
+   "commit": "17279fb3a820ea2181a8296debcdd4e6dfc72024",
+   "sha256": "1lj8ifw8cymyxskv4w18pk5magj79rv1q9f0w75mwrs6mbm5fnj6"
   },
   "stable": {
    "version": [
@@ -70624,11 +70977,11 @@
   "repo": "HaoZeke/lammps-mode",
   "unstable": {
    "version": [
-    20180801,
-    1319
+    20250311,
+    47
    ],
-   "commit": "a5b68d7a59975770b56ee8f6e66fa4f703a72ffe",
-   "sha256": "1ma33bszv7d6am47n5r74ja4ks7n46m8xfkkr3vcqymlfhbdpq73"
+   "commit": "92d262c755c3aedf02bbe19743ba761ccdc7c0c2",
+   "sha256": "0hm2dbb28yb179af0674600zhfgqaivzq7zvdnlqr0jfw2b1w87j"
   }
  },
  {
@@ -70881,14 +71234,14 @@
   "repo": "slotThe/change-env",
   "unstable": {
    "version": [
-    20240318,
-    855
+    20250210,
+    637
    ],
    "deps": [
     "auctex"
    ],
-   "commit": "8b6bcd562c8ba5753551f7a6837b01b562b6439a",
-   "sha256": "0qqhxbxynii3sqywqvni9i0r32jrnljriky0fsfs8bf1sndzpdc7"
+   "commit": "c39f8fbc6c378e6969bd94a19213f548c88a949c",
+   "sha256": "04018ravgjkpvg1qn9cgpfs3bzk5w8lrqj1sgfpn5k525278bck2"
   }
  },
  {
@@ -71275,14 +71628,14 @@
   "repo": "AnselmC/le-gpt.el",
   "unstable": {
    "version": [
-    20250125,
-    1952
+    20250311,
+    1510
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "f880e6f7529a080599aadaedebdb88884849d01c",
-   "sha256": "1xm4sc9iv86cwral9fmndni67clyzl1rfsngh2gc1vkckcny3w27"
+   "commit": "f1c43803df8078ee5f0de5d1e5300ca8b3449568",
+   "sha256": "11ismm1fyfngy74cwhddp49kjjc93mqj9q2zzd0w6b97ziagjbzh"
   }
  },
  {
@@ -71562,11 +71915,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20241114,
-    1751
+    20250313,
+    459
    ],
-   "commit": "15b7d29f2539f9e9671ab3c062bd5165e5b80ae8",
-   "sha256": "1hn6lznhis7xgq0c14yp3jdazgq3c23k53zlm3fkqs9qzy1h1j4m"
+   "commit": "0365501aeaffdd8955f4cad25c9eaf3bee30efe5",
+   "sha256": "1q4sn6xisgq0pyp26j5fj3r69blh7v5vfazwpfryrrlr78s8ni5y"
   },
   "stable": {
    "version": [
@@ -71601,16 +71954,16 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20241115,
-    527
+    20250312,
+    806
    ],
    "deps": [
     "aio",
     "log4e",
     "s"
    ],
-   "commit": "bf259182a18a44c49ccc5449d1353ec4009a9480",
-   "sha256": "095cmlizfmpbygn9x6yavjnlkczfycay3ijfxqd64idagvwkx0dp"
+   "commit": "b0c466fa58254ee7396ae23310d718fc14a6b3df",
+   "sha256": "05zk1fwcclk74658m3r9igsada1fjyk681pc3x4jkqlwqijbzxsh"
   },
   "stable": {
    "version": [
@@ -71845,20 +72198,20 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20250119,
-    1708
+    20250301,
+    1634
    ],
-   "commit": "264ed5beac3ab6917d28dc38dae2bdb0a81e9af6",
-   "sha256": "11pv98060cdavfbz33by4ll188lnivfnppaqh8gdp2ympvfhqwf0"
+   "commit": "43c9836cd3a3b96a56b200a340eb5c92e0766efa",
+   "sha256": "1qwn8565bpdqs1w1k248i2xg3lr6al5v8bzmj90d8ysqpalhr235"
   },
   "stable": {
    "version": [
-    1,
-    3,
-    0
+    2,
+    5,
+    301
    ],
-   "commit": "264ed5beac3ab6917d28dc38dae2bdb0a81e9af6",
-   "sha256": "11pv98060cdavfbz33by4ll188lnivfnppaqh8gdp2ympvfhqwf0"
+   "commit": "43c9836cd3a3b96a56b200a340eb5c92e0766efa",
+   "sha256": "1qwn8565bpdqs1w1k248i2xg3lr6al5v8bzmj90d8ysqpalhr235"
   }
  },
  {
@@ -73055,6 +73408,21 @@
   }
  },
  {
+  "ename": "lithium",
+  "commit": "93e8296ad72da89e029052e9dc51030ba3dcfc74",
+  "sha256": "1lisrfzi87q6wbb4kks5jnjw0xk28p1alc1hd9sv72ddfx6pxn36",
+  "fetcher": "github",
+  "repo": "countvajhula/lithium",
+  "unstable": {
+   "version": [
+    20250305,
+    2355
+   ],
+   "commit": "4618600e9443dabf5f9d3856a78645a2099f5987",
+   "sha256": "011hfn1y929r6wg1ld4v3vn9i46cis80pzvc98yp62cxd4145ccn"
+  }
+ },
+ {
   "ename": "live-code-talks",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "1ji4lww71dqxnn5c9inix8xqcmgc76wbps0ylxhhgs44ki4hlyrm",
@@ -73232,26 +73600,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250201,
-    1300
+    20250312,
+    1428
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9802c215a3eea748d9d7f81a1465850388006897",
-   "sha256": "0f2v1fw5iahlh0ypbwxfpav48h43h0zqqmicgs2hg7r251ss2j8j"
+   "commit": "ff77af7c5df678041aebb48497418ff8af0acefc",
+   "sha256": "1a43lm4i7lppigi9mk9alylm3vganqn8prfx7dxiagxdrifif58k"
   },
   "stable": {
    "version": [
     0,
     6,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9802c215a3eea748d9d7f81a1465850388006897",
-   "sha256": "0f2v1fw5iahlh0ypbwxfpav48h43h0zqqmicgs2hg7r251ss2j8j"
+   "commit": "c1b320d6308a68d8841116745310cc55ac5ce74b",
+   "sha256": "0pa7sdj7rxj8hr3r2lcwz3z04b8b9k61d9j9a7qr1n3n9x9krdjd"
   }
  },
  {
@@ -73467,14 +73835,14 @@
   "repo": "phf-1/locs-and-refs",
   "unstable": {
    "version": [
-    20250131,
-    944
+    20250303,
+    2053
    ],
    "deps": [
     "pcre2el"
    ],
-   "commit": "25a1e5c0bbd32ad488fbe6ff8879b06c45f73622",
-   "sha256": "1hbrs1akqlb835nl860k549yxjf537fajwzlrs9m1hcjzgnwpja5"
+   "commit": "5c3f0e04ea6cc4728219dfd716d95c7d044b8030",
+   "sha256": "1iml5zrf9xvb1f9wmidp132hnk1r6vcrdz20gzfgsl0ibyxj90jf"
   }
  },
  {
@@ -73697,30 +74065,30 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20250203,
-    1956
+    20250306,
+    1331
    ],
    "deps": [
     "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "cac74558ed8f363f222d2e0d52eab5562436347a",
-   "sha256": "0kw8asfsv3pbjkzi55skibp94hrji80hxrankgnkrsl7dzq556qm"
+   "commit": "cd990bf63785897bfdfa0ec954db986f0361449f",
+   "sha256": "1zxsyx61nh2x1lx55k1w0w3cj0p541dwc5i5pps7qfwqa0184f22"
   },
   "stable": {
    "version": [
     0,
     19,
-    1
+    2
    ],
    "deps": [
     "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "9ce423a9fc319bb919c681e16939b9f561f7a942",
-   "sha256": "0qgkmjw5prc5zrsccdmh9wfr1fyk9jfdfnqn6ldsbi7jhbr71366"
+   "commit": "e9b40730c6abea7d1e0235fa5ba790d175b008ef",
+   "sha256": "1dhs2l2lx1gvvwg840a9y4nf2zxk9nljpyr8xqzi3si8wa7b3jdj"
   }
  },
  {
@@ -73856,8 +74224,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20250119,
-    135
+    20250306,
+    206
    ],
    "deps": [
     "compat",
@@ -73865,8 +74233,8 @@
     "seq",
     "stream"
    ],
-   "commit": "36f76980ea52a31a4c7682f7bd26c4baa32a1d4c",
-   "sha256": "0a0yjn5g8bsaaamc5374jw2wvs6mi7i5p77rd48xn4vmrb24h3b9"
+   "commit": "348eae3bc01b920e38bfdc8fb1a14e38f5886bda",
+   "sha256": "1syawy975wf1s8q63x3gpwpx6bglaxlrfyq4md5d6mjnkg6hi2k5"
   },
   "stable": {
    "version": [
@@ -74014,8 +74382,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20241114,
-    2005
+    20250301,
+    2106
    ],
    "deps": [
     "dap-mode",
@@ -74027,8 +74395,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "7e3d3429418bc42cda7fa7b58e6644a705cf2f89",
-   "sha256": "06mxy8vw64szhik58g5qsw4a6jwzm92v474dkb2sfi8cxw5zp8vs"
+   "commit": "2170823139269b77c39e3bf7600ff6c751a73b0d",
+   "sha256": "1g66pxq9cfhbk3gnp581y1frhmrraw8b4wcpvmw9xgimnf0k0y1p"
   },
   "stable": {
    "version": [
@@ -74058,8 +74426,8 @@
   "repo": "emacs-lsp/lsp-docker",
   "unstable": {
    "version": [
-    20240419,
-    1428
+    20250228,
+    2210
    ],
    "deps": [
     "dash",
@@ -74069,8 +74437,25 @@
     "s",
     "yaml"
    ],
-   "commit": "16a0cfbe06813a1191b19e412445f9d34cd7493f",
-   "sha256": "1ry8yxrb0172n1lnqi4av4wmqvhaqyh55ih2xs0hnd8b6ziywafq"
+   "commit": "3960c73349e5658220f0f48587894ac098e62b97",
+   "sha256": "05sblmvj1vhk4rgfqahr0i0dnaczcixcddd88w3rsdyh72wpxdg6"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "dash",
+    "f",
+    "ht",
+    "lsp-mode",
+    "s",
+    "yaml"
+   ],
+   "commit": "ce291d0f80533f8eaca120eb745d55669e062636",
+   "sha256": "01q76a6xndkqwxm3nf764h0ssfzd8n9g1a0ww5klxy8h7nbhwvn4"
   }
  },
  {
@@ -74113,8 +74498,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20250101,
-    850
+    20250226,
+    2340
    ],
    "deps": [
     "grammarly",
@@ -74123,8 +74508,8 @@
     "request",
     "s"
    ],
-   "commit": "0ae43b9d92c0f324d0ad9f3c28c34a305381f13e",
-   "sha256": "03kpxas4b6ld9pzpcy331i9gbn8pyhpvqbb3mr1y66j18czr5vnj"
+   "commit": "7b788f97d21d689d152c31e7876a04813391d48a",
+   "sha256": "1jh2hmlvb7v8srwkvazdvhcr33hdgs0f1r0ji1p6r68czfsxxmmg"
   },
   "stable": {
    "version": [
@@ -74151,14 +74536,14 @@
   "repo": "emacs-lsp/lsp-haskell",
   "unstable": {
    "version": [
-    20250126,
-    1101
+    20250301,
+    213
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "1d618c62e87e0dd254cb267e7c41a24f2f054296",
-   "sha256": "1jb069k7n7w46wfl2wk158nih2km1z94c2ayqgnjdr8iyrk0fj9v"
+   "commit": "cd0f5d251c14e90f2896d26d18de8ace462e011b",
+   "sha256": "181x8d13mmqlkhq0jdid7b1wx8r8gcfkvxinxf7898hvzvkqmzrr"
   }
  },
  {
@@ -74220,8 +74605,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20240524,
-    2207
+    20250228,
+    2147
    ],
    "deps": [
     "dap-mode",
@@ -74233,8 +74618,8 @@
     "request",
     "treemacs"
    ],
-   "commit": "4909c14b9012eed669a9c3f11a8df055d5bb8a0e",
-   "sha256": "0qw824vdqk92r8hrrjsi7pd00rw60wf5jfjk1x3nhs06hijs0x0s"
+   "commit": "6cfff8761e9f23889c002984f61e4ae04979eaf5",
+   "sha256": "15y8brajnp6y4ii8dylgrfyq7n9a7jd80m3jjk2g9ra04mqzfhw5"
   },
   "stable": {
    "version": [
@@ -74377,14 +74762,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20250131,
-    1652
+    20250228,
+    2215
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "fc394cf8779e86e2d14c7ed209dafe225be90a6f",
-   "sha256": "1vhd9pm4445nf068g600dlnpnriq0a3ks69r5xj3wdic5l34yfvi"
+   "commit": "3cfb4ed92b71ab63daaab77962fd6dd23a2851e7",
+   "sha256": "04hy89zd04vrpp558chv1rypkc6aqyjjz9z15jnd515gjy9r26r5"
   },
   "stable": {
    "version": [
@@ -74409,8 +74794,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20250102,
-    1828
+    20250228,
+    2145
    ],
    "deps": [
     "dap-mode",
@@ -74422,8 +74807,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "6a6a345a8a6cd8814b40909aef8e99055b128fa0",
-   "sha256": "0cik7mq8g32h98iyqjmai3k5gi17f71mp3y39a04cp4grbv1jxky"
+   "commit": "345b4fa80e31c58fd14e4c0cf9b88eb2aededcb0",
+   "sha256": "0y1pkzc7symdzgh0vk5plcn2r23ai2gbnjps1cr5kjjbwqq1yz4q"
   },
   "stable": {
    "version": [
@@ -74453,8 +74838,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20250203,
-    2137
+    20250312,
+    2052
    ],
    "deps": [
     "dash",
@@ -74465,8 +74850,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "230608ad65809806481adab40ecf41d3780e7b8d",
-   "sha256": "1196swvh0z3qw1iv7jgpjmwp72nnz6q6hpsy4pjldj5bjxx1lfac"
+   "commit": "d3110e3d7dfcae2340353e30c523153ab9c1f347",
+   "sha256": "0a73pnm5x1jcx966img8s6w7mps6sgldamjy98j38j7bhimgb6lw"
   },
   "stable": {
    "version": [
@@ -74495,8 +74880,8 @@
   "repo": "emacs-lsp/lsp-mssql",
   "unstable": {
    "version": [
-    20230510,
-    1124
+    20250301,
+    131
    ],
    "deps": [
     "dash",
@@ -74505,8 +74890,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "a0dba8f86a2ace7e800a9dc8f814767625a509af",
-   "sha256": "1bsixap2ql98aic6vvxb67c7gslf1dpsrnkms203iv3h3w2ywdmb"
+   "commit": "60a1548be01c2d6570d662a50f0d09cb20680df7",
+   "sha256": "12h2llkhjs7256xz9h4b3rd39jbsg14bixj65f4nsgj0ll564nfg"
   }
  },
  {
@@ -74585,16 +74970,16 @@
   "repo": "emacs-lsp/lsp-pyright",
   "unstable": {
    "version": [
-    20241102,
-    1425
+    20250301,
+    131
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "dd54b3ae7c22d34faaced7b1a89739063c552b1f",
-   "sha256": "1807i3127m08h47aj3jj92yrhlf4xjkj3irs02vwlgsbix6fnlqg"
+   "commit": "b4cee81af46274303f2cb9b75de9fc8ddcba04d9",
+   "sha256": "1l65kh188886y06402d8v2989r6n69wxcr2hfzwb0400g3fzda9m"
   },
   "stable": {
    "version": [
@@ -74730,16 +75115,16 @@
   "repo": "emacs-lsp/lsp-sonarlint",
   "unstable": {
    "version": [
-    20240806,
-    305
+    20250301,
+    131
    ],
    "deps": [
     "dash",
     "ht",
     "lsp-mode"
    ],
-   "commit": "ad668f7451664c901f798878534d85dd5e09a4a8",
-   "sha256": "15hsgbansrl08i6rbw5hkl3jqva4jwhlj1rlv33vxfkhkamv0krs"
+   "commit": "f9c61eafce62edf15f05d7262290ea87f2beb60d",
+   "sha256": "0v8jvgy5y0s0nyiga4p2xmfdjzkhl29y6kl12kw6zfz82r3y4smv"
   },
   "stable": {
    "version": [
@@ -74764,14 +75149,14 @@
   "repo": "emacs-lsp/lsp-sourcekit",
   "unstable": {
    "version": [
-    20240905,
-    218
+    20250301,
+    131
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "63ff1ab638b655089077d17fdd728a48f8906e02",
-   "sha256": "1vy7bjazsgkx01gg1qvvipphzxgn20w6lrwhqj0yhfz9ablhcd7p"
+   "commit": "3bd9750e7ec97706c0455f41ea4e5cff3391dba8",
+   "sha256": "04hbvldgz4rxpkanzq2kywi8camq4vy50i6sraq6pyx4qbq0nabi"
   }
  },
  {
@@ -74812,8 +75197,8 @@
   "repo": "emacs-lsp/lsp-treemacs",
   "unstable": {
    "version": [
-    20240406,
-    2141
+    20250301,
+    131
    ],
    "deps": [
     "dash",
@@ -74822,8 +75207,8 @@
     "lsp-mode",
     "treemacs"
    ],
-   "commit": "e223fbb6c09ebcd1366d631c191fab485f0678b8",
-   "sha256": "181rlny54gn2621jrihgq6dwdmpdhmb63awlw6jdzvv4v62fs2r1"
+   "commit": "2495abd9df2f19335b4a280d9db641e02e2ddcfa",
+   "sha256": "1xnj2kjiwwy4pdaif2yp7n1iirmgpdmi5w9ala0hmqki4yi5rgcc"
   },
   "stable": {
    "version": [
@@ -74849,16 +75234,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20241204,
-    1808
+    20250228,
+    2155
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "f0edfac7b3736fcab617cbeb07e465c9153ae68b",
-   "sha256": "0i84623jnzp8bdi6bw5r90rcjgfn651qrahvb8qaah5xzrs31kh1"
+   "commit": "09d40806429fadc01a12d9a1841b49430f58adb5",
+   "sha256": "136pb5nggfixa681k43f5ii4k9mhg6wfi3af9qm1wa63yly8cphq"
   },
   "stable": {
    "version": [
@@ -74914,11 +75299,11 @@
   "repo": "immerrr/lua-mode",
   "unstable": {
    "version": [
-    20231023,
-    947
+    20250310,
+    1150
    ],
-   "commit": "d074e4134b1beae9ed4c9b512af741ca0d852ba3",
-   "sha256": "1n1k55xy9zaknb9hfv7qlxi3ij1dvspldzzn6vc68c7yzskn88zv"
+   "commit": "2f6b8d7a6317e42c953c5119b0119ddb337e0a5f",
+   "sha256": "0q11y28hgxsdfhsdgmhda1j654s9yq95sx8g1gb129gzxxa9ygca"
   },
   "stable": {
    "version": [
@@ -75406,32 +75791,33 @@
  },
  {
   "ename": "magik-mode",
-  "commit": "291cce8e8e3475348b446ba38833eb1e37d4db65",
-  "sha256": "1d6n7mpwavrajcgai6j0y5khhgc4jaag1ig1xx8w04mr48xrjxqk",
+  "commit": "6f0cac5a5c86d160012cbb19608ad67c97afb9f1",
+  "sha256": "01zsjzxmax65a89x78cvi4ff0dxk1p9jlil0dhn3z2g8z92zhwvv",
   "fetcher": "github",
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20241111,
-    1446
+    20250312,
+    815
    ],
    "deps": [
-    "compat"
+    "compat",
+    "yasnippet"
    ],
-   "commit": "441389f75bdf6990556b96597979bf4a0b9cbdec",
-   "sha256": "1df4dpaygy0nnkqw4f6df5i186396dg05cp6imf83ipg7jnlypsq"
+   "commit": "0c5131285845c7147b41dc5bd04372c71b690684",
+   "sha256": "0wkvvdnpaa9079sdv0x3l3l56mhisnklp39mngk30hs7833fnpzq"
   },
   "stable": {
    "version": [
     0,
-    3,
-    2
+    4,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dfbb5482b18633adf9790599f415aa5c507228ca",
-   "sha256": "15kshz11g2h6d13vpayhl9p3d95qm253s5knhhlwxm8yykw94pp4"
+   "commit": "dacb19bff41b464ee209d7a2bb5bbf8589e9a37e",
+   "sha256": "1ps9nmirqchhvp6v9xzxv2cjp4i9fnqn06lmz93bwcmzk2akm95q"
   }
  },
  {
@@ -75442,8 +75828,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250208,
-    1839
+    20250312,
+    1432
    ],
    "deps": [
     "compat",
@@ -75453,14 +75839,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "085baa2ac96df90bdb2a1bedd3598df19919d731",
-   "sha256": "0w6phljp6l4fn7sa17n6jhfq8r0q03lv2xl5pqyrbdg8q373v1d7"
+   "commit": "ed4fa09eeeb531c0cfc3c7bf713d3929c2b2107d",
+   "sha256": "06lshr77f3avgryc1pryiadhayxb3djw8rcvb8qj35g66rpdr6jl"
   },
   "stable": {
    "version": [
     4,
     3,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -75470,8 +75856,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "f52dfada8fa0fa6cd70886819868d84e198773a3",
-   "sha256": "1xz68154qmik4xs3ldl1gv87rb3famgd73k0174xbsr48d40ccyg"
+   "commit": "28d272ce0bcecc2e312d22ed15a48ad4cea564eb",
+   "sha256": "07harzpyqrskx4xslj4xa1w1d0sza13zw5z0nam9kagi72cklvjv"
   }
  },
  {
@@ -75559,38 +75945,6 @@
    ],
    "commit": "ad58efa312d708f25661dfcc2a7f83a833cca328",
    "sha256": "0h0bg8vm8rf4rppx2gpxjcklnjfnbxv0c5n8fia2a3f9qaz4m0as"
-  }
- },
- {
-  "ename": "magit-file-icons",
-  "commit": "d3d921177674e531d53df5b6205ea6a426491186",
-  "sha256": "0qcw8mr78mc7bpyzxcix23cvk89fkd8f9ykj7qaxixgizfcmgyhj",
-  "fetcher": "github",
-  "repo": "gekoke/magit-file-icons",
-  "unstable": {
-   "version": [
-    20250204,
-    811
-   ],
-   "deps": [
-    "el-patch",
-    "nerd-icons"
-   ],
-   "commit": "85e4bc0184eb34cd2a799c3749889c6f74f80bea",
-   "sha256": "1yjm2xy00vsq2d14w4xcpriiaraav07i389vbx6g8i79bajgln25"
-  },
-  "stable": {
-   "version": [
-    3,
-    0,
-    1
-   ],
-   "deps": [
-    "el-patch",
-    "nerd-icons"
-   ],
-   "commit": "85e4bc0184eb34cd2a799c3749889c6f74f80bea",
-   "sha256": "1yjm2xy00vsq2d14w4xcpriiaraav07i389vbx6g8i79bajgln25"
   }
  },
  {
@@ -75795,16 +76149,16 @@
   "repo": "douo/magit-gptcommit",
   "unstable": {
    "version": [
-    20250209,
-    903
+    20250216,
+    922
    ],
    "deps": [
     "dash",
     "llm",
     "magit"
    ],
-   "commit": "2c3af41c40fb9fd849945b43f744bd788d3aa6f5",
-   "sha256": "140gcmdfkasf3rkgkal4a4j3kj1ni7b97y20bj7kja1rslcqrk48"
+   "commit": "f943440459eebec979defe4161d7505fb76f4675",
+   "sha256": "1vb361dxjgmh76hryviprvmy3djm2dj723f8sipfbshgrgqwpsl8"
   }
  },
  {
@@ -76029,30 +76383,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250206,
-    2317
+    20250307,
+    1739
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "3f2a501ec8c327da166e000c5bd9dd77e139aa65",
-   "sha256": "0wjcmv075zd4z053cq1r80prmyiam9nnxvk487ydr6iy81slr6pm"
+   "commit": "3f79700f1b9a6f5f6fd6a77fd1e812c1b8e6463b",
+   "sha256": "0hm4wcnr9ybsll507xdhmprb2in93pdn2mw9a1zf7cfvr4ygk0yg"
   },
   "stable": {
    "version": [
     4,
     3,
-    0
+    1
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "f52dfada8fa0fa6cd70886819868d84e198773a3",
-   "sha256": "1xz68154qmik4xs3ldl1gv87rb3famgd73k0174xbsr48d40ccyg"
+   "commit": "28d272ce0bcecc2e312d22ed15a48ad4cea564eb",
+   "sha256": "07harzpyqrskx4xslj4xa1w1d0sza13zw5z0nam9kagi72cklvjv"
   }
  },
  {
@@ -76078,28 +76432,30 @@
   "repo": "stacked-git/magit-stgit",
   "unstable": {
    "version": [
-    20241012,
-    119
+    20250215,
+    2223
    ],
    "deps": [
+    "llama",
     "magit",
     "transient"
    ],
-   "commit": "51168b7438dfb5ca6b9239b8564397cc0cc6e798",
-   "sha256": "1z2dhc1m510iyrks5lxp3jlqg4n7qwwirbmxg4c4ll0xngfhnalc"
+   "commit": "b19d96f8f62bd4def83eb1c09e9cd2582856351e",
+   "sha256": "10ql7gi586w65vds6wsh8bw5nr444xqhgh87khzcpfaglnw2lyaf"
   },
   "stable": {
    "version": [
     3,
-    0,
+    1,
     0
    ],
    "deps": [
+    "llama",
     "magit",
     "transient"
    ],
-   "commit": "51168b7438dfb5ca6b9239b8564397cc0cc6e798",
-   "sha256": "1z2dhc1m510iyrks5lxp3jlqg4n7qwwirbmxg4c4ll0xngfhnalc"
+   "commit": "b19d96f8f62bd4def83eb1c09e9cd2582856351e",
+   "sha256": "10ql7gi586w65vds6wsh8bw5nr444xqhgh87khzcpfaglnw2lyaf"
   }
  },
  {
@@ -76119,7 +76475,7 @@
     "transient"
    ],
    "commit": "ca637c648835eddbeb277cc8089d3ffd6f75ae13",
-   "sha256": "sha256-p+uDl+TUStmtbiPk64oRAbvni0LADklStClHgD5OgXQ="
+   "sha256": "0x419qz80ir9ni94j3n08a5ygfq1265fpr13dsnxjjnlwjbq7sx7"
   },
   "stable": {
    "version": [
@@ -76317,21 +76673,6 @@
    ],
    "commit": "6309c001355126e3ade79493479b517925943d17",
    "sha256": "0fg4hi65qdix0lpfw29ymy2naskn2af661pzg695f47xhknsir1r"
-  }
- },
- {
-  "ename": "majapahit-themes",
-  "commit": "0b1748b5a5d355df319cd50b369caa23a8169add",
-  "sha256": "0y34a4w9wha9bycz7fg28b1vgivp7v81s7bwsv60xkbszwpcakgr",
-  "fetcher": "github",
-  "repo": "emacsmirror/majapahit-themes",
-  "unstable": {
-   "version": [
-    20221207,
-    121
-   ],
-   "commit": "7200f16f0fd4cc18e8c7d82b62cc351b610609af",
-   "sha256": "0r47k03m21w206kq8n3q10374xxw0278l8wilb2ls1bmr2bsd2sa"
   }
  },
  {
@@ -76965,19 +77306,19 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20250115,
-    1658
+    20250310,
+    417
    ],
-   "commit": "7659bc470d096e7a53285fa246cbabcb07d66a33",
-   "sha256": "1h4yksxdy0ah6dw97vgl6li9dcsx561x04yjj5r3fiz2bb2qrvv3"
+   "commit": "dd2cb2cdcd6594c3663cda20b465f09c773fcc90",
+   "sha256": "16myq0adw6n38qlai7zzmrln5ckdhv668nyg52mkdyr5hamcpwp0"
   },
   "stable": {
    "version": [
     2,
-    6
+    7
    ],
-   "commit": "193b61605f44c85d261b8bd82e0a213fd8f1ff32",
-   "sha256": "1i0b32z3zis39k412xa7jsikp5wdv2rxvbg8slm4phwi31n52r47"
+   "commit": "1c7aecba67cc478ca3f6bd7899dc06956e4762f4",
+   "sha256": "1w6y18bg0fpvb5xwr827ynzbj0f0nh3dms3n0xq6hg38dcyly46b"
   }
  },
  {
@@ -77243,6 +77584,21 @@
   }
  },
  {
+  "ename": "marron-gold-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "0854v04g796fv9478b70qxvvg0f99v2865ca25g18yygm80fx4zb",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250224,
+    923
+   ],
+   "commit": "ae9a0c318c371ed70ec568f3a618d47124817fe7",
+   "sha256": "10pkpv4i1xv2cv9ma3mnavrm3xvffa5nwxa66nrzvvrkvcjbpg82"
+  }
+ },
+ {
   "ename": "marshal",
   "commit": "203f2061c5c7d4aefab3175de5e0538f12158ee3",
   "sha256": "17ikd8f1k42f28d4v5dn83zb44bsx7g336db60q068w6z8d4jbgl",
@@ -77310,30 +77666,30 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20250204,
-    1902
+    20250305,
+    2104
    ],
    "deps": [
     "persist",
     "request",
     "tp"
    ],
-   "commit": "1dfe4368488d2b0539b7626b0c105343ca92322e",
-   "sha256": "0ry329cnbmb43xdh51xjgdx3mghrvyw221884vmyrnhh8fb3wnz9"
+   "commit": "fd59828c89e808d0a6d0d9abab8e830df494b515",
+   "sha256": "1wc3y3pwg9xc27fa6xc2bcv809rxcbjy372r998wl95a81apx32g"
   },
   "stable": {
    "version": [
     1,
     1,
-    9
+    12
    ],
    "deps": [
     "persist",
     "request",
     "tp"
    ],
-   "commit": "1dfe4368488d2b0539b7626b0c105343ca92322e",
-   "sha256": "0ry329cnbmb43xdh51xjgdx3mghrvyw221884vmyrnhh8fb3wnz9"
+   "commit": "fd59828c89e808d0a6d0d9abab8e830df494b515",
+   "sha256": "1wc3y3pwg9xc27fa6xc2bcv809rxcbjy372r998wl95a81apx32g"
   }
  },
  {
@@ -78252,26 +78608,26 @@
   "repo": "KeyWeeUsr/mermaid-docker-mode",
   "unstable": {
    "version": [
-    20241206,
-    734
+    20250313,
+    652
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "92dd790c099f2d90899622421d76cbcc29e36c10",
-   "sha256": "0l879kfi72fasd3067l3fh8mw0ir6nhs8mjaiddxgiqgxwlrdr6q"
+   "commit": "d40e4a4c031f363b58ef1cef9eefc097d4c4d85a",
+   "sha256": "0aj9pk0wjx9swza884frk7jgqlm0ggxm9w7yj8z7wmpi55jcfzr8"
   },
   "stable": {
    "version": [
     2,
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "92dd790c099f2d90899622421d76cbcc29e36c10",
-   "sha256": "0l879kfi72fasd3067l3fh8mw0ir6nhs8mjaiddxgiqgxwlrdr6q"
+   "commit": "d40e4a4c031f363b58ef1cef9eefc097d4c4d85a",
+   "sha256": "0aj9pk0wjx9swza884frk7jgqlm0ggxm9w7yj8z7wmpi55jcfzr8"
   }
  },
  {
@@ -78713,20 +79069,20 @@
   "repo": "daut/miasma-theme.el",
   "unstable": {
    "version": [
-    20250202,
-    950
+    20250312,
+    2221
    ],
-   "commit": "56eff6ff70c41ea5a86641770f917ea622dce19f",
-   "sha256": "1iiwr8ly8cn8aw0gmwk9hdcapclkcr1nskdw5ndzqci41lp1hxbz"
+   "commit": "6604a9cd76183394447e9b2cec2265d7e62aa26b",
+   "sha256": "1limia5jnq9fxhvnhws1b5iw3ssdqajnyvrlzvbx3axvbgix1c2c"
   },
   "stable": {
    "version": [
     1,
-    5,
+    6,
     0
    ],
-   "commit": "251408da3b7243035c773c5c299353ab36bd2ec0",
-   "sha256": "0pb2caf4bj1aynj8mf1cy5syw0v3bf8xjxv78krpa6h9j3zpy7nb"
+   "commit": "232e4ea1d8182c53b7ed803e1df3ad687dd22a92",
+   "sha256": "07fci5vli5d8m607v0v6q535gnmcf4aqyw7020pzq0d7ij4vwacj"
   }
  },
  {
@@ -78812,14 +79168,11 @@
   "repo": "emacs-jp/migemo",
   "unstable": {
    "version": [
-    20231120,
-    842
+    20250228,
+    324
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "7d78901773da3b503e5c0d5fa14a53ad6060c97f",
-   "sha256": "1098lf50fcm25wb41g1b27wg8hc3g2w6cgjq02sc8pq6qnrr0ql2"
+   "commit": "fbc16b57eace9bf25bcb325032c59c50b186b9d7",
+   "sha256": "10d27jrmn7k4mqqd5cgqf8jwa0pq9yh2550b1r6lwmz6wx509552"
   },
   "stable": {
    "version": [
@@ -78895,14 +79248,14 @@
   "repo": "countvajhula/mindstream",
   "unstable": {
    "version": [
-    20241121,
-    19
+    20250307,
+    1736
    ],
    "deps": [
     "magit"
    ],
-   "commit": "cad6a33c7e45f7c52f627d38d3d1f8f35a53413e",
-   "sha256": "1xvmm53s59fkg0cibcim0ivi258w26a2sg9aizg1gw3iqhyjy1rr"
+   "commit": "ccd154e861223378c59b346319498df327301704",
+   "sha256": "03bnskwaz76f56rzk9j2rn2xh9dbqgkdzfgrx42nrxp24ssry9sl"
   },
   "stable": {
    "version": [
@@ -78957,15 +79310,15 @@
   "repo": "eki3z/mini-echo.el",
   "unstable": {
    "version": [
-    20250209,
-    1407
+    20250216,
+    1955
    ],
    "deps": [
-    "dash",
-    "hide-mode-line"
+    "hide-mode-line",
+    "llama"
    ],
-   "commit": "197260e3e7121d60aa6f6d8f86de9a921fa1230c",
-   "sha256": "0dzj538cfdgpb5ca82nnfgwg7wiyahk81nav7gh4zijqzqiixkhi"
+   "commit": "a604f1c6630452e99a18a61586cc984822550985",
+   "sha256": "0nrqwyqr38gd0200my1qf8bjnwwi8dk6d2pf3dqnc2w0xgs936ms"
   },
   "stable": {
    "version": [
@@ -79149,11 +79502,11 @@
   "repo": "rolandwalker/minimal-session-saver",
   "unstable": {
    "version": [
-    20140508,
-    2041
+    20250228,
+    1021
    ],
-   "commit": "ac42b6835f777a8a7e04599d8f20ec650997ba96",
-   "sha256": "0n2drkqnd02d7n5f4qlxlzlh4gkdi33w4hprndpw15gyny2i8x29"
+   "commit": "1146d071c370bc3de33538e2d20172a9cca29ba2",
+   "sha256": "00c2b28zkms8r8n5zh9q9j911b2bv3vfdlsw0g7qdhb35qkfw174"
   },
   "stable": {
    "version": [
@@ -79332,27 +79685,28 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250205,
-    1919
+    20250310,
+    1934
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "034317580d67f5eb3113a0d597c509ccbcc57adc",
-   "sha256": "1hlzkn5qgv9dpis5y6vdi8ncyw3yl227cr5nf5k9y6mpkrxlyycm"
+   "commit": "fffbb3a39a996fabb65b8f06ab5422bb53c500cd",
+   "sha256": "0cq06rmm7j3xxfvsnb5s69byna3pwljcgp7bklfqm395h2d39wyr"
   },
   "stable": {
    "version": [
     0,
-    3
+    4,
+    4
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "cc8c890413cab2008e7674b4b9ef55627fcf5766",
-   "sha256": "1ff9ia8lcz919p5n9jnqw6259nlqj7vdb58lhxvps86xcralrk4h"
+   "commit": "fffbb3a39a996fabb65b8f06ab5422bb53c500cd",
+   "sha256": "0cq06rmm7j3xxfvsnb5s69byna3pwljcgp7bklfqm395h2d39wyr"
   }
  },
  {
@@ -79402,15 +79756,15 @@
   "repo": "eki3z/mise.el",
   "unstable": {
    "version": [
-    20250123,
-    1922
+    20250216,
+    2030
    ],
    "deps": [
-    "dash",
-    "inheritenv"
+    "inheritenv",
+    "llama"
    ],
-   "commit": "2ba633b84c5d678ef128901c443ee43f6052d3de",
-   "sha256": "0insbf8gcg172yg1w7gmy4hf3krv58gxqbb1ch2902djyvsfwwdn"
+   "commit": "97d244417d28605306f3a98eac0b67564677f277",
+   "sha256": "1qk24z3rmyc1s4cxg3d2pzzdzc0yvn3h07q2bybyqb2dbmqcs2hq"
   },
   "stable": {
    "version": [
@@ -79434,19 +79788,19 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20250130,
-    1831
+    20250311,
+    2051
    ],
-   "commit": "373f3f4d32302beac9c423008b1ef5c3234ac45a",
-   "sha256": "1wn3paw6c5923v7j0kskp6wkhhxhjxqwbnzypqi86r5iqqysc9d8"
+   "commit": "d7f0b02575e640a724caf26bad2f076ce0d9614d",
+   "sha256": "02af8bd0bhz8n1s7amrnwkxyrwavxaf42gwvrdpzdggcrdf2nv9j"
   },
   "stable": {
    "version": [
     1,
-    3
+    4
    ],
-   "commit": "cdf32f4c9f803633f4d2684a70d48858c142faf8",
-   "sha256": "0wyhv6skml0p9lajhmfbwc8wm3r1107kgwyvh31dyi9m4zhc52zh"
+   "commit": "012007eefee8b5dd454c0d4671902e454b0de199",
+   "sha256": "1garqzcx14mwakbrp5p2vqynlbh819w8gjnf24x4xhv5aa5xy81j"
   }
  },
  {
@@ -79927,6 +80281,30 @@
   }
  },
  {
+  "ename": "mode-line-keyboard",
+  "commit": "5da0167796fae2967e2538c6104f1f4a9b093c1d",
+  "sha256": "1si3fp24457wsdm9miviqyf6dx71lii7irj9q3zld8zy4cyr2ii2",
+  "fetcher": "github",
+  "repo": "Lindydancer/mode-line-keyboard",
+  "unstable": {
+   "version": [
+    20250303,
+    2002
+   ],
+   "commit": "e5613ccd81bd58161efb53ebeaee7bd4dea197ee",
+   "sha256": "1pyyan6zgpkzpk74fd7rrw266cxwkydwl4jj34398pwgb2hq8j65"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    3
+   ],
+   "commit": "e5613ccd81bd58161efb53ebeaee7bd4dea197ee",
+   "sha256": "1pyyan6zgpkzpk74fd7rrw266cxwkydwl4jj34398pwgb2hq8j65"
+  }
+ },
+ {
   "ename": "modelica-mode",
   "commit": "7c490aa852043e71eb5d3bb8e8b36160e0ac888b",
   "sha256": "1jq8jsm7ap14r7vrhbicsrcq9g07yv8adl733c3fil02db6aipfm",
@@ -80063,11 +80441,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20250208,
-    958
+    20250220,
+    647
    ],
-   "commit": "610ae60123707c4669651b8da3308e9c54b83620",
-   "sha256": "0wv8vyjpnmdqmwhizk35x9zz624zygx77ca659rigybmaczjk3ag"
+   "commit": "f3cd4d6983566dab0ef3bcddf812cfd565d00d08",
+   "sha256": "1w0hkbpcy08n6czrxmw1v4cr4pfh84brjiiaxl6dnwi525l70b6p"
   },
   "stable": {
    "version": [
@@ -80552,11 +80930,11 @@
   "repo": "tarsius/morlock",
   "unstable": {
    "version": [
-    20250121,
-    1634
+    20250312,
+    1417
    ],
-   "commit": "538ce842358172b97fc5028b6faa6fdf2549f0c3",
-   "sha256": "1gmnx2s4qjcbfkhpnvhpc9833ibkb2wkj4jgdkw7i4hda63as4d9"
+   "commit": "64946a45e9bf02abf9cb39ca3aed98af98e82824",
+   "sha256": "0rkkx0f3lgk64mc5jmrmqil71nqhmsqiszmw5p6synqpk4gbvqaf"
   },
   "stable": {
    "version": [
@@ -81140,14 +81518,14 @@
   "repo": "lorniu/mpvi",
   "unstable": {
    "version": [
-    20240315,
-    214
+    20250308,
+    438
    ],
    "deps": [
     "emms"
    ],
-   "commit": "2412e4cd2879e1ebeaf29b92104abc94226b50bc",
-   "sha256": "19h35qzr7n4rza1phmk67p5ri747sl1smnp7pzayidibcvhcynvc"
+   "commit": "29b9c378cbcf668b3e67a2d896af5530d2b6f342",
+   "sha256": "059sawgmdk8rhm7jrsgb952r05377im88922q0b1sxvh2jy671lb"
   }
  },
  {
@@ -81398,14 +81776,14 @@
   "url": "https://repo.or.cz/mu4e-marker-icons.git",
   "unstable": {
    "version": [
-    20230423,
-    1039
+    20250228,
+    218
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "09fe0ca72b5c000d45a875c7cfa58016f740c1ae",
-   "sha256": "0xv1k3wp1f80qkd4gxnm9jvzfbbgf76khlw282377i0gp5gkc18r"
+   "commit": "13541181d5144ee91d570ab74558abce194b083f",
+   "sha256": "1lvwg0yb993j57y7663jm33g7j0x0jqbhqgf8vdy6qv198wpj5nc"
   }
  },
  {
@@ -81455,16 +81833,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20241206,
-    1347
+    20250302,
+    1417
    ],
    "deps": [
     "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "0187c2197761af6df87193c5c1ebd3ed7759f695",
-   "sha256": "05mz45p9f9b39jwm0p41v4mm0xmq0fw3dyqlq8slwllkzyqzf11r"
+   "commit": "0be7be5cf10808adabf93cdcb892a340a761ddd9",
+   "sha256": "0p6zkn8kzspfilig6hbm9a6sx1fr9p8mw968sg2xz7dmkdlvwvkk"
   },
   "stable": {
    "version": [
@@ -81789,26 +82167,26 @@
   "repo": "magnars/multiple-cursors.el",
   "unstable": {
    "version": [
-    20241201,
-    1841
+    20250210,
+    1813
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "46635e7f693560213b56ca8eca1adb13559672e5",
-   "sha256": "19ldrdwpv7ga4vk3lx397zl875kdnr94apg3ni5manr2x0fdcl2c"
+   "commit": "89f1a8df9b1fc721b1672b4c7b6d3ab451e7e3ef",
+   "sha256": "01ccwbfrnc66ax4bngw1b6k9rzw0m85cm4s0wzk1gkdsc2z647jn"
   },
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b3bd49c756cd959c0fb998d27eaf3d273570b05e",
-   "sha256": "1ijgvzv5r44xqvz751fd5drbvrspapw6xwv47582w255j363r6ss"
+   "commit": "89f1a8df9b1fc721b1672b4c7b6d3ab451e7e3ef",
+   "sha256": "01ccwbfrnc66ax4bngw1b6k9rzw0m85cm4s0wzk1gkdsc2z647jn"
   }
  },
  {
@@ -82698,17 +83076,17 @@
  },
  {
   "ename": "nav",
-  "commit": "0fda2b54a0ff0b6fc3bd6d20cfcbbf63cae5380f",
-  "sha256": "0ly1fk4ak1p8gkz3qmmxyslcjgicnfm8bpqqgndvwcznp8pvpjml",
+  "commit": "ed952164529951679398bd977838a88716952987",
+  "sha256": "00vbqrpkzhzv7zig33za7v0rg2vsr6ks2k0119g0zbvn4990yvmx",
   "fetcher": "github",
-  "repo": "ijt/emacs-nav",
+  "repo": "emacsorphanage/nav",
   "unstable": {
    "version": [
-    20120507,
-    707
+    20250211,
+    1523
    ],
-   "commit": "c5eb234c063f435dbdcd1f8bdc46cfc68c973ebe",
-   "sha256": "0kfqpji6z3ra8sc951vmm1bzyhkws7vb5q6djvl45wlf1wrgkc4p"
+   "commit": "c9446387e337888778ea289ed7acc009691450da",
+   "sha256": "01k9amadvgrsdnpk7fwirs7s9pg0m9s41sjdg9lgz6w73cl49852"
   }
  },
  {
@@ -82805,40 +83183,6 @@
    ],
    "commit": "5f2f2ecfbd91c35bfbe4946915462872acf58310",
    "sha256": "0fszhjf6bj8frvlnim86sfv6sab3qyignxqh8x6i4bqgwnb6svkf"
-  }
- },
- {
-  "ename": "navorski",
-  "commit": "9246cef94029d2da2211345c076ed55deb91e8fa",
-  "sha256": "0dnzpsm0ya8rbcik5wp378hc9k7gjb3gwmkqqj889c38q5cdwsx7",
-  "fetcher": "github",
-  "repo": "roman/navorski.el",
-  "unstable": {
-   "version": [
-    20141203,
-    1824
-   ],
-   "deps": [
-    "dash",
-    "multi-term",
-    "s"
-   ],
-   "commit": "698c1c62da70164aebe9a7a5d034778fbc30ea5b",
-   "sha256": "0g7rmvfm0ldv0d2x7f8k761mgmi47siyspfi1ns40ijhkpc15x8l"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    7
-   ],
-   "deps": [
-    "dash",
-    "multi-term",
-    "s"
-   ],
-   "commit": "4546d4e4dfbec20ee8c423c045408a3388a9eab9",
-   "sha256": "09cb07f98aclgq8jf5419305zydkk1hz4nvzrwqz7syrlpvx8xi5"
   }
  },
  {
@@ -83018,11 +83362,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20241230,
-    716
+    20250308,
+    1335
    ],
-   "commit": "546ee20caf825e65da4c5435d31f13d269ed2a81",
-   "sha256": "0vmzywzaizphj15rqvihw1znjp1i74w8fkhrg7kvic10iv0fpga8"
+   "commit": "43178575201e3d2ef8c4a507ed4c281b0936f39a",
+   "sha256": "1hvnl3xpn5d3pg6i1minzv6sjc9dahs2snzlsy76wvwf4kcjf9z5"
   },
   "stable": {
    "version": [
@@ -83061,26 +83405,26 @@
   "repo": "LuigiPiucco/nerd-icons-corfu",
   "unstable": {
    "version": [
-    20241202,
-    2355
+    20250226,
+    1715
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "41110180ceab9d0edaa856d19633b2b3fdf82e75",
-   "sha256": "0mwng5khhq6iqmr0ip8fv227cnkv0mv5664qz57r7sbjplqyabgf"
+   "commit": "13166345b290d6c6a2ac6ba94a8d28ec3bb58c67",
+   "sha256": "0ah215zl9f867n4wlim4f8b1lm33xpr3vz3c06pbaznnp9ym18ka"
   },
   "stable": {
    "version": [
     0,
-    4,
-    2
+    5,
+    0
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "721830b42b35e326a88b338fc53e4752f333fad2",
-   "sha256": "0mls7hz1c2f68lzj4g38plgxyndr3km8lpzyi91ssg4j61zmrbgm"
+   "commit": "13166345b290d6c6a2ac6ba94a8d28ec3bb58c67",
+   "sha256": "0ah215zl9f867n4wlim4f8b1lm33xpr3vz3c06pbaznnp9ym18ka"
   }
  },
  {
@@ -83109,14 +83453,14 @@
   "repo": "seagle0128/nerd-icons-ibuffer",
   "unstable": {
    "version": [
-    20230417,
-    1549
+    20250307,
+    958
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "18c00c03a0d7193bab5e3374ec02c5428db057fd",
-   "sha256": "1wj6kcgvh700maj9i5pmgzc48lbj0dbxx849a8w519m4anr7b23s"
+   "commit": "46f57138e57329d841b1745e586b4f2c69f82b87",
+   "sha256": "020nl0q6ab08frbikd78lnk821wsv6r3i7p5g1jmfw05zywj2jyr"
   },
   "stable": {
    "version": [
@@ -83139,15 +83483,15 @@
   "repo": "seagle0128/nerd-icons-ivy-rich",
   "unstable": {
    "version": [
-    20230721,
-    357
+    20250307,
+    1005
    ],
    "deps": [
     "ivy-rich",
     "nerd-icons"
    ],
-   "commit": "b3b605efa03d464d6138454ac3f60dcae50e7acb",
-   "sha256": "10xilnlp9nb1j8h5m413qsf52zi3rvz5ca7wj4zar8j2wmsszdkv"
+   "commit": "5006f91b49e86e232cdc1a628501b76124c41dac",
+   "sha256": "0m62l4cl9j3ssd25rz40vgrv99bmwn6l4ig2sf8zzi0fpzm8axgh"
   },
   "stable": {
    "version": [
@@ -83520,11 +83864,11 @@
   "repo": "aaronjensen/night-owl-emacs",
   "unstable": {
    "version": [
-    20200622,
-    1943
+    20250224,
+    1841
    ],
-   "commit": "50315d6a4e170dccc83bf2d59a8a761f5ea32bb6",
-   "sha256": "075payr4jb7lbz29icl0afrnjkxjm8h74xjahwplz3ybim43s67z"
+   "commit": "13d9966ffda746231eef0dc905b50303309f115e",
+   "sha256": "0w50g67j2kbfbx590iky4di7vngqfvg71c40h33ammmckl7wn2hq"
   },
   "stable": {
    "version": [
@@ -83622,11 +83966,11 @@
   "repo": "mrcnski/nimbus-theme",
   "unstable": {
    "version": [
-    20240819,
-    14
+    20250307,
+    659
    ],
-   "commit": "f184a3eaf61616a23c27147700bac883c4237fc4",
-   "sha256": "01711zjyfj21gjb7l9vwypfzk8gvkf1lx86ay2mkpb2r6xv8xnxm"
+   "commit": "6a0b5a9d70a1067df5ada409584952f7e465b947",
+   "sha256": "1xx1njb7h1y9ixr4dm9kywx1g3db37bn46xg8cg2il475hldk0ax"
   },
   "stable": {
    "version": [
@@ -84089,14 +84433,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20250101,
-    1420
+    20250304,
+    1951
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0c119d46cce5c018e162fae4b36fd95ef26a76ac",
-   "sha256": "1qr0spndzv03h0lcs2bjajadp9rg7clm506bnwbcqwfqxz9cxnvx"
+   "commit": "de767a4952b2375a2ce1a2f7fe17a417bfbf512e",
+   "sha256": "0cxxkc55jd7mzsdk873jyv0pfj9bzvy7mfyas0mg5kn6g35zh968"
   },
   "stable": {
    "version": [
@@ -84275,6 +84619,24 @@
   }
  },
  {
+  "ename": "noether",
+  "commit": "e9b94d7fc3bb267471675b670316df3e6e447464",
+  "sha256": "1qspibl78xdvzwwpdpxzv1qxfkvx8fzxv3xsz4gyaqbx1v75wzm8",
+  "fetcher": "sourcehut",
+  "repo": "lxsameer/noether",
+  "unstable": {
+   "version": [
+    20250309,
+    1704
+   ],
+   "deps": [
+    "posframe"
+   ],
+   "commit": "0a32429a6cf4c0f3f8157a16f778a7996a85e189",
+   "sha256": "00mfqph58022ykfakgvs4qfg1ywignprhfpw45lfrjhf5k670xlv"
+  }
+ },
+ {
   "ename": "noflet",
   "commit": "df33a7230e0e4a67ce75e5cce6a436e2a0d205e8",
   "sha256": "0vzamqb52n330mi6rydrd4ls8nbwh5s42fc2gs5y15zakp6mvhr3",
@@ -84422,20 +84784,20 @@
   "repo": "nordtheme/emacs",
   "unstable": {
    "version": [
-    20230311,
-    1131
+    20250312,
+    2046
    ],
-   "commit": "5335a7e782fd4ea5b33cd630feae37d902709024",
-   "sha256": "144mxg8dialcn1q9skryrmqp5ipfnd1npm0jb5fzl5zw4pfnf3im"
+   "commit": "551b2b8a0751c0a22e5c5daa6958152f208e668f",
+   "sha256": "0gsfjb07mgmch3vw7wx4q1xhmagrkiqjx7k3529nsii5xd2rwmbn"
   },
   "stable": {
    "version": [
     0,
-    5,
+    6,
     0
    ],
-   "commit": "0f5295f99005a200191ce7b660e56cd0510cf710",
-   "sha256": "096f8cik4jz89bvkifwp3gm9iraqrd75ljy2q9js724v7yj88711"
+   "commit": "551b2b8a0751c0a22e5c5daa6958152f208e668f",
+   "sha256": "0gsfjb07mgmch3vw7wx4q1xhmagrkiqjx7k3529nsii5xd2rwmbn"
   }
  },
  {
@@ -84567,11 +84929,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20240816,
-    2039
+    20250218,
+    1254
    ],
-   "commit": "2355ff274d3694fc79c655bb45c61245fb9a9302",
-   "sha256": "0xipy48rpalnqp24dh424xl6d8vh8f6r5b31rwq5n5f23m9hz300"
+   "commit": "0e10ca3a625c25c0238ecca2767aab7035b88a22",
+   "sha256": "0h46qgyr5c6g3ylgxcxgjynf0bf51sf6738fpy0bc3n88y87pzph"
   },
   "stable": {
    "version": [
@@ -84683,28 +85045,28 @@
   "repo": "tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20250117,
-    1241
+    20250301,
+    1647
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "82462458718eb5dd4c26638879ff933cd5f7590b",
-   "sha256": "1aj07s374iildmmi0mrak13ghl7g11xchhhblsqdyn4cg8cfqk0q"
+   "commit": "3e458cefe3289b56072a76300a0140054c64040f",
+   "sha256": "1lvfr4g4l3nnvw44h3x3zz22j7lqn9m6mq7hslpsdvn03r5h7gsi"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "82462458718eb5dd4c26638879ff933cd5f7590b",
-   "sha256": "1aj07s374iildmmi0mrak13ghl7g11xchhhblsqdyn4cg8cfqk0q"
+   "commit": "3e458cefe3289b56072a76300a0140054c64040f",
+   "sha256": "1lvfr4g4l3nnvw44h3x3zz22j7lqn9m6mq7hslpsdvn03r5h7gsi"
   }
  },
  {
@@ -84749,26 +85111,26 @@
   "url": "https://depp.brause.cc/nov.el.git",
   "unstable": {
    "version": [
-    20240825,
-    1528
+    20250309,
+    1937
    ],
    "deps": [
     "esxml"
    ],
-   "commit": "bbb5c60bfd6b09cffe0406a56930105335f07887",
-   "sha256": "1j5yxjcp4510n0xhhrbvl426kzannrbwgck6asnnmcvly9j22pzm"
+   "commit": "b37d9380752e541db3f4b947c219ca54d50ca273",
+   "sha256": "1s1ar3c9819mzalybp0pi6pzzwwnihal7pjyin2804h1gbappli8"
   },
   "stable": {
    "version": [
     0,
-    4,
+    5,
     0
    ],
    "deps": [
     "esxml"
    ],
-   "commit": "12faf16fbbaf09aadec26dfbda5809d886248c02",
-   "sha256": "10507fdfx02wb3j7g34w4ii8rgnjbmriq63ir6x1agf38s3i9p52"
+   "commit": "b37d9380752e541db3f4b947c219ca54d50ca273",
+   "sha256": "1s1ar3c9819mzalybp0pi6pzzwwnihal7pjyin2804h1gbappli8"
   }
  },
  {
@@ -84992,8 +85354,8 @@
   "repo": "pyluyten/emacs-nu",
   "unstable": {
    "version": [
-    20190404,
-    2032
+    20250211,
+    1243
    ],
    "deps": [
     "ace-window",
@@ -85003,8 +85365,8 @@
     "undo-tree",
     "which-key"
    ],
-   "commit": "d5fb4d26d1b0bb383ea2827cc5af5dfb2a269d2b",
-   "sha256": "0nd7ypin9kl784iqffznld6kknghdjywqnjw5nwinfgkwhcrjpdd"
+   "commit": "6510bc3f22e921aeb8ef3190bca1f432acc2870e",
+   "sha256": "0i636xql6s9fg9ggs5a1j70bsn6qgabdhqdic8vmxy1sjggiv2g7"
   }
  },
  {
@@ -86393,6 +86755,21 @@
   }
  },
  {
+  "ename": "ob-pic",
+  "commit": "fd5c246447ccbd49521057b6861e5f7efbf491d8",
+  "sha256": "1p4z0mnxsq1sagqgx9ppabgrm4f7p8hk97cjvfpr4rw9hgdq4mqn",
+  "fetcher": "github",
+  "repo": "ddoherty03/ob-pic",
+  "unstable": {
+   "version": [
+    20241209,
+    1043
+   ],
+   "commit": "6bb3cbf814ab0c3e3dfc41a7535dee5e30340ba3",
+   "sha256": "0mi78pa8985zxw2nmxshpf4kdinany8wgb5p2680l0b17bmaad1k"
+  }
+ },
+ {
   "ename": "ob-powershell",
   "commit": "d97a205d5bf6431f7f1f6e0fac66f09fc056e1f0",
   "sha256": "1hmj18akqbrr8kamrag28rdjmwpbrf1171950v7hszn35jgsj38b",
@@ -86400,11 +86777,11 @@
   "repo": "rkiggen/ob-powershell",
   "unstable": {
    "version": [
-    20240718,
-    1429
+    20250220,
+    1241
    ],
-   "commit": "3f00ffdca27e52e0bac64d6616a4a3054f74a711",
-   "sha256": "154jmhdfnb1wwzxdp30ln3xza2cqq6y4j7cvchgs1banp36ddgnd"
+   "commit": "1ba2f3bff0fcb8f4c58ddf534d5bf23bf52a87ca",
+   "sha256": "1kr67h0d57c4ma8igpwgjs0cxjf67cgk34y9nr54afa6mr7gnr7q"
   }
  },
  {
@@ -86952,19 +87329,20 @@
   "repo": "licht1stein/obsidian.el",
   "unstable": {
    "version": [
-    20240713,
-    906
+    20250220,
+    2245
    ],
    "deps": [
     "dash",
     "elgrep",
     "f",
+    "ht",
     "markdown-mode",
     "s",
     "yaml"
    ],
-   "commit": "5730759eb22d6d3bc78761865dd0f2fdb4100e37",
-   "sha256": "0llf7ahgf2rb0b2znq99mr1wkvxnh1lb0lppk2zcklqhdw05ylzk"
+   "commit": "0b31775d5da1dfd3d1ffcf9fa05908a3ba26ed15",
+   "sha256": "0djxlkhqm1zrrq2xqjlcc1vygd4a6h4jcivn7iq8ryg2iga15i9z"
   },
   "stable": {
    "version": [
@@ -87007,11 +87385,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20250124,
-    1030
+    20250310,
+    1359
    ],
-   "commit": "795bc3c14a74fc018af47f05cbf1f1cbd9e2daa3",
-   "sha256": "1vz7sfavhfdzn39gw21h06dl8ppfglnrwr50yl9wc0c5fn23yzz8"
+   "commit": "52e59e3dba1f8af1e90166c556e6f3b567cd9857",
+   "sha256": "1352ckf64dijgpdmsgqs4mbl7hpd942f2px251br986v7k16vscl"
   },
   "stable": {
    "version": [
@@ -87261,26 +87639,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20241218,
-    1342
+    20250220,
+    1248
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "a0b9d95e0b17cce0bcccdfbcb813381c18d1eb7e",
-   "sha256": "0f8cfbf0jkg181jbbfl2d7v4l1wgpfwhcm4amcr2ghy9ls0visfa"
+   "commit": "86fb46ae523b1c953af4172fb6b468fd62fa3a71",
+   "sha256": "1w8ryyh6f1imibyvkzipjhfby0jqh5mvihs0kni4l0wwpbjys21k"
   },
   "stable": {
    "version": [
     4,
     28,
-    2
+    4
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "a0b9d95e0b17cce0bcccdfbcb813381c18d1eb7e",
-   "sha256": "0f8cfbf0jkg181jbbfl2d7v4l1wgpfwhcm4amcr2ghy9ls0visfa"
+   "commit": "414a4627a414f3c499637a4347326b345d0768fb",
+   "sha256": "1w8ryyh6f1imibyvkzipjhfby0jqh5mvihs0kni4l0wwpbjys21k"
   }
  },
  {
@@ -87451,6 +87829,30 @@
    ],
    "commit": "b64c0ac8c3ec9bdc67373fa754fe493be4cc81bd",
    "sha256": "0q1z07z0nkvzplmsqni25hqhv81x3r7f1xahjjkskmllrhksz0bh"
+  }
+ },
+ {
+  "ename": "ollama-buddy",
+  "commit": "33b508111b2e43f0a550386a6e0e109604cd5a8c",
+  "sha256": "0f0f7sgb6bjlx6mc4bbr9aby7bycpsblpbhj8sipvd5bwr3i9d06",
+  "fetcher": "github",
+  "repo": "captainflasmr/ollama-buddy",
+  "unstable": {
+   "version": [
+    20250312,
+    2035
+   ],
+   "commit": "b734f1220973bd54a8e96569bddfc6da55f10f56",
+   "sha256": "1a4ygzn25ghd8997d7l201wz5h6ph2zjchnaaxpfiz14qb64qggf"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "2e200f55c893e7b8c24da3c343e753ace7f9df93",
+   "sha256": "055ffm4ipj85fk1lq31gwbqfnimz44b2b1rns326nqfdgqvsvw4p"
   }
  },
  {
@@ -88640,25 +89042,25 @@
   "repo": "zondo/org-autoexport",
   "unstable": {
    "version": [
-    20241130,
-    1655
+    20250302,
+    1553
    ],
    "deps": [
     "org"
    ],
-   "commit": "f5819f21ba4a92d1742371a3422102bb965f0706",
-   "sha256": "1fpn2f0fl32n4hqsdfvld1qfz5xz8d0hv16wak2mhn5ssw4qw68j"
+   "commit": "0cd22707014f3ee14da6fa823b3991e2ebddf0dc",
+   "sha256": "14lmx124ng1jgvgvni0ciik1xgsa9riy2y6nywica7ijxmvyqh6r"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
    "deps": [
     "org"
    ],
-   "commit": "0d3944d055ce4e8922991f892418a9bafd3eba15",
-   "sha256": "1fpn2f0fl32n4hqsdfvld1qfz5xz8d0hv16wak2mhn5ssw4qw68j"
+   "commit": "0cd22707014f3ee14da6fa823b3991e2ebddf0dc",
+   "sha256": "14lmx124ng1jgvgvni0ciik1xgsa9riy2y6nywica7ijxmvyqh6r"
   }
  },
  {
@@ -88947,14 +89349,14 @@
   "repo": "dengste/org-caldav",
   "unstable": {
    "version": [
-    20241214,
-    2358
+    20250212,
+    334
    ],
    "deps": [
     "org"
    ],
-   "commit": "875bebe266f28c77110779b7819227957faab2ba",
-   "sha256": "0bsdmar1s9cwn0i0rccyxpml8xbrmlb1a15b5xvg61adhqz6x8mw"
+   "commit": "44a6d463cee3c3be8acf7511db785ab55519b375",
+   "sha256": "0qxnms7libsq1q7hbvpbbza8g9kzyry0fi3ayhdv9sddnm2wx2d4"
   },
   "stable": {
    "version": [
@@ -89297,14 +89699,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20241203,
-    1941
+    20250309,
+    1659
    ],
    "deps": [
     "org"
    ],
-   "commit": "9d80dfa5bfe1eb503e79229cc2f19f841c563709",
-   "sha256": "117l9llrwavwynhp0ws7z9s9s4sjya69h8l97i24l0f7gxzbkgy9"
+   "commit": "b06a59736800865b8a7e8d6d45774169cb31528a",
+   "sha256": "0kpk62606is9wwigwd8bwna24zz95nbcz3r052x5fg7rq7v5wq0h"
   }
  },
  {
@@ -89386,6 +89788,25 @@
    ],
    "commit": "ad399cde0ee21adc67ed0c95ae20900fa936f008",
    "sha256": "0l3814b0f3s35cspyim5q639f0jp6mw3ri2hqb1in6r2igacaq7d"
+  }
+ },
+ {
+  "ename": "org-daily-reflection",
+  "commit": "623cb5b38c5dde44c8daf7ceacc622d7a23b7798",
+  "sha256": "1941iyzh34cm8am6ps4nadcfmvcvl3qqyb1cnklpi43hrhzm5lh1",
+  "fetcher": "github",
+  "repo": "emacsomancer/org-daily-reflection",
+  "unstable": {
+   "version": [
+    20250307,
+    1733
+   ],
+   "deps": [
+    "compat",
+    "org"
+   ],
+   "commit": "c38def9361dfef62eeead9fbe42394844df16176",
+   "sha256": "1qkrifhnk2kmjz3qkcfn4innx368zkwk66qddw87mnsahyd2icy2"
   }
  },
  {
@@ -90306,16 +90727,16 @@
   "repo": "beacoder/org-ivy-search",
   "unstable": {
    "version": [
-    20250106,
-    1704
+    20250305,
+    159
    ],
    "deps": [
     "beacon",
     "ivy",
     "org"
    ],
-   "commit": "5e09d3dbdc99d4d6a88067f1113f3cd43c0107ed",
-   "sha256": "121kzq26szdj068x8fssr78gqi6ww07kc8wz08avacdl77635fpq"
+   "commit": "d09472c5ae5c099bee17fb0e4f3f017ce7ebd031",
+   "sha256": "1p48k2fjiig8kfpgrnsrpcyfpyfm17gjr80p0r52bq6ijh2z53bj"
   }
  },
  {
@@ -90390,14 +90811,14 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20240218,
-    1645
+    20250306,
+    1429
    ],
    "deps": [
     "org"
    ],
-   "commit": "859dc19168dc6b10eba3843f24980a7db79f6869",
-   "sha256": "0flp1nl4pb30g4r86xj627wavv9pdqqi5rjwwr3734z5x870srf1"
+   "commit": "cf721732332d707de5d5af71e6d9a87599cc84a2",
+   "sha256": "1clw4dyqh3dqv2d8ky5r1sjk35jx546wrzq8dg6v76aicq3nka7p"
   },
   "stable": {
    "version": [
@@ -90469,28 +90890,28 @@
   "repo": "gizmomogwai/org-kanban",
   "unstable": {
    "version": [
-    20250115,
-    2301
+    20250312,
+    2032
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "90b135d534e428f1b06626ec9ce2f3e735ab5ddd",
-   "sha256": "1iawkr1nkaw7lhdh5cf6g6yy4il311kl2970cyykn98x7s804q7h"
+   "commit": "cb96fa3ae526b6b000e279bc8cd650d6d359771b",
+   "sha256": "1f31496pqxx29xmlysw52092bfcw9zkjrf7ds5wdvjiq60qf443c"
   },
   "stable": {
    "version": [
     0,
     6,
-    10
+    13
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "90b135d534e428f1b06626ec9ce2f3e735ab5ddd",
-   "sha256": "1iawkr1nkaw7lhdh5cf6g6yy4il311kl2970cyykn98x7s804q7h"
+   "commit": "cb96fa3ae526b6b000e279bc8cd650d6d359771b",
+   "sha256": "1f31496pqxx29xmlysw52092bfcw9zkjrf7ds5wdvjiq60qf443c"
   }
  },
  {
@@ -90563,15 +90984,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250204,
-    1618
+    20250313,
+    929
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "1d088d4ea6efd4ccaf6b1efaaee2bb85dd73f98f",
-   "sha256": "1l1gw3987fd2xri1byvj1jx26gksc9a5adjr71c5zkva0gl2zhlq"
+   "commit": "a1eedcee788e0484df13dd54940f47b4c98c1761",
+   "sha256": "124bliixzcwlv2pn822amhrhlmij4g858fzazi01sq33dx09ln34"
   },
   "stable": {
    "version": [
@@ -90827,25 +91248,25 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20250101,
-    923
+    20250311,
+    1701
    ],
    "deps": [
     "compat"
    ],
-   "commit": "17549799a05a46d391765e36b544741a3a704cd0",
-   "sha256": "0pyaa0ay8zdw1mnndcfhqsik54nqjrpf1w1zbv6rqszj7ycf6rpq"
+   "commit": "e7a4c5e4a1d309895c60b3a3b3e62ab1f6a926b4",
+   "sha256": "04bmlwc81d8h8n10xb2nhwmcvn1701nr73hxajl6hasswzqqmh70"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8420e4f839bee2c34488ce94fa08212dfe0b2797",
-   "sha256": "0a7viid1lrn02w1n4yjivjyssbd1qq850giqwnp3mrjf9adwzh2a"
+   "commit": "e7a4c5e4a1d309895c60b3a3b3e62ab1f6a926b4",
+   "sha256": "04bmlwc81d8h8n10xb2nhwmcvn1701nr73hxajl6hasswzqqmh70"
   }
  },
  {
@@ -91061,30 +91482,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20250203,
-    1402
+    20250313,
+    1124
    ],
    "deps": [
-    "compat",
     "el-job",
-    "llama"
+    "llama",
+    "magit-section"
    ],
-   "commit": "0f58a8e584e036a97aaa023813c273b9fc83f41e",
-   "sha256": "0h2kmpki4c8c87lm3wzpl23adilfrrg9vbcv2yf4s034r4bvd949"
+   "commit": "983e0ef82598cad83614f88daa259ed0d14e6419",
+   "sha256": "1ypwwbj8dnjrnvpflv8lfg1dsi5kzrjqgmn1ca2s8naj262dlyw9"
   },
   "stable": {
    "version": [
-    1,
-    9,
-    35
+    2,
+    3,
+    2
    ],
    "deps": [
-    "compat",
     "el-job",
-    "llama"
+    "llama",
+    "magit-section"
    ],
-   "commit": "0f58a8e584e036a97aaa023813c273b9fc83f41e",
-   "sha256": "0h2kmpki4c8c87lm3wzpl23adilfrrg9vbcv2yf4s034r4bvd949"
+   "commit": "983e0ef82598cad83614f88daa259ed0d14e6419",
+   "sha256": "1ypwwbj8dnjrnvpflv8lfg1dsi5kzrjqgmn1ca2s8naj262dlyw9"
   }
  },
  {
@@ -91095,8 +91516,8 @@
   "repo": "meedstrom/org-node-fakeroam",
   "unstable": {
    "version": [
-    20241229,
-    1552
+    20250306,
+    2208
    ],
    "deps": [
     "compat",
@@ -91104,13 +91525,13 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "125ef95cee77a19d59d8e071aa14049dd2bbd1e8",
-   "sha256": "1m0qpixf8mnrfrp8p8z4zz8lqnz541lz02b8wkw90ajb81s6k7b9"
+   "commit": "9befbb231df050d31fb8b8d01880668bc90f0799",
+   "sha256": "0m7iijjf58hcx0mz80z6nrwszhqzw8fv0r7q81xg3pfzigc3xr7g"
   },
   "stable": {
    "version": [
-    1,
-    7,
+    2,
+    0,
     0
    ],
    "deps": [
@@ -91119,8 +91540,8 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "125ef95cee77a19d59d8e071aa14049dd2bbd1e8",
-   "sha256": "1m0qpixf8mnrfrp8p8z4zz8lqnz541lz02b8wkw90ajb81s6k7b9"
+   "commit": "6e0c5afed0f99eebcda6d824c2ef7ec258ad3546",
+   "sha256": "1gy88r44625vis6md88sh38z8i8viav42sg52x9p48374lhrchdx"
   }
  },
  {
@@ -91365,16 +91786,16 @@
   "repo": "fuxialexander/org-pdftools",
   "unstable": {
    "version": [
-    20220320,
-    301
+    20250210,
+    118
    ],
    "deps": [
     "org",
     "org-noter",
     "pdf-tools"
    ],
-   "commit": "967f48fb5038bba32915ee9da8dc4e8b10ba3376",
-   "sha256": "0f47ww8r00b7lb1msybnmnqdhm9i2vwz5lrz9m9bn6gbh97mzhn8"
+   "commit": "5613b7ae561e0af199f25aacc0a9c34c16638408",
+   "sha256": "0p86943abk55bc2402w5lb7115l3b61wv0w07m84wxi4hbfqk8k6"
   }
  },
  {
@@ -91775,28 +92196,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20241218,
-    1239
+    20250220,
+    1236
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "f04b2227f962c39afb18408b433d5d84d1e136fe",
-   "sha256": "1b7j1bnw51ad49vx3rbncxiq8jizbjbhfq18jmkxlaxkrccmz8bf"
+   "commit": "88e9d9e679e75e40acd93566a27a342437419992",
+   "sha256": "1i7r7i6r1s3bzw2vnmb5j052461n95bdj0kj0k8l9vbrhgs602v3"
   },
   "stable": {
    "version": [
     3,
-    33,
-    0
+    34,
+    2
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "91610ba9b010b05c52ae7ab77a7890851222db06",
-   "sha256": "09d0hy5nb485d3dd71a9dmjpbwvhj7zx1wwkl9hggc2gzj4f0snp"
+   "commit": "88e9d9e679e75e40acd93566a27a342437419992",
+   "sha256": "1i7r7i6r1s3bzw2vnmb5j052461n95bdj0kj0k8l9vbrhgs602v3"
   }
  },
  {
@@ -91954,8 +92375,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20241124,
-    2012
+    20250301,
+    1918
    ],
    "deps": [
     "avy",
@@ -91971,8 +92392,8 @@
     "request",
     "s"
    ],
-   "commit": "a61fe2a76294dcf4b216c25f789c4dba15f5986d",
-   "sha256": "05fb0ihnflm14z4fhphjx3zfg172asmjl8lf602vgimyj28xbidy"
+   "commit": "edbb80863ef63ef52ef04fce3239e063843f8d30",
+   "sha256": "1i55p4gyh6k83qyc5ka9gbikk969rwyavyy3w528wplngjfn5772"
   },
   "stable": {
    "version": [
@@ -92096,11 +92517,11 @@
   "repo": "unhammer/org-rich-yank",
   "unstable": {
    "version": [
-    20250124,
-    1418
+    20250304,
+    907
    ],
-   "commit": "6e63e2f0d448edf6aea26146dfabb55de4117e25",
-   "sha256": "0vnbzlg96ykpnsd89yslg2rr51dyynrz10j38hdgjhp0ln5hd13d"
+   "commit": "66414a3c8c9de97e23e6d0edfb05abbaaf8d00a9",
+   "sha256": "0p8v2bj3dn9a80ls6bzn3a4lf2d131s284mfs6aab72z1vgf22v2"
   },
   "stable": {
    "version": [
@@ -92120,8 +92541,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20250111,
-    252
+    20250313,
+    134
    ],
    "deps": [
     "dash",
@@ -92129,8 +92550,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "64e302c1269a1a16c4c0b5a7d1e3baf2d5ded174",
-   "sha256": "1vfbmfs0rhlzpij2zcgq7297vyp3vw4asvjqy3v5n6xvki8fqzna"
+   "commit": "db4170a459cba06bd3d36fb6dc748364774ec204",
+   "sha256": "1dc9z9xpr13iklz47mncrb9ccqbaa30jaxlki0ymr4pcwb5b4sl2"
   },
   "stable": {
    "version": [
@@ -92157,15 +92578,15 @@
   "repo": "org-roam/org-roam-bibtex",
   "unstable": {
    "version": [
-    20240229,
-    1913
+    20250215,
+    1156
    ],
    "deps": [
     "bibtex-completion",
     "org-roam"
    ],
-   "commit": "d9b8a57cfca832e3e7c7f414bf93060acbf63573",
-   "sha256": "1ww421apmn887602b9pddh76sd25x6jq3z1x0vah5zpglh2sqd6z"
+   "commit": "b065198f2c3bc2a47ae520acd2b1e00e7b0171e6",
+   "sha256": "1hywqrab07lpssc08aqpwa2asly92dhdn09ikx8jp0bi3l26wryy"
   },
   "stable": {
    "version": [
@@ -92420,14 +92841,14 @@
   "repo": "Endi1/org-shortcut",
   "unstable": {
    "version": [
-    20241228,
-    1533
+    20250223,
+    0
    ],
    "deps": [
     "plz"
    ],
-   "commit": "69f444830d31e89f2693449f9c122f25989930b9",
-   "sha256": "1pws0v49qyba7fhi0afv5k9jvpizxf8lhnp8hx9dq4mz9y40xpsq"
+   "commit": "5344d2011e749b59cb54ed405e7c2d4adcaa6539",
+   "sha256": "1cm371nqm8ncwkx22a08v7vbh7bvikbmhgy381b3m6jsnmz5x9s1"
   }
  },
  {
@@ -93989,30 +94410,30 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20240808,
-    1945
+    20250301,
+    2339
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "59d21fdb21f84238c3172d37fdd2446b753e98dc",
-   "sha256": "0864y78kvcvha0rx0pzrxlyivr65zk21ji4md757alw1lr4zf408"
+   "commit": "6ad0dc35c8df54fae4ef27e5145760e22fbbf890",
+   "sha256": "0yi73l7hm6x5pyalfmcv0mnklhc574xij35q8zkh6ahrnfbyv8ks"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    1
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "59d21fdb21f84238c3172d37fdd2446b753e98dc",
-   "sha256": "0864y78kvcvha0rx0pzrxlyivr65zk21ji4md757alw1lr4zf408"
+   "commit": "6ad0dc35c8df54fae4ef27e5145760e22fbbf890",
+   "sha256": "0yi73l7hm6x5pyalfmcv0mnklhc574xij35q8zkh6ahrnfbyv8ks"
   }
  },
  {
@@ -94061,30 +94482,30 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20240805,
-    1431
+    20250301,
+    1703
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "bc6135ef091c871b40e9fecd3126a177aed93e17",
-   "sha256": "1mmaaacpiwzd63qi9f7xi0giqn411vj0330wyxh5kgi5kls360ba"
+   "commit": "dca26f299545aa74a0caf5381daa53ad8ae2227f",
+   "sha256": "0i6qm2vsz9csi7zxlwdfh26pvq86bdjznxiixydh11czkzdv3s3v"
   },
   "stable": {
    "version": [
     1,
     2,
-    4
+    5
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "bc6135ef091c871b40e9fecd3126a177aed93e17",
-   "sha256": "1mmaaacpiwzd63qi9f7xi0giqn411vj0330wyxh5kgi5kls360ba"
+   "commit": "dca26f299545aa74a0caf5381daa53ad8ae2227f",
+   "sha256": "0i6qm2vsz9csi7zxlwdfh26pvq86bdjznxiixydh11czkzdv3s3v"
   }
  },
  {
@@ -94216,11 +94637,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20250102,
-    748
+    20250303,
+    1454
    ],
-   "commit": "366677c0a5792cdcc5157362fd36416c76b9660b",
-   "sha256": "09lrprny3a9hb0wc5y7mclfcdnvlzr3ai9x4inmikngx3m469rkb"
+   "commit": "51a95f9322ffa61db5b3f037206085d3e44d59be",
+   "sha256": "0kr4i8331mjlv6vcs4mcw111xawvcaasnwhc4wp9bkga31brhyxj"
   }
  },
  {
@@ -94246,11 +94667,11 @@
   "repo": "tbanel/orgtblfit",
   "unstable": {
    "version": [
-    20250102,
-    735
+    20250210,
+    1535
    ],
-   "commit": "3ab53c983b647fec4dfdd0e3e25bc5d247130c70",
-   "sha256": "1khmvk44g9p17w2pkz6zd46j1x0mz66h77arddgdrs280yps26vy"
+   "commit": "aa4c132d8186e10ddb3c2a336be72123c284eb2c",
+   "sha256": "09yyp8a7p068kjg2vg27fzv130bkabq6ln32h511wcbfk84ix6fi"
   }
  },
  {
@@ -94261,11 +94682,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250102,
-    758
+    20250218,
+    903
    ],
-   "commit": "0b16ccdfadb55bec75d91edea2caaa1a161146ff",
-   "sha256": "01kws6m021msrmpsplkz3lzwp85ajpq7h25374hnz82rrn2hgksm"
+   "commit": "c0ddfc7f0550918cbb22d5f5cf102caf57275826",
+   "sha256": "0mqzk2nyp8r731ssicypxs435mvngnv9rmjj3nrkzjynlm4ilsp3"
   }
  },
  {
@@ -94424,14 +94845,14 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20250128,
-    824
+    20250301,
+    1613
    ],
    "deps": [
     "compat"
    ],
-   "commit": "308e67cc25c2c2725a32f48fed6e67c87dcc3eed",
-   "sha256": "078dd89jyz51755adrxm90ka0kvmgmm5h2w2c9f0986g3jmb9daq"
+   "commit": "7af69f09465219d65ec75ffd4bb44a47d7f56dc9",
+   "sha256": "0i6n3hf4g286fkry7k25032cm0jg2njcrnws2kh39mml31vp8a4z"
   },
   "stable": {
    "version": [
@@ -94747,11 +95168,11 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20250130,
-    2007
+    20250227,
+    1641
    ],
-   "commit": "ef49c673802a4127d6fcdc4771f74a9cef8d8894",
-   "sha256": "0sgmhfn6dc4f4i645z457qw81f7v07qbzd7vkrlmzsdzsccgcypf"
+   "commit": "ff1b6ecf642c673936f3c258d329c76c45e30854",
+   "sha256": "044qxaczp50bxpdwcyyxi6lqpq2rdm4yfjv7g3867kz44nxvwspq"
   },
   "stable": {
    "version": [
@@ -95106,14 +95527,14 @@
   "repo": "mmitch/ox-bb",
   "unstable": {
    "version": [
-    20210222,
-    2002
+    20240903,
+    2115
    ],
    "deps": [
     "org"
    ],
-   "commit": "a79dc519cd28c000ebca4254a4744ce2b9b82168",
-   "sha256": "1ffpslv58kzw9nhrfv2cp42vq0pdx5gm1bk20g6k697ijiz1r1jj"
+   "commit": "129ea37caf6de6f43845bd36f16fd78251a3afe9",
+   "sha256": "1qbaqfbz43z2acyxgsjbj07xldm04jrf2ncjdzcwbnkz29prflqd"
   },
   "stable": {
    "version": [
@@ -95126,6 +95547,21 @@
    ],
    "commit": "37e22316afac9dd73dec072ac6420e5c1c4471b6",
    "sha256": "0a2vp4br1s4zjvjz7z7j3kzzlnb4rzmash1425rz55zg2v3zsi0a"
+  }
+ },
+ {
+  "ename": "ox-beamer-lecture",
+  "commit": "ccc81f4cda4bfec906bead0e6787fc2669c1bd3e",
+  "sha256": "15rcbywnbclnsaxbjafm8qnkb3qlbzj5qpq76lp6w46gbwfmhs5i",
+  "fetcher": "github",
+  "repo": "fjesser/ox-beamer-lecture",
+  "unstable": {
+   "version": [
+    20250306,
+    4
+   ],
+   "commit": "647e7ef74c559ca189b46f1e79e9fcf8146a2af3",
+   "sha256": "0v450b65mixl73sp3iwyv5lkik65575wpynbhy4y9wxcgkyvz98p"
   }
  },
  {
@@ -95300,14 +95736,14 @@
   "repo": "kaushalmodi/ox-hugo",
   "unstable": {
    "version": [
-    20240305,
-    1923
+    20250212,
+    310
    ],
    "deps": [
     "tomelr"
    ],
-   "commit": "c4156d9d383bf97853ba9e16271b7c4d5e697f49",
-   "sha256": "13bjhjgvpp1lr4m1wmcbka4wfi4ikvnix4rq9ryhdj679q176x7h"
+   "commit": "a7641fc810c5e15142a3cede3a439a3189929bf5",
+   "sha256": "0anmnq56r8wnmc41qx3nmzlf9k5y9hi4ql51r0178d8kmfkh87x8"
   },
   "stable": {
    "version": [
@@ -95773,14 +96209,14 @@
   "repo": "lorniu/ox-spectacle",
   "unstable": {
    "version": [
-    20230307,
-    316
+    20250217,
+    832
    ],
    "deps": [
     "org"
    ],
-   "commit": "c2d34f170f470461aeec983b778e9d165bdb4d1f",
-   "sha256": "02z8fdc7lcj10xh3ix58ddk96wqkrxxgsfsc1061c62fq1b6l5bs"
+   "commit": "8774cf855c5585e70563a8edce80c763881f25b1",
+   "sha256": "0fkq0vg3fkqqqfmz3xvhw1bzcaqqg6myp02myycfl20j9yi4cadl"
   }
  },
  {
@@ -96203,14 +96639,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20250101,
-    1820
+    20250224,
+    2129
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c8ddc4a9a23b8514a8ee8d95e508b58adbeebd64",
-   "sha256": "1f89570dphwzizk1yyzh630j4a7qd2bzrn2r5cnksin44zj8qlvp"
+   "commit": "d1722503145facf96631ac118ec0213a73082b76",
+   "sha256": "0q14k0mgr7wg9r6y6cb5ig3ww3f0cvr5li8c9wjda5s8dwp1knxs"
   },
   "stable": {
    "version": [
@@ -96245,25 +96681,25 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20250108,
-    1407
+    20250307,
+    912
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "6f05a369e0718e93c5dce0951cad5e6646296612",
-   "sha256": "08f8pw27nk6pjx8qydn2xf6d5026afhaa50263wlwsgymsbkyimb"
+   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
+   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
   },
   "stable": {
    "version": [
     0,
-    24
+    25
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "e3d3fb254221d053c75edfd9f0ebfa58d1eb52f9",
-   "sha256": "0qbzhpmwsgrp6z541jc1cy7jqr7ipdindwfji210279v2w6yrj1p"
+   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
+   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
   }
  },
  {
@@ -96274,25 +96710,25 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20240923,
-    931
+    20250307,
+    912
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "e3d3fb254221d053c75edfd9f0ebfa58d1eb52f9",
-   "sha256": "0qbzhpmwsgrp6z541jc1cy7jqr7ipdindwfji210279v2w6yrj1p"
+   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
+   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
   },
   "stable": {
    "version": [
     0,
-    24
+    25
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "e3d3fb254221d053c75edfd9f0ebfa58d1eb52f9",
-   "sha256": "0qbzhpmwsgrp6z541jc1cy7jqr7ipdindwfji210279v2w6yrj1p"
+   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
+   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
   }
  },
  {
@@ -96407,11 +96843,11 @@
   "repo": "purcell/page-break-lines",
   "unstable": {
    "version": [
-    20240911,
-    1714
+    20250218,
+    1607
    ],
-   "commit": "4a20d4a28a1228c561b151f868611ad75de90e5e",
-   "sha256": "069aa64y2bvjl6wax1ik9dx05gbdddjh6b28sfm3idhx1mlpgipv"
+   "commit": "982571749c8fe2b5e2997dd043003a1b9fe87b38",
+   "sha256": "0d74j7mqgzbwj00sirz3wa37f5yv0y48lgp2v20k61lq54sxk75g"
   },
   "stable": {
    "version": [
@@ -96630,15 +97066,15 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20250117,
-    843
+    20250225,
+    852
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "bbb687a6ad9d8af07e38910a0bffeb707b334688",
-   "sha256": "1kraah7663cr9lsymqff25ad80nlih94y871byd925nhyl908kfl"
+   "commit": "d7f6fa119bb0e883cfd615009d197e4b87916033",
+   "sha256": "0dyf0d5qmshbf5zi2kimplj1byrdhm31yx3fr0mvnq5hp076820d"
   },
   "stable": {
    "version": [
@@ -96884,26 +97320,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20240805,
-    1433
+    20250301,
+    1705
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9d369e6da2638702ce617a4ae4cf8d05cdc50d0b",
-   "sha256": "1zj99wz8649ixxvz3d0qg1sbi2sb54g42qwgi0ngqzr6qzdc03wa"
+   "commit": "9a7c19aab050c23962049fdeb8d27091ff7bbf10",
+   "sha256": "1j619m08lz6bg2kr4jm2rbyn2r8a9f1z124ashzjkiwky0mvs1v9"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9d369e6da2638702ce617a4ae4cf8d05cdc50d0b",
-   "sha256": "1zj99wz8649ixxvz3d0qg1sbi2sb54g42qwgi0ngqzr6qzdc03wa"
+   "commit": "9a7c19aab050c23962049fdeb8d27091ff7bbf10",
+   "sha256": "1j619m08lz6bg2kr4jm2rbyn2r8a9f1z124ashzjkiwky0mvs1v9"
   }
  },
  {
@@ -96938,14 +97374,14 @@
   "repo": "justinbarclay/parinfer-rust-mode",
   "unstable": {
    "version": [
-    20241108,
-    1719
+    20250303,
+    2113
    ],
    "deps": [
     "track-changes"
    ],
-   "commit": "044c3fe8f68e3e69d1157359bbfb1cf95423fe26",
-   "sha256": "1p00m757maw6dxig0x45gry1l7vm9dm6wg1anfm2rwl6hw1f5q25"
+   "commit": "d5578ec0b2e907cb1a2600057f524135c4553050",
+   "sha256": "0yrydplbkdhk04gi8jk10w4303sq6byqyvzrj35sfr6726xaw5ww"
   },
   "stable": {
    "version": [
@@ -97037,11 +97473,11 @@
   "repo": "joostkremers/parsebib",
   "unstable": {
    "version": [
-    20250208,
-    2251
+    20250225,
+    840
    ],
-   "commit": "a25621930e67e267133b08698a72fa80a42edfc8",
-   "sha256": "0gh8bv6q9041q0b9spw7glj3lfvkj8yl743b4xc1y5mjj8alb466"
+   "commit": "735e308fc5b7aaed975764f6c7139d1c4bf28d0c",
+   "sha256": "0zr4i8gaa6vnkm4ggrgpc7fsdayfxxb8wi59c3dhkyydmvcdzqsp"
   },
   "stable": {
    "version": [
@@ -97634,11 +98070,11 @@
   "repo": "JonWaltman/pcmpl-args.el",
   "unstable": {
    "version": [
-    20220510,
-    2056
+    20250217,
+    342
    ],
-   "commit": "43229e1096f89c277190f09a3d794781f8fa0015",
-   "sha256": "0p2mpifr3ycy4ibr9y1r5lvq91dbw6vvi8g6n3jx1mqnxnh9ld63"
+   "commit": "bccbfe931a8383fb4ecc75551305057a9bd33700",
+   "sha256": "0l6qa2l34cp0bg29z058hn8c28g3s77zgdqyzacmk8ripfaklbdf"
   },
   "stable": {
    "version": [
@@ -97652,10 +98088,10 @@
  },
  {
   "ename": "pcmpl-homebrew",
-  "commit": "cdd1f8002636bf02c7a3d3d0a075758972eaf228",
-  "sha256": "100a64d8qvxdz1lk42pidj48iqsycyyw92jjqcrn8rnqw1rnb3s7",
+  "commit": "05b68616c1ddc8ab47621edee9eccba57dd8e3f0",
+  "sha256": "1j769yvqhkxandan3bs30slxvqsa9fp8db5cgmlckijxbq6vs2cc",
   "fetcher": "github",
-  "repo": "zwild/pcmpl-homebrew",
+  "repo": "suzzvv/pcmpl-homebrew",
   "unstable": {
    "version": [
     20200911,
@@ -97667,10 +98103,10 @@
  },
  {
   "ename": "pcmpl-pip",
-  "commit": "cdd1f8002636bf02c7a3d3d0a075758972eaf228",
-  "sha256": "1vl21i3aqdk2qr2r64sqg8jbslj3vxblwmbpzv732sl9gafsl990",
+  "commit": "ee77e0965052d4dae0cd4f9f88bc48068b386c05",
+  "sha256": "1wnh618wvcv75hqia7wi41bzhdl2wid4k4r0ls61dppsw56dc8wq",
   "fetcher": "github",
-  "repo": "zwild/pcmpl-pip",
+  "repo": "suzzvv/pcmpl-pip",
   "unstable": {
    "version": [
     20181229,
@@ -98116,6 +98552,21 @@
   }
  },
  {
+  "ename": "perl-ts-mode",
+  "commit": "e6f5c090d4ff0c19697976a8da2e74aa26a83d85",
+  "sha256": "1zpyj6x6qn393rh87kdqm5nvmm178nsg9w79sd0iqmkvj40q8ak9",
+  "fetcher": "hg",
+  "url": "https://hg.sr.ht/~pranshu/perl-ts-mode",
+  "unstable": {
+   "version": [
+    20250128,
+    1327
+   ],
+   "commit": "c343d3573e3165f151b93fc7517b22d72bbd5d6d",
+   "sha256": "0s4cy4i1a3a3sa0vc0vndvv5vrfgabrfci96qiil6dawq7lrmjxa"
+  }
+ },
+ {
   "ename": "perlbrew",
   "commit": "24bd9c2cd848f5003a244a7127e8fc5ef46bdca4",
   "sha256": "1qadwkcic2qckqy8hgrnj08ajhxayknhpyxkc6ir15vfqjk5crr8",
@@ -98281,24 +98732,6 @@
   }
  },
  {
-  "ename": "persp-mode-project-bridge",
-  "commit": "fa5d72aad13e1f7e1863deb5487a6ebc9eb09e1f",
-  "sha256": "0h7k03z91h7qx0kgdy5nam886730w9llmrbaajcz801892ddkn3a",
-  "fetcher": "github",
-  "repo": "CIAvash/persp-mode-project-bridge",
-  "unstable": {
-   "version": [
-    20220115,
-    602
-   ],
-   "deps": [
-    "persp-mode"
-   ],
-   "commit": "cacc22942ca5dffdfc3d16cf88576ce0bd9e3a68",
-   "sha256": "1avcc4nlnp1a87p2yaq09yljl639l3j2d44xjkp4vhxqrx9v3xv8"
-  }
- },
- {
   "ename": "persp-mode-projectile-bridge",
   "commit": "2c049b0067b70577511114dc8abac0a00a9e0588",
   "sha256": "169mpikixa33ljmh2n9sm186yibrik3f5p8m1hcisnzdsc3wgxmp",
@@ -98360,14 +98793,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20241030,
-    1848
+    20250221,
+    2026
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e32d3ea731f6bc551ce196527b3cb0dc19d71151",
-   "sha256": "1vpjc9mk96siabl5j0k023bag00cwb852cpc9f89jyqhavm6011b"
+   "commit": "81d790e7ddaf7212874eb8f49287f8880cc26d4c",
+   "sha256": "1l9qdzp54h1kp6xxrfp6hxdskzi1ihf50myq29shxd5dx2krw7nm"
   },
   "stable": {
    "version": [
@@ -98549,25 +98982,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250208,
-    1320
+    20250308,
+    1028
    ],
    "deps": [
     "peg"
    ],
-   "commit": "1f3cd5f9ee473c367040a2523dde0dfa852725c9",
-   "sha256": "1dq8h9b8n6s11nsdav2hlnwcppswy2ccfz18dhp2lvkd48dw469f"
+   "commit": "e1815943e14b97ff03aa81b4e6bddb2bb582da52",
+   "sha256": "08sjsgjkzi53xwi8l1vjb48qc6clnsknlrv3pikr81dhbjr986i8"
   },
   "stable": {
    "version": [
     0,
-    46
+    49
    ],
    "deps": [
     "peg"
    ],
-   "commit": "e6199fa1e883c0e6eb47ce6547bd2a782e35820e",
-   "sha256": "0i2ckljbfnc1sgjs14zpzppv1i1icidkrhzss3gkl7fj5wqgdqlh"
+   "commit": "f957bb6679dce1a24b06e245f695c04556977752",
+   "sha256": "0k7fyr7bkmbb2s0w36rachn3qh5xczgla5vps49kzavqfcfhk9fc"
   }
  },
  {
@@ -98852,14 +99285,11 @@
   "repo": "pivaldi/php-cs-fixer",
   "unstable": {
    "version": [
-    20241103,
-    1232
+    20250211,
+    214
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "710208cc2efc2e241d1e7421b3c2581d46a81a5c",
-   "sha256": "1681w4jsszcvva3xs9kj6a0crckwqhscy9lzsrk7zw8cjbb2q14b"
+   "commit": "4bf549c1dedad2a2a52257b866bcb180a31f129d",
+   "sha256": "182qrhf6c03r050mblfglhswkxfql8n95wka1rccf9rqk1n05g7y"
   },
   "stable": {
    "version": [
@@ -99009,8 +99439,8 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20250112,
-    201
+    20250307,
+    1931
    ],
    "deps": [
     "async",
@@ -99018,8 +99448,8 @@
     "f",
     "php-runtime"
    ],
-   "commit": "7d08be074a96778eddb07118c016dd1b6ad5f302",
-   "sha256": "07qgxpwcxkc13r4lzw57mgs43n6a4709fqs9xhly2h17vmf4b153"
+   "commit": "005f5bff81d66ac362a163778fd433eef43dabfc",
+   "sha256": "0jaccwf00xjm7nhwl51q9v3lwha8rwn7wm511klkc1g7dq0mzzaf"
   },
   "stable": {
    "version": [
@@ -100148,14 +100578,14 @@
   "repo": "8dcc/plumber.el",
   "unstable": {
    "version": [
-    20241110,
-    2234
+    20250306,
+    1106
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7655ed6d6d69249488abf57a3b39fc762792be6f",
-   "sha256": "19p7jq1d9sy8fpby0m1lj6v6z8hr1cgr0jvkasgl5l1gjn12fxrl"
+   "commit": "ddab8a2a81eb9d59c29e2ce19752fbe4fef4f254",
+   "sha256": "0chz9nrghndcg6vlshrciva7x8jivyqr0ywi0hgi3s2qvfpfqbq8"
   }
  },
  {
@@ -101098,20 +101528,20 @@
   "repo": "karthink/popper",
   "unstable": {
    "version": [
-    20241201,
-    110
+    20250222,
+    2118
    ],
-   "commit": "faf155059e519fb036324af579c342365795dbbb",
-   "sha256": "17hgpyyr1p0501i8rqi83x8dhsfla8hy5pj7m73gs3aigcp173l5"
+   "commit": "91b71955db19014d7139191660272c736458d87d",
+   "sha256": "1x1nnc0li8jd609lnmmax2hl69wmbq84c6b2mdg0wb7zf0k29lba"
   },
   "stable": {
    "version": [
     0,
     4,
-    7
+    8
    ],
-   "commit": "031e4d093c1e52337a3ca137740933a185f3d61d",
-   "sha256": "1gvg0xalnhi4vvfl5d2q5458k7plyc1j4yzq2pir6sw3y2s3g4vi"
+   "commit": "91b71955db19014d7139191660272c736458d87d",
+   "sha256": "1x1nnc0li8jd609lnmmax2hl69wmbq84c6b2mdg0wb7zf0k29lba"
   }
  },
  {
@@ -101386,11 +101816,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20241202,
-    1311
+    20250211,
+    110
    ],
-   "commit": "81651536827c96bf5af5265ee7918ab70e1dd5b1",
-   "sha256": "1jpwmzzzsv0p4iv20wk39apg9mahq48d63drlkr6n5ry246g99dd"
+   "commit": "12f540c9ad5da09673b2bca1132b41f94c134e82",
+   "sha256": "1sw5jkm3wqgfbgs044wr32w109kjy94jg8wwcr4z4npxi3dxlk8k"
   },
   "stable": {
    "version": [
@@ -101653,8 +102083,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20241223,
-    230
+    20250305,
+    1646
    ],
    "deps": [
     "ghub",
@@ -101662,8 +102092,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "9fa4ef4d1922cbd6dd37b631ea05aed0ef358178",
-   "sha256": "1cm92263jqvq2lg378xqi8ikbqw98lxjpsl29sja2xg2wf6p7gml"
+   "commit": "47bc3b00fd509a7bfd0bf5697cf9f7cb9cfacdd3",
+   "sha256": "0c28xbgq837694z9dag24y48mb3r4ffalci1zxp8hgqrijfqmakd"
   },
   "stable": {
    "version": [
@@ -101950,8 +102380,8 @@
   "repo": "jerrypnz/major-mode-hydra.el",
   "unstable": {
    "version": [
-    20231003,
-    2046
+    20250310,
+    2303
    ],
    "deps": [
     "compat",
@@ -101959,8 +102389,8 @@
     "hydra",
     "s"
    ],
-   "commit": "5181a31631589ffd870f70293aeee00b7b773b58",
-   "sha256": "019rnqz3mhakpx5vilgv8kicp3xrlh91rqacllr35jkziz9bnmm7"
+   "commit": "2494d71e24b61c1f5ef2dc17885e2f65bf98b3b2",
+   "sha256": "0rqjjfl2x77w1jw9i75w0ghax050df0acsmscxy0rsz6fa1x90az"
   },
   "stable": {
    "version": [
@@ -102105,11 +102535,11 @@
   "repo": "nverno/prisma-ts-mode",
   "unstable": {
    "version": [
-    20231022,
-    1802
+    20250217,
+    202
    ],
-   "commit": "a7029980140ae60612ef876efa17ab81bf4b3add",
-   "sha256": "0isym89c4432qrdzpbmg85pw97jw6lvbz9sdv1xy08c448dydg79"
+   "commit": "afbf682f6d302c8c6d0ddbba6fa7cac88c95d15d",
+   "sha256": "0w3i7wjlal4ifh5nqnij35wldygfg34pfqrx4m3zvsv9gjs7r0yx"
   }
  },
  {
@@ -102637,20 +103067,20 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20250209,
-    605
+    20250312,
+    1659
    ],
-   "commit": "cdb22f6b588c8ffa508f6fda586ee1253c73490b",
-   "sha256": "0h38f64c2dfayjakwlj8xf86jnybclb8d9xj4v72fprssfp8vm55"
+   "commit": "55db082cdf7b849335ccf24b7ba5aa2607d6fe93",
+   "sha256": "1h0kz0k0vjlw59q6r3vi84agwyqp66qps70bs10g8aag1im0zcx4"
   },
   "stable": {
    "version": [
     2,
-    8,
-    0
+    9,
+    1
    ],
-   "commit": "e6889d7f4bc0d2c48ceac56dfe6f4a3d742a3b69",
-   "sha256": "022ca1185ywmw8pjpkrxkd6d2wp4vbq67x2w724iiw2asy69j7wb"
+   "commit": "ef17d2971bbcce13b1ac16e0e36d44fa0defca63",
+   "sha256": "15wc2ivmac0kgbdgsaaxngmcffgd3227zsb4n7inhn14cqwr6qxd"
   }
  },
  {
@@ -103248,11 +103678,11 @@
   },
   "stable": {
    "version": [
-    29,
-    3
+    30,
+    0
    ],
-   "commit": "b407e8416e3893036aee5af9a12bd9b6a0e2b2e6",
-   "sha256": "0hjngw4bdl2zjw42l5srkn87p3k0rmzzvialfjmj9lsdnz683lyd"
+   "commit": "d295af5c3002c08e1bfd9d7f9e175d0a4d015f1e",
+   "sha256": "1yini3rs17yf122ldzq19rywa4rl11gqayqwrwpvnixj7f3m560c"
   }
  },
  {
@@ -103421,15 +103851,15 @@
   "repo": "thierryvolpiatto/psession",
   "unstable": {
    "version": [
-    20240820,
-    910
+    20250307,
+    1629
    ],
    "deps": [
     "async",
     "cl-lib"
    ],
-   "commit": "75834fe016f30a72890a1c284c1bd400ad61ea9f",
-   "sha256": "0snfdymlgx4dg5iin5mq53b1apz6i2i233yfm0zaqqnjsxmf4hlm"
+   "commit": "371e23c9cc1ad5d8ccb149ccdaf6500935f27da1",
+   "sha256": "0js23n82xhygg6hwzsy93y9jyicjp14n1vdplyskbc5g6386sa0m"
   },
   "stable": {
    "version": [
@@ -103817,11 +104247,11 @@
   "repo": "smoeding/puppet-ts-mode",
   "unstable": {
    "version": [
-    20250107,
-    1617
+    20250226,
+    723
    ],
-   "commit": "052145cf6c30114c6e6492a1b6fdfda4945e0ac9",
-   "sha256": "0hnd7xixrji80c3k3khm2ypwd4ixij9fix5cpb784xq276y84h7z"
+   "commit": "459e831ac40e7375864f4d6ae8571421f4e8533b",
+   "sha256": "0i3z6d255ibpchy3ml3q3wdycw757d28hzqfzgxkr1fyh1bczwfa"
   }
  },
  {
@@ -103832,11 +104262,11 @@
   "repo": "purescript-emacs/purescript-mode",
   "unstable": {
    "version": [
-    20250204,
-    1410
+    20250307,
+    416
    ],
-   "commit": "e0de552627487e4c6613318e42d4402563362d28",
-   "sha256": "0afrcaxrj2ih822s41l6cbdzn3acfmm0ajc2j1c82cmbwbh8xga3"
+   "commit": "a3d6ca4ba5b6ead6f19cf635258f2560c25a6e1f",
+   "sha256": "1sghd6mi1nm0yyl5wg5gbv3hnyd3gfrsrfkfwh1ks8j31xqqnwyc"
   }
  },
  {
@@ -103957,11 +104387,11 @@
   "repo": "ideasman42/emacs-py-autopep8",
   "unstable": {
    "version": [
-    20240421,
-    840
+    20250224,
+    2305
    ],
-   "commit": "3b103f2a99a71c4b4733689d074f895b2606fbe4",
-   "sha256": "0zmpbg1zi66mx9r1nbzkx0nkimzhfzvhfcl8cjfffbpqpikpw50w"
+   "commit": "45e46abc8dcf271505de6a75929b704fca663a91",
+   "sha256": "01zbpjyi7kpxafl9jnhxp0y8xi16a99cjkvrqc3ah3rpxdmww352"
   },
   "stable": {
    "version": [
@@ -104319,15 +104749,15 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20240508,
-    256
+    20250225,
+    650
    ],
    "deps": [
     "async",
     "xr"
    ],
-   "commit": "f22c20f2e6af55b3a758defabe4c842fb94cde2b",
-   "sha256": "0bnlz5bja6gg619sldlwqzdy1pccmcsxkk4g91njp7d8670xc241"
+   "commit": "f5f1be270feb3cade25e9ef910bd58e442e4b016",
+   "sha256": "0lhqirjkv9a6b2km78yiqwp0i682g3ff9di9y7n1wnw1glx04hhl"
   },
   "stable": {
    "version": [
@@ -104372,10 +104802,10 @@
  },
  {
   "ename": "pyim-cangjiedict",
-  "commit": "9e0d6c5698267d6f355c319071c4a6b39640e3fd",
-  "sha256": "1y7np5g7c921vczj8h0jjzr68j08qx48dw2h8lgj80idk8mc8zhg",
+  "commit": "e5886262459d25a03839fd3a854510a7415bd241",
+  "sha256": "13lr9ms87s3b0hf97hx81lvag8kqk5pn99hnzi5nwwlj7nlf6xj4",
   "fetcher": "github",
-  "repo": "con5tella/pyim-cangjiedict",
+  "repo": "cor5corpii/pyim-cangjiedict",
   "unstable": {
    "version": [
     20210617,
@@ -104390,10 +104820,10 @@
  },
  {
   "ename": "pyim-smzmdict",
-  "commit": "49fec74868b77d36882176ab41473c3c8a0fd5c2",
-  "sha256": "0rymxr89vsr7j0pb49s8lrrnh79q395270b29z0w6s6hwyygqv3k",
+  "commit": "f42c59e7af89ec9a24363c1f942ef92e89d11a65",
+  "sha256": "1bl6b0zyv45wjz2fbb12a7vfb27439n2vgby6wxlya2d0pljfgk8",
   "fetcher": "github",
-  "repo": "con5tella/pyim-smzmdict",
+  "repo": "cor5corpii/pyim-smzmdict",
   "unstable": {
    "version": [
     20210505,
@@ -104847,11 +105277,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250206,
-    947
+    20250224,
+    1104
    ],
-   "commit": "4162b0dc8359a50ea322a4a3874150d9b16a7cb5",
-   "sha256": "1qd0lzr4iq8gnaq1ssi632bw7cfhsdp5i2br3kcgxdykd5wxqkf7"
+   "commit": "7a4a93e972152ae224e88c25183115fb64ab87d0",
+   "sha256": "0gmd018zna46p7wbzq8d1ibp3vlskfqngn2amxyg8nkgvbqmahma"
   },
   "stable": {
    "version": [
@@ -104955,16 +105385,16 @@
   "repo": "wavexx/python-x.el",
   "unstable": {
    "version": [
-    20250207,
-    2008
+    20250304,
+    1139
    ],
    "deps": [
     "cl-lib",
     "folding",
     "python"
    ],
-   "commit": "6d98ab5fb46e93aece4320b509878fd078e2ba88",
-   "sha256": "0s3gq3mp6ig65qg0i49i6ynkgwpf6gdy14c246sr6zski69n59qd"
+   "commit": "331e96403e4ad4f45607c7c555f97b0906e442a3",
+   "sha256": "0hk79p6l2yajzcfz7knhbiw5hjyz17k979f91g36iy6az4kz5yby"
   },
   "stable": {
    "version": [
@@ -105389,11 +105819,11 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20250121,
-    2019
+    20250304,
+    216
    ],
-   "commit": "c7aa436449f7329304913b1d08ce504b3c56ff1e",
-   "sha256": "0mqaz3828iz3nbzd01x1p84f3h179371i4vw2hwcls89wvaky8g4"
+   "commit": "c114a2917845d51942cb893bd819e07580e6dbdc",
+   "sha256": "03ak9prizffazmv91c7mxpj3ckq786lirjs360pv9n4kxchldcdc"
   },
   "stable": {
    "version": [
@@ -105447,14 +105877,14 @@
   "repo": "emacsorphanage/quickrun",
   "unstable": {
    "version": [
-    20240924,
-    2359
+    20250214,
+    813
    ],
    "deps": [
     "ht"
    ],
-   "commit": "bb0f7580cd95022c4f8d016700a73260687c9722",
-   "sha256": "0bv299q0fsddxkgh25bpkyxv7wl7ai3vhwd2ds568v9ci9lxiz81"
+   "commit": "7345432cea36d4a6cdfcf5371f76af640cc6d192",
+   "sha256": "0jjqxcf6x5si095z1aj26hyqjcnrm5m6cy13m361k5gq9cqkb63q"
   },
   "stable": {
    "version": [
@@ -105630,11 +106060,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250205,
-    2128
+    20250212,
+    1523
    ],
-   "commit": "d9e66c7571722101a87a86ef611056c47b791ad4",
-   "sha256": "1basymv6r8aaq858s9ffniy0zi03hlzy4j6ffipilns2hf1ylgsp"
+   "commit": "eef5e9ab2c8991e7c73d4232bde28a77124005a5",
+   "sha256": "1shjcrdqw1fpwlksk7wpr2m1s30lhy144wik2kx8hjdbna4ygl0f"
   }
  },
  {
@@ -106370,11 +106800,11 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20250204,
-    2355
+    20250211,
+    710
    ],
-   "commit": "25355ab197e8a7c63196bf672719276093adc132",
-   "sha256": "199v2yry0jhjijzkhxcfg1h5wy24mvqq8wb1nlxmd1rs3z4563m2"
+   "commit": "7a37e6fe82d74d525d1e0280f68d357a22c1a312",
+   "sha256": "0c9lgk40p19ji5hcrgz957i70ap3z35jbpaw5paf9ba72x3rn3mk"
   },
   "stable": {
    "version": [
@@ -107820,11 +108250,11 @@
   "repo": "tkf/emacs-request",
   "unstable": {
    "version": [
-    20230127,
-    417
+    20250219,
+    2213
    ],
-   "commit": "01e338c335c07e4407239619e57361944a82cb8a",
-   "sha256": "1arhjsybb1nhq14p06jzbvp25pyp1pddq1ldyq25vj1qrsh81rjq"
+   "commit": "6f419b5cdd2dfa83675ae53f04d8463d00a533f8",
+   "sha256": "1jcypw3qymq4lx9hydhf4lba3wd03lci41c17h53skqgh2v8m2rl"
   },
   "stable": {
    "version": [
@@ -108862,14 +109292,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20241226,
-    520
+    20250219,
+    1910
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "175d97f6321f9247d2831df9119f3bf376f5b572",
-   "sha256": "1f0scs63crz440v5j1hykxjs1jy7r08lmxng5p7m9wrgbl7bcjsj"
+   "commit": "73a78e55394c1c70c11f9354ef52e7ffce31547c",
+   "sha256": "124rh9z8x99y7lxv2sv08cgj5dhrbxi50nwjkgd9xqj4vzafbjdw"
   },
   "stable": {
    "version": [
@@ -108964,11 +109394,11 @@
   "repo": "tad-lispy/roc-ts-mode",
   "unstable": {
    "version": [
-    20250122,
-    208
+    20250311,
+    1928
    ],
-   "commit": "8b652d53e3eeb457c4a820a5ca0c1ad4430c9d73",
-   "sha256": "1zxhyx555jwfcrf31sxi24v066d23nvw0ng3ylrlzh3k4fkm1njl"
+   "commit": "f96ba038e53efbc4113bf675a22d2599be8c21ad",
+   "sha256": "0f5l0aiyasjz12k0zikh73lv8cv6v04h44kf9vylb6kcyy2m0nj6"
   }
  },
  {
@@ -109132,8 +109562,8 @@
   "repo": "mbeutelspacher/ros.el",
   "unstable": {
    "version": [
-    20240831,
-    1909
+    20250224,
+    943
    ],
    "deps": [
     "cl-lib",
@@ -109145,8 +109575,23 @@
     "transient",
     "with-shell-interpreter"
    ],
-   "commit": "7a1b1ff428a1b93aeb379d37849d55edfff1d9ec",
-   "sha256": "1h4qs79c7hsqck536xwrf4ikdid75npg8ncmma2bmpp4av7nk7b8"
+   "commit": "2108aed4d075652c342e537fab120392f4703d74",
+   "sha256": "1ww1ldxwpghkfri1j1y29nc2wp0yqszddhgv3k4knrnqla889ssq"
+  }
+ },
+ {
+  "ename": "roseline-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "001zqxqcyzd6hnn145w4d6b1parvjpypggpgj2lq9b2sp0c7cjpd",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250305,
+    936
+   ],
+   "commit": "43afeb68b3ba0394f8cc925ebb90e9a6620b4b28",
+   "sha256": "17cc82qdsq0y2ypq4vx91ywhvdcmmrlg0csnvk05k64769xw9kvh"
   }
  },
  {
@@ -109277,11 +109722,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20220818,
-    1535
+    20250218,
+    2303
    ],
-   "commit": "b449eb7461e09ca3a839c2d49d22b975be1ad367",
-   "sha256": "1z8kjyrrwkyk54c6rqg92b0g40l481wz0qh6ynqbrvmda23da2iy"
+   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
+   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
   },
   "stable": {
    "version": [
@@ -109300,14 +109745,14 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20210721,
-    2314
+    20250218,
+    2303
    ],
    "deps": [
     "rtags"
    ],
-   "commit": "1f938a71106489e587c806181cdf2a0018a0cd41",
-   "sha256": "1ldwk50azixdry56zl5l1gvzsnyr6bf4gz6ljkf8dxskmam1md8h"
+   "commit": "94269d3558e5db8bab381379dc347bdc7f7ded68",
+   "sha256": "12iv0h14brybqlld5b7z8yicpm3y0wcmmswx9pv261izp7dr41xc"
   }
  },
  {
@@ -109976,13 +110421,12 @@
   "repo": "emacs-rustic/rustic",
   "unstable": {
    "version": [
-    20250202,
-    336
+    20250310,
+    1415
    ],
    "deps": [
     "dash",
     "f",
-    "flycheck",
     "let-alist",
     "markdown-mode",
     "project",
@@ -109991,8 +110435,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "31ecd5582cd8f54c736a3ee5f0b0ec1f6d128dcf",
-   "sha256": "1mw7i98fkg3mqjp5g4sik1fhpmazz9igfyq5si7b86wdranvavds"
+   "commit": "22a5ef8bfd5a34ced945c2722938eb29632371d4",
+   "sha256": "1lpa887lf1jvyzwpdpa2j8qdzymh60qbdfqgk11xyh0rkh057bjw"
   },
   "stable": {
    "version": [
@@ -111099,11 +111543,11 @@
   "repo": "precompute/sculpture-themes",
   "unstable": {
    "version": [
-    20240424,
-    1715
+    20250303,
+    1824
    ],
-   "commit": "723a3b348e9970e3f85910bdf319925c4f241a7d",
-   "sha256": "1nr1zd651mjgqaqfbmmn8l06iylszcn5qcrfswq9l5p3znm0d1x9"
+   "commit": "59e8962f34a33a73be7bfd2d69ae53c14bba6b33",
+   "sha256": "0a3xq8mjaa4qam0vw4cfp1l7hyqzvrm4bf2a3andaww1yv2fm1sl"
   },
   "stable": {
    "version": [
@@ -111443,14 +111887,14 @@
   "repo": "captainflasmr/selected-window-accent-mode",
   "unstable": {
    "version": [
-    20241019,
-    1342
+    20250304,
+    1623
    ],
    "deps": [
     "transient"
    ],
-   "commit": "32c0dc7d2bfc66fff1487019c03d7277f2411fe4",
-   "sha256": "1kd1qv0bnq9gsgmqfi1w7c0lnzvf0yhk1dx9xgdj63dpk6243668"
+   "commit": "e51f58ebbe51d17a16912c0c16e402db68013a69",
+   "sha256": "1rzqz27v45i44h2hpbx2hc26r71gvczcl12z04rai5vw5zzlzfz2"
   },
   "stable": {
    "version": [
@@ -112128,6 +112572,21 @@
   }
  },
  {
+  "ename": "sexy-theme",
+  "commit": "fce1e2e203a53dea0077d0806d1918c4ebe0987d",
+  "sha256": "118nmw29izb7q6kzkb4swdbz45alp16p203ksi8csfdv79ky3qxw",
+  "fetcher": "github",
+  "repo": "bgcicca/sexy-theme.el",
+  "unstable": {
+   "version": [
+    20250312,
+    1640
+   ],
+   "commit": "57cca02c067ded3964de6cf1566ef08cf5130189",
+   "sha256": "0qn0h309dqdi08bjfwdm1l0rpq1r2gzv88v2azwnnrxqldk2lkzs"
+  }
+ },
+ {
   "ename": "sfz-mode",
   "commit": "6e61f77045deaf0dd6a344911b73cf5b1a779a52",
   "sha256": "1x7873xvqwj1nwp18pj50bp2s9djqbqzp37fr2hjx2rygfvpxzmg",
@@ -112405,11 +112864,11 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20241226,
-    2102
+    20250301,
+    2230
    ],
-   "commit": "72ce76bb3059e6c715b2471856851aac21198ac7",
-   "sha256": "0df0mxaz2g4fzdlhxygifmsjnxw7n8v1ghz1pnlhad0anpwdsdv9"
+   "commit": "98780ec0a8ac4fe1d6be9e2f8047195cdfad5f70",
+   "sha256": "0pmk9c2xbbqy3d0q5kjf74d06wxdnxyfpd10qmnzj384nkaqwm8w"
   },
   "stable": {
    "version": [
@@ -112690,17 +113149,17 @@
  },
  {
   "ename": "shift-number",
-  "commit": "b06be6b25078ddfabc1ef1145c817552f679c41c",
-  "sha256": "1sbzkmd336d0dcdpk29pzk2b5bhlahrn083x62l6m150n2xzxn4p",
-  "fetcher": "github",
-  "repo": "alezost/shift-number.el",
+  "commit": "e2f2214c6d48ca283df84bcb591f598425ec4a35",
+  "sha256": "08vc8n300ll1xbhm4yj1ra77pkp3ir34l6k4n54l47023sivpv7x",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20170301,
-    1459
+    20250313,
+    1138
    ],
-   "commit": "94c3713cc11283a831f66d5205d112762edc186b",
-   "sha256": "17a5aifj37pv3jm6k7ilc3s4vwhiy2dwyjjy9dxy3qqc8w9h4rr1"
+   "commit": "8d910a7f0f42027f6526fc0bb0d145c196c19b52",
+   "sha256": "17ganlyvb3d7ibpyapnywhj9a1667h66g8hiwajgryciar958mnj"
   },
   "stable": {
    "version": [
@@ -112738,11 +113197,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20241225,
-    152
+    20250306,
+    131
    ],
-   "commit": "9712e5703cb846b3cff448d5c40b3f8c7e6eedde",
-   "sha256": "1yk3nbgirjv54kkw720x28vq8jr2f2vba096sqn3s2xxvxy2d1jx"
+   "commit": "7a817d45d354f576bdd1e6f54baed1e628073f8a",
+   "sha256": "1f35bsdx6k489s5bi97p18pchhkxwqwszyv114vdqf03xy3zhvdp"
   }
  },
  {
@@ -112943,15 +113402,15 @@
   "repo": "chenyanming/shrface",
   "unstable": {
    "version": [
-    20250201,
-    903
+    20250308,
+    1630
    ],
    "deps": [
     "language-detection",
     "org"
    ],
-   "commit": "e13af9a9f165b2a68277cdb8e868f9f5070cd608",
-   "sha256": "18wxw9rzajynvlqz0wa9f473drzv3nflh326z824vlsh8xjjwzg6"
+   "commit": "779c94b561177210ae03c042f191a7a6cec663c2",
+   "sha256": "0jbmp1f9bdv18k9xfkblyv2gxawcj8hwacd76ygr2xrgj3i5d89p"
   },
   "stable": {
    "version": [
@@ -113222,14 +113681,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20250131,
-    2055
+    20250311,
+    2149
    ],
    "deps": [
     "ht"
    ],
-   "commit": "06565011f7f91fb819567f0a7b9974ba2c256199",
-   "sha256": "0a8z3pzapdrm248rrczbl35ggpl517fg9y6f5x7g8g6xdr918abs"
+   "commit": "ed0d5ca69104aea2e3de0d9ab62f8709fa07b8e1",
+   "sha256": "1z39crhdpsn96qxqi66yls3cpgn378nphjcy4sqnxka20dnz4d9p"
   },
   "stable": {
    "version": [
@@ -113274,6 +113733,39 @@
    ],
    "commit": "c3721eeb01cea8acc520c60b9c0a802c39114c6e",
    "sha256": "1rbb7sazdrp3ixvr5plby8i033j34ww52f6igljvzyclpv8w9rqi"
+  }
+ },
+ {
+  "ename": "sideline-eglot",
+  "commit": "7053cc57be509e84b0eaa5674b622c04a8c30270",
+  "sha256": "1g5pghxnszlrbiwknnaigl1zxgbkbg13fcp3dmps441j7gf6x2ps",
+  "fetcher": "github",
+  "repo": "emacs-sideline/sideline-eglot",
+  "unstable": {
+   "version": [
+    20250210,
+    2010
+   ],
+   "deps": [
+    "eglot",
+    "ht",
+    "sideline"
+   ],
+   "commit": "bc6e30805c4b5dcd8d1b0cefe2d9367f1739dbaa",
+   "sha256": "04l343agbs9q3bh9d1vryyjbfd8ip59390lm16w81dkn31hx0qh0"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "ht",
+    "sideline"
+   ],
+   "commit": "158e8819172b144364658833db80b7aa0ef24e72",
+   "sha256": "130lc0dfbik3ibik1r7iz4nf27v87fbd4dbd918zn206amp75b8q"
   }
  },
  {
@@ -113832,8 +114324,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20250101,
-    1807
+    20250302,
+    1547
    ],
    "deps": [
     "compat",
@@ -113841,14 +114333,14 @@
     "llama",
     "magit"
    ],
-   "commit": "b5303108fcccca495fe36202d023a068ee7af2f7",
-   "sha256": "1kc91jicm5xmlchcnvx2mpalqglzxmxkwbvs1kfvkgvkgh5z8d1y"
+   "commit": "a93f6329efddbd1273f774046904886b6d2f20c3",
+   "sha256": "1qm9bwbbkypnd5dp8f1ag3hfwsg6f0snggymwhc082bvdifpmxxk"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -113856,8 +114348,8 @@
     "llama",
     "magit"
    ],
-   "commit": "b5303108fcccca495fe36202d023a068ee7af2f7",
-   "sha256": "1kc91jicm5xmlchcnvx2mpalqglzxmxkwbvs1kfvkgvkgh5z8d1y"
+   "commit": "f04a145396e5534e09d381d218ec051e2137c9e0",
+   "sha256": "1fq9axf5h3l3qk6pgv2vzz33hbl2fmbv4vsg9l0il7vhwlj7k04a"
   }
  },
  {
@@ -113873,6 +114365,21 @@
    ],
    "commit": "4124a8cf664b04a4bf4c39f7c3b7da3e480b99c8",
    "sha256": "1gk5h51k3lk5d0q1k63xpq3q3gs07jgi3qg24f5g2m1q738l4rlr"
+  }
+ },
+ {
+  "ename": "sixcolors-theme",
+  "commit": "9d20e782472fa3400bfec8342a86a2179bf82ba3",
+  "sha256": "0dx13zw94lcifji5gd5ryyvpdxwd4hk9w825418gcj5bx512x3nx",
+  "fetcher": "github",
+  "repo": "mastro35/sixcolors-theme",
+  "unstable": {
+   "version": [
+    20250309,
+    1750
+   ],
+   "commit": "0c61d87110b1e38337d9dffc63bf29ecb72209d2",
+   "sha256": "03h05yjs0k3s6plvlhf1ys15xy329fzdz4s0khnlbbhxyib6x6zw"
   }
  },
  {
@@ -114085,8 +114592,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250208,
-    1653
+    20250310,
+    2351
    ],
    "deps": [
     "alert",
@@ -114098,8 +114605,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "d81c18a90cec42bea58c74e902cfad27900f8de6",
-   "sha256": "0qmviqv67qzfl7w8sdl3l0ds6g7fhz58vx41d2mjm6ny0qd6ksq5"
+   "commit": "7fc183f9deadc7e3d4e0c89776cdc2968bba0164",
+   "sha256": "1fimrkd4p15pm2vy8g7j9cxv4l5i1n7pgkzhzyd0jlha5g8il8ij"
   }
  },
  {
@@ -114157,14 +114664,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250203,
-    1829
+    20250310,
+    2032
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "95b722de9f59b2af2d2b42d38669d43230e7af69",
-   "sha256": "17lhgjygpjrlpch7shimp7yami8vb18y1zsmhg66s7gimabgxqhm"
+   "commit": "9bba7e93105ab4d8517423894eaaa9b097543b1e",
+   "sha256": "0f2fhiv12jg7pld5zhv14v6hg466bhi7pff8iv91bnfmr1cv0d1c"
   },
   "stable": {
    "version": [
@@ -114186,27 +114693,27 @@
   "repo": "anwyn/slime-company",
   "unstable": {
    "version": [
-    20210124,
-    1627
+    20250301,
+    21
    ],
    "deps": [
     "company",
     "slime"
    ],
-   "commit": "f20ecc4104d4c35052696e7e760109fb02060e72",
-   "sha256": "05dnnc4ms5c9yp9h65k2gbkg3pw9k38nx5wzlwdlfr4shqmw54w0"
+   "commit": "e4f012bf989d832275e7ba43b46134666a34cd90",
+   "sha256": "1lzl08fadjn58s9r8kcn1m2sj8qpkg230cjx382jkd5h7ahksx1n"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
    "deps": [
     "company",
     "slime"
    ],
-   "commit": "f20ecc4104d4c35052696e7e760109fb02060e72",
-   "sha256": "05dnnc4ms5c9yp9h65k2gbkg3pw9k38nx5wzlwdlfr4shqmw54w0"
+   "commit": "e4f012bf989d832275e7ba43b46134666a34cd90",
+   "sha256": "1lzl08fadjn58s9r8kcn1m2sj8qpkg230cjx382jkd5h7ahksx1n"
   }
  },
  {
@@ -114620,11 +115127,11 @@
   "repo": "zenitani/elisp",
   "unstable": {
    "version": [
-    20240102,
-    1350
+    20250227,
+    1850
    ],
-   "commit": "09f31e1adf2bd900138b0b8e6d2060c336eb07ad",
-   "sha256": "0xbb4v23xvjgrby15lp4an2spvcp5m41112z9pmzvs5wj49w8zks"
+   "commit": "f48f508e2669f4ba66d26806bc40da1515dec85f",
+   "sha256": "1zj5s26pflwqk7qz2yw5vci7fnvzrl6pgb723yv79lr3wz1hcspz"
   }
  },
  {
@@ -115808,6 +116315,21 @@
   }
  },
  {
+  "ename": "solarized-gruvbox-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "1955iaf25kszra63mnw3wf6dcky9ziza1yqpq7p0ngmmfyyl8lvq",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250305,
+    936
+   ],
+   "commit": "43afeb68b3ba0394f8cc925ebb90e9a6620b4b28",
+   "sha256": "17cc82qdsq0y2ypq4vx91ywhvdcmmrlg0csnvk05k64769xw9kvh"
+  }
+ },
+ {
   "ename": "solarized-theme",
   "commit": "cae2ac3513e371a256be0f1a7468e38e686c2487",
   "sha256": "15d8k32sj8i11806byvf7r57rivz391ljr0zb4dx8n8vjjkyja12",
@@ -115815,20 +116337,20 @@
   "repo": "bbatsov/solarized-emacs",
   "unstable": {
    "version": [
-    20250209,
-    905
+    20250222,
+    1429
    ],
-   "commit": "ac09b782f26936d72f0cf1bbe1ff8d589ca49b04",
-   "sha256": "0l8pzld3pwx5p74sc7amxfii0q7wh1pgnjzljy2ls43wxd2phrd2"
+   "commit": "5d136736f76c85a83fef737d10ecd32af4d493fd",
+   "sha256": "0nwyax9dikpw4fcplnk0az9k1pk02wnhkadvfp325s7rl2j8y23b"
   },
   "stable": {
    "version": [
     2,
     0,
-    4
+    5
    ],
-   "commit": "922b5956a9e2e474f1595bad7b2b35f148b4df3f",
-   "sha256": "18z36nzyh4dsd8igys37x0r3lnav77fvjrkxv48v3yjsrwli19gl"
+   "commit": "5d136736f76c85a83fef737d10ecd32af4d493fd",
+   "sha256": "0nwyax9dikpw4fcplnk0az9k1pk02wnhkadvfp325s7rl2j8y23b"
   }
  },
  {
@@ -116669,22 +117191,27 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20230926,
-    838
+    20250302,
+    2246
    ],
    "deps": [
-    "compat"
+    "compat",
+    "dash"
    ],
-   "commit": "28b8e8c1cc24511758168f30bcac18d8fb93706d",
-   "sha256": "0vdkpka364cgb1y15z3klcdcqszxzys9rrdqb0ww3my2yssay93l"
+   "commit": "9602ac6a794ff16393f6665afe7096b2690e4393",
+   "sha256": "1iwvv8m8xmyvjwyqs6vjyw17qifx53c7ybwykd802lciqpxiixlw"
   },
   "stable": {
    "version": [
     1,
-    3
+    4
    ],
-   "commit": "657946280a540587831494415b16df3194ae7c52",
-   "sha256": "0nnvk3qnn61hg5rgwpiy1dqg6sqfh1m5256sbsk2pwrdmk54k85k"
+   "deps": [
+    "compat",
+    "dash"
+   ],
+   "commit": "d38e1cee6f6760ee0e624e2f8146dea85850f4f3",
+   "sha256": "1rw3lgm65jxcs7vbj0055ays4wv23mk2kj3xivnqmhnm030vk868"
   }
  },
  {
@@ -116840,6 +117367,21 @@
    ],
    "commit": "f55c2b6dd35caace0ec7250b5c7b5d119235a23d",
    "sha256": "1jkqwclk65rcyv5qj2vq7qpiimlrqij7c7fbjvxv4pf4zd2wx0k8"
+  }
+ },
+ {
+  "ename": "spider-man-theme",
+  "commit": "5b4f894550eaf41d04bb2884f34d8da2901e90d2",
+  "sha256": "0wd8c7frakblg3bbj6nz7xgivnirhz2hyngrxgw56m5rax03jjsv",
+  "fetcher": "github",
+  "repo": "madara123pain/unique-emacs-theme-pack",
+  "unstable": {
+   "version": [
+    20250305,
+    936
+   ],
+   "commit": "43afeb68b3ba0394f8cc925ebb90e9a6620b4b28",
+   "sha256": "17cc82qdsq0y2ypq4vx91ywhvdcmmrlg0csnvk05k64769xw9kvh"
   }
  },
  {
@@ -117656,8 +118198,8 @@
   "repo": "daanturo/starhugger.el",
   "unstable": {
    "version": [
-    20250204,
-    1630
+    20250216,
+    948
    ],
    "deps": [
     "compat",
@@ -117666,8 +118208,8 @@
     "s",
     "spinner"
    ],
-   "commit": "46f32d4444d4cf6a8937e89538371c97eb0a65dd",
-   "sha256": "19v8gaj1msnn94kmxrrapsb1ldrwjqf7hkw9wm25mv6f9h0lxjs8"
+   "commit": "c9753808184eaa9328b6ada18bfe418150b92eac",
+   "sha256": "15wd84n94j0q46ch5d4ddsycxn56clfs01qz15ni4rblqy99zl1b"
   },
   "stable": {
    "version": [
@@ -117853,20 +118395,20 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20250118,
-    2328
+    20250222,
+    2041
    ],
-   "commit": "67c7c7b25f5d128b1b5a6ab8d2195ef130540b8e",
-   "sha256": "0ahilkpwh56lv1c02sdlnnxmq5r37v8mxm7sd3pyq0li93789am7"
+   "commit": "a9fd1cb3baf5ea3f7d0edb6c319a16507aa9a64c",
+   "sha256": "1876366a0vmn90sfwhzx1l7lwyhc2527yvz2lsbzj228wgi5zck2"
   },
   "stable": {
    "version": [
     2,
     5,
-    1
+    3
    ],
-   "commit": "67c7c7b25f5d128b1b5a6ab8d2195ef130540b8e",
-   "sha256": "0ahilkpwh56lv1c02sdlnnxmq5r37v8mxm7sd3pyq0li93789am7"
+   "commit": "a9fd1cb3baf5ea3f7d0edb6c319a16507aa9a64c",
+   "sha256": "1876366a0vmn90sfwhzx1l7lwyhc2527yvz2lsbzj228wgi5zck2"
   }
  },
  {
@@ -117946,14 +118488,14 @@
   "repo": "neeasade/stillness-mode.el",
   "unstable": {
    "version": [
-    20250126,
-    2133
+    20250307,
+    1608
    ],
    "deps": [
     "dash"
    ],
-   "commit": "b7bdde04529126a0b4fba263efd7b4786fd24682",
-   "sha256": "0m8yslpvpgzaqj85wawqwzmvnsgdzwi1m9y6i1yndcka52pvk7kx"
+   "commit": "05029febdb451941ed218e6ddbef5294776e31d4",
+   "sha256": "06gj5fjjq922fafn2wi8i0c6sx3s95zi17crmgv2dy0k1f4ljvkz"
   }
  },
  {
@@ -119189,26 +119731,26 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20240829,
-    1723
+    20250224,
+    2125
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "8dc02d5b725f78d1f80904807b46f5406f129674",
-   "sha256": "10gggaddmny3jgvppmka854cbf4ifv5gljdlhqyww6g7zlhwz48d"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   },
   "stable": {
    "version": [
     0,
-    14,
-    2
+    15,
+    0
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "8c30f4cab5948aa8d942a3b2bbf5fb6a94d9441d",
-   "sha256": "1iqj27pc2iivmwfh329v0d9g0z1y0whlnamrl7g2bi374h41m368"
+   "commit": "7a0d554aaf4ebbb2c45f2451d77747df4f7e2742",
+   "sha256": "0219m3afsn7s7188hphpq1nh7fqbgjxixaw0js0mmcmzhbzh5x64"
   }
  },
  {
@@ -119519,11 +120061,11 @@
   "repo": "liushihao456/symbols-outline.el",
   "unstable": {
    "version": [
-    20240701,
-    849
+    20250226,
+    456
    ],
-   "commit": "9664a1338b5755fe811eddd59f20a64a23da4063",
-   "sha256": "172hnb2jgc5z3c89sdb3jnif4lwisrj7yanr2kl418mg61ngm024"
+   "commit": "01e4438981e4884cf44ecc44dbf2e6e4e89c0a1a",
+   "sha256": "07gs54hwhr019d9zxv6a3inhr5b2065y5ykrdp76j6cabzlpj5gp"
   }
  },
  {
@@ -119580,7 +120122,7 @@
   "stable": {
    "version": [
     1,
-    0
+    1
    ],
    "deps": [
     "evil",
@@ -119589,12 +120131,10 @@
     "hydra",
     "lispy",
     "paredit",
-    "seq",
-    "smartparens",
-    "undo-tree"
+    "seq"
    ],
-   "commit": "d37532a9dcff8ec5a2fdc54f27b517890f972bfb",
-   "sha256": "19ffgdvmnys2hby1iwb85kwr74iadnp8mfd0816jlaafjsga7inf"
+   "commit": "47b5296cf357eb0fc94b531e0126740aa168ed8d",
+   "sha256": "1ksmqj6kk0l3k57yswwqy49qrz2nggg487p10i2zbza7wk5hnra3"
   }
  },
  {
@@ -120682,15 +121222,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20250203,
-    1232
+    20250304,
+    1550
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "85ad1717de4a47ebeb293e836e5a89e901b55dbd",
-   "sha256": "099a9269fb9p4hj9v8lqgij9cnc2zr0ayzxws4bh3w82qz5hvi22"
+   "commit": "ff06f58364375c96477561f265e3dbf55a8ad231",
+   "sha256": "0bircjqj2zm67zspsy2r76zygvkxq6y65f3bchlhhhj1rr19kalh"
   },
   "stable": {
    "version": [
@@ -120868,11 +121408,11 @@
   "repo": "danderson/templ-ts-mode",
   "unstable": {
    "version": [
-    20240118,
-    338
+    20250223,
+    2347
    ],
-   "commit": "e43dc22adada160906bd411b03cfa022d787486d",
-   "sha256": "1pr53b3jcv0wb7gn32ifsmgq957hvfq58mviz9ym8csi9ijv44vz"
+   "commit": "ddf13c1a08ed3d05d9701b1a2e8bb4b9febad57b",
+   "sha256": "1g6ycbxkvhca43ir5aqdf10khrm633q7bkz2c5sj30ixb6sdkqf9"
   },
   "stable": {
    "version": [
@@ -121551,15 +122091,28 @@
   "repo": "johannes-mueller/test-cockpit.el",
   "unstable": {
    "version": [
-    20250208,
-    2126
+    20250216,
+    1832
    ],
    "deps": [
     "projectile",
     "toml"
    ],
-   "commit": "56e52623ed302d307a2aa6b0ee9e828297cb20e6",
-   "sha256": "0wbnf4bh739za194709m51f98l5cwn1352021q6f3nv6km5y0if9"
+   "commit": "75711b58b9d087b15ebc6c6a754d6e1289e02e72",
+   "sha256": "1vr0ab29lgh4fw2nawq31nja438lpwdpfa46r7pmviz4mjyck63h"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "projectile",
+    "toml"
+   ],
+   "commit": "75711b58b9d087b15ebc6c6a754d6e1289e02e72",
+   "sha256": "1vr0ab29lgh4fw2nawq31nja438lpwdpfa46r7pmviz4mjyck63h"
   }
  },
  {
@@ -121789,6 +122342,21 @@
    ],
    "commit": "13ee3f528ff616880611f563a68d921250692ef8",
    "sha256": "035avqp9m1mbffvc1xd5qvyg93vsxjsphmf394mq15gawqs33ik4"
+  }
+ },
+ {
+  "ename": "thankful-eyes-theme",
+  "commit": "a93b3d998590e77fcf6bf4438ee98dacc839c067",
+  "sha256": "0h4br1a2aymx6dp6139ps4n1ny0dmqhi3rr5s8cllf8clwmznrhc",
+  "fetcher": "github",
+  "repo": "tanrax/thankful-eyes-theme.el",
+  "unstable": {
+   "version": [
+    20250302,
+    1920
+   ],
+   "commit": "5d2e4fdf7b9b7206cfcfbf06f2de3211f9b9e630",
+   "sha256": "1x9mkk90p4pairhwxlgzz2l3ia1rcaqyhfqvn7npc7ln07nm0cwi"
   }
  },
  {
@@ -122023,21 +122591,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20250130,
-    2231
+    20250310,
+    1351
    ],
-   "commit": "0b1692802fd3a95daad427b3aced684837fdb3bd",
-   "sha256": "1s7p8iqgn05j4xh67pdbajf57sb37g2fvj6n9xsqs3h5hlfh2zfp"
+   "commit": "772356bade276e39d537812d57f28a2880f5a72a",
+   "sha256": "1lhs2ss03fbj89ga522l8pin8c3b6jkj4l9aw8xns6llz569ylys"
   },
   "stable": {
    "version": [
     2025,
-    2,
     3,
+    10,
     0
    ],
-   "commit": "0b1692802fd3a95daad427b3aced684837fdb3bd",
-   "sha256": "1s7p8iqgn05j4xh67pdbajf57sb37g2fvj6n9xsqs3h5hlfh2zfp"
+   "commit": "772356bade276e39d537812d57f28a2880f5a72a",
+   "sha256": "1lhs2ss03fbj89ga522l8pin8c3b6jkj4l9aw8xns6llz569ylys"
   }
  },
  {
@@ -122450,19 +123018,19 @@
   "repo": "aimebertrand/timu-line",
   "unstable": {
    "version": [
-    20250113,
-    1710
+    20250226,
+    2325
    ],
-   "commit": "b3222491602e29f79c2e569903fc7d3b67c18f34",
-   "sha256": "10kxxzbjdb5kvpbjc4jxa476c5kvcikjjrr60gkf9zajzd372nhn"
+   "commit": "b2ad1e2353b2b425537ddf5eb5ebedde5cd826b2",
+   "sha256": "07kh8raxz6kbak091g2m4hrhnmr49jvxk6qskji19spvfmpzrhy9"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
-   "commit": "7320c7eddd18703d0897283556f0ad68c50ec4e6",
-   "sha256": "19xj74m7i2mvk0xy6yx16brwpf8m4riwfphh5qzdwaib7nha5q26"
+   "commit": "b2ad1e2353b2b425537ddf5eb5ebedde5cd826b2",
+   "sha256": "07kh8raxz6kbak091g2m4hrhnmr49jvxk6qskji19spvfmpzrhy9"
   }
  },
  {
@@ -122473,19 +123041,19 @@
   "repo": "aimebertrand/timu-macos-theme",
   "unstable": {
    "version": [
-    20250120,
-    1937
+    20250306,
+    1122
    ],
-   "commit": "1371531fd95cf034b3069f91a678dd0ab0d52027",
-   "sha256": "0dxirpnahni75waj9dng2vpflay3hzd89crqsx27c5xx01fqbn1p"
+   "commit": "f5810cd705ae7e8c82894847fbbce9eb9556b53f",
+   "sha256": "0m1j8a6pb77l9v03myw6a6lv8vxl2539nmccgz4shjpn63lmw885"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
-   "commit": "1371531fd95cf034b3069f91a678dd0ab0d52027",
-   "sha256": "0dxirpnahni75waj9dng2vpflay3hzd89crqsx27c5xx01fqbn1p"
+   "commit": "f5810cd705ae7e8c82894847fbbce9eb9556b53f",
+   "sha256": "0m1j8a6pb77l9v03myw6a6lv8vxl2539nmccgz4shjpn63lmw885"
   }
  },
  {
@@ -123024,11 +123592,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20250124,
-    1956
+    20250307,
+    2022
    ],
-   "commit": "b8f714d4d5d97660206abe626b1d887cb49f7031",
-   "sha256": "1dh1ffqypf5pi2ij9hsldw4xc7wpf1dkbrrw0hb3f9qfsjd506j7"
+   "commit": "5263c0a561913b09d21d9c6e9a32703e7f7d48d5",
+   "sha256": "17l3gvhv3qp1v0blr7daxaw6wfprd6bx0r75nshhrmaxl11y8vlg"
   },
   "stable": {
    "version": [
@@ -123226,14 +123794,14 @@
   "repo": "fledermaus/totp.el",
   "unstable": {
    "version": [
-    20240227,
-    1841
+    20250312,
+    2000
    ],
    "deps": [
     "base32"
    ],
-   "commit": "af2ca2f0623d5268e31f1fe19bc1370c14b601b1",
-   "sha256": "1vw1vpnxa4qxbdsmis8d0df3qhwr1c5h0q04rvwmyviixd729mlr"
+   "commit": "6acb5f3cdac840fc2d1e5c4b73a90f4c035d7116",
+   "sha256": "1sw7d9j3qzxih3l5rjlapgm07zdfrqq3556mwz4bcjarxdvsimas"
   },
   "stable": {
    "version": [
@@ -123255,11 +123823,11 @@
   "repo": "chmouel/tox.el",
   "unstable": {
    "version": [
-    20170404,
-    1059
+    20250216,
+    1042
    ],
-   "commit": "7655eb254038d5e34433e8a9d66b3ffc9c72e40c",
-   "sha256": "1212b7s00kw9hk5gc2jx88hqd825rvkz1ss7phnxkrz833l062ki"
+   "commit": "831521fdfdd0b903c50616c6d675e63279c8b4aa",
+   "sha256": "0kyg6bczgzjp79fiaqa2imq9xlmy40x3sbql3v1bdk6543r6dv2m"
   },
   "stable": {
    "version": [
@@ -123508,20 +124076,20 @@
   "repo": "fosskers/transducers.el",
   "unstable": {
    "version": [
-    20250205,
-    1149
+    20250215,
+    1046
    ],
-   "commit": "7019f7e4d26afbb601f660ed959eb88257f23f6d",
-   "sha256": "13pz16w06rnjj939x2my0pvqqjcprywg35hcbnj1ggzry7q5673s"
+   "commit": "08509ab201973e412dfd5292f721a367514db32a",
+   "sha256": "1hgyq4n96174889jdl8jilh5km6ss9pjg0721qzmp6c7s8p9rvla"
   },
   "stable": {
    "version": [
     1,
-    3,
-    1
+    4,
+    0
    ],
-   "commit": "18f61af19d9187bebe4d4cbd95ed855618a81668",
-   "sha256": "00kb7fq1ljms0mwr1m0kq9dy7f6hah5g7x57f93fnhaf769bsc2j"
+   "commit": "08509ab201973e412dfd5292f721a367514db32a",
+   "sha256": "1hgyq4n96174889jdl8jilh5km6ss9pjg0721qzmp6c7s8p9rvla"
   }
  },
  {
@@ -123569,28 +124137,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20250205,
-    2244
+    20250306,
+    1916
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "32a7e256aab281bada5db8569e0871c8c3ad2115",
-   "sha256": "01704zjh94km5nhc60kcgy22hwb1g74llb5kdqjwsz7q1nrad8h7"
+   "commit": "4030862396130b3dcfedabe509a4fc6cb218c49f",
+   "sha256": "0qyc1gp6i8hznz7smab7xlxi76sphl6sy49zlciq7rhl4k87hka8"
   },
   "stable": {
    "version": [
     0,
     8,
-    4
+    5
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "e5cb1fd7e8d35e264313436f47972acae0819764",
-   "sha256": "01g6r5pmprkg75n23zr27nml7dg0ncsrwgbpfnjf0snhjwb4cbhx"
+   "commit": "b51a52a9c7a6562c19d03de4ce30b9c071bca8d2",
+   "sha256": "0f1gdxdj7mrmjmqswlj2lwagr6dpfhkm7732gh0jcgc4iy40vac9"
   }
  },
  {
@@ -124058,13 +124626,13 @@
    "version": [
     0,
     12,
-    255
+    264
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "2ff446b4b813543b7a90015808d38f362f039b10",
-   "sha256": "0dnm1iph0ysa797npc9flinyh7vc55lqgv7k5k2gsn3bibm85blc"
+   "commit": "ca28bd803de0af069a8a931bc4b3295af02633cc",
+   "sha256": "03hbb94miz2rd11inp3cmwxzchvwxpkbjgd5p8zs4sl3lzq37w7m"
   }
  },
  {
@@ -124902,14 +125470,14 @@
   "repo": "ocaml/tuareg",
   "unstable": {
    "version": [
-    20231009,
-    2143
+    20250228,
+    257
    ],
    "deps": [
     "caml"
    ],
-   "commit": "1d53723e39f22ab4ab76d31f2b188a2879305092",
-   "sha256": "05afiixj9ag3r36k4xhfizb7frldc2g6i3jr3mxmdgnbm08r3l2v"
+   "commit": "1600fdad28bdd2c55e52a87e7987713c6d5d1718",
+   "sha256": "0s5nc0pqk9l28gw5sv3wzv9qk7r1p25m1kjmkrnl9agk6f1rck0i"
   },
   "stable": {
    "version": [
@@ -125165,30 +125733,6 @@
   }
  },
  {
-  "ename": "twittering-mode",
-  "commit": "091dcc3775ec2137cb61d66df4e72aca4900897a",
-  "sha256": "0v9ijxw5jazh2hc0qab48y71za2l9ryff0mpkxhr3f79irlqy0a1",
-  "fetcher": "github",
-  "repo": "hayamiz/twittering-mode",
-  "unstable": {
-   "version": [
-    20181121,
-    1402
-   ],
-   "commit": "114891e8fdb4f06b1326a6cf795e49c205cf9e29",
-   "sha256": "1w1p5pg3ambixhc5l7490wf5qasw3xv9qg6f0xhfsnqk44fp70ia"
-  },
-  "stable": {
-   "version": [
-    3,
-    0,
-    0
-   ],
-   "commit": "27e7f3aab238bd0788fd3b471c645c3ceceb0f13",
-   "sha256": "193v98i84xybm3n0f30jin5q10i87vbcnbdhl4zqi7jij9p5v98z"
-  }
- },
- {
   "ename": "twtxt",
   "commit": "32ad9cfa9ce6471b368488c3048052668c48a616",
   "sha256": "08001bdqa3q6klirad26skqigp6dv04w9992m1my1smvbbvjyppq",
@@ -125196,14 +125740,14 @@
   "repo": "deadblackclover/twtxt-el",
   "unstable": {
    "version": [
-    20250208,
-    1103
+    20250306,
+    1612
    ],
    "deps": [
     "request"
    ],
-   "commit": "401f8c8371855396a530dbe98ac7f0adf58fe40c",
-   "sha256": "0ci3zynrhpibxlvyzsbyjcg2mync0h3f6811wamz2b2m0q9fxb8x"
+   "commit": "d5767d7775757b592fbdc2f4c45b32caf142c7b3",
+   "sha256": "19c9l9rchpvmq4j0i62pvkshn1xqrcql6hmdn9mhhwkpdcxal8k6"
   }
  },
  {
@@ -126223,14 +126767,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20250207,
-    810
+    20250309,
+    1626
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "a5781dc09035faf81e404578f8834d3ee11af0e5",
-   "sha256": "0r83nwf23kd4ash4pyy65x1pcmb53c464r891nwmfa52lg0br29h"
+   "commit": "6ee84401a55f446f53cb2785760914dbd85aa36a",
+   "sha256": "1rb06224xn5zwfw4wm8ih847qg8122g5x53h20ac61pwlpi1hzwr"
   }
  },
  {
@@ -127040,11 +127584,11 @@
   "repo": "kborling/uwu-theme",
   "unstable": {
    "version": [
-    20231103,
-    130
+    20250308,
+    155
    ],
-   "commit": "821c3a84c8e26263d898566cc27b3982854db60c",
-   "sha256": "0p4lgn39k8r57b2q92hnx3mja9mp8ypvw27jbwms4mipy3qspr7d"
+   "commit": "c68f7698ebae174fd72ef7ef88b4b42829e1ee73",
+   "sha256": "0p0hgp9k92x6fc7sfg8drpzjqrlfz811vfr7grqri9a2zgbrqsbn"
   }
  },
  {
@@ -127228,21 +127772,6 @@
   }
  },
  {
-  "ename": "vampyricdark-theme",
-  "commit": "37f00aa9b7158a5f00a19eb2bdcf5342d8037268",
-  "sha256": "1rdi1bh3q1v2bq4w9wd2z858kqn0psxh159mahr46xr9kilvn1mm",
-  "fetcher": "github",
-  "repo": "VampyricDark/emacs",
-  "unstable": {
-   "version": [
-    20220405,
-    2235
-   ],
-   "commit": "24e43991ae50098e1f8fecaaabc768183de76947",
-   "sha256": "0xhy860w17aj79mc5pz6cppbmv7ks7zcyh95qdw8kw5cm9cv1wfj"
-  }
- },
- {
   "ename": "varuga",
   "commit": "66011b5520df38daf9ba775c3ad80ba779f8835e",
   "sha256": "05vmlr5mdcy2nnj00ckw5bgvwnnkvyfpaay13i0mh195113zdiwm",
@@ -127407,14 +127936,14 @@
   "repo": "redguardtoo/vc-msg",
   "unstable": {
    "version": [
-    20221005,
-    1228
+    20250218,
+    237
    ],
    "deps": [
     "popup"
    ],
-   "commit": "027fefad63868cd7695372510c27922656cf996a",
-   "sha256": "05iqjc9g2kxdbhkywbisc2fkv15vw81hxjzphwiq46ikimrppy6a"
+   "commit": "d55a128616a876936f085e5af486924062e57d66",
+   "sha256": "0zcqbs2yf53y26i5vvvz8wgxvgxwr3ki4blk1b86i23jm4c6plkp"
   },
   "stable": {
    "version": [
@@ -127544,16 +128073,16 @@
   "repo": "justbur/emacs-vdiff-magit",
   "unstable": {
    "version": [
-    20220518,
-    1948
+    20250308,
+    1214
    ],
    "deps": [
     "magit",
     "transient",
     "vdiff"
    ],
-   "commit": "413f32c9f7e66f8379c23b5ab6341695dbcc2f20",
-   "sha256": "1zr6j6lw0x5w06sjlx8vnrrp1kx87zhm505plkb31hspf0ggsqlq"
+   "commit": "cc9e2dbd81d7f717381981501472808b7a4c6d79",
+   "sha256": "0jybs0ddgvl1xfa750prw3phvilqxq3a4gpjpcljyjbjdqhdfrym"
   },
   "stable": {
    "version": [
@@ -127768,11 +128297,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20250129,
-    2117
+    20250309,
+    2043
    ],
-   "commit": "bfffe206d5413de338ed3f03450efb49315c89b0",
-   "sha256": "1l3m1d0vxxl694nl0wlh8f3h0nmxfp0nylr6dlx0phwh0l3grq0k"
+   "commit": "151ed6bbfff71939a1481b60b9cfd2d720d56785",
+   "sha256": "1wh0a7ilgdm76xjpjcj7salxbkgcacyks5rkjdx41kl1r0rbsc63"
   },
   "stable": {
    "version": [
@@ -127829,8 +128358,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20250109,
-    1727
+    20250225,
+    2258
    ],
    "deps": [
     "ag",
@@ -127845,8 +128374,8 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "3d5ca4d0f74ac23336f5e970e2b0ea8bcc520513",
-   "sha256": "1ngf1sdxhcnlm4d0p3gm487wsxmzgbjxjw3a373kxvxkl384dgp7"
+   "commit": "f742d531412733b0217147eb862fecfa09fa3753",
+   "sha256": "04iwmybmgasz12gc2ghqm36q36537srgkz4c6w3s836sg3ahzljm"
   },
   "stable": {
    "version": [
@@ -127879,14 +128408,14 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20250110,
-    122
+    20250303,
+    1538
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "aab6050757e95bf7afbbc3de66d4f9525fd9b6cf",
-   "sha256": "0c7lch9mix76cjdhnnlyzl0qznc2qqfzcx5vc8gkd4wk5nsby2n2"
+   "commit": "dc26feeff79afb4206723f5b7e0d69f0baec298c",
+   "sha256": "009kzdkvvpv4r329d03bciz890d2sbcil5b6i2z5s7f4gf861fjn"
   },
   "stable": {
    "version": [
@@ -127987,25 +128516,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250203,
-    1055
+    20250311,
+    1655
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e69ef62ffa4bc42dd42437881c251ecdcae0e0c5",
-   "sha256": "1s0m38nxrlgcmr4nd02p33hi6bf60jswmysvlv1q5vvpygq4j84z"
+   "commit": "026a81a9c893b1d73cdbcb12436a0fad3ebdeb5f",
+   "sha256": "0qgw0mhfrjylhyznjmjf7wqs5p3xvdv0lq19pql54plbnr6fspqk"
   },
   "stable": {
    "version": [
-    1,
-    11
+    2,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9eb0168d32ddc4cb43a8a7c916094ae7b1d696d6",
-   "sha256": "0h1hvrd6z42vhjbmm7l16l42fr4xkb3bdzh7cgrmpm1s69cvn2fs"
+   "commit": "026a81a9c893b1d73cdbcb12436a0fad3ebdeb5f",
+   "sha256": "0qgw0mhfrjylhyznjmjf7wqs5p3xvdv0lq19pql54plbnr6fspqk"
   }
  },
  {
@@ -128506,11 +129035,11 @@
   "repo": "joostkremers/visual-fill-column",
   "unstable": {
    "version": [
-    20240411,
-    656
+    20250204,
+    2336
    ],
-   "commit": "e04d3521b6dc2435de4c4a4b9cac5feb194f0d5b",
-   "sha256": "1bsymwzpvp4rqljidrixp3kc7kxjwsy5mkap6jw9rvpm6apy3b0n"
+   "commit": "d4464130a21733671a53f915a697dea65888473f",
+   "sha256": "1a7xqc4cnpwy8rd4grp539zmb7qaqjvx906qbzdixcb3dq7szj3b"
   },
   "stable": {
    "version": [
@@ -128618,29 +129147,6 @@
    ],
    "commit": "07c4a12904f2700fb8420c4e71395fd59a5e6faa",
    "sha256": "1hk474a6s02fz34ngw3xy3zv3bh2zsyr1kfg0niqnkxy3wydf9zg"
-  }
- },
- {
-  "ename": "vlf",
-  "error": "No recipe info",
-  "fetcher": "github",
-  "repo": "m00natic/vlfi",
-  "unstable": {
-   "version": [
-    20191126,
-    2250
-   ],
-   "commit": "cc02f2533782d6b9b628cec7e2dcf25b2d05a27c",
-   "sha256": "00wqq9x3p4iwgsga3wvlr8c7iifvh3b0j41sahccdx6hqh4a0pzp"
-  },
-  "stable": {
-   "version": [
-    1,
-    7,
-    1
-   ],
-   "commit": "a01e9ed416cd81ccddebebbf05d4ca80060b07dc",
-   "sha256": "0ziz08ylhkqwj2rp6h1z1yi309f6791b9r91nvr255l2331481pm"
   }
  },
  {
@@ -128757,19 +129263,19 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20250101,
-    910
+    20250211,
+    133
    ],
-   "commit": "a1a59ebd0fb9294224da31d4b62070ea3fe3c28d",
-   "sha256": "1fml15d9hy8fqbz1wnkz4l31h2fdfpb64dqd3pphqzqgxrx5qamr"
+   "commit": "8fac750fc562f89c94bfa76ea2032f90a0cb4237",
+   "sha256": "01qi23f723574jklayig8ngvaf4gc8s24f2zy6wci3177dzgr0vq"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
-   "commit": "a888af1719d3954892fb659985d4b74637fb6532",
-   "sha256": "1wmg75wnrw091dx1v31pyj3slaq7syhb1wypmmlg2a1kf8vbh40w"
+   "commit": "b350d516e413632fc897af8de011db0f93044321",
+   "sha256": "19z7kn6mb90w7lyfsqfyyf8nz2jirv6p8yavzi2h552f5ymf49kc"
   }
  },
  {
@@ -128780,19 +129286,19 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20250101,
-    910
+    20250211,
+    133
    ],
-   "commit": "b469a2b7376789494e3448b0722b12556043204a",
-   "sha256": "03cyfkww8kss3xpsymb9y2ld7jhsb6rslyl5skhjpmsr85gj74wa"
+   "commit": "3690bb3eea3863bc81e6864b3f34546d9660b86e",
+   "sha256": "120rar8gpm878jbjngz7w7g2gjap1v31amxg3v00464qkqvqhdyd"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
-   "commit": "2ebed00305ff4ae67e8ed18c1fce8de2f169b753",
-   "sha256": "0apzkbcx9rgcv3hrcdbmjnib6c4kalvdjs45pfci42jsc2rd4lzh"
+   "commit": "0e0d53d595249fa716f0a12fba3c44622132bce3",
+   "sha256": "1fzy9ag0lpf072mgph401h4qyk1vhmj89vvnrjprgn19zijh089z"
   }
  },
  {
@@ -129149,11 +129655,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20241220,
-    536
+    20250226,
+    28
    ],
-   "commit": "2118b53c2ce16bb8568a9948d7378d3515c2471c",
-   "sha256": "1ynmaml2hyf1r1pmm5b2fkrmj4kslgqq55bhy32ps0759imwv7la"
+   "commit": "dbae2cc7020be1622eb116e6b5b2d79311c1bfd5",
+   "sha256": "08aglcga9lnzzjcn2vsmdw7cfvmkrnywww00fzi66px32d56xfhb"
   }
  },
  {
@@ -129836,11 +130342,11 @@
   "repo": "mauroaranda/emacs-webdriver",
   "unstable": {
    "version": [
-    20231016,
-    1331
+    20250224,
+    2303
    ],
-   "commit": "f73fc53aea5733d630e66d8da178218983d5898a",
-   "sha256": "1m1zd3dyp1jy3ki6jsmmn583s0vbpvk12g0dy34kfdjxdlp7sx8y"
+   "commit": "dfe26adc9482d50c7c6ca765916443bd74cf548d",
+   "sha256": "03nl3wrfhzc4xhibrb31hdd4rn4cysw3zcgb3hc63f0mr5rcrzkg"
   }
  },
  {
@@ -130300,15 +130806,15 @@
   "repo": "SalOrak/whaler.el",
   "unstable": {
    "version": [
-    20241124,
-    1732
+    20250310,
+    1131
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "8de85180c2a66f999f3effeef88aa9468d1499eb",
-   "sha256": "01h4srxrrjcqxg7x103q76k2ckzbsxld20g272wlh315mxji8dix"
+   "commit": "9237c4c01b33dd3a6609372def616ae548fd49fc",
+   "sha256": "18wj8kyblkknq4qy7lg8njygnbai5bmkxjnryq288bmpy3rmic80"
   }
  },
  {
@@ -131809,14 +132315,14 @@
   "repo": "joostkremers/writeroom-mode",
   "unstable": {
    "version": [
-    20231103,
-    931
+    20250204,
+    2335
    ],
    "deps": [
     "visual-fill-column"
    ],
-   "commit": "f4d035e91d20bf1dd3f2857b9cc344f844979a78",
-   "sha256": "0d9yq0qk6f61axpn4r2iby31c97sbra3lni2zg7nrckx2dn0kskd"
+   "commit": "cca2b4b3cfcfea1919e1870519d79ed1a69aa5e2",
+   "sha256": "1zrjb2iw877v5vgxi56x572cybw3m1mjnkvz1x6kf4xjycrf6gdn"
   },
   "stable": {
    "version": [
@@ -132006,14 +132512,14 @@
   "repo": "jobbflykt/x509-mode",
   "unstable": {
    "version": [
-    20250130,
-    1233
+    20250225,
+    632
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1349dbec0074a46e037a93f7d58d3a95c96a7fdc",
-   "sha256": "1rqswfdhxs2vbq56bf0cgdhvj9xc8zq087cvlmzxg6374rm80dfg"
+   "commit": "fe2ebffaf4f1d876108df5c386ae55e0154eed02",
+   "sha256": "0fgfvr64gbdfgqjvng5bqg2jpg5s5d99di77fn3vfkay2zadpmji"
   }
  },
  {
@@ -133220,14 +133726,14 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20241207,
-    2221
+    20250225,
+    950
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "f1907ed38acc479e78d5c113810465e4d77d8604",
-   "sha256": "063vfm49909qqy6m2qh8bcliwznh6758178va3g2vn06hqhz3znb"
+   "commit": "46945ccf63122190dc564af4ec26f828eaa29b43",
+   "sha256": "0ab7b033lvvh6ijzg9y27wbhzwcqyp0829jzn5fqy63m7a4lwihy"
   },
   "stable": {
    "version": [
@@ -133278,19 +133784,19 @@
   "url": "https://www.yatex.org/hgrepos/yatex",
   "unstable": {
    "version": [
-    20221225,
-    512
+    20250224,
+    1034
    ],
-   "commit": "157aa7974191bbb4707d26b05ce830282ad70ef5",
-   "sha256": "0k23snhqj9vqzrv8mbyjfqv1q3riv67dmphbdrpxprfm0k6bd3ds"
+   "commit": "b00018b5a0b487be347d1abf944f8ae165c5a50b",
+   "sha256": "1lg8bxr8ykdvmrxrk49l9dhwh9xx0jniwr8hqipi7yxzxhhh48ry"
   },
   "stable": {
    "version": [
     1,
-    83
+    84
    ],
-   "commit": "157aa7974191bbb4707d26b05ce830282ad70ef5",
-   "sha256": "0k23snhqj9vqzrv8mbyjfqv1q3riv67dmphbdrpxprfm0k6bd3ds"
+   "commit": "b00018b5a0b487be347d1abf944f8ae165c5a50b",
+   "sha256": "1lg8bxr8ykdvmrxrk49l9dhwh9xx0jniwr8hqipi7yxzxhhh48ry"
   }
  },
  {
@@ -133413,14 +133919,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20250126,
-    231
+    20250225,
+    1735
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7b1bc7529b58dfe93a284959d5f494d5562adb00",
-   "sha256": "0y1195l8lf957irkckdb5bym7axixkiklk19hk4vivmircdc5x7m"
+   "commit": "eb76b1d644170f2a685882a207e4644c399bb668",
+   "sha256": "05n56s56xpiy47f88an1qm30y0dcjiz5ah7almz5mnc0fsb4qsrn"
   },
   "stable": {
    "version": [
@@ -134280,11 +134786,11 @@
   "repo": "meow_king/zig-ts-mode",
   "unstable": {
    "version": [
-    20241026,
-    1427
+    20250308,
+    216
    ],
-   "commit": "020500ac3c9ac2cadedccb5cd6c506eb38327443",
-   "sha256": "0kq29pw124bcir5fgnb6xkhas9xqzywzsciv85d0rh0nfbbnbjxy"
+   "commit": "3898b70d6f72da688e086323fa2922f1542d1318",
+   "sha256": "1lw7iwc422dj9zcd5bpi2n24zgssjvqc9hgnay4iv3ah0ayvraf6"
   }
  },
  {
@@ -134648,11 +135154,11 @@
   "repo": "cyrus-and/zoom",
   "unstable": {
    "version": [
-    20241019,
-    2101
+    20250214,
+    1251
    ],
-   "commit": "f5f635e1fc5a8f606b7386286546bb6439e7124c",
-   "sha256": "1zzm8kchm5wwxras4bfl46flyfj44bf7qazc5yyahx9qr2ksfnhd"
+   "commit": "36f9db90941b10d34bac976aee35dfe25242cd03",
+   "sha256": "0y01yn0gaycyhqifg8gq0ilr20qr0xm51rh97vbp1vh1n74fca4q"
   },
   "stable": {
    "version": [
@@ -134948,13 +135454,13 @@
   "unstable": {
    "version": [
     20250209,
-    109
+    1933
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "a13ea87e2845644211b8f5912b5cb3dfa8627630",
-   "sha256": "1ldd8nij22v6zi3d8idsv85c33vzb230r6lx0hmjhqy0lqn2dgq3"
+   "commit": "9905f1be006fe02417fc6598be4990746053bbec",
+   "sha256": "0nhhiznr0ls26as1l6550idccmjvrsv4hh2amdw5lwakyz2lsz70"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -90984,15 +90984,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250313,
-    929
+    20250314,
+    2312
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "a1eedcee788e0484df13dd54940f47b4c98c1761",
-   "sha256": "124bliixzcwlv2pn822amhrhlmij4g858fzazi01sq33dx09ln34"
+   "commit": "a8e4c53b5890780b1ce5ddd2b009c80d94c4378a",
+   "sha256": "1ipv16hcm52ba81rnl9wzvkfsamc1bcv6z0g6x2y9gyl47llvrnr"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
- emacs-overlay commit: 7066864e5344c117e53320bfa798e9131b0eb5db
- [hydra](https://hydra.nix-community.org/eval/329519?filter=x86_64-linux.unstable.packages.)
- new failed toplevel builds:
  - [X] [emacs-cider-decompile-20151122.537](https://hydra.nix-community.org/build/4188683)
  - [X] [emacs-consult-tex-20250306.1724](https://hydra.nix-community.org/build/4160275)
  - [X] [emacs-counsel-codesearch-20180925.803](https://hydra.nix-community.org/build/4121614)
  - [X] [emacs-projectile-codesearch-20180508.1522](https://hydra.nix-community.org/build/4186518)
  - [X] [emacs-brainfuck-mode-20150113.842](https://hydra.nix-community.org/build/4121158)
  - [X] [emacs-clojure-quick-repls-20150814.736](https://hydra.nix-community.org/build/4188690)
  - [X] [emacs-codesearch-20240828.618](https://hydra.nix-community.org/build/4121422)
  - [X] [emacs-consult-gh-with-pr-review-20250309.2223](https://hydra.nix-community.org/build/417710)
  - [X] [emacs-debbugs-0.44](https://hydra.nix-community.org/build/4121766)
  - [X] [emacs-edraw-1.2.0-unstable-2025-02-15](https://hydra.nix-community.org/build/4122119)
  - [X] [emacs-empv-20250225.1652](https://hydra.nix-community.org/build/4123198)
  - [X] [emacs-iregister-20150515.2107](https://hydra.nix-community.org/build/4124597)
  - [X] [emacs-javap-mode-20120223.2208](https://hydra.nix-community.org/build/4124676)
  - [X] [emacs-keystore-mode-20190409.1946](https://hydra.nix-community.org/build/4177463)
  - [X] [emacs-lsp-origami-20230815.704](https://hydra.nix-community.org/build/4186301)
  - [X] [emacs-org-link-beautify-20250313.929](https://hydra.nix-community.org/build/4188827)
  - [X] [emacs-org-timeblock-20241027.805](https://hydra.nix-community.org/build/4135510)
  - [X] [emacs-origami-predef-20200615.1044](https://hydra.nix-community.org/build/4179329)
  - [X] [emacs-rustic-20250310.1415](https://hydra.nix-community.org/build/4179423)
  - [X] [emacs-shampoo-20230522.1722](https://hydra.nix-community.org/build/4136422)
  - [X] [emacs-shell-quasiquote-0.0.20221221.82030](https://hydra.nix-community.org/build/4136437)  [upstream bug](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=77030)
  - [X] [emacs-sx-20240126.2120](https://hydra.nix-community.org/build/4136790)
  - [X] [emacs-workgroups2-20230328.1331](https://hydra.nix-community.org/build/4137393)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
