### PR TITLE
Fix systemd-ssh changes

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -593,7 +593,6 @@ in
           environment.LD_LIBRARY_PATH = nssModulesPath;
 
           serviceConfig = {
-            Type = "notify";
             ExecStart = lib.concatStringsSep " " [
               "-${lib.getExe' cfg.package "sshd"}"
               "-i"
@@ -618,7 +617,6 @@ in
           restartTriggers = [ config.environment.etc."ssh/sshd_config".source ];
 
           serviceConfig = {
-            Type = "notify";
             Restart = "always";
             ExecStart = lib.concatStringsSep " " [
               (lib.getExe' cfg.package "sshd")

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -274,5 +274,8 @@ in {
             "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-no-pam true",
             timeout=30
         )
+
+    # None of the per-connection units should have failed.
+    server_lazy.fail("systemctl is-failed 'sshd@*.service'")
   '';
 })


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/372979 Introduced a few major problems.

1. The test required building a new ISO on every iteration. This is a significant storage cost for Hydra.
2. The test required nested virtualisation to work, which is not a given on our builder hardware.
3. Most importantly, it broke `sshd@.service`, because every SSH connection that closed resulted in its corresponding systemd unit entering a failed state. Not fatal to functionality, but makes the system considered degraded. There may have been an avenue for a DoS attack, though we didn't get that far examining it.

This no longer tests systemd-ssh's `AF_VSOCK` functionality. Unfortunately, without nested virtualisation, I'm not sure this is possible. In theory, you could use the host's vsock space, but `/dev/vhost-vsock` is not available in the sandbox, and you have to hard code a cid for the guest which will clash with others. I think you really do need nested virtualisation, unless qemu has a way to create a unix socket on the host that presents as vsock to the guest.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
