### PR TITLE
rustPlatform.cargoInstallHook: support multiple outputs

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-install-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-install-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154
+
 cargoInstallPostBuildHook() {
     echo "Executing cargoInstallPostBuildHook"
 
@@ -29,19 +31,19 @@ cargoInstallHook() {
       rm -rf "$target/../../${cargoBuildType}"
       ln -srf "$target" "$target/../../"
     done
-    mkdir -p $out/bin $out/lib
+    mkdir -p "${!outputBin}/bin" "${!outputLib}/lib"
 
-    xargs -r cp -t $out/bin <<< $bins
+    xargs -r cp -t "${!outputBin}/bin" <<< $bins
     find $tmpDir \
       -maxdepth 1 \
       -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \
-      -print0 | xargs -r -0 cp -t $out/lib
+      -print0 | xargs -r -0 cp -t "${!outputLib}/lib"
 
     # If present, copy any .dSYM directories for debugging on darwin
     # https://github.com/NixOS/nixpkgs/issues/330036
-    find "${releaseDir}" -maxdepth 1 -name '*.dSYM' -exec cp -RLt $out/bin/ {} +
+    find "${releaseDir}" -maxdepth 1 -name '*.dSYM' -exec cp -RLt "${!outputBin}/bin/" {} +
 
-    rmdir --ignore-fail-on-non-empty $out/lib $out/bin
+    rmdir --ignore-fail-on-non-empty "${!outputLib}/lib" "${!outputBin}/bin"
     runHook postInstall
 
     echo "Finished cargoInstallHook"


### PR DESCRIPTION
This makes it easier for packages built with `rustPlatform.buildRustPackage` to have multiple outputs.

Outputs of single‐output packages should remain the same.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
