### PR TITLE
nixos/ircd-hybrid: fix bug in which fails to substitute iproute2

### DIFF
--- a/nixos/modules/services/networking/ircd-hybrid/control.in
+++ b/nixos/modules/services/networking/ircd-hybrid/control.in
@@ -6,7 +6,7 @@ export PATH=@coreutils@/bin
 if test "$1" = "start"; then
 	if ! @procps@/bin/pgrep ircd; then
 	if @ipv6Enabled@; then 
-		while ! @iproute@/sbin/ip addr | 
+		while ! @iproute2@/sbin/ip addr | 
 			@gnugrep@/bin/grep inet6 | 
 			@gnugrep@/bin/grep global; do
 			sleep 1;


### PR DESCRIPTION
… to substitute iproute2

iproute2 is named wrongly as iproute which causes the control.in file to have @iproute@ unsubstituted for the nix store path. This causes the service to fail instantly. This PR fixes this bug by naming it iproute2.

Example:

```bash
#! /nix/store/8vpg72ik2kgxfj05lc56hkqrdrfl8xi9-bash-5.2p37/bin/bash -e

# Make sure that the environment is deterministic.
export PATH=/nix/store/9m68vvhnsq5cpkskphgw84ikl9m6wjwp-coreutils-9.5/bin

if test "$1" = "start"; then
	if ! /nix/store/9bzy8ydbfsg3gkk11wcaxaj5kmgvp9s9-procps-4.0.4/bin/pgrep ircd; then
	if true; then 
		while ! @iproute@/sbin/ip addr | 
			/nix/store/qjsj5vnbfpbg6r7jhd7znfgmcy0arn8n-gnugrep-3.11/bin/grep inet6 | 
			/nix/store/qjsj5vnbfpbg6r7jhd7znfgmcy0arn8n-gnugrep-3.11/bin/grep global; do
			sleep 1;
		done;
	fi;
	rm -rf /home/ircd
	mkdir -p /home/ircd
	chown ircd: /home/ircd
	cd /home/ircd
    env - HOME=/homeless-shelter $extraEnv \
        /nix/store/hny4q04ns200gn6kvcmwj4w1pf9vv5zf-shadow-4.16.0-su/bin/su ircd --shell=/bin/sh -c ' /nix/store/grii6znymhv7rjfk2gp47c42bzj7gxpy-ircd-hybrid-8.2.45/bin/ircd -configfile /nix/store/7a54cd81klvx50h8hpjp49777h60p1bq-ircd-hybrid-service/conf/ircd.conf </dev/null -logfile /home/ircd/ircd.log' 2>&1 >/var/log/ircd-hybrid.out
	fi;
fi

if test "$1" = "stop" ; then 
	/nix/store/9bzy8ydbfsg3gkk11wcaxaj5kmgvp9s9-procps-4.0.4/bin/pkill ircd;
fi;
```
The problem line is: `while ! @iproute@/sbin/ip addr |`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
