### PR TITLE
python312Packages.click-option-group: cleanup & skip failing test

### DIFF
--- a/pkgs/development/python-modules/click-option-group/default.nix
+++ b/pkgs/development/python-modules/click-option-group/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
+  setuptools,
   click,
   pytestCheckHook,
 }:
@@ -10,23 +10,31 @@
 buildPythonPackage rec {
   pname = "click-option-group";
   version = "0.5.6";
-  format = "setuptools";
-  disabled = pythonOlder "3.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "click-contrib";
-    repo = pname;
+    repo = "click-option-group";
     tag = "v${version}";
     hash = "sha256-uR5rIZPPT6pRk/jJEy2rZciOXrHWVWN6BfGroQ3znas=";
   };
 
-  propagatedBuildInputs = [ click ];
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ click ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTests = [
+    # AssertionError (assert result.exception)
+    "test_missing_group_decl_first_api"
+  ];
+
   pythonImportsCheck = [ "click_option_group" ];
 
-  meta = with lib; {
+  meta = {
     description = "Option groups missing in Click";
     longDescription = ''
       Option groups are convenient mechanism for logical structuring
@@ -36,7 +44,8 @@ buildPythonPackage rec {
       functionality out of the box.
     '';
     homepage = "https://github.com/click-contrib/click-option-group";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ hexa ];
+    changelog = "https://github.com/click-contrib/click-option-group/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ hexa ];
   };
 }


### PR DESCRIPTION
## Things done


```
=================================== FAILURES ===================================
______________________ test_missing_group_decl_first_api _______________________

runner = <click.testing.CliRunner object at 0x7ffff652ce00>

    def test_missing_group_decl_first_api(runner):
        @click.command()
        @click.option('--hello1')
        @optgroup.option('--foo')
        @optgroup.option('--bar')
        @click.option('--hello2')
        def cli(**params):
            pass

        result = runner.invoke(cli, ['--help'])

>       assert result.exception
E       assert None
E        +  where None = <Result okay>.exception

tests/test_click_option_group.py:111: AssertionError
=========================== short test summary info ============================
FAILED tests/test_click_option_group.py::test_missing_group_decl_first_api - assert None
========================= 1 failed, 30 passed in 0.13s =========================
```

cc @mweinelt 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
