### PR TITLE
beets-unstable: 2024-12-02 -> 2025-03-12

### DIFF
--- a/pkgs/development/python-modules/lap/default.nix
+++ b/pkgs/development/python-modules/lap/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  cython,
+  fetchPypi,
+  numpy,
+  pytestCheckHook,
+  python-utils,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "lap";
+  version = "0.5.12";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-VwtBTqeubAS9SdDsjNrB3FY0c3dVeE1E43+fZourRP0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ cython ];
+
+  dependencies = [
+    numpy
+    python-utils
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "lap" ];
+  # See https://github.com/NixOS/nixpkgs/issues/255262
+  preCheck = ''
+    cd "$out"
+  '';
+
+  meta = {
+    description = "Linear Assignment Problem solver (LAPJV/LAPMOD)";
+    homepage = "https://github.com/gatagat/lap";
+    changelog = "https://github.com/gatagat/lap/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      doronbehar
+      tebriel
+    ];
+  };
+}

--- a/pkgs/tools/audio/beets/builtin-plugins.nix
+++ b/pkgs/tools/audio/beets/builtin-plugins.nix
@@ -7,6 +7,8 @@
   mp3gain,
   mp3val,
   python3Packages,
+  version,
+  lib,
   ...
 }:
 {
@@ -169,4 +171,10 @@
     flask-cors
   ];
   zero = { };
+}
+# NOTE: There will be no need for this conditional once beets is updated.
+// lib.optionalAttrs (lib.versionAtLeast version "2.2.0-unstable-2025-03-12") {
+  _typing = {
+    testPaths = [ ];
+  };
 }

--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -82,17 +82,6 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   patches = [
-    (fetchpatch {
-      # Already on master. TODO: remove when updating to the next release
-      # Issue: https://github.com/beetbox/beets/issues/5527
-      # PR: https://github.com/beetbox/beets/pull/5650
-      name = "fix-im-backend";
-      url = "https://github.com/beetbox/beets/commit/1f938674015ee71431fe9bd97c2214f58473efd2.patch";
-      hash = "sha256-koCYeiUhk1ifo6CptOSu3p7Nz0FFUeiuArTknM/tpVQ=";
-      excludes = [
-        "docs/changelog.rst"
-      ];
-    })
   ] ++ extraPatches;
 
   build-system = [
@@ -112,6 +101,9 @@ python3Packages.buildPythonApplication {
       pyyaml
       unidecode
       typing-extensions
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "2.2.0-unstable-2025-03-12") [
+      lap
     ]
     ++ (concatMap (p: p.propagatedBuildInputs) (attrValues enabledPlugins));
 
@@ -159,6 +151,9 @@ python3Packages.buildPythonApplication {
       mock
       rarfile
       responses
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "2.2.0-unstable-2025-03-12") [
+      requests-mock
     ]
     ++ [
       writableTmpDirAsHomeHook

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -20,6 +20,17 @@
 */
 let
   extraPatches = [
+    (fetchpatch {
+      # Already on master. TODO: remove when updating to the next release
+      # Issue: https://github.com/beetbox/beets/issues/5527
+      # PR: https://github.com/beetbox/beets/pull/5650
+      name = "fix-im-backend";
+      url = "https://github.com/beetbox/beets/commit/1f938674015ee71431fe9bd97c2214f58473efd2.patch";
+      hash = "sha256-koCYeiUhk1ifo6CptOSu3p7Nz0FFUeiuArTknM/tpVQ=";
+      excludes = [
+        "docs/changelog.rst"
+      ];
+    })
     # Bash completion fix for Nix
     ./patches/bash-completion-always-print.patch
     # Remove after next release.
@@ -46,13 +57,13 @@ lib.makeExtensible (self: {
   beets-minimal = self.beets.override { disableAllPlugins = true; };
 
   beets-unstable = callPackage ./common.nix {
-    inherit python3Packages extraPatches;
-    version = "2.2.0-unstable-2024-12-02";
+    inherit python3Packages;
+    version = "2.2.0-unstable-2025-03-12";
     src = fetchFromGitHub {
       owner = "beetbox";
       repo = "beets";
-      rev = "f92c0ec8b14fbd59e58374fd123563123aef197b";
-      hash = "sha256-jhwXRgUUQJgQ/PLwvY1UfHCJ9UC8DcdBpE/janao0RM=";
+      rev = "670a3bcd17a46883c71cf07dd313fcd0dff4be9d";
+      hash = "sha256-hSY7FhpPL4poOY1/gqk7oLNgQ7KA/MJqx50xOLIP0QA=";
     };
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7317,6 +7317,8 @@ self: super: with self; {
     inherit (pkgs.__splicedPackages) laszip;
   };
 
+  lap = callPackage ../development/python-modules/lap { };
+
   latex2mathml = callPackage ../development/python-modules/latex2mathml { };
 
   latex2pydata = callPackage ../development/python-modules/latex2pydata { };


### PR DESCRIPTION
- Update the `unstable` package to the latest commit (from 2025-03-12).
- Introduce `python-packages.lap` which is a new dependency for beets.
`pkgs/top-level/python-packages.nix` [which I modified to add a package to] wasn't nixfmt'd so I did that as I was editing the file. If this is a bad idea (due to merge conflicts, history, etc) I'm happy to back that change out.

I'm new to packaging python in nixos, please provide any feedback, happy to alter! Comments inline for reasoning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
