### PR TITLE
lib.licenses.asl20-llvm: replace with separate llvm-exception

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -140,11 +140,6 @@ lib.mapAttrs mkLicense ({
     fullName = "Apache License 2.0";
   };
 
-  asl20-llvm = {
-    spdxId = "Apache-2.0 WITH LLVM-exception";
-    fullName = "Apache License 2.0 with LLVM Exceptions";
-  };
-
   bitstreamVera = {
     spdxId = "Bitstream-Vera";
     fullName = "Bitstream Vera Font License";
@@ -857,6 +852,11 @@ lib.mapAttrs mkLicense ({
   llgpl21 = {
     fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
     url = "https://opensource.franz.com/preamble.html";
+  };
+
+  llvm-exception = {
+    spdxId = "LLVM-exception";
+    fullName = "LLVM Exception"; # LLVM exceptions to the Apache 2.0 License
   };
 
   lppl1 = {

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -113,7 +113,10 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/Ericsson/codechecker";
     changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${version}";
     description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
-    license = licenses.asl20-llvm;
+    license = with licenses; [
+      asl20
+      llvm-exception
+    ];
     maintainers = with maintainers; [
       zebreus
       felixsinger

--- a/pkgs/by-name/en/enzyme/package.nix
+++ b/pkgs/by-name/en/enzyme/package.nix
@@ -44,6 +44,9 @@ llvmPackages.stdenv.mkDerivation rec {
     description = "High-performance automatic differentiation of LLVM and MLIR";
     maintainers = with lib.maintainers; [ kiranshila ];
     platforms = lib.platforms.all;
-    license = lib.licenses.asl20-llvm;
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
   };
 }

--- a/pkgs/by-name/ko/kokkos/package.nix
+++ b/pkgs/by-name/ko/kokkos/package.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ Performance Portability Programming EcoSystem";
     homepage = "https://github.com/kokkos/kokkos";
     changelog = "https://github.com/kokkos/kokkos/blob/${finalAttrs.src.rev}/CHANGELOG.md";
-    license = with licenses; [ asl20-llvm ];
+    license = with licenses; [
+      asl20
+      llvm-exception
+    ];
     maintainers = with maintainers; [ Madouura ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/li/libabigail/package.nix
+++ b/pkgs/by-name/li/libabigail/package.nix
@@ -58,7 +58,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "ABI Generic Analysis and Instrumentation Library";
     homepage = "https://sourceware.org/libabigail/";
-    license = licenses.asl20-llvm;
+    license = with licenses; [
+      asl20
+      llvm-exception
+    ];
     maintainers = [ ];
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -144,7 +144,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "A shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion";
     homepage = "https://github.com/shader-slang/slang";
-    license = lib.licenses.asl20-llvm;
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
     maintainers = with lib.maintainers; [ niklaskorz ];
     mainProgram = "slangc";
     platforms = lib.platforms.all;

--- a/pkgs/development/compilers/llvm/common/common-let.nix
+++ b/pkgs/development/compilers/llvm/common/common-let.nix
@@ -10,9 +10,9 @@
 rec {
   llvm_meta = {
     license = with lib.licenses; [ ncsa ] ++
-      # Contributions after June 1st, 2024 are only licensed under asl20-llvm:
-      # https://github.com/llvm/llvm-project/pull/92394
-      lib.optional (lib.versionAtLeast release_version "19") asl20-llvm;
+      # Contributions after June 1st, 2024 are only licensed under asl20 and
+      # llvm-exception: https://github.com/llvm/llvm-project/pull/92394
+      lib.optionals (lib.versionAtLeast release_version "19") [ asl20 llvm-exception ];
     maintainers = lib.teams.llvm.members;
 
     # See llvm/cmake/config-ix.cmake.

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -72,7 +72,8 @@ stdenv.mkDerivation {
       rvolosatovs
     ];
     license = with licenses; [
-      asl20-llvm
+      asl20
+      llvm-exception
       mit
     ];
   };


### PR DESCRIPTION
This essentially reverts 7ce8e7c4cf90492a631e96bcfe70724104914381

asl20-llvm does not produce a valid SPDX ID, it produces a valid SPDX Expression. However, this is not what the spdxId field promises.

This is relevant because we cannot produce valid SBOMs (e.g. CycloneDX) using this field as the schemas for these SBOMs check that the IDs are valid.

This change leaves us with consistently valid SPDX IDs at the cost of slightly less convenience.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
