### PR TITLE
psi-plus: 1.5.1653 → 1.5.2072

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -103,15 +103,15 @@ mkDerivation rec {
     )
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://psi-plus.com";
     description = "XMPP (Jabber) client based on Qt5";
     mainProgram = "psi-plus";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       orivej
       unclechu
     ];
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -14,10 +14,7 @@
   hunspell,
   libsecret,
   libgcrypt,
-  libotr,
-  html-tidy,
   libgpg-error,
-  libsignal-protocol-c,
   usrsctp,
 
   chatType ? "basic", # See the assertion below for available options
@@ -25,6 +22,9 @@
   qtwebengine,
 
   enablePlugins ? true,
+  html-tidy,
+  libotr,
+  libsignal-protocol-c,
 
   # Voice messages
   voiceMessagesSupport ? true,
@@ -80,15 +80,17 @@ mkDerivation rec {
       hunspell
       libsecret
       libgcrypt
-      libotr
-      html-tidy
       libgpg-error
-      libsignal-protocol-c
       usrsctp
     ]
     ++ lib.optionals voiceMessagesSupport [
       gst_all_1.gst-plugins-base
       gst_all_1.gst-plugins-good
+    ]
+    ++ lib.optionals enablePlugins [
+      html-tidy
+      libotr
+      libsignal-protocol-c
     ]
     ++ lib.optionals (chatType == "webkit") [
       qtwebkit

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -16,6 +16,7 @@
   libgcrypt,
   libgpg-error,
   usrsctp,
+  qtkeychain,
 
   chatType ? "basic", # See the assertion below for available options
   qtwebkit,
@@ -23,13 +24,13 @@
 
   enablePlugins ? true,
   html-tidy,
+  http-parser,
   libotr,
-  libsignal-protocol-c,
+  libomemo-c,
 
   # Voice messages
   voiceMessagesSupport ? true,
   gst_all_1,
-
   enablePsiMedia ? false,
   pkg-config,
 }:
@@ -44,13 +45,13 @@ assert enablePsiMedia -> enablePlugins;
 
 mkDerivation rec {
   pname = "psi-plus";
-  version = "1.5.1653";
 
+  version = "1.5.2072";
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
     rev = version;
-    sha256 = "sha256-9WT2S6ZgIsrHoEAvlWUB078gzCdrPylvSjkkogU5tsU=";
+    sha256 = "sha256-RlZwMBWjhCTEEV08UHbf8NvuqmuihXwR1aA/vMmD1BM=";
   };
 
   cmakeFlags = [
@@ -82,6 +83,7 @@ mkDerivation rec {
       libgcrypt
       libgpg-error
       usrsctp
+      qtkeychain
     ]
     ++ lib.optionals voiceMessagesSupport [
       gst_all_1.gst-plugins-base
@@ -89,8 +91,9 @@ mkDerivation rec {
     ]
     ++ lib.optionals enablePlugins [
       html-tidy
+      http-parser
       libotr
-      libsignal-protocol-c
+      libomemo-c
     ]
     ++ lib.optionals (chatType == "webkit") [
       qtwebkit


### PR DESCRIPTION
## Things done

originally opened @ #390708 by @everypizza1 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
