### PR TITLE
foldit: init at 52

### DIFF
--- a/pkgs/by-name/fo/foldit/hot-updates.json
+++ b/pkgs/by-name/fo/foldit/hot-updates.json
@@ -1,0 +1,56 @@
+{
+  "x86_64-darwin": {
+    "versions": {
+      "release_id": 52,
+      "components": {
+        "binary": {
+          "version": "ba1072bdf309d0220baa188855078a90",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGc3IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--672f364c03c62101fe2b1a868367aaf7453a42b7/cmp-binary-macos_x64-ba1072bdf309d0220baa188855078a90.zip",
+          "size": 77171159
+        },
+        "database": {
+          "version": "9cc626267aa5f6df9bcb5f94584712fd",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcXdpIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--cf01fb04c0546502f488194e90ba9eec2f1d4fff/cmp-database-9cc626267aa5f6df9bcb5f94584712fd.zip",
+          "size": 193753489
+        },
+        "resources": {
+          "version": "1fd546a9c0ff2fb29a2217c75775d81f",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcEF4IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9f2f79638b4baf9745988ea9afda0f38bec53f37/cmp-resources-1fd546a9c0ff2fb29a2217c75775d81f.zip",
+          "size": 89416219
+        }
+      }
+    },
+    "hashes": {
+      "binary": "sha256-PX4gl9WNYVhVWT7CmgYtxlZQWj3cdN6K6/Cv6zFTsks=",
+      "database": "sha256-iY1sIK5ADQRofE6GB0ktenyb1TEyADLshLQMTlCG0U0=",
+      "resources": "sha256-Zco9jJWIxkZXz7Yp9gIdv3ea0vcy5F1i53c89Zv/zdc="
+    }
+  },
+  "x86_64-linux": {
+    "versions": {
+      "release_id": 52,
+      "components": {
+        "binary": {
+          "version": "8bb217fc2ccc488e28dec61feb10096c",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdGM3IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8b8c2726c3f51a6fb2e0b07357334edf303999a9/cmp-binary-linux_x64-8bb217fc2ccc488e28dec61feb10096c.zip",
+          "size": 105642801
+        },
+        "database": {
+          "version": "9cc626267aa5f6df9bcb5f94584712fd",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcXdpIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--cf01fb04c0546502f488194e90ba9eec2f1d4fff/cmp-database-9cc626267aa5f6df9bcb5f94584712fd.zip",
+          "size": 193753489
+        },
+        "resources": {
+          "version": "1fd546a9c0ff2fb29a2217c75775d81f",
+          "download": "https://fold.it/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcEF4IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--9f2f79638b4baf9745988ea9afda0f38bec53f37/cmp-resources-1fd546a9c0ff2fb29a2217c75775d81f.zip",
+          "size": 89416219
+        }
+      }
+    },
+    "hashes": {
+      "binary": "sha256-0tif7q4n4cpxwaWnZumi8lb4UNFqOMV8xre03Aw0+38=",
+      "database": "sha256-iY1sIK5ADQRofE6GB0ktenyb1TEyADLshLQMTlCG0U0=",
+      "resources": "sha256-Zco9jJWIxkZXz7Yp9gIdv3ea0vcy5F1i53c89Zv/zdc="
+    }
+  }
+}

--- a/pkgs/by-name/fo/foldit/package.nix
+++ b/pkgs/by-name/fo/foldit/package.nix
@@ -1,0 +1,204 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  fetchzip,
+  undmg,
+  autoPatchelfHook,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeWrapper,
+  unzip,
+  jq,
+  runtimeShell,
+  buildFHSEnv,
+  patchelfUnstable,
+}:
+
+# not used anywhere, but otherwise nixpkgs-update bot won't open a PR
+# x86_64-darwin-release-id = "52";
+# x86_64-linux-release-id = "52";
+
+let
+  pname = "foldit";
+  meta = {
+    description = "Revolutionary crowdsourcing computer game";
+    homepage = "https://fold.it";
+    changelog = "https://fold.it/releases";
+    downloadPage = "https://fold.it/play";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "Foldit";
+  };
+
+  stdenv = stdenvNoCC;
+
+  hotUpdates = (lib.importJSON ./hot-updates.json).${stdenv.hostPlatform.system} or { };
+  versions = hotUpdates.versions or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+  version = builtins.toString versions.release_id or 0;
+  components = versions.components;
+  componentHashes = hotUpdates.hashes or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+  updateSrc = builtins.mapAttrs (
+    name: value:
+    fetchurl {
+      url = value.download;
+      hash = componentHashes.${name};
+    }
+  ) components;
+
+  buildCommands = ''
+    jq '.["${stdenv.hostPlatform.system}"].versions' ${./hot-updates.json} > versions.json
+    ${lib.concatStrings (
+      lib.mapAttrsToList (componentName: componentSrc: ''
+        component_version=${components.${componentName}.version}
+        echo -n $component_version > version-${componentName}.txt
+        component_dir=cmp-${componentName}-$component_version
+        rm -r cmp-${componentName}-*
+        mkdir -p $component_dir
+        unzip -d $component_dir ${componentSrc}
+      '') updateSrc
+    )}
+  '';
+
+  wrapper = buildFHSEnv {
+    pname = "foldit-wrapper";
+    inherit version;
+
+    targetPkgs =
+      ps: with ps; [
+        libGL
+        libGLU
+        xclip
+        freeglut
+        libx11
+        libpulseaudio
+      ];
+  };
+
+  linuxArgs = {
+    src = fetchzip {
+      url = "https://web.archive.org/web/20260308095039/https://files.ipd.uw.edu/pub/foldit/Foldit-linux_x64.tar.gz";
+      hash = "sha256-xMbPevtnrBZx9hT8/uVSpMvUwNfcWdHqZ9v5FJLMR3g=";
+    };
+
+    nativeBuildInputs = [
+      copyDesktopItems
+      makeWrapper
+      unzip
+      jq
+      patchelfUnstable
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      ${buildCommands}
+
+      runHook postBuild
+    '';
+
+    installPhase =
+      let
+        phome = "${placeholder "out"}/opt/Foldit";
+      in
+      ''
+        runHook preInstall
+
+        mkdir -p ${phome}
+        cp -r * ${phome}
+
+        mkdir -p $out/bin
+        # Upstream refused to make it work without write access to its installation dir:
+        # https://fold.it/forum/discussion/allow-tweaks-to-foldit-behavior-with-files-in-linux-to-meet-the-requirement-of-package-managers
+        cat <<'EOF' > $out/bin/Foldit
+        #!${runtimeShell}
+        writableHome="''${XDG_DATA_DIR:-''$HOME/.local/share}/Foldit"
+        mkdir -p "$writableHome"
+        cd "$writableHome"
+        if [ ! -f Foldit ] || [ "$(readlink -f Foldit)" != ${phome}/Foldit ]; then
+          rm -rf cmp-*
+          for f in ${phome}/*; do
+            ln -sf "$f" -t .
+          done
+        fi
+        exec ${lib.getExe wrapper} -c 'exec -a "$0" ./Foldit "$@"' "$0" "$@"
+        EOF
+        chmod +x $out/bin/Foldit
+
+        # required by glibc >= 2.41
+        patchelf --clear-execstack $out/opt/Foldit/cmp-binary-*/libtorch_cpu.so
+
+        mkdir -p $out/share/pixmaps
+        ln -s ${phome}/cmp-resources-${components.resources.version}/resources/images/big/logo_button.png $out/share/pixmaps/foldit.png
+
+        runHook postInstall
+      '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "Foldit";
+        comment = meta.description;
+        desktopName = "Foldit";
+        genericName = "Foldit";
+        exec = "Foldit";
+        icon = "foldit";
+      })
+    ];
+
+    dontFixup = true;
+  };
+
+  darwinArgs = {
+    src = fetchurl {
+      url = "https://web.archive.org/web/20260308095303/https://files.ipd.uw.edu/pub/foldit/Foldit-macos_x64.dmg";
+      hash = "sha256-NXi0a0zE6BwYc8/+k9Qj3C3zJe/ikdJCX6ZE4013fpk=";
+    };
+
+    nativeBuildInputs = [
+      undmg
+      unzip
+      jq
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      cd Contents/Resources
+      ${buildCommands}
+      cd ../..
+
+      runHook postBuild
+    '';
+
+    installPhase =
+      let
+        phome = "$out/Applications/Foldit.app";
+      in
+      ''
+        runHook preInstall
+
+        mkdir -p ${phome}
+        cp -r * ${phome}
+
+        runHook postInstall
+      '';
+  };
+in
+stdenv.mkDerivation (
+  {
+    inherit pname version meta;
+    strictDeps = true;
+    __structuredAttrs = true;
+    passthru.updateScript = ./update.sh;
+  }
+  // {
+    x86_64-linux = linuxArgs;
+    x86_64-darwin = darwinArgs;
+  }
+  .${stdenv.hostPlatform.system} or { }
+)

--- a/pkgs/by-name/fo/foldit/update.sh
+++ b/pkgs/by-name/fo/foldit/update.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq
+
+set -euo pipefail
+
+cd "$(dirname "$(nix-instantiate --eval -A foldit.meta.position | tr -d '"' | cut -d : -f 1)")"
+
+REQUEST_URL=https://fold.it/api/get_update_components
+MERGED_FILE="hot-updates.json"
+
+archiveUrl() {
+    url=$1
+    res_headers=$(curl -s -D - -o /dev/null "https://web.archive.org/save/$url")
+    location=$(printf "%s" "$res_headers" | awk 'BEGIN{IGNORECASE=1}/^Content-Location:/ {print $2}' | tr -d '\r\n')
+    if [ -n "$location" ] && echo "$location" | grep -q '^/web/'; then
+        echo "https://web.archive.org$location"
+        return 0
+    fi
+    redirect=$(printf "%s" "$res_headers" | awk 'BEGIN{IGNORECASE=1}/^Location:/ {print $2}' | tr -d '\r\n')
+    if [ -n "$redirect" ] && echo "$redirect" | grep -q '/web/'; then
+        echo "$redirect"
+        return 0
+    fi
+    return 1
+}
+
+update() {
+    platform_name=$1
+    platform=$2
+    original_url=$3
+    prefetch_args=$4
+
+    nix_file="package.nix"
+    versions_file="$platform-versions.json"
+    hashes_file="$platform-hashes.json"
+
+    new_versions="$(curl -X POST "$REQUEST_URL" \
+        -H "Content-Type: application/json" \
+        -d '{"platform": "'$platform_name'", "update_group": "main"}' | jq)"
+
+    output="{}"
+    while read -r name version download; do
+        if [ "$(jq -r '.components["'$name'"].version' "$versions_file")" = "$version" ]; then
+            output="$(echo "$output" | jq --arg name "$name" --arg hash "$(jq -r '.["'$name'"]' "$hashes_file")" '.[$name] = $hash')"
+            continue
+        fi
+        hash=$(nix hash convert --hash-algo sha256 --to sri $(nix-prefetch-url "$download"))
+        output="$(echo "$output" | jq --arg name "$name" --arg hash "$hash" '.[$name] = $hash')"
+    done < <(echo $new_versions | jq -r '.components | to_entries[] | "\(.key) \(.value.version) \(.value.download)"')
+    echo "$output" > "$hashes_file"
+
+    old_release_id="$(jq -r '.release_id' "$versions_file")"
+    new_release_id="$(echo "$new_versions" | jq -r '.release_id')"
+    if [ "$old_release_id" != "$new_release_id" ]; then
+        sed -i "s/$platform-release-id = \"$old_release_id\";/$platform-release-id = \"$new_release_id\";/" "$nix_file"
+        url=$(archiveUrl "$original_url")
+        hash=$(nix hash convert --hash-algo sha256 --to sri $(nix-prefetch-url $prefetch_args "$url"))
+        sed -i -E '/'"$(printf '%s\n' "$original_url" | sed 's/[\/&]/\\&/g')"'/ {
+            s|^( *url = ")https://[^"]*";|\1'"$url"'";|
+            n
+            s|sha256-[^"]*|'"$hash"'|
+        }' "$nix_file"
+    fi
+
+    echo "$new_versions" > "$versions_file"
+}
+
+platforms=$(jq -r 'keys[]' "$MERGED_FILE")
+for platform in $platforms; do
+    jq -c ".\"$platform\".hashes" "$MERGED_FILE" > "${platform}-hashes.json"
+    jq -c ".\"$platform\".versions" "$MERGED_FILE" > "${platform}-versions.json"
+done
+
+update linux_x64 x86_64-linux https://files.ipd.uw.edu/pub/foldit/Foldit-linux_x64.tar.gz "--unpack"
+update macos_x64 x86_64-darwin https://files.ipd.uw.edu/pub/foldit/Foldit-macos_x64.dmg ""
+
+merged_json='{}'
+for platform in $platforms; do
+    merged_json="$(echo "$merged_json" | jq \
+        --arg platform "$platform" \
+        --argjson versions "$(jq -c . "${platform}-versions.json")" \
+        --argjson hashes "$(jq -c . "${platform}-hashes.json")" \
+        '.[$platform] = {versions: $versions, hashes: $hashes}')"
+done
+echo "$merged_json" > "$MERGED_FILE"
+for platform in $platforms; do
+    rm "${platform}-hashes.json" "${platform}-versions.json"
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Foldit is a revolutionary crowdsourcing computer game enabling you to contribute to scientific research.

An update script is used to keep package up with the hot updates because the auto updater will attempt to write in read-only out paths. See [here](https://fold.it/forum/discussion/allow-tweaks-to-foldit-behavior-with-files-in-linux-to-meet-the-requirement-of-package-managers) for details.

~~On Linux, there is a segfault when the program quits. It seems to be a upstream bug and does not affect usage.~~ Segfault may happen when the program quits because it tries to write data in the installation dir which is read-only. Therefore offline data are not persistent.

I need to ask about my usage of the "save page now" function of the Wayback Machine in the update script. The only other package that does this is `immich`. I don't know why, but the `/wayback/available` API does not seem to work as expected (returning an old timestamp despite that I just saved a new one). I wonder whether we should rely on this API.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
