### PR TITLE
pdm: fix AGPL issues

### DIFF
--- a/pkgs/by-name/pd/pdm/package.nix
+++ b/pkgs/by-name/pd/pdm/package.nix
@@ -21,8 +21,8 @@ let
       });
       # pdm requires hishel and subsequentially pytest-regressions -> matplotlib -> ghostscript -> jbig2dec which is AGPL only
       matplotlib = super.matplotlib.override ({ enableGhostscript = false; });
-      # pdm requires hishel and subsequentially moto -> graphql-core -> pytest-benchmark -> pygal-cairosvg -> cairocffi -> pikepdf -> jbig2dec which is AGPL only
-      cairocffi = super.cairocffi.overridePythonAttrs (old: rec {
+      # avoid many extra dependencies
+      moto = super.moto.overridePythonAttrs (old: rec {
         doCheck = false;
       });
     };

--- a/pkgs/by-name/pd/pdm/package.nix
+++ b/pkgs/by-name/pd/pdm/package.nix
@@ -19,6 +19,12 @@ let
           hash = "sha256-UBdgFN+fvbjz+rp8+rog8FW2jwO/jCfUPV7UehJKiV8=";
         };
       });
+      # pdm requires hishel and subsequentially pytest-regressions -> matplotlib -> ghostscript -> jbig2dec which is AGPL only
+      matplotlib = super.matplotlib.override ({ enableGhostscript = false; });
+      # pdm requires hishel and subsequentially moto -> graphql-core -> pytest-benchmark -> pygal-cairosvg -> cairocffi -> pikepdf -> jbig2dec which is AGPL only
+      cairocffi = super.cairocffi.overridePythonAttrs (old: rec {
+        doCheck = false;
+      });
     };
   };
 in


### PR DESCRIPTION
PDM has a runtime dependency which ends up in inclusion of AGPL software, this can get fixed by setting a property. A backport to 24.11 would be highly appreciated as well

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
error:
       … while evaluating the attribute 'drvPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:418:7:
          417|     // {
          418|       drvPath =
             |       ^
          419|         assert condition;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'pdm-2.22.3'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'pdm-2.22.3'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:429:7:
          428|       depsHostHostPropagated      = elemAt (elemAt propagatedDependencies 1) 0;
          429|       propagatedBuildInputs       = elemAt (elemAt propagatedDependencies 1) 1;
             |       ^
          430|       depsTargetTargetPropagated  = elemAt (elemAt propagatedDependencies 2) 0;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-hishel-0.1.1'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-hishel-0.1.1'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-moto-5.0.28'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-moto-5.0.28'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-docker-7.1.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-docker-7.1.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-paramiko-3.5.1'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-paramiko-3.5.1'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-icecream-2.1.4'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.12-icecream-2.1.4'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:429:7:
          428|       depsHostHostPropagated      = elemAt (elemAt propagatedDependencies 1) 0;
          429|       propagatedBuildInputs       = elemAt (elemAt propagatedDependencies 1) 1;
             |       ^
          430|       depsTargetTargetPropagated  = elemAt (elemAt propagatedDependencies 2) 0;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-executing-2.1.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-executing-2.1.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-rich-13.9.4'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'propagatedBuildInputs' of derivation 'python3.12-rich-13.9.4'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:429:7:
          428|       depsHostHostPropagated      = elemAt (elemAt propagatedDependencies 1) 0;
          429|       propagatedBuildInputs       = elemAt (elemAt propagatedDependencies 1) 1;
             |       ^
          430|       depsTargetTargetPropagated  = elemAt (elemAt propagatedDependencies 2) 0;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-markdown-it-py-3.0.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-markdown-it-py-3.0.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-pytest-regressions-2.7.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'python3.12-pytest-regressions-2.7.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:419:7:
          418|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          419|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          420|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'python3.12-matplotlib-3.10.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'buildInputs' of derivation 'python3.12-matplotlib-3.10.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:422:7:
          421|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          422|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          423|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       … while calling the 'getAttr' builtin
         at <nix/derivation-internal.nix>:44:19:
           43|       value = commonAttrs // {
           44|         outPath = builtins.getAttr outputName strict;
             |                   ^
           45|         drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
           33|
           34|   strict = derivationStrict drvAttrs;
             |            ^
           35|

       … while evaluating derivation 'ghostscript-10.04.0'
         whose name attribute is located at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'buildInputs' of derivation 'ghostscript-10.04.0'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/make-derivation.nix:422:7:
          421|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          422|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          423|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       … in the condition of the assert statement
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/lib/customisation.nix:401:15:
          400|             outPath =
          401|               assert condition;
             |               ^
          402|               drv.${outputName}.outPath;

       … while evaluating the attribute 'handled'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/check-meta.nix:507:7:
          506|       # or, alternatively, just output a warning message.
          507|       handled =
             |       ^
          508|         (

       … from call site
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/check-meta.nix:511:13:
          510|           else if valid == "no" then (
          511|             handleEvalIssue { inherit meta attrs; } { inherit (validity) reason errormsg; }
             |             ^
          512|           )

       … while calling 'handleEvalIssue'
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/check-meta.nix:269:38:
          268|
          269|   handleEvalIssue = { meta, attrs }: { reason , errormsg ? "" }:
             |                                      ^
          270|     let

       … while calling the 'throw' builtin
         at /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/stdenv/generic/check-meta.nix:281:8:
          280|         else throw;
          281|     in handler msg;
             |        ^
          282|

       error: Package ‘jbig2dec-0.20’ in /nix/store/alzxn3hjisc84hrlv44x6hni48crww26-source/pkgs/by-name/jb/jbig2dec/package.nix:39 has a blocklisted license (‘agpl3Only’), refusing to evaluate.

```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
