### PR TITLE
legcord: refactor; 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -2,48 +2,70 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_9,
+  pnpm,
   nodejs,
-  electron_34,
+  electron,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
+  autoPatchelfHook,
+  pipewire,
+  libpulseaudio,
   nix-update-script,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "legcord";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "Legcord";
     repo = "Legcord";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0RbLvRCvy58HlOhHLcAoErRFgYxjWrKFQ6DPJD50c5Q=";
   };
 
   nativeBuildInputs = [
-    pnpm_9.configHook
+    pnpm.configHook
     nodejs
+    # we use a script wrapper here for environment variable expansion at runtime
+    # https://github.com/NixOS/nixpkgs/issues/172583
     makeWrapper
     copyDesktopItems
+    # legcord uses venmic, which is a shipped as a prebuilt node module
+    # and needs to be patched
+    autoPatchelfHook
   ];
 
-  pnpmDeps = pnpm_9.fetchDeps {
-    inherit pname version src;
-    hash = "sha256-UivO0e50zGNV69AaV4RilmJ9L6L6lctUrUh9CVIOry4=";
-  };
+  buildInputs = [
+    libpulseaudio
+    pipewire
+    (lib.getLib stdenv.cc.cc)
+  ];
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-zAf3EGIt/BWSZ9BMHWWVPWo3m+whnl/p+SahmpdLoZ4=";
+  };
 
   buildPhase = ''
     runHook preBuild
 
     pnpm build
 
-    npm exec electron-builder -- \
+    # Replicating the build step to copy venmic from the vendored node module manually,
+    # since the install script does not do this for whatever reason
+    cp ./node_modules/@vencord/venmic/prebuilds/venmic-addon-linux-x64/node-napi-v7.node ./dist/venmic-x64.node
+    cp ./node_modules/@vencord/venmic/prebuilds/venmic-addon-linux-arm64/node-napi-v7.node ./dist/venmic-arm64.node
+
+    # Patch venmic before putting it into the ASAR archive
+    autoPatchelf ./dist
+
+    pnpm exec electron-builder \
       --dir \
-      -c.electronDist="${electron_34.dist}" \
-      -c.electronVersion="${electron_34.version}"
+      -c.asarUnpack="**/*.node" \
+      -c.electronDist="${electron.dist}" \
+      -c.electronVersion="${electron.version}"
 
     runHook postBuild
   '';
@@ -56,37 +78,57 @@ stdenv.mkDerivation rec {
 
     install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/legcord.png"
 
-    makeShellWrapper "${lib.getExe electron_34}" "$out/bin/legcord" \
+    # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
+    # see https://github.com/NixOS/nixpkgs/issues/172583
+    makeShellWrapper "${lib.getExe electron}" "$out/bin/legcord" \
       --add-flags "$out/share/lib/legcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
 
     runHook postInstall
   '';
 
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
   desktopItems = [
     (makeDesktopItem {
       name = "legcord";
+      genericName = "Internet Messenger";
       desktopName = "Legcord";
       exec = "legcord %U";
       icon = "legcord";
-      comment = meta.description;
-      categories = [ "Network" ];
+      comment = finalAttrs.meta.description;
+      keywords = [
+        "discord"
+        "vencord"
+        "electron"
+        "chat"
+      ];
+      categories = [
+        "Network"
+        "InstantMessaging"
+        "Chat"
+      ];
       startupWMClass = "Legcord";
       terminal = false;
     })
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    inherit (finalAttrs) pnpmDeps;
+    updateScript = nix-update-script { };
+  };
 
-  meta = with lib; {
+  meta = {
     description = "Lightweight, alternative desktop client for Discord";
     homepage = "https://legcord.app";
     downloadPage = "https://github.com/Legcord/Legcord";
-    license = licenses.osl3;
-    maintainers = with maintainers; [
+    license = lib.licenses.osl3;
+    maintainers = with lib.maintainers; [
       wrmilling
       water-sucks
     ];
@@ -96,4 +138,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "legcord";
   };
-}
+})

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       wrmilling
       water-sucks
+      nyabinary
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -12,13 +12,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "legcord";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "Legcord";
     repo = "Legcord";
     rev = "v${version}";
-    hash = "sha256-IfRjblC3L6A7HgeEDeDrRxtIMvWQB3P7mpq5bhaHWqk=";
+    hash = "sha256-0RbLvRCvy58HlOhHLcAoErRFgYxjWrKFQ6DPJD50c5Q=";
   };
 
   nativeBuildInputs = [
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-LbHYY97HsNF9cBQzAfFw+A/tLf27y3he9Bbw9H3RKK4=";
+    hash = "sha256-UivO0e50zGNV69AaV4RilmJ9L6L6lctUrUh9CVIOry4=";
   };
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Refactor to use `finalAttrs`
Refactor to remove `with lib` usage in `meta`
Update to `1.1.1`
Make the `.desktop` file more accurate
Add `nyabinary` (me) as a maintainer
Use `tag` instead of `rev`
Fix `venmic` (thanks @wrmilling and @water-sucks); supersedes #388827

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
