### PR TITLE
opentelemetry-cpp: version update and extra configurability

### DIFF
--- a/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
+++ b/pkgs/by-name/op/opentelemetry-cpp/0001-Disable-tests-requiring-network-access.patch
@@ -1,8 +1,8 @@
 diff --git a/ext/test/http/curl_http_test.cc b/ext/test/http/curl_http_test.cc
-index 7c66d98b..62d40f49 100644
+index e8299202..19dbd7b1 100644
 --- a/ext/test/http/curl_http_test.cc
 +++ b/ext/test/http/curl_http_test.cc
-@@ -229,7 +229,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
+@@ -270,7 +270,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
    ASSERT_EQ(count, 4);
  }
  
@@ -11,8 +11,8 @@ index 7c66d98b..62d40f49 100644
  {
    received_requests_.clear();
    auto session_manager = http_client::HttpClientFactory::Create();
-@@ -246,7 +246,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
-   ASSERT_TRUE(handler->got_response_);
+@@ -287,7 +287,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
+   ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
  }
  
 -TEST_F(BasicCurlHttpTests, SendPostRequest)
@@ -20,25 +20,25 @@ index 7c66d98b..62d40f49 100644
  {
    received_requests_.clear();
    auto session_manager = http_client::HttpClientFactory::Create();
-@@ -325,7 +325,7 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
-   delete handler;
+@@ -313,7 +313,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
+   session_manager->FinishAllSessions();
  }
+ 
+-TEST_F(BasicCurlHttpTests, RequestTimeout)
++TEST_F(BasicCurlHttpTests, DISABLED_RequestTimeout)
+ {
+   received_requests_.clear();
+   auto session_manager = http_client::HttpClientFactory::Create();
+@@ -442,7 +442,7 @@ TEST_F(BasicCurlHttpTests, ExponentialBackoffRetry)
+ }
+ #endif  // ENABLE_OTLP_RETRY_PREVIEW
  
 -TEST_F(BasicCurlHttpTests, SendGetRequestSync)
 +TEST_F(BasicCurlHttpTests, DISABLED_SendGetRequestSync)
  {
    received_requests_.clear();
    curl::HttpClientSync http_client;
-@@ -336,7 +336,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestSync)
-   EXPECT_EQ(result.GetSessionState(), http_client::SessionState::Response);
- }
- 
--TEST_F(BasicCurlHttpTests, SendGetRequestSyncTimeout)
-+TEST_F(BasicCurlHttpTests, DISABLED_SendGetRequestSyncTimeout)
- {
-   received_requests_.clear();
-   curl::HttpClientSync http_client;
-@@ -350,7 +350,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestSyncTimeout)
+@@ -467,7 +467,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestSyncTimeout)
                result.GetSessionState() == http_client::SessionState::SendFailed);
  }
  
@@ -47,7 +47,7 @@ index 7c66d98b..62d40f49 100644
  {
    received_requests_.clear();
    curl::HttpClientSync http_client;
-@@ -378,7 +378,7 @@ TEST_F(BasicCurlHttpTests, GetBaseUri)
+@@ -495,7 +495,7 @@ TEST_F(BasicCurlHttpTests, GetBaseUri)
              "http://127.0.0.1:31339/");
  }
  
@@ -56,7 +56,7 @@ index 7c66d98b..62d40f49 100644
  {
    curl::HttpClient http_client;
  
-@@ -452,7 +452,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
+@@ -570,7 +570,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
    }
  }
  
@@ -65,7 +65,7 @@ index 7c66d98b..62d40f49 100644
  {
    curl::HttpClient http_client;
  
-@@ -491,7 +491,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequestAsync)
+@@ -609,7 +609,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequestAsync)
    }
  }
  
@@ -74,6 +74,12 @@ index 7c66d98b..62d40f49 100644
  {
    curl::HttpClient http_client;
  
--- 
-2.40.1
-
+@@ -647,7 +647,7 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
+   }
+ }
+ 
+-TEST_F(BasicCurlHttpTests, ElegantQuitQuick)
++TEST_F(BasicCurlHttpTests, DISABLED_ElegantQuitQuick)
+ {
+   auto http_client = http_client::HttpClientFactory::Create();
+   std::static_pointer_cast<curl::HttpClient>(http_client)->MaybeSpawnBackgroundThread();

--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -10,8 +10,8 @@
   prometheus-cpp,
   nlohmann_json,
   nix-update-script,
+  cxxStandard ? null,
 }:
-
 let
   opentelemetry-proto = fetchFromGitHub {
     owner = "open-telemetry";
@@ -53,17 +53,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DWITH_OTLP_HTTP=ON"
-    "-DWITH_OTLP_GRPC=ON"
-    "-DWITH_ABSEIL=ON"
-    "-DWITH_PROMETHEUS=ON"
-    "-DWITH_ELASTICSEARCH=ON"
-    "-DWITH_ZIPKIN=ON"
-    "-DWITH_BENCHMARK=OFF"
-    "-DOTELCPP_PROTO_PATH=${opentelemetry-proto}"
-  ];
+  cmakeFlags =
+    [
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DWITH_OTLP_HTTP=ON"
+      "-DWITH_OTLP_GRPC=ON"
+      "-DWITH_ABSEIL=ON"
+      "-DWITH_PROMETHEUS=ON"
+      "-DWITH_ELASTICSEARCH=ON"
+      "-DWITH_ZIPKIN=ON"
+      "-DWITH_BENCHMARK=OFF"
+      "-DOTELCPP_PROTO_PATH=${opentelemetry-proto}"
+    ]
+    ++ lib.optionals (cxxStandard != null) [
+      "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+      "-DWITH_STL=CXX${cxxStandard}"
+    ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/op/opentelemetry-cpp/package.nix
+++ b/pkgs/by-name/op/opentelemetry-cpp/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  abseil-cpp,
   cmake,
   gtest,
   protobuf,
@@ -22,19 +21,19 @@ let
   opentelemetry-proto = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-proto";
-    rev = "v1.3.2";
-    hash = "sha256-bkVqPSVhyMHrmFvlI9DTAloZzDozj3sefIEwfW7OVrI=";
+    rev = "v1.5.0";
+    hash = "sha256-PkG0npG3nKQwq6SxWdIliIQ/wrYAOG9qVb26IeVkBfc=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentelemetry-cpp";
-  version = "1.16.1";
+  version = "1.20.0";
 
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-cpp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-31zwIZ4oehhfn+oCyg8VQTurPOmdgp72plH1Pf/9UKQ=";
+    hash = "sha256-ibLuHIg01wGYPhLRz+LVYA34WaWzlUlNtg7DSONLe9g=";
   };
 
   patches = [
@@ -49,8 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs =
-    [ abseil-cpp ]
-    ++
     lib.optionals (enableGrpc || enableHttp) [ protobuf ]
     ++ lib.optionals enableGrpc [
       grpc
@@ -89,8 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = ''
-    substituteInPlace $out/lib/cmake/opentelemetry-cpp/opentelemetry-cpp-target.cmake \
-      --replace-fail "\''${_IMPORT_PREFIX}/include" "$dev/include"
+    substituteInPlace $out/lib/cmake/opentelemetry-cpp/opentelemetry-cpp*-target.cmake \
+      --replace-quiet "\''${_IMPORT_PREFIX}/include" "$dev/include"
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update package versions:
    opentelemetry-cpp: update versions.
opentelemetry-proto 1.3.2 -> 1.5.0 https://github.com/open-telemetry/opentelemetry-proto/compare/v1.3.2...v1.5.0
opentelemetry 1.16.1 -> 1.20.0 https://github.com/open-telemetry/opentelemetry-cpp/compare/v1.16.1...v1.20.0

Note that the update script isn't quite right because there's actually two sources -- it (`nix-shell maintainers/scripts/update.nix --argstr package opentelemetry-cpp`) will update only opentelemetry-cpp but not the opentelemetry-proto. 

Add STL option. I think it's nicer to use, as a developer using the library (versus otlp-cpp's own stl-like implementations). Plus, using nix, I should be assured of retaining ABI compatibility, which appears to be the main reason not to use the STL here. Also I was surprised that I needed both WITH_STL and CMAKE_CXX_STANDARD cmake flags, versus just WITH_STL.

Make the exporter-specific dependencies opt-in since I don't want to pull in unnecessary ones.

Moved some packages to propagatedBuildInputs along the above change, since whoever's enabled the particular exporter is probably going to want to build with those dependencies. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
