### PR TITLE
armagetronad: fix build

### DIFF
--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -19,7 +19,10 @@
   SDL2,
   SDL2_image,
   SDL2_mixer,
+  libGL,
+  libGLU,
   libpng,
+  libX11,
   libxml2,
   protobuf,
   xvfb-run,
@@ -54,6 +57,9 @@ let
           inherit version;
           src = fetchArmagetron rev hash;
           extraBuildInputs = lib.optionals (!dedicatedServer) [
+            libGL
+            libGLU
+            libX11
             libpng
             SDL
             SDL_image
@@ -79,6 +85,9 @@ let
               glew
               ftgl
               freetype
+              libGL
+              libGLU
+              libX11
               SDL2
               SDL2_image
               SDL2_mixer
@@ -96,6 +105,9 @@ let
           version = "${latestVersionMajor}-sty+ct+ap-${builtins.substring 0 8 rev}";
           src = fetchArmagetron rev hash;
           extraBuildInputs = lib.optionals (!dedicatedServer) [
+            libGL
+            libGLU
+            libX11
             libpng
             SDL
             SDL_image


### PR DESCRIPTION
commit 7aeac03f40021f4b213d460ef5813e52184368db (PR #386495) dropped libX11 and libGLU from propagatedBuildInputs in SDL_compat, and #389106 pointed SDL to SDL_compat, which broke this build

Hydra fail: https://hydra.nixos.org/build/292728775/nixlog/1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
