### PR TITLE
ynetd: init at 2024.02.17

### DIFF
--- a/pkgs/by-name/yn/ynetd/package.nix
+++ b/pkgs/by-name/yn/ynetd/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ynetd";
+  version = "2024.02.17";
+
+  src = fetchurl {
+    url = "https://yx7.cc/code/ynetd/ynetd-2024.02.17.tar.xz";
+    hash = "sha256-7gioQ0r0LlUftIWKRwTqeZQl0GtskcRKaEE5z6A0S24=";
+  };
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile --replace-fail "-Wl,-z,relro,-z,now" ""
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ynetd $out/bin/ynetd
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Small server for binding programs to TCP ports";
+    homepage = "https://yx7.cc/code/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "ynetd";
+  };
+})


### PR DESCRIPTION
[ynetd](https://yx7.cc/code) is a small (< 400 lines of C) server for binding programs to TCP ports. Its current version is 2024.02.17.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
