### PR TITLE
nixos/dokuwiki: Remove unused enable option

### DIFF
--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -124,10 +124,29 @@ let
 
   siteOpts = { options, config, lib, name, ... }:
     {
+      # TODO: Remove in time for 25.11 and/or simplify once https://github.com/NixOS/nixpkgs/issues/96006 is fixed
+      imports = [
+        ({config, options, ... }: let
+          removalNote = "The option has had no effect for 3+ years. There is no replacement available.";
+          optPath = lib.options.showOption [ "services" "dokuwiki" "sites" name "enable" ];
+        in {
+          options.enable = mkOption {
+            visible = false;
+            apply = x: throw "The option `${optPath}' can no longer be used since it's been removed. ${removalNote}";
+          };
+          config.assertions = [
+            {
+              assertion = !options.enable.isDefined;
+              message = ''
+                The option definition `${optPath}' in ${showFiles options.enable.files} no longer has any effect; please remove it.
+              ${removalNote}
+              '';
+            }
+          ];
+        })
+      ];
 
       options = {
-        enable = mkEnableOption "DokuWiki web application";
-
         package = mkPackageOption pkgs "dokuwiki" { };
 
         stateDir = mkOption {
@@ -338,6 +357,13 @@ let
           '';
         };
 
+        # TODO: Remove when no submodule-level assertions are needed anymore
+        assertions = mkOption {
+          type = types.listOf types.unspecified;
+          default = [ ];
+          visible = false;
+          internal = true;
+        };
     };
   };
 in
@@ -370,6 +396,8 @@ in
 
   # implementation
   config = mkIf (eachSite != {}) (mkMerge [{
+    # TODO: Remove when no submodule-level assertions are needed anymore
+    assertions = flatten (mapAttrsToList (_: cfg: cfg.assertions) eachSite);
 
     services.phpfpm.pools = mapAttrs' (hostName: cfg: (
       nameValuePair "dokuwiki-${hostName}" {


### PR DESCRIPTION
The option has been added in 50029ed89ce5e38f0b893689762c7ead26c2f678 but never had any effect. As far as I could tell, it was only added for backward compatibility. I think it's safe to remove this after 3+ years.

I opted for removal instead of implementing it since the module will just do nothing if no site is configure, thus no enable / disable switch is needed. Especially on a per-site level.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
