### PR TITLE
rke2: add image archive assets to passthru attributes

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/1_29/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_29/images-versions.json
@@ -1,0 +1,122 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "4b3743795b3fb431c53f183d43b004925ff06863bd95e9fbf3949c5c5092c7bd"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "eca2ac2eda2fcaf055f54dfc1baf7f21a88f3454a84716d8d0f57574f2a36664"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "d2baf446c4ec832bf870d57bc7cfd496de6bd1df3cc26b83ea7853a8e6e85de9"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "18922628e7c9a9045b60393fe049a01ec2137b80b3312ea09735bce978ae88c8"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "351c2c73acc9a88869735430b604a60237122e778f5eb95c503530e8cc42d790"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "a8b0825efd30f2e4ee0e82730d820b5ab0e2074b76d99a4662555726440a1542"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "5a43dd70e1efac0ee0deeb5637b8fd8b19c4f70b5854d9af69dde7299c7315c0"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "d42f6de81cc2a0ca8cb8716189c782c58de3ec7f6159ac240228755bfc586b4a"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "b8ead14a0c131f9a91997635670cb03191c4f4e4b14bee77fe0da0b9629d5b01"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "b89382ac45f36536ff8d458d74938f6558f510f7bed5cebbaf0834abbb81d03d"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "f6918df76be1395bb193091d5a356555284da56294f0ab6ed6e2c5f11bf9ddbb"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "7715c4073dfbba766605ec16aa238a7e171b53def9933e9e3cd6c69780dc669c"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "2d138c9f5c08e0783bcec973de388e21cb0733a30a8f87123662f155e22d1cb6"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "2eaae797f44ab269b271fa9fb0f02ecaf14d1209c16d83b395d9549b736c149d"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "caee89bef5f95aa812de8314cc8612b525840b98e7e654c7b256277df7faaf07"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "252cbe2f8f7d262a884094411b84a0e98b16886d2c0e13edea02b81993395283"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "1495baefc0b8d727e5baf16b71a56f3d8a9dee414e614e7511fd9ca629e6146f"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "925e1b36c1d1fd65e61de76f21816866dd539a3345e29ba9aca8a66b6aa1e135"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "fcf737645558c91d525fc8c855c3f674fa0c0dea2d2114b67d2df8236c1905ca"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "a1eda6aba79af9eb58614d656106196c9159253bb17f1418ee23c4eabf400410"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "3aff7d410d88fbffed80642c044958601e325a7fb3b5f11b7b989179659b8f14"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "3d7a80dc64e96c27fd5fe4210c02357c7f2870d25b8067338f45b12c92d80d9f"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "4fbefae4e2fd15e97e81f4a6eaa1b407d39125caaf60feb766197b1914afbef6"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "d1644e15125da089225372f44d9c537f5c4ac3b298024ecda0b1537bc245f896"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "2327286a7d695c0596e7536018710373aff10c3f1adc847f07f820c33b68ad81"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "2d5cb1b383aa2a6bb840d185e01a09e7d667b05c91e4be42a04dffa5cd6b4d92"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "9bbd253fdb9fd7913569b651c2591e2b97bdd3b98d0398bcc563a09f1387d6a3"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "ce929e823814cda57d187a219dc2719cbab390bf2a2d939e44d48d70f288d25c"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "d405c544026e9aac8edad7cc64abcb4c20578a3abb8aff114910df3161aac28a"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.29.14%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "d71d9dbc916988b2d9236c56ed46dfdd269db892bcbf8e5e11675d851ec7a3f6"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_29/versions.nix
@@ -8,4 +8,5 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.29.10-0.20241016053521-9510ac25fefb-build20241016";
   dockerizedVersion = "v1.29.14-rke2r1";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_30/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "ad47733ffcfa7194ff3f8e9b1aad4028868b6def24bfc613d30104dfbaa103d2"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "fda9d7d50ed44dd15a31b74720fa71fa5d6d504091a47bfa6f766adbeaf5eb08"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "bb01eca1bb1a30e2ef83d4c528934a445e56e7e4c38d4ba795699827bcab1f79"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "020b55868818efbf5b27854416ad2f5c71a757c674a49e493f44c1b4146b16cf"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "827fe2baa8ba2429cc5a6853c7447461e0452ad46bae46e47ab53d078c34856c"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "931a778ff65cfca3b76bddf65d71792422d6ffe0abc6feecc1ca8923555550a3"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "49d4502fab5236c7b96f07636349f902d781c55d03ecd2e563a8f7e544fd30af"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "f75946b503600b0ca1b24f0da7355ece0a96380772fdc8c75f94ab6839bc559f"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "000c57f474e1b70a81dc7f0b831fd01cb8d147664e00eff566ab8d89fa9caf8a"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "00a5971a62c02e192de910f6c5f1cd230d23547335d94399fa306a355e23750f"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "da8793a53ac5c64387872db810d3b94f11ba063af6e11b48ac6df2a943ea8f79"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "85e78feaeac5dba9ef18eac8dd42081afe4f0bffe11921dbfd6b7cc585ca1496"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "c5c4c7389312642c6dc9ef3a07d954be5d3776a8fc1e6df90bb46eb95fd75513"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "8ec619a8b458c27f14bfdb796b1aa399ed34b7db176ea3ae64ba20189f529835"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "413566078e9315aa5d9339e6fb1f7859aea399a7f7934019aa7b1229e223e293"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "586a55ed0aff2bd149bd2a5ad586177ba78814a7da8acb0640365bffaa5c39bb"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "6eaa3a7f058abd192eab13533cc47a47d4571eee3f6f688f1c316c8a62c1f9d8"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "42e2f3ce038d7262afcea8c5603f59bd501653e6dcbcbf571e71c8637a85297a"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "e2a9164923bec9998879224c74edf36fa14e6534cddb20220f399679c28348ef"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "8b49d5670be6794813d70fbebf1b681d8d0661ada1cd15d74bf08d6302a85898"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "5c0e2ab04cf30e6e862f88d75cc2c5130da68d893be723f91212b9b49caa2a60"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "787ae168c950c6d5a10296511fc4a54d819f4587a8ffaaccafd766ea5252cc4d"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "89d2713b0843eb9638f3d242fd3d8f6a4ceb35d83c62067940d8624025fbfc0f"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "64c2a373c19ed7fc0254e24ce8d9dae4ae21826fea9094b14ece90471706b753"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "20e1811dae1c233a836162b432540cb3e2f974aecf0d1b57bcf79d4b269a8531"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "025ded7faf603991975c4f17708b0887bffbc265aa5546e6df96ab625ebb65ac"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "e8919421560a548576eed90c9d442d84ce1a3cfab0739cd98c400f7ed17876d9"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "55bb64bd256ac9a185db583d4dd178a609cb8a047123dbae5aadf9b56183f99b"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "c219b1c1fb311b2e0981c2c280e0e51e7b0e2081f5521ed0dedcc25aeaf701f4"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "5118c0fe338141c154eca5386db49b40d55f29a07d77486e6f82117c433176ae"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "0b618a0a48ffb91d61dc0f685dc1a0859ed7824c5ac315b7a62856cdd1282a83"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "24f90b544f5b962ca35333b9ae6bb3b1b5ce0bf0d270d006cad7c8c6ffa3f011"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "93f668a01a753c40b72ba9936909bf49bc2c6c857bdb900eef22f237a2600d07"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.30.10%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "e68ff9127360537ef0f351741fbbd27b6fe927cf792a0a80c25a9a78f1aeeab1"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/1_30/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_30/versions.nix
@@ -8,4 +8,5 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.30.6-0.20241016053533-5ec454f50e7a-build20241016";
   dockerizedVersion = "v1.30.10-rke2r1";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_31/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_31/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "5a3b85760345b131e733be993b5a7fff7b244095d04d1f3b09085167eda5ec48"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "3c4b349c4c5dcf77d5c064ac7d8e7cd17b86575f1861d423f02f5e5dde4bab2a"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "11db0d5a766421ffd11009f78444d42f20fca5ddc35654aaadcc32aae31f487b"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "d1570a698616ee0f9dc430e6374f299fc93b0b53da7b61f9b0e0e66562ddb001"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "d26574208df6e8196066620c12854c73ec3f9d92ae927ba401447f54bbd9bf65"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "b5945ac08d74bcc67415efc1c293b2af119befe04f377880eb045ca7dcf4276c"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "8a63fe4069c811d94004132afa16fb21b8ca1548eba075529ef3d812b682119a"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "8cbb92e40590b372cb1b962de2c2e8d6b92d26bd5d9b71aee577865587e46e56"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "f989d984753b166cffbfaec8866ec9b28ca852978de737f5195cd8da929fbd31"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "784b5817f5f8ab4226cbce3d074d467d397dd0ed0ed6397e4c1be0a327423f13"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "b4dc7787e43d3148cd45f56ba2197469b9901e710a844b49024e7d675862f1d8"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "209d566b382c6c8af5ddfd2350228ec0669b341ce503ac001cc79928add3accd"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "e8e687f3063cfdc7e6f93feffc0a2e63b90f3228c4f6c85532d4e1f436fbaeb7"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "2faf4f9ee2e77b7db6963147d3685197f32f6af5b3dd2305221273bcfefa5af9"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "1d514169c112dd295a03f22ba35905edd0c550e0b09ef5191b9389bb7fd1a945"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "b4e3cfe5f250dcdb1daa02002d4caf9349add11c4392df644c9fb16c5605ffd9"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "1f069844a35857e264065c2e5f9157b1005fda3eb7dcffd20e2218f7ab64c250"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "1bd4e97a5391916cf703d8503d51f05c8db1fe5e130a718fe8fefb4cf8d95e4b"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "c49971bcc55765e3ac036f59cb6df5158efcb664d4fc5a3e0f7f40e962e5b153"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "9dc874dc452cd3c28cb313c70b1cbfb465195b4c308d893555b1fb8b20296756"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "4837a8c559fca6e31436128040b99e90f3ab2210022f02a618405ccfc7185e7a"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "a38aa37f2f8362055ef5dfa16a3c4d9f85eaed6e1b56b928bb4888c52e96b76f"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "beea6e39cc1f522b59de42598a8431ee006292bb6568cb8a0b46ed614225264d"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "cf7f030fd86fcc2425a7a7819c523f6497eae59066fab04a56d8f1cf01c7aac2"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "d473aee06f24d49d1d6b6baee9bfd2079036ef40c0cda126a83851078b0f7e40"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "18957569b6a5fa5aab5fd4dc180fec8b403cae2c07ee07b18505a5f6901d5e5b"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "b5acbce9e9ccd2213807bd27896a6d6b29795dd2f55e5b2281a77dfa41366a60"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "eb7ea1b45d01cab215a1bba7bfc223ed03c16d1383a5e0df141e5ecee9708def"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "2b29e30e1daac4277da7f6a27ad021e0380a4585278d7e8440b38b2e1207ee68"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "70147f487109bd7e4db5b525a8a2a01030f3a6e985e4ce06e8c28dd98e6ff131"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "15c03df525be312caac8431bfb9d0a3842834b25faf0551bc8e185337d623522"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "4b53b94f2dbdc142987718dff210d381cb6d38ad01846278654d77ec1f6f44f0"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "169828a17efdd4a14682c49c0bed437bcec6cde27378d985e15ecbfdfa1523e4"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.6%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "4f7663357f47f696eaf2de34d980ba3aebaa8e42de635e17736ae1ef6c58629c"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_31/versions.nix
@@ -8,4 +8,5 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.31.2-0.20241016053446-0955fa330f90-build20241016";
   dockerizedVersion = "v1.31.6-rke2r1";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "a5bbae876483eac841d0c86d07b9a2f681d14ceba49127d86f206c60416dea02"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "f5bb26e2d2c755b19459af960c5e06f45771f95c257aa40aa206d65712664784"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "8a1854a27c1269628a2318ef9b200f861a3a9b390948ac50340d1fa2c338c22d"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "844d7ed5be7525971de7612980a49f0c326be638dbd59146bf22d02b65687ac6"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "052ffd11c271daf158361d6b2ad99b8c2a7b30d110e6530b3db1d08a809861b9"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "c4f2434302fa287e13385d3c7f50ec0b3f9989cf8a16a70f5d0c85232570371a"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "433d22412cdeadaf3dad899517af66aaf2167c096c95ef2462b0b2ed74bbd036"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "445cd57b28cc69f487e95698c84c4339729a5a6f11fd36d57b37cc3ef49d11ab"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "e6facccbc711757982f5b625427e04e286671a14be7fed13647d7ce59fdd6f5b"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "745216763991e712800edb5f04ba0a3a647a73e5076d28237cd44064da0254e8"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "3ab86ac3c021681ee1cb10d0d7bb4dd05f96830ea84e8bfdd1d5c239e1c1db00"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "b160d69f45818dbc8526aa92784c935c471863d9d6ad5f83a434419cee0d1dd1"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "5da5bc70814ae25f55e75d194d3e56eed9d48d2e2bd50cce329f72a8658a2c71"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "9542793ad13822d02bc5b3aef237c21cb8ea807cde8c1f7edd50c9c8de3257a1"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "b48c79e0e68d7c8ae3dd52f6647f4f859eb0a81e4cb81ca98a08788a3eeb208c"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "97ebc6e37d73d2fefbd861ae9e44a97c649c5876def02fa0e99b136e4cc43834"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "cebc30d3648804c8f6a57de63b7a8c6dd131e2338e4c7e40bb4a3a4ec9962033"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "2caa2ba283f683070cedfbcef4058a0172541c0675d2582cffc09a8ab97c3af8"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "cbbbadf33bb38b22340db52c7f72e2685ad20f64f27a31eb3c90ae2575ac676d"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "db13267b1bf8d27003f6056cea683e34af4ff3743d05de7f84bfb089cc2e28ad"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "b54b4ba783469334a492fdb4f2cfb68ce4a57a7f700d27d060d11213bb026a33"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "68e232d40c9ddb67ce17181e48e8accd6be6b55ee01d78937100ce3faf3f7042"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "3847f03a2351ed9182ae52b0b03f8cf7705123b301f1cc4d7da01cfd2359f743"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "abdae17a19b8da8aeda83e434052c86e4be24bb37dc64c696e42ed59dac9d3c9"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "712ff37f4ea472c485fa887ab6b60df441ebda40c7b6bc66c28433b52f69a0d9"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "e556ae1d1db3923e57a050da3a9176fa9e7c3a0378229f7dd7a1c34145e8b96e"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "0308c83ee9f8affa237cc7b528639558e18b9fdbf5a914220f1c1818654c5874"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "d420a305e3d5b95f05da90177484df38b7178381acdb0806bd17aa2612a26583"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "39f6f02a012e24237b8ed0106d83f6248f133a6d83feaca2aaf4c692b31edd94"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "8608cd8d01fd2ad00fcc28bf7a9a54e89f96b2d0efe45ea6ce940fefc22ba36e"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "3a47c3207fcf3e670f8b58262aecb777d63a56f744feb3b99612d86516f63f90"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "afd2e4c6066fcbbde4d7cb2245cdc18542b9f510e8908c4ffe07181a459d6703"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "5c5531032ded256f0834169fe4db65e698ef4b44a76128b9aec174d8cc24d6e0"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "5f38ba2a8060f82ee407edb77433afb53635798f1be6f1fa53fbe9921c2eb3a0"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
@@ -8,4 +8,5 @@
   pauseVersion = "3.6";
   ccmVersion = "v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101";
   dockerizedVersion = "v1.32.2-rke2r1";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -10,6 +10,7 @@ lib:
   pauseVersion,
   ccmVersion,
   dockerizedVersion,
+  imagesVersions,
 }:
 
 # Build dependencies
@@ -20,6 +21,7 @@ lib:
   go,
   makeWrapper,
   fetchzip,
+  fetchurl,
 
   # Runtime dependencies
   procps,
@@ -118,18 +120,19 @@ let
 
     doCheck = false;
 
-    passthru.updateScript = updateScript;
-
-    passthru.tests =
-      {
-        version = testers.testVersion {
-          package = rke2;
-          version = "v${version}";
+    passthru = {
+      inherit updateScript;
+      tests =
+        {
+          version = testers.testVersion {
+            package = rke2;
+            version = "v${version}";
+          };
+        }
+        // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+          inherit (nixosTests) rke2;
         };
-      }
-      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-        inherit (nixosTests) rke2;
-      };
+    } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
 
     meta = with lib; {
       homepage = "https://github.com/rancher/rke2";


### PR DESCRIPTION
The image assets are released together with every RKE2 version. They contain all container images that RKE2 needs to run, depending on the configuration. Adding them to passthru gives users direct access to the images, this is especially useful in air-gapped situations and NixOS VM tests.

## Motivation

Adding the image assets is the first step in the direction to enable users to run RKE2 in air-gapped environments and NixOS VM tests. The images are automatically imported by RKE2, if placed in `/var/lib/rancher/rke2/agent/images/`. The k3s package does the same and also uses this to run in NixOS tests.

All the `images-versions.json` files are created automatically by the update script, they will also be created automatically for all future versions. The update script gets all images archives assigned to a release via the github API and matches them with the corresponding hash, which are also provided with every release. Hence, the script doesn't need to prefetch the images and the update process isn't affected negatively by adding the images.

More specifically, this allows to make the RKE2 VM tests finally work. Currently the tests are missing all required container images, and they cannot download them due to the test sandbox.  Adding the images to passthru allows to prepare the test VMs accordingly so they automatically import the images.

@zimbatm @stefan-bordei 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
