### PR TITLE
[24.11] py7zr: init at 0.22.0; pyppmd: init at 1.1.1; pybcj: init at 1.0.3; multivolumefile: init at 0.2.3; inflate64: init at 1.0.1; pyzstd: init at 0.16.2

### DIFF
--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "inflate64";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "inflate64";
+    tag = "v${version}";
+    hash = "sha256-deFx8NMbGLP51CdNvmZ25LQ5FLPBb1PB3QhGhIfTMfc=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "inflate64"
+  ];
+
+  meta = {
+    description = "Compress and decompress with Enhanced Deflate compression algorithm";
+    homepage = "https://codeberg.org/miurahr/inflate64";
+    changelog = "https://codeberg.org/miurahr/inflate64/src/tag/v${version}/docs/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+
+}

--- a/pkgs/development/python-modules/multivolumefile/default.nix
+++ b/pkgs/development/python-modules/multivolumefile/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "multivolumefile";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "multivolume";
+    tag = "v${version}";
+    hash = "sha256-7gjfF7biQZOcph2dfwi2ouDn/uIYik/KBQ0k6u5Ne+Q=";
+  };
+
+  postPatch =
+    # Fix typo: `tools` -> `tool`
+    # upstream PR: https://codeberg.org/miurahr/multivolume/pulls/9
+    ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'tools.setuptools_scm' 'tool.setuptools_scm'
+    '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "multivolumefile"
+  ];
+
+  meta = {
+    description = "Library to provide a file-object wrapping multiple files as virtually like as a single file";
+    homepage = "https://codeberg.org/miurahr/multivolume";
+    changelog = "https://codeberg.org/miurahr/multivolume/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/py7zr/default.nix
+++ b/pkgs/development/python-modules/py7zr/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  brotli,
+  inflate64,
+  multivolumefile,
+  psutil,
+  pybcj,
+  pycryptodomex,
+  pyppmd,
+  pyzstd,
+  texttable,
+  py-cpuinfo,
+  pytest-benchmark,
+  pytest-remotedata,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "py7zr";
+  version = "0.22.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "miurahr";
+    repo = "py7zr";
+    tag = "v${version}";
+    hash = "sha256-YR2cuHZWwqrytidAMbNvRV1/N4UZG8AMMmzcTcG9FvY=";
+  };
+
+  postPatch =
+    # Replace inaccessible mirror (qt.mirrors.tds.net):
+    # upstream PR: https://github.com/miurahr/py7zr/pull/637
+    ''
+      substituteInPlace tests/test_concurrent.py \
+        --replace-fail 'http://qt.mirrors.tds.net/qt/' 'https://download.qt.io/'
+    '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    brotli
+    inflate64
+    multivolumefile
+    psutil
+    pybcj
+    pycryptodomex
+    pyppmd
+    pyzstd
+    texttable
+  ];
+
+  nativeCheckInputs = [
+    py-cpuinfo
+    pytest-benchmark
+    pytest-remotedata
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "py7zr"
+  ];
+
+  meta = {
+    description = "7zip in Python 3 with ZStandard, PPMd, LZMA2, LZMA1, Delta, BCJ, BZip2";
+    homepage = "https://github.com/miurahr/py7zr";
+    changelog = "https://github.com/miurahr/py7zr/blob/v${version}/docs/Changelog.rst#v${
+      builtins.replaceStrings [ "." ] [ "" ] version
+    }";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pybcj/default.nix
+++ b/pkgs/development/python-modules/pybcj/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pybcj";
+  version = "1.0.3";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "pybcj";
+    tag = "v${version}";
+    hash = "sha256-ExSt7E7ZaVEa0NwAQHU0fOaXJW9jYmEUUy/1iUilGz8=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "bcj"
+  ];
+
+  meta = {
+    description = "BCJ (Branch-Call-Jump) filter for Python";
+    homepage = "https://codeberg.org/miurahr/pybcj";
+    changelog = "https://codeberg.org/miurahr/pybcj/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  hypothesis,
+  pytest-benchmark,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyppmd";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "miurahr";
+    repo = "pyppmd";
+    tag = "v${version}";
+    hash = "sha256-0t1vyVMtmhb38C2teJ/Lq7dx4usm4Bzx+k7Zalf/nXE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-benchmark
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyppmd"
+  ];
+
+  meta = {
+    description = "PPMd compression/decompression library";
+    homepage = "https://codeberg.org/miurahr/pyppmd";
+    changelog = "https://codeberg.org/miurahr/pyppmd/src/tag/v${version}/Changelog.rst#v${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      pitkling
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+  zstd-c,
+}:
+buildPythonPackage rec {
+  pname = "pyzstd";
+  version = "0.16.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Rogdham";
+    repo = "pyzstd";
+    tag = version;
+    hash = "sha256-Az+0m1XUFxExBZK8bcjK54Zt2d5ZlAKRMZRdr7rPcss=";
+  };
+
+  postPatch = ''
+    # pyzst specifies setuptools<74 because 74+ drops `distutils.msvc9compiler`,
+    # required for Python 3.9 under Windows
+    substituteInPlace pyproject.toml \
+        --replace-fail '"setuptools>=64,<74"' '"setuptools"'
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  buildInputs = [
+    zstd-c
+  ];
+
+  pypaBuildFlags = [
+    "--config-setting=--global-option=--dynamic-link-zstd"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyzstd"
+  ];
+
+  meta = {
+    description = "Python bindings to Zstandard (zstd) compression library";
+    homepage = "https://pyzstd.readthedocs.io";
+    changelog = "https://github.com/Rogdham/pyzstd/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      MattSturgeon
+      PopeRigby
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyzstd/default.nix
+++ b/pkgs/development/python-modules/pyzstd/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       MattSturgeon
+      pitkling
       PopeRigby
     ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1092,6 +1092,8 @@ with pkgs;
 
   pricehist = python3Packages.callPackage ../tools/misc/pricehist { };
 
+  py7zr = with python3Packages; toPythonApplication py7zr;
+
   q = callPackage ../tools/networking/q { };
 
   qFlipper = libsForQt5.callPackage ../tools/misc/qflipper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10400,6 +10400,8 @@ self: super: with self; {
 
   pyatome = callPackage ../development/python-modules/pyatome { };
 
+  pybcj = callPackage ../development/python-modules/pybcj { };
+
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
   pycomm3 = callPackage ../development/python-modules/pycomm3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6227,6 +6227,8 @@ self: super: with self; {
 
   infinity = callPackage ../development/python-modules/infinity { };
 
+  inflate64 = callPackage ../development/python-modules/inflate64 { };
+
   inflect = callPackage ../development/python-modules/inflect { };
 
   inflection = callPackage ../development/python-modules/inflection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10387,6 +10387,8 @@ self: super: with self; {
 
   py65 = callPackage ../development/python-modules/py65 { };
 
+  py7zr = callPackage ../development/python-modules/py7zr { };
+
   pyabpoa = toPythonModule (pkgs.abpoa.override {
     enablePython = true;
     python3Packages = self;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10519,6 +10519,8 @@ self: super: with self; {
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };
 
+  pyppmd = callPackage ../development/python-modules/pyppmd { };
+
   pyrdfa3 = callPackage ../development/python-modules/pyrdfa3 { };
 
   pyre-extensions = callPackage ../development/python-modules/pyre-extensions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10686,6 +10686,10 @@ self: super: with self; {
 
   pyzipper = callPackage ../development/python-modules/pyzipper { };
 
+  pyzstd = callPackage ../development/python-modules/pyzstd {
+    zstd-c = pkgs.zstd;
+  };
+
   plac = callPackage ../development/python-modules/plac { };
 
   plaid-python = callPackage ../development/python-modules/plaid-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8454,6 +8454,8 @@ self: super: with self; {
 
   multitasking = callPackage ../development/python-modules/multitasking { };
 
+  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
+
   munch = callPackage ../development/python-modules/munch { };
 
   mung = callPackage ../development/python-modules/mung { };


### PR DESCRIPTION
Manual (partial) backport of https://github.com/NixOS/nixpkgs/pull/381975 and https://github.com/NixOS/nixpkgs/pull/384329

This is required to backport https://github.com/NixOS/nixpkgs/pull/356882

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
