### PR TITLE
vmaware: init at 2.4.1

### DIFF
--- a/pkgs/by-name/vm/vmaware/package.nix
+++ b/pkgs/by-name/vm/vmaware/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  dmidecode,
+  makeWrapper,
+  nix-update-script,
+}:
+
+let
+  isPlatformSupported = drv: builtins.elem stdenv.hostPlatform.system drv.meta.platforms;
+  runtimeDeps = builtins.filter isPlatformSupported [
+    dmidecode
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vmaware";
+  version = "2.4.1";
+  src = fetchFromGitHub {
+    owner = "kernelwernel";
+    repo = "VMAware";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MubqoAA+F0XO4dpkQcIR7rb+LfcuaWjf7xVkkF6juEA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    makeWrapper
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace CMakeLists.txt --replace-fail "/usr/bin" "$out/bin"
+    substituteInPlace CMakeLists.txt --replace-fail "/usr/include" "$out/include"
+
+    runHook postPatch
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/vmaware \
+      --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "VM detection library and tool";
+    homepage = "https://github.com/kernelwernel/VMAware";
+    changelog = "https://github.com/kernelwernel/VMAware/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3
+      mit
+    ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ners ];
+    mainProgram = "vmaware";
+  };
+})


### PR DESCRIPTION
<img src="https://github.com/kernelwernel/VMAware/raw/main/assets/banner.jpg">

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
