### PR TITLE
spotube: 4.0.0 -> 4.0.2

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spotube";
-  version = "4.0.0";
+  version = "4.0.2";
 
   src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
 
@@ -84,28 +84,29 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.sources =
     let
       fetchArtifact =
-        { filename, hash }:
+        { suffix, hash }:
         fetchurl {
-          url = "https://github.com/KRTirtho/spotube/releases/download/v${finalAttrs.version}/${filename}";
+          name = "Spotube-${finalAttrs.version}-${suffix}";
+          url = "https://github.com/KRTirtho/spotube/releases/download/v${finalAttrs.version}/Spotube-${suffix}";
           inherit hash;
         };
     in
     {
       "aarch64-linux" = fetchArtifact {
-        filename = "Spotube-linux-aarch64.deb";
-        hash = "sha256-q+0ah6C83zVdrWWMmaBvZebRQP0Ie83Ewp7hjnp2NPw=";
+        suffix = "linux-aarch64.deb";
+        hash = "sha256-zoJ0WPui6KdUyML47RbEBNySTZ8FvStYAOj1mndjh1s=";
       };
       "x86_64-linux" = fetchArtifact {
-        filename = "Spotube-linux-x86_64.deb";
-        hash = "sha256-pk+xi7y0Qilmzk70T4u747zzFn4urZ6Kwuiqq+/q8uM=";
+        suffix = "linux-x86_64.deb";
+        hash = "sha256-SM/lWUhXe20FCgneegn5As5a53YBsoDIMfIYhRBHWjI=";
       };
       "x86_64-darwin" = fetchArtifact {
-        filename = "Spotube-macos-universal.dmg";
-        hash = "sha256-ielRdH+D1QdrKH4OxQFdw6rpzURBs/dRf/synS/Vrdk=";
+        suffix = "macos-universal.dmg";
+        hash = "sha256-0eNeMpC8usPfbuh2aj43n6KLysRQ55yLdOT7Z5faVLU=";
       };
       "aarch64-darwin" = fetchArtifact {
-        filename = "Spotube-macos-universal.dmg";
-        hash = "sha256-ielRdH+D1QdrKH4OxQFdw6rpzURBs/dRf/synS/Vrdk=";
+        suffix = "macos-universal.dmg";
+        hash = "sha256-0eNeMpC8usPfbuh2aj43n6KLysRQ55yLdOT7Z5faVLU=";
       };
     };
 


### PR DESCRIPTION
Releases: https://github.com/KRTirtho/spotube/releases

I also updated how the files are fetched: I now include the version in the name of the FOD, so that cache invalidation happens on version updates.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
