### PR TITLE
mc: update project links

### DIFF
--- a/pkgs/applications/file-managers/mc/default.nix
+++ b/pkgs/applications/file-managers/mc/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   version = "4.8.33";
 
   src = fetchurl {
-    url = "https://www.midnight-commander.org/downloads/${pname}-${version}.tar.xz";
+    url = "https://ftp.osuosl.org/pub/midnightcommander/${pname}-${version}.tar.xz";
     hash = "sha256-yuFJ1C+ETlGF2MgdfbOROo+iFMZfhSIAqdiWtGivFkw=";
   };
 
@@ -100,8 +100,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "File Manager and User Shell for the GNU Project, known as Midnight Commander";
-    downloadPage = "https://www.midnight-commander.org/downloads/";
-    homepage = "https://www.midnight-commander.org";
+    downloadPage = "https://ftp.osuosl.org/pub/midnightcommander/";
+    homepage = "https://midnight-commander.org";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sander ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/file-managers/mc/default.nix
+++ b/pkgs/applications/file-managers/mc/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
     description = "File Manager and User Shell for the GNU Project, known as Midnight Commander";
     downloadPage = "https://ftp.osuosl.org/pub/midnightcommander/";
     homepage = "https://midnight-commander.org";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ sander ];
     platforms = with platforms; linux ++ darwin;
     mainProgram = "mc";


### PR DESCRIPTION
Hi @trofi,

I'm preparing the migration to a new website. As part of this, we will be dropping the www prefix. Also, the site will be statically hosted on GitHub and will no longer support outdated redirects. I have updated the package source to use our official OSU OSL mirror directly.

Thank you!

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
