### PR TITLE
nodePackages.ijavascript: drop

### DIFF
--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -127,6 +127,7 @@ mapAliases {
   inherit (pkgs) http-server; # added 2024-01-20
   hueadm = pkgs.hueadm; # added 2023-07-31
   inherit (pkgs) hyperpotamus; # added 2023-08-19
+  ijavascript = throw "ijavascript has been removed because it was broken"; # added 2025-03-18
   immich = pkgs.immich-cli; # added 2023-08-19
   indium = throw "indium was removed because it was broken"; # added 2023-08-19
   inliner = throw "inliner was removed because it was abandoned upstream"; # added 2024-08-23

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -93,7 +93,6 @@
 , "gulp-cli"
 , "he"
 , "hs-airdrop"
-, "ijavascript"
 , "imapnotify"
 , "joplin"
 , "js-beautify"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -54272,33 +54272,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  ijavascript = nodeEnv.buildNodePackage {
-    name = "ijavascript";
-    packageName = "ijavascript";
-    version = "5.2.1";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/ijavascript/-/ijavascript-5.2.1.tgz";
-      sha512 = "kH7hudp+S+8++ngjUXbiyHOhp3qa4oDVUkmf6p7+7s15PIBDv5zx878pxNRdGcWhYGy5TT683EOqeKMQw8jrFA==";
-    };
-    dependencies = [
-      sources."jmp-2.0.0"
-      sources."jp-kernel-2.0.0"
-      sources."nan-2.17.0"
-      sources."nel-1.3.0"
-      sources."node-gyp-build-4.8.4"
-      sources."uuid-3.4.0"
-      sources."zeromq-5.3.1"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "IJavascript is a Javascript kernel for the Jupyter notebook";
-      homepage = "https://n-riesco.github.io/ijavascript";
-      license = "BSD-3-Clause";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   imapnotify = nodeEnv.buildNodePackage {
     name = "imapnotify";
     packageName = "imapnotify";

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -54,13 +54,6 @@ final: prev: {
     '';
   };
 
-  ijavascript = prev.ijavascript.override (oldAttrs: {
-    preRebuild = ''
-      export npm_config_zmq_external=true
-    '';
-    buildInputs = oldAttrs.buildInputs ++ [ final.node-gyp-build pkgs.zeromq ];
-  });
-
   joplin = prev.joplin.override (oldAttrs:{
     nativeBuildInputs = [
       pkgs.pkg-config


### PR DESCRIPTION
It fails to build with

    npm error /nix/store/bhc0grw1nwzwgh55qapfqwb3vil5s49y-node-sources/deps/v8/include/v8-local-handle.h: In instantiation of 'v8::Local<T>::Local(v8::Local<S>) [with S = v8::Data; T = v8::Value]':
    npm error ../../nan/nan_callbacks_12_inl.h:175:53:   required from here
    npm error   175 |       cbinfo(info, obj->GetInternalField(kDataIndex));
    npm error       |                                                     ^
    npm error /nix/store/bhc0grw1nwzwgh55qapfqwb3vil5s49y-node-sources/deps/v8/include/v8-local-handle.h:269:42: error: static assertion failed: type check
    npm error   269 |     static_assert(std::is_base_of<T, S>::value, "type check");
    npm error       |                                          ^~~~~
    npm error /nix/store/bhc0grw1nwzwgh55qapfqwb3vil5s49y-node-sources/deps/v8/include/v8-local-handle.h:269:42: note: 'std::integral_constant<bool, false>::value' evaluates to false


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
