### PR TITLE
conduit: init at 0.9.3

### DIFF
--- a/pkgs/by-name/co/conduit/package.nix
+++ b/pkgs/by-name/co/conduit/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  openmpi,
+
+  # passthru
+  conduit,
+  nix-update-script,
+
+  mpiSupport ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "conduit";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "conduit";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-R7DiMwaMG9VfqDJiO3kFPb76j6P2GZl/6qLxDfVex8A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeDir = "../src";
+
+  buildInputs = lib.optionals mpiSupport [
+    openmpi
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_MPI" mpiSupport)
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    make test
+
+    runHook postInstallCheck
+  '';
+  doInstallCheck = true;
+
+  passthru = {
+    tests = {
+      withMpi = conduit.override { mpiSupport = true; };
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Simplified Data Exchange for HPC Simulations";
+    homepage = "https://github.com/LLNL/conduit";
+    changelog = "https://github.com/LLNL/conduit/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.bsd3Lbnl;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

Add [conduit](https://github.com/llnl/conduit), a library that provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python.

cc @theabm 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
