### PR TITLE
python3Packages.langchain*: fix automatic updates 

### DIFF
--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -53,6 +53,9 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     # Boto @ 1.35 has outstripped the version requirement
     "boto3"
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -74,8 +74,6 @@ buildPythonPackage rec {
       "^langchain-aws==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain-aws/releases/tag/v${version}";

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   poetry-core,
@@ -64,11 +65,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_aws" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-aws==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain-aws/releases/tag/v${version}";

--- a/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
+++ b/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   poetry-core,
@@ -65,11 +66,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_azure_dynamic_sessions" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-azure-dynamic-sessions==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Integration package connecting Azure Container Apps dynamic sessions and LangChain";

--- a/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
+++ b/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
@@ -42,6 +42,12 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
+
   dependencies = [
     azure-identity
     langchain-core

--- a/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
+++ b/pkgs/development/python-modules/langchain-azure-dynamic-sessions/default.nix
@@ -78,8 +78,6 @@ buildPythonPackage rec {
       "^langchain-azure-dynamic-sessions==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Integration package connecting Azure Container Apps dynamic sessions and LangChain";

--- a/pkgs/development/python-modules/langchain-chroma/default.nix
+++ b/pkgs/development/python-modules/langchain-chroma/default.nix
@@ -62,8 +62,6 @@ buildPythonPackage rec {
       "^langchain-chroma==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-chroma==${version}";

--- a/pkgs/development/python-modules/langchain-chroma/default.nix
+++ b/pkgs/development/python-modules/langchain-chroma/default.nix
@@ -30,7 +30,12 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
-  pythonRelaxDeps = [ "numpy" ];
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+    "numpy"
+  ];
 
   dependencies = [
     chromadb

--- a/pkgs/development/python-modules/langchain-chroma/default.nix
+++ b/pkgs/development/python-modules/langchain-chroma/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
   chromadb,
   langchain-core,
   langchain-tests,
@@ -50,11 +51,14 @@ buildPythonPackage rec {
     "test_chroma_update_document"
   ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-chroma==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-chroma==${version}";

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -57,7 +57,10 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "langchain" # Can fail during updates where building sees the old langchain
+    # Each component release requests the exact latest langchain and -core.
+    # That prevents us from updating individul components.
+    "langchain"
+    "langchain-core"
     "numpy"
     "pydantic-settings"
     "tenacity"
@@ -122,7 +125,7 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^langchain-community==([0-9.]+)$"
+      "^langchain-community==(.*)"
     ];
   };
   # updates the wrong fetcher rev attribute

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -98,12 +99,6 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "tests/unit_tests" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
-  };
-
   __darwinAllowLocalNetworking = true;
 
   disabledTests = [
@@ -123,6 +118,15 @@ buildPythonPackage rec {
     # Fails due to the lack of blockbuster
     "test_group_dependencies"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-community==([0-9.]+)$"
+    ];
+  };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-community==${version}";

--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -128,8 +128,6 @@ buildPythonPackage rec {
       "^langchain-community==(.*)"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-community==${version}";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -101,8 +101,6 @@ buildPythonPackage rec {
         "^langchain-core==([0-9.]+)$"
       ];
     };
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
   };
 
   disabledTests =

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -30,7 +30,7 @@
   syrupy,
 
   # passthru
-  writeScript,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -94,26 +94,13 @@ buildPythonPackage rec {
     tests.pytest = langchain-core.overridePythonAttrs (_: {
       doCheck = true;
     });
-    # Updates to core tend to drive updates in everything else
-    updateScript = writeScript "update.sh" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p nix-update
 
-      set -u -o pipefail +e
-      # Common core
-      nix-update --commit --version-regex 'langchain-core==(.*)' python3Packages.langchain-core
-      nix-update --commit --version-regex 'langchain-text-splitters==(.*)' python3Packages.langchain-text-splitters
-      nix-update --commit --version-regex 'langchain==(.*)' python3Packages.langchain
-      nix-update --commit --version-regex 'langchain-community==(.*)' python3Packages.langchain-community
-
-      # Extensions
-      nix-update --commit --version-regex 'langchain-aws==(.*)' python3Packages.langchain-aws
-      nix-update --commit --version-regex 'langchain-azure-dynamic-sessions==(.*)' python3Packages.langchain-azure-dynamic-sessions
-      nix-update --commit --version-regex 'langchain-chroma==(.*)' python3Packages.langchain-chroma
-      nix-update --commit --version-regex 'langchain-huggingface==(.*)' python3Packages.langchain-huggingface
-      nix-update --commit --version-regex 'langchain-mongodb==(.*)' python3Packages.langchain-mongodb
-      nix-update --commit --version-regex 'langchain-openai==(.*)' python3Packages.langchain-openai
-    '';
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^langchain-core==([0-9.]+)$"
+      ];
+    };
     # updates the wrong fetcher rev attribute
     skipBulkUpdate = true;
   };

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -58,8 +58,6 @@ buildPythonPackage rec {
       "^langchain-groq==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-groq==${version}";

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -47,10 +48,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_groq" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-groq==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-groq==${version}";

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -32,7 +32,11 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
-  pythonRelaxDeps = [ "langchain-core" ];
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
 
   dependencies = [
     langchain-core

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   poetry-core,
@@ -71,11 +72,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_huggingface" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-huggingface==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-huggingface==${version}";

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -45,6 +45,12 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
+
   dependencies = [
     huggingface-hub
     langchain-core

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -84,8 +84,6 @@ buildPythonPackage rec {
       "^langchain-huggingface==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-huggingface==${version}";

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage rec {
   build-system = [ poetry-core ];
 
   pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
     "numpy"
   ];
 

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -70,8 +70,6 @@ buildPythonPackage rec {
       "^langchain-mongodb==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-mongodb==${version}";

--- a/pkgs/development/python-modules/langchain-mongodb/default.nix
+++ b/pkgs/development/python-modules/langchain-mongodb/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   poetry-core,
@@ -60,11 +61,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_mongodb" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-mongodb==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-mongodb==${version}";

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -63,8 +63,6 @@ buildPythonPackage rec {
       "langchain-ollama==(.*)"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-ollama==${version}";

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -35,6 +35,12 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
+
   dependencies = [
     langchain-core
     ollama

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -48,6 +48,12 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
+
   dependencies = [
     langchain-core
     openai

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -89,11 +90,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain_openai" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-openai==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-openai==${version}";

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -102,8 +102,6 @@ buildPythonPackage rec {
       "^langchain-openai==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-openai==${version}";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -68,8 +68,6 @@ buildPythonPackage rec {
       "^langchain-tests==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Build context-aware reasoning applications";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -53,6 +54,15 @@ buildPythonPackage rec {
     numpy
     pytestCheckHook
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-tests==([0-9.]+)$"
+    ];
+  };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Build context-aware reasoning applications";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -38,6 +38,13 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+    "numpy"
+  ];
+
   dependencies = [
     httpx
     langchain-core

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -43,11 +44,14 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [ "tests/unit_tests" ];
 
-  passthru = {
-    inherit (langchain-core) updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain-test-splitters==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-text-splitters==${version}";

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -32,6 +32,12 @@ buildPythonPackage rec {
 
   build-system = [ pdm-backend ];
 
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
+  ];
+
   dependencies = [ langchain-core ];
 
   pythonImportsCheck = [ "langchain_text_splitters" ];

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -56,8 +56,6 @@ buildPythonPackage rec {
       "^langchain-test-splitters==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-text-splitters==${version}";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -63,6 +63,9 @@ buildPythonPackage rec {
   buildInputs = [ bash ];
 
   pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individul components.
+    "langchain-core"
     "numpy"
     "tenacity"
   ];

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -144,11 +145,14 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "langchain" ];
 
-  passthru = {
-    updateScript = langchain-core.updateScript;
-    # updates the wrong fetcher rev attribute
-    skipBulkUpdate = true;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^langchain==([0-9.]+)$"
+    ];
   };
+  # updates the wrong fetcher rev attribute
+  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Building applications with LLMs through composability";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -154,8 +154,6 @@ buildPythonPackage rec {
       "^langchain==([0-9.]+)$"
     ];
   };
-  # updates the wrong fetcher rev attribute
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Building applications with LLMs through composability";


### PR DESCRIPTION
TL;dr: The bulk updater kept updating each component to the wrong tag. It turns out each package needs to specify its version regex indepedently.

langchain is a monorepo that uses tags such as `langchain-sdk==0.1.2` for its components. Unfortunately, the generic updater chooses the latest tag without looking at the tag expression in the fetcher.

`passthru.skipBulkUpdates = true`  was intended to disable auto updates, but r-ryantm keept issuing piecemeal updates which updated the each component to the wrong tag (newest tag overwrote all).

This PR adds an explicit `--versionRegex` value to the update script per module. It also re-enables bulk updates as the per-component regex solves the problem.

P.S. Apologies for the long comment thread. I originally approached this from a different direction that didn't work out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
