### PR TITLE
cudaPackages_12: 12.4 -> 12.8

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -218,6 +218,7 @@ with lib.maintainers;
   cuda = {
     members = [
       connorbaker
+      prusnak
       samuela
       SomeoneSerge
     ];

--- a/pkgs/development/cuda-modules/cudnn/releases.nix
+++ b/pkgs/development/cuda-modules/cudnn/releases.nix
@@ -10,7 +10,7 @@
       {
         version = "8.9.5.30";
         minCudaVersion = "12.0";
-        maxCudaVersion = "12.4";
+        maxCudaVersion = "12.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-aarch64/cudnn-linux-aarch64-8.9.5.30_cuda12-archive.tar.xz";
         hash = "sha256-BJH3sC9VwiB362eL8xTB+RdSS9UHz1tlgjm/mKRyM6E=";
       }
@@ -85,7 +85,7 @@
       {
         version = "8.9.7.29";
         minCudaVersion = "12.0";
-        maxCudaVersion = "12.4";
+        maxCudaVersion = "12.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-sbsa/cudnn-linux-sbsa-8.9.7.29_cuda12-archive.tar.xz";
         hash = "sha256-6Yt8gAEHheXVygHuTOm1sMjHNYfqb4ZIvjTT+NHUe9E=";
       }
@@ -207,7 +207,7 @@
       {
         version = "8.9.7.29";
         minCudaVersion = "12.0";
-        maxCudaVersion = "12.4";
+        maxCudaVersion = "12.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz";
         hash = "sha256-R1MzYlx+QqevPKCy91BqEG4wyTsaoAgc2cE++24h47s=";
       }

--- a/pkgs/development/cuda-modules/cudnn/releases.nix
+++ b/pkgs/development/cuda-modules/cudnn/releases.nix
@@ -28,6 +28,13 @@
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-aarch64/cudnn-linux-aarch64-9.7.1.26_cuda12-archive.tar.xz";
         hash = "sha256-jDPWAXKOiJYpblPwg5FUSh7F0Dgg59LLnd+pX9y7r1w=";
       }
+      {
+        version = "9.8.0.87";
+        minCudaVersion = "12.0";
+        maxCudaVersion = "12.8";
+        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-aarch64/cudnn-linux-aarch64-9.8.0.87_cuda12-archive.tar.xz";
+        hash = "sha256-8D7OP/B9FxnwYhiXOoeXzsG+OHzDF7qrW7EY3JiBmec=";
+      }
     ];
     # powerpc
     linux-ppc64le = [ ];
@@ -116,6 +123,20 @@
         maxCudaVersion = "11.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-sbsa/cudnn-linux-sbsa-9.7.1.26_cuda11-archive.tar.xz";
         hash = "sha256-JcpY/ylUAaj37bzrJlerSDxO5KgPmpL40Mvl8VquHN4=";
+      }
+      {
+        version = "9.8.0.87";
+        minCudaVersion = "12.0";
+        maxCudaVersion = "12.8";
+        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-sbsa/cudnn-linux-sbsa-9.8.0.87_cuda12-archive.tar.xz";
+        hash = "sha256-IvYvR08MuzW+9UCtsdhB2mPJzT33azxOQwEPQ2ss2Fw=";
+      }
+      {
+        version = "9.8.0.87";
+        minCudaVersion = "11.8";
+        maxCudaVersion = "11.8";
+        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-sbsa/cudnn-linux-sbsa-9.8.0.87_cuda11-archive.tar.xz";
+        hash = "sha256-j/EXcV+zMjAy0bSJiAEXVWrYteV6kGAUPwy3I4TbdxA=";
       }
     ];
     # x86_64
@@ -238,6 +259,20 @@
         maxCudaVersion = "11.8";
         url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.7.1.26_cuda11-archive.tar.xz";
         hash = "sha256-c6rfLRtyGjS9e5CQjQKQYlfyrdvSRs+NtY4h1o2FXqI=";
+      }
+      {
+        version = "9.8.0.87";
+        minCudaVersion = "12.0";
+        maxCudaVersion = "12.8";
+        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz";
+        hash = "sha256-MhubM7sSh0BNk9VnLTUvFv6rxLIgrGrguG5LJ/JX3PQ=";
+      }
+      {
+        version = "9.8.0.87";
+        minCudaVersion = "11.8";
+        maxCudaVersion = "11.8";
+        url = "https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda11-archive.tar.xz";
+        hash = "sha256-z03674MR2YfWQKMi9mjNUkCsPlMCq+lhfdmRtbJTJ1g=";
       }
     ];
   };

--- a/pkgs/development/cuda-modules/gpus.nix
+++ b/pkgs/development/cuda-modules/gpus.nix
@@ -26,6 +26,9 @@
 # Many thanks to Arnon Shimoni for maintaining a list of these architectures and capabilities.
 # Without your work, this would have been much more difficult.
 # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+#
+# https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+
 [
   {
     # Tesla K40
@@ -55,7 +58,7 @@
     maxCudaVersion = null;
   }
   {
-    # Quadro M6000 , GeForce 900, GTX-970, GTX-980, GTX Titan X
+    # Quadro M6000, GeForce 900, GTX-970, GTX-980, GTX Titan X
     archName = "Maxwell";
     computeCapability = "5.2";
     isJetson = false;
@@ -199,7 +202,7 @@
     computeCapability = "10.0a";
     isJetson = false;
     minCudaVersion = "12.8";
-    dontDefaultAfter = null;
+    dontDefaultAfter = "12.0"; # disable to reduce size of OnnxRuntime and Torch CUDA binaries
     maxCudaVersion = null;
   }
   {
@@ -208,7 +211,7 @@
     computeCapability = "10.1";
     isJetson = false;
     minCudaVersion = "12.8";
-    dontDefaultAfter = null;
+    dontDefaultAfter = "12.0"; # disable to reduce size of OnnxRuntime and Torch CUDA binaries
     maxCudaVersion = null;
   }
   {
@@ -217,7 +220,7 @@
     computeCapability = "10.1a";
     isJetson = false;
     minCudaVersion = "12.8";
-    dontDefaultAfter = null;
+    dontDefaultAfter = "12.0"; # disable to reduce size of OnnxRuntime and Torch CUDA binaries
     maxCudaVersion = null;
   }
   {
@@ -235,7 +238,7 @@
     computeCapability = "12.0a";
     isJetson = false;
     minCudaVersion = "12.8";
-    dontDefaultAfter = null;
+    dontDefaultAfter = "12.0"; # disable to reduce size of OnnxRuntime and Torch CUDA binaries
     maxCudaVersion = null;
   }
 ]

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -66,11 +66,11 @@ let
 
     nativeBuildInputs = [ cmake gbenchmark gtest ];
     cmakeFlags = [
-      "-DUSE_SYSTEM_GOOGLEBENCHMARK=ON"
-      "-DUSE_SYSTEM_GOOGLETEST=ON"
-      "-DUSE_SYSTEM_LIBS=ON"
+      (lib.cmakeBool "USE_SYSTEM_GOOGLEBENCHMARK" true)
+      (lib.cmakeBool "USE_SYSTEM_GOOGLETEST" true)
+      (lib.cmakeBool "USE_SYSTEM_LIBS" true)
       # 'clog' tests set 'CXX_STANDARD 11'; this conflicts with our 'gtest'.
-      "-DCLOG_BUILD_TESTS=OFF"
+      (lib.cmakeBool "CLOG_BUILD_TESTS" false)
     ];
   };
 
@@ -178,27 +178,27 @@ effectiveStdenv.mkDerivation rec {
   cmakeDir = "../cmake";
 
   cmakeFlags = [
-    "-DABSL_ENABLE_INSTALL=ON"
-    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
-    "-DFETCHCONTENT_QUIET=OFF"
-    "-DFETCHCONTENT_SOURCE_DIR_ABSEIL_CPP=${abseil-cpp_202407.src}"
-    "-DFETCHCONTENT_SOURCE_DIR_DLPACK=${dlpack}"
-    "-DFETCHCONTENT_SOURCE_DIR_FLATBUFFERS=${flatbuffers_23.src}"
-    "-DFETCHCONTENT_SOURCE_DIR_MP11=${mp11}"
-    "-DFETCHCONTENT_SOURCE_DIR_ONNX=${onnx}"
-    "-DFETCHCONTENT_SOURCE_DIR_RE2=${re2.src}"
-    "-DFETCHCONTENT_SOURCE_DIR_SAFEINT=${safeint}"
-    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    (lib.cmakeBool "ABSL_ENABLE_INSTALL" true)
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeBool "FETCHCONTENT_QUIET" false)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL_CPP" "${abseil-cpp_202407.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DLPACK" "${dlpack}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_FLATBUFFERS" "${flatbuffers_23.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MP11" "${mp11}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ONNX" "${onnx}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_RE2" "${re2.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SAFEINT" "${safeint}")
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
     # fails to find protoc on darwin, so specify it
-    "-DONNX_CUSTOM_PROTOC_EXECUTABLE=${protobuf_21}/bin/protoc"
-    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    (lib.cmakeFeature "ONNX_CUSTOM_PROTOC_EXECUTABLE" "${protobuf_21}/bin/protoc")
+    (lib.cmakeBool "onnxruntime_BUILD_SHARED_LIB" true)
     (lib.cmakeBool "onnxruntime_BUILD_UNIT_TESTS" doCheck)
-    "-Donnxruntime_ENABLE_LTO=ON"
-    "-Donnxruntime_USE_FULL_PROTOBUF=OFF"
+    (lib.cmakeBool "onnxruntime_USE_FULL_PROTOBUF" false)
     (lib.cmakeBool "onnxruntime_USE_CUDA" cudaSupport)
     (lib.cmakeBool "onnxruntime_USE_NCCL" (cudaSupport && ncclSupport))
+    (lib.cmakeBool "onnxruntime_ENABLE_LTO" (!cudaSupport || cudaPackages.cudaOlder "12.8"))
   ] ++ lib.optionals pythonSupport [
-    "-Donnxruntime_ENABLE_PYTHON=ON"
+    (lib.cmakeBool "onnxruntime_ENABLE_PYTHON" true)
   ] ++ lib.optionals cudaSupport [
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CUTLASS" "${cutlass}")
     (lib.cmakeFeature "onnxruntime_CUDNN_HOME" "${cudaPackages.cudnn}")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2860,7 +2860,7 @@ with pkgs;
   cudaPackages_12_5 = callPackage ./cuda-packages.nix { cudaVersion = "12.5"; };
   cudaPackages_12_6 = callPackage ./cuda-packages.nix { cudaVersion = "12.6"; };
   cudaPackages_12_8 = callPackage ./cuda-packages.nix { cudaVersion = "12.8"; };
-  cudaPackages_12 = cudaPackages_12_4; # Latest supported by cudnn
+  cudaPackages_12 = cudaPackages_12_8; # Latest supported by cudnn
 
   cudaPackages = recurseIntoAttrs cudaPackages_12;
 


### PR DESCRIPTION
I finally managed to fix onnxruntime build with CUDA 12.8 which was AFAIK the only blocker for changing the default.

The fix is to turn off LTO when linking with CUDA, because otherwise the linking takes too much time and then ends up in infinite loop anyway.

Also in the past I enthusiastically added support for Compute Capability 10.0 and 10.1 GPUs but this is causing linking errors for onnxruntime (resulting shared library >2 GB, similar to what we face with magma), so I removed them and only kept CC 12.0 to save space (e.g. ollama upstream also does not build for CC 10.x but only for 12.0) and this makes it possible for onnxruntime shared library to link again.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
