### PR TITLE
lib.modules: Expose the freeform results readonly via '_module.freeformConfig'

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -234,6 +234,27 @@ let
               within a configuration, but can be used in module imports.
             '';
           };
+
+          _module.freeformConfig = mkOption {
+            # Do not show this in the documentation
+            internal = true;
+            visible = false;
+            readOnly = true;
+            # We need a valid type here,
+            # ideally we'd only define this whole option, if there is a 'freeformType', however that is not possible due to technical limitations currently
+            type =
+              if declaredConfig._module.freeformType != null then
+                declaredConfig._module.freeformType
+              else
+                types.raw;
+            description = ''
+              Read-only version of the freeform definitions. This includes all definitions that don't have matching options if the freeformType is set.
+              Otherwise this is an empty attribute set.
+            '';
+            # It's currently(?) not possible to compute the option value normally, using the type.
+            # Instead, we set it directly here, without evaluating the merge result from the type.
+            apply = _value: freeformConfig;
+          };
         };
 
         config = {
@@ -242,6 +263,8 @@ let
             moduleType = type;
           };
           _module.specialArgs = specialArgs;
+
+          _module.freeformConfig = lib.mkMerge (map mkDefinition freeformDefs);
         };
       };
 
@@ -266,23 +289,19 @@ let
 
       options = merged.matchedOptions;
 
-      config =
+      freeformDefs = map (def: {
+        file = def.file;
+        value = setAttrByPath def.prefix def.value;
+      }) (merged.unmatchedDefns);
+
+      declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
+      freeformConfig =
         let
-
-          # For definitions that have an associated option
-          declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
-
-          # If freeformType is set, this is for definitions that don't have an associated option
-          freeformConfig =
-            let
-              defs = map (def: {
-                file = def.file;
-                value = setAttrByPath def.prefix def.value;
-              }) merged.unmatchedDefns;
-            in
-            if defs == [ ] then { } else declaredConfig._module.freeformType.merge prefix defs;
-
+          defs = freeformDefs;
         in
+        if defs == [ ] then { } else declaredConfig._module.freeformType.merge prefix defs;
+
+      config =
         if declaredConfig._module.freeformType == null then
           declaredConfig
         # Because all definitions that had an associated option ended in
@@ -652,11 +671,11 @@ let
         name: _: addErrorContext (context name) (args.${name} or config._module.args.${name})
       ) (functionArgs f);
 
-      # Note: we append in the opposite order such that we can add an error
-      # context on the explicit arguments of "args" too. This update
-      # operator is used to make the "args@{ ... }: with args.lib;" notation
-      # works.
     in
+    # Note: we append in the opposite order such that we can add an error
+    # context on the explicit arguments of "args" too. This update
+    # operator is used to make the "args@{ ... }: with args.lib;" notation
+    # works.
     f (args // extraArgs);
 
   /**
@@ -1095,7 +1114,7 @@ let
   mergeDefinitions = loc: type: defs: rec {
     defsFinal' =
       let
-        # Process mkMerge and mkIf properties.
+        # Process properties
         defs' = concatMap (
           m:
           map (

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -129,10 +129,10 @@ let
       # When extended with extendModules or moduleType, a fresh instance of
       # this module is used, to avoid conflicts and allow chaining of
       # extendModules.
-      internalModule = rec {
+      internalModule = {
         _file = "lib/modules.nix";
 
-        key = _file;
+        key = "lib/modules.nix";
 
         options = {
           _module.args = mkOption {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -703,7 +703,10 @@ checkConfigOutput '"nixos"' config.sub.nixos.foo ./specialArgs-class.nix
 checkConfigOutput '"bar"' config.sub.conditionalImportAsNixos.foo ./specialArgs-class.nix
 checkConfigError 'attribute .*bar.* not found' config.sub.conditionalImportAsNixos.bar ./specialArgs-class.nix
 checkConfigError 'attribute .*foo.* not found' config.sub.conditionalImportAsDarwin.foo ./specialArgs-class.nix
-checkConfigOutput '"foo"' config.sub.conditionalImportAsDarwin.bar ./specialArgs-class.nix
+
+# Checks for _module.freeformConfig
+checkConfigOutput 'true' config.result ./freeform-options.nix
+
 
 cat <<EOF
 ====== module tests ======

--- a/lib/tests/modules/adhoc-freeformType-survives-type-merge.nix
+++ b/lib/tests/modules/adhoc-freeformType-survives-type-merge.nix
@@ -6,10 +6,10 @@
   };
   freeformType =
     let
-      a = lib.types.attrsOf (lib.types.submodule { options.bar = lib.mkOption { }; });
+      a = lib.types.attrsOf lib.types.anything;
     in
-    # modifying types like this breaks type merging.
-    # This test makes sure that type merging is not performed when only a single declaration exists.
+    # Modifying types like this is unsafe. Type merging or using a submodule type will discard those modifications.
+    # This test makes sure that type.merge can return definitions that don't intersect with the original definitions (unmatchedDefns).
     # Don't modify types in practice!
     a
     // {

--- a/lib/tests/modules/freeform-options.nix
+++ b/lib/tests/modules/freeform-options.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+{
+  freeformType = with lib.types; attrsOf int;
+
+  # Regular options
+  options.bar = lib.mkOption {
+    default = 1;
+  };
+
+  # This should be in _module.freeformConfig
+  # With 'definitions' and 'type' in the corresponding options._module.freeformConfig
+  config.foo = 42;
+
+  imports = [
+    {
+      foo = 42;
+    }
+    {
+      bar = 1;
+    }
+  ];
+
+  options.result = lib.mkOption {
+    default =
+      assert config._module.freeformConfig == { foo = 42; };
+      # option has the merged value
+      assert options._module.freeformConfig.value == { foo = 42; };
+      # option contains freeform definitions
+      assert
+        options._module.freeformConfig.definitions == [
+          { foo = 42; }
+          { foo = 42; }
+        ];
+      # The type should be inherited from freeformType
+      assert options._module.freeformConfig.type.nestedTypes.elemType.name == "int";
+      true;
+  };
+}


### PR DESCRIPTION
For any kind of Introspection tooling we needed access to the definitions and the highestPrio of options.

Definitions via freeform are not accessible / observable at all which makes building debuggers, frontends, or introspection tools in general impossible. Also manual debugging by looking into freeform to see what was matched is nice and makes peoples life easier.

Overall:

- This provides access for introspection of freeform, including 'prios' and 'definitions' 

Thx @roberth who helped me out finding a design that works quite a bit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
