### PR TITLE
godot: fix eval on Nix 2.3

### DIFF
--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -7,7 +7,7 @@ let
   mkGodotPackages =
     versionPrefix:
     let
-      attrs = import ./${versionPrefix};
+      attrs = import (./. + "/${versionPrefix}/default.nix");
       inherit (attrs)
         version
         hash


### PR DESCRIPTION
Fix evaluation on `nixVersions.minimum` (Nix 2.3) so that `nixpkgs-vet` is able to work on all versions of Nix that are supported in nixpkgs.

This was detected with `nixpkgs-vet`'s automated update: https://github.com/NixOS/nixpkgs-vet/pull/157

Before:

- https://github.com/NixOS/nixpkgs/pull/347114
- https://github.com/NixOS/nixpkgs/pull/329212


The error is:

```
while evaluating 'callPackage' at /build/nixpkgs-vetuXjxj1/eval.nix:17:11, called from /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/pkgs/top-level/all-packages.nix:3437:12:
while evaluating 'addVariantInfo' at /build/nixpkgs-vetuXjxj1/eval.nix:36:12, called from /build/nixpkgs-vetuXjxj1/eval.nix:18:7:
while evaluating 'callPackageWith' at /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/lib/customisation.nix:240:19, called from /build/nixpkgs-vetuXjxj1/eval.nix:18:23:
while evaluating 'filterAttrs' at /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/lib/attrsets.nix:646:5, called from /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/lib/customisation.nix:254:11:
while evaluating 'functionArgs' at /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/lib/trivial.nix:1018:18, called from /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/lib/customisation.nix:243:15:
syntax error, unexpected '/', expecting ID or OR_KW or DOLLAR_CURLY or '"', at /nix/store/mpj7y2ambvj9wf6p724kxzsynzz19v6h-source/pkgs/development/tools/godot/default.nix:10:23
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).