### PR TITLE
nixos: add boot.isVM option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -40,6 +40,9 @@
 - A `nixos-rebuild build-image` sub-command has been added.
   It allows users to build platform-specific (disk) images from their NixOS configurations. `nixos-rebuild build-image` works similar to the popular [nix-community/nixos-generators](https://github.com/nix-community/nixos-generators) project. See new [section on image building in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-image-nixos-rebuild-build-image). It is also available for `nixos-rebuild-ng`.
 
+- The {option}`virtualisation` options to configure a NixOS VM are now always defined and will take effect based on the value of the new option `boot.isVM` (automatically set when doing `nixos-rebuild build-vm`, etc.).
+  Previously, to use these options users had to either manually add `virtualisation/qemu-vm.nix` to module imports list or place them under {option}`virtualisation.vmVariant`.
+
 - `nixos-option` has been rewritten to a Nix expression called by a simple bash script. This lowers our maintenance threshold, makes eval errors less verbose, adds support for flake-based configurations, descending into `attrsOf` and `listOf` submodule options, and `--show-trace`.
 
 - The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.

--- a/nixos/lib/testing/nixos-test-base.nix
+++ b/nixos/lib/testing/nixos-test-base.nix
@@ -7,8 +7,11 @@ let
 in
 {
   imports = [
-    ../../modules/virtualisation/qemu-vm.nix
     ../../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
+    {
+      key = "is-vm";
+      boot.isVM = true;
+    }
     {
       key = "no-manual";
       documentation.nixos.enable = false;

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -306,6 +306,7 @@ if ($virt eq "parallels") {
 # Likewise for QEMU.
 if ($virt eq "qemu" || $virt eq "kvm" || $virt eq "bochs") {
     push @imports, "(modulesPath + \"/profiles/qemu-guest.nix\")";
+    push @attrs, "boot.isVM = true;";
 }
 
 # Also for Hyper-V.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1827,6 +1827,7 @@
   ./virtualisation/parallels-guest.nix
   ./virtualisation/podman/default.nix
   ./virtualisation/qemu-guest-agent.nix
+  ./virtualisation/qemu-vm.nix
   ./virtualisation/rosetta.nix
   ./virtualisation/spice-usb-redirection.nix
   ./virtualisation/virtualbox-guest.nix
@@ -1839,7 +1840,6 @@
   ./virtualisation/xen-dom0.nix
   {
     documentation.nixos.extraModules = [
-      ./virtualisation/qemu-vm.nix
       ./image/repart.nix
     ];
   }

--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -26,14 +26,13 @@ in
 
 {
   imports = [
-    ../virtualisation/qemu-vm.nix
-
     # Avoid a dependency on stateVersion
     {
       disabledModules = [
         ../virtualisation/nixos-containers.nix
         ../services/x11/desktop-managers/xterm.nix
       ];
+      options.boot.isVM = true;
       # swraid's default depends on stateVersion
       config.boot.swraid.enable = false;
       options.boot.isContainer = lib.mkOption {

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -147,19 +147,7 @@ in
     systemd.services."serial-getty@${qemu-common.qemuSerialDevice}".enable = false;
     systemd.services."serial-getty@hvc0".enable = false;
 
-    # Only set these settings when the options exist. Some tests (e.g. those
-    # that do not specify any nodes, or an empty attr set as nodes) will not
-    # have the QEMU module loaded and thuse these options can't and should not
-    # be set.
-    virtualisation = lib.optionalAttrs (options ? virtualisation.qemu) {
-      qemu = {
-        # NOTE: optionalAttrs
-        #       test-instrumentation.nix appears to be used without qemu-vm.nix, so
-        #       we avoid defining attributes if not possible.
-        # TODO: refactor such that test-instrumentation can import qemu-vm
-        package  = lib.mkDefault pkgs.qemu_test;
-      };
-    };
+    virtualisation.qemu.package = lib.mkDefault pkgs.qemu_test;
 
     boot.kernel.sysctl = {
       "kernel.hung_task_timeout_secs" = 600;

--- a/nixos/modules/virtualisation/build-vm.nix
+++ b/nixos/modules/virtualisation/build-vm.nix
@@ -11,7 +11,7 @@ let
     ;
 
   vmVariant = extendModules {
-    modules = [ ./qemu-vm.nix ];
+    modules = [ { boot.isVM = true; } ];
   };
 
   vmVariantWithBootLoader = vmVariant.extendModules {

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -385,6 +385,12 @@ in
 
   options = {
 
+    boot.isVM = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether this NixOS machine is a QEMU virtual machine";
+    };
+
     virtualisation.fileSystems = options.fileSystems;
 
     virtualisation.memorySize = mkOption {
@@ -1071,7 +1077,7 @@ in
 
   };
 
-  config = {
+  config = lib.mkIf config.boot.isVM {
 
     assertions =
       lib.concatLists (

--- a/nixos/tests/nixops/legacy/base-configuration.nix
+++ b/nixos/tests/nixops/legacy/base-configuration.nix
@@ -19,7 +19,6 @@ let
 in
 {
   imports = [
-    (modulesPath + "/virtualisation/qemu-vm.nix")
     (modulesPath + "/testing/test-instrumentation.nix")
   ];
   virtualisation.writableStore = true;

--- a/nixos/tests/nixos-rebuild-target-host.nix
+++ b/nixos/tests/nixos-rebuild-target-host.nix
@@ -87,13 +87,14 @@
       configFile = hostname: hostPkgs.writeText "configuration.nix" /* nix */ ''
         { lib, modulesPath, ... }: {
           imports = [
-            (modulesPath + "/virtualisation/qemu-vm.nix")
             (modulesPath + "/testing/test-instrumentation.nix")
             (modulesPath + "/../tests/common/user-account.nix")
             (lib.modules.importJSON ./target-configuration.json)
             (lib.modules.importJSON ./target-network.json)
             ./hardware-configuration.nix
           ];
+
+          boot.isVM = true;
 
           boot.loader.grub = {
             enable = true;


### PR DESCRIPTION
This adds an option, similar to boot.isContainer, to gate the
configuration of qemu-vm.nix behind, which is now imported by default.

This solves the longstanding issue that users would get errors about the
`virtualisation.*` not existing when used outside of the scope of
`virtualisation.vmVariant`, while at same time being listed in the NixOS
manual.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- Tested with
  - [x] nixosTests.simple
  - [x] nixosTests.nixos-test-driver
  - [x] nixosTests.nixos-rebuild-specialisations 
  - [x] nixosTests.nixos-rebuild-target-host
  - [x] nixosTests.nixos-generate-config 
  - [x] nixosTests.nixos-rebuild-specialisations-ng
  - [x] nixosTests.nixos-rebuild-install-bootloader
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
