### PR TITLE
metasploit: 6.4.43 -> 6.4.53

### DIFF
--- a/pkgs/tools/security/metasploit/Gemfile
+++ b/pkgs/tools/security/metasploit/Gemfile
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/6.4.43"
+gem "metasploit-framework", git: "https://github.com/rapid7/metasploit-framework", ref: "refs/tags/6.4.53"
+
+gem "syslog", "~> 0.3.0"

--- a/pkgs/tools/security/metasploit/Gemfile.lock
+++ b/pkgs/tools/security/metasploit/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/rapid7/metasploit-framework
-  revision: 726e819f87e3022dc90232087bf30edb0d149ba5
-  ref: refs/tags/6.4.43
+  revision: ce6990ff84c944186dfa104b3aa1edd98962b468
+  ref: refs/tags/6.4.53
   specs:
-    metasploit-framework (6.4.43)
+    metasploit-framework (6.4.53)
       aarch64
       abbrev
       actionpack (~> 7.0.0)
@@ -17,10 +17,12 @@ GIT
       base64
       bcrypt
       bcrypt_pbkdf
+      benchmark
       bigdecimal
       bootsnap
       bson
       chunky_png
+      concurrent-ruby (= 1.3.4)
       csv
       dnsruby
       drb
@@ -33,6 +35,7 @@ GIT
       faraday-retry
       faye-websocket
       ffi (< 1.17.0)
+      fiddle
       filesize
       getoptlong
       hrr_rb_ssh-ed25519
@@ -62,6 +65,7 @@ GIT
       octokit (~> 4.0)
       openssl-ccm
       openvas-omp
+      ostruct
       packetfu
       patch_finder
       pcaprub
@@ -69,7 +73,7 @@ GIT
       pg
       puma
       railties
-      rasn1 (= 0.13.0)
+      rasn1 (= 0.14.0)
       rb-readline
       recog
       redcarpet
@@ -179,6 +183,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     bindata (2.4.15)
     bootsnap (1.18.4)
@@ -223,6 +228,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.16.3)
+    fiddle (1.1.6)
     filesize (0.2.0)
     getoptlong (0.2.1)
     gssapi (1.3.1)
@@ -249,6 +255,7 @@ GEM
       rkelly-remix
     json (2.7.5)
     little-plugger (1.1.4)
+    logger (1.6.6)
     logging (2.4.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
@@ -322,6 +329,7 @@ GEM
     openssl-ccm (1.2.3)
     openssl-cmac (2.0.2)
     openvas-omp (0.0.4)
+    ostruct (0.6.1)
     packetfu (2.0.0)
       pcaprub (~> 0.13.1)
     patch_finder (1.0.2)
@@ -358,7 +366,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.2.1)
-    rasn1 (0.13.0)
+    rasn1 (0.14.0)
       strptime (~> 0.2.5)
     rb-readline (0.5.5)
     recog (3.1.11)
@@ -443,6 +451,8 @@ GEM
     sshkey (3.0.0)
     strptime (0.2.5)
     swagger-blocks (3.0.0)
+    syslog (0.3.0)
+      logger
     thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -487,6 +497,7 @@ PLATFORMS
 
 DEPENDENCIES
   metasploit-framework!
+  syslog (~> 0.3.0)
 
 BUNDLED WITH
    2.5.22

--- a/pkgs/tools/security/metasploit/default.nix
+++ b/pkgs/tools/security/metasploit/default.nix
@@ -18,13 +18,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "metasploit-framework";
-  version = "6.4.43";
+  version = "6.4.53";
 
   src = fetchFromGitHub {
     owner = "rapid7";
     repo = "metasploit-framework";
     tag = finalAttrs.version;
-    hash = "sha256-1zUt6nInDUIY97fBJa0dQ/hD4WZ1v5LXYdPQhnYKlYw=";
+    hash = "sha256-yHat9U8EZbUWo4j9ut6K9IPtPFm130pfSmIuhtQhFoQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/metasploit/gemset.nix
+++ b/pkgs/tools/security/metasploit/gemset.nix
@@ -239,6 +239,16 @@
     };
     version = "1.1.1";
   };
+  benchmark = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0jl71qcgamm96dzyqk695j24qszhcc7liw74qc83fpjljp2gh4hg";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
   bigdecimal = {
     groups = [ "default" ];
     platforms = [ ];
@@ -509,6 +519,16 @@
     };
     version = "1.16.3";
   };
+  fiddle = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1as92bp6pgkab73kj3mh5d1idjr9wykczz7r9i1pkn82wq4xks3r";
+      type = "gem";
+    };
+    version = "1.1.6";
+  };
   filesize = {
     groups = [ "default" ];
     platforms = [ ];
@@ -679,6 +699,16 @@
     };
     version = "1.1.4";
   };
+  logger = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "05s008w9vy7is3njblmavrbdzyrwwc1fsziffdr58w9pwqj8sqfx";
+      type = "gem";
+    };
+    version = "1.6.6";
+  };
   logging = {
     groups = [ "default" ];
     platforms = [ ];
@@ -734,12 +764,12 @@
     platforms = [ ];
     source = {
       fetchSubmodules = false;
-      rev = "726e819f87e3022dc90232087bf30edb0d149ba5";
-      sha256 = "134m19v8dl6kc7br5gvmcvhl7y233nnjbhdpywc44397fbm2sdfp";
+      rev = "ce6990ff84c944186dfa104b3aa1edd98962b468";
+      sha256 = "110n47a8cbk299glmpxmb4yfv0zlibgbmzc8lcbbar849zsssxn8";
       type = "git";
       url = "https://github.com/rapid7/metasploit-framework";
     };
-    version = "6.4.43";
+    version = "6.4.53";
   };
   metasploit-model = {
     groups = [ "default" ];
@@ -1025,6 +1055,16 @@
     };
     version = "0.0.4";
   };
+  ostruct = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "05xqijcf80sza5pnlp1c8whdaay8x5dc13214ngh790zrizgp8q9";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
   packetfu = {
     groups = [ "default" ];
     platforms = [ ];
@@ -1180,10 +1220,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "07dvrv2s9hs2vcbr6lai8vj4vk2i3m4jf468hyvkp9k8xzjvc0fi";
+      sha256 = "1rz96j4jzm02rdxrs70hj5an3kmxrfd77d4hy97b80fasj049992";
       type = "gem";
     };
-    version = "0.13.0";
+    version = "0.14.0";
   };
   rb-readline = {
     groups = [ "default" ];
@@ -1564,6 +1604,16 @@
       type = "gem";
     };
     version = "3.0.0";
+  };
+  syslog = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "023lbh48fcn72gwyh1x52ycs1wx1bnhdajmv0qvkidmdsmxnxzjd";
+      type = "gem";
+    };
+    version = "0.3.0";
   };
   thin = {
     groups = [ "default" ];

--- a/pkgs/tools/security/metasploit/shell.nix
+++ b/pkgs/tools/security/metasploit/shell.nix
@@ -1,10 +1,11 @@
-# Env to update Gemfile.lock / gemset.nix
 {
   pkgs ? import ../../../.. { },
 }:
-pkgs.stdenv.mkDerivation {
-  name = "env";
-  nativeBuildInputs = [ pkgs.pkg-config ];
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.pkg-config
+    pkgs.libffi # libffi as native input
+  ];
   buildInputs = with pkgs; [
     bundix
     git
@@ -16,4 +17,9 @@ pkgs.stdenv.mkDerivation {
     ruby.devEnv
     sqlite
   ];
+  # Ensure that pkg-config finds libffi
+  shellHook = ''
+    export PKG_CONFIG_PATH="${pkgs.libffi.out}/lib/pkgconfig:$PKG_CONFIG_PATH"
+    echo "PKG_CONFIG_PATH set to: $PKG_CONFIG_PATH"
+  '';
 }


### PR DESCRIPTION
Update metasploit to 6.4.53 to keep up with bugfixes and security updates. 

* Update metasploit-framework to version 6.4.53.
  - Incorporates upstream bug fixes, performance improvements, and additional module support.

* Improve packaging in Nix by:
  - Adjusting nativeBuildInputs to include libffi so that pkg-config finds the proper .pc files.
  - Adding a shellHook in shell.nix to export PKG_CONFIG_PATH and ensure that gem native extensions (such as the one used by the fiddle gem) build correctly.
  - Adding syslog to the Gemfile (using `bundle add syslog`) to support improved logging.

These changes address build issues (such as Rex::BindFailed errors related to port binding and libffi detection problems) previously encountered in our Nix environment. This update not only makes Metasploit build more reliably in Nix but also brings in the latest security patches and features from upstream.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
