### PR TITLE
isrcsubmit: 2.1.0 -> 2.1.0-unstable-2023-08-10

### DIFF
--- a/pkgs/by-name/is/isrcsubmit/package.nix
+++ b/pkgs/by-name/is/isrcsubmit/package.nix
@@ -2,30 +2,47 @@
   lib,
   fetchFromGitHub,
   python3Packages,
+  nix-update-script,
+  withKeyring ? true,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication {
   pname = "isrcsubmit";
-  version = "2.1.0";
+  version = "2.1.0-unstable-2023-08-10";
 
   src = fetchFromGitHub {
     owner = "JonnyJD";
     repo = "musicbrainz-isrcsubmit";
-    rev = "v${version}";
-    sha256 = "1lqs4jl2xv1zxmf0xsihk9rxzx2awq87g51vd7y3cq1vhj1icxqa";
+    rev = "8f4c3b9f9b8f983443d58fba381baaa3a74edad7";
+    hash = "sha256-6SJt0wtXC49Eh6g7DBy73MeCueF7CRuCvYC27es1qAM=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    musicbrainzngs
-    discid
-  ];
+  postPatch = ''
+    # Change binary name to isrcsubmit so that `import isrcsubmit` in the wrapper doesn't fail
+    substituteInPlace setup.py --replace-fail "'isrcsubmit.py=isrcsubmit:main'," "'isrcsubmit=isrcsubmit:main',"
+    # Set default argument for main, which is set `if __name__ == '__main__'` upstream
+    substituteInPlace isrcsubmit.py --replace-fail "main(argv):" "main(argv=sys.argv):"
+  '';
 
-  meta = with lib; {
-    # drutil is required on Darwin, which does not seem to be available in nixpkgs
-    broken = true; # 2022-11-16
+  dependencies =
+    with python3Packages;
+    [
+      musicbrainzngs
+      discid
+    ]
+    ++ lib.optional withKeyring [
+      keyring
+    ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
     description = "Script to submit ISRCs from disc to MusicBrainz";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     homepage = "http://jonnyjd.github.io/musicbrainz-isrcsubmit/";
     maintainers = [ ];
+    mainProgram = "isrcsubmit";
   };
 }


### PR DESCRIPTION
This fixes the long-broken build and adds the keyring python library, which is an optional dependency for isrcsubmit to not have to enter the musicbrainz password every time.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
