### PR TITLE
kicad/opencascade-occt: build with OCCT with rapidJSON support

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -69,7 +69,9 @@ assert lib.assertMsg (
 assert testing -> !stable -> throw "testing implies stable and cannot be used with stable = false";
 
 let
-  opencascade-occt = opencascade-occt_7_6;
+  opencascade-occt = opencascade-occt_7_6.override {
+    withRapidJSON = true;
+  };
   inherit (lib) optional optionals optionalString;
 in
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -13,6 +13,8 @@
   libXmu,
   libXi,
   darwin,
+  rapidjson,
+  withRapidJSON ? false,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,15 +42,22 @@ stdenv.mkDerivation rec {
     ninja
   ];
 
-  buildInputs = [
-    tcl
-    tk
-    libGL
-    libGLU
-    libXext
-    libXmu
-    libXi
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+  buildInputs =
+    [
+      tcl
+      tk
+      libGL
+      libGLU
+      libXext
+      libXmu
+      libXi
+    ]
+    ++ lib.optional withRapidJSON rapidjson
+    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Cocoa;
+
+  cmakeFlags = lib.optional withRapidJSON [
+    "-D USE_RAPIDJSON=ON"
+  ];
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
 


### PR DESCRIPTION
Kicad uses opencascade/OCCT with rapidjson support to do 3d model exports to `glb`. Nixpkgs' OCCT is currently built without this, so this export functionality in KiCAD doesn't work.

This PR does two things:
- adds a (default `false`) `withRapidJSON` option to the occt derivation
- overrides it in kicad to true

I wasn't sure whether or not to "thread" `opencascade-occt` through kicad's `default.nix` to `base.nix` so that the override could happen in `all-packages.nix` - with how I have it currently it's harder to override, but then - so is everything in `base.nix` *anyway*...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
