### PR TITLE
python3Packages.watchdog: fix `checkPhase` on sandboxed Darwin

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -44,37 +44,21 @@ buildPythonPackage rec {
     # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
     "tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-    # segfaults the testsuite
-    "tests/test_emitter.py"
-    # unsupported on x86_64-darwin
-    "tests/test_fsevents.py"
-    # fails to stop process in teardown
-    "tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    # FileCreationEvent != FileDeletionEvent
-    "tests/test_emitter.py::test_separate_consecutive_moves"
-    "tests/test_observers_polling.py::test___init__"
-    # segfaults
-    "tests/test_delayed_queue.py::test_delayed_get"
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/test_emitter.py::test_case_change"
+    "tests/test_emitter.py::test_chmod"
+    "tests/test_emitter.py::test_create"
     "tests/test_emitter.py::test_delete"
-    # AttributeError: '_thread.RLock' object has no attribute 'key'"
-    "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    # segfaults
-    "tests/test_delayed_queue.py::test_delayed_get"
-    "tests/test_0_watchmedo.py::test_tricks_from_file"
-    "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_1"
-    "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2"
-    "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-    "tests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
-    # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
-    "tests/test_fsevents.py::test_watchdog_recursive"
-    # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
-    "tests/test_fsevents.py::test_add_watch_twice"
-    # gets stuck
+    "tests/test_emitter.py::test_fast_subdirectory_creation_deletion"
+    "tests/test_emitter.py::test_file_lifecyle"
+    "tests/test_emitter.py::test_modify"
+    "tests/test_emitter.py::test_move_from"
+    "tests/test_emitter.py::test_move_nested_subdirectories"
+    "tests/test_emitter.py::test_move"
+    "tests/test_emitter.py::test_recursive_off"
+    "tests/test_emitter.py::test_recursive_on"
+    "tests/test_emitter.py::test_renaming_top_level_directory"
+    "tests/test_emitter.py::test_separate_consecutive_moves"
     "tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
   ];
 

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -78,6 +78,10 @@ buildPythonPackage rec {
     "tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
   ];
 
+  sandboxProfile = ''
+    (allow mach-lookup (global-name "com.apple.FSEvents"))
+  '';
+
   pythonImportsCheck = [ "watchdog" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[watchdog defaults to the FSEvents backend on macOS][1]. Update the sandbox profile to allow access to the FSEvents API, which allows the corresponding tests to pass with the sandbox enabled.

[1]: https://python-watchdog.readthedocs.io/en/stable/installation.html#supported-platforms-and-caveats

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
