### PR TITLE
python312Packages.pytest-notebook: skip failing tests, modernize

### DIFF
--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -2,19 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   flit-core,
+
+  # dependencies
   attrs,
   jsonschema,
   nbclient,
   nbdime,
   nbformat,
+
+  # buildInputs
   pytest,
+
+  # tests
   black,
   coverage,
   ipykernel,
   pytest-cov-stub,
   pytest-regressions,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -29,7 +38,7 @@ buildPythonPackage rec {
     hash = "sha256-LoK0wb7rAbVbgyURCbSfckWvJDef3tPY+7V4YU1IBRU=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     flit-core
   ];
 
@@ -38,7 +47,7 @@ buildPythonPackage rec {
     "nbclient"
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     attrs
     jsonschema
     nbclient
@@ -57,26 +66,23 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytest-regressions
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
-  preCheck = ''
-    export HOME="$TEMP"
-  '';
-
   disabledTests = [
+    # AssertionError: FILES DIFFER:
     "test_diff_to_string"
+
+    # pytest_notebook.execution.CoverageError: An error occurred while executing coverage start-up
+    # TypeError: expected str, bytes or os.PathLike object, not NoneType
     "test_execute_notebook_with_coverage"
     "test_regression_coverage"
-    "test_collection"
-    "test_setup_with_skip_meta"
-    "test_run_fail"
-    "test_run_pass_with_meta"
   ];
 
   __darwinAllowLocalNetworking = true;
 
   meta = {
-    changelog = "https://github.com/chrisjsewell/pytest-notebook/blob/${src.rev}/docs/source/changelog.md";
+    changelog = "https://github.com/chrisjsewell/pytest-notebook/blob/${src.tag}/docs/source/changelog.md";
     description = "Pytest plugin for regression testing and regenerating Jupyter Notebooks";
     homepage = "https://github.com/chrisjsewell/pytest-notebook";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -77,6 +77,9 @@ buildPythonPackage rec {
     # TypeError: expected str, bytes or os.PathLike object, not NoneType
     "test_execute_notebook_with_coverage"
     "test_regression_coverage"
+
+    # pytest_notebook.nb_regression.NBRegressionError
+    "test_regression_regex_replace_pass"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
## Things done

cc @dotlambda

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
