### PR TITLE
dpms-off: init at 0.2.1

### DIFF
--- a/pkgs/by-name/dp/dpms-off/package.nix
+++ b/pkgs/by-name/dp/dpms-off/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dpms-off";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "lilydjwg";
+    repo = "dpms-off";
+    rev = "17c5600fdfcf3f5aeb7c85b649dc53e18565b21f";
+    hash = "sha256-fADydBO4XISt2n7vrkCuca8db9jtMVsUUvqYAqeVy60=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wpX14e+J+n1it+1D6OD/AyDn+bOuSoJCEEWlmuZ7c0Y=";
+
+  meta = {
+    description = "Turn off monitors to save power (for Wayland)";
+    homepage = "https://github.com/lilydjwg/dpms-off";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.philiptaron ];
+    mainProgram = "dpms-off";
+  };
+}


### PR DESCRIPTION
[`dpms-off`](https://github.com/lilydjwg/dpms-off): same as `xset dpms force off`, but for Wayland.

It requires [zwlr_output_power_manager_v1](https://wayland.app/protocols/wlr-output-power-management-unstable-v1) and [ext_idle_notifier_v1](https://wayland.app/protocols/ext-idle-notify-v1) support from the Wayland compositer. wlroots supports them.

It turns off all monitors, and then it turns them back on when user activity re-occurs. Don't interrupt the process, or your monitor won't be turned on later!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).