### PR TITLE
opengamepadui: 0.35.8 -> 0.37.0

### DIFF
--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -5,7 +5,7 @@
   dbus,
   fetchFromGitHub,
   gamescope,
-  godot_4_3,
+  godot_4_4,
   hwdata,
   lib,
   libGL,
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opengamepadui";
-  version = "0.35.8";
+  version = "0.37.0";
 
   buildType = if withDebug then "debug" else "release";
 
@@ -32,21 +32,21 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ShadowBlip";
     repo = "OpenGamepadUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vMb08Wqjt5j6IgMnXuZr6MGNk1CprVn2GTNDdOxnFG0=";
+    hash = "sha256-kzGFyzOu4Pkj+a7kExFwxFu35qfoLoWz3uqd8COUTNA=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     sourceRoot = "source/${finalAttrs.cargoRoot}";
-    hash = "sha256-sTzMewIfKHbmVhSPZgUIzFFz1ahK+PMoQ5oB4GEt8nY=";
+    hash = "sha256-T79G2bShJuFRfaCqG3IDHqW0s68yAdGyv58kdDYg6kg=";
   };
   cargoRoot = "extensions";
 
   nativeBuildInputs = [
     autoPatchelfHook
     cargo
-    godot_4_3
-    godot_4_3.export-templates-bin
+    godot_4_4
+    godot_4_4.export-templates-bin
     pkg-config
     rustPlatform.cargoSetupHook
   ];
@@ -75,13 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   env =
     let
-      versionAndRelease = lib.splitString "-" godot_4_3.version;
+      versionAndRelease = lib.splitString "-" godot_4_4.version;
     in
     {
-      GODOT = lib.getExe godot_4_3;
+      GODOT = lib.getExe godot_4_4;
       GODOT_VERSION = lib.elemAt versionAndRelease 0;
       GODOT_RELEASE = lib.elemAt versionAndRelease 1;
-      EXPORT_TEMPLATE = "${godot_4_3.export-templates-bin}";
+      EXPORT_TEMPLATE = "${godot_4_4.export-templates-bin}";
       BUILD_TYPE = "${finalAttrs.buildType}";
     };
 
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Godot looks for export templates in HOME
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.local/share/godot/export_templates
-    ln -s "${godot_4_3.export-templates-bin}" "$HOME/.local/share/godot/export_templates/$GODOT_VERSION.$GODOT_RELEASE"
+    ln -s "${godot_4_4.export-templates-bin}" "$HOME/.local/share/godot/export_templates/$GODOT_VERSION.$GODOT_RELEASE"
   '';
 
   postInstall = ''


### PR DESCRIPTION
Updates OpenGamepadUI (fixes PR #390277)

meta.description for opengamepadui is: Open source gamepad-native game launcher and overlay
meta.homepage for opengamepadui is: https://github.com/ShadowBlip/OpenGamepadUI
meta.changelog for opengamepadui is: https://github.com/ShadowBlip/OpenGamepadUI/releases/tag/v0.37.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
