### PR TITLE
yew-fmt: 0.5.5 -> 0.6

### DIFF
--- a/pkgs/by-name/ye/yew-fmt/package.nix
+++ b/pkgs/by-name/ye/yew-fmt/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "yew-fmt";
-  version = "0.5.5";
+  version = "0.6";
 
   src = fetchFromGitHub {
     owner = "its-the-shrimp";
     repo = "yew-fmt";
     tag = "v${version}";
-    hash = "sha256-2sOw8wWfnEphYsruQyhZMW3KofcGkNHJB6Q1jhFP3oo=";
+    hash = "sha256-KhZezkR9VhdfGkNe1hSF90pe9K4VGDlBltasb7xnmRI=";
   };
 
-  cargoHash = "sha256-o4oRVI3+Nz8fwdwlyVvXUuhCQr4Bbg5Kife/PJoJCJY=";
+  cargoHash = "sha256-Y6OicST0GbUL4RpvdvtBLFlLwryQMKlaut5x9+cNiM8=";
   nativeCheckInputs = [ rustfmt ];
   passthru.updateScript = nix-update-script { };
   useFetchCargoVendor = true;


### PR DESCRIPTION
Updating the [`yew-fmt`](https://github.com/its-the-shrimp/yew-fmt) to the latest version `0.6`.

~~I just tried to upgrade it this afternoon and ran into the error logs below:~~

```shell
       >    Compiling shrimple-parser v0.0.12
       >    Compiling syn v2.0.98
       >    Compiling dirs-sys v0.4.1
       > error: Option::<T>::expect is not yet stable as a const fn
       >   --> /build/yew-fmt-0.6-vendor/shrimple-parser-0.0.12/src/loc.rs:95:23
       >    |
       > 95 |                 line: NonZero::new(self.line.get() + rhs.line.get() - 1).expect("no overflow"),
       >    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >
       >    Compiling dirs v5.0.1
       > error: could not compile shrimple-parser (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
```

~~The reason of this error is the versions of `rustc` and `cargo` in `RustPlatform` is not new enough. Hence, I specified the latest stable versions with `rust-bin`.~~

> Thanks for the reviewer helping me understand that I don't need to do this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
