### PR TITLE
_1password-gui: Allow Linux and Darwin versions to move separately

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -12,7 +12,8 @@ let
   pname = "1password";
 
   versions = builtins.fromJSON (builtins.readFile ./versions.json);
-  inherit (versions.${channel} or (throw "unknown channel ${channel}")) version;
+  hostOs = if stdenv.hostPlatform.isLinux then "linux" else "darwin";
+  version = versions."${channel}-${hostOs}" or (throw "unknown channel-os ${channel}-${hostOs}");
 
   sources = builtins.fromJSON (builtins.readFile ./sources.json);
 

--- a/pkgs/applications/misc/1password-gui/sources.json
+++ b/pkgs/applications/misc/1password-gui/sources.json
@@ -1,20 +1,20 @@
 {
   "stable": {
     "x86_64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.60.x64.tar.gz",
-      "hash": "sha256-QCoV66LvGo6vA5fjuE3fG+LwehKVMPmgaDghh9YEvmA="
+      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.68.x64.tar.gz",
+      "hash": "sha256-6MekdtKnjvrP0dai6VfBEFJ+oKf2WvPp+sU/kVIzCTw="
     },
     "aarch64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.60.arm64.tar.gz",
-      "hash": "sha256-E5TniXur9ATJ3ER/zTFc6EiBrH/kbNvIao0ADLyBZZE="
+      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.68.arm64.tar.gz",
+      "hash": "sha256-2SpfkLu/4K1t2ILwOBMVAXeW7rbEzsjofn8naM1Szfc="
     },
     "x86_64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.60-x86_64.zip",
-      "hash": "sha256-2Nv4CHKLgCFbU1TeJQhIq8YdkJSQJXtUw2S17B8cS4s="
+      "url": "https://downloads.1password.com/mac/1Password-8.10.68-x86_64.zip",
+      "hash": "sha256-t/glPvEGJH+IcYyrnW0fMSEeLB8mKqGqmZ8wnVFCJpo="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.60-aarch64.zip",
-      "hash": "sha256-drJiM8EiUM3M54+KPQdLvAmSfBH5YPqQk14yjHzoBtM="
+      "url": "https://downloads.1password.com/mac/1Password-8.10.68-aarch64.zip",
+      "hash": "sha256-bhmuy8gUVCv+hYSIpYXgm8a0f1+JtyKb4g5cUIJCb28="
     }
   },
   "beta": {

--- a/pkgs/applications/misc/1password-gui/update.sh
+++ b/pkgs/applications/misc/1password-gui/update.sh
@@ -30,8 +30,8 @@ mk_url() {
 }
 
 cleanup() {
-  if [[ -f ${GPG_KEYRING-} ]]; then
-    rm "${GPG_KEYRING}"
+  if [[ -d ${TMP_GNUPGHOME-} ]]; then
+    rm -r "${TMP_GNUPGHOME}"
   fi
 
   if [[ -f ${JSON_HEAP-} ]]; then
@@ -47,8 +47,9 @@ while IFS='=' read -r key value; do
   versions["${key}"]="${value}"
 done < <(jq -r 'to_entries[] | "\(.key)=\(.value)"' versions.json)
 
-GPG_KEYRING=$(mktemp -t 1password.kbx.XXXXXX)
-gpg --no-default-keyring --keyring "${GPG_KEYRING}" \
+TMP_GNUPGHOME=$(mktemp -dt 1password-gui.gnupghome.XXXXXX)
+export GNUPGHOME="${TMP_GNUPGHOME}"
+gpg --no-default-keyring --keyring trustedkeys.kbx \
   --keyserver keyserver.ubuntu.com \
   --receive-keys 3FEF9748469ADBE15DA7CA80AC2D62742012EA22
 
@@ -71,7 +72,7 @@ for channel in stable beta; do
 
       # For some reason 1Password PGP signs only Linux binaries.
       if [[ ${os} == "linux" ]]; then
-         gpgv --keyring "${GPG_KEYRING}" \
+         gpgv \
            $(nix store prefetch-file --json "${url}.sig" | jq -r .storePath) \
            $(jq -r --slurp ".[-1].[].[].storePath" "${JSON_HEAP}")
       fi

--- a/pkgs/applications/misc/1password-gui/versions.json
+++ b/pkgs/applications/misc/1password-gui/versions.json
@@ -1,6 +1,6 @@
 {
-  "stable-linux": "8.10.60",
-  "stable-darwin": "8.10.60",
+  "stable-linux": "8.10.68",
+  "stable-darwin": "8.10.68",
   "beta-linux":"8.10.68-12.BETA",
   "beta-darwin": "8.10.68-12.BETA"
 }

--- a/pkgs/applications/misc/1password-gui/versions.json
+++ b/pkgs/applications/misc/1password-gui/versions.json
@@ -1,9 +1,6 @@
 {
-  "stable": {
-    "version": "8.10.60"
-  },
-
-  "beta": {
-    "version": "8.10.68-12.BETA"
-  }
+  "stable-linux": "8.10.60",
+  "stable-darwin": "8.10.60",
+  "beta-linux":"8.10.68-12.BETA",
+  "beta-darwin": "8.10.68-12.BETA"
 }


### PR DESCRIPTION
Addresses the issue pointed out by @khaneliman in #387535, Darwin and Linux versions aren't necessarily in lockstep.

Isolates GnuPG homedir into a temporary directory.

Bump from 8.10.60 -> 8.10.68


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
