### PR TITLE
python312Packages.nbdime: modernize, skip failing test on darwin

### DIFF
--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -1,31 +1,35 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchPypi,
+
+  # build-system
   hatch-jupyter-builder,
   hatchling,
   jupyterlab,
-  nbformat,
+
+  # dependencies
   colorama,
-  pygments,
-  tornado,
-  requests,
   gitpython,
+  jinja2,
   jupyter-server,
   jupyter-server-mathjax,
-  jinja2,
+  nbformat,
+  pygments,
+  requests,
+  tornado,
+
+  # tests
   gitMinimal,
   pytest-tornado,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "nbdime";
   version = "4.0.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -39,32 +43,39 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    nbformat
     colorama
-    pygments
-    tornado
-    requests
     gitpython
+    jinja2
     jupyter-server
     jupyter-server-mathjax
-    jinja2
+    nbformat
+    pygments
+    requests
+    tornado
   ];
 
   nativeCheckInputs = [
     gitMinimal
     pytest-tornado
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   disabledTests = [
+    # subprocess.CalledProcessError: Command '['git', 'diff', 'base', 'diff.ipynb']' returned non-zero exit status 128.
+    # git-nbdiffdriver diff: line 1: git-nbdiffdriver: command not found
+    # fatal: external diff died, stopping at diff.ipynb
     "test_git_diffdriver"
-    "test_git_difftool"
+
+    # subprocess.CalledProcessError: Command '['git', 'merge', 'remote-no-conflict']' returned non-zero exit status 1.
     "test_git_mergedriver"
+
+    # Require network access
+    "test_git_difftool"
     "test_git_mergetool"
   ];
 
   preCheck = ''
-    export HOME="$TEMP"
     git config --global user.email "janedoe@example.com"
     git config --global user.name "Jane Doe"
   '';
@@ -73,11 +84,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "nbdime" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/jupyter/nbdime";
     changelog = "https://github.com/jupyter/nbdime/blob/${version}/CHANGELOG.md";
     description = "Tools for diffing and merging of Jupyter notebooks";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ tbenst ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tbenst ];
   };
 }

--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
 
@@ -61,19 +62,24 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  disabledTests = [
-    # subprocess.CalledProcessError: Command '['git', 'diff', 'base', 'diff.ipynb']' returned non-zero exit status 128.
-    # git-nbdiffdriver diff: line 1: git-nbdiffdriver: command not found
-    # fatal: external diff died, stopping at diff.ipynb
-    "test_git_diffdriver"
+  disabledTests =
+    [
+      # subprocess.CalledProcessError: Command '['git', 'diff', 'base', 'diff.ipynb']' returned non-zero exit status 128.
+      # git-nbdiffdriver diff: line 1: git-nbdiffdriver: command not found
+      # fatal: external diff died, stopping at diff.ipynb
+      "test_git_diffdriver"
 
-    # subprocess.CalledProcessError: Command '['git', 'merge', 'remote-no-conflict']' returned non-zero exit status 1.
-    "test_git_mergedriver"
+      # subprocess.CalledProcessError: Command '['git', 'merge', 'remote-no-conflict']' returned non-zero exit status 1.
+      "test_git_mergedriver"
 
-    # Require network access
-    "test_git_difftool"
-    "test_git_mergetool"
-  ];
+      # Require network access
+      "test_git_difftool"
+      "test_git_mergetool"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # OSError: Could not find system gitattributes location!
+      "test_locate_gitattributes_syste"
+    ];
 
   preCheck = ''
     git config --global user.email "janedoe@example.com"

--- a/pkgs/development/python-modules/pytest-notebook/default.nix
+++ b/pkgs/development/python-modules/pytest-notebook/default.nix
@@ -24,6 +24,7 @@
   pytest-regressions,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -69,18 +70,23 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
-  disabledTests = [
-    # AssertionError: FILES DIFFER:
-    "test_diff_to_string"
+  disabledTests =
+    [
+      # AssertionError: FILES DIFFER:
+      "test_diff_to_string"
 
-    # pytest_notebook.execution.CoverageError: An error occurred while executing coverage start-up
-    # TypeError: expected str, bytes or os.PathLike object, not NoneType
-    "test_execute_notebook_with_coverage"
-    "test_regression_coverage"
+      # pytest_notebook.execution.CoverageError: An error occurred while executing coverage start-up
+      # TypeError: expected str, bytes or os.PathLike object, not NoneType
+      "test_execute_notebook_with_coverage"
+      "test_regression_coverage"
 
-    # pytest_notebook.nb_regression.NBRegressionError
-    "test_regression_regex_replace_pass"
-  ];
+      # pytest_notebook.nb_regression.NBRegressionError
+      "test_regression_regex_replace_pass"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # AssertionError: FILES DIFFER:
+      "test_documentation"
+    ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
## Things done

- **python312Packages.nbdime: modernize, fix failing tests on darwin**
- **python312Packages.nbdime: skip failing test on darwin**

cc @tbenst

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
