### PR TITLE
octoprint.plugins.bgcode: init at 0.2.0

### DIFF
--- a/pkgs/by-name/li/libbgcode/package.nix
+++ b/pkgs/by-name/li/libbgcode/package.nix
@@ -7,17 +7,17 @@
   heatshrink,
   zlib,
   boost,
-  catch2,
+  catch2_3,
 }:
 stdenv.mkDerivation {
   pname = "libbgcode";
-  version = "2023-11-16";
+  version = "2025-02-19";
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "libbgcode";
-    rev = "bc390aab4427589a6402b4c7f65cf4d0a8f987ec";
-    hash = "sha256-TZShYeDAh+fNdmTr1Xqctji9f0vEGpNZv1ba/IY5EoY=";
+    rev = "5041c093b33e2748e76d6b326f2251310823f3df";
+    hash = "sha256-EaxVZerH2v8b1Yqk+RW/r3BvnJvrAelkKf8Bd+EHbEc=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     heatshrink
     zlib
     boost
-    catch2
+    catch2_3
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -665,6 +665,26 @@ in
       maintainers = with maintainers; [ j0hax ];
     };
   };
+
+  bgcode = buildPlugin rec {
+    pname = "OctoPrint-BGCode";
+    version = "0.2.0";
+    src = fetchFromGitHub {
+      owner = "jneilliii";
+      repo = pname;
+      rev = "refs/tags/${version}";
+      hash = "sha256-LHK1LfYXAQV2GvWfG6AFf9haU9zcCP/fZB2UwKbm1i4=";
+    };
+
+    propagatedBuildInputs = with super; [ pybgcode ];
+
+    meta = with lib; {
+      description = "Binary Gcode support for Octoprint";
+      homepage = "https://github.com/jneilliii/OctoPrint-BGCode";
+      license = licenses.agpl3Plus;
+      maintainers = with maintainers; [ lach ];
+    };
+  };
 } // lib.optionalAttrs config.allowAliases {
   octoprint-dashboard = super.dashboard;
 }

--- a/pkgs/development/python-modules/py-build-cmake/0001-fix-relax-build-system-dependencies.patch
+++ b/pkgs/development/python-modules/py-build-cmake/0001-fix-relax-build-system-dependencies.patch
@@ -1,0 +1,52 @@
+From c46e4db9cf92b41092a3805549aad8b2e5f28987 Mon Sep 17 00:00:00 2001
+From: Lach <iam@lach.pw>
+Date: Sun, 16 Mar 2025 19:39:54 +0100
+Subject: [PATCH] fix: relax build-system dependencies
+
+Signed-off-by: Lach <iam@lach.pw>
+---
+ pyproject.toml | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 9413600..7ba178f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,10 +1,10 @@
+ [build-system]
+ requires = [
+-    "distlib~=0.3.5",
+-    "packaging>=23.2",
+-    "pyproject-metadata~=0.7.1",
+-    "tomli>=1.2.3,<3; python_version < '3.11'",
+-    "lark>=1.1.9,<2",
++    "distlib",
++    "packaging",
++    "pyproject-metadata",
++    "tomli",
++    "lark",
+ ]
+ build-backend = "py_build_cmake.build"
+ backend-path = ["src"]
+@@ -34,12 +34,12 @@ classifiers = [
+     "Operating System :: MacOS",
+ ]
+ dependencies = [
+-    "distlib~=0.3.5",
+-    "packaging>=23.2",
+-    "pyproject-metadata~=0.7.1",
+-    "tomli>=1.2.3,<3; python_version < '3.11'",
+-    "lark>=1.1.9,<2",
+-    "click~=8.1.3",
++    "distlib",
++    "packaging",
++    "pyproject-metadata",
++    "tomli",
++    "lark",
++    "click",
+ ]
+ dynamic = ["version", "description"]
+ 
+-- 
+2.48.1
+

--- a/pkgs/development/python-modules/py-build-cmake/default.nix
+++ b/pkgs/development/python-modules/py-build-cmake/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  pyproject-metadata,
+  setuptools,
+  distlib,
+  packaging,
+  tomli,
+  lark,
+  click,
+}:
+
+let
+  version = "0.4.2";
+
+  build-system = [
+    distlib
+    packaging
+    tomli
+    lark
+
+    setuptools
+    pyproject-metadata
+  ];
+in
+
+buildPythonPackage {
+  inherit version;
+  pname = "py-build-cmake";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "py_build_cmake";
+    hash = "sha256-AzAxm/VJPSldUdYK3rbmb4qx8N3ChPvY0LVAlHjssRE=";
+  };
+
+  patches = [
+    ./0001-fix-relax-build-system-dependencies.patch
+  ];
+
+  inherit build-system;
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = build-system ++ [
+    click
+  ];
+
+  meta = {
+    description = "A modern, PEP 517 compliant build backend for creating Python packages with extensions built using CMake.";
+    homepage = "https://github.com/tttapa/py-build-cmake";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lach ];
+  };
+}

--- a/pkgs/development/python-modules/pybgcode/0001-build-update-py-build-cmake-to-0.4.2.patch
+++ b/pkgs/development/python-modules/pybgcode/0001-build-update-py-build-cmake-to-0.4.2.patch
@@ -1,0 +1,67 @@
+From d7a608f82d902acdf0756422d6171c9fb1f935b1 Mon Sep 17 00:00:00 2001
+From: Lach <iam@lach.pw>
+Date: Sun, 16 Mar 2025 19:57:27 +0100
+Subject: [PATCH] build: update py-build-cmake to 0.4.2
+
+Signed-off-by: Lach <iam@lach.pw>
+---
+ pybgcode/CMakeLists.txt | 12 ++++++------
+ pyproject.toml          |  2 +-
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/pybgcode/CMakeLists.txt b/pybgcode/CMakeLists.txt
+index abfa3d9..f2fea43 100644
+--- a/pybgcode/CMakeLists.txt
++++ b/pybgcode/CMakeLists.txt
+@@ -30,10 +30,10 @@ set(PY_VERSION_SUFFIX "")
+ set(PY_FULL_VERSION ${PROJECT_VERSION}${PY_VERSION_SUFFIX})
+ 
+ # Make sure that the Python and CMake versions match
+-if (DEFINED PY_BUILD_CMAKE_PACKAGE_VERSION)
+-    if (NOT "${PY_BUILD_CMAKE_PACKAGE_VERSION}" MATCHES "^${PY_FULL_VERSION}$")
++if (DEFINED PY_BUILD_CMAKE_PROJECT_VERSION)
++    if (NOT "${PY_BUILD_CMAKE_PROJECT_VERSION}" MATCHES "^${PY_FULL_VERSION}$")
+         message(FATAL_ERROR "Version number does not match "
+-                             "(${PY_BUILD_CMAKE_PACKAGE_VERSION} - ${PY_FULL_VERSION}).")
++                             "(${PY_BUILD_CMAKE_PROJECT_VERSION} - ${PY_FULL_VERSION}).")
+     endif()
+ endif()
+ 
+@@ -58,18 +58,18 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+     target_link_options(_bgcode PRIVATE "LINKER:--exclude-libs,ALL")
+ endif()
+ 
+-if (PY_BUILD_CMAKE_MODULE_NAME)
++if (PY_BUILD_CMAKE_IMPORT_NAME)
+     # Install the Python module
+     install(TARGETS _bgcode
+             EXCLUDE_FROM_ALL
+             COMPONENT python_modules
+-            DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME})
++            DESTINATION ${PY_BUILD_CMAKE_IMPORT_NAME})
+     # Install the debug file for the Python module (Windows only)
+     if (WIN32)
+         install(FILES $<TARGET_PDB_FILE:_bgcode>
+                 EXCLUDE_FROM_ALL
+                 COMPONENT python_modules
+-                DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME}
++                DESTINATION ${PY_BUILD_CMAKE_IMPORT_NAME}
+                 OPTIONAL)
+     endif()
+ endif ()
+diff --git a/pyproject.toml b/pyproject.toml
+index 1a93b3b..d471059 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -19,7 +19,7 @@ requires-python = ">=3.7"
+ "Bug Tracker" = "https://github.com/prusa3d/libbgcode/issues"
+ 
+ [build-system]
+-requires = ["py-build-cmake~=0.1.8", "pytest"]
++requires = ["py-build-cmake~=0.4.2", "pytest"]
+ build-backend = "py_build_cmake.build"
+ 
+ [tool.py-build-cmake.module] # Where to find the Python module to package
+-- 
+2.48.1
+

--- a/pkgs/development/python-modules/pybgcode/default.nix
+++ b/pkgs/development/python-modules/pybgcode/default.nix
@@ -1,0 +1,33 @@
+{boost, cmake, heatshrink, libbgcode, buildPythonPackage, zlib, pybind11, py-build-cmake, pytest, git }:
+
+buildPythonPackage {
+  inherit (libbgcode) version src meta buildInputs;
+  pname = "pybgcode";
+  pyproject = true;
+
+  dontUseCmakeConfigure = true;
+  patches = [
+    ./0001-build-update-py-build-cmake-to-0.4.2.patch
+  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        "options = { \"PyBGCode_LINK_SYSTEM_LIBBGCODE\" = \"off\" }" \
+        "options = { \"PyBGCode_LINK_SYSTEM_LIBBGCODE\" = \"on\", \"LibBGCode_BUILD_DEPS\" = \"off\" }"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  build-system = [
+    py-build-cmake
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    libbgcode
+    pybind11
+  ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11749,6 +11749,8 @@ self: super: with self; {
 
   pybtex-docutils = callPackage ../development/python-modules/pybtex-docutils { };
 
+  py-build-cmake = callPackage ../development/python-modules/py-build-cmake { };
+
   pybullet = callPackage ../development/python-modules/pybullet { };
 
   pycairo = callPackage ../development/python-modules/pycairo {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10622,6 +10622,8 @@ self: super: with self; {
 
   pybars3 = callPackage ../development/python-modules/pybars3 { };
 
+  pybgcode = callPackage ../development/python-modules/pybgcode { };
+
   pyembroidery = callPackage ../development/python-modules/pyembroidery { };
 
   pymeta3 = callPackage ../development/python-modules/pymeta3 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://plugins.octoprint.org/plugins/bgcode/

Plugin allows for the upload and conversion of bgcode files introduced in PrusaSlicer version 2.7.0+. Upon upload of the file, it will still have the bgcode extension but will be an ascii formatted text file that can be streamed to the printer as a standard gcode file from OctoPrint.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
