### PR TITLE
ko: 0.15.4 -> 0.17.1

### DIFF
--- a/pkgs/by-name/ko/ko/package.nix
+++ b/pkgs/by-name/ko/ko/package.nix
@@ -9,21 +9,23 @@
 
 buildGo123Module rec {
   pname = "ko";
-  version = "0.15.4";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "ko-build";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-MeFoy2WoPsJIgUhpzt/4sEP6J9lM4nsSAK2VZiTS7jo=";
+    hash = "sha256-OQtYyokARrjaf0MWQ0sMqJPb+C5pRkKFumAmtxS4SBo=";
   };
 
-  vendorHash = "sha256-n/NbbitSyjl05gESPVG3Uv2ek1U0Cd2fQqcxBhDKULU=";
+  vendorHash = "sha256-YQggwX6fUsfZMM+GdgeNAIHkfX84FMF84xHsP/SNiS4=";
 
   nativeBuildInputs = [ installShellFiles ];
 
   # Pin so that we don't build the several other development tools
   subPackages = ".";
+
+  env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"
@@ -32,8 +34,8 @@ buildGo123Module rec {
   ];
 
   checkFlags = [
-    # requires docker daemon
-    "-skip=TestNewPublisherCanPublish"
+    # requires docker daemon, pulls and builds delve debugger
+    "-skip=(TestNewPublisherCanPublish|TestDebugger)"
   ];
 
   nativeCheckInputs = [ gitMinimal ];
@@ -64,13 +66,13 @@ buildGo123Module rec {
   meta = with lib; {
     homepage = "https://github.com/ko-build/ko";
     changelog = "https://github.com/ko-build/ko/releases/tag/v${version}";
-    description = "Build and deploy Go applications on Kubernetes";
+    description = "Build and deploy Go applications";
     mainProgram = "ko";
     longDescription = ''
       ko is a simple, fast container image builder for Go applications.
       It's ideal for use cases where your image contains a single Go application without any/many dependencies on the OS base image (e.g. no cgo, no OS package dependencies).
       ko builds images by effectively executing go build on your local machine, and as such doesn't require docker to be installed. This can make it a good fit for lightweight CI/CD use cases.
-      ko also includes support for simple YAML templating which makes it a powerful tool for Kubernetes applications.
+      ko makes multi-platform builds easy, produces SBOMs by default, and includes support for simple YAML templating which makes it a powerful tool for Kubernetes applications.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [


### PR DESCRIPTION
This PR updates the go container build tool `ko` from `0.15.4` to the most recent version `0.17.1`.

As part of the update, the description texts where updated to align with the upstream GitHub repo text: https://github.com/ko-build/ko

Note that the test `TestDebugger` have been disabled to avoid pulling and building the delve go debugger as part of the checkPhase.

The changelog for `ko` between version `0.15.4` and version `0.17.1`: https://github.com/ko-build/ko/releases

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note 'tested basic functionality' above was done by:
- Installing the `ko` package on a x86_64 NixOS VM
- Building container with the new version of `ko` and running the projects specific container tests to validate the container. This project was used to test container building : https://github.com/krm-functions/starlark
