### PR TITLE
Fix #385012

### DIFF
--- a/pkgs/development/coq-modules/jasmin/default.nix
+++ b/pkgs/development/coq-modules/jasmin/default.nix
@@ -16,11 +16,12 @@ mkCoqDerivation {
   defaultVersion =
     with lib.versions;
     lib.switch [ coq.version mathcomp.version ] [
-      { cases = [ (range "8.18" "8.20") (range "2.2" "2.3") ];
-        out = "2024.07.2"; }
+      { cases = [ (range "8.19" "8.20") (range "2.2" "2.3") ]; out = "2024.07.3"; }
+      { cases = [ (isEq "8.18") (isEq "2.2") ]; out = "2024.07.2"; }
     ] null;
   releaseRev = v: "v${v}";
 
+  release."2024.07.3".sha256 = "sha256-n/X8d7ILuZ07l24Ij8TxbQzAG7E8kldWFcUI65W4r+c=";
   release."2024.07.2".sha256 = "sha256-aF8SYY5jRxQ6iEr7t6mRN3BEmIDhJ53PGhuZiJGB+i8=";
 
   propagatedBuildInputs = [

--- a/pkgs/development/coq-modules/jasmin/default.nix
+++ b/pkgs/development/coq-modules/jasmin/default.nix
@@ -16,11 +16,12 @@ mkCoqDerivation {
   defaultVersion =
     with lib.versions;
     lib.switch [ coq.version mathcomp.version ] [
-      { cases = [ (range "8.19" "8.20") (range "2.2" "2.3") ]; out = "2024.07.3"; }
+      { cases = [ (range "8.19" "9.0") (range "2.2" "2.3") ]; out = "2025.02.0"; }
       { cases = [ (isEq "8.18") (isEq "2.2") ]; out = "2024.07.2"; }
     ] null;
   releaseRev = v: "v${v}";
 
+  release."2025.02.0".sha256 = "sha256-Jlf0+VPuYWXdWyKHKHSp7h/HuCCp4VkcrgDAmh7pi5s=";
   release."2024.07.3".sha256 = "sha256-n/X8d7ILuZ07l24Ij8TxbQzAG7E8kldWFcUI65W4r+c=";
   release."2024.07.2".sha256 = "sha256-aF8SYY5jRxQ6iEr7t6mRN3BEmIDhJ53PGhuZiJGB+i8=";
 

--- a/pkgs/development/coq-modules/jasmin/default.nix
+++ b/pkgs/development/coq-modules/jasmin/default.nix
@@ -17,11 +17,11 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch [ coq.version mathcomp.version ] [
       { cases = [ (range "8.18" "8.20") (range "2.2" "2.3") ];
-        out = "2025.02.0"; }
+        out = "2024.07.2"; }
     ] null;
   releaseRev = v: "v${v}";
 
-  release."2025.02.0".sha256 = "sha256-Jlf0+VPuYWXdWyKHKHSp7h/HuCCp4VkcrgDAmh7pi5s=";
+  release."2024.07.2".sha256 = "sha256-aF8SYY5jRxQ6iEr7t6mRN3BEmIDhJ53PGhuZiJGB+i8=";
 
   propagatedBuildInputs = [
     mathcomp-algebra-tactics


### PR DESCRIPTION
Tested: https://github.com/coq-community/coq-nix-toolbox/pull/336

cc @wolfgangwalther.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
