### PR TITLE
ynetd: add hardened ctf-centric fork

### DIFF
--- a/pkgs/by-name/yn/ynetd/hardened.nix
+++ b/pkgs/by-name/yn/ynetd/hardened.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ctf-ynetd";
+  version = "2024.12.31";
+
+  src = fetchurl {
+    url = "https://hxp.io/assets/data/code/ctf-ynetd-2024.12.31.tar.xz";
+    hash = "sha256-hUEZZEulmaV3KfKOqE1wl7y4SRUn2/HoOjVDabk5+YA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ynetd $out/bin/ynetd
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fork of ynetd hardened for CTFs with isolation using PID namespaces, minimal overhead proof-of-work checking, and strict resource limits via cgroups";
+    homepage = "https://hxp.io/code/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "ynetd";
+  };
+})

--- a/pkgs/by-name/yn/ynetd/package.nix
+++ b/pkgs/by-name/yn/ynetd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  callPackage,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ynetd";
@@ -21,6 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 ynetd $out/bin/ynetd
     runHook postInstall
   '';
+
+  # ctf-ynetd releases are based on the last stable ynetd version
+  # these should be kept in sync when possible
+  passthru.hardened = callPackage ./hardened.nix { };
 
   meta = {
     description = "Small server for binding programs to TCP ports";


### PR DESCRIPTION
Introduced the hardened ctf focused version of ynetd created by the hxp CTF team. Unlike the main ynetd it only supports linux due to the cgroup based resource restrictions and namespaces. I'm not sure if it would make more sense as it's own package, but this just kinda feels right. 
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
