### PR TITLE
authelia: 4.38.19 -> 4.39.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -392,6 +392,10 @@
   [v1.8.0](https://github.com/jtroo/kanata/releases/tag/v1.8.0)
   for more information.
 
+- `authelia` version 4.39.0 has made changes on the default claims for ID Tokens, to mirror the standard claims from the specification.
+  This change may affect some clients in unexpected ways, so manual intervention may be required.
+  Read the [release notes](https://www.authelia.com/blog/4.39-release-notes/), along with [the guide](https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter) to work around issues that may be encountered.
+
 - `ags` was updated to v2, which is just a CLI for Astal now. Components are available as a different package set `astal.*`.
   If you want to use v1, it is available as `ags_1` package.
 
@@ -638,6 +642,10 @@
   ReiserFS has not been actively maintained for many years. It has been marked as obsolete since Linux 6.6, and
   [is removed](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c01f664e4ca210823b7594b50669bbd9b0a3c3b0)
   in Linux 6.13.
+
+- `authelia` version 4.39.0 has made some changes which deprecate older configurations.
+  They are still expected to be working until future version 5.0.0, but will generate warnings in logs.
+  Read the [release notes](https://www.authelia.com/blog/4.39-release-notes/) for human readable summaries of the changes.
 
 - `programs.fzf.keybindings` now supports the fish shell.
 

--- a/pkgs/servers/authelia/sources.nix
+++ b/pkgs/servers/authelia/sources.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub }:
 rec {
   pname = "authelia";
-  version = "4.38.19";
+  version = "4.39.1";
 
   src = fetchFromGitHub {
     owner = "authelia";
     repo = "authelia";
     rev = "v${version}";
-    hash = "sha256-VqdSDrvsue8NqUNN5H++psxAyvvSyFNqt2U8yUXhTo8=";
+    hash = "sha256-Q/NGjJphuZ7MMnOSTAukzEg4iAQWc/VDFWs0jj4e0dY=";
   };
-  vendorHash = "sha256-NONSCqRalxZq1n0Q3fXKVXpkALkoyIl3+Fsx7Xb3M2w=";
-  pnpmDepsHash = "sha256-9ZqAoktMS28GTqbOsWDYUsS1H0unWSEPO0Z2b5xXV54=";
+  vendorHash = "sha256-FE4YABsWKhifVjdzJSnjWPesjuSe/hWDa6oTg8MZjo8=";
+  pnpmDepsHash = "sha256-TJ/Uz7Q+mXfvZ/Zu12Pv1O8LKTzEPJ+Pa+3vrKghPks=";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1637,7 +1637,7 @@ with pkgs;
   };
 
   authelia = callPackage ../servers/authelia {
-    buildGoModule = buildGo123Module;
+    buildGoModule = buildGo124Module;
     pnpm = pnpm_10;
   };
 


### PR DESCRIPTION
https://github.com/authelia/authelia/releases/tag/v4.39.0

- Changes about the ID Tokens are to be checked by users depending on their usage.
  - The release notes have been updated with the corresponding info

https://github.com/authelia/authelia/releases/tag/v4.39.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
