### PR TITLE
nixos/test-driver: improve error reporting and assertions

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -121,8 +121,7 @@ and checks that the output is more-or-less correct:
 ```py
 machine.start()
 machine.wait_for_unit("default.target")
-if not "Linux" in machine.succeed("uname"):
-  raise Exception("Wrong OS")
+t.assertIn("Linux", machine.succeed("uname"), "Wrong OS")
 ```
 
 The first line is technically unnecessary; machines are implicitly started
@@ -133,6 +132,8 @@ starting them in parallel:
 ```py
 start_all()
 ```
+
+Under the variable `t`, all assertions from [`unittest.TestCase`](https://docs.python.org/3/library/unittest.html) are available.
 
 If the hostname of a node contains characters that can't be used in a
 Python variable name, those characters will be replaced with

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -31,6 +31,7 @@ python3Packages.buildPythonApplication {
       colorama
       junit-xml
       ptpython
+      ipython
     ]
     ++ extraPythonPackages python3Packages;
 

--- a/nixos/lib/test-driver/src/pyproject.toml
+++ b/nixos/lib/test-driver/src/pyproject.toml
@@ -21,7 +21,7 @@ target-version = "py312"
 line-length = 88
 
 lint.select = ["E", "F", "I", "U", "N"]
-lint.ignore = ["E501"]
+lint.ignore = ["E501", "N818"]
 
 # xxx: we can import https://pypi.org/project/types-colorama/ here
 [[tool.mypy.overrides]]

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -3,7 +3,7 @@ import os
 import time
 from pathlib import Path
 
-import ptpython.repl
+import ptpython.ipython
 
 from test_driver.driver import Driver
 from test_driver.logger import (
@@ -136,11 +136,10 @@ def main() -> None:
         if args.interactive:
             history_dir = os.getcwd()
             history_path = os.path.join(history_dir, ".nixos-test-history")
-            ptpython.repl.embed(
-                driver.test_symbols(),
-                {},
+            ptpython.ipython.embed(
+                user_ns=driver.test_symbols(),
                 history_filename=history_path,
-            )
+            )  # type:ignore
         else:
             tic = time.time()
             driver.run_tests()

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -188,6 +188,8 @@ class Driver:
                 sys.exit(1)
             except RequestedAssertionFailed:
                 exc_type, exc, tb = sys.exc_info()
+                # We manually print the stack frames, keeping only the ones from the test script
+                # (note: because the script is not a real file, the frame filename is `<string>`)
                 filtered = [
                     frame
                     for frame in traceback.extract_tb(tb)

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 from unittest import TestCase
 
-from test_driver.errors import RequestedAssertionFailed, TestScriptError
+from test_driver.errors import MachineError, RequestedAssertionFailed
 from test_driver.logger import AbstractLogger
 from test_driver.machine import Machine, NixStartScript, retry
 from test_driver.polling_condition import PollingCondition
@@ -182,7 +182,11 @@ class Driver:
             symbols = self.test_symbols()  # call eagerly
             try:
                 exec(self.tests, symbols, None)
-            except TestScriptError:
+            except MachineError:
+                for line in traceback.format_exc().splitlines():
+                    self.logger.log_test_error(line)
+                sys.exit(1)
+            except RequestedAssertionFailed:
                 exc_type, exc, tb = sys.exc_info()
                 filtered = [
                     frame

--- a/nixos/lib/test-driver/src/test_driver/errors.py
+++ b/nixos/lib/test-driver/src/test_driver/errors.py
@@ -15,6 +15,6 @@ class RequestedAssertionFailed(AssertionError):
     e.g. a failing `t.assertEqual(...)` or `machine.succeed(...)`.
 
     This gets special treatment in error reporting: i.e. it gets
-    `!!!` as prefix just as `MachineError`, but all stack frames that are
-    not from `testScript` also get removed.
+    `!!!` as prefix just as `MachineError`, but only stack frames coming
+    from `testScript` will show up in logs.
     """

--- a/nixos/lib/test-driver/src/test_driver/errors.py
+++ b/nixos/lib/test-driver/src/test_driver/errors.py
@@ -1,0 +1,23 @@
+class TestScriptError(Exception):
+    """
+    The base error class to indicate that the test script failed.
+    This (and its subclasses) get special treatment, i.e. only stack
+    frames from `testScript` are printed and the error gets prefixed
+    with `!!!` to make it easier to spot between other log-lines.
+
+    This class is used for errors that aren't an actual test failure,
+    but also not a bug in the driver, e.g. failing OCR.
+    """
+
+
+class RequestedAssertionFailed(TestScriptError):
+    """
+    Subclass of `TestScriptError` that gets special treatment.
+
+    Exception raised when a requested assertion fails,
+    e.g. `machine.succeed(...)` or `t.assertEqual(...)`.
+
+    This is separate from the base error class, to have a dedicated class name
+    that better represents this kind of failures.
+    (better readability in test output)
+    """

--- a/nixos/lib/test-driver/src/test_driver/errors.py
+++ b/nixos/lib/test-driver/src/test_driver/errors.py
@@ -1,23 +1,20 @@
-class TestScriptError(Exception):
+class MachineError(Exception):
     """
-    The base error class to indicate that the test script failed.
-    This (and its subclasses) get special treatment, i.e. only stack
-    frames from `testScript` are printed and the error gets prefixed
-    with `!!!` to make it easier to spot between other log-lines.
+    Exception that indicates an error that is NOT the user's fault,
+    i.e. something went wrong without the test being necessarily invalid,
+    such as failing OCR.
 
-    This class is used for errors that aren't an actual test failure,
-    but also not a bug in the driver, e.g. failing OCR.
+    To make it easier to spot, this exception (and its subclasses)
+    get a `!!!` prefix in the log output.
     """
 
 
-class RequestedAssertionFailed(TestScriptError):
+class RequestedAssertionFailed(AssertionError):
     """
-    Subclass of `TestScriptError` that gets special treatment.
+    Special assertion that gets thrown on an assertion error,
+    e.g. a failing `t.assertEqual(...)` or `machine.succeed(...)`.
 
-    Exception raised when a requested assertion fails,
-    e.g. `machine.succeed(...)` or `t.assertEqual(...)`.
-
-    This is separate from the base error class, to have a dedicated class name
-    that better represents this kind of failures.
-    (better readability in test output)
+    This gets special treatment in error reporting: i.e. it gets
+    `!!!` as prefix just as `MachineError`, but all stack frames that are
+    not from `testScript` also get removed.
     """

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -213,7 +213,7 @@ class TerminalLogger(AbstractLogger):
         tic = time.time()
         yield
         toc = time.time()
-        self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)")
+        self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
         self.log(*args, **kwargs)

--- a/nixos/lib/test-driver/src/test_driver/machine.py
+++ b/nixos/lib/test-driver/src/test_driver/machine.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from queue import Queue
 from typing import Any
 
+from test_driver.errors import RequestedAssertionFailed, TestScriptError
 from test_driver.logger import AbstractLogger
 
 from .qmp import QMPSession
@@ -128,7 +129,7 @@ def _preprocess_screenshot(screenshot_path: str, negate: bool = False) -> str:
     )
 
     if ret.returncode != 0:
-        raise Exception(
+        raise TestScriptError(
             f"Image processing failed with exit code {ret.returncode}, stdout: {ret.stdout.decode()}, stderr: {ret.stderr.decode()}"
         )
 
@@ -139,7 +140,7 @@ def _perform_ocr_on_screenshot(
     screenshot_path: str, model_ids: Iterable[int]
 ) -> list[str]:
     if shutil.which("tesseract") is None:
-        raise Exception("OCR requested but enableOCR is false")
+        raise TestScriptError("OCR requested but enableOCR is false")
 
     processed_image = _preprocess_screenshot(screenshot_path, negate=False)
     processed_negative = _preprocess_screenshot(screenshot_path, negate=True)
@@ -162,7 +163,7 @@ def _perform_ocr_on_screenshot(
                 capture_output=True,
             )
             if ret.returncode != 0:
-                raise Exception(f"OCR failed with exit code {ret.returncode}")
+                raise TestScriptError(f"OCR failed with exit code {ret.returncode}")
             model_results.append(ret.stdout.decode("utf-8"))
 
     return model_results
@@ -179,7 +180,9 @@ def retry(fn: Callable, timeout: int = 900) -> None:
         time.sleep(1)
 
     if not fn(True):
-        raise Exception(f"action timed out after {timeout} seconds")
+        raise RequestedAssertionFailed(
+            f"action timed out after {timeout} tries with one-second pause in-between"
+        )
 
 
 class StartCommand:
@@ -402,14 +405,14 @@ class Machine:
         def check_active(_last_try: bool) -> bool:
             state = self.get_unit_property(unit, "ActiveState", user)
             if state == "failed":
-                raise Exception(f'unit "{unit}" reached state "{state}"')
+                raise RequestedAssertionFailed(f'unit "{unit}" reached state "{state}"')
 
             if state == "inactive":
                 status, jobs = self.systemctl("list-jobs --full 2>&1", user)
                 if "No jobs" in jobs:
                     info = self.get_unit_info(unit, user)
                     if info["ActiveState"] == state:
-                        raise Exception(
+                        raise RequestedAssertionFailed(
                             f'unit "{unit}" is inactive and there are no pending jobs'
                         )
 
@@ -424,7 +427,7 @@ class Machine:
     def get_unit_info(self, unit: str, user: str | None = None) -> dict[str, str]:
         status, lines = self.systemctl(f'--no-pager show "{unit}"', user)
         if status != 0:
-            raise Exception(
+            raise RequestedAssertionFailed(
                 f'retrieving systemctl info for unit "{unit}"'
                 + ("" if user is None else f' under user "{user}"')
                 + f" failed with exit code {status}"
@@ -454,7 +457,7 @@ class Machine:
             user,
         )
         if status != 0:
-            raise Exception(
+            raise RequestedAssertionFailed(
                 f'retrieving systemctl property "{property}" for unit "{unit}"'
                 + ("" if user is None else f' under user "{user}"')
                 + f" failed with exit code {status}"
@@ -502,7 +505,7 @@ class Machine:
             info = self.get_unit_info(unit)
             state = info["ActiveState"]
             if state != require_state:
-                raise Exception(
+                raise RequestedAssertionFailed(
                     f"Expected unit '{unit}' to to be in state "
                     f"'{require_state}' but it is in state '{state}'"
                 )
@@ -656,7 +659,9 @@ class Machine:
                 (status, out) = self.execute(command, timeout=timeout)
                 if status != 0:
                     self.log(f"output: {out}")
-                    raise Exception(f"command `{command}` failed (exit code {status})")
+                    raise RequestedAssertionFailed(
+                        f"command `{command}` failed (exit code {status})"
+                    )
                 output += out
         return output
 
@@ -670,7 +675,9 @@ class Machine:
             with self.nested(f"must fail: {command}"):
                 (status, out) = self.execute(command, timeout=timeout)
                 if status == 0:
-                    raise Exception(f"command `{command}` unexpectedly succeeded")
+                    raise RequestedAssertionFailed(
+                        f"command `{command}` unexpectedly succeeded"
+                    )
                 output += out
         return output
 
@@ -915,7 +922,7 @@ class Machine:
             ret = subprocess.run(f"pnmtopng '{tmp}' > '{filename}'", shell=True)
             os.unlink(tmp)
             if ret.returncode != 0:
-                raise Exception("Cannot convert screenshot")
+                raise TestScriptError("Cannot convert screenshot")
 
     def copy_from_host_via_shell(self, source: str, target: str) -> None:
         """Copy a file from the host into the guest by piping it over the

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -8,6 +8,7 @@ from test_driver.logger import AbstractLogger
 from typing import Callable, Iterator, ContextManager, Optional, List, Dict, Any, Union
 from typing_extensions import Protocol
 from pathlib import Path
+from unittest import TestCase
 
 
 class RetryProtocol(Protocol):
@@ -51,3 +52,4 @@ join_all: Callable[[], None]
 serial_stdout_off: Callable[[], None]
 serial_stdout_on: Callable[[], None]
 polling_condition: PollingConditionProtocol
+t: TestCase


### PR DESCRIPTION
This essentially does the following things (and I'd recommend to review commit-by-commit):

* add `t` as instance of `unittest.TestCase` to write assertions in the style of `t.assertEqual` etc.. This has the benefit that we get proper reporting for assertion failures for free in contrast to an empty `AssertionError`.

  I considered using pytest before, but this requires messing around with its internals and probably even touching the `ast` and we already came to the conclusion in #345948 that we don't really want to have this in our framework.

  I'm considering to create a feature-request to pytest for a reasonable entry-point, but I'm not too optimistic about this.

  The name `t` is chosen as shorthand since the assertion methods are already kinda verbose and having something like `tester.assertEqual()` feels quite annoying to type. Happy to discuss other names, though ;) 

* Create a new exception class-structure that - when caught - only prints stack frames in the `testScript` (this indicates a test failure, not a bug in the framework, so the frames from the framework are just visual noise) and prefixes the error with `!!! ` (in red) so that it's easier to spot what the interesting lines are between the other logs.

* Switched to the `ipython` integration of `ptpython` for interaction: this handles `sys.exit` properly and thus also fixes #180089 (and doesn't cause an exit on failing `machine.succeed` on this branch).

* Added a `machine: ` prefix to the log message indicating a finished subtest.

Thank you @bew for working on this together!

Example:
![2025-03-18_16h48m47s_screenshot](https://github.com/user-attachments/assets/76440791-8c2a-4654-8bcf-7a9e0e610efc)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
