### PR TITLE
rustPlatform.{fetchCargoVendor,importCargoLock}: fix dereferencing logic

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from os.path import islink, realpath
 from pathlib import Path
 from typing import Any, TypedDict, cast
 from urllib.parse import unquote
@@ -194,11 +195,41 @@ def find_crate_manifest_in_tree(tree: Path, crate_name: str) -> Path:
 
 
 def copy_and_patch_git_crate_subtree(git_tree: Path, crate_name: str, crate_out_dir: Path) -> None:
+
+    # This function will get called by copytree to decide which entries of a directory should be copied
+    # We'll copy everything except symlinks that are invalid
+    def ignore_func(dir_str: str, path_strs: list[str]) -> list[str]:
+        ignorelist: list[str] = []
+
+        dir = Path(realpath(dir_str, strict=True))
+
+        for path_str in path_strs:
+            path = dir / path_str
+            if not islink(path):
+                continue
+
+            # Filter out cyclic symlinks and symlinks pointing at nonexistant files
+            try:
+                target_path = Path(realpath(path, strict=True))
+            except OSError:
+                ignorelist.append(path_str)
+                eprint(f"Failed to resolve symlink, ignoring: {path}")
+                continue
+
+            # Filter out symlinks that point outside of the current crate's base git tree
+            # This can be useful if the nix build sandbox is turned off and there is a symlink to a common absolute path
+            if not target_path.is_relative_to(git_tree):
+                ignorelist.append(path_str)
+                eprint(f"Symlink points outside of the crate's base git tree, ignoring: {path} -> {target_path}")
+                continue
+
+        return ignorelist
+
     crate_manifest_path = find_crate_manifest_in_tree(git_tree, crate_name)
     crate_tree = crate_manifest_path.parent
 
     eprint(f"Copying to {crate_out_dir}")
-    shutil.copytree(crate_tree, crate_out_dir, ignore_dangling_symlinks=True)
+    shutil.copytree(crate_tree, crate_out_dir, ignore=ignore_func)
     crate_out_dir.chmod(0o755)
 
     with open(crate_manifest_path, "r") as f:

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -195,7 +195,7 @@ let
         echo Found crate ${pkg.name} at $crateCargoTOML
         tree=$(dirname $crateCargoTOML)
 
-        ${python3Packages.python.interpreter} -c 'import sys, shutil; shutil.copytree(sys.argv[1], sys.argv[2], ignore_dangling_symlinks=True)' "$tree" "$out"
+        cp -prvL "$tree" "$out" || echo "Warning: certain files couldn't be copied!" >&2
         chmod u+w $out
 
         if grep -q workspace "$out/Cargo.toml"; then


### PR DESCRIPTION

### Related:
- previous PR that broke it accidentally: https://github.com/NixOS/nixpkgs/pull/379049
  -  the issue it fixed https://github.com/NixOS/nixpkgs/issues/376590
  - e.g. the `lighthouse` package was fixed by it
- fixes https://github.com/NixOS/nixpkgs/issues/389638
  - `rustdesk-flutter` should build now

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
