### PR TITLE
Fix k3s.service crash on multi-node clusters with suggested config

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/docs/USAGE.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/USAGE.md
@@ -21,7 +21,6 @@
 ```
 
 Once the above changes are active, you can access your cluster through `sudo k3s kubectl` (e.g. `sudo k3s kubectl cluster-info`) or by using the generated kubeconfig file in `/etc/rancher/k3s/k3s.yaml`.
-Multi-node setup
 
 ## Multi-Node
 
@@ -45,7 +44,7 @@ Any other subsequent nodes can be added with a slightly different config:
 {
   services.k3s = {
     enable = true;
-    role = "server"; # Or "agent" for worker only nodes
+    role = "agent";
     token = "<randomized common secret>";
     serverAddr = "https://<ip of first node>:6443";
   };


### PR DESCRIPTION
The existing documentation's multi-node config, if used as written, caused `k3s.service` to crash on my cluster with the following error:

```
Mar 15 21:56:39 homelab-2 k3s[2675]: time="2025-03-15T21:56:39-04:00" level=info msg="Handling backend connection request [homelab-2]"
Mar 15 21:56:39 homelab-2 k3s[2675]: time="2025-03-15T21:56:39-04:00" level=info msg="Remotedialer connected to proxy" url="wss://127.0.0.1:6443/v1-k3s/connect"
Mar 15 21:56:39 homelab-2 k3s[2675]: time="2025-03-15T21:56:39-04:00" level=info msg="Cluster-Http-Server 2025/03/15 21:56:39 http: TLS handshake error from 127.0.0.1:4>
Mar 15 21:56:40 homelab-2 k3s[2675]: time="2025-03-15T21:56:40-04:00" level=error msg="Sending HTTP 503 response to 127.0.0.1:49588: runtime core not ready"
Mar 15 21:56:40 homelab-2 k3s[2675]: time="2025-03-15T21:56:40-04:00" level=info msg="Adding member homelab-2-6db61cf2=https://192.168.30.6:2380 to etcd cluster [homela>
Mar 15 21:56:40 homelab-2 k3s[2675]: time="2025-03-15T21:56:40-04:00" level=info msg="Running kube-proxy --cluster-cidr=10.42.0.0/16 --conntrack-max-per-core=0 --conntr>
Mar 15 21:56:40 homelab-2 k3s[2675]: E0315 21:56:40.092696    2675 server.go:1051] "Failed to retrieve node info" err="apiserver not ready"
Mar 15 21:56:41 homelab-2 k3s[2675]: E0315 21:56:41.263604    2675 server.go:1051] "Failed to retrieve node info" err="apiserver not ready"
Mar 15 21:56:43 homelab-2 k3s[2675]: E0315 21:56:43.586905    2675 server.go:1051] "Failed to retrieve node info" err="apiserver not ready"
Mar 15 21:56:44 homelab-2 k3s[2675]: time="2025-03-15T21:56:44-04:00" level=debug msg="Wrote ping"
```

It seems having `k3s.role` set to `server` on subsequent nodes after the first server causes those subsequent nodes to try and access their own server as a condition of startup, which they're obviously not able to do and causes them to fail startup. Changing the `k3s.role` on subsequent nodes to `agent` fixed this issue for me. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested, as applicable:
  - Config built and k3s service started successfully
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
