### PR TITLE
amazon-q-cli: init at 1.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10688,6 +10688,13 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamesward = {
+    email = "james@jamesward.com";
+    name = "James Ward";
+    github = "jamesward";
+    githubId = 65043;
+    keys = [ { fingerprint = "82F9 4BBD F95C 247B BD21  396B 9A0B 94DE C0FF A7EE"; } ];
+  };
   jamiemagee = {
     email = "jamie.magee@gmail.com";
     github = "JamieMagee";

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  protobuf_26,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "amazon-q-cli";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "amazon-q-developer-cli";
+    tag = "v${version}";
+    hash = "sha256-uKsj7QBKomkO1xP5VgOGI5W8CHIgPQx4QsS2voghrVc=";
+  };
+
+  useFetchCargoVendor = true;
+
+  cargoHash = "sha256-G99vb+7eomxDy9xFJjKA+KpCH2NUzitAKHZE5b62Db8=";
+
+  cargoBuildFlags = [
+    "-p"
+    "q_cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "q_cli"
+  ];
+
+  # skip integration tests that have external dependencies
+  checkFlags = [
+    "--skip=cli::chat::tests::test_flow"
+    "--skip=cli::init::tests::test_prompts"
+    "--skip=debug_get_index"
+    "--skip=debug_list_intellij_variants"
+    "--skip=debug_refresh_auth_token"
+    "--skip=local_state_all"
+    "--skip=local_state_get"
+    "--skip=settings_all"
+    "--skip=settings_get"
+    "--skip=user_whoami"
+    "--skip=init_lint_bash_post_bash_profile"
+    "--skip=init_lint_bash_post_bashrc"
+    "--skip=init_lint_bash_pre_bash_profile"
+    "--skip=init_lint_bash_pre_bashrc"
+    "--skip=init_lint_fish_pre_00_fig_pre"
+    "--skip=init_lint_zsh_post_zprofile"
+    "--skip=init_lint_zsh_post_zshrc"
+    "--skip=init_lint_zsh_pre_zprofile"
+    "--skip=init_lint_zsh_pre_zshrc"
+  ];
+
+  nativeBuildInputs = [
+    protobuf_26
+  ];
+
+  postInstall = ''
+    mv $out/bin/q_cli $out/bin/amazon-q
+  '';
+
+  meta = {
+    description = "Amazon Q Developer AI coding agent CLI";
+    homepage = "https://github.com/aws/amazon-q-developer-cli";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = [ lib.maintainers.jamesward ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
The [Amazon Q CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html) is an AI coding agent.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
