### PR TITLE
ocamlPackages.monolith: init at 20250314

### DIFF
--- a/pkgs/development/ocaml-modules/monolith/default.nix
+++ b/pkgs/development/ocaml-modules/monolith/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitLab,
+  afl-persistent,
+  pprint,
+  version ? "20250314",
+}:
+
+buildDunePackage {
+  pname = "monolith";
+  inherit version;
+
+  minimalOCamlVersion = "4.12";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "fpottier";
+    repo = "monolith";
+    tag = version;
+    hash = "sha256-hIB3QSOLARumRgpUroTFUzSreHw7kMikGde+mB28sGM=";
+  };
+
+  propagatedBuildInputs = [
+    afl-persistent
+    pprint
+  ];
+
+  meta = {
+    description = "Facilities for testing an OCaml library";
+    homepage = "https://cambium.inria.fr/~fpottier/monolith/doc/monolith/Monolith/index.html";
+    changelog = "https://gitlab.inria.fr/fpottier/monolith/-/raw/${version}/CHANGES.md";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1252,6 +1252,8 @@ let
 
     mmap =  callPackage ../development/ocaml-modules/mmap { };
 
+    monolith = callPackage ../development/ocaml-modules/monolith { };
+
     mopsa = callPackage ../development/ocaml-modules/mopsa { };
 
     morbig = callPackage ../development/ocaml-modules/morbig { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
