### PR TITLE
denemo: mark as broken

### DIFF
--- a/pkgs/by-name/de/denemo/package.nix
+++ b/pkgs/by-name/de/denemo/package.nix
@@ -83,11 +83,14 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Music notation and composition software used with lilypond";
     homepage = "http://denemo.org";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.olynch ];
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.olynch ];
+    # sffile.c:38:10: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
+    # sffile.c:54:10: error: type defaults to 'int' in declaration of 'initialized' [-Wimplicit-int]
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

```
sffile.c: In function 'ConvertIllegalChar':
sffile.c:38:10: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
   38 |     if (!isprint(*p) || *p == '{' || *p == '}')
      |          ^~~~~~~
sffile.c:28:1: note: include '<ctype.h>' or provide a declaration of 'isprint'
   27 | #include "sf_util.h"
  +++ |+#include <ctype.h>
   28 |
sffile.c: In function 'ParseSoundfont':
sffile.c:54:10: error: type defaults to 'int' in declaration of 'initialized' [-Wimplicit-int]
   54 |   static initialized = FALSE;
      |          ^~~~~~~~~~~
make[2]: *** [Makefile:563: libsffile_a-sffile.o] Error 1
make[2]: Leaving directory '/build/denemo-2.6.0/libs/libsffile'
make[1]: *** [Makefile:653: all-recursive] Error 1
make[1]: Leaving directory '/build/denemo-2.6.0'
make: *** [Makefile:562: all] Error 2
```

cc @olynch

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
