### PR TITLE
nvimpager: enable strictDeps & cleanup inputs

### DIFF
--- a/pkgs/by-name/nv/nvimpager/package.nix
+++ b/pkgs/by-name/nv/nvimpager/package.nix
@@ -2,6 +2,7 @@
   fetchFromGitHub,
   lib,
   stdenv,
+  bash,
   ncurses,
   neovim,
   procps,
@@ -22,10 +23,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    ncurses # for tput
-    procps # for nvim_get_proc() which uses ps(1)
+    bash
   ];
   nativeBuildInputs = [ scdoc ];
+
+  strictDeps = true;
 
   makeFlags = [ "PREFIX=$(out)" ];
   buildFlags = [
@@ -40,8 +42,10 @@ stdenv.mkDerivation rec {
   doCheck = true;
   nativeCheckInputs = [
     lua51Packages.busted
-    util-linux
+    ncurses # for tput
     neovim
+    procps # for nvim_get_proc() which uses ps(1)
+    util-linux
   ];
   # filter out one test that fails in the sandbox of nix or with neovim v0.10
   # or on macOS
@@ -49,6 +53,10 @@ stdenv.mkDerivation rec {
     checkFlagsArray+=('BUSTED=busted --output TAP --exclude-tags=${
       "nix,v10" + lib.optionalString stdenv.hostPlatform.isDarwin ",mac"
     }')
+  '';
+
+  postFixup = ''
+    patchShebangs --update --host $out/bin/nvimpager
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
