### PR TITLE
ztools: init at 7/3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9353,6 +9353,12 @@
     githubId = 1379411;
     name = "Georg Haas";
   };
+  haylin = {
+    email = "me@haylinmoore.com";
+    github = "haylinmoore";
+    githubId = 8162992;
+    name = "Haylin Moore";
+  };
   hbjydev = {
     email = "hayden@kuraudo.io";
     github = "hbjydev";

--- a/pkgs/by-name/zt/ztools/package.nix
+++ b/pkgs/by-name/zt/ztools/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unixtools,
+  groff,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ztools";
+  version = "7/3.1";
+
+  src = fetchurl {
+    url = "http://mirror.ifarchive.org/if-archive/infocom/tools/ztools/ztools731.tar.gz";
+    hash = "sha256-vlQX0/fCAr88KJwMnYUSROFOg9tfVK5Hz58AUDuhNXg=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    groff
+    unixtools.col
+  ];
+
+  # compiler flags as defaults have changed
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-implicit-int";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin/
+    cp {check,infodump,pix2gif,txd} $out/bin/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An essential set of Z-machine tools for interpreter authors, experienced Inform programmers, and Z-code hackers.";
+    homepage = "http://inform-fiction.org/zmachine/ztools.html";
+    license = lib.licenses.cc-by-sa-40;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "txd";
+  };
+})


### PR DESCRIPTION
Introduces the package ztools from http://inform-fiction.org/zmachine/ztools.html used for interacting with Z-Machine story files.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc