### PR TITLE
vimPlugins: inherit lua & node packages before overrides

### DIFF
--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -24,6 +24,11 @@ let
     inherit (neovimUtils) buildNeovimPlugin;
   };
 
+  extras = callPackage ./extras.nix {
+    inherit buildVimPlugin;
+    inherit (neovimUtils) buildNeovimPlugin;
+  };
+
   # TL;DR
   # * Add your plugin to ./vim-plugin-names
   # * run ./update.py
@@ -36,9 +41,11 @@ let
   };
 
   aliases = if config.allowAliases then (import ./aliases.nix lib) else final: prev: { };
-
-  extensible-self = lib.makeExtensible (
-    extends aliases (extends overrides (extends plugins initialPackages))
-  );
 in
-extensible-self
+lib.pipe initialPackages [
+  (extends plugins)
+  (extends extras)
+  (extends overrides)
+  (extends aliases)
+  lib.makeExtensible
+]

--- a/pkgs/applications/editors/vim/plugins/extras.nix
+++ b/pkgs/applications/editors/vim/plugins/extras.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  buildVimPlugin,
+  buildNeovimPlugin,
+  nodePackages,
+  neovim-unwrapped,
+}:
+let
+  luaPackages = neovim-unwrapped.lua.pkgs;
+in
+self: super:
+(
+  let
+    nodePackageNames = [
+      "coc-cmake"
+      "coc-docker"
+      "coc-emmet"
+      "coc-eslint"
+      "coc-explorer"
+      "coc-flutter"
+      "coc-git"
+      "coc-go"
+      "coc-haxe"
+      "coc-highlight"
+      "coc-html"
+      "coc-java"
+      "coc-jest"
+      "coc-json"
+      "coc-lists"
+      "coc-ltex"
+      "coc-markdownlint"
+      "coc-pairs"
+      "coc-prettier"
+      "coc-r-lsp"
+      "coc-rls"
+      "coc-rust-analyzer"
+      "coc-sh"
+      "coc-smartf"
+      "coc-snippets"
+      "coc-solargraph"
+      "coc-spell-checker"
+      "coc-sqlfluff"
+      "coc-stylelint"
+      "coc-sumneko-lua"
+      "coc-tabnine"
+      "coc-texlab"
+      "coc-tsserver"
+      "coc-ultisnips"
+      "coc-vetur"
+      "coc-vimlsp"
+      "coc-vimtex"
+      "coc-wxml"
+      "coc-yaml"
+      "coc-yank"
+    ];
+    nodePackage2VimPackage =
+      name:
+      buildVimPlugin {
+        pname = name;
+        inherit (nodePackages.${name}) version meta;
+        src = "${nodePackages.${name}}/lib/node_modules/${name}";
+      };
+  in
+  lib.genAttrs nodePackageNames nodePackage2VimPackage
+)
+// (
+  let
+    luarocksPackageNames = [
+      "fidget-nvim"
+      "gitsigns-nvim"
+      "image-nvim"
+      "lsp-progress-nvim"
+      "lualine-nvim"
+      "luasnip"
+      "lush-nvim"
+      "lz-n"
+      "lze"
+      "lzextras"
+      "lzn-auto-require"
+      "middleclass"
+      "mini-test"
+      "neorg"
+      "neotest"
+      "nui-nvim"
+      "nvim-cmp"
+      "nvim-nio"
+      "nvim-web-devicons"
+      "oil-nvim"
+      "orgmode"
+      "papis-nvim"
+      "rest-nvim"
+      "rocks-config-nvim"
+      "rtp-nvim"
+      "telescope-manix"
+      "telescope-nvim"
+    ];
+    toVimPackage =
+      name:
+      buildNeovimPlugin {
+        luaAttr = luaPackages.${name};
+      };
+  in
+  lib.genAttrs luarocksPackageNames toVimPackage
+)

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1281,6 +1281,7 @@ in
     dependencies = [ self.plenary-nvim ];
   };
 
+  # NOTE: this overrides a luaPackages-based plugin
   gitsigns-nvim = super.gitsigns-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };
@@ -1421,6 +1422,7 @@ in
     doInstallCheck = true;
   };
 
+  # NOTE: this overrides a luaPackages-based plugin
   image-nvim = super.image-nvim.overrideAttrs {
     dependencies = with self; [
       nvim-treesitter
@@ -1683,6 +1685,7 @@ in
     dependencies = [ self.lualine-nvim ];
   };
 
+  # NOTE: this overrides a luaPackages-based plugin
   luasnip = super.luasnip.overrideAttrs {
     dependencies = [ luaPackages.jsregexp ];
   };
@@ -1949,6 +1952,7 @@ in
     ];
   };
 
+  # NOTE: this overrides a luaPackages-based plugin
   neotest = super.neotest.overrideAttrs {
     dependencies = with self; [
       nvim-nio
@@ -2838,6 +2842,7 @@ in
   };
 
   # needs  "http" and "json" treesitter grammars too
+  # NOTE: this overrides a luaPackages-based plugin
   rest-nvim = super.rest-nvim.overrideAttrs {
     dependencies = with self; [
       plenary-nvim
@@ -3225,6 +3230,7 @@ in
     dependencies = [ self.plenary-nvim ];
   };
 
+  # NOTE: this overrides a luaPackages-based plugin
   telescope-nvim = super.telescope-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
   };
@@ -3988,101 +3994,6 @@ in
     '';
 
   };
-}
-// (
-  let
-    nodePackageNames = [
-      "coc-cmake"
-      "coc-docker"
-      "coc-emmet"
-      "coc-eslint"
-      "coc-explorer"
-      "coc-flutter"
-      "coc-git"
-      "coc-go"
-      "coc-haxe"
-      "coc-highlight"
-      "coc-html"
-      "coc-java"
-      "coc-jest"
-      "coc-json"
-      "coc-lists"
-      "coc-ltex"
-      "coc-markdownlint"
-      "coc-pairs"
-      "coc-prettier"
-      "coc-r-lsp"
-      "coc-rls"
-      "coc-rust-analyzer"
-      "coc-sh"
-      "coc-smartf"
-      "coc-snippets"
-      "coc-solargraph"
-      "coc-spell-checker"
-      "coc-sqlfluff"
-      "coc-stylelint"
-      "coc-sumneko-lua"
-      "coc-tabnine"
-      "coc-texlab"
-      "coc-tsserver"
-      "coc-ultisnips"
-      "coc-vetur"
-      "coc-vimlsp"
-      "coc-vimtex"
-      "coc-wxml"
-      "coc-yaml"
-      "coc-yank"
-    ];
-    nodePackage2VimPackage =
-      name:
-      buildVimPlugin {
-        pname = name;
-        inherit (nodePackages.${name}) version meta;
-        src = "${nodePackages.${name}}/lib/node_modules/${name}";
-      };
-  in
-  lib.genAttrs nodePackageNames nodePackage2VimPackage
-)
-// (
-  let
-    luarocksPackageNames = [
-      "fidget-nvim"
-      "gitsigns-nvim"
-      "image-nvim"
-      "lsp-progress-nvim"
-      "lualine-nvim"
-      "luasnip"
-      "lush-nvim"
-      "lz-n"
-      "lze"
-      "lzextras"
-      "lzn-auto-require"
-      "middleclass"
-      "mini-test"
-      "neorg"
-      "neotest"
-      "nui-nvim"
-      "nvim-cmp"
-      "nvim-nio"
-      "nvim-web-devicons"
-      "oil-nvim"
-      "orgmode"
-      "papis-nvim"
-      "rest-nvim"
-      "rocks-config-nvim"
-      "rtp-nvim"
-      "telescope-manix"
-      "telescope-nvim"
-    ];
-    toVimPackage =
-      name:
-      neovimUtils.buildNeovimPlugin {
-        luaAttr = luaPackages.${name};
-      };
-  in
-  lib.genAttrs luarocksPackageNames toVimPackage
-)
-// {
 
   rocks-nvim =
     (neovimUtils.buildNeovimPlugin {


### PR DESCRIPTION
I noticed that since https://github.com/NixOS/nixpkgs/pull/377508 vimPlugins overrides are not being applied to plugins that are now based on luaPackages.

- Move lua & node package inheritance to a dedicated file
- Apply lua & node package inheritance before overrides
- Simplify impl using `lib.pipe`

I've added some `NOTE` comments to each of the plugins with overrides affected by this PR, hopefully this'll aid the review. My assumption is that these overrides are still relevant even after https://github.com/NixOS/nixpkgs/pull/377508. I can remove these comments if you think they aren't needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
