### PR TITLE
nixos/snips-sh: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1681,6 +1681,7 @@
   ./services/web-apps/simplesamlphp.nix
   ./services/web-apps/slskd.nix
   ./services/web-apps/snipe-it.nix
+  ./services/web-apps/snips-sh.nix
   ./services/web-apps/sogo.nix
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix

--- a/nixos/modules/services/web-apps/snips-sh.nix
+++ b/nixos/modules/services/web-apps/snips-sh.nix
@@ -1,0 +1,159 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mapAttrs
+    optional
+    boolToString
+    isBool
+    mkIf
+    getExe
+    types
+    ;
+
+  cfg = config.services.snips-sh;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    isabelroses
+    NotAShelf
+  ];
+
+  options.services.snips-sh = {
+    enable = mkEnableOption "snips.sh";
+
+    package = mkPackageOption pkgs "snips-sh" {
+      example = "pkgs.snips-sh.override {withTensorflow = true;}";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/snips-sh";
+      description = "The state directory of the service.";
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (
+          types.nullOr (
+            types.oneOf [
+              types.str
+              types.int
+              types.bool
+            ]
+          )
+        );
+
+        options = {
+          SNIPS_HTTP_INTERNAL = mkOption {
+            type = types.str;
+            description = "The internal HTTP address of the service";
+          };
+
+          SNIPS_SSH_INTERNAL = mkOption {
+            type = types.str;
+            description = "The internal SSH address of the service";
+          };
+        };
+      };
+
+      default = { };
+      example = {
+        SNIPS_HTTP_INTERNAL = "http://0.0.0.0:8080";
+        SNIPS_SSH_INTERNAL = "ssh://0.0.0.0:2222";
+      };
+
+      description = ''
+        The configuration of snips-sh is done through environment variables,
+        therefore you must use upper snake case (e.g. {env}`SNIPS_HTTP_INTERNAL`).
+
+        Based on the attributes passed to this config option an environment file will be generated
+        that is passed to snips-sh's systemd service.
+
+        The available configuration options can be found in
+        [self-hosting guide](https://github.com/robherley/snips.sh/blob/main/docs/self-hosting.md#configuration) to
+        find about the environment variables you can use.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      example = "/etc/snips-sh.env";
+      description = ''
+        Additional environment file as defined in {manpage}`systemd.exec(5)`.
+
+        Sensitive secrets such as {env}`SNIPS_SSH_HOSTKEYPATH` and {env}`SNIPS_METRICS_STATSD`
+        may be passed to the service while avoiding potentially making them world-readable in the nix store or
+        to convert an existing non-nix installation with minimum hassle.
+
+        Note that this file needs to be available on the host on which
+        `snips-sh` is running.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd = {
+      tmpfiles.settings."10-snips-sh" = {
+        "${cfg.stateDir}/data".D = {
+          mode = "0755";
+        };
+      };
+
+      services.snips-sh = {
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = mapAttrs (_: v: if isBool v then boolToString v else toString v) cfg.settings;
+
+        serviceConfig = {
+          EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+          ExecStart = getExe cfg.package;
+          LimitNOFILE = "1048576";
+          AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+          WorkingDirectory = cfg.stateDir;
+          RuntimeDirectory = "snips-sh";
+          StateDirectory = "snips-sh";
+          StateDirectoryMode = "0700";
+          Restart = "always";
+
+          # hardening
+          DynamicUser = true;
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictSUIDSGID = true;
+          SystemCallFilter = "@system-service";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+          RemoveIPC = true;
+        };
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1335,6 +1335,7 @@ in
   snapcast = runTest ./snapcast.nix;
   snapper = runTest ./snapper.nix;
   snipe-it = runTest ./web-apps/snipe-it.nix;
+  snips-sh = runTest ./snips-sh.nix;
   soapui = runTest ./soapui.nix;
   soft-serve = runTest ./soft-serve.nix;
   sogo = runTest ./sogo.nix;

--- a/nixos/tests/snips-sh.nix
+++ b/nixos/tests/snips-sh.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+{
+  name = "snips-sh";
+
+  nodes.machine = {
+    services.snips-sh = {
+      enable = true;
+      settings = {
+        SNIPS_HTTP_INTERNAL = "http://0.0.0.0:8080";
+        SNIPS_SSH_INTERNAL = "ssh://0.0.0.0:2222";
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("snips-sh.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl --fail http://localhost:8080")
+  '';
+
+  meta.maintainers = with lib.maintainers; [
+    isabelroses
+    NotAShelf
+  ];
+}

--- a/pkgs/by-name/sn/snips-sh/package.nix
+++ b/pkgs/by-name/sn/snips-sh/package.nix
@@ -5,6 +5,7 @@
   sqlite,
   libtensorflow,
   withTensorflow ? false,
+  nixosTests,
 }:
 buildGoModule rec {
   pname = "snips-sh";
@@ -21,6 +22,8 @@ buildGoModule rec {
   tags = (lib.optional (!withTensorflow) "noguesser");
 
   buildInputs = [ sqlite ] ++ (lib.optional withTensorflow libtensorflow);
+
+  passthru.tests = nixosTests.snips-sh;
 
   meta = {
     description = "Passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI";


### PR DESCRIPTION
Adds a nixos module for https://snips.sh

supersedes https://github.com/NixOS/nixpkgs/pull/372029

Compared to the original I took a approach where I used a freefrom module similar to https://github.com/NixOS/nixpkgs/pull/350645. And dropped the camel casing stuff that complicated things.

I also converted the tests to `runTest`

@NotAShelf would you like to be included as a maintainer as the maker of the original PR?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
