### PR TITLE
lib/modules: Init lib.mkDefinition

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -446,6 +446,7 @@ let
         fixupOptionType
         mkIf
         mkAssert
+        mkDefinition
         mkMerge
         mkOverride
         mkOptionDefault

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1177,8 +1177,6 @@ let
       map (mapAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
     else if cfg._type or "" == "override" then
       map (mapAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
-    # else if cfg._type or "" == "definition" then
-    #   map (mapAttrs (n: v: mkDefinition v)) (pushDownProperties cfg.content)
     # FIXME: handle mkOrder?
     else
       [ cfg ];

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -673,6 +673,14 @@ checkConfigError 'The option .conflictingPathOptionType. in .*/pathWith.nix. is 
 # types.pathWith { inStore = true; absolute = false; }
 checkConfigError 'In pathWith, inStore means the path must be absolute' config.impossiblePathOptionType ./pathWith.nix
 
+# mkDefinition
+# check that mkDefinition 'file' is printed in the error message
+checkConfigError 'Cannot merge definitions.*\n\s*- In .file.*\n\s*- In .other.*' config.conflict ./mkDefinition.nix
+checkConfigError 'A definition for option .viaOptionDefault. is not of type .boolean.*' config.viaOptionDefault ./mkDefinition.nix
+checkConfigOutput '^true$' config.viaConfig ./mkDefinition.nix
+checkConfigOutput '^true$' config.mkMerge ./mkDefinition.nix
+checkConfigOutput '^true$' config.mkForce ./mkDefinition.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/mkDefinition.nix
+++ b/lib/tests/modules/mkDefinition.nix
@@ -1,0 +1,71 @@
+{ lib, ... }:
+let
+  inherit (lib)
+    mkOption
+    mkDefinition
+    mkOptionDefault
+    ;
+in
+{
+  imports = [
+    {
+      _file = "file";
+      options.conflict = mkOption {
+        default = 1;
+      };
+      config.conflict = mkDefinition {
+        file = "other";
+        value = mkOptionDefault 42;
+      };
+    }
+    {
+      # Check that mkDefinition works within 'config'
+      options.viaConfig = mkOption { };
+      config.viaConfig = mkDefinition {
+        file = "other";
+        value = true;
+      };
+    }
+    {
+      # Check mkMerge can wrap mkDefinitions
+      # Not the other way around
+      options.mkMerge = mkOption {
+        type = lib.types.bool;
+      };
+      config.mkMerge = lib.mkMerge [
+        (mkDefinition {
+          file = "a.nix";
+          value = true;
+        })
+        (mkDefinition {
+          file = "b.nix";
+          value = true;
+        })
+      ];
+    }
+    {
+      # Check mkDefinition can use mkForce on the value
+      # Not the other way around
+      options.mkForce = mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+      config.mkForce = mkDefinition {
+        file = "other";
+        value = lib.mkForce true;
+      };
+    }
+    {
+      # Currently expects an error
+      # mkDefinition doesn't work on option default
+      # This is a limitation and might be resolved in the future
+      options.viaOptionDefault = mkOption {
+        type = lib.types.bool;
+        default = mkDefinition {
+          file = "other";
+          value = true;
+        };
+      };
+    }
+  ];
+}

--- a/nixos/doc/manual/development/option-def.section.md
+++ b/nixos/doc/manual/development/option-def.section.md
@@ -139,7 +139,25 @@ A free-floating definition is created with `mkDefinition { file = ...; value = .
 
 Preserving the file location creates better error messages, for example when copying definitions from one option to another.
 
-Other properties like `mkOverride` `mkMerge` `mkAfter` can be used in the `value` attribute but not the other way around.
+Other properties like `mkOverride` `mkMerge` `mkAfter` can be used in the `value` attribute but not on the entire definition.
+
+This is what would work
+
+```nix
+mkDefinition {
+   value = mkForce 42;
+   file = "somefile.nix";
+}
+```
+
+While this would NOT work.
+
+```nix
+mkForce (mkDefinition {
+   value = 42;
+   file = "somefile.nix";
+})
+```
 
 The following shows an example configuration that yields an error with the custom position information:
 

--- a/nixos/doc/manual/development/option-def.section.md
+++ b/nixos/doc/manual/development/option-def.section.md
@@ -123,3 +123,47 @@ they were declared in separate modules. This can be done using
     ];
 }
 ```
+
+## Free-floating definitions {#sec-option-definitions-definitions}
+
+:::{.note}
+The module system internally transforms module syntax into definitions. This always happens internally.
+:::
+
+It is possible to create first class definitions which are not transformed _again_ into definitions by the module system.
+
+Usually the file location of a definition is implicit and equal to the file it came from.
+However, when manipulating definitions, it may be useful for them to be completely self-contained (or "free-floating").
+
+A free-floating definition is created with `mkDefinition { file = ...; value = ...; }`.
+
+Preserving the file location creates better error messages, for example when copying definitions from one option to another.
+
+Other properties like `mkOverride` `mkMerge` `mkAfter` can be used in the `value` attribute but not the other way around.
+
+The following shows an example configuration that yields an error with the custom position information:
+
+```nix
+{
+  _file = "file.nix";
+  options.foo = mkOption {
+    default = 13;
+  };
+  config.foo = lib.mkDefinition {
+    file = "custom place";
+    # mkOptionDefault creates a conflict with the option foo's `default = 1` on purpose
+    # So we see the error message below contains the conflicting values and different positions
+    value = lib.mkOptionDefault 42;
+  };
+}
+```
+
+evaluating the module yields the following error:
+
+```
+error: Cannot merge definitions of `foo'. Definition values:
+- In `file.nix': 13
+- In `custom place': 42
+```
+
+To set the file location for all definitions in a module, you may add the `_file` module syntax attribute, which has a similar effect to using `mkDefinition` on all definitions in the module, without the hassle.

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1664,6 +1664,9 @@
   "sec-option-definitions-merging": [
     "index.html#sec-option-definitions-merging"
   ],
+  "sec-option-definitions-definitions": [
+    "index.html#sec-option-definitions-definitions"
+  ],
   "sec-assertions": [
     "index.html#sec-assertions"
   ],


### PR DESCRIPTION
Add free-floating definitions. This allows better error messages.

Also unblocking things like: #390952

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
