### PR TITLE
rust-stakeholder: init at 2025-03-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9061,6 +9061,12 @@
     githubId = 11212268;
     name = "gruve-p";
   };
+  gs-101 = {
+    email = "gabrielsantosdesouza@disroot.org";
+    github = "gs-101";
+    githubId = 172639817;
+    name = "Gabriel Santos";
+  };
   gschwartz = {
     email = "gsch@pennmedicine.upenn.edu";
     github = "GregorySchwartz";

--- a/pkgs/by-name/ru/rust-stakeholder/package.nix
+++ b/pkgs/by-name/ru/rust-stakeholder/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-stakeholder";
+  version = "0.1.0-unstable-2025-03-17";
+
+  src = fetchFromGitHub {
+    owner = "giacomo-b";
+    repo = "rust-stakeholder";
+    rev = "3717557bd297b16ce4a40bd9cea3fb6167ce338d";
+    hash = "sha256-gm9VH8aegJ71MroxgtokSi4lo/eqAjtHaO42ewBJccQ=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-p3E4Yk7sDI6u5dv8bxRyE/Hj3kOIU54EYodX4PG23Dw=";
+
+  meta = {
+    description = "Nonsensical terminal output generator that comes in various developer flavors";
+    homepage = "https://github.com/giacomo-b/rust-stakeholder";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gs-101 ];
+    mainProgram = "rust-stakeholder";
+  };
+}


### PR DESCRIPTION
[rust-stakeholder](https://github.com/giacomo-b/rust-stakeholder) is a joke program in the likes of [hollywood](https://a.hollywood.computer/).

It shows nonsensical terminal output for a variety of developer types.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
> [!NOTE]
> This package has no tests.
> Also, there's no `nix-update-script` because the version isn't tagged.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
> [!NOTE]
> I'm getting an error when running the previous command:
> `nixpkgs_review.errors.NixpkgsReviewError: Failed to list packages: nix-env failed with exit code -9`
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
