### PR TITLE
root: 6.34.08 -> 6.36.00

### DIFF
--- a/pkgs/by-name/ro/root/Fix-find_package-LLVM-overwriting-LLVM_LINK_LLVM_DYLIB.patch
+++ b/pkgs/by-name/ro/root/Fix-find_package-LLVM-overwriting-LLVM_LINK_LLVM_DYLIB.patch
@@ -1,0 +1,55 @@
+From a4ed1625ee4e74c4e8664742165d6a485b737d57 Mon Sep 17 00:00:00 2001
+From: Jonas Rembser <jonas.rembser@cern.ch>
+Date: Tue, 22 Apr 2025 12:36:46 +0200
+Subject: [PATCH] Work around find_package(LLVM) overwriting
+ LLVM_LINK_LLVM_DYLIB
+
+---
+ clang/CMakeLists.txt          | 10 ++++++++++
+ .../clang/cmake/modules/ClangConfig.cmake.in           |  6 ++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/clang/CMakeLists.txt b/clang/CMakeLists.txt
+index 5f2b7f064d..a9581d081e 100644
+--- a/clang/CMakeLists.txt
++++ b/clang/CMakeLists.txt
+@@ -28,7 +28,17 @@ if(CLANG_BUILT_STANDALONE)
+     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
+   endif()
+ 
++  # Remember current value of LLVM_LINK_LLVM_DYLIB and reset later, because
++  # find_package(LLVM) is overwriting it without a good reason. See:
++  # https://github.com/llvm/llvm-project/pull/135570
++  if(DEFINED LLVM_LINK_LLVM_DYLIB)
++    set(llvm_link_llvm_dylib ${LLVM_LINK_LLVM_DYLIB})
++  endif()
+   find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_DIR}")
++  if(DEFINED llvm_link_llvm_dylib)
++    set(LLVM_LINK_LLVM_DYLIB ${llvm_link_llvm_dylib})
++  endif()
++
+   list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
+ 
+   # Turn into CACHE PATHs for overwritting
+diff --git a/clang/cmake/modules/ClangConfig.cmake.in b/clang/cmake/modules/ClangConfig.cmake.in
+index 5f67681649..36a34ddab2 100644
+--- a/clang/cmake/modules/ClangConfig.cmake.in
++++ b/clang/cmake/modules/ClangConfig.cmake.in
+@@ -3,8 +3,14 @@
+ @CLANG_CONFIG_CODE@
+ 
+ set(LLVM_VERSION @LLVM_VERSION_MAJOR@.@LLVM_VERSION_MINOR@.@LLVM_VERSION_PATCH@)
++
++# ROOT calls find_package(LLVM) before find_package(Clang), and
++# find_package(LLVM) is overwriting LLVM_LINK_LLVM_DYLIB without a good
++# reason. See: https://github.com/llvm/llvm-project/pull/135570
++# So we need to set it to what it needs to be for ROOT.
+ find_package(LLVM ${LLVM_VERSION} EXACT REQUIRED CONFIG
+              HINTS "@CLANG_CONFIG_LLVM_CMAKE_DIR@")
++set(LLVM_LINK_LLVM_DYLIB OFF)
+ 
+ set(CLANG_EXPORTED_TARGETS "@CLANG_EXPORTS@")
+ set(CLANG_CMAKE_DIR "@CLANG_CONFIG_CMAKE_DIR@")
+-- 
+2.49.0
+

--- a/pkgs/by-name/ro/root/clang-root.nix
+++ b/pkgs/by-name/ro/root/clang-root.nix
@@ -1,0 +1,58 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  apple-sdk,
+  cmake,
+  git,
+  llvm_18,
+  pkg-config,
+  python3,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clang-root";
+  version = "18-20250506-01";
+
+  src = fetchgit {
+    url = "https://github.com/root-project/llvm-project";
+    rev = "refs/tags/ROOT-llvm${version}";
+    hash = "sha256-8tviNWNmvIJhxF4j9Z7zMnjltTX0Ka2fN9HIgLfNAco=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    git
+  ];
+  buildInputs = [
+    llvm_18
+    python3
+  ];
+
+  patches = [
+    ./Fix-find_package-LLVM-overwriting-LLVM_LINK_LLVM_DYLIB.patch
+  ];
+
+  preConfigure = ''
+    cd clang
+  '';
+
+  cmakeFlags =
+    [
+      "-DCLANG_BUILD_TOOLS=OFF"
+      "-DCLANG_ENABLE_ARCMT=OFF"
+      "-DCLANG_ENABLE_STATIC_ANALYZER=OFF"
+      "-DCLANG_LINK_CLANG_DYLIB=OFF"
+      "-DC_INCLUDE_DIRS=${lib.getDev stdenv.cc.libc}/include"
+      "-DLLVM_INCLUDE_TESTS=OFF"
+      "-DLLVM_LINK_LLVM_DYLIB=OFF"
+      "-DLLVM_MAIN_SRC_DIR=${llvm_18.src}"
+    ]
+    ++ (
+      if stdenv.hostPlatform.isDarwin then
+        [ "-DC_INCLUDE_DIRS=${apple-sdk.sdkroot}/usr/include" ]
+      else
+        lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${lib.getDev stdenv.cc.libc}/include"
+    );
+}

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -2,7 +2,8 @@
   stdenv,
   lib,
   callPackage,
-  fetchgit,
+  fetchFromGitHub,
+  fetchpatch,
   fetchurl,
   makeWrapper,
   writeText,
@@ -51,7 +52,7 @@
 
 stdenv.mkDerivation rec {
   pname = "root";
-  version = "6.34.08";
+  version = "6.36.00";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
@@ -59,16 +60,20 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    hash = "sha256-gGBFsVbeA/6PVmGmcOq4d/Lk0tpsI03D4x6Y4tfZb+g=";
+    hash = "sha256-lK/I3vkoQmeaEwonUhvmbiq9qjdiCIjmHYKKQ/xLAaI=";
   };
 
-  clad_src = fetchgit {
-    url = "https://github.com/vgvassilev/clad";
+  clad_src = fetchFromGitHub {
+    owner = "vgvassilev";
+    repo = "clad";
     # Make sure that this is the same tag as in the ROOT build files!
     # https://github.com/root-project/root/blob/master/interpreter/cling/tools/plugins/clad/CMakeLists.txt#L76
-    rev = "refs/tags/v1.7";
-    hash = "sha256-iKrZsuUerrlrjXBrxcTsFu/t0Pb0sa4UlfSwd1yhg3g=";
+    rev = "refs/tags/v1.9";
+    hash = "sha256-TKCRAfwdTp/uDH7rk9EE4z2hwqBybklHhhYH6hQFYpg=";
   };
+
+  # ROOT requires a patched version of clang
+  clang = (callPackage ./clang-root.nix { });
 
   nativeBuildInputs = [
     makeWrapper
@@ -81,6 +86,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs =
     [
+      clang
       davix
       fftw
       ftgl
@@ -118,6 +124,20 @@ stdenv.mkDerivation rec {
       xorg.libXext
     ];
 
+  patches = [
+    # Backport that can be removed once ROOT is updated to 6.38.00
+    (fetchpatch {
+      url = "https://github.com/root-project/root/commit/8f21acb893977bc651a4c4fe5c4fa020a48d31de.patch";
+      hash = "sha256-xo3BbaJRyW4Wy2eVuX1bY3FFH7Jm3vN2ZojMsVNIK2I=";
+    })
+    # Revert because it introduces usage of the xcrun executable from xcode:
+    (fetchpatch {
+      url = "https://github.com/root-project/root/commit/6bd0dbad38bb524491c5109bc408942246db8b50.patch";
+      hash = "sha256-D7LZWJnGF9DtKcM8EF3KILU81cqTcZolW+HMe3fmXTw=";
+      revert = true;
+    })
+  ];
+
   preConfigure =
     ''
       for path in builtins/*; do
@@ -127,9 +147,6 @@ stdenv.mkDerivation rec {
       done
       substituteInPlace cmake/modules/SearchInstalledSoftware.cmake \
         --replace-fail 'set(lcgpackages ' '#set(lcgpackages '
-
-      substituteInPlace interpreter/llvm-project/clang/tools/driver/CMakeLists.txt \
-        --replace-fail 'add_clang_symlink(''${link} clang)' ""
 
       patchShebangs cmake/unix/
     ''
@@ -151,20 +168,17 @@ stdenv.mkDerivation rec {
       "-DCMAKE_INSTALL_BINDIR=bin"
       "-DCMAKE_INSTALL_INCLUDEDIR=include"
       "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DClang_DIR=${clang}/lib/cmake/clang"
+      "-Dbuiltin_clang=OFF"
       "-Dbuiltin_llvm=OFF"
       "-Dfail-on-missing=ON"
       "-Dfftw3=ON"
       "-Dfitsio=OFF"
       "-Dgnuinstall=ON"
       "-Dmathmore=ON"
-      "-Dmysql=OFF"
-      "-Dpgsql=OFF"
       "-Dsqlite=OFF"
       "-Dvdt=OFF"
     ]
-    ++ lib.optional (
-      (!stdenv.hostPlatform.isDarwin) && (stdenv.cc.libc != null)
-    ) "-DC_INCLUDE_DIRS=${lib.getDev stdenv.cc.libc}/include"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # fatal error: module map file '/nix/store/<hash>-Libsystem-osx-10.12.6/include/module.modulemap' not found
       # fatal error: could not build module '_Builtin_intrinsics'


### PR DESCRIPTION
Also, factorize the `root` derivation such that the patched clang version is built separately, and then ROOT is built on top of it. This will be very helpful for ROOT developers, because then it's possible to produce local development builds on top of the `root.clang`.

FYI, @veprbl.