### PR TITLE
nixos-rebuild-ng: improve README.md

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -6,16 +6,16 @@ Work-in-Progress rewrite of
 ## Why the rewrite?
 
 The current state of `nixos-rebuild` is dire: it is one of the most critical
-piece of code we have in NixOS, but it has tons of issues:
+pieces of code we have in NixOS, but it has tons of issues:
 - The code is written in Bash, and while this by itself is not necessary bad,
   it means that it is difficult to do refactorings due to the lack of tooling
   for the language
 - The code itself is a hacky mess. Changing even one line of code can cause
-  issues that affects dozens of people
+  issues that affect dozens of people
 - Lack of proper testing (we do have some integration tests, but no unit tests
   and coverage is probably pitiful)
-- The code predates some of the improvements `nix` had over the years, e.g.: it
-  builds Flakes inside a temporary directory and read the resulting symlink
+- The code predates some of the improvements `nix` had over the years, e.g., it
+  builds Flakes inside a temporary directory and reads the resulting symlink
   since the code seems to predate `--print-out-paths` flag
 
 Given all of those above, improvements in the `nixos-rebuild` are difficult to
@@ -32,7 +32,7 @@ an attempt of the rewrite.
 - It is a scripting language that fits well with the scope of this project
 - Python's standard library is great and it means we will need a low number of
   external dependencies for this project. For example, `nixos-rebuild`
-  currently depends in `jq` for JSON parsing, while Python has `json` in
+  currently depends on `jq` for JSON parsing, while Python has `json` in
   standard library
 
 ## Do's and Don'ts
@@ -44,8 +44,8 @@ an attempt of the rewrite.
 
 ## How to use
 
-If you want to use `nixos-rebuild-ng` without replacing `nixos-rebuild`, add to
-your NixOS configuration:
+If you want to use `nixos-rebuild-ng` without replacing `nixos-rebuild`, add the
+following to your NixOS configuration:
 
 ```nix
 { pkgs, ... }:
@@ -57,7 +57,7 @@ your NixOS configuration:
 And use `nixos-rebuild-ng` instead of `nixos-rebuild`.
 
 If you want to completely replace `nixos-rebuild` with `nixos-rebuild-ng`, add
-to your NixOS configuration:
+the following to your NixOS configuration:
 
 ```nix
 { ... }:
@@ -104,12 +104,12 @@ ruff format .
 ## Breaking changes
 
 While `nixos-rebuild-ng` tries to be as much of a clone of the original as
-possible, there are still some breaking changes that were done in other to
+possible, there are still some breaking changes that were done in order to
 improve the user experience. If they break your workflow in some way that is
 not possible to fix, please open an issue and we can discuss a solution.
 
 - For `--build-host` and `--target-host`, `nixos-rebuild-ng` does not allocate
-  a pseudo-TTY via SSH (e.g.: `ssh -t`) anymore. The reason for this is because
+  a pseudo-TTY via SSH (e.g., `ssh -t`) anymore. The reason for this is that
   pseudo-TTY breaks some expectations from SSH, like it mangles stdout and
   stderr, and can
   [break terminal output](https://github.com/NixOS/nixpkgs/issues/336967) in
@@ -122,7 +122,7 @@ not possible to fix, please open an issue and we can discuss a solution.
   every `sudo` request. Keep in mind that there is no check, so if you type
   your password wrong, it will fail during activation (this can be improved
   though)
-- When `--build-host` and `--target-host` is used together, we will use `nix
+- When `--build-host` and `--target-host` are used together, we will use `nix
   copy` (or 2 `nix-copy-closure` if you're using Nix <2.18) instead of SSH'ing
   to build host and using `nix-copy-closure --to target-host`. The reason for
   this is documented in PR
@@ -142,7 +142,7 @@ not possible to fix, please open an issue and we can discuss a solution.
 - Bugs in the profile manipulation can cause corruption of your profile that
   may be difficult to fix, so right now I only recommend using
   `nixos-rebuild-ng` if you are testing in a VM or in a filesystem with
-  snapshots like btrfs or ZFS. Those bugs are unlikely to be unfixable but the
+  snapshots like BTRFS or ZFS. Those bugs are unlikely to be unfixable but the
   errors can be difficult to understand. If you want to go anyway,
   `nix-collect-garbage -d` and `nix store repair` are your friends
 


### PR DESCRIPTION
After https://github.com/NixOS/nixpkgs/issues/342657 was closed I found this package and read the `README.md` for it. I immediately found a few mistakes and typos, so thought that it's a yet another good opportunity to contribute. Later during the second reading I found some more. I also changed the `console` code block language (where did it come from anyway?) to one (of) that is use more regularly and describes the syntax more precisely — `sh` (`shell`). This also enabled treesitter syntax highlighting for me (I use Neovim, btw). I tried to make as few changes as possible (cuz perfectionism ain't easy).

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
