### PR TITLE
python312Packages.coffea: 2025.1.1 -> 2025.3.0

### DIFF
--- a/pkgs/development/python-modules/coffea/default.nix
+++ b/pkgs/development/python-modules/coffea/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -34,7 +33,7 @@
   uproot,
   vector,
 
-  # checks
+  # tests
   distributed,
   pyinstrument,
   pytest-xdist,
@@ -43,14 +42,14 @@
 
 buildPythonPackage rec {
   pname = "coffea";
-  version = "2025.1.1";
+  version = "2025.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CoffeaTeam";
     repo = "coffea";
     tag = "v${version}";
-    hash = "sha256-AGYi1w4e8XJOWRbuPX5eB/rTY5dCPji49zD0VQ4FvAs=";
+    hash = "sha256-NZ3r/Dyw5bB4qOO29DUAARPzdJJxgR9OO9LxVu3YbNo=";
   };
 
   build-system = [
@@ -98,40 +97,16 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "coffea" ];
 
-  disabledTests =
-    [
-      # Requires internet access
-      # https://github.com/CoffeaTeam/coffea/issues/1094
-      "test_lumimask"
+  disabledTests = [
+    # Requires internet access
+    # https://github.com/CoffeaTeam/coffea/issues/1094
+    "test_lumimask"
 
-      # Flaky: FileNotFoundError: [Errno 2] No such file or directory
-      # https://github.com/scikit-hep/coffea/issues/1246
-      "test_packed_selection_cutflow_dak" # cutflow.npz
-      "test_packed_selection_nminusone_dak" # nminusone.npz
-
-      # AssertionError: bug in Awkward Array: attempt to convert TypeTracerArray into a concrete array
-      "test_apply_to_fileset"
-      "test_lorentz_behavior"
-
-      # ValueError: The array to mask was deleted before it could be masked.
-      # If you want to construct this mask, you must either keep the array alive or use 'ak.mask' explicitly.
-      "test_read_nanomc"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-      # Fatal Python error: Segmentation fault
-      # coffea/nanoevents/transforms.py", line 287 in index_range
-      "test_KaonParent_to_PionDaughters_Loop"
-      "test_MCRecoAssociations"
-      "test_MC_daughters"
-      "test_MC_parents"
-      "test_field_is_present"
-
-      # Fatal Python error: Segmentation fault
-      # File "/build/source/tests/test_lumi_tools.py", line 37 in test_lumidata
-      "test_lumidata"
-      # coffea/lumi_tools/lumi_tools.py", line 113 in get_lumi
-      "test_lumilist"
-    ];
+    # Flaky: FileNotFoundError: [Errno 2] No such file or directory
+    # https://github.com/scikit-hep/coffea/issues/1246
+    "test_packed_selection_cutflow_dak" # cutflow.npz
+    "test_packed_selection_nminusone_dak" # nminusone.npz
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
## Things done

Changelog: https://github.com/CoffeaTeam/coffea/releases/tag/v2025.3.0

cc @veprbl

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
