### PR TITLE
rustPlatform.buildRustPackage: integrate cargo-c

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-c-build-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-c-build-hook.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash disable=SC2514,SC2164
+
+cargoCBuildHook() {
+  echo "Executing cargoCBuildHook"
+
+  # let stdenv handle stripping
+  export "CARGO_PROFILE_${cargoBuildType@U}_STRIP"=false
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    # ensure the output doesn't end up in the subdirectory
+    CARGO_TARGET_DIR="$(pwd)/target"
+    export CARGO_TARGET_DIR
+
+    pushd "${buildAndTestSubdir}"
+  fi
+
+  local -a flagsArray
+  concatTo flagsArray cargoCFlags cargoCInstallFlags
+
+  if [ "${cargoBuildType}" != "debug" ]; then
+    flagsArray+=("--profile" "${cargoBuildType}")
+  fi
+
+  if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+    flagsArray+=("--no-default-features")
+  fi
+
+  if [ -n "${cargoBuildFeatures-}" ]; then
+    flagsArray+=("--features=$(concatStringsSep "," cargoBuildFeatures)")
+  fi
+
+  concatTo flagsArray cargoBuildFlags
+
+  echoCmd 'cargoCBuildHook flags' "${flagsArray[@]}"
+  @setEnv@ cargo cbuild "${flagsArray[@]}"
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    popd
+  fi
+
+  echo "Finished cargoCBuildHook"
+}
+
+if [ -z "${dontCargoCBuild-}" ]; then
+  postBuildHooks+=(cargoCBuildHook)
+fi

--- a/pkgs/build-support/rust/hooks/cargo-c-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-c-check-hook.sh
@@ -1,0 +1,43 @@
+cargoCCheckHook() {
+  echo "Executing cargoCCheckHook"
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    pushd "${buildAndTestSubdir}"
+  fi
+
+  local -a flagsArray
+  concatTo flagsArray cargoCFlags
+
+  export RUST_TEST_THREADS="$NIX_BUILD_CORES"
+  if [ -n "${dontUseCargoParallelTests-}" ]; then
+    RUST_TEST_THREADS=1
+  fi
+
+  if [ "${cargoCheckType}" != "debug" ]; then
+    flagsArray+=("--profile" "${cargoCheckType}")
+  fi
+
+  if [ -n "${cargoCheckNoDefaultFeatures-}" ]; then
+    flagsArray+=("--no-default-features")
+  fi
+
+  if [ -n "${cargoCheckFeatures-}" ]; then
+    flagsArray+=("--features=$(concatStringsSep "," cargoCheckFeatures)")
+  fi
+
+  prependToVar checkFlags --
+  concatTo flagsArray cargoTestFlags checkFlags checkFlagsArray
+
+  echoCmd 'cargoCCheckHook flags' "${flagsArray[@]}"
+  @setEnv@ cargo ctest "${flagsArray[@]}"
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    popd
+  fi
+
+  echo "Finished cargoCCheckHook"
+}
+
+if [ -z "${dontCargoCCheck-}"]; then
+  postCheckHooks+=(cargoCCheckHook)
+fi

--- a/pkgs/build-support/rust/hooks/cargo-c-fixup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-c-fixup-hook.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=bash disable=SC2514
+
+cargoCFixupHook() {
+  echo "Executing cargoCFixupHook"
+
+  # remove static library archives
+  if [ -z "${dontDisableStatic-}" ]; then
+    find "${!outputLib}/lib" \( -type f -o -type l \) -name '*.@staticLibrary@' -delete
+  fi
+
+  echo "Finished cargoCFixupHook"
+}
+
+if [ -z "${dontCargoCFixup-}"]; then
+  postFixupHooks+=(cargoCFixupHook)
+fi

--- a/pkgs/build-support/rust/hooks/cargo-c-install-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-c-install-hook.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash disable=SC2164
+
+cargoCInstallHook() {
+  echo "Executing cargoCInstallHook"
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    pushd "$buildAndTestSubdir"
+  fi
+
+  local -a flagsArray
+  concatTo flagsArray cargoCFlags cargoCInstallFlags
+
+  if [ "${cargoBuildType}" != "debug" ]; then
+    flagsArray+=("--profile" "${cargoBuildType}")
+  fi
+
+  if [ -n "${cargoBuildNoDefaultFeatures-}" ]; then
+    flagsArray+=("--no-default-features")
+  fi
+
+  if [ -n "${cargoBuildFeatures-}" ]; then
+    flagsArray+=("--features=$(concatStringsSep "," cargoBuildFeatures)")
+  fi
+
+  concatTo flagsArray cargoBuildFlags
+
+  echoCmd 'cargoCInstallHook flags' "${flagsArray[@]}"
+  @setEnv@ cargo cinstall "${flagsArray[@]}"
+
+  if [ -n "${buildAndTestSubdir-}" ]; then
+    popd
+  fi
+
+  echo "Finished cargoCInstallHook"
+}
+
+if [ -z "${dontCargoCInstall-}"]; then
+  appendToVar postInstallHooks cargoCInstallHook
+fi

--- a/pkgs/build-support/rust/hooks/cargo-c-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-c-setup-hook.sh
@@ -1,0 +1,28 @@
+# shellcheck shell=bash disable=SC2514
+
+cargoCSetupPhase() {
+  echo "Executing cargoCSetupPhase"
+
+  prependToVar cargoCFlags \
+    -j "$NIX_BUILD_CORES" \
+    --target @rustcTarget@ \
+    --frozen
+
+  if [ -z "${dontDisableStatic-}" ]; then
+    prependToVar cargoCInstallFlags \
+      --library-type cdylib
+  fi
+
+  prependToVar cargoCInstallFlags \
+    --prefix "$out" \
+    --libdir "${!outputLib}/lib" \
+    --includedir "${!outputInclude}/include" \
+    --bindir "${!outputBin}/bin" \
+    --pkgconfigdir "${!outputDev}/lib/pkgconfig"
+
+  echo "Finished cargoCSetupPhase"
+}
+
+if [ -z "${dontCargoCSetup-}" ]; then
+  prePhases+=(cargoCSetupPhase)
+fi

--- a/pkgs/build-support/rust/hooks/cargo-install-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-install-hook.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash disable=SC2154
+
 cargoInstallPostBuildHook() {
     echo "Executing cargoInstallPostBuildHook"
 
@@ -29,19 +31,19 @@ cargoInstallHook() {
       rm -rf "$target/../../${cargoBuildType}"
       ln -srf "$target" "$target/../../"
     done
-    mkdir -p $out/bin $out/lib
+    mkdir -p "${!outputBin}/bin" "${!outputLib}/lib"
 
-    xargs -r cp -t $out/bin <<< $bins
+    xargs -r cp -t "${!outputBin}/bin" <<< $bins
     find $tmpDir \
       -maxdepth 1 \
       -regex ".*\.\(so.[0-9.]+\|so\|a\|dylib\)" \
-      -print0 | xargs -r -0 cp -t $out/lib
+      -print0 | xargs -r -0 cp -t "${!outputLib}/lib"
 
     # If present, copy any .dSYM directories for debugging on darwin
     # https://github.com/NixOS/nixpkgs/issues/330036
-    find "${releaseDir}" -maxdepth 1 -name '*.dSYM' -exec cp -RLt $out/bin/ {} +
+    find "${releaseDir}" -maxdepth 1 -name '*.dSYM' -exec cp -RLt "${!outputBin}/bin/" {} +
 
-    rmdir --ignore-fail-on-non-empty $out/lib $out/bin
+    rmdir --ignore-fail-on-non-empty "${!outputLib}/lib" "${!outputBin}/bin"
     runHook postInstall
 
     echo "Finished cargoInstallHook"

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -12,6 +12,7 @@
   rustc,
   stdenv,
   pkgsTargetTarget,
+  removeReferencesTo,
 
   # This confusingly-named parameter indicates the *subdirectory of
   # `target/` from which to copy the build artifacts.  It is derived
@@ -154,5 +155,74 @@
         inherit clang;
       };
     } ./rust-bindgen-hook.sh
+  ) { };
+
+  cargoCSetupHook = callPackage (
+    { }:
+    makeSetupHook {
+      name = "cargo-c-setup-hook.sh";
+      substitutions = {
+        inherit (stdenv.targetPlatform.rust) rustcTarget;
+      };
+    } ./cargo-c-setup-hook.sh
+  ) { };
+
+  cargoCBuildHook = callPackage (
+    { pkgsHostTarget }:
+    makeSetupHook {
+      name = "cargo-c-build-hook.sh";
+      propagatedBuildInputs = [
+        pkgsHostTarget.cargo-c
+        pkgsHostTarget.cargo
+        pkgsHostTarget.rustc
+      ];
+      substitutions = {
+        inherit (stdenv.targetPlatform.rust) rustcTarget;
+        inherit (rust.envVars) setEnv;
+      };
+    } ./cargo-c-build-hook.sh
+  ) { };
+
+  cargoCCheckHook = callPackage (
+    { pkgsHostTarget }:
+    makeSetupHook {
+      name = "cargo-c-check-hook.sh";
+      propagatedBuildInputs = [
+        pkgsHostTarget.cargo-c
+        pkgsHostTarget.cargo
+        pkgsHostTarget.rustc
+      ];
+      substitutions = {
+        inherit (stdenv.targetPlatform.rust) rustcTarget;
+        inherit (rust.envVars) setEnv;
+      };
+    } ./cargo-c-check-hook.sh
+  ) { };
+
+  cargoCInstallHook = callPackage (
+    { pkgsHostTarget }:
+    makeSetupHook {
+      name = "cargo-c-install-hook.sh";
+      propagatedBuildInputs = [
+        pkgsHostTarget.cargo-c
+        pkgsHostTarget.cargo
+        pkgsHostTarget.rustc
+        pkgsHostTarget.validatePkgConfig
+      ];
+      substitutions = {
+        inherit (stdenv.targetPlatform.rust) rustcTarget;
+        inherit (rust.envVars) setEnv;
+      };
+    } ./cargo-c-install-hook.sh
+  ) { };
+
+  cargoCFixupHook = callPackage (
+    { }:
+    makeSetupHook {
+      name = "cargo-c-fixup-hook.sh";
+      substitutions = {
+        inherit (stdenv.targetPlatform.extensions) staticLibrary;
+      };
+    } ./cargo-c-fixup-hook.sh
   ) { };
 }

--- a/pkgs/by-name/li/libdovi/package.nix
+++ b/pkgs/by-name/li/libdovi/package.nix
@@ -2,9 +2,6 @@
   lib,
   rustPlatform,
   fetchCrate,
-  cargo-c,
-  rust,
-  stdenv,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,28 +16,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoLock.lockFile = ./Cargo.lock;
 
+  buildCAPIOnly = true;
+
   postPatch = ''
     ln -s ${./Cargo.lock} Cargo.lock
-  '';
-
-  nativeBuildInputs = [ cargo-c ];
-
-  buildPhase = ''
-    runHook preBuild
-    ${rust.envVars.setEnv} cargo cbuild -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    ${rust.envVars.setEnv} cargo cinstall -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postInstall
-  '';
-
-  checkPhase = ''
-    runHook preCheck
-    ${rust.envVars.setEnv} cargo ctest -j $NIX_BUILD_CORES --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    runHook postCheck
   '';
 
   meta = with lib; {
@@ -48,5 +27,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://crates.io/crates/dolby_vision";
     license = licenses.mit;
     maintainers = with maintainers; [ kranzes ];
+    pkgConfigModules = [ "dovi" ];
   };
 }

--- a/pkgs/by-name/li/libimagequant/package.nix
+++ b/pkgs/by-name/li/libimagequant/package.nix
@@ -1,15 +1,10 @@
 { lib
-, stdenv
 , fetchFromGitHub
-, rust
 , rustPlatform
-, cargo-c
 , python3
 
 # tests
-, testers
 , vips
-, libimagequant
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -32,28 +27,12 @@ rustPlatform.buildRustPackage rec {
     ln -s ${./Cargo.lock} Cargo.lock
   '';
 
-  nativeBuildInputs = [ cargo-c ];
-
-  postBuild = ''
-    pushd imagequant-sys
-    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    popd
-  '';
-
-  postInstall = ''
-    pushd imagequant-sys
-    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    popd
-  '';
+  buildCAPIOnly = true;
+  cargoCFlags = [ "--package=imagequant-sys" ];
 
   passthru.tests = {
     inherit vips;
     inherit (python3.pkgs) pillow;
-
-    pkg-config = testers.hasPkgConfigModules {
-      package = libimagequant;
-      moduleNames = [ "imagequant" ];
-    };
   };
 
   meta = with lib; {
@@ -63,5 +42,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ma9e ];
+    pkgConfigModules = [ "imagequant" ];
   };
 }

--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -1,10 +1,8 @@
 {
   lib,
-  rust,
   stdenv,
   rustPlatform,
   fetchCrate,
-  cargo-c,
   nasm,
   nix-update-script,
   testers,
@@ -15,6 +13,12 @@ rustPlatform.buildRustPackage rec {
   pname = "rav1e";
   version = "0.7.1";
 
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
+
   src = fetchCrate {
     inherit pname version;
     hash = "sha256-Db7qb7HBAy6lniIiN07iEzURmbfNtuhmgJRv7OUagUM=";
@@ -23,10 +27,10 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-sJO40DN/Zfchg9J/7wTmO/RS88Zb6fIJ7nX4VNGe/eA=";
 
-  nativeBuildInputs = [
-    cargo-c
-    nasm
-  ];
+  buildCAPI = true;
+  dontCargoCCheck = true;
+
+  nativeBuildInputs = [ nasm ];
 
   postPatch =
     ''
@@ -43,14 +47,6 @@ rustPlatform.buildRustPackage rec {
     '';
 
   checkType = "debug";
-
-  postBuild = ''
-    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  '';
-
-  postInstall = ''
-    ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-  '';
 
   passthru = {
     tests.version = testers.testVersion { package = rav1e; };
@@ -70,5 +66,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "rav1e";
+    pkgConfigModules = [ "rav1e" ];
   };
 }

--- a/pkgs/by-name/ya/yara-x/package.nix
+++ b/pkgs/by-name/ya/yara-x/package.nix
@@ -1,11 +1,9 @@
 {
   lib,
-  rust,
   stdenv,
   fetchFromGitHub,
   rustPlatform,
   installShellFiles,
-  cargo-c,
   testers,
   yara-x,
 }:
@@ -13,6 +11,12 @@
 rustPlatform.buildRustPackage rec {
   pname = "yara-x";
   version = "0.13.0";
+
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
@@ -24,25 +28,16 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-pD4qyw+TTpmcoX1N3C65VelYszYifm9sFOsEkXEysvo=";
 
-  nativeBuildInputs = [
-    installShellFiles
-    cargo-c
-  ];
+  buildCAPI = true;
 
-  postBuild = ''
-    ${rust.envVars.setEnv} cargo cbuild --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd yr \
+      --bash <($bin/bin/yr completion bash) \
+      --fish <($bin/bin/yr completion fish) \
+      --zsh <($bin/bin/yr completion zsh)
   '';
-
-  postInstall =
-    ''
-      ${rust.envVars.setEnv} cargo cinstall --release --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
-    ''
-    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      installShellCompletion --cmd yr \
-        --bash <($out/bin/yr completion bash) \
-        --fish <($out/bin/yr completion fish) \
-        --zsh <($out/bin/yr completion zsh)
-    '';
 
   passthru.tests.version = testers.testVersion {
     package = yara-x;
@@ -58,5 +53,6 @@ rustPlatform.buildRustPackage rec {
       lesuisse
     ];
     mainProgram = "yr";
+    pkgConfigModules = [ "yara_x_capi" ];
   };
 }

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -73,6 +73,11 @@
         cargoSetupHook
         maturinBuildHook
         bindgenHook
+        cargoCSetupHook
+        cargoCBuildHook
+        cargoCCheckHook
+        cargoCInstallHook
+        cargoCFixupHook
         ;
     };
 })


### PR DESCRIPTION
This enables cargo-c support in `rustPlatform.buildRustPackage` through the `buildCAPI` and `buildCAPIOnly` attributes.

I considered the following alternatives:
- Standalone hook(s) for cargo-c,
- a wrapper around `buildRustPackage` using `lib.extendMkDerivation`.

I chose integration with `buildRustPackage` for the following reasons:

- Most Rust packages providing C libraries rely on `rustPlatform` infrastructure anyway,
- some packages provide both binaries (built with the regular Cargo build hooks) and C libraries,
- hooks cannot modify derivation attributes.

By default `buildCAPI` enables multiple outputs, separating libraries from development files to reduce closure size. It also enables hooks and pass‐through tests to check the installed pkg-config files.

Unless `dontDisableStatic` is enabled, only shared libraries are built. I considered separating static library archives into the `dev` output or a dedicated `static` output, but I haven’t figured out how to best deal with pkg-config in this case.

The `buildCAPIOnly` attributes overrides the default build, check and install phases, so that if enabled, the default Cargo build, check and install hooks are skipped.

The remaining commits enable use of `buildCAPI` in all packages using cargo-c. These can be split off into a separate PR if preferred.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
