### PR TITLE
prusa-slicer: 2.9.0 -> 2.9.1

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -6,7 +6,7 @@
 , cmake
 , pkg-config
 , wrapGAppsHook3
-, boost186
+, boost
 , cereal
 , cgal
 , curl
@@ -34,8 +34,9 @@
 , xorg
 , libbgcode
 , heatshrink
-, catch2
+, catch2_3
 , webkitgtk_4_0
+, z3-cmake
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 , wxGTK-override ? null
 , opencascade-override ? null
@@ -71,29 +72,27 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prusa-slicer";
-  version = "2.9.0";
+  version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "PrusaSlicer";
-    hash = "sha256-6BrmTNIiu6oI/CbKPKoFQIh1aHEVfJPIkxomQou0xKk=";
+    hash = "sha256-i93P0W2/FQDpBSigKBFIi98fsx4ZAWh3g5fbqXzosss=";
     rev = "version_${finalAttrs.version}";
   };
 
-  # https://github.com/prusa3d/PrusaSlicer/pull/14010
-  patches = [(fetchpatch {
-    url = "https://github.com/prusa3d/PrusaSlicer/commit/cdc3db58f9002778a0ca74517865527f50ade4c3.patch";
-    hash = "sha256-zgpGg1jtdnCBaWjR6oUcHo5sGuZx5oEzpux3dpRdMAM=";
-  })];
-
-  # required for GCC 14
-  # (not applicable to super-slicer fork)
-  postPatch = lib.optionalString (finalAttrs.pname == "prusa-slicer") ''
-    substituteInPlace src/slic3r-arrange/include/arrange/DataStoreTraits.hpp \
-      --replace-fail \
-      "WritableDataStoreTraits<ArrItem>::template set" \
-      "WritableDataStoreTraits<ArrItem>::set"
-  '';
+  patches = [
+    (fetchpatch {
+      name = "build-with-boost-187";
+      url = "https://946495.bugs.gentoo.org/attachment.cgi?id=914594";
+      hash = "sha256-FVCpfkOe8a7zRG7QXoBu6i8I4sFu2i/j+E9uKPGmcec=";
+    })
+    # https://github.com/prusa3d/PrusaSlicer/pull/14010
+    (fetchpatch {
+      url = "https://github.com/prusa3d/PrusaSlicer/commit/cdc3db58f9002778a0ca74517865527f50ade4c3.patch";
+      hash = "sha256-zgpGg1jtdnCBaWjR6oUcHo5sGuZx5oEzpux3dpRdMAM=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -104,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     binutils
-    boost186  # does not build with 1.87, see https://github.com/prusa3d/PrusaSlicer/issues/13799
+    boost
     cereal
     cgal
     curl
@@ -131,8 +130,9 @@ stdenv.mkDerivation (finalAttrs: {
     xorg.libX11
     libbgcode
     heatshrink
-    catch2
+    catch2_3
     webkitgtk_4_0
+    z3-cmake
   ] ++ lib.optionals withSystemd [
     systemd
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/li/libbgcode/package.nix
+++ b/pkgs/by-name/li/libbgcode/package.nix
@@ -7,17 +7,17 @@
   heatshrink,
   zlib,
   boost,
-  catch2,
+  catch2_3,
 }:
 stdenv.mkDerivation {
   pname = "libbgcode";
-  version = "2023-11-16";
+  version = "2025-02-19";
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "libbgcode";
-    rev = "bc390aab4427589a6402b4c7f65cf4d0a8f987ec";
-    hash = "sha256-TZShYeDAh+fNdmTr1Xqctji9f0vEGpNZv1ba/IY5EoY=";
+    rev = "5041c093b33e2748e76d6b326f2251310823f3df";
+    hash = "sha256-EaxVZerH2v8b1Yqk+RW/r3BvnJvrAelkKf8Bd+EHbEc=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     heatshrink
     zlib
     boost
-    catch2
+    catch2_3
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/z3/z3-cmake/0001-fix-pkgconfig-prefixes.patch
+++ b/pkgs/by-name/z3/z3-cmake/0001-fix-pkgconfig-prefixes.patch
@@ -1,0 +1,29 @@
+From b978d9f7573c6e3ea7ab8bd5d73846eba159fbc5 Mon Sep 17 00:00:00 2001
+From: Lach <iam@lach.pw>
+Date: Sat, 15 Mar 2025 19:38:44 +0100
+Subject: [PATCH] fix: pkgconfig prefixes
+
+Signed-off-by: Lach <iam@lach.pw>
+---
+ z3.pc.cmake.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/z3.pc.cmake.in b/z3.pc.cmake.in
+index 436dd62..78fb937 100644
+--- a/z3.pc.cmake.in
++++ b/z3.pc.cmake.in
+@@ -1,8 +1,8 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-sharedlibdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_LIBDIR@
++sharedlibdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: z3
+ Description: The Z3 Theorem Prover
+-- 
+2.48.1
+

--- a/pkgs/by-name/z3/z3-cmake/package.nix
+++ b/pkgs/by-name/z3/z3-cmake/package.nix
@@ -1,0 +1,23 @@
+{
+  stdenv,
+  z3,
+  cmake,
+  python3,
+}:
+
+stdenv.mkDerivation {
+  inherit (z3) pname version src;
+
+  patches = [
+    ./0001-fix-pkgconfig-prefixes.patch
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+}


### PR DESCRIPTION
https://blog.prusa3d.com/prusaslicer-2-9-1-smarter-sequential-printing-stronger-multi-material-interlocking_111458/

Fixes #415703

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Fixes: https://github.com/NixOS/nixpkgs/issues/389178

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
