### PR TITLE
cppadcodegen: init at 2.5.0, python3Packages.pycppad: init at 1.2.4, pinocchio: add cppadcodegen support, eigenpy: clean, coal: clean

### DIFF
--- a/pkgs/by-name/co/coal/package.nix
+++ b/pkgs/by-name/co/coal/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   boost,
   eigen,
+  fontconfig,
   jrl-cmakemodules,
   assimp,
   octomap,
@@ -23,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
@@ -44,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "COAL_HAS_QHULL" true)
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;
@@ -57,6 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput share/ament_index "$dev"
     moveToOutput share/coal "$dev"
   '';
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
   meta = {
     description = "Collision Detection Library, previously hpp-fcl";

--- a/pkgs/by-name/cp/cppadcodegen/package.nix
+++ b/pkgs/by-name/cp/cppadcodegen/package.nix
@@ -1,0 +1,245 @@
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+  fetchpatch,
+
+  # nativeBuildInputs
+  cmake,
+  ctestCheckHook,
+  doxygen,
+  graphviz,
+  pkg-config,
+  texlive,
+  writableTmpDirAsHomeHook,
+
+  # propagatedBuildInputs
+  cppad,
+  eigen,
+
+  # buildInputs
+  adolc,
+  llvmPackages,
+  makeFontsConf,
+
+  # checkInputs
+  gtest,
+  valgrind,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cppadcodegen";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "joaoleal";
+    repo = "CppADCodeGen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-na8o+bqzign2nSk5AQdkIVQm3CIb0oFqEneGnYKQDyg=";
+  };
+
+  # get rid of annoying "#warning _FORTIFY_SOURCE requires compiling with optimization (-O) "
+  postPatch = ''
+    substituteInPlace \
+      test/CMakeLists.txt \
+      test/cppad/cg/dae_index_reduction/CMakeLists.txt \
+      test/cppad/cg/evaluator/adolc/CMakeLists.txt \
+      test/cppad/cg/evaluator/cg/CMakeLists.txt \
+      test/cppad/cg/evaluator/CMakeLists.txt \
+      test/cppad/cg/model/lang/c/CMakeLists.txt \
+      test/cppad/cg/model/lang/dot/CMakeLists.txt \
+      test/cppad/cg/model/lang/latex/CMakeLists.txt \
+      test/cppad/cg/model/lang/mathml/CMakeLists.txt \
+      test/cppad/cg/models/CMakeLists.txt \
+      test/cppad/cg/patterns/CMakeLists.txt \
+      test/cppad/cg/solve/CMakeLists.txt \
+      --replace-quiet \
+        "SET(CMAKE_BUILD_TYPE DEBUG)" \
+        "SET(CMAKE_BUILD_TYPE RELWITHDEBINFO)"
+  '';
+
+  patches = [
+    # Use gtest from nixpkgs instead of downloading it from github
+    # ref https://github.com/joaoleal/CppADCodeGen/pull/90
+    # This was merged upstream and can be removed on next release
+    (fetchpatch {
+      name = "use-system-gtest.patch";
+      url = "https://github.com/joaoleal/CppADCodeGen/commit/80430a64e863ed09c2293db5408998089ef8afcb.patch";
+      hash = "sha256-vSn+T+sCHOCYzjVZgKQuVBXm2dpzgJlYxU/q3Yv3b3c=";
+    })
+  ];
+
+  outputs = [
+    "doc"
+    "out"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ctestCheckHook
+    doxygen
+    graphviz
+    pkg-config
+    texlive.combined.scheme-basic
+    writableTmpDirAsHomeHook
+  ];
+  propagatedBuildInputs = [
+    cppad
+    eigen
+  ];
+  buildInputs = [
+    adolc
+    llvmPackages.clang
+    llvmPackages.libclang
+    llvmPackages.llvm
+  ];
+  checkInputs = [
+    gtest
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux valgrind;
+
+  disabledTests = [
+    # never ending
+    "dynamiclib_pthreadpool_memcheck"
+
+    # failed / aborted / segfault
+    # that is a lot, but 145 are still OK
+    "abs"
+    "abs_memcheck"
+    "acos"
+    "acos_memcheck"
+    "acosh"
+    "acosh_memcheck"
+    "add"
+    "add_memcheck"
+    "asin"
+    "asin_memcheck"
+    "asinh"
+    "asinh_memcheck"
+    "assign"
+    "assign_memcheck"
+    "atan"
+    "atan_memcheck"
+    "atan_2"
+    "atan_2_memcheck"
+    "atanh"
+    "atanh_memcheck"
+    "cond_exp"
+    "cond_exp_memcheck"
+    "cos"
+    "cos_memcheck"
+    "cosh"
+    "cosh_memcheck"
+    "div"
+    "div_memcheck"
+    "erf"
+    "erf_memcheck"
+    "erfc"
+    "erfc_memcheck"
+    "exp"
+    "exp_memcheck"
+    "expm1"
+    "expm1_memcheck"
+    "log"
+    "log_memcheck"
+    "log1p"
+    "log1p_memcheck"
+    "log_10"
+    "log_10_memcheck"
+    "mul"
+    "mul_memcheck"
+    "parameter"
+    "parameter_memcheck"
+    "pow"
+    "pow_memcheck"
+    "sin"
+    "sin_memcheck"
+    "sub"
+    "sub_memcheck"
+    "tan"
+    "tan_memcheck"
+    "unary"
+    "unary_memcheck"
+    "cstr"
+    "cstr_memcheck"
+    "cstr_2"
+    "cstr_2_memcheck"
+    "dynamic_atomic_cstr"
+    "dynamic_atomic_cstr_memcheck"
+    "dynamic_atomic_cstr_nested"
+    "dynamic_atomic_cstr_nested_memcheck"
+    "dynamic"
+    "dynamic_memcheck"
+    "cg_atomic_generic_model"
+    "cg_atomic_generic_model_memcheck"
+    "dynamic_atomic"
+    "dynamic_atomic_memcheck"
+    "dynamic_atomic_2"
+    "dynamic_atomic_2_memcheck"
+    "dynamic_atomic_3"
+    "dynamic_atomic_3_memcheck"
+    "dynamic_cond_exp"
+    "dynamic_cond_exp_memcheck"
+    "dynamic_forward_reverse"
+    "dynamic_forward_reverse_memcheck"
+    "dynamic_forward_reverse_2"
+    "dynamic_forward_reverse_2_memcheck"
+    "latex"
+    "latex_memcheck"
+    "pattern_matcher"
+    "pattern_matcher_memcheck"
+    "missing_equation"
+    "missing_equation_memcheck"
+    "cross_iteration"
+    "cross_iteration_memcheck"
+    "hessian_with_loops"
+    "hessian_with_loops_memcheck"
+    "simple_atomic"
+    "simple_atomic_memcheck"
+    "simple_atomic_2"
+    "simple_atomic_2_memcheck"
+    "simple_atomic_deploop"
+    "simple_atomic_deploop_memcheck"
+    "plug_flow"
+    "plug_flow_memcheck"
+    "cstr_collocation"
+    "cstr_collocation_memcheck"
+    "tank_battery"
+    "tank_battery_memcheck"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # SIGTRAP on GHA
+    "dummy_derivative"
+    "dummy_derivative_destil"
+    "dummy_derivative_linear"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CREATE_DOXYGEN_DOC" true)
+    (lib.cmakeBool "ENABLE_TEST_CPPCHECKS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  preCheck = ''
+    cmake --build . -t build_tests
+  '';
+
+  doCheck = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/joaoleal/CppADCodeGen/releases/tag/${finalAttrs.src.tag}";
+    description = "Source Code Generation for Automatic Differentiation using Operator Overloading";
+    homepage = "https://github.com/joaoleal/CppADCodeGen";
+    license = with lib.licenses; [
+      epl10
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+})

--- a/pkgs/by-name/pi/pinocchio/package.nix
+++ b/pkgs/by-name/pi/pinocchio/package.nix
@@ -13,6 +13,8 @@
   casadi,
   coal,
   console-bridge,
+  cppad,
+  cppadcodegen,
   eigen,
   urdfdom,
 
@@ -22,9 +24,13 @@
   # checkInputs = [
   example-robot-data,
 
+  autodiffSupport ? true,
   casadiSupport ? true,
+  codegenSupport ? true,
   collisionSupport ? true,
 }:
+
+assert codegenSupport -> autodiffSupport;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pinocchio";
@@ -45,9 +51,20 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # silence matplotlib warning
     export MPLCONFIGDIR=$(mktemp -d)
+
+    # error: invalid use of incomplete type 'struct Eigen::internal::traits<double>'
+    # ref. https://github.com/stack-of-tasks/pinocchio/pull/2880
+    substituteInPlace unittest/cppad/basic.cpp \
+      --replace-fail \
+        "ad_Y = ad_X.array().min(Scalar(0.));" \
+        "ad_Y = ad_X.array().min(CppAD::AD<double>(0.));" \
+      --replace-fail \
+        "ad_Y = ad_X.array().max(Scalar(0.));" \
+        "ad_Y = ad_X.array().max(CppAD::AD<double>(0.));"
   '';
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
 
@@ -62,8 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
     urdfdom
   ]
-  ++ lib.optionals collisionSupport [ coal ]
-  ++ lib.optionals casadiSupport [ casadi ];
+  ++ lib.optionals autodiffSupport [ cppad ]
+  ++ lib.optionals casadiSupport [ casadi ]
+  ++ lib.optionals codegenSupport [ cppadcodegen ]
+  ++ lib.optionals collisionSupport [ coal ];
 
   nativeCheckInputs = [
     ctestCheckHook
@@ -86,14 +105,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_WITH_AUTODIFF_SUPPORT" autodiffSupport)
     (lib.cmakeBool "BUILD_WITH_CASADI_SUPPORT" casadiSupport)
+    (lib.cmakeBool "BUILD_WITH_CODEGEN_SUPPORT" codegenSupport)
     (lib.cmakeBool "BUILD_WITH_COLLISION_SUPPORT" collisionSupport)
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
   ];
 
   doCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    inherit
+      autodiffSupport
+      casadiSupport
+      codegenSupport
+      collisionSupport
+      ;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives";

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -15,9 +15,14 @@
   # propagatedBuildInputs
   eigen,
   numpy,
+
+  # nativeCheckInputs
+  ctestCheckHook,
+
+  nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "eigenpy";
   version = "3.13.0";
   pyproject = false; # Built with cmake
@@ -25,23 +30,24 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "stack-of-tasks";
     repo = "eigenpy";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-05G0U1RjVwggfnABxZH+9kxDIo7M9rgxHCcTvNgTZCQ=";
   };
 
   outputs = [
+    "out"
     "dev"
     "doc"
-    "out"
   ];
 
   cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
-    "-DINSTALL_DOCUMENTATION=ON"
-    "-DBUILD_TESTING=ON"
-    "-DBUILD_TESTING_SCIPY=ON"
+    (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+    (lib.cmakeBool "BUILD_TESTING_SCIPY" finalAttrs.finalPackage.doInstallCheck)
   ];
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   # Fontconfig error: Cannot load default config file: No such file: (null)
   env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
@@ -60,21 +66,32 @@ buildPythonPackage rec {
     numpy
   ];
 
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   preInstallCheck = ''
-    make test
+    ctestCheckHook
   '';
 
   pythonImportsCheck = [ "eigenpy" ];
 
+  postFixup = ''
+    moveToOutput share/ament_index "$dev"
+    moveToOutput share/eigenpy "$dev"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Bindings between Numpy and Eigen using Boost.Python";
     homepage = "https://github.com/stack-of-tasks/eigenpy";
-    changelog = "https://github.com/stack-of-tasks/eigenpy/releases/tag/${src.tag}";
+    changelog = "https://github.com/stack-of-tasks/eigenpy/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
       nim65s
       wegank
     ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
-}
+})

--- a/pkgs/development/python-modules/pinocchio/default.nix
+++ b/pkgs/development/python-modules/pinocchio/default.nix
@@ -10,12 +10,19 @@
   casadi,
   matplotlib,
   pybind11,
+  pycppad,
   python,
 
+  autodiffSupport ? true,
   buildStandalone ? true,
+  codegenSupport ? true,
 }:
+
+assert codegenSupport -> autodiffSupport;
+assert codegenSupport -> pycppad.codegenSupport;
+
 toPythonModule (
-  pinocchio.overrideAttrs (super: {
+  (pinocchio.override { inherit autodiffSupport codegenSupport; }).overrideAttrs (super: {
     pname = "py-${super.pname}";
 
     cmakeFlags = super.cmakeFlags ++ [
@@ -31,6 +38,7 @@ toPythonModule (
       casadi
       coal
     ]
+    ++ lib.optional autodiffSupport pycppad
     ++ super.propagatedBuildInputs
     ++ lib.optional buildStandalone pinocchio;
 
@@ -46,5 +54,9 @@ toPythonModule (
     pythonImportsCheck = [
       "pinocchio"
     ];
+
+    passthru = {
+      inherit buildStandalone;
+    };
   })
 )

--- a/pkgs/development/python-modules/pycppad/default.nix
+++ b/pkgs/development/python-modules/pycppad/default.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+
+  buildPythonPackage,
+  fetchFromGitHub,
+  fontconfig,
+
+  # buildInputs
+  boost,
+  jrl-cmakemodules,
+
+  # propagatedBuildInputs
+  cppad,
+  cppadcodegen,
+  eigen,
+  eigenpy,
+  numpy,
+
+  # nativeCheckInputs
+  ctestCheckHook,
+
+  nix-update-script,
+
+  codegenSupport ? true,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pycppad";
+  version = "1.2.4";
+  pyproject = false; # Built with cmake
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "simple-robotics";
+    repo = "pycppad";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-f+Wz1w4hW2k2ZRrsBV0eVwxsdDGKlEUud6+YWNZbCHw=";
+    fetchSubmodules = true; # remove after next release
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  nativeBuildInputs = jrl-cmakemodules.docsNativeBuildInputs;
+
+  buildInputs = [
+    boost
+    jrl-cmakemodules
+  ];
+
+  propagatedBuildInputs = [
+    cppad
+    eigen
+    eigenpy
+    numpy
+  ]
+  ++ lib.optional codegenSupport cppadcodegen;
+
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
+  cmakeFlags = jrl-cmakemodules.docsCmakeFlags ++ [
+    (lib.cmakeBool "BUILD_WITH_CPPAD_CODEGEN_BINDINGS" codegenSupport)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck)
+  ];
+
+  preInstallCheck = ''
+    ctestCheckHook
+  '';
+
+  pythonImportsCheck = [ "pycppad" ];
+
+  postFixup = ''
+    moveToOutput share/ament_index "$dev"
+    moveToOutput share/pycppad "$dev"
+  '';
+
+  passthru = {
+    inherit codegenSupport;
+    updateScript = nix-update-script { };
+  };
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  meta = {
+    description = "Python bindings for CppAD and CppADCodeGen using Boost.Python";
+    homepage = "https://github.com/simple-robotics/pycppad";
+    changelog = "https://github.com/simple-robotics/pycppad/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14623,6 +14623,8 @@ self: super: with self; {
 
   pycparser = callPackage ../development/python-modules/pycparser { };
 
+  pycppad = callPackage ../development/python-modules/pycppad { };
+
   pycrashreport = callPackage ../development/python-modules/pycrashreport { };
 
   pycrate = callPackage ../development/python-modules/pycrate { };


### PR DESCRIPTION
This PR add https://github.com/joaoleal/CppADCodeGen

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
