### PR TITLE
ci: add keep-sorted workflow; format and sort top-level/python-packages.nix

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -241,3 +241,6 @@ e0fe216f4912dd88a021d12a44155fd2cfeb31c8
 
 # nixos/iso-image.nix: nixfmt
 da9a092c34cef6947d7aee2b134f61df45171631
+
+# python-packages: format with nixfmt-rfc-style
+5f6f5e13ae0b6960cbf1be8aeb3d0048285a08d1

--- a/.github/workflows/keep-sorted.yml
+++ b/.github/workflows/keep-sorted.yml
@@ -1,0 +1,40 @@
+name: Check that files are sorted
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  nixos:
+    name: keep-sorted
+    runs-on: ubuntu-24.04
+    needs: get-merge-commit
+    if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - name: Get Nixpkgs revision for keep-sorted
+        run: |
+          # Pin to a commit from nixpkgs-unstable to avoid e.g. building nixfmt from staging.
+          # This should not be a URL, because it would allow PRs to run arbitrary code in CI!
+          rev=$(jq -r .rev ci/pinned-nixpkgs.json)
+          echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
+
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        with:
+          extra_nix_config: sandbox = true
+          nix_path: nixpkgs=${{ env.url }}
+
+      - name: Install keep-sorted
+        run: "nix-env -f '<nixpkgs>' -iAP keep-sorted"
+
+      - name: Check that Nix files are sorted
+        run: |
+          git ls-files | xargs keep-sorted --mode lint

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27,6 +27,8 @@ self: super: with self; {
 
   setuptools = callPackage ../development/python-modules/setuptools { };
 
+  # keep-sorted start block=yes newline_separated=yes
+
   a2wsgi = callPackage ../development/python-modules/a2wsgi { };
 
   aafigure = callPackage ../development/python-modules/aafigure { };
@@ -13095,11 +13097,9 @@ self: super: with self; {
 
   pyqt5-multimedia = self.pyqt5.override { withMultimedia = true; };
 
-  /*
-    `pyqt5-webkit` should not be used by python libraries in
-    pkgs/development/python-modules/*. Putting this attribute in
-    `propagatedBuildInputs` may cause collisions.
-  */
+  # `pyqt5-webkit` should not be used by python libraries in
+  # pkgs/development/python-modules/*. Putting this attribute in
+  # `propagatedBuildInputs` may cause collisions.
   pyqt5-webkit = self.pyqt5.override { withWebKit = true; };
 
   pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
@@ -19507,4 +19507,6 @@ self: super: with self; {
   zxcvbn-rs-py = callPackage ../development/python-modules/zxcvbn-rs-py { };
 
   zxing-cpp = callPackage ../development/python-modules/zxing-cpp { libzxing-cpp = pkgs.zxing-cpp; };
+
+  # keep-sorted end
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10,15 +10,19 @@ self: super: with self; {
 
   bootstrap = lib.recurseIntoAttrs {
     flit-core = toPythonModule (callPackage ../development/python-modules/bootstrap/flit-core { });
-    installer = toPythonModule (callPackage ../development/python-modules/bootstrap/installer {
-      inherit (bootstrap) flit-core;
-    });
-    build = toPythonModule (callPackage ../development/python-modules/bootstrap/build {
-      inherit (bootstrap) flit-core installer;
-    });
-    packaging = toPythonModule (callPackage ../development/python-modules/bootstrap/packaging {
-      inherit (bootstrap) flit-core installer;
-    });
+    installer = toPythonModule (
+      callPackage ../development/python-modules/bootstrap/installer { inherit (bootstrap) flit-core; }
+    );
+    build = toPythonModule (
+      callPackage ../development/python-modules/bootstrap/build {
+        inherit (bootstrap) flit-core installer;
+      }
+    );
+    packaging = toPythonModule (
+      callPackage ../development/python-modules/bootstrap/packaging {
+        inherit (bootstrap) flit-core installer;
+      }
+    );
   };
 
   setuptools = callPackage ../development/python-modules/setuptools { };
@@ -141,15 +145,25 @@ self: super: with self; {
 
   aio-geojson-client = callPackage ../development/python-modules/aio-geojson-client { };
 
-  aio-geojson-generic-client = callPackage ../development/python-modules/aio-geojson-generic-client { };
+  aio-geojson-generic-client =
+    callPackage ../development/python-modules/aio-geojson-generic-client
+      { };
 
-  aio-geojson-geonetnz-quakes = callPackage ../development/python-modules/aio-geojson-geonetnz-quakes { };
+  aio-geojson-geonetnz-quakes =
+    callPackage ../development/python-modules/aio-geojson-geonetnz-quakes
+      { };
 
-  aio-geojson-geonetnz-volcano = callPackage ../development/python-modules/aio-geojson-geonetnz-volcano { };
+  aio-geojson-geonetnz-volcano =
+    callPackage ../development/python-modules/aio-geojson-geonetnz-volcano
+      { };
 
-  aio-geojson-nsw-rfs-incidents = callPackage ../development/python-modules/aio-geojson-nsw-rfs-incidents { };
+  aio-geojson-nsw-rfs-incidents =
+    callPackage ../development/python-modules/aio-geojson-nsw-rfs-incidents
+      { };
 
-  aio-geojson-usgs-earthquakes = callPackage ../development/python-modules/aio-geojson-usgs-earthquakes { };
+  aio-geojson-usgs-earthquakes =
+    callPackage ../development/python-modules/aio-geojson-usgs-earthquakes
+      { };
 
   aio-georss-client = callPackage ../development/python-modules/aio-georss-client { };
 
@@ -547,10 +561,12 @@ self: super: with self; {
 
   algebraic-data-types = callPackage ../development/python-modules/algebraic-data-types { };
 
-  aligator = toPythonModule (pkgs.aligator.override {
-    python3Packages = self;
-    pythonSupport = true;
-  });
+  aligator = toPythonModule (
+    pkgs.aligator.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
 
   alive-progress = callPackage ../development/python-modules/alive-progress { };
 
@@ -574,7 +590,9 @@ self: super: with self; {
 
   allure-python-commons = callPackage ../development/python-modules/allure-python-commons { };
 
-  allure-python-commons-test = callPackage ../development/python-modules/allure-python-commons-test { };
+  allure-python-commons-test =
+    callPackage ../development/python-modules/allure-python-commons-test
+      { };
 
   allure-pytest = callPackage ../development/python-modules/allure-pytest { };
 
@@ -620,13 +638,13 @@ self: super: with self; {
 
   androguard = callPackage ../development/python-modules/androguard { };
 
-  anel-pwrctrl-homeassistant = callPackage ../development/python-modules/anel-pwrctrl-homeassistant { };
+  anel-pwrctrl-homeassistant =
+    callPackage ../development/python-modules/anel-pwrctrl-homeassistant
+      { };
 
   angr = callPackage ../development/python-modules/angr { };
 
-  angrcli = callPackage ../development/python-modules/angrcli {
-    inherit (pkgs) coreutils;
-  };
+  angrcli = callPackage ../development/python-modules/angrcli { inherit (pkgs) coreutils; };
 
   angrop = callPackage ../development/python-modules/angrop { };
 
@@ -700,9 +718,7 @@ self: super: with self; {
 
   anysqlite = callPackage ../development/python-modules/anysqlite { };
 
-  anytree = callPackage ../development/python-modules/anytree {
-    inherit (pkgs) graphviz;
-  };
+  anytree = callPackage ../development/python-modules/anytree { inherit (pkgs) graphviz; };
 
   anywidget = callPackage ../development/python-modules/anywidget { };
 
@@ -752,7 +768,9 @@ self: super: with self; {
 
   apptools = callPackage ../development/python-modules/apptools { };
 
-  appthreat-vulnerability-db = callPackage ../development/python-modules/appthreat-vulnerability-db { };
+  appthreat-vulnerability-db =
+    callPackage ../development/python-modules/appthreat-vulnerability-db
+      { };
 
   apricot-select = callPackage ../development/python-modules/apricot-select { };
 
@@ -790,13 +808,9 @@ self: super: with self; {
 
   area = callPackage ../development/python-modules/area { };
 
-  arelle = callPackage ../development/python-modules/arelle {
-    gui = true;
-  };
+  arelle = callPackage ../development/python-modules/arelle { gui = true; };
 
-  arelle-headless = callPackage ../development/python-modules/arelle {
-    gui = false;
-  };
+  arelle-headless = callPackage ../development/python-modules/arelle { gui = false; };
 
   aresponses = callPackage ../development/python-modules/aresponses { };
 
@@ -1008,7 +1022,9 @@ self: super: with self; {
 
   atomicwrites = callPackage ../development/python-modules/atomicwrites { };
 
-  atomicwrites-homeassistant = callPackage ../development/python-modules/atomicwrites-homeassistant { };
+  atomicwrites-homeassistant =
+    callPackage ../development/python-modules/atomicwrites-homeassistant
+      { };
 
   atopile = callPackage ../development/python-modules/atopile { };
 
@@ -1034,7 +1050,8 @@ self: super: with self; {
 
   audio-metadata = callPackage ../development/python-modules/audio-metadata { };
 
-  audioop-lts = if pythonAtLeast "3.13" then callPackage ../development/python-modules/audioop-lts { } else null;
+  audioop-lts =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/audioop-lts { } else null;
 
   audioread = callPackage ../development/python-modules/audioread { };
 
@@ -1045,12 +1062,15 @@ self: super: with self; {
   auditok = callPackage ../development/python-modules/auditok { };
 
   auditwheel = callPackage ../development/python-modules/auditwheel {
-    inherit (pkgs) bzip2 gnutar patchelf unzip;
+    inherit (pkgs)
+      bzip2
+      gnutar
+      patchelf
+      unzip
+      ;
   };
 
-  augeas = callPackage ../development/python-modules/augeas {
-    inherit (pkgs) augeas;
-  };
+  augeas = callPackage ../development/python-modules/augeas { inherit (pkgs) augeas; };
 
   augmax = callPackage ../development/python-modules/augmax { };
 
@@ -1102,16 +1122,18 @@ self: super: with self; {
 
   autoslot = callPackage ../development/python-modules/autoslot { };
 
-  avahi = toPythonModule (pkgs.avahi.override {
-    inherit python;
-    withPython = true;
-  });
+  avahi = toPythonModule (
+    pkgs.avahi.override {
+      inherit python;
+      withPython = true;
+    }
+  );
 
   av = callPackage ../development/python-modules/av { };
 
   avea = callPackage ../development/python-modules/avea { };
 
- avidtools = callPackage ../development/python-modules/avidtools { };
+  avidtools = callPackage ../development/python-modules/avidtools { };
 
   avion = callPackage ../development/python-modules/avion { };
 
@@ -1135,9 +1157,7 @@ self: super: with self; {
 
   awkward = callPackage ../development/python-modules/awkward { };
 
-  awkward-cpp = callPackage ../development/python-modules/awkward-cpp {
-    inherit (pkgs) cmake ninja;
-  };
+  awkward-cpp = callPackage ../development/python-modules/awkward-cpp { inherit (pkgs) cmake ninja; };
 
   awkward-pandas = callPackage ../development/python-modules/awkward-pandas { };
 
@@ -1153,7 +1173,9 @@ self: super: with self; {
 
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 
-  aws-secretsmanager-caching = callPackage ../development/python-modules/aws-secretsmanager-caching { };
+  aws-secretsmanager-caching =
+    callPackage ../development/python-modules/aws-secretsmanager-caching
+      { };
 
   aws-sso-lib = callPackage ../development/python-modules/aws-sso-lib { };
 
@@ -1181,9 +1203,13 @@ self: super: with self; {
 
   ayla-iot-unofficial = callPackage ../development/python-modules/ayla-iot-unofficial { };
 
-  azure-ai-documentintelligence = callPackage ../development/python-modules/azure-ai-documentintelligence { };
+  azure-ai-documentintelligence =
+    callPackage ../development/python-modules/azure-ai-documentintelligence
+      { };
 
-  azure-ai-vision-imageanalysis = callPackage ../development/python-modules/azure-ai-vision-imageanalysis { };
+  azure-ai-vision-imageanalysis =
+    callPackage ../development/python-modules/azure-ai-vision-imageanalysis
+      { };
 
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };
 
@@ -1219,9 +1245,13 @@ self: super: with self; {
 
   azure-keyvault = callPackage ../development/python-modules/azure-keyvault { };
 
-  azure-keyvault-administration = callPackage ../development/python-modules/azure-keyvault-administration { };
+  azure-keyvault-administration =
+    callPackage ../development/python-modules/azure-keyvault-administration
+      { };
 
-  azure-keyvault-certificates = callPackage ../development/python-modules/azure-keyvault-certificates { };
+  azure-keyvault-certificates =
+    callPackage ../development/python-modules/azure-keyvault-certificates
+      { };
 
   azure-keyvault-keys = callPackage ../development/python-modules/azure-keyvault-keys { };
 
@@ -1239,11 +1269,15 @@ self: super: with self; {
 
   azure-mgmt-apimanagement = callPackage ../development/python-modules/azure-mgmt-apimanagement { };
 
-  azure-mgmt-appconfiguration = callPackage ../development/python-modules/azure-mgmt-appconfiguration { };
+  azure-mgmt-appconfiguration =
+    callPackage ../development/python-modules/azure-mgmt-appconfiguration
+      { };
 
   azure-mgmt-appcontainers = callPackage ../development/python-modules/azure-mgmt-appcontainers { };
 
-  azure-mgmt-applicationinsights = callPackage ../development/python-modules/azure-mgmt-applicationinsights { };
+  azure-mgmt-applicationinsights =
+    callPackage ../development/python-modules/azure-mgmt-applicationinsights
+      { };
 
   azure-mgmt-authorization = callPackage ../development/python-modules/azure-mgmt-authorization { };
 
@@ -1259,7 +1293,9 @@ self: super: with self; {
 
   azure-mgmt-cdn = callPackage ../development/python-modules/azure-mgmt-cdn { };
 
-  azure-mgmt-cognitiveservices = callPackage ../development/python-modules/azure-mgmt-cognitiveservices { };
+  azure-mgmt-cognitiveservices =
+    callPackage ../development/python-modules/azure-mgmt-cognitiveservices
+      { };
 
   azure-mgmt-commerce = callPackage ../development/python-modules/azure-mgmt-commerce { };
 
@@ -1269,11 +1305,17 @@ self: super: with self; {
 
   azure-mgmt-consumption = callPackage ../development/python-modules/azure-mgmt-consumption { };
 
-  azure-mgmt-containerinstance = callPackage ../development/python-modules/azure-mgmt-containerinstance { };
+  azure-mgmt-containerinstance =
+    callPackage ../development/python-modules/azure-mgmt-containerinstance
+      { };
 
-  azure-mgmt-containerregistry = callPackage ../development/python-modules/azure-mgmt-containerregistry { };
+  azure-mgmt-containerregistry =
+    callPackage ../development/python-modules/azure-mgmt-containerregistry
+      { };
 
-  azure-mgmt-containerservice = callPackage ../development/python-modules/azure-mgmt-containerservice { };
+  azure-mgmt-containerservice =
+    callPackage ../development/python-modules/azure-mgmt-containerservice
+      { };
 
   azure-mgmt-core = callPackage ../development/python-modules/azure-mgmt-core { };
 
@@ -1283,7 +1325,9 @@ self: super: with self; {
 
   azure-mgmt-datafactory = callPackage ../development/python-modules/azure-mgmt-datafactory { };
 
-  azure-mgmt-datalake-analytics = callPackage ../development/python-modules/azure-mgmt-datalake-analytics { };
+  azure-mgmt-datalake-analytics =
+    callPackage ../development/python-modules/azure-mgmt-datalake-analytics
+      { };
 
   azure-mgmt-datalake-nspkg = callPackage ../development/python-modules/azure-mgmt-datalake-nspkg { };
 
@@ -1291,7 +1335,9 @@ self: super: with self; {
 
   azure-mgmt-datamigration = callPackage ../development/python-modules/azure-mgmt-datamigration { };
 
-  azure-mgmt-deploymentmanager = callPackage ../development/python-modules/azure-mgmt-deploymentmanager { };
+  azure-mgmt-deploymentmanager =
+    callPackage ../development/python-modules/azure-mgmt-deploymentmanager
+      { };
 
   azure-mgmt-devspaces = callPackage ../development/python-modules/azure-mgmt-devspaces { };
 
@@ -1303,7 +1349,9 @@ self: super: with self; {
 
   azure-mgmt-eventhub = callPackage ../development/python-modules/azure-mgmt-eventhub { };
 
-  azure-mgmt-extendedlocation = callPackage ../development/python-modules/azure-mgmt-extendedlocation { };
+  azure-mgmt-extendedlocation =
+    callPackage ../development/python-modules/azure-mgmt-extendedlocation
+      { };
 
   azure-mgmt-frontdoor = callPackage ../development/python-modules/azure-mgmt-frontdoor { };
 
@@ -1317,7 +1365,9 @@ self: super: with self; {
 
   azure-mgmt-iothub = callPackage ../development/python-modules/azure-mgmt-iothub { };
 
-  azure-mgmt-iothubprovisioningservices = callPackage ../development/python-modules/azure-mgmt-iothubprovisioningservices { };
+  azure-mgmt-iothubprovisioningservices =
+    callPackage ../development/python-modules/azure-mgmt-iothubprovisioningservices
+      { };
 
   azure-mgmt-keyvault = callPackage ../development/python-modules/azure-mgmt-keyvault { };
 
@@ -1327,17 +1377,27 @@ self: super: with self; {
 
   azure-mgmt-logic = callPackage ../development/python-modules/azure-mgmt-logic { };
 
-  azure-mgmt-machinelearningcompute = callPackage ../development/python-modules/azure-mgmt-machinelearningcompute { };
+  azure-mgmt-machinelearningcompute =
+    callPackage ../development/python-modules/azure-mgmt-machinelearningcompute
+      { };
 
-  azure-mgmt-managedservices = callPackage ../development/python-modules/azure-mgmt-managedservices { };
+  azure-mgmt-managedservices =
+    callPackage ../development/python-modules/azure-mgmt-managedservices
+      { };
 
-  azure-mgmt-managementgroups = callPackage ../development/python-modules/azure-mgmt-managementgroups { };
+  azure-mgmt-managementgroups =
+    callPackage ../development/python-modules/azure-mgmt-managementgroups
+      { };
 
-  azure-mgmt-managementpartner = callPackage ../development/python-modules/azure-mgmt-managementpartner { };
+  azure-mgmt-managementpartner =
+    callPackage ../development/python-modules/azure-mgmt-managementpartner
+      { };
 
   azure-mgmt-maps = callPackage ../development/python-modules/azure-mgmt-maps { };
 
-  azure-mgmt-marketplaceordering = callPackage ../development/python-modules/azure-mgmt-marketplaceordering { };
+  azure-mgmt-marketplaceordering =
+    callPackage ../development/python-modules/azure-mgmt-marketplaceordering
+      { };
 
   azure-mgmt-media = callPackage ../development/python-modules/azure-mgmt-media { };
 
@@ -1345,31 +1405,45 @@ self: super: with self; {
 
   azure-mgmt-msi = callPackage ../development/python-modules/azure-mgmt-msi { };
 
-  azure-mgmt-mysqlflexibleservers = callPackage ../development/python-modules/azure-mgmt-mysqlflexibleservers { };
+  azure-mgmt-mysqlflexibleservers =
+    callPackage ../development/python-modules/azure-mgmt-mysqlflexibleservers
+      { };
 
   azure-mgmt-netapp = callPackage ../development/python-modules/azure-mgmt-netapp { };
 
   azure-mgmt-network = callPackage ../development/python-modules/azure-mgmt-network { };
 
-  azure-mgmt-notificationhubs = callPackage ../development/python-modules/azure-mgmt-notificationhubs { };
+  azure-mgmt-notificationhubs =
+    callPackage ../development/python-modules/azure-mgmt-notificationhubs
+      { };
 
   azure-mgmt-nspkg = callPackage ../development/python-modules/azure-mgmt-nspkg { };
 
   azure-mgmt-policyinsights = callPackage ../development/python-modules/azure-mgmt-policyinsights { };
 
-  azure-mgmt-postgresqlflexibleservers = callPackage ../development/python-modules/azure-mgmt-postgresqlflexibleservers { };
+  azure-mgmt-postgresqlflexibleservers =
+    callPackage ../development/python-modules/azure-mgmt-postgresqlflexibleservers
+      { };
 
-  azure-mgmt-powerbiembedded = callPackage ../development/python-modules/azure-mgmt-powerbiembedded { };
+  azure-mgmt-powerbiembedded =
+    callPackage ../development/python-modules/azure-mgmt-powerbiembedded
+      { };
 
   azure-mgmt-privatedns = callPackage ../development/python-modules/azure-mgmt-privatedns { };
 
   azure-mgmt-rdbms = callPackage ../development/python-modules/azure-mgmt-rdbms { };
 
-  azure-mgmt-recoveryservicesbackup = callPackage ../development/python-modules/azure-mgmt-recoveryservicesbackup { };
+  azure-mgmt-recoveryservicesbackup =
+    callPackage ../development/python-modules/azure-mgmt-recoveryservicesbackup
+      { };
 
-  azure-mgmt-recoveryservices = callPackage ../development/python-modules/azure-mgmt-recoveryservices { };
+  azure-mgmt-recoveryservices =
+    callPackage ../development/python-modules/azure-mgmt-recoveryservices
+      { };
 
-  azure-mgmt-redhatopenshift = callPackage ../development/python-modules/azure-mgmt-redhatopenshift { };
+  azure-mgmt-redhatopenshift =
+    callPackage ../development/python-modules/azure-mgmt-redhatopenshift
+      { };
 
   azure-mgmt-redis = callPackage ../development/python-modules/azure-mgmt-redis { };
 
@@ -1389,7 +1463,9 @@ self: super: with self; {
 
   azure-mgmt-servicefabric = callPackage ../development/python-modules/azure-mgmt-servicefabric { };
 
-  azure-mgmt-servicefabricmanagedclusters = callPackage ../development/python-modules/azure-mgmt-servicefabricmanagedclusters { };
+  azure-mgmt-servicefabricmanagedclusters =
+    callPackage ../development/python-modules/azure-mgmt-servicefabricmanagedclusters
+      { };
 
   azure-mgmt-servicelinker = callPackage ../development/python-modules/azure-mgmt-servicelinker { };
 
@@ -1397,7 +1473,9 @@ self: super: with self; {
 
   azure-mgmt-sql = callPackage ../development/python-modules/azure-mgmt-sql { };
 
-  azure-mgmt-sqlvirtualmachine = callPackage ../development/python-modules/azure-mgmt-sqlvirtualmachine { };
+  azure-mgmt-sqlvirtualmachine =
+    callPackage ../development/python-modules/azure-mgmt-sqlvirtualmachine
+      { };
 
   azure-mgmt-storage = callPackage ../development/python-modules/azure-mgmt-storage { };
 
@@ -1423,7 +1501,9 @@ self: super: with self; {
 
   azure-servicefabric = callPackage ../development/python-modules/azure-servicefabric { };
 
-  azure-servicemanagement-legacy = callPackage ../development/python-modules/azure-servicemanagement-legacy { };
+  azure-servicemanagement-legacy =
+    callPackage ../development/python-modules/azure-servicemanagement-legacy
+      { };
 
   azure-storage-blob = callPackage ../development/python-modules/azure-storage-blob { };
 
@@ -1431,7 +1511,9 @@ self: super: with self; {
 
   azure-storage-file = callPackage ../development/python-modules/azure-storage-file { };
 
-  azure-storage-file-datalake = callPackage ../development/python-modules/azure-storage-file-datalake { };
+  azure-storage-file-datalake =
+    callPackage ../development/python-modules/azure-storage-file-datalake
+      { };
 
   azure-storage-file-share = callPackage ../development/python-modules/azure-storage-file-share { };
 
@@ -1439,11 +1521,15 @@ self: super: with self; {
 
   azure-storage-queue = callPackage ../development/python-modules/azure-storage-queue { };
 
-  azure-synapse-accesscontrol = callPackage ../development/python-modules/azure-synapse-accesscontrol { };
+  azure-synapse-accesscontrol =
+    callPackage ../development/python-modules/azure-synapse-accesscontrol
+      { };
 
   azure-synapse-artifacts = callPackage ../development/python-modules/azure-synapse-artifacts { };
 
-  azure-synapse-managedprivateendpoints = callPackage ../development/python-modules/azure-synapse-managedprivateendpoints { };
+  azure-synapse-managedprivateendpoints =
+    callPackage ../development/python-modules/azure-synapse-managedprivateendpoints
+      { };
 
   azure-synapse-spark = callPackage ../development/python-modules/azure-synapse-spark { };
 
@@ -1457,16 +1543,20 @@ self: super: with self; {
 
   babelgladeextractor = callPackage ../development/python-modules/babelgladeextractor { };
 
-  babeltrace = toPythonModule (pkgs.babeltrace.override {
-    pythonPackages = self;
-    enablePython = true;
-  });
+  babeltrace = toPythonModule (
+    pkgs.babeltrace.override {
+      pythonPackages = self;
+      enablePython = true;
+    }
+  );
 
-  babeltrace2 = toPythonModule (pkgs.babeltrace2.override {
-    inherit (self) python;
-    pythonPackages = self;
-    enablePython = true;
-  });
+  babeltrace2 = toPythonModule (
+    pkgs.babeltrace2.override {
+      inherit (self) python;
+      pythonPackages = self;
+      enablePython = true;
+    }
+  );
 
   baize = callPackage ../development/python-modules/baize { };
 
@@ -1504,9 +1594,13 @@ self: super: with self; {
 
   backoff = callPackage ../development/python-modules/backoff { };
 
-  backports-datetime-fromisoformat = callPackage ../development/python-modules/backports-datetime-fromisoformat { };
+  backports-datetime-fromisoformat =
+    callPackage ../development/python-modules/backports-datetime-fromisoformat
+      { };
 
-  backports-entry-points-selectable = callPackage ../development/python-modules/backports-entry-points-selectable { };
+  backports-entry-points-selectable =
+    callPackage ../development/python-modules/backports-entry-points-selectable
+      { };
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which { };
 
@@ -1596,10 +1690,11 @@ self: super: with self; {
 
   bch = callPackage ../development/python-modules/bch { };
 
-  bcrypt = if stdenv.hostPlatform.system == "i686-linux" then
-    callPackage ../development/python-modules/bcrypt/3.nix { }
-  else
-    callPackage ../development/python-modules/bcrypt { };
+  bcrypt =
+    if stdenv.hostPlatform.system == "i686-linux" then
+      callPackage ../development/python-modules/bcrypt/3.nix { }
+    else
+      callPackage ../development/python-modules/bcrypt { };
 
   bdffont = callPackage ../development/python-modules/bdffont { };
 
@@ -1737,7 +1832,9 @@ self: super: with self; {
 
   python-bitcoinlib = callPackage ../development/python-modules/python-bitcoinlib { };
 
-  bitcoin-utils-fork-minimal = callPackage ../development/python-modules/bitcoin-utils-fork-minimal { };
+  bitcoin-utils-fork-minimal =
+    callPackage ../development/python-modules/bitcoin-utils-fork-minimal
+      { };
 
   bitcoinrpc = callPackage ../development/python-modules/bitcoinrpc { };
 
@@ -1833,9 +1930,11 @@ self: super: with self; {
 
   bluetooth-auto-recovery = callPackage ../development/python-modules/bluetooth-auto-recovery { };
 
-  bluetooth-data-tools= callPackage ../development/python-modules/bluetooth-data-tools { };
+  bluetooth-data-tools = callPackage ../development/python-modules/bluetooth-data-tools { };
 
-  bluetooth-sensor-state-data = callPackage ../development/python-modules/bluetooth-sensor-state-data { };
+  bluetooth-sensor-state-data =
+    callPackage ../development/python-modules/bluetooth-sensor-state-data
+      { };
 
   blurhash = callPackage ../development/python-modules/blurhash { };
 
@@ -1875,10 +1974,12 @@ self: super: with self; {
 
   # Build boost for this specific Python version
   # TODO: use separate output for libboost_python.so
-  boost = toPythonModule (pkgs.boost.override {
-    inherit (self) python numpy;
-    enablePython = true;
-  });
+  boost = toPythonModule (
+    pkgs.boost.override {
+      inherit (self) python numpy;
+      enablePython = true;
+    }
+  );
 
   borb = callPackage ../development/python-modules/borb { };
 
@@ -1920,9 +2021,7 @@ self: super: with self; {
 
   bracex = callPackage ../development/python-modules/bracex { };
 
-  brainflow = callPackage ../development/python-modules/brainflow {
-    inherit (pkgs) brainflow;
-  };
+  brainflow = callPackage ../development/python-modules/brainflow { inherit (pkgs) brainflow; };
 
   braintree = callPackage ../development/python-modules/braintree { };
 
@@ -1954,9 +2053,7 @@ self: super: with self; {
 
   brotli-asgi = callPackage ../development/python-modules/brotli-asgi { };
 
-  brotlicffi = callPackage ../development/python-modules/brotlicffi {
-    inherit (pkgs) brotli;
-  };
+  brotlicffi = callPackage ../development/python-modules/brotlicffi { inherit (pkgs) brotli; };
 
   brotlipy = callPackage ../development/python-modules/brotlipy { };
 
@@ -2064,10 +2161,12 @@ self: super: with self; {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
-  caffe = toPythonModule (pkgs.caffe.override {
-    pythonSupport = true;
-    inherit (self) python numpy boost;
-  });
+  caffe = toPythonModule (
+    pkgs.caffe.override {
+      pythonSupport = true;
+      inherit (self) python numpy boost;
+    }
+  );
 
   caio = callPackage ../development/python-modules/caio { };
 
@@ -2107,9 +2206,7 @@ self: super: with self; {
 
   camelot = callPackage ../development/python-modules/camelot { };
 
-  capstone = callPackage ../development/python-modules/capstone {
-    inherit (pkgs) capstone;
-  };
+  capstone = callPackage ../development/python-modules/capstone { inherit (pkgs) capstone; };
   capstone_4 = callPackage ../development/python-modules/capstone/4.nix {
     inherit (pkgs) capstone_4;
   };
@@ -2132,7 +2229,12 @@ self: super: with self; {
 
   casa-formats-io = callPackage ../development/python-modules/casa-formats-io { };
 
-  casadi = toPythonModule (pkgs.casadi.override { pythonSupport = true; python3Packages = self; });
+  casadi = toPythonModule (
+    pkgs.casadi.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   casbin = callPackage ../development/python-modules/casbin { };
 
@@ -2140,7 +2242,7 @@ self: super: with self; {
 
   cashaddress = callPackage ../development/python-modules/cashaddress { };
 
-  cashews = callPackage ../development/python-modules/cashews {  };
+  cashews = callPackage ../development/python-modules/cashews { };
 
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
@@ -2169,9 +2271,7 @@ self: super: with self; {
 
   cbor = callPackage ../development/python-modules/cbor { };
 
-  cccolutils = callPackage ../development/python-modules/cccolutils {
-    krb5-c = pkgs.krb5;
-  };
+  cccolutils = callPackage ../development/python-modules/cccolutils { krb5-c = pkgs.krb5; };
 
   cdcs = callPackage ../development/python-modules/cdcs { };
 
@@ -2193,18 +2293,18 @@ self: super: with self; {
 
   cexprtk = callPackage ../development/python-modules/cexprtk { };
 
-  coal = toPythonModule (pkgs.coal.override {
-    pythonSupport = true;
-    python3Packages = self;
-  });
+  coal = toPythonModule (
+    pkgs.coal.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   coffea = callPackage ../development/python-modules/coffea { };
 
   cohere = callPackage ../development/python-modules/cohere { };
 
-  coincurve = callPackage ../development/python-modules/coincurve {
-    inherit (pkgs) secp256k1;
-  };
+  coincurve = callPackage ../development/python-modules/coincurve { inherit (pkgs) secp256k1; };
 
   comicapi = callPackage ../development/python-modules/comicapi { };
 
@@ -2222,7 +2322,7 @@ self: super: with self; {
 
   connio = callPackage ../development/python-modules/connio { };
 
-  conway-polynomials = callPackage ../development/python-modules/conway-polynomials {};
+  conway-polynomials = callPackage ../development/python-modules/conway-polynomials { };
 
   correctionlib = callPackage ../development/python-modules/correctionlib { };
 
@@ -2276,9 +2376,7 @@ self: super: with self; {
 
   cftime = callPackage ../development/python-modules/cftime { };
 
-  cgal = callPackage ../development/python-modules/cgal {
-    inherit (pkgs) cgal;
-  };
+  cgal = callPackage ../development/python-modules/cgal { inherit (pkgs) cgal; };
 
   cgen = callPackage ../development/python-modules/cgen { };
 
@@ -2286,7 +2384,9 @@ self: super: with self; {
 
   chacha20poly1305 = callPackage ../development/python-modules/chacha20poly1305 { };
 
-  chacha20poly1305-reuseable = callPackage ../development/python-modules/chacha20poly1305-reuseable { };
+  chacha20poly1305-reuseable =
+    callPackage ../development/python-modules/chacha20poly1305-reuseable
+      { };
 
   chai = callPackage ../development/python-modules/chai { };
 
@@ -2538,9 +2638,7 @@ self: super: with self; {
 
   cmdstanpy = callPackage ../development/python-modules/cmdstanpy { };
 
-  cmigemo = callPackage ../development/python-modules/cmigemo {
-    inherit (pkgs) cmigemo;
-  };
+  cmigemo = callPackage ../development/python-modules/cmigemo { inherit (pkgs) cmigemo; };
 
   cmsdials = callPackage ../development/python-modules/cmsdials { };
 
@@ -2738,9 +2836,7 @@ self: super: with self; {
 
   cose = callPackage ../development/python-modules/cose { };
 
-  cot = callPackage ../development/python-modules/cot {
-    inherit (pkgs) qemu;
-  };
+  cot = callPackage ../development/python-modules/cot { inherit (pkgs) qemu; };
 
   courlan = callPackage ../development/python-modules/courlan { };
 
@@ -2750,9 +2846,7 @@ self: super: with self; {
 
   cpe = callPackage ../development/python-modules/cpe { };
 
-  cppe = callPackage ../development/python-modules/cppe {
-    inherit (pkgs) cppe;
-  };
+  cppe = callPackage ../development/python-modules/cppe { inherit (pkgs) cppe; };
 
   cppheaderparser = callPackage ../development/python-modules/cppheaderparser { };
 
@@ -2804,10 +2898,12 @@ self: super: with self; {
 
   crochet = callPackage ../development/python-modules/crochet { };
 
-  crocoddyl = toPythonModule (pkgs.crocoddyl.override {
-    pythonSupport = true;
-    python3Packages = self;
-  });
+  crocoddyl = toPythonModule (
+    pkgs.crocoddyl.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   cron-descriptor = callPackage ../development/python-modules/cron-descriptor { };
 
@@ -2845,9 +2941,9 @@ self: super: with self; {
 
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };
 
-  cson  = callPackage ../development/python-modules/cson { };
+  cson = callPackage ../development/python-modules/cson { };
 
-  csrmesh  = callPackage ../development/python-modules/csrmesh { };
+  csrmesh = callPackage ../development/python-modules/csrmesh { };
 
   cssbeautifier = callPackage ../development/python-modules/cssbeautifier { };
 
@@ -2894,11 +2990,13 @@ self: super: with self; {
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
   cupy = callPackage ../development/python-modules/cupy {
-    cudaPackages = pkgs.cudaPackages.overrideScope (cu-fi: _: {
-      # CuDNN 9 is not supported:
-      # https://github.com/cupy/cupy/issues/8215
-      cudnn = cu-fi.cudnn_8_9;
-    });
+    cudaPackages = pkgs.cudaPackages.overrideScope (
+      cu-fi: _: {
+        # CuDNN 9 is not supported:
+        # https://github.com/cupy/cupy/issues/8215
+        cudnn = cu-fi.cudnn_8_9;
+      }
+    );
   };
 
   curio = callPackage ../development/python-modules/curio { };
@@ -2969,7 +3067,9 @@ self: super: with self; {
 
   cython_0 = callPackage ../development/python-modules/cython/0.nix { };
 
-  cython-test-exception-raiser = callPackage ../development/python-modules/cython-test-exception-raiser { };
+  cython-test-exception-raiser =
+    callPackage ../development/python-modules/cython-test-exception-raiser
+      { };
 
   cytoolz = callPackage ../development/python-modules/cytoolz { };
 
@@ -3144,9 +3244,7 @@ self: super: with self; {
 
   dbus-next = callPackage ../development/python-modules/dbus-next { };
 
-  dbus-python = callPackage ../development/python-modules/dbus-python {
-    inherit (pkgs) dbus;
-  };
+  dbus-python = callPackage ../development/python-modules/dbus-python { inherit (pkgs) dbus; };
 
   dbus-python-client-gen = callPackage ../development/python-modules/dbus-python-client-gen { };
 
@@ -3436,7 +3534,7 @@ self: super: with self; {
 
   dissononce = callPackage ../development/python-modules/dissononce { };
 
-  dist-meta  = callPackage ../development/python-modules/dist-meta { };
+  dist-meta = callPackage ../development/python-modules/dist-meta { };
 
   distlib = callPackage ../development/python-modules/distlib { };
 
@@ -3448,7 +3546,8 @@ self: super: with self; {
 
   distro = callPackage ../development/python-modules/distro { };
 
-  distutils = if pythonOlder "3.12" then null else callPackage ../development/python-modules/distutils { };
+  distutils =
+    if pythonOlder "3.12" then null else callPackage ../development/python-modules/distutils { };
 
   distutils-extra = callPackage ../development/python-modules/distutils-extra { };
 
@@ -3528,7 +3627,9 @@ self: super: with self; {
 
   django-compressor = callPackage ../development/python-modules/django-compressor { };
 
-  django-compression-middleware = callPackage ../development/python-modules/django-compression-middleware { };
+  django-compression-middleware =
+    callPackage ../development/python-modules/django-compression-middleware
+      { };
 
   django-configurations = callPackage ../development/python-modules/django-configurations { };
 
@@ -3560,11 +3661,15 @@ self: super: with self; {
 
   django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };
 
-  django-dynamic-preferences = callPackage ../development/python-modules/django-dynamic-preferences { };
+  django-dynamic-preferences =
+    callPackage ../development/python-modules/django-dynamic-preferences
+      { };
 
   django-elasticsearch-dsl = callPackage ../development/python-modules/django-elasticsearch-dsl { };
 
-  django-encrypted-model-fields = callPackage ../development/python-modules/django-encrypted-model-fields { };
+  django-encrypted-model-fields =
+    callPackage ../development/python-modules/django-encrypted-model-fields
+      { };
 
   django-environ = callPackage ../development/python-modules/django-environ { };
 
@@ -3578,15 +3683,21 @@ self: super: with self; {
 
   django-formtools = callPackage ../development/python-modules/django-formtools { };
 
-  django-formset-js-improved = callPackage ../development/python-modules/django-formset-js-improved { };
+  django-formset-js-improved =
+    callPackage ../development/python-modules/django-formset-js-improved
+      { };
 
   django-fsm = callPackage ../development/python-modules/django-fsm { };
 
-  django-graphiql-debug-toolbar = callPackage ../development/python-modules/django-graphiql-debug-toolbar { };
+  django-graphiql-debug-toolbar =
+    callPackage ../development/python-modules/django-graphiql-debug-toolbar
+      { };
 
   django-gravatar2 = callPackage ../development/python-modules/django-gravatar2 { };
 
-  django-google-analytics-app = callPackage ../development/python-modules/django-google-analytics-app { };
+  django-google-analytics-app =
+    callPackage ../development/python-modules/django-google-analytics-app
+      { };
 
   django-guardian = callPackage ../development/python-modules/django-guardian { };
 
@@ -3624,7 +3735,9 @@ self: super: with self; {
 
   django-logentry-admin = callPackage ../development/python-modules/django-logentry-admin { };
 
-  django-login-required-middleware = callPackage ../development/python-modules/django-login-required-middleware { };
+  django-login-required-middleware =
+    callPackage ../development/python-modules/django-login-required-middleware
+      { };
 
   django-localflavor = callPackage ../development/python-modules/django-localflavor { };
 
@@ -3680,7 +3793,9 @@ self: super: with self; {
 
   django-polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
-  django-postgresql-netfields = callPackage ../development/python-modules/django-postgresql-netfields { };
+  django-postgresql-netfields =
+    callPackage ../development/python-modules/django-postgresql-netfields
+      { };
 
   django-prometheus = callPackage ../development/python-modules/django-prometheus { };
 
@@ -3722,21 +3837,33 @@ self: super: with self; {
 
   djangorestframework = callPackage ../development/python-modules/djangorestframework { };
 
-  djangorestframework-dataclasses = callPackage ../development/python-modules/djangorestframework-dataclasses { };
+  djangorestframework-dataclasses =
+    callPackage ../development/python-modules/djangorestframework-dataclasses
+      { };
 
-  djangorestframework-camel-case = callPackage ../development/python-modules/djangorestframework-camel-case { };
+  djangorestframework-camel-case =
+    callPackage ../development/python-modules/djangorestframework-camel-case
+      { };
 
   djangorestframework-csv = callPackage ../development/python-modules/djangorestframework-csv { };
 
-  djangorestframework-guardian = callPackage ../development/python-modules/djangorestframework-guardian { };
+  djangorestframework-guardian =
+    callPackage ../development/python-modules/djangorestframework-guardian
+      { };
 
-  djangorestframework-guardian2 = callPackage ../development/python-modules/djangorestframework-guardian2 { };
+  djangorestframework-guardian2 =
+    callPackage ../development/python-modules/djangorestframework-guardian2
+      { };
 
   djangorestframework-jsonp = callPackage ../development/python-modules/djangorestframework-jsonp { };
 
-  djangorestframework-recursive = callPackage ../development/python-modules/djangorestframework-recursive { };
+  djangorestframework-recursive =
+    callPackage ../development/python-modules/djangorestframework-recursive
+      { };
 
-  djangorestframework-simplejwt = callPackage ../development/python-modules/djangorestframework-simplejwt { };
+  djangorestframework-simplejwt =
+    callPackage ../development/python-modules/djangorestframework-simplejwt
+      { };
 
   djangorestframework-stubs = callPackage ../development/python-modules/djangorestframework-stubs { };
 
@@ -3790,7 +3917,9 @@ self: super: with self; {
 
   django-types = callPackage ../development/python-modules/django-types { };
 
-  django-versatileimagefield = callPackage ../development/python-modules/django-versatileimagefield { };
+  django-versatileimagefield =
+    callPackage ../development/python-modules/django-versatileimagefield
+      { };
 
   django-vite = callPackage ../development/python-modules/django-vite { };
 
@@ -3816,9 +3945,7 @@ self: super: with self; {
 
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
-  dlib = callPackage ../development/python-modules/dlib {
-    inherit (pkgs) dlib;
-  };
+  dlib = callPackage ../development/python-modules/dlib { inherit (pkgs) dlib; };
 
   dlinfo = callPackage ../development/python-modules/dlinfo { };
 
@@ -3843,9 +3970,7 @@ self: super: with self; {
   dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
 
   dm-tree = callPackage ../development/python-modules/dm-tree {
-    abseil-cpp = pkgs.abseil-cpp.override {
-      cxxStandard = "14";
-    };
+    abseil-cpp = pkgs.abseil-cpp.override { cxxStandard = "14"; };
   };
 
   dnachisel = callPackage ../development/python-modules/dnachisel { };
@@ -3944,9 +4069,7 @@ self: super: with self; {
 
   dotty-dict = callPackage ../development/python-modules/dotty-dict { };
 
-  dot2tex = callPackage ../development/python-modules/dot2tex {
-    inherit (pkgs) graphviz;
-  };
+  dot2tex = callPackage ../development/python-modules/dot2tex { inherit (pkgs) graphviz; };
 
   dotwiz = callPackage ../development/python-modules/dotwiz { };
 
@@ -4014,7 +4137,7 @@ self: super: with self; {
 
   dropmqttapi = callPackage ../development/python-modules/dropmqttapi { };
 
-  dscribe  = callPackage ../development/python-modules/dscribe { };
+  dscribe = callPackage ../development/python-modules/dscribe { };
 
   ds-store = callPackage ../development/python-modules/ds-store { };
 
@@ -4034,9 +4157,7 @@ self: super: with self; {
 
   ducc0 = callPackage ../development/python-modules/ducc0 { };
 
-  duckdb = callPackage ../development/python-modules/duckdb {
-    inherit (pkgs) duckdb;
-  };
+  duckdb = callPackage ../development/python-modules/duckdb { inherit (pkgs) duckdb; };
 
   duckdb-engine = callPackage ../development/python-modules/duckdb-engine { };
 
@@ -4054,9 +4175,7 @@ self: super: with self; {
 
   dukpy = callPackage ../development/python-modules/dukpy { };
 
-  dulwich = callPackage ../development/python-modules/dulwich {
-    inherit (pkgs) gnupg;
-  };
+  dulwich = callPackage ../development/python-modules/dulwich { inherit (pkgs) gnupg; };
 
   dunamai = callPackage ../development/python-modules/dunamai { };
 
@@ -4068,41 +4187,41 @@ self: super: with self; {
 
   durationpy = callPackage ../development/python-modules/durationpy { };
 
-  durus = callPackage ../development/python-modules/durus {  };
+  durus = callPackage ../development/python-modules/durus { };
 
-  dvc = callPackage ../development/python-modules/dvc {  };
+  dvc = callPackage ../development/python-modules/dvc { };
 
-  dvc-azure = callPackage ../development/python-modules/dvc-azure {  };
+  dvc-azure = callPackage ../development/python-modules/dvc-azure { };
 
-  dvc-data = callPackage ../development/python-modules/dvc-data {  };
+  dvc-data = callPackage ../development/python-modules/dvc-data { };
 
-  dvc-gdrive = callPackage ../development/python-modules/dvc-gdrive {  };
+  dvc-gdrive = callPackage ../development/python-modules/dvc-gdrive { };
 
   dvc-gs = callPackage ../development/python-modules/dvc-gs { };
 
-  dvc-hdfs = callPackage ../development/python-modules/dvc-hdfs {  };
+  dvc-hdfs = callPackage ../development/python-modules/dvc-hdfs { };
 
-  dvc-http = callPackage ../development/python-modules/dvc-http {  };
+  dvc-http = callPackage ../development/python-modules/dvc-http { };
 
-  dvc-objects = callPackage ../development/python-modules/dvc-objects {  };
+  dvc-objects = callPackage ../development/python-modules/dvc-objects { };
 
-  dvc-oss = callPackage ../development/python-modules/dvc-oss {  };
+  dvc-oss = callPackage ../development/python-modules/dvc-oss { };
 
-  dvc-render = callPackage ../development/python-modules/dvc-render {  };
+  dvc-render = callPackage ../development/python-modules/dvc-render { };
 
   dvc-s3 = callPackage ../development/python-modules/dvc-s3 { };
 
   dvc-ssh = callPackage ../development/python-modules/dvc-ssh { };
 
-  dvc-studio-client = callPackage ../development/python-modules/dvc-studio-client {  };
+  dvc-studio-client = callPackage ../development/python-modules/dvc-studio-client { };
 
-  dvc-task = callPackage ../development/python-modules/dvc-task {  };
+  dvc-task = callPackage ../development/python-modules/dvc-task { };
 
-  dvc-webdav = callPackage ../development/python-modules/dvc-webdav {  };
+  dvc-webdav = callPackage ../development/python-modules/dvc-webdav { };
 
-  dvc-webhdfs = callPackage ../development/python-modules/dvc-webhdfs {  };
+  dvc-webhdfs = callPackage ../development/python-modules/dvc-webhdfs { };
 
-  dvclive = callPackage ../development/python-modules/dvclive {  };
+  dvclive = callPackage ../development/python-modules/dvclive { };
 
   dwdwfsapi = callPackage ../development/python-modules/dwdwfsapi { };
 
@@ -4148,10 +4267,12 @@ self: super: with self; {
 
   ec2-metadata = callPackage ../development/python-modules/ec2-metadata { };
 
-  eccodes = toPythonModule (pkgs.eccodes.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  eccodes = toPythonModule (
+    pkgs.eccodes.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
   ecdsa = callPackage ../development/python-modules/ecdsa { };
 
@@ -4163,7 +4284,7 @@ self: super: with self; {
 
   ecpy = callPackage ../development/python-modules/ecpy { };
 
-  ecs-logging =  callPackage ../development/python-modules/ecs-logging { };
+  ecs-logging = callPackage ../development/python-modules/ecs-logging { };
 
   ed25519 = callPackage ../development/python-modules/ed25519 { };
 
@@ -4185,9 +4306,7 @@ self: super: with self; {
 
   edk2-pytool-library = callPackage ../development/python-modules/edk2-pytool-library { };
 
-  edlib = callPackage ../development/python-modules/edlib {
-    inherit (pkgs) edlib;
-  };
+  edlib = callPackage ../development/python-modules/edlib { inherit (pkgs) edlib; };
 
   eduvpn-common = callPackage ../development/python-modules/eduvpn-common { };
 
@@ -4273,7 +4392,7 @@ self: super: with self; {
 
   energyflow = callPackage ../development/python-modules/energyflow { };
 
-  energyzero =  callPackage ../development/python-modules/energyzero { };
+  energyzero = callPackage ../development/python-modules/energyzero { };
 
   enlighten = callPackage ../development/python-modules/enlighten { };
 
@@ -4285,9 +4404,7 @@ self: super: with self; {
 
   enterpriseattack = callPackage ../development/python-modules/enterpriseattack { };
 
-  entrance = callPackage ../development/python-modules/entrance {
-    routerFeatures = false;
-  };
+  entrance = callPackage ../development/python-modules/entrance { routerFeatures = false; };
 
   entrance-with-router-features = callPackage ../development/python-modules/entrance {
     routerFeatures = true;
@@ -4363,9 +4480,7 @@ self: super: with self; {
 
   etcd = callPackage ../development/python-modules/etcd { };
 
-  etcd3 = callPackage ../development/python-modules/etcd3 {
-    inherit (pkgs) etcd;
-  };
+  etcd3 = callPackage ../development/python-modules/etcd3 { inherit (pkgs) etcd; };
 
   ete3 = callPackage ../development/python-modules/ete3 { };
 
@@ -4439,10 +4554,12 @@ self: super: with self; {
 
   ewmhlib = callPackage ../development/python-modules/ewmhlib { };
 
-  example-robot-data = toPythonModule (pkgs.example-robot-data.override {
-    pythonSupport = true;
-    python3Packages = self;
-  });
+  example-robot-data = toPythonModule (
+    pkgs.example-robot-data.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   exdown = callPackage ../development/python-modules/exdown { };
 
@@ -4462,9 +4579,7 @@ self: super: with self; {
 
   exifread = callPackage ../development/python-modules/exifread { };
 
-  exiv2 = callPackage ../development/python-modules/exiv2 {
-    inherit (pkgs) exiv2;
-  };
+  exiv2 = callPackage ../development/python-modules/exiv2 { inherit (pkgs) exiv2; };
 
   expandvars = callPackage ../development/python-modules/expandvars { };
 
@@ -4503,7 +4618,8 @@ self: super: with self; {
       lz4
       xz
       zlib
-      zstd;
+      zstd
+      ;
   };
 
   extras = callPackage ../development/python-modules/extras { };
@@ -4516,15 +4632,19 @@ self: super: with self; {
 
   ezyrb = callPackage ../development/python-modules/ezyrb { };
 
-  f3d = toPythonModule (pkgs.f3d.override {
-    withPythonBinding = true;
-    python3Packages = self;
-  });
+  f3d = toPythonModule (
+    pkgs.f3d.override {
+      withPythonBinding = true;
+      python3Packages = self;
+    }
+  );
 
-  f3d_egl = toPythonModule (pkgs.f3d_egl.override {
-    withPythonBinding = true;
-    python3Packages = self;
-  });
+  f3d_egl = toPythonModule (
+    pkgs.f3d_egl.override {
+      withPythonBinding = true;
+      python3Packages = self;
+    }
+  );
 
   f5-icontrol-rest = callPackage ../development/python-modules/f5-icontrol-rest { };
 
@@ -4577,7 +4697,9 @@ self: super: with self; {
 
   falconpy = callPackage ../development/python-modules/falconpy { };
 
-  faraday-agent-parameters-types = callPackage ../development/python-modules/faraday-agent-parameters-types { };
+  faraday-agent-parameters-types =
+    callPackage ../development/python-modules/faraday-agent-parameters-types
+      { };
 
   faraday-plugins = callPackage ../development/python-modules/faraday-plugins { };
 
@@ -4629,10 +4751,12 @@ self: super: with self; {
 
   fastjsonschema = callPackage ../development/python-modules/fastjsonschema { };
 
-  fastnlo-toolkit = toPythonModule (pkgs.fastnlo-toolkit.override {
-    withPython = true;
-    inherit (self) python;
-  });
+  fastnlo-toolkit = toPythonModule (
+    pkgs.fastnlo-toolkit.override {
+      withPython = true;
+      inherit (self) python;
+    }
+  );
 
   fastmri = callPackage ../development/python-modules/fastmri { };
 
@@ -4650,7 +4774,12 @@ self: super: with self; {
 
   fasttext-predict = callPackage ../development/python-modules/fasttext-predict { };
 
-  fatrop = toPythonModule (pkgs.fatrop.override { pythonSupport = true; python3Packages = self; });
+  fatrop = toPythonModule (
+    pkgs.fatrop.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   faust-cchardet = callPackage ../development/python-modules/faust-cchardet { };
 
@@ -4674,9 +4803,7 @@ self: super: with self; {
 
   feedparser = callPackage ../development/python-modules/feedparser { };
 
-  fenics = callPackage ../development/python-modules/fenics {
-    hdf5 = pkgs.hdf5_1_10;
-  };
+  fenics = callPackage ../development/python-modules/fenics { hdf5 = pkgs.hdf5_1_10; };
 
   ffcv = callPackage ../development/python-modules/ffcv { };
 
@@ -4910,9 +5037,7 @@ self: super: with self; {
 
   flask-wtf = callPackage ../development/python-modules/flask-wtf { };
 
-  flatbuffers = callPackage ../development/python-modules/flatbuffers {
-    inherit (pkgs) flatbuffers;
-  };
+  flatbuffers = callPackage ../development/python-modules/flatbuffers { inherit (pkgs) flatbuffers; };
 
   flatdict = callPackage ../development/python-modules/flatdict { };
 
@@ -4998,12 +5123,14 @@ self: super: with self; {
 
   fontfeatures = callPackage ../development/python-modules/fontfeatures { };
 
-  fontforge = disabledIf
-    (pythonOlder "3.10")
-    (toPythonModule (pkgs.fontforge.override {
-      withPython = true;
-      python3 = python;
-    }));
+  fontforge = disabledIf (pythonOlder "3.10") (
+    toPythonModule (
+      pkgs.fontforge.override {
+        withPython = true;
+        python3 = python;
+      }
+    )
+  );
 
   fontmath = callPackage ../development/python-modules/fontmath { };
 
@@ -5059,7 +5186,9 @@ self: super: with self; {
 
   formulaic = callPackage ../development/python-modules/formulaic { };
 
-  foundationdb73 = callPackage ../servers/foundationdb/python.nix { foundationdb = pkgs.foundationdb73; };
+  foundationdb73 = callPackage ../servers/foundationdb/python.nix {
+    foundationdb = pkgs.foundationdb73;
+  };
 
   fountains = callPackage ../development/python-modules/fountains { };
 
@@ -5079,9 +5208,7 @@ self: super: with self; {
 
   freertos-gdb = callPackage ../development/python-modules/freertos-gdb { };
 
-  freesasa = callPackage ../development/python-modules/freesasa {
-    inherit (pkgs) freesasa;
-  };
+  freesasa = callPackage ../development/python-modules/freesasa { inherit (pkgs) freesasa; };
 
   freetype-py = callPackage ../development/python-modules/freetype-py { };
 
@@ -5147,9 +5274,7 @@ self: super: with self; {
 
   furo = callPackage ../development/python-modules/furo { };
 
-  fuse = callPackage ../development/python-modules/fuse-python {
-    inherit (pkgs) fuse;
-  };
+  fuse = callPackage ../development/python-modules/fuse-python { inherit (pkgs) fuse; };
 
   fusepy = callPackage ../development/python-modules/fusepy { };
 
@@ -5175,10 +5300,12 @@ self: super: with self; {
 
   g2pkk = callPackage ../development/python-modules/g2pkk { };
 
-  galario = toPythonModule (pkgs.galario.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  galario = toPythonModule (
+    pkgs.galario.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
   galois = callPackage ../development/python-modules/galois { };
 
@@ -5226,10 +5353,12 @@ self: super: with self; {
 
   gdb-pt-dump = callPackage ../development/python-modules/gdb-pt-dump { };
 
-  gdcm = toPythonModule (pkgs.gdcm.override {
-    inherit (self) python;
-    enablePython = true;
-  });
+  gdcm = toPythonModule (
+    pkgs.gdcm.override {
+      inherit (self) python;
+      enablePython = true;
+    }
+  );
 
   gdown = callPackage ../development/python-modules/gdown { };
 
@@ -5237,10 +5366,12 @@ self: super: with self; {
 
   ge25519 = callPackage ../development/python-modules/ge25519 { };
 
-  geant4 = toPythonModule (pkgs.geant4.override {
-    enablePython = true;
-    python3 = python;
-  });
+  geant4 = toPythonModule (
+    pkgs.geant4.override {
+      enablePython = true;
+      python3 = python;
+    }
+  );
 
   geeknote = callPackage ../development/python-modules/geeknote { };
 
@@ -5254,10 +5385,12 @@ self: super: with self; {
 
   gemfileparser2 = callPackage ../development/python-modules/gemfileparser2 { };
 
-  gemmi = toPythonModule (pkgs.gemmi.override {
-    enablePython = true;
-    python3Packages = self;
-  });
+  gemmi = toPythonModule (
+    pkgs.gemmi.override {
+      enablePython = true;
+      python3Packages = self;
+    }
+  );
 
   genanki = callPackage ../development/python-modules/genanki { };
 
@@ -5301,9 +5434,7 @@ self: super: with self; {
 
   geoip2 = callPackage ../development/python-modules/geoip2 { };
 
-  geoip = callPackage ../development/python-modules/geoip {
-    libgeoip = pkgs.geoip;
-  };
+  geoip = callPackage ../development/python-modules/geoip { libgeoip = pkgs.geoip; };
 
   geojson = callPackage ../development/python-modules/geojson { };
 
@@ -5315,7 +5446,7 @@ self: super: with self; {
 
   geopandas = callPackage ../development/python-modules/geopandas { };
 
-  geoparquet = callPackage  ../development/python-modules/geoparquet { };
+  geoparquet = callPackage ../development/python-modules/geoparquet { };
 
   geopy = callPackage ../development/python-modules/geopy { };
 
@@ -5323,21 +5454,33 @@ self: super: with self; {
 
   georss-generic-client = callPackage ../development/python-modules/georss-generic-client { };
 
-  georss-ign-sismologia-client = callPackage ../development/python-modules/georss-ign-sismologia-client { };
+  georss-ign-sismologia-client =
+    callPackage ../development/python-modules/georss-ign-sismologia-client
+      { };
 
-  georss-ingv-centro-nazionale-terremoti-client = callPackage ../development/python-modules/georss-ingv-centro-nazionale-terremoti-client { };
+  georss-ingv-centro-nazionale-terremoti-client =
+    callPackage ../development/python-modules/georss-ingv-centro-nazionale-terremoti-client
+      { };
 
-  georss-nrcan-earthquakes-client = callPackage ../development/python-modules/georss-nrcan-earthquakes-client { };
+  georss-nrcan-earthquakes-client =
+    callPackage ../development/python-modules/georss-nrcan-earthquakes-client
+      { };
 
-  georss-qld-bushfire-alert-client = callPackage ../development/python-modules/georss-qld-bushfire-alert-client { };
+  georss-qld-bushfire-alert-client =
+    callPackage ../development/python-modules/georss-qld-bushfire-alert-client
+      { };
 
-  georss-tfs-incidents-client = callPackage ../development/python-modules/georss-tfs-incidents-client { };
+  georss-tfs-incidents-client =
+    callPackage ../development/python-modules/georss-tfs-incidents-client
+      { };
 
   georss-wa-dfes-client = callPackage ../development/python-modules/georss-wa-dfes-client { };
 
   gepetto-gui = toPythonModule (gepetto-viewer.withPlugins [ gepetto-viewer-corba ]);
 
-  gepetto-viewer-corba = toPythonModule (pkgs.gepetto-viewer-corba.override { python3Packages = self; });
+  gepetto-viewer-corba = toPythonModule (
+    pkgs.gepetto-viewer-corba.override { python3Packages = self; }
+  );
 
   gepetto-viewer = toPythonModule (pkgs.gepetto-viewer.override { python3Packages = self; });
 
@@ -5361,9 +5504,7 @@ self: super: with self; {
 
   gfal2-python = callPackage ../development/python-modules/gfal2-python { };
 
-  gfal2-util = callPackage ../development/python-modules/gfal2-util {
-    inherit (pkgs) xrootd;
-  };
+  gfal2-util = callPackage ../development/python-modules/gfal2-util { inherit (pkgs) xrootd; };
 
   gflags = callPackage ../development/python-modules/gflags { };
 
@@ -5401,8 +5542,7 @@ self: super: with self; {
 
   gistyc = callPackage ../development/python-modules/gistyc { };
 
-  git-annex-adapter =
-    callPackage ../development/python-modules/git-annex-adapter { };
+  git-annex-adapter = callPackage ../development/python-modules/git-annex-adapter { };
 
   git-filter-repo = callPackage ../development/python-modules/git-filter-repo { };
 
@@ -5436,9 +5576,9 @@ self: super: with self; {
 
   git-versioner = callPackage ../development/python-modules/git-versioner { };
 
-  glad =  callPackage ../development/python-modules/glad { };
+  glad = callPackage ../development/python-modules/glad { };
 
-  glad2 =  callPackage ../development/python-modules/glad2 { };
+  glad2 = callPackage ../development/python-modules/glad2 { };
 
   glances-api = callPackage ../development/python-modules/glances-api { };
 
@@ -5466,10 +5606,12 @@ self: super: with self; {
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 
-  gmsh = toPythonModule (pkgs.gmsh.override {
-    inherit (self) python;
-    enablePython = true;
-  });
+  gmsh = toPythonModule (
+    pkgs.gmsh.override {
+      inherit (self) python;
+      enablePython = true;
+    }
+  );
 
   gmqtt = callPackage ../development/python-modules/gmqtt { };
 
@@ -5493,7 +5635,9 @@ self: super: with self; {
 
   google = callPackage ../development/python-modules/google { };
 
-  google-ai-generativelanguage = callPackage ../development/python-modules/google-ai-generativelanguage { };
+  google-ai-generativelanguage =
+    callPackage ../development/python-modules/google-ai-generativelanguage
+      { };
 
   google-api-core = callPackage ../development/python-modules/google-api-core { };
 
@@ -5507,11 +5651,17 @@ self: super: with self; {
 
   google-auth-oauthlib = callPackage ../development/python-modules/google-auth-oauthlib { };
 
-  google-cloud-access-context-manager = callPackage ../development/python-modules/google-cloud-access-context-manager { };
+  google-cloud-access-context-manager =
+    callPackage ../development/python-modules/google-cloud-access-context-manager
+      { };
 
-  google-cloud-appengine-logging = callPackage ../development/python-modules/google-cloud-appengine-logging { };
+  google-cloud-appengine-logging =
+    callPackage ../development/python-modules/google-cloud-appengine-logging
+      { };
 
-  google-cloud-artifact-registry = callPackage ../development/python-modules/google-cloud-artifact-registry { };
+  google-cloud-artifact-registry =
+    callPackage ../development/python-modules/google-cloud-artifact-registry
+      { };
 
   google-cloud-asset = callPackage ../development/python-modules/google-cloud-asset { };
 
@@ -5521,11 +5671,17 @@ self: super: with self; {
 
   google-cloud-bigquery = callPackage ../development/python-modules/google-cloud-bigquery { };
 
-  google-cloud-bigquery-datatransfer = callPackage ../development/python-modules/google-cloud-bigquery-datatransfer { };
+  google-cloud-bigquery-datatransfer =
+    callPackage ../development/python-modules/google-cloud-bigquery-datatransfer
+      { };
 
-  google-cloud-bigquery-logging = callPackage ../development/python-modules/google-cloud-bigquery-logging { };
+  google-cloud-bigquery-logging =
+    callPackage ../development/python-modules/google-cloud-bigquery-logging
+      { };
 
-  google-cloud-bigquery-storage = callPackage ../development/python-modules/google-cloud-bigquery-storage { };
+  google-cloud-bigquery-storage =
+    callPackage ../development/python-modules/google-cloud-bigquery-storage
+      { };
 
   google-cloud-bigtable = callPackage ../development/python-modules/google-cloud-bigtable { };
 
@@ -5545,7 +5701,9 @@ self: super: with self; {
 
   google-cloud-dns = callPackage ../development/python-modules/google-cloud-dns { };
 
-  google-cloud-error-reporting = callPackage ../development/python-modules/google-cloud-error-reporting { };
+  google-cloud-error-reporting =
+    callPackage ../development/python-modules/google-cloud-error-reporting
+      { };
 
   google-cloud-firestore = callPackage ../development/python-modules/google-cloud-firestore { };
 
@@ -5565,7 +5723,9 @@ self: super: with self; {
 
   google-cloud-netapp = callPackage ../development/python-modules/google-cloud-netapp { };
 
-  google-cloud-network-connectivity = callPackage ../development/python-modules/google-cloud-network-connectivity { };
+  google-cloud-network-connectivity =
+    callPackage ../development/python-modules/google-cloud-network-connectivity
+      { };
 
   google-cloud-org-policy = callPackage ../development/python-modules/google-cloud-org-policy { };
 
@@ -5575,13 +5735,21 @@ self: super: with self; {
 
   google-cloud-redis = callPackage ../development/python-modules/google-cloud-redis { };
 
-  google-cloud-resource-manager = callPackage ../development/python-modules/google-cloud-resource-manager { };
+  google-cloud-resource-manager =
+    callPackage ../development/python-modules/google-cloud-resource-manager
+      { };
 
-  google-cloud-runtimeconfig = callPackage ../development/python-modules/google-cloud-runtimeconfig { };
+  google-cloud-runtimeconfig =
+    callPackage ../development/python-modules/google-cloud-runtimeconfig
+      { };
 
-  google-cloud-secret-manager = callPackage ../development/python-modules/google-cloud-secret-manager { };
+  google-cloud-secret-manager =
+    callPackage ../development/python-modules/google-cloud-secret-manager
+      { };
 
-  google-cloud-securitycenter = callPackage ../development/python-modules/google-cloud-securitycenter { };
+  google-cloud-securitycenter =
+    callPackage ../development/python-modules/google-cloud-securitycenter
+      { };
 
   google-cloud-shell = callPackage ../development/python-modules/google-cloud-shell { };
 
@@ -5601,7 +5769,9 @@ self: super: with self; {
 
   google-cloud-translate = callPackage ../development/python-modules/google-cloud-translate { };
 
-  google-cloud-videointelligence = callPackage ../development/python-modules/google-cloud-videointelligence { };
+  google-cloud-videointelligence =
+    callPackage ../development/python-modules/google-cloud-videointelligence
+      { };
 
   google-cloud-vision = callPackage ../development/python-modules/google-cloud-vision { };
 
@@ -5609,7 +5779,9 @@ self: super: with self; {
 
   google-cloud-webrisk = callPackage ../development/python-modules/google-cloud-webrisk { };
 
-  google-cloud-websecurityscanner = callPackage ../development/python-modules/google-cloud-websecurityscanner { };
+  google-cloud-websecurityscanner =
+    callPackage ../development/python-modules/google-cloud-websecurityscanner
+      { };
 
   google-cloud-workflows = callPackage ../development/python-modules/google-cloud-workflows { };
 
@@ -5617,9 +5789,7 @@ self: super: with self; {
 
   google-compute-engine = callPackage ../tools/virtualization/google-compute-engine { };
 
-  google-crc32c = callPackage ../development/python-modules/google-crc32c {
-    inherit (pkgs) crc32c;
-  };
+  google-crc32c = callPackage ../development/python-modules/google-crc32c { inherit (pkgs) crc32c; };
 
   google-genai = callPackage ../development/python-modules/google-genai { };
 
@@ -5671,15 +5841,11 @@ self: super: with self; {
 
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 
-  gpgme = callPackage ../development/python-modules/gpgme {
-    inherit (pkgs) gpgme;
-  };
+  gpgme = callPackage ../development/python-modules/gpgme { inherit (pkgs) gpgme; };
 
   gphoto2 = callPackage ../development/python-modules/gphoto2 { };
 
-  gprof2dot = callPackage ../development/python-modules/gprof2dot {
-    inherit (pkgs) graphviz;
-  };
+  gprof2dot = callPackage ../development/python-modules/gprof2dot { inherit (pkgs) graphviz; };
 
   gps3 = callPackage ../development/python-modules/gps3 { };
 
@@ -5731,7 +5897,7 @@ self: super: with self; {
 
   graphlib-backport = callPackage ../development/python-modules/graphlib-backport { };
 
-  graphqlclient= callPackage ../development/python-modules/graphqlclient { };
+  graphqlclient = callPackage ../development/python-modules/graphqlclient { };
 
   graphql-core = callPackage ../development/python-modules/graphql-core { };
 
@@ -5739,13 +5905,13 @@ self: super: with self; {
 
   graphql-server-core = callPackage ../development/python-modules/graphql-server-core { };
 
-  graphql-subscription-manager = callPackage ../development/python-modules/graphql-subscription-manager { };
+  graphql-subscription-manager =
+    callPackage ../development/python-modules/graphql-subscription-manager
+      { };
 
   graphrag = callPackage ../development/python-modules/graphrag { };
 
-  graph-tool = callPackage ../development/python-modules/graph-tool {
-    inherit (pkgs) cgal;
-  };
+  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal; };
 
   graphtage = callPackage ../development/python-modules/graphtage { };
 
@@ -5820,9 +5986,7 @@ self: super: with self; {
 
   gruut = callPackage ../development/python-modules/gruut { };
 
-  gruut-ipa = callPackage ../development/python-modules/gruut-ipa {
-    inherit (pkgs) espeak;
-  };
+  gruut-ipa = callPackage ../development/python-modules/gruut-ipa { inherit (pkgs) espeak; };
 
   gsd = callPackage ../development/python-modules/gsd { };
 
@@ -5852,13 +6016,9 @@ self: super: with self; {
 
   guessit = callPackage ../development/python-modules/guessit { };
 
-  guestfs = callPackage ../development/python-modules/guestfs {
-    qemu = pkgs.qemu;
-  };
+  guestfs = callPackage ../development/python-modules/guestfs { qemu = pkgs.qemu; };
 
-  gudhi = callPackage ../development/python-modules/gudhi {
-    inherit (pkgs) cgal;
-  };
+  gudhi = callPackage ../development/python-modules/gudhi { inherit (pkgs) cgal; };
 
   guidance = callPackage ../development/python-modules/guidance { };
 
@@ -5894,9 +6054,7 @@ self: super: with self; {
 
   h2 = callPackage ../development/python-modules/h2 { };
 
-  h3 = callPackage ../development/python-modules/h3 {
-    h3 = pkgs.h3_4;
-  };
+  h3 = callPackage ../development/python-modules/h3 { h3 = pkgs.h3_4; };
 
   h5io = callPackage ../development/python-modules/h5io { };
 
@@ -5904,9 +6062,7 @@ self: super: with self; {
 
   h5py = callPackage ../development/python-modules/h5py { };
 
-  h5py-mpi = self.h5py.override {
-    hdf5 = pkgs.hdf5-mpi;
-  };
+  h5py-mpi = self.h5py.override { hdf5 = pkgs.hdf5-mpi; };
 
   habanero = callPackage ../development/python-modules/habanero { };
 
@@ -5928,13 +6084,18 @@ self: super: with self; {
 
   ha-mqtt-discoverable = callPackage ../development/python-modules/ha-mqtt-discoverable { };
 
-  ha-philipsjs = callPackage ../development/python-modules/ha-philipsjs{ };
+  ha-philipsjs = callPackage ../development/python-modules/ha-philipsjs { };
 
   hahomematic = callPackage ../development/python-modules/hahomematic { };
 
   hakuin = callPackage ../development/python-modules/hakuin { };
 
-  halide = toPythonModule (pkgs.halide.override { pythonSupport = true; python3Packages = self; }).lib;
+  halide =
+    toPythonModule
+      (pkgs.halide.override {
+        pythonSupport = true;
+        python3Packages = self;
+      }).lib;
 
   halo = callPackage ../development/python-modules/halo { };
 
@@ -6016,9 +6177,7 @@ self: super: with self; {
 
   helper = callPackage ../development/python-modules/helper { };
 
-  hepmc3 = toPythonModule (pkgs.hepmc3.override {
-    inherit python;
-  });
+  hepmc3 = toPythonModule (pkgs.hepmc3.override { inherit python; });
 
   hepunits = callPackage ../development/python-modules/hepunits { };
 
@@ -6054,13 +6213,9 @@ self: super: with self; {
 
   hightime = callPackage ../development/python-modules/hightime { };
 
-  hid = callPackage ../development/python-modules/hid {
-    inherit (pkgs) hidapi;
-  };
+  hid = callPackage ../development/python-modules/hid { inherit (pkgs) hidapi; };
 
-  hidapi = callPackage ../development/python-modules/hidapi {
-    inherit (pkgs) hidapi udev;
-  };
+  hidapi = callPackage ../development/python-modules/hidapi { inherit (pkgs) hidapi udev; };
 
   hid-parser = callPackage ../development/python-modules/hid-parser { };
 
@@ -6098,9 +6253,7 @@ self: super: with self; {
 
   hlk-sw16 = callPackage ../development/python-modules/hlk-sw16 { };
 
-  hnswlib = callPackage ../development/python-modules/hnswlib {
-    inherit (pkgs) hnswlib;
-  };
+  hnswlib = callPackage ../development/python-modules/hnswlib { inherit (pkgs) hnswlib; };
 
   hmmlearn = callPackage ../development/python-modules/hmmlearn { };
 
@@ -6116,9 +6269,13 @@ self: super: with self; {
 
   home-assistant-bluetooth = callPackage ../development/python-modules/home-assistant-bluetooth { };
 
-  home-assistant-chip-wheels = toPythonModule (callPackage ../development/python-modules/home-assistant-chip-wheels { });
+  home-assistant-chip-wheels = toPythonModule (
+    callPackage ../development/python-modules/home-assistant-chip-wheels { }
+  );
 
-  home-assistant-chip-clusters = callPackage ../development/python-modules/home-assistant-chip-clusters { };
+  home-assistant-chip-clusters =
+    callPackage ../development/python-modules/home-assistant-chip-clusters
+      { };
 
   home-assistant-chip-core = callPackage ../development/python-modules/home-assistant-chip-core { };
 
@@ -6136,9 +6293,7 @@ self: super: with self; {
 
   hopcroftkarp = callPackage ../development/python-modules/hopcroftkarp { };
 
-  horizon-eda = callPackage ../development/python-modules/horizon-eda {
-    inherit (pkgs) horizon-eda;
-  };
+  horizon-eda = callPackage ../development/python-modules/horizon-eda { inherit (pkgs) horizon-eda; };
 
   howdoi = callPackage ../development/python-modules/howdoi { };
 
@@ -6304,9 +6459,7 @@ self: super: with self; {
 
   hyrule = callPackage ../development/python-modules/hyrule { };
 
-  i2c-tools = callPackage ../development/python-modules/i2c-tools {
-    inherit (pkgs) i2c-tools;
-  };
+  i2c-tools = callPackage ../development/python-modules/i2c-tools { inherit (pkgs) i2c-tools; };
 
   i2csense = callPackage ../development/python-modules/i2csense { };
 
@@ -6352,9 +6505,7 @@ self: super: with self; {
 
   idasen-ha = callPackage ../development/python-modules/idasen-ha { };
 
-  icoextract = toPythonModule (pkgs.icoextract.override {
-    python3Packages = self;
-  });
+  icoextract = toPythonModule (pkgs.icoextract.override { python3Packages = self; });
 
   icontract = callPackage ../development/python-modules/icontract { };
 
@@ -6382,9 +6533,7 @@ self: super: with self; {
 
   ignite = callPackage ../development/python-modules/ignite { };
 
-  igraph = callPackage ../development/python-modules/igraph {
-    inherit (pkgs) igraph;
-  };
+  igraph = callPackage ../development/python-modules/igraph { inherit (pkgs) igraph; };
 
   ihcsdk = callPackage ../development/python-modules/ihcsdk { };
 
@@ -6457,7 +6606,12 @@ self: super: with self; {
   importmagic = callPackage ../development/python-modules/importmagic { };
 
   imread = callPackage ../development/python-modules/imread {
-    inherit (pkgs) libjpeg libpng libtiff libwebp;
+    inherit (pkgs)
+      libjpeg
+      libpng
+      libtiff
+      libwebp
+      ;
   };
 
   imutils = callPackage ../development/python-modules/imutils { };
@@ -6532,7 +6686,9 @@ self: super: with self; {
 
   installer = callPackage ../development/python-modules/installer { };
 
-  insteon-frontend-home-assistant = callPackage ../development/python-modules/insteon-frontend-home-assistant { };
+  insteon-frontend-home-assistant =
+    callPackage ../development/python-modules/insteon-frontend-home-assistant
+      { };
 
   instructor = callPackage ../development/python-modules/instructor { };
 
@@ -6658,9 +6814,7 @@ self: super: with self; {
 
   isbnlib = callPackage ../development/python-modules/isbnlib { };
 
-  islpy = callPackage ../development/python-modules/islpy {
-    isl = pkgs.isl_0_24;
-  };
+  islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_24; };
 
   iso3166 = callPackage ../development/python-modules/iso3166 { };
 
@@ -6688,13 +6842,15 @@ self: super: with self; {
 
   itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
 
-  itk = toPythonModule (pkgs.itk.override {
-    inherit python numpy;
-    enablePython = true;
-    enableRtk = false;
-    stdenv = if stdenv.cc.isGNU then pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv else stdenv;
-  });
-
+  itk = toPythonModule (
+    pkgs.itk.override {
+      inherit python numpy;
+      enablePython = true;
+      enableRtk = false;
+      stdenv =
+        if stdenv.cc.isGNU then pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv else stdenv;
+    }
+  );
 
   item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };
 
@@ -6864,9 +7020,7 @@ self: super: with self; {
 
   jpype1 = callPackage ../development/python-modules/jpype1 { };
 
-  jq = callPackage ../development/python-modules/jq {
-    inherit (pkgs) jq;
-  };
+  jq = callPackage ../development/python-modules/jq { inherit (pkgs) jq; };
 
   jsbeautifier = callPackage ../development/python-modules/jsbeautifier { };
 
@@ -7008,11 +7162,15 @@ self: super: with self; {
 
   jupyter-events = callPackage ../development/python-modules/jupyter-events { };
 
-  jupyter-highlight-selected-word = callPackage ../development/python-modules/jupyter-highlight-selected-word { };
+  jupyter-highlight-selected-word =
+    callPackage ../development/python-modules/jupyter-highlight-selected-word
+      { };
 
   jupyter-lsp = callPackage ../development/python-modules/jupyter-lsp { };
 
-  jupyter-nbextensions-configurator = callPackage ../development/python-modules/jupyter-nbextensions-configurator { };
+  jupyter-nbextensions-configurator =
+    callPackage ../development/python-modules/jupyter-nbextensions-configurator
+      { };
 
   jupyter-server = callPackage ../development/python-modules/jupyter-server { };
 
@@ -7028,11 +7186,15 @@ self: super: with self; {
 
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };
 
-  jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };
+  jupyterhub-ldapauthenticator =
+    callPackage ../development/python-modules/jupyterhub-ldapauthenticator
+      { };
 
   jupyterhub-systemdspawner = callPackage ../development/python-modules/jupyterhub-systemdspawner { };
 
-  jupyterhub-tmpauthenticator = callPackage ../development/python-modules/jupyterhub-tmpauthenticator { };
+  jupyterhub-tmpauthenticator =
+    callPackage ../development/python-modules/jupyterhub-tmpauthenticator
+      { };
 
   jupyterlab = callPackage ../development/python-modules/jupyterlab { };
 
@@ -7103,7 +7265,7 @@ self: super: with self; {
 
   kaleido = callPackage ../development/python-modules/kaleido { };
 
-  kalshi-python = callPackage ../development/python-modules/kalshi-python {};
+  kalshi-python = callPackage ../development/python-modules/kalshi-python { };
 
   kanidm = callPackage ../development/python-modules/kanidm { };
 
@@ -7165,7 +7327,9 @@ self: super: with self; {
 
   keyrings-cryptfile = callPackage ../development/python-modules/keyrings-cryptfile { };
 
-  keyrings-google-artifactregistry-auth = callPackage ../development/python-modules/keyrings-google-artifactregistry-auth { };
+  keyrings-google-artifactregistry-auth =
+    callPackage ../development/python-modules/keyrings-google-artifactregistry-auth
+      { };
 
   keyrings-alt = callPackage ../development/python-modules/keyrings-alt { };
 
@@ -7175,17 +7339,13 @@ self: super: with self; {
 
   keystoneauth1 = callPackage ../development/python-modules/keystoneauth1 { };
 
-  keyutils = callPackage ../development/python-modules/keyutils {
-    inherit (pkgs) keyutils;
-  };
+  keyutils = callPackage ../development/python-modules/keyutils { inherit (pkgs) keyutils; };
 
   kfactory = callPackage ../development/python-modules/kfactory { };
 
-  khanaa = callPackage ../development/python-modules/khanaa {};
+  khanaa = callPackage ../development/python-modules/khanaa { };
 
-  kicad = toPythonModule (pkgs.kicad.override {
-    python3 = python;
-  }).src;
+  kicad = toPythonModule (pkgs.kicad.override { python3 = python; }).src;
 
   kinparse = callPackage ../development/python-modules/kinparse { };
 
@@ -7213,10 +7373,12 @@ self: super: with self; {
 
   kml2geojson = callPackage ../development/python-modules/kml2geojson { };
 
-  kmsxx = toPythonModule (pkgs.kmsxx.override {
-    withPython = true;
-    python3Packages = self;
-  });
+  kmsxx = toPythonModule (
+    pkgs.kmsxx.override {
+      withPython = true;
+      python3Packages = self;
+    }
+  );
 
   knack = callPackage ../development/python-modules/knack { };
 
@@ -7242,9 +7404,7 @@ self: super: with self; {
 
   krakenex = callPackage ../development/python-modules/krakenex { };
 
-  krb5 = callPackage ../development/python-modules/krb5 {
-    krb5-c = pkgs.krb5;
-  };
+  krb5 = callPackage ../development/python-modules/krb5 { krb5-c = pkgs.krb5; };
 
   krfzf-py = callPackage ../development/python-modules/krfzf-py { };
 
@@ -7272,19 +7432,17 @@ self: super: with self; {
 
   lakeside = callPackage ../development/python-modules/lakeside { };
 
-  lammps = callPackage ../development/python-modules/lammps {
-    inherit (pkgs) lammps;
-  };
+  lammps = callPackage ../development/python-modules/lammps { inherit (pkgs) lammps; };
 
-  lancedb = callPackage ../development/python-modules/lancedb {
-    inherit (pkgs) protobuf;
-  };
+  lancedb = callPackage ../development/python-modules/lancedb { inherit (pkgs) protobuf; };
 
   langchain = callPackage ../development/python-modules/langchain { };
 
   langchain-aws = callPackage ../development/python-modules/langchain-aws { };
 
-  langchain-azure-dynamic-sessions = callPackage ../development/python-modules/langchain-azure-dynamic-sessions { };
+  langchain-azure-dynamic-sessions =
+    callPackage ../development/python-modules/langchain-azure-dynamic-sessions
+      { };
 
   langchain-chroma = callPackage ../development/python-modules/langchain-chroma { };
 
@@ -7316,11 +7474,17 @@ self: super: with self; {
 
   langgraph-checkpoint = callPackage ../development/python-modules/langgraph-checkpoint { };
 
-  langgraph-checkpoint-postgres = callPackage ../development/python-modules/langgraph-checkpoint-postgres { };
+  langgraph-checkpoint-postgres =
+    callPackage ../development/python-modules/langgraph-checkpoint-postgres
+      { };
 
-  langgraph-checkpoint-duckdb = callPackage ../development/python-modules/langgraph-checkpoint-duckdb { };
+  langgraph-checkpoint-duckdb =
+    callPackage ../development/python-modules/langgraph-checkpoint-duckdb
+      { };
 
-  langgraph-checkpoint-sqlite = callPackage ../development/python-modules/langgraph-checkpoint-sqlite { };
+  langgraph-checkpoint-sqlite =
+    callPackage ../development/python-modules/langgraph-checkpoint-sqlite
+      { };
 
   langgraph-cli = callPackage ../development/python-modules/langgraph-cli { };
 
@@ -7417,10 +7581,13 @@ self: super: with self; {
 
   led-ble = callPackage ../development/python-modules/led-ble { };
 
-  ledger = (toPythonModule (pkgs.ledger.override {
-    usePython = true;
-    python3 = python;
-  })).py;
+  ledger =
+    (toPythonModule (
+      pkgs.ledger.override {
+        usePython = true;
+        python3 = python;
+      }
+    )).py;
 
   ledger-agent = callPackage ../development/python-modules/ledger-agent { };
 
@@ -7436,9 +7603,7 @@ self: super: with self; {
 
   legacy-cgi = callPackage ../development/python-modules/legacy-cgi { };
 
-  leidenalg = callPackage ../development/python-modules/leidenalg {
-    igraph-c = pkgs.igraph;
-  };
+  leidenalg = callPackage ../development/python-modules/leidenalg { igraph-c = pkgs.igraph; };
 
   lektricowifi = callPackage ../development/python-modules/lektricowifi { };
 
@@ -7452,9 +7617,7 @@ self: super: with self; {
 
   lexilang = callPackage ../development/python-modules/lexilang { };
 
-  lhapdf = toPythonModule (pkgs.lhapdf.override {
-    inherit python;
-  });
+  lhapdf = toPythonModule (pkgs.lhapdf.override { inherit python; });
 
   lib4package = callPackage ../development/python-modules/lib4package { };
 
@@ -7472,13 +7635,9 @@ self: super: with self; {
     inherit (pkgs) libarchive;
   };
 
-  libarcus = callPackage ../development/python-modules/libarcus {
-    protobuf = pkgs.protobuf_21;
-  };
+  libarcus = callPackage ../development/python-modules/libarcus { protobuf = pkgs.protobuf_21; };
 
-  libasyncns = callPackage ../development/python-modules/libasyncns {
-    inherit (pkgs) libasyncns;
-  };
+  libasyncns = callPackage ../development/python-modules/libasyncns { inherit (pkgs) libasyncns; };
 
   libclang = callPackage ../development/python-modules/libclang { };
 
@@ -7486,7 +7645,14 @@ self: super: with self; {
 
   libcomps = lib.pipe pkgs.libcomps [
     toPythonModule
-    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
     (p: p.override { inherit python; })
     (p: p.py)
   ];
@@ -7495,32 +7661,40 @@ self: super: with self; {
 
   libdnf = lib.pipe pkgs.libdnf [
     toPythonModule
-    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
     (p: p.override { inherit python; })
     (p: p.py)
   ];
 
   libevdev = callPackage ../development/python-modules/libevdev { };
 
-  libfdt = toPythonModule (pkgs.dtc.override {
-    inherit python;
-    pythonSupport = true;
-  });
+  libfdt = toPythonModule (
+    pkgs.dtc.override {
+      inherit python;
+      pythonSupport = true;
+    }
+  );
 
-  libfive = toPythonModule (pkgs.libfive.override {
-    inherit python;
-  });
+  libfive = toPythonModule (pkgs.libfive.override { inherit python; });
 
-  libgpiod = callPackage ../development/python-modules/libgpiod {
-    inherit (pkgs) libgpiod;
-  };
+  libgpiod = callPackage ../development/python-modules/libgpiod { inherit (pkgs) libgpiod; };
 
   libgravatar = callPackage ../development/python-modules/libgravatar { };
 
-  libiio = (toPythonModule (pkgs.libiio.override {
-    pythonSupport = true;
-    inherit python;
-  })).python;
+  libiio =
+    (toPythonModule (
+      pkgs.libiio.override {
+        pythonSupport = true;
+        inherit python;
+      }
+    )).python;
 
   libipld = callPackage ../development/python-modules/libipld { };
 
@@ -7530,35 +7704,35 @@ self: super: with self; {
 
   liblarch = callPackage ../development/python-modules/liblarch { };
 
-  liblzfse = callPackage ../development/python-modules/liblzfse {
-    inherit (pkgs) lzfse;
-  };
+  liblzfse = callPackage ../development/python-modules/liblzfse { inherit (pkgs) lzfse; };
 
   libmambapy = callPackage ../development/python-modules/libmambapy { };
 
   libmodulemd = lib.pipe pkgs.libmodulemd [
     toPythonModule
-    (p:
+    (
+      p:
       p.overrideAttrs (super: {
         meta = super.meta // {
           outputsToInstall = [ "py" ]; # The package always builds python3 bindings
           broken = (super.meta.broken or false) || !isPy3k;
         };
-      }))
+      })
+    )
     (p: p.override { python3 = python; })
     (p: p.py)
   ];
 
   libmr = callPackage ../development/python-modules/libmr { };
 
-  libnacl = callPackage ../development/python-modules/libnacl {
-    inherit (pkgs) libsodium;
-  };
+  libnacl = callPackage ../development/python-modules/libnacl { inherit (pkgs) libsodium; };
 
-  libnbd = toPythonModule (pkgs.libnbd.override {
-    buildPythonBindings = true;
-    python3 = python;
-  });
+  libnbd = toPythonModule (
+    pkgs.libnbd.override {
+      buildPythonBindings = true;
+      python3 = python;
+    }
+  );
 
   libpcap = callPackage ../development/python-modules/libpcap {
     pkgsLibpcap = pkgs.libpcap; # Needs the C library
@@ -7574,19 +7748,41 @@ self: super: with self; {
 
   libpwquality = lib.pipe pkgs.libpwquality [
     toPythonModule
-    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
-    (p: p.override { enablePython = true; inherit python; })
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
+    (
+      p:
+      p.override {
+        enablePython = true;
+        inherit python;
+      }
+    )
     (p: p.py)
   ];
 
-  libredwg = toPythonModule (pkgs.libredwg.override {
-    enablePython = true;
-    inherit (self) python libxml2;
-  });
+  libredwg = toPythonModule (
+    pkgs.libredwg.override {
+      enablePython = true;
+      inherit (self) python libxml2;
+    }
+  );
 
   librepo = lib.pipe pkgs.librepo [
     toPythonModule
-    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
     (p: p.override { inherit python; })
     (p: p.py)
   ];
@@ -7599,36 +7795,38 @@ self: super: with self; {
 
   librouteros = callPackage ../development/python-modules/librouteros { };
 
-  libsass = callPackage ../development/python-modules/libsass {
-    inherit (pkgs) libsass;
-  };
+  libsass = callPackage ../development/python-modules/libsass { inherit (pkgs) libsass; };
 
   libsavitar = callPackage ../development/python-modules/libsavitar { };
 
-  libsbml = toPythonModule (pkgs.libsbml.override {
-    withPython = true;
-    inherit (self) python;
-  });
+  libsbml = toPythonModule (
+    pkgs.libsbml.override {
+      withPython = true;
+      inherit (self) python;
+    }
+  );
 
-  libsixel = callPackage ../development/python-modules/libsixel {
-    inherit (pkgs) libsixel;
-  };
+  libsixel = callPackage ../development/python-modules/libsixel { inherit (pkgs) libsixel; };
 
   libselinux = lib.pipe pkgs.libselinux [
     toPythonModule
-    (p:
+    (
+      p:
       p.overrideAttrs (super: {
         meta = super.meta // {
           outputsToInstall = [ "py" ];
           broken = super.meta.broken or isPy27;
         };
-      }))
-    (p:
+      })
+    )
+    (
+      p:
       p.override {
         enablePython = true;
         python3 = python;
         python3Packages = pythonPackages;
-      })
+      }
+    )
     (p: p.py)
   ];
 
@@ -7638,35 +7836,34 @@ self: super: with self; {
 
   libtmux = callPackage ../development/python-modules/libtmux { };
 
-  libtorrent-rasterbar = (toPythonModule (pkgs.libtorrent-rasterbar.override { python3 = python; })).python;
+  libtorrent-rasterbar =
+    (toPythonModule (pkgs.libtorrent-rasterbar.override { python3 = python; })).python;
 
-  libusb1 = callPackage ../development/python-modules/libusb1 {
-    inherit (pkgs) libusb1;
-  };
+  libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };
 
-  libusbsio = callPackage ../development/python-modules/libusbsio {
-    inherit (pkgs) libusbsio;
-  };
+  libusbsio = callPackage ../development/python-modules/libusbsio { inherit (pkgs) libusbsio; };
 
   libuuu = callPackage ../development/python-modules/libuuu { };
 
-  libversion = callPackage ../development/python-modules/libversion {
-    inherit (pkgs) libversion;
-  };
+  libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion; };
 
-  libvirt = callPackage ../development/python-modules/libvirt {
-    inherit (pkgs) libvirt;
-  };
+  libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };
 
-  libxml2 = (toPythonModule (pkgs.libxml2.override {
-    pythonSupport = true;
-    inherit python;
-  })).py;
+  libxml2 =
+    (toPythonModule (
+      pkgs.libxml2.override {
+        pythonSupport = true;
+        inherit python;
+      }
+    )).py;
 
-  libxslt = (toPythonModule (pkgs.libxslt.override {
-    pythonSupport = true;
-    inherit (self) python libxml2;
-  })).py;
+  libxslt =
+    (toPythonModule (
+      pkgs.libxslt.override {
+        pythonSupport = true;
+        inherit (self) python libxml2;
+      }
+    )).py;
 
   liccheck = callPackage ../development/python-modules/liccheck { };
 
@@ -7674,9 +7871,7 @@ self: super: with self; {
 
   lida = callPackage ../development/python-modules/lida { };
 
-  lief = (toPythonModule (pkgs.lief.override {
-    inherit python;
-  })).py;
+  lief = (toPythonModule (pkgs.lief.override { inherit python; })).py;
 
   life360 = callPackage ../development/python-modules/life360 { };
 
@@ -7686,7 +7881,7 @@ self: super: with self; {
 
   lightify = callPackage ../development/python-modules/lightify { };
 
-  lightning-utilities  = callPackage ../development/python-modules/lightning-utilities { };
+  lightning-utilities = callPackage ../development/python-modules/lightning-utilities { };
 
   lightparam = callPackage ../development/python-modules/lightparam { };
 
@@ -7698,7 +7893,7 @@ self: super: with self; {
 
   lime = callPackage ../development/python-modules/lime { };
 
-  limiter= callPackage ../development/python-modules/limiter { };
+  limiter = callPackage ../development/python-modules/limiter { };
 
   limitlessled = callPackage ../development/python-modules/limitlessled { };
 
@@ -7746,9 +7941,7 @@ self: super: with self; {
 
   liquidctl = callPackage ../development/python-modules/liquidctl { };
 
-  lirc = toPythonModule (pkgs.lirc.override {
-    python3 = python;
-  });
+  lirc = toPythonModule (pkgs.lirc.override { python3 = python; });
 
   lit = callPackage ../development/python-modules/lit { };
 
@@ -7782,23 +7975,41 @@ self: super: with self; {
 
   llama-index-core = callPackage ../development/python-modules/llama-index-core { };
 
-  llama-index-embeddings-gemini = callPackage ../development/python-modules/llama-index-embeddings-gemini { };
+  llama-index-embeddings-gemini =
+    callPackage ../development/python-modules/llama-index-embeddings-gemini
+      { };
 
-  llama-index-embeddings-google = callPackage ../development/python-modules/llama-index-embeddings-google { };
+  llama-index-embeddings-google =
+    callPackage ../development/python-modules/llama-index-embeddings-google
+      { };
 
-  llama-index-embeddings-huggingface = callPackage ../development/python-modules/llama-index-embeddings-huggingface { };
+  llama-index-embeddings-huggingface =
+    callPackage ../development/python-modules/llama-index-embeddings-huggingface
+      { };
 
-  llama-index-embeddings-ollama = callPackage ../development/python-modules/llama-index-embeddings-ollama { };
+  llama-index-embeddings-ollama =
+    callPackage ../development/python-modules/llama-index-embeddings-ollama
+      { };
 
-  llama-index-embeddings-openai = callPackage ../development/python-modules/llama-index-embeddings-openai { };
+  llama-index-embeddings-openai =
+    callPackage ../development/python-modules/llama-index-embeddings-openai
+      { };
 
-  llama-index-graph-stores-nebula = callPackage ../development/python-modules/llama-index-graph-stores-nebula { };
+  llama-index-graph-stores-nebula =
+    callPackage ../development/python-modules/llama-index-graph-stores-nebula
+      { };
 
-  llama-index-graph-stores-neo4j = callPackage ../development/python-modules/llama-index-graph-stores-neo4j { };
+  llama-index-graph-stores-neo4j =
+    callPackage ../development/python-modules/llama-index-graph-stores-neo4j
+      { };
 
-  llama-index-graph-stores-neptune = callPackage ../development/python-modules/llama-index-graph-stores-neptune { };
+  llama-index-graph-stores-neptune =
+    callPackage ../development/python-modules/llama-index-graph-stores-neptune
+      { };
 
-  llama-index-indices-managed-llama-cloud = callPackage ../development/python-modules/llama-index-indices-managed-llama-cloud { };
+  llama-index-indices-managed-llama-cloud =
+    callPackage ../development/python-modules/llama-index-indices-managed-llama-cloud
+      { };
 
   llama-index-legacy = callPackage ../development/python-modules/llama-index-legacy { };
 
@@ -7806,45 +8017,67 @@ self: super: with self; {
 
   llama-index-llms-openai = callPackage ../development/python-modules/llama-index-llms-openai { };
 
-  llama-index-llms-openai-like = callPackage ../development/python-modules/llama-index-llms-openai-like { };
+  llama-index-llms-openai-like =
+    callPackage ../development/python-modules/llama-index-llms-openai-like
+      { };
 
-  llama-index-multi-modal-llms-openai = callPackage ../development/python-modules/llama-index-multi-modal-llms-openai { };
+  llama-index-multi-modal-llms-openai =
+    callPackage ../development/python-modules/llama-index-multi-modal-llms-openai
+      { };
 
-  llama-index-program-openai = callPackage ../development/python-modules/llama-index-program-openai { };
+  llama-index-program-openai =
+    callPackage ../development/python-modules/llama-index-program-openai
+      { };
 
-  llama-index-question-gen-openai = callPackage ../development/python-modules/llama-index-question-gen-openai { };
+  llama-index-question-gen-openai =
+    callPackage ../development/python-modules/llama-index-question-gen-openai
+      { };
 
-  llama-index-readers-database = callPackage ../development/python-modules/llama-index-readers-database { };
+  llama-index-readers-database =
+    callPackage ../development/python-modules/llama-index-readers-database
+      { };
 
   llama-index-readers-file = callPackage ../development/python-modules/llama-index-readers-file { };
 
   llama-index-readers-json = callPackage ../development/python-modules/llama-index-readers-json { };
 
-  llama-index-readers-llama-parse = callPackage ../development/python-modules/llama-index-readers-llama-parse { };
+  llama-index-readers-llama-parse =
+    callPackage ../development/python-modules/llama-index-readers-llama-parse
+      { };
 
   llama-index-readers-s3 = callPackage ../development/python-modules/llama-index-readers-s3 { };
 
-  llama-index-readers-twitter = callPackage ../development/python-modules/llama-index-readers-twitter { };
+  llama-index-readers-twitter =
+    callPackage ../development/python-modules/llama-index-readers-twitter
+      { };
 
   llama-index-readers-txtai = callPackage ../development/python-modules/llama-index-readers-txtai { };
 
-  llama-index-readers-weather = callPackage ../development/python-modules/llama-index-readers-weather { };
+  llama-index-readers-weather =
+    callPackage ../development/python-modules/llama-index-readers-weather
+      { };
 
-  llama-index-vector-stores-chroma = callPackage ../development/python-modules/llama-index-vector-stores-chroma { };
+  llama-index-vector-stores-chroma =
+    callPackage ../development/python-modules/llama-index-vector-stores-chroma
+      { };
 
-  llama-index-vector-stores-google = callPackage ../development/python-modules/llama-index-vector-stores-google { };
+  llama-index-vector-stores-google =
+    callPackage ../development/python-modules/llama-index-vector-stores-google
+      { };
 
-  llama-index-vector-stores-postgres = callPackage ../development/python-modules/llama-index-vector-stores-postgres { };
+  llama-index-vector-stores-postgres =
+    callPackage ../development/python-modules/llama-index-vector-stores-postgres
+      { };
 
-  llama-index-vector-stores-qdrant = callPackage ../development/python-modules/llama-index-vector-stores-qdrant { };
+  llama-index-vector-stores-qdrant =
+    callPackage ../development/python-modules/llama-index-vector-stores-qdrant
+      { };
 
   llama-parse = callPackage ../development/python-modules/llama-parse { };
 
   llamaindex-py-client = callPackage ../development/python-modules/llamaindex-py-client { };
 
-  llfuse = callPackage ../development/python-modules/llfuse {
-    inherit (pkgs) fuse;
-  };
+  llfuse = callPackage ../development/python-modules/llfuse { inherit (pkgs) fuse; };
 
   llguidance = callPackage ../development/python-modules/llguidance { };
 
@@ -7873,9 +8106,7 @@ self: super: with self; {
 
   lm-format-enforcer = callPackage ../development/python-modules/lm-format-enforcer { };
 
-  lmdb = callPackage ../development/python-modules/lmdb {
-    inherit (pkgs) lmdb;
-  };
+  lmdb = callPackage ../development/python-modules/lmdb { inherit (pkgs) lmdb; };
 
   lmfit = callPackage ../development/python-modules/lmfit { };
 
@@ -7991,11 +8222,9 @@ self: super: with self; {
 
   lupupy = callPackage ../development/python-modules/lupupy { };
 
-  lxmf= callPackage ../development/python-modules/lxmf { };
+  lxmf = callPackage ../development/python-modules/lxmf { };
 
-  lxml = callPackage ../development/python-modules/lxml {
-    inherit (pkgs) libxml2 libxslt zlib;
-  };
+  lxml = callPackage ../development/python-modules/lxml { inherit (pkgs) libxml2 libxslt zlib; };
 
   lxml-html-clean = callPackage ../development/python-modules/lxml-html-clean { };
 
@@ -8019,7 +8248,7 @@ self: super: with self; {
 
   mac-vendor-lookup = callPackage ../development/python-modules/mac-vendor-lookup { };
 
-  macaddress = callPackage ../development/python-modules/macaddress{ };
+  macaddress = callPackage ../development/python-modules/macaddress { };
 
   macfsevents = callPackage ../development/python-modules/macfsevents {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
@@ -8041,9 +8270,13 @@ self: super: with self; {
 
   magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
 
-  magic-wormhole-mailbox-server = callPackage ../development/python-modules/magic-wormhole-mailbox-server { };
+  magic-wormhole-mailbox-server =
+    callPackage ../development/python-modules/magic-wormhole-mailbox-server
+      { };
 
-  magic-wormhole-transit-relay = callPackage ../development/python-modules/magic-wormhole-transit-relay { };
+  magic-wormhole-transit-relay =
+    callPackage ../development/python-modules/magic-wormhole-transit-relay
+      { };
 
   magika = callPackage ../development/python-modules/magika { };
 
@@ -8111,7 +8344,9 @@ self: super: with self; {
 
   manifestoo-core = callPackage ../development/python-modules/manifestoo-core { };
 
-  manifestparser = callPackage ../development/python-modules/marionette-harness/manifestparser.nix { };
+  manifestparser =
+    callPackage ../development/python-modules/marionette-harness/manifestparser.nix
+      { };
 
   manuel = callPackage ../development/python-modules/manuel { };
 
@@ -8125,9 +8360,7 @@ self: super: with self; {
 
   marimo = callPackage ../development/python-modules/marimo { };
 
-  marisa = callPackage ../development/python-modules/marisa {
-    inherit (pkgs) marisa;
-  };
+  marisa = callPackage ../development/python-modules/marisa { inherit (pkgs) marisa; };
 
   marisa-trie = callPackage ../development/python-modules/marisa-trie { };
 
@@ -8141,9 +8374,9 @@ self: super: with self; {
 
   markdown-macros = callPackage ../development/python-modules/markdown-macros { };
 
-  markdownify  = callPackage ../development/python-modules/markdownify { };
+  markdownify = callPackage ../development/python-modules/markdownify { };
 
-  markitdown  = callPackage ../development/python-modules/markitdown { };
+  markitdown = callPackage ../development/python-modules/markitdown { };
 
   marko = callPackage ../development/python-modules/marko { };
 
@@ -8225,7 +8458,17 @@ self: super: with self; {
     inherit buildPythonPackage pythonOlder pythonAtLeast;
     # when next release contains numpy2 support unpin
     # https://github.com/enthought/mayavi/pull/1315
-    inherit (self) pyface pygments numpy_1 packaging vtk traitsui envisage apptools pyqt5;
+    inherit (self)
+      pyface
+      pygments
+      numpy_1
+      packaging
+      vtk
+      traitsui
+      envisage
+      apptools
+      pyqt5
+      ;
   };
 
   mayim = callPackage ../development/python-modules/mayim { };
@@ -8262,7 +8505,7 @@ self: super: with self; {
   mdformat-gfm = callPackage ../development/python-modules/mdformat-gfm { };
   mdformat-gfm-alerts = callPackage ../development/python-modules/mdformat-gfm-alerts { };
   mdformat-mkdocs = callPackage ../development/python-modules/mdformat-mkdocs { };
-  mdformat-myst = callPackage ../development/python-modules/mdformat-myst{ };
+  mdformat-myst = callPackage ../development/python-modules/mdformat-myst { };
   mdformat-nix-alejandra = callPackage ../development/python-modules/mdformat-nix-alejandra { };
   mdformat-simple-breaks = callPackage ../development/python-modules/mdformat-simple-breaks { };
   mdformat-tables = callPackage ../development/python-modules/mdformat-tables { };
@@ -8327,9 +8570,7 @@ self: super: with self; {
 
   mercantile = callPackage ../development/python-modules/mercantile { };
 
-  mercurial = toPythonModule (pkgs.mercurial.override {
-    python3Packages = self;
-  });
+  mercurial = toPythonModule (pkgs.mercurial.override { python3Packages = self; });
 
   merge3 = callPackage ../development/python-modules/merge3 { };
 
@@ -8355,16 +8596,16 @@ self: super: with self; {
 
   meshtastic = callPackage ../development/python-modules/meshtastic { };
 
-  meson = toPythonModule ((pkgs.meson.override { python3 = python; }).overridePythonAttrs
-    (oldAttrs: { # We do not want the setup hook in Python packages because the build is performed differently.
+  meson = toPythonModule (
+    (pkgs.meson.override { python3 = python; }).overridePythonAttrs (oldAttrs: {
+      # We do not want the setup hook in Python packages because the build is performed differently.
       setupHook = null;
-    }));
+    })
+  );
 
   mesonpep517 = callPackage ../development/python-modules/mesonpep517 { };
 
-  meson-python = callPackage ../development/python-modules/meson-python {
-    inherit (pkgs) ninja;
-  };
+  meson-python = callPackage ../development/python-modules/meson-python { inherit (pkgs) ninja; };
 
   messagebird = callPackage ../development/python-modules/messagebird { };
 
@@ -8404,21 +8645,35 @@ self: super: with self; {
 
   microdata = callPackage ../development/python-modules/microdata { };
 
-  microsoft-kiota-abstractions = callPackage ../development/python-modules/microsoft-kiota-abstractions { };
+  microsoft-kiota-abstractions =
+    callPackage ../development/python-modules/microsoft-kiota-abstractions
+      { };
 
-  microsoft-kiota-authentication-azure = callPackage ../development/python-modules/microsoft-kiota-authentication-azure { };
+  microsoft-kiota-authentication-azure =
+    callPackage ../development/python-modules/microsoft-kiota-authentication-azure
+      { };
 
   microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
 
-  microsoft-kiota-serialization-form = callPackage ../development/python-modules/microsoft-kiota-serialization-form { };
+  microsoft-kiota-serialization-form =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-form
+      { };
 
-  microsoft-kiota-serialization-json = callPackage ../development/python-modules/microsoft-kiota-serialization-json { };
+  microsoft-kiota-serialization-json =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-json
+      { };
 
-  microsoft-kiota-serialization-multipart = callPackage ../development/python-modules/microsoft-kiota-serialization-multipart { };
+  microsoft-kiota-serialization-multipart =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-multipart
+      { };
 
-  microsoft-kiota-serialization-text = callPackage ../development/python-modules/microsoft-kiota-serialization-text { };
+  microsoft-kiota-serialization-text =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-text
+      { };
 
-  microsoft-security-utilities-secret-masker = callPackage ../development/python-modules/microsoft-security-utilities-secret-masker { };
+  microsoft-security-utilities-secret-masker =
+    callPackage ../development/python-modules/microsoft-security-utilities-secret-masker
+      { };
 
   midea-beautiful-air = callPackage ../development/python-modules/midea-beautiful-air { };
 
@@ -8440,10 +8695,12 @@ self: super: with self; {
 
   millheater = callPackage ../development/python-modules/millheater { };
 
-  mim-solvers = toPythonModule (pkgs.mim-solvers.override {
-    python3Packages = self;
-    pythonSupport = true;
-  });
+  mim-solvers = toPythonModule (
+    pkgs.mim-solvers.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
 
   minari = callPackage ../development/python-modules/minari { };
 
@@ -8474,9 +8731,7 @@ self: super: with self; {
 
   minimock = callPackage ../development/python-modules/minimock { };
 
-  mininet-python = (toPythonModule (pkgs.mininet.override {
-    python3 = python;
-  })).py;
+  mininet-python = (toPythonModule (pkgs.mininet.override { python3 = python; })).py;
 
   minio = callPackage ../development/python-modules/minio { };
 
@@ -8535,9 +8790,13 @@ self: super: with self; {
 
   mkdocs-git-authors-plugin = callPackage ../development/python-modules/mkdocs-git-authors-plugin { };
 
-  mkdocs-git-committers-plugin-2 = callPackage ../development/python-modules/mkdocs-git-committers-plugin-2 { };
+  mkdocs-git-committers-plugin-2 =
+    callPackage ../development/python-modules/mkdocs-git-committers-plugin-2
+      { };
 
-  mkdocs-git-revision-date-localized-plugin = callPackage ../development/python-modules/mkdocs-git-revision-date-localized-plugin { };
+  mkdocs-git-revision-date-localized-plugin =
+    callPackage ../development/python-modules/mkdocs-git-revision-date-localized-plugin
+      { };
 
   mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };
 
@@ -8551,7 +8810,9 @@ self: super: with self; {
 
   mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
 
-  mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
+  mkdocs-material-extensions =
+    callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
+      { };
 
   mkdocs-mermaid2-plugin = callPackage ../development/python-modules/mkdocs-mermaid2-plugin { };
 
@@ -8585,10 +8846,12 @@ self: super: with self; {
 
   mlxtend = callPackage ../development/python-modules/mlxtend { };
 
-  mlt = toPythonModule (pkgs.mlt.override {
-    python3 = python;
-    enablePython = true;
-  });
+  mlt = toPythonModule (
+    pkgs.mlt.override {
+      python3 = python;
+      enablePython = true;
+    }
+  );
 
   mmcif-pdbx = callPackage ../development/python-modules/mmcif-pdbx { };
 
@@ -8763,9 +9026,7 @@ self: super: with self; {
 
   mpris-server = callPackage ../development/python-modules/mpris-server { };
 
-  mpv = callPackage ../development/python-modules/mpv {
-    inherit (pkgs) mpv;
-  };
+  mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };
 
   mpyq = callPackage ../development/python-modules/mpyq { };
 
@@ -8863,9 +9124,7 @@ self: super: with self; {
 
   mutf8 = callPackage ../development/python-modules/mutf8 { };
 
-  mujoco = callPackage ../development/python-modules/mujoco {
-    inherit (pkgs) mujoco;
-  };
+  mujoco = callPackage ../development/python-modules/mujoco { inherit (pkgs) mujoco; };
 
   mujson = callPackage ../development/python-modules/mujson { };
 
@@ -8891,9 +9150,7 @@ self: super: with self; {
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };
 
-  myhdl = callPackage ../development/python-modules/myhdl {
-    inherit (pkgs) ghdl iverilog;
-  };
+  myhdl = callPackage ../development/python-modules/myhdl { inherit (pkgs) ghdl iverilog; };
 
   myhome = callPackage ../development/python-modules/myhome { };
 
@@ -9254,7 +9511,7 @@ self: super: with self; {
     mypy-boto3-workspaces
     mypy-boto3-workspaces-web
     mypy-boto3-xray
-  ;
+    ;
 
   mypy-extensions = callPackage ../development/python-modules/mypy/extensions.nix { };
 
@@ -9308,7 +9565,12 @@ self: super: with self; {
 
   natural = callPackage ../development/python-modules/natural { };
 
-  ndcurves = toPythonModule (pkgs.ndcurves.override { python3Packages = self; pythonSupport = true; });
+  ndcurves = toPythonModule (
+    pkgs.ndcurves.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
 
   nglview = callPackage ../development/python-modules/nglview { };
 
@@ -9316,7 +9578,7 @@ self: super: with self; {
 
   nonbloat-db = callPackage ../development/python-modules/nonbloat-db { };
 
-  noneprompt = callPackage ../development/python-modules/noneprompt {  };
+  noneprompt = callPackage ../development/python-modules/noneprompt { };
 
   nox = callPackage ../development/python-modules/nox { };
 
@@ -9418,7 +9680,12 @@ self: super: with self; {
 
   nessclient = callPackage ../development/python-modules/nessclient { };
 
-  nest = toPythonModule(pkgs.nest-mpi.override { withPython = true; python3 = python; });
+  nest = toPythonModule (
+    pkgs.nest-mpi.override {
+      withPython = true;
+      python3 = python;
+    }
+  );
 
   nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
 
@@ -9442,11 +9709,15 @@ self: super: with self; {
 
   netbox-floorplan-plugin = callPackage ../development/python-modules/netbox-floorplan-plugin { };
 
-  netbox-interface-synchronization = callPackage ../development/python-modules/netbox-interface-synchronization { };
+  netbox-interface-synchronization =
+    callPackage ../development/python-modules/netbox-interface-synchronization
+      { };
 
   netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };
 
-  netbox-plugin-prometheus-sd = callPackage ../development/python-modules/netbox-plugin-prometheus-sd { };
+  netbox-plugin-prometheus-sd =
+    callPackage ../development/python-modules/netbox-plugin-prometheus-sd
+      { };
 
   netbox-qrcode = callPackage ../development/python-modules/netbox-qrcode { };
 
@@ -9510,9 +9781,7 @@ self: super: with self; {
 
   nfcpy = callPackage ../development/python-modules/nfcpy { };
 
-  nftables = callPackage ../os-specific/linux/nftables/python.nix {
-    inherit (pkgs) nftables;
-  };
+  nftables = callPackage ../os-specific/linux/nftables/python.nix { inherit (pkgs) nftables; };
 
   nh3 = callPackage ../development/python-modules/nh3 { };
 
@@ -9560,9 +9829,7 @@ self: super: with self; {
 
   nipy = callPackage ../development/python-modules/nipy { };
 
-  nipype = callPackage ../development/python-modules/nipype {
-    inherit (pkgs) which;
-  };
+  nipype = callPackage ../development/python-modules/nipype { inherit (pkgs) which; };
 
   nitime = callPackage ../development/python-modules/nitime { };
 
@@ -9574,9 +9841,7 @@ self: super: with self; {
 
   niworkflows = callPackage ../development/python-modules/niworkflows { };
 
-  nix-kernel = callPackage ../development/python-modules/nix-kernel {
-    inherit (pkgs) nix;
-  };
+  nix-kernel = callPackage ../development/python-modules/nix-kernel { inherit (pkgs) nix; };
 
   nixpkgs = callPackage ../development/python-modules/nixpkgs { };
 
@@ -9590,13 +9855,11 @@ self: super: with self; {
 
   nlpcloud = callPackage ../development/python-modules/nlpcloud { };
 
-  nlpo3 =  callPackage ../development/python-modules/nlpo3 { };
+  nlpo3 = callPackage ../development/python-modules/nlpo3 { };
 
   nltk = callPackage ../development/python-modules/nltk { };
 
-  nnpdf = toPythonModule (pkgs.nnpdf.override {
-    python3 = python;
-  });
+  nnpdf = toPythonModule (pkgs.nnpdf.override { python3 = python; });
 
   nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };
 
@@ -9640,7 +9903,9 @@ self: super: with self; {
 
   notifications-android-tv = callPackage ../development/python-modules/notifications-android-tv { };
 
-  notifications-python-client = callPackage ../development/python-modules/notifications-python-client { };
+  notifications-python-client =
+    callPackage ../development/python-modules/notifications-python-client
+      { };
 
   notify-events = callPackage ../development/python-modules/notify-events { };
 
@@ -9650,13 +9915,9 @@ self: super: with self; {
 
   notion-client = callPackage ../development/python-modules/notion-client { };
 
-  notmuch = callPackage ../development/python-modules/notmuch {
-    inherit (pkgs) notmuch;
-  };
+  notmuch = callPackage ../development/python-modules/notmuch { inherit (pkgs) notmuch; };
 
-  notmuch2 = callPackage ../development/python-modules/notmuch2 {
-    inherit (pkgs) notmuch;
-  };
+  notmuch2 = callPackage ../development/python-modules/notmuch2 { inherit (pkgs) notmuch; };
 
   notobuilder = callPackage ../development/python-modules/notobuilder { };
 
@@ -9666,7 +9927,7 @@ self: super: with self; {
 
   nplusone = callPackage ../development/python-modules/nplusone { };
 
-  nptyping  = callPackage ../development/python-modules/nptyping { };
+  nptyping = callPackage ../development/python-modules/nptyping { };
 
   npyscreen = callPackage ../development/python-modules/npyscreen { };
 
@@ -9688,13 +9949,9 @@ self: super: with self; {
 
   num2words = callPackage ../development/python-modules/num2words { };
 
-  numba = callPackage ../development/python-modules/numba {
-    inherit (pkgs.config) cudaSupport;
-  };
+  numba = callPackage ../development/python-modules/numba { inherit (pkgs.config) cudaSupport; };
 
-  numbaWithCuda = self.numba.override {
-    cudaSupport = true;
-  };
+  numbaWithCuda = self.numba.override { cudaSupport = true; };
 
   numba-scipy = callPackage ../development/python-modules/numba-scipy { };
 
@@ -9740,7 +9997,7 @@ self: super: with self; {
 
   petl = callPackage ../development/python-modules/petl { };
 
-  plugp100 = callPackage ../development/python-modules/plugp100 {};
+  plugp100 = callPackage ../development/python-modules/plugp100 { };
 
   python-bugzilla = callPackage ../development/python-modules/python-bugzilla { };
 
@@ -9837,9 +10094,7 @@ self: super: with self; {
 
   ocifs = callPackage ../development/python-modules/ocifs { };
 
-  ocrmypdf = callPackage ../development/python-modules/ocrmypdf {
-    tesseract = pkgs.tesseract5;
-  };
+  ocrmypdf = callPackage ../development/python-modules/ocrmypdf { tesseract = pkgs.tesseract5; };
 
   od = callPackage ../development/python-modules/od { };
 
@@ -9961,7 +10216,7 @@ self: super: with self; {
   openapi3 = callPackage ../development/python-modules/openapi3 { };
 
   openbabel-bindings = callPackage ../development/python-modules/openbabel-bindings {
-      openbabel = callPackage ../development/libraries/openbabel { inherit (self) python; };
+    openbabel = callPackage ../development/libraries/openbabel { inherit (self) python; };
   };
 
   opencensus = callPackage ../development/python-modules/opencensus { };
@@ -9972,10 +10227,12 @@ self: super: with self; {
 
   opencontainers = callPackage ../development/python-modules/opencontainers { };
 
-  opencv4 = toPythonModule (pkgs.opencv4.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  opencv4 = toPythonModule (
+    pkgs.opencv4.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
   opencv-python = callPackage ../development/python-modules/opencv-python { };
 
@@ -9989,10 +10246,12 @@ self: super: with self; {
 
   openidc-client = callPackage ../development/python-modules/openidc-client { };
 
-  openmm = toPythonModule (pkgs.openmm.override {
-    python3Packages = self;
-    enablePython = true;
-  });
+  openmm = toPythonModule (
+    pkgs.openmm.override {
+      python3Packages = self;
+      enablePython = true;
+    }
+  );
 
   openpyxl = callPackage ../development/python-modules/openpyxl { };
 
@@ -10024,51 +10283,95 @@ self: super: with self; {
 
   opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
 
-  opentelemetry-exporter-otlp = callPackage ../development/python-modules/opentelemetry-exporter-otlp { };
+  opentelemetry-exporter-otlp =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp
+      { };
 
-  opentelemetry-exporter-otlp-proto-common = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common { };
+  opentelemetry-exporter-otlp-proto-common =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common
+      { };
 
-  opentelemetry-exporter-otlp-proto-grpc = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc { };
+  opentelemetry-exporter-otlp-proto-grpc =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc
+      { };
 
-  opentelemetry-exporter-otlp-proto-http = callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-http { };
+  opentelemetry-exporter-otlp-proto-http =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-http
+      { };
 
-  opentelemetry-exporter-prometheus = callPackage ../development/python-modules/opentelemetry-exporter-prometheus { };
+  opentelemetry-exporter-prometheus =
+    callPackage ../development/python-modules/opentelemetry-exporter-prometheus
+      { };
 
-  opentelemetry-instrumentation = callPackage ../development/python-modules/opentelemetry-instrumentation { };
+  opentelemetry-instrumentation =
+    callPackage ../development/python-modules/opentelemetry-instrumentation
+      { };
 
-  opentelemetry-instrumentation-aiohttp-client = callPackage ../development/python-modules/opentelemetry-instrumentation-aiohttp-client { };
+  opentelemetry-instrumentation-aiohttp-client =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-aiohttp-client
+      { };
 
-  opentelemetry-instrumentation-asgi = callPackage ../development/python-modules/opentelemetry-instrumentation-asgi { };
+  opentelemetry-instrumentation-asgi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-asgi
+      { };
 
-  opentelemetry-instrumentation-celery = callPackage ../development/python-modules/opentelemetry-instrumentation-celery { };
+  opentelemetry-instrumentation-celery =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-celery
+      { };
 
-  opentelemetry-instrumentation-botocore = callPackage ../development/python-modules/opentelemetry-instrumentation-botocore { };
+  opentelemetry-instrumentation-botocore =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-botocore
+      { };
 
-  opentelemetry-instrumentation-dbapi = callPackage ../development/python-modules/opentelemetry-instrumentation-dbapi { };
+  opentelemetry-instrumentation-dbapi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-dbapi
+      { };
 
-  opentelemetry-instrumentation-django = callPackage ../development/python-modules/opentelemetry-instrumentation-django { };
+  opentelemetry-instrumentation-django =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-django
+      { };
 
-  opentelemetry-instrumentation-fastapi = callPackage ../development/python-modules/opentelemetry-instrumentation-fastapi { };
+  opentelemetry-instrumentation-fastapi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-fastapi
+      { };
 
-  opentelemetry-instrumentation-flask = callPackage ../development/python-modules/opentelemetry-instrumentation-flask { };
+  opentelemetry-instrumentation-flask =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-flask
+      { };
 
-  opentelemetry-instrumentation-grpc = callPackage ../development/python-modules/opentelemetry-instrumentation-grpc { };
+  opentelemetry-instrumentation-grpc =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-grpc
+      { };
 
-  opentelemetry-instrumentation-logging = callPackage ../development/python-modules/opentelemetry-instrumentation-logging { };
+  opentelemetry-instrumentation-logging =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-logging
+      { };
 
-  opentelemetry-instrumentation-psycopg2 = callPackage ../development/python-modules/opentelemetry-instrumentation-psycopg2 { };
+  opentelemetry-instrumentation-psycopg2 =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-psycopg2
+      { };
 
-  opentelemetry-instrumentation-requests = callPackage ../development/python-modules/opentelemetry-instrumentation-requests { };
+  opentelemetry-instrumentation-requests =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-requests
+      { };
 
-  opentelemetry-instrumentation-redis = callPackage ../development/python-modules/opentelemetry-instrumentation-redis { };
+  opentelemetry-instrumentation-redis =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-redis
+      { };
 
-  opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };
+  opentelemetry-instrumentation-wsgi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi
+      { };
 
-  opentelemetry-propagator-aws-xray = callPackage ../development/python-modules/opentelemetry-propagator-aws-xray { };
+  opentelemetry-propagator-aws-xray =
+    callPackage ../development/python-modules/opentelemetry-propagator-aws-xray
+      { };
 
   opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
 
-  opentelemetry-semantic-conventions = callPackage ../development/python-modules/opentelemetry-semantic-conventions { };
+  opentelemetry-semantic-conventions =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions
+      { };
 
   opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
 
@@ -10076,19 +10379,19 @@ self: super: with self; {
 
   opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };
 
-  openturns = toPythonModule (pkgs.openturns.override {
-    python3Packages = self;
-    enablePython = true;
-  });
+  openturns = toPythonModule (
+    pkgs.openturns.override {
+      python3Packages = self;
+      enablePython = true;
+    }
+  );
 
   opentsne = callPackage ../development/python-modules/opentsne { };
 
   opentypespec = callPackage ../development/python-modules/opentypespec { };
 
   openvino = callPackage ../development/python-modules/openvino {
-    openvino-native = pkgs.openvino.override {
-      python3Packages = self;
-    };
+    openvino-native = pkgs.openvino.override { python3Packages = self; };
   };
 
   openwebifpy = callPackage ../development/python-modules/openwebifpy { };
@@ -10273,9 +10576,7 @@ self: super: with self; {
 
   pandantic = callPackage ../development/python-modules/pandantic { };
 
-  pandas = callPackage ../development/python-modules/pandas {
-    inherit (pkgs.darwin) adv_cmds;
-  };
+  pandas = callPackage ../development/python-modules/pandas { inherit (pkgs.darwin) adv_cmds; };
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
 
@@ -10320,7 +10621,9 @@ self: super: with self; {
 
   paramax = callPackage ../development/python-modules/paramax { };
 
-  parameter-expansion-patched = callPackage ../development/python-modules/parameter-expansion-patched { };
+  parameter-expansion-patched =
+    callPackage ../development/python-modules/parameter-expansion-patched
+      { };
 
   parameterized = callPackage ../development/python-modules/parameterized { };
 
@@ -10501,9 +10804,7 @@ self: super: with self; {
 
   peft = callPackage ../development/python-modules/peft { };
 
-  pelican = callPackage ../development/python-modules/pelican {
-    inherit (pkgs) glibcLocales git;
-  };
+  pelican = callPackage ../development/python-modules/pelican { inherit (pkgs) glibcLocales git; };
 
   pem = callPackage ../development/python-modules/pem { };
 
@@ -10543,11 +10844,13 @@ self: super: with self; {
 
   pesq = callPackage ../development/python-modules/pesq { };
 
-  petsc4py = toPythonModule (pkgs.petsc.override {
-    python3 = python;
-    python3Packages = self;
-    pythonSupport = true;
-  });
+  petsc4py = toPythonModule (
+    pkgs.petsc.override {
+      python3 = python;
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
 
   pex = callPackage ../development/python-modules/pex { };
 
@@ -10627,9 +10930,7 @@ self: super: with self; {
 
   opentype-feature-freezer = callPackage ../development/python-modules/opentype-feature-freezer { };
 
-  openusd = callPackage ../development/python-modules/openusd {
-    alembic = pkgs.alembic;
-  };
+  openusd = callPackage ../development/python-modules/openusd { alembic = pkgs.alembic; };
 
   outlines = callPackage ../development/python-modules/outlines { };
 
@@ -10697,7 +10998,9 @@ self: super: with self; {
 
   pi1wire = callPackage ../development/python-modules/pi1wire { };
 
-  piano-transcription-inference = callPackage ../development/python-modules/piano-transcription-inference { };
+  piano-transcription-inference =
+    callPackage ../development/python-modules/piano-transcription-inference
+      { };
 
   piccata = callPackage ../development/python-modules/piccata { };
 
@@ -10746,7 +11049,7 @@ self: super: with self; {
       libwebp
       openjpeg
       zlib
-    ;
+      ;
     inherit (pkgs.xorg) libxcb;
   };
 
@@ -10758,10 +11061,12 @@ self: super: with self; {
 
   pinboard = callPackage ../development/python-modules/pinboard { };
 
-  pinocchio = toPythonModule (pkgs.pinocchio.override {
-    pythonSupport = true;
-    python3Packages = self;
-  });
+  pinocchio = toPythonModule (
+    pkgs.pinocchio.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   pint = callPackage ../development/python-modules/pint { };
 
@@ -10805,10 +11110,13 @@ self: super: with self; {
 
   pixel-ring = callPackage ../development/python-modules/pixel-ring { };
 
-  pjsua2 = (toPythonModule (pkgs.pjsip.override {
-    pythonSupport = true;
-    python3 = self.python;
-  })).py;
+  pjsua2 =
+    (toPythonModule (
+      pkgs.pjsip.override {
+        pythonSupport = true;
+        python3 = self.python;
+      }
+    )).py;
 
   pkce = callPackage ../development/python-modules/pkce { };
 
@@ -10856,9 +11164,19 @@ self: super: with self; {
 
   prosemirror = callPackage ../development/python-modules/prosemirror { };
 
-  proxsuite = toPythonModule (pkgs.proxsuite.override { pythonSupport = true; python3Packages = self; });
+  proxsuite = toPythonModule (
+    pkgs.proxsuite.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
-  proxsuite-nlp = toPythonModule (pkgs.proxsuite-nlp.override { pythonSupport = true; python3Packages = self; });
+  proxsuite-nlp = toPythonModule (
+    pkgs.proxsuite-nlp.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   proxy-tools = callPackage ../development/python-modules/proxy-tools { };
 
@@ -10872,10 +11190,12 @@ self: super: with self; {
 
   py7zr = callPackage ../development/python-modules/py7zr { };
 
-  pyabpoa = toPythonModule (pkgs.abpoa.override {
-    enablePython = true;
-    python3Packages = self;
-  });
+  pyabpoa = toPythonModule (
+    pkgs.abpoa.override {
+      enablePython = true;
+      python3Packages = self;
+    }
+  );
 
   pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
 
@@ -11184,7 +11504,12 @@ self: super: with self; {
 
   python-xapp = callPackage ../development/python-modules/python-xapp {
     inherit (pkgs.buildPackages) meson;
-    inherit (pkgs) gtk3 gobject-introspection polkit xapp;
+    inherit (pkgs)
+      gtk3
+      gobject-introspection
+      polkit
+      xapp
+      ;
   };
 
   python-tado = callPackage ../development/python-modules/python-tado { };
@@ -11217,9 +11542,7 @@ self: super: with self; {
 
   pyzipper = callPackage ../development/python-modules/pyzipper { };
 
-  pyzstd = callPackage ../development/python-modules/pyzstd {
-    zstd-c = pkgs.zstd;
-  };
+  pyzstd = callPackage ../development/python-modules/pyzstd { zstd-c = pkgs.zstd; };
 
   plac = callPackage ../development/python-modules/plac { };
 
@@ -11253,9 +11576,7 @@ self: super: with self; {
 
   plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
 
-  plfit = toPythonModule (pkgs.plfit.override {
-    inherit (self) python;
-  });
+  plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
 
   plone-testing = callPackage ../development/python-modules/plone-testing { };
 
@@ -11420,7 +11741,9 @@ self: super: with self; {
 
   praw = callPackage ../development/python-modules/praw { };
 
-  prayer-times-calculator-offline = callPackage ../development/python-modules/prayer-times-calculator-offline { };
+  prayer-times-calculator-offline =
+    callPackage ../development/python-modules/prayer-times-calculator-offline
+      { };
 
   precis-i18n = callPackage ../development/python-modules/precis-i18n { };
 
@@ -11474,7 +11797,9 @@ self: super: with self; {
 
   prometheus-client = callPackage ../development/python-modules/prometheus-client { };
 
-  prometheus-fastapi-instrumentator = callPackage ../development/python-modules/prometheus-fastapi-instrumentator { };
+  prometheus-fastapi-instrumentator =
+    callPackage ../development/python-modules/prometheus-fastapi-instrumentator
+      { };
 
   prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
 
@@ -11515,7 +11840,9 @@ self: super: with self; {
 
   proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
 
-  proton-vpn-network-manager = callPackage ../development/python-modules/proton-vpn-network-manager { };
+  proton-vpn-network-manager =
+    callPackage ../development/python-modules/proton-vpn-network-manager
+      { };
 
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };
 
@@ -11538,7 +11865,8 @@ self: super: with self; {
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
   psutil = callPackage ../development/python-modules/psutil {
-    stdenv = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
+    stdenv =
+      if pkgs.stdenv.hostPlatform.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation IOKit;
   };
 
@@ -11600,7 +11928,9 @@ self: super: with self; {
 
   pure-python-adb = callPackage ../development/python-modules/pure-python-adb { };
 
-  pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
+  pure-python-adb-homeassistant =
+    callPackage ../development/python-modules/pure-python-adb-homeassistant
+      { };
 
   puremagic = callPackage ../development/python-modules/puremagic { };
 
@@ -11624,9 +11954,7 @@ self: super: with self; {
 
   pwlf = callPackage ../development/python-modules/pwlf { };
 
-  pwntools = callPackage ../development/python-modules/pwntools {
-    debugger = pkgs.gdb;
-  };
+  pwntools = callPackage ../development/python-modules/pwntools { debugger = pkgs.gdb; };
 
   py-air-control = callPackage ../development/python-modules/py-air-control { };
 
@@ -11664,9 +11992,7 @@ self: super: with self; {
 
   py3buddy = callPackage ../development/python-modules/py3buddy { };
 
-  py3exiv2 = callPackage ../development/python-modules/py3exiv2 {
-    inherit (pkgs) exiv2;
-  };
+  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { inherit (pkgs) exiv2; };
 
   py3langid = callPackage ../development/python-modules/py3langid { };
 
@@ -11722,9 +12048,7 @@ self: super: with self; {
 
   pyarr = callPackage ../development/python-modules/pyarr { };
 
-  pyarrow = callPackage ../development/python-modules/pyarrow {
-    inherit (pkgs) arrow-cpp cmake;
-  };
+  pyarrow = callPackage ../development/python-modules/pyarrow { inherit (pkgs) arrow-cpp cmake; };
 
   pyarrow-hotfix = callPackage ../development/python-modules/pyarrow-hotfix { };
 
@@ -11782,9 +12106,7 @@ self: super: with self; {
 
   pyblu = callPackage ../development/python-modules/pyblu { };
 
-  pybluez = callPackage ../development/python-modules/pybluez {
-    inherit (pkgs) bluez;
-  };
+  pybluez = callPackage ../development/python-modules/pybluez { inherit (pkgs) bluez; };
 
   pybotvac = callPackage ../development/python-modules/pybotvac { };
 
@@ -11802,9 +12124,7 @@ self: super: with self; {
 
   pybullet = callPackage ../development/python-modules/pybullet { };
 
-  pycairo = callPackage ../development/python-modules/pycairo {
-    inherit (pkgs.buildPackages) meson;
-  };
+  pycairo = callPackage ../development/python-modules/pycairo { inherit (pkgs.buildPackages) meson; };
 
   py = callPackage ../development/python-modules/py { };
 
@@ -11834,9 +12154,7 @@ self: super: with self; {
 
   pycfdns = callPackage ../development/python-modules/pycfdns { };
 
-  pycflow2dot = callPackage ../development/python-modules/pycflow2dot {
-    inherit (pkgs) graphviz;
-  };
+  pycflow2dot = callPackage ../development/python-modules/pycflow2dot { inherit (pkgs) graphviz; };
 
   pycfmodel = callPackage ../development/python-modules/pycfmodel { };
 
@@ -11906,9 +12224,7 @@ self: super: with self; {
 
   pyctr = callPackage ../development/python-modules/pyctr { };
 
-  pycuda = callPackage ../development/python-modules/pycuda {
-    inherit (pkgs.stdenv) mkDerivation;
-  };
+  pycuda = callPackage ../development/python-modules/pycuda { inherit (pkgs.stdenv) mkDerivation; };
 
   pycups = callPackage ../development/python-modules/pycups { };
 
@@ -11928,7 +12244,9 @@ self: super: with self; {
 
   pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };
 
-  pydantic-argparse-extensible = callPackage ../development/python-modules/pydantic-argparse-extensible { };
+  pydantic-argparse-extensible =
+    callPackage ../development/python-modules/pydantic-argparse-extensible
+      { };
 
   pydantic-compat = callPackage ../development/python-modules/pydantic-compat { };
 
@@ -11964,9 +12282,7 @@ self: super: with self; {
 
   pydemumble = callPackage ../development/python-modules/pydemumble { };
 
-  pydeps = callPackage ../development/python-modules/pydeps {
-    inherit (pkgs) graphviz;
-  };
+  pydeps = callPackage ../development/python-modules/pydeps { inherit (pkgs) graphviz; };
 
   pydes = callPackage ../development/python-modules/pydes { };
 
@@ -12006,15 +12322,13 @@ self: super: with self; {
 
   pydoe = callPackage ../development/python-modules/pydoe { };
 
-  pydot = callPackage ../development/python-modules/pydot {
-    inherit (pkgs) graphviz;
-  };
+  pydot = callPackage ../development/python-modules/pydot { inherit (pkgs) graphviz; };
 
   pydrawise = callPackage ../development/python-modules/pydrawise { };
 
   pydrive2 = callPackage ../development/python-modules/pydrive2 { };
 
-  pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam  { };
+  pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam { };
 
   pydruid = callPackage ../development/python-modules/pydruid { };
 
@@ -12072,9 +12386,7 @@ self: super: with self; {
 
   pyemvue = callPackage ../development/python-modules/pyemvue { };
 
-  pyenchant = callPackage ../development/python-modules/pyenchant {
-    inherit (pkgs) enchant2;
-  };
+  pyenchant = callPackage ../development/python-modules/pyenchant { inherit (pkgs) enchant2; };
 
   pyenphase = callPackage ../development/python-modules/pyenphase { };
 
@@ -12160,21 +12472,15 @@ self: super: with self; {
 
   pyfuse3 = callPackage ../development/python-modules/pyfuse3 { };
 
-  pyfwup = callPackage ../development/python-modules/pyfwup {
-    inherit (pkgs) libusb1;
-  };
+  pyfwup = callPackage ../development/python-modules/pyfwup { inherit (pkgs) libusb1; };
 
   pyfxa = callPackage ../development/python-modules/pyfxa { };
 
-  pyfzf = callPackage ../development/python-modules/pyfzf {
-    inherit (pkgs) fzf;
-  };
+  pyfzf = callPackage ../development/python-modules/pyfzf { inherit (pkgs) fzf; };
 
   pygal = callPackage ../development/python-modules/pygal { };
 
-  pygame = callPackage ../development/python-modules/pygame {
-    SDL2_image = pkgs.SDL2_image_2_0;
-  };
+  pygame = callPackage ../development/python-modules/pygame { SDL2_image = pkgs.SDL2_image_2_0; };
 
   pygame-ce = callPackage ../development/python-modules/pygame-ce {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
@@ -12231,17 +12537,13 @@ self: super: with self; {
 
   pygpgme = callPackage ../development/python-modules/pygpgme { };
 
-  pygraphviz = callPackage ../development/python-modules/pygraphviz {
-    inherit (pkgs) graphviz;
-  };
+  pygraphviz = callPackage ../development/python-modules/pygraphviz { inherit (pkgs) graphviz; };
 
   pygreat = callPackage ../development/python-modules/pygreat { };
 
   pygrok = callPackage ../development/python-modules/pygrok { };
 
-  pygsl = callPackage ../development/python-modules/pygsl {
-    inherit (pkgs) gsl swig;
-  };
+  pygsl = callPackage ../development/python-modules/pygsl { inherit (pkgs) gsl swig; };
 
   pygtfs = callPackage ../development/python-modules/pygtfs { };
 
@@ -12285,9 +12587,7 @@ self: super: with self; {
 
   pyicumessageformat = callPackage ../development/python-modules/pyicumessageformat { };
 
-  pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy {
-    inherit (pkgs) ssdeep;
-  };
+  pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy { inherit (pkgs) ssdeep; };
 
   pyinotify = callPackage ../development/python-modules/pyinotify { };
 
@@ -12337,9 +12637,7 @@ self: super: with self; {
 
   pykeepass = callPackage ../development/python-modules/pykeepass { };
 
-  pykerberos = callPackage ../development/python-modules/pykerberos {
-    krb5-c = pkgs.krb5;
-  };
+  pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };
 
   pykeyatome = callPackage ../development/python-modules/pykeyatome { };
 
@@ -12393,9 +12691,7 @@ self: super: with self; {
 
   pylibdmtx = callPackage ../development/python-modules/pylibdmtx { };
 
-  pylibftdi = callPackage ../development/python-modules/pylibftdi {
-    inherit (pkgs) libusb1;
-  };
+  pylibftdi = callPackage ../development/python-modules/pylibftdi { inherit (pkgs) libusb1; };
 
   pylibjpeg = callPackage ../development/python-modules/pylibjpeg { };
 
@@ -12559,9 +12855,7 @@ self: super: with self; {
 
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };
 
-  pymssql = callPackage ../development/python-modules/pymssql {
-    krb5-c = pkgs.krb5;
-  };
+  pymssql = callPackage ../development/python-modules/pymssql { krb5-c = pkgs.krb5; };
 
   pymsteams = callPackage ../development/python-modules/pymsteams { };
 
@@ -12602,9 +12896,7 @@ self: super: with self; {
 
   pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
 
-  pync = callPackage ../development/python-modules/pync {
-    inherit (pkgs) which;
-  };
+  pync = callPackage ../development/python-modules/pync { inherit (pkgs) which; };
 
   pynecil = callPackage ../development/python-modules/pynecil { };
 
@@ -12648,9 +12940,7 @@ self: super: with self; {
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };
 
-  pyocr = callPackage ../development/python-modules/pyocr {
-    tesseract = pkgs.tesseract4;
-  };
+  pyocr = callPackage ../development/python-modules/pyocr { tesseract = pkgs.tesseract4; };
 
   pyoctoprintapi = callPackage ../development/python-modules/pyoctoprintapi { };
 
@@ -12686,9 +12976,7 @@ self: super: with self; {
 
   pyosf = callPackage ../development/python-modules/pyosf { };
 
-  pyosmium = callPackage ../development/python-modules/pyosmium {
-    inherit (pkgs) lz4;
-  };
+  pyosmium = callPackage ../development/python-modules/pyosmium { inherit (pkgs) lz4; };
 
   pyosohotwaterapi = callPackage ../development/python-modules/pyosohotwaterapi { };
 
@@ -12702,10 +12990,12 @@ self: super: with self; {
 
   pypager = callPackage ../development/python-modules/pypager { };
 
-  pypamtest = toPythonModule (pkgs.libpam-wrapper.override {
-    enablePython = true;
-    inherit python;
-  });
+  pypamtest = toPythonModule (
+    pkgs.libpam-wrapper.override {
+      enablePython = true;
+      inherit python;
+    }
+  );
 
   pypalazzetti = callPackage ../development/python-modules/pypalazzetti { };
 
@@ -12761,7 +13051,7 @@ self: super: with self; {
 
   pypitoken = callPackage ../development/python-modules/pypitoken { };
 
-  pyplaato  = callPackage ../development/python-modules/pyplaato { };
+  pyplaato = callPackage ../development/python-modules/pyplaato { };
 
   pyplatec = callPackage ../development/python-modules/pyplatec { };
 
@@ -12797,26 +13087,20 @@ self: super: with self; {
 
   pyqt-builder = callPackage ../development/python-modules/pyqt-builder { };
 
-  pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix {
-    inherit (pkgs) mesa;
-  };
+  pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { inherit (pkgs) mesa; };
 
   pyqt5-stubs = callPackage ../development/python-modules/pyqt5-stubs { };
 
   pyqt5-sip = callPackage ../development/python-modules/pyqt/sip.nix { };
 
-  pyqt5-multimedia = self.pyqt5.override {
-    withMultimedia = true;
-  };
+  pyqt5-multimedia = self.pyqt5.override { withMultimedia = true; };
 
   /*
     `pyqt5-webkit` should not be used by python libraries in
     pkgs/development/python-modules/*. Putting this attribute in
     `propagatedBuildInputs` may cause collisions.
   */
-  pyqt5-webkit = self.pyqt5.override {
-    withWebKit = true;
-  };
+  pyqt5-webkit = self.pyqt5.override { withWebKit = true; };
 
   pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
 
@@ -12827,21 +13111,44 @@ self: super: with self; {
   pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine { };
 
   pyqt3d = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt3d {
-    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
-      setuptools sip;
+    inherit (self)
+      buildPythonPackage
+      pyqt5
+      pyqt-builder
+      python
+      pythonOlder
+      setuptools
+      sip
+      ;
   };
 
   pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
-    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
-      setuptools sip;
+    inherit (self)
+      buildPythonPackage
+      pyqt5
+      pyqt-builder
+      python
+      pythonOlder
+      setuptools
+      sip
+      ;
   };
 
   pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
 
-  pyqtdatavisualization = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization {
-    inherit (self) buildPythonPackage pyqt5 pyqt-builder python pythonOlder
-      setuptools sip;
-  };
+  pyqtdatavisualization =
+    pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization
+      {
+        inherit (self)
+          buildPythonPackage
+          pyqt5
+          pyqt-builder
+          python
+          pythonOlder
+          setuptools
+          sip
+          ;
+      };
 
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 
@@ -12889,21 +13196,27 @@ self: super: with self; {
 
   pyreadstat = callPackage ../development/python-modules/pyreadstat { };
 
-  pyrealsense2 = toPythonModule (pkgs.librealsense.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  pyrealsense2 = toPythonModule (
+    pkgs.librealsense.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
-  pyrealsense2WithCuda = toPythonModule (pkgs.librealsenseWithCuda.override {
-    cudaSupport = true;
-    enablePython = true;
-    pythonPackages = self;
-  });
+  pyrealsense2WithCuda = toPythonModule (
+    pkgs.librealsenseWithCuda.override {
+      cudaSupport = true;
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
-  pyrealsense2WithoutCuda = toPythonModule (pkgs.librealsenseWithoutCuda.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  pyrealsense2WithoutCuda = toPythonModule (
+    pkgs.librealsenseWithoutCuda.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
   pyrect = callPackage ../development/python-modules/pyrect { };
 
@@ -12945,9 +13258,7 @@ self: super: with self; {
 
   pysam = callPackage ../development/python-modules/pysam { };
 
-  pysaml2 = callPackage ../development/python-modules/pysaml2 {
-    inherit (pkgs) xmlsec;
-  };
+  pysaml2 = callPackage ../development/python-modules/pysaml2 { inherit (pkgs) xmlsec; };
 
   pysatochip = callPackage ../development/python-modules/pysatochip { };
 
@@ -12959,9 +13270,13 @@ self: super: with self; {
 
   pyscaffold = callPackage ../development/python-modules/pyscaffold { };
 
-  pyscaffoldext-cookiecutter = callPackage ../development/python-modules/pyscaffoldext-cookiecutter { };
+  pyscaffoldext-cookiecutter =
+    callPackage ../development/python-modules/pyscaffoldext-cookiecutter
+      { };
 
-  pyscaffoldext-custom-extension = callPackage ../development/python-modules/pyscaffoldext-custom-extension { };
+  pyscaffoldext-custom-extension =
+    callPackage ../development/python-modules/pyscaffoldext-custom-extension
+      { };
 
   pyscaffoldext-django = callPackage ../development/python-modules/pyscaffoldext-django { };
 
@@ -12989,9 +13304,7 @@ self: super: with self; {
 
   pysdl2 = callPackage ../development/python-modules/pysdl2 { };
 
-  pysearpc = toPythonModule (pkgs.libsearpc.override {
-    python3 = self.python;
-  });
+  pysearpc = toPythonModule (pkgs.libsearpc.override { python3 = self.python; });
 
   pysecuritas = callPackage ../development/python-modules/pysecuritas { };
 
@@ -13013,25 +13326,29 @@ self: super: with self; {
 
   pyshp = callPackage ../development/python-modules/pyshp { };
 
-  pyside2-tools = toPythonModule (callPackage ../development/python-modules/pyside2-tools {
-    inherit (pkgs) cmake qt5;
-  });
+  pyside2-tools = toPythonModule (
+    callPackage ../development/python-modules/pyside2-tools { inherit (pkgs) cmake qt5; }
+  );
 
-  pyside2 = toPythonModule (callPackage ../development/python-modules/pyside2 {
-    inherit (pkgs) cmake ninja qt5;
-  });
+  pyside2 = toPythonModule (
+    callPackage ../development/python-modules/pyside2 { inherit (pkgs) cmake ninja qt5; }
+  );
 
-  pyside6 = toPythonModule (callPackage ../development/python-modules/pyside6 {
-    inherit (pkgs) cmake ninja;
-  });
+  pyside6 = toPythonModule (
+    callPackage ../development/python-modules/pyside6 { inherit (pkgs) cmake ninja; }
+  );
 
   pyside6-qtads = callPackage ../development/python-modules/pyside6-qtads { };
 
   pysigma = callPackage ../development/python-modules/pysigma { };
 
-  pysigma-backend-elasticsearch = callPackage ../development/python-modules/pysigma-backend-elasticsearch { };
+  pysigma-backend-elasticsearch =
+    callPackage ../development/python-modules/pysigma-backend-elasticsearch
+      { };
 
-  pysigma-backend-opensearch = callPackage ../development/python-modules/pysigma-backend-opensearch { };
+  pysigma-backend-opensearch =
+    callPackage ../development/python-modules/pysigma-backend-opensearch
+      { };
 
   pysigma-backend-qradar = callPackage ../development/python-modules/pysigma-backend-qradar { };
 
@@ -13039,11 +13356,15 @@ self: super: with self; {
 
   pysigma-backend-sqlite = callPackage ../development/python-modules/pysigma-backend-sqlite { };
 
-  pysigma-backend-insightidr = callPackage ../development/python-modules/pysigma-backend-insightidr { };
+  pysigma-backend-insightidr =
+    callPackage ../development/python-modules/pysigma-backend-insightidr
+      { };
 
   pysigma-backend-loki = callPackage ../development/python-modules/pysigma-backend-loki { };
 
-  pysigma-pipeline-crowdstrike = callPackage ../development/python-modules/pysigma-pipeline-crowdstrike { };
+  pysigma-pipeline-crowdstrike =
+    callPackage ../development/python-modules/pysigma-pipeline-crowdstrike
+      { };
 
   pysigma-pipeline-sysmon = callPackage ../development/python-modules/pysigma-pipeline-sysmon { };
 
@@ -13059,9 +13380,7 @@ self: super: with self; {
 
   pyslim = callPackage ../development/python-modules/pyslim { };
 
-  pyslurm = callPackage ../development/python-modules/pyslurm {
-    inherit (pkgs) slurm;
-  };
+  pyslurm = callPackage ../development/python-modules/pyslurm { inherit (pkgs) slurm; };
 
   pysma = callPackage ../development/python-modules/pysma { };
 
@@ -13141,9 +13460,7 @@ self: super: with self; {
 
   pyspx = callPackage ../development/python-modules/pyspx { };
 
-  pysqlcipher3 = callPackage ../development/python-modules/pysqlcipher3 {
-    inherit (pkgs) sqlcipher;
-  };
+  pysqlcipher3 = callPackage ../development/python-modules/pysqlcipher3 { inherit (pkgs) sqlcipher; };
 
   pysqueezebox = callPackage ../development/python-modules/pysqueezebox { };
 
@@ -13159,9 +13476,7 @@ self: super: with self; {
 
   pystatgrab = callPackage ../development/python-modules/pystatgrab { };
 
-  pystemd = callPackage ../development/python-modules/pystemd {
-    inherit (pkgs) systemd;
-  };
+  pystemd = callPackage ../development/python-modules/pystemd { inherit (pkgs) systemd; };
 
   pystemmer = callPackage ../development/python-modules/pystemmer { };
 
@@ -13172,7 +13487,12 @@ self: super: with self; {
   pysvg-py3 = callPackage ../development/python-modules/pysvg-py3 { };
 
   pysvn = callPackage ../development/python-modules/pysvn {
-    inherit (pkgs) bash subversion apr aprutil;
+    inherit (pkgs)
+      bash
+      subversion
+      apr
+      aprutil
+      ;
   };
 
   pyswitchbee = callPackage ../development/python-modules/pyswitchbee { };
@@ -13252,7 +13572,7 @@ self: super: with self; {
 
   pytest-base-url = callPackage ../development/python-modules/pytest-base-url { };
 
-  pytest-cases = callPackage ../development/python-modules/pytest-cases{ };
+  pytest-cases = callPackage ../development/python-modules/pytest-cases { };
 
   pytest-catchlog = callPackage ../development/python-modules/pytest-catchlog { };
 
@@ -13378,7 +13698,7 @@ self: super: with self; {
 
   pytest-parallel = callPackage ../development/python-modules/pytest-parallel { };
 
-  pytest-playwright = callPackage ../development/python-modules/pytest-playwright {};
+  pytest-playwright = callPackage ../development/python-modules/pytest-playwright { };
 
   pytest-plt = callPackage ../development/python-modules/pytest-plt { };
 
@@ -13594,7 +13914,9 @@ self: super: with self; {
 
   python-hglib = callPackage ../development/python-modules/python-hglib { };
 
-  python-homeassistant-analytics = callPackage ../development/python-modules/python-homeassistant-analytics { };
+  python-homeassistant-analytics =
+    callPackage ../development/python-modules/python-homeassistant-analytics
+      { };
 
   python-homewizard-energy = callPackage ../development/python-modules/python-homewizard-energy { };
 
@@ -13645,9 +13967,7 @@ self: super: with self; {
 
   python-lzf = callPackage ../development/python-modules/python-lzf { };
 
-  python-lzo = callPackage ../development/python-modules/python-lzo {
-    inherit (pkgs) lzo;
-  };
+  python-lzo = callPackage ../development/python-modules/python-lzo { inherit (pkgs) lzo; };
 
   python-magic = callPackage ../development/python-modules/python-magic { };
 
@@ -13656,17 +13976,23 @@ self: super: with self; {
   python-manilaclient = callPackage ../development/python-modules/python-manilaclient { };
 
   python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
-    inherit (pkgs) pkg-config cairo icu libjpeg libpng libtiff libwebp proj zlib;
+    inherit (pkgs)
+      pkg-config
+      cairo
+      icu
+      libjpeg
+      libpng
+      libtiff
+      libwebp
+      proj
+      zlib
+      ;
     boost = pkgs.boost.override {
       enablePython = true;
       inherit python;
     };
-    harfbuzz = pkgs.harfbuzz.override {
-      withIcu = true;
-    };
-    mapnik = pkgs.mapnik.override {
-      inherit boost harfbuzz;
-    };
+    harfbuzz = pkgs.harfbuzz.override { withIcu = true; };
+    mapnik = pkgs.mapnik.override { inherit boost harfbuzz; };
   };
 
   python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
@@ -13703,11 +14029,18 @@ self: super: with self; {
 
   python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
 
-  pythonocc-core = toPythonModule (callPackage ../development/python-modules/pythonocc-core {
-    inherit (pkgs) fontconfig rapidjson;
-    inherit (pkgs.xorg) libX11 libXi libXmu libXext;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
-  });
+  pythonocc-core = toPythonModule (
+    callPackage ../development/python-modules/pythonocc-core {
+      inherit (pkgs) fontconfig rapidjson;
+      inherit (pkgs.xorg)
+        libX11
+        libXi
+        libXmu
+        libXext
+        ;
+      inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+    }
+  );
 
   python-olm = callPackage ../development/python-modules/python-olm { };
 
@@ -13725,9 +14058,7 @@ self: super: with self; {
 
   python-pae = callPackage ../development/python-modules/python-pae { };
 
-  python-pam = callPackage ../development/python-modules/python-pam {
-    inherit (pkgs) pam;
-  };
+  python-pam = callPackage ../development/python-modules/python-pam { inherit (pkgs) pam; };
 
   python-periphery = callPackage ../development/python-modules/python-periphery { };
 
@@ -13754,7 +14085,12 @@ self: super: with self; {
   python-roborock = callPackage ../development/python-modules/python-roborock { };
 
   python-rtmidi = callPackage ../development/python-modules/python-rtmidi {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices Foundation;
+    inherit (pkgs.darwin.apple_sdk.frameworks)
+      CoreAudio
+      CoreMIDI
+      CoreServices
+      Foundation
+      ;
   };
 
   python-sat = callPackage ../development/python-modules/python-sat { };
@@ -13765,13 +14101,9 @@ self: super: with self; {
 
   python-smarttub = callPackage ../development/python-modules/python-smarttub { };
 
-  python-snap7 = callPackage ../development/python-modules/python-snap7 {
-    inherit (pkgs) snap7;
-  };
+  python-snap7 = callPackage ../development/python-modules/python-snap7 { inherit (pkgs) snap7; };
 
-  python-snappy = callPackage ../development/python-modules/python-snappy {
-    inherit (pkgs) snappy;
-  };
+  python-snappy = callPackage ../development/python-modules/python-snappy { inherit (pkgs) snappy; };
 
   python-socketio = callPackage ../development/python-modules/python-socketio { };
 
@@ -13835,9 +14167,7 @@ self: super: with self; {
 
   python-zunclient = callPackage ../development/python-modules/python-zunclient { };
 
-  pythran = callPackage ../development/python-modules/pythran {
-    inherit (pkgs.llvmPackages) openmp;
-  };
+  pythran = callPackage ../development/python-modules/pythran { inherit (pkgs.llvmPackages) openmp; };
 
   pyeapi = callPackage ../development/python-modules/pyeapi { };
 
@@ -13909,9 +14239,7 @@ self: super: with self; {
 
   pyu2f = callPackage ../development/python-modules/pyu2f { };
 
-  pyudev = callPackage ../development/python-modules/pyudev {
-    inherit (pkgs) udev;
-  };
+  pyudev = callPackage ../development/python-modules/pyudev { inherit (pkgs) udev; };
 
   pyunbound = callPackage ../development/python-modules/pyunbound { };
 
@@ -13923,9 +14251,7 @@ self: super: with self; {
 
   pyuptimerobot = callPackage ../development/python-modules/pyuptimerobot { };
 
-  pyusb = callPackage ../development/python-modules/pyusb {
-    inherit (pkgs) libusb1;
-  };
+  pyusb = callPackage ../development/python-modules/pyusb { inherit (pkgs) libusb1; };
 
   pyuseragents = callPackage ../development/python-modules/pyuseragents { };
 
@@ -13963,9 +14289,7 @@ self: super: with self; {
 
   pyvizio = callPackage ../development/python-modules/pyvizio { };
 
-  pyvips = callPackage ../development/python-modules/pyvips {
-    inherit (pkgs) vips glib;
-  };
+  pyvips = callPackage ../development/python-modules/pyvips { inherit (pkgs) vips glib; };
 
   pyvlx = callPackage ../development/python-modules/pyvlx { };
 
@@ -13993,9 +14317,7 @@ self: super: with self; {
 
   pywaze = callPackage ../development/python-modules/pywaze { };
 
-  pywbem = callPackage ../development/python-modules/pywbem {
-    inherit (pkgs) libxml2;
-  };
+  pywbem = callPackage ../development/python-modules/pywbem { inherit (pkgs) libxml2; };
 
   pyweatherflowrest = callPackage ../development/python-modules/pyweatherflowrest { };
 
@@ -14023,9 +14345,7 @@ self: super: with self; {
 
   pywizlight = callPackage ../development/python-modules/pywizlight { };
 
-  pywlroots = callPackage ../development/python-modules/pywlroots {
-    wlroots = pkgs.wlroots_0_17;
-  };
+  pywlroots = callPackage ../development/python-modules/pywlroots { wlroots = pkgs.wlroots_0_17; };
 
   pyws66i = callPackage ../development/python-modules/pyws66i { };
 
@@ -14095,9 +14415,7 @@ self: super: with self; {
 
   qgrid = callPackage ../development/python-modules/qgrid { };
 
-  qemu = callPackage ../development/python-modules/qemu {
-    qemu = pkgs.qemu;
-  };
+  qemu = callPackage ../development/python-modules/qemu { qemu = pkgs.qemu; };
 
   qiling = callPackage ../development/python-modules/qiling { };
 
@@ -14123,7 +14441,7 @@ self: super: with self; {
 
   qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
 
-  qnap-qsw = callPackage ../development/python-modules/qnap-qsw{ };
+  qnap-qsw = callPackage ../development/python-modules/qnap-qsw { };
 
   qnapstats = callPackage ../development/python-modules/qnapstats { };
 
@@ -14149,17 +14467,13 @@ self: super: with self; {
 
   qt5reactor = callPackage ../development/python-modules/qt5reactor { };
 
-  qt6 = pkgs.qt6.override {
-    python3 = self.python;
-  };
+  qt6 = pkgs.qt6.override { python3 = self.python; };
 
   qtawesome = callPackage ../development/python-modules/qtawesome { };
 
   qtconsole = callPackage ../development/python-modules/qtconsole { };
 
-  qtile = callPackage ../development/python-modules/qtile {
-    wlroots = pkgs.wlroots_0_17;
-  };
+  qtile = callPackage ../development/python-modules/qtile { wlroots = pkgs.wlroots_0_17; };
   qtile-extras = callPackage ../development/python-modules/qtile-extras { };
 
   qtile-bonsai = callPackage ../development/python-modules/qtile-bonsai { };
@@ -14264,9 +14578,7 @@ self: super: with self; {
 
   rapt-ble = callPackage ../development/python-modules/rapt-ble { };
 
-  rarfile = callPackage ../development/python-modules/rarfile {
-    inherit (pkgs) libarchive;
-  };
+  rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
 
   rasterio = callPackage ../development/python-modules/rasterio { };
 
@@ -14286,7 +14598,7 @@ self: super: with self; {
 
   ray = callPackage ../development/python-modules/ray { };
 
-  raylib-python-cffi = callPackage ../development/python-modules/raylib-python-cffi {};
+  raylib-python-cffi = callPackage ../development/python-modules/raylib-python-cffi { };
 
   razdel = callPackage ../development/python-modules/razdel { };
 
@@ -14333,9 +14645,7 @@ self: super: with self; {
 
   recline = callPackage ../development/python-modules/recline { };
 
-  recoll = toPythonModule (pkgs.recoll.override {
-    python3Packages = self;
-  });
+  recoll = toPythonModule (pkgs.recoll.override { python3Packages = self; });
 
   recommonmark = callPackage ../development/python-modules/recommonmark { };
 
@@ -14349,7 +14659,9 @@ self: super: with self; {
 
   recurring-ical-events = callPackage ../development/python-modules/recurring-ical-events { };
 
-  recursive-pth-loader = toPythonModule (callPackage ../development/python-modules/recursive-pth-loader { });
+  recursive-pth-loader = toPythonModule (
+    callPackage ../development/python-modules/recursive-pth-loader { }
+  );
 
   red-black-tree-mod = callPackage ../development/python-modules/red-black-tree-mod { };
 
@@ -14393,9 +14705,7 @@ self: super: with self; {
 
   remarshal = callPackage ../development/python-modules/remarshal { };
 
-  remctl = callPackage ../development/python-modules/remctl {
-    remctl-c = pkgs.remctl;
-  };
+  remctl = callPackage ../development/python-modules/remctl { remctl-c = pkgs.remctl; };
 
   remi = callPackage ../development/python-modules/remi { };
 
@@ -14433,7 +14743,9 @@ self: super: with self; {
 
   repoze-lru = callPackage ../development/python-modules/repoze-lru { };
 
-  repoze-sphinx-autointerface = callPackage ../development/python-modules/repoze-sphinx-autointerface { };
+  repoze-sphinx-autointerface =
+    callPackage ../development/python-modules/repoze-sphinx-autointerface
+      { };
 
   repoze-who = callPackage ../development/python-modules/repoze-who { };
 
@@ -14601,9 +14913,7 @@ self: super: with self; {
 
   ritassist = callPackage ../development/python-modules/ritassist { };
 
-  rivet = toPythonModule (pkgs.rivet.override {
-    python3 = python;
-  });
+  rivet = toPythonModule (pkgs.rivet.override { python3 = python; });
 
   rjpl = callPackage ../development/python-modules/rjpl { };
 
@@ -14647,17 +14957,25 @@ self: super: with self; {
 
   robotframework = callPackage ../development/python-modules/robotframework { };
 
-  robotframework-databaselibrary = callPackage ../development/python-modules/robotframework-databaselibrary { };
+  robotframework-databaselibrary =
+    callPackage ../development/python-modules/robotframework-databaselibrary
+      { };
 
   robotframework-excellib = callPackage ../development/python-modules/robotframework-excellib { };
 
-  robotframework-pythonlibcore = callPackage ../development/python-modules/robotframework-pythonlibcore { };
+  robotframework-pythonlibcore =
+    callPackage ../development/python-modules/robotframework-pythonlibcore
+      { };
 
   robotframework-requests = callPackage ../development/python-modules/robotframework-requests { };
 
-  robotframework-selenium2library = callPackage ../development/python-modules/robotframework-selenium2library { };
+  robotframework-selenium2library =
+    callPackage ../development/python-modules/robotframework-selenium2library
+      { };
 
-  robotframework-seleniumlibrary = callPackage ../development/python-modules/robotframework-seleniumlibrary { };
+  robotframework-seleniumlibrary =
+    callPackage ../development/python-modules/robotframework-seleniumlibrary
+      { };
 
   robotframework-sshlibrary = callPackage ../development/python-modules/robotframework-sshlibrary { };
 
@@ -14721,9 +15039,7 @@ self: super: with self; {
 
   rply = callPackage ../development/python-modules/rply { };
 
-  rpm = toPythonModule (pkgs.rpm.override {
-    python3 = self.python;
-  });
+  rpm = toPythonModule (pkgs.rpm.override { python3 = self.python; });
 
   rpmfile = callPackage ../development/python-modules/rpmfile { };
 
@@ -14759,9 +15075,7 @@ self: super: with self; {
 
   rtp = callPackage ../development/python-modules/rtp { };
 
-  rtree = callPackage ../development/python-modules/rtree {
-    inherit (pkgs) libspatialindex;
-  };
+  rtree = callPackage ../development/python-modules/rtree { inherit (pkgs) libspatialindex; };
 
   rtslib-fb = callPackage ../development/python-modules/rtslib-fb { };
 
@@ -14779,9 +15093,7 @@ self: super: with self; {
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
-  ruff = callPackage ../development/python-modules/ruff {
-    inherit (pkgs) ruff;
-  };
+  ruff = callPackage ../development/python-modules/ruff { inherit (pkgs) ruff; };
 
   ruff-api = callPackage ../development/python-modules/ruff-api { };
 
@@ -14849,17 +15161,13 @@ self: super: with self; {
 
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
-  sane = callPackage ../development/python-modules/sane {
-    inherit (pkgs) sane-backends;
-  };
+  sane = callPackage ../development/python-modules/sane { inherit (pkgs) sane-backends; };
 
   saneyaml = callPackage ../development/python-modules/saneyaml { };
 
   samarium = callPackage ../development/python-modules/samarium { };
 
-  samplerate = callPackage ../development/python-modules/samplerate {
-    inherit (pkgs) libsamplerate;
-  };
+  samplerate = callPackage ../development/python-modules/samplerate { inherit (pkgs) libsamplerate; };
 
   samsungctl = callPackage ../development/python-modules/samsungctl { };
 
@@ -15021,9 +15329,7 @@ self: super: with self; {
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };
 
-  seaserv = toPythonModule (pkgs.seafile-server.override {
-    python3 = self.python;
-  });
+  seaserv = toPythonModule (pkgs.seafile-server.override { python3 = self.python; });
 
   seasonal = callPackage ../development/python-modules/seasonal { };
 
@@ -15031,9 +15337,7 @@ self: super: with self; {
 
   seccomp = callPackage ../development/python-modules/seccomp { };
 
-  secp256k1 = callPackage ../development/python-modules/secp256k1 {
-    inherit (pkgs) secp256k1;
-  };
+  secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1; };
 
   secretstorage = callPackage ../development/python-modules/secretstorage { };
 
@@ -15057,9 +15361,7 @@ self: super: with self; {
 
   segno = callPackage ../development/python-modules/segno { };
 
-  segyio = callPackage ../development/python-modules/segyio {
-    inherit (pkgs) cmake ninja;
-  };
+  segyio = callPackage ../development/python-modules/segyio { inherit (pkgs) cmake ninja; };
 
   selenium = callPackage ../development/python-modules/selenium { };
 
@@ -15143,9 +15445,13 @@ self: super: with self; {
 
   setupmeta = callPackage ../development/python-modules/setupmeta { };
 
-  setuptools-changelog-shortener = callPackage ../development/python-modules/setuptools-changelog-shortener { };
+  setuptools-changelog-shortener =
+    callPackage ../development/python-modules/setuptools-changelog-shortener
+      { };
 
-  setuptools-declarative-requirements = callPackage ../development/python-modules/setuptools-declarative-requirements { };
+  setuptools-declarative-requirements =
+    callPackage ../development/python-modules/setuptools-declarative-requirements
+      { };
 
   setuptools-dso = callPackage ../development/python-modules/setuptools-dso { };
 
@@ -15165,7 +15471,9 @@ self: super: with self; {
 
   setuptools-scm = callPackage ../development/python-modules/setuptools-scm { };
 
-  setuptools-scm-git-archive = callPackage ../development/python-modules/setuptools-scm-git-archive { };
+  setuptools-scm-git-archive =
+    callPackage ../development/python-modules/setuptools-scm-git-archive
+      { };
 
   setuptools-trial = callPackage ../development/python-modules/setuptools-trial { };
 
@@ -15207,13 +15515,13 @@ self: super: with self; {
 
   shellingham = callPackage ../development/python-modules/shellingham { };
 
-  shiboken2 = toPythonModule (callPackage ../development/python-modules/shiboken2 {
-    inherit (pkgs) cmake llvmPackages_15 qt5;
-  });
+  shiboken2 = toPythonModule (
+    callPackage ../development/python-modules/shiboken2 { inherit (pkgs) cmake llvmPackages_15 qt5; }
+  );
 
-  shiboken6 = toPythonModule (callPackage ../development/python-modules/shiboken6 {
-    inherit (pkgs) cmake llvmPackages;
-  });
+  shiboken6 = toPythonModule (
+    callPackage ../development/python-modules/shiboken6 { inherit (pkgs) cmake llvmPackages; }
+  );
 
   shimmy = callPackage ../development/python-modules/shimmy { };
 
@@ -15281,9 +15589,7 @@ self: super: with self; {
 
   simplehound = callPackage ../development/python-modules/simplehound { };
 
-  simpleitk = callPackage ../development/python-modules/simpleitk {
-    inherit (pkgs) itk simpleitk;
-  };
+  simpleitk = callPackage ../development/python-modules/simpleitk { inherit (pkgs) itk simpleitk; };
 
   simplejson = callPackage ../development/python-modules/simplejson { };
 
@@ -15345,10 +15651,12 @@ self: super: with self; {
 
   sipyco = callPackage ../development/python-modules/sipyco { };
 
-  sirius = toPythonModule (pkgs.sirius.override {
-    enablePython = true;
-    pythonPackages = self;
-  });
+  sirius = toPythonModule (
+    pkgs.sirius.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
 
   sismic = callPackage ../development/python-modules/sismic { };
 
@@ -15410,14 +15718,21 @@ self: super: with self; {
 
   sleepyq = callPackage ../development/python-modules/sleepyq { };
 
-  slepc4py = toPythonModule (pkgs.slepc.override {
-    pythonSupport = true;
-    python3 = self.python;
-    python3Packages = self;
-    petsc = petsc4py;
-  });
+  slepc4py = toPythonModule (
+    pkgs.slepc.override {
+      pythonSupport = true;
+      python3 = self.python;
+      python3Packages = self;
+      petsc = petsc4py;
+    }
+  );
 
-  sleqp = toPythonModule (pkgs.sleqp.override { pythonSupport = true; python3Packages = self; });
+  sleqp = toPythonModule (
+    pkgs.sleqp.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   slicedimage = callPackage ../development/python-modules/slicedimage { };
 
@@ -15431,9 +15746,7 @@ self: super: with self; {
 
   slimit = callPackage ../development/python-modules/slimit { };
 
-  slixmpp = callPackage ../development/python-modules/slixmpp {
-    inherit (pkgs) gnupg;
-  };
+  slixmpp = callPackage ../development/python-modules/slixmpp { inherit (pkgs) gnupg; };
 
   slob = callPackage ../development/python-modules/slob { };
 
@@ -15479,29 +15792,41 @@ self: super: with self; {
 
   smtpdfix = callPackage ../development/python-modules/smtpdfix { };
 
-  snack = toPythonModule (pkgs.newt.override {
-    inherit (self) python;
-  });
+  snack = toPythonModule (pkgs.newt.override { inherit (self) python; });
 
-  snakemake = toPythonModule (pkgs.snakemake.override {
-    python3Packages = self;
-  });
+  snakemake = toPythonModule (pkgs.snakemake.override { python3Packages = self; });
 
-  snakemake-executor-plugin-cluster-generic = callPackage ../development/python-modules/snakemake-executor-plugin-cluster-generic { };
+  snakemake-executor-plugin-cluster-generic =
+    callPackage ../development/python-modules/snakemake-executor-plugin-cluster-generic
+      { };
 
-  snakemake-interface-common = callPackage ../development/python-modules/snakemake-interface-common { };
+  snakemake-interface-common =
+    callPackage ../development/python-modules/snakemake-interface-common
+      { };
 
-  snakemake-interface-executor-plugins = callPackage ../development/python-modules/snakemake-interface-executor-plugins { };
+  snakemake-interface-executor-plugins =
+    callPackage ../development/python-modules/snakemake-interface-executor-plugins
+      { };
 
-  snakemake-interface-report-plugins = callPackage ../development/python-modules/snakemake-interface-report-plugins { };
+  snakemake-interface-report-plugins =
+    callPackage ../development/python-modules/snakemake-interface-report-plugins
+      { };
 
-  snakemake-interface-storage-plugins = callPackage ../development/python-modules/snakemake-interface-storage-plugins { };
+  snakemake-interface-storage-plugins =
+    callPackage ../development/python-modules/snakemake-interface-storage-plugins
+      { };
 
-  snakemake-storage-plugin-fs = callPackage ../development/python-modules/snakemake-storage-plugin-fs { };
+  snakemake-storage-plugin-fs =
+    callPackage ../development/python-modules/snakemake-storage-plugin-fs
+      { };
 
-  snakemake-storage-plugin-s3 = callPackage ../development/python-modules/snakemake-storage-plugin-s3 { };
+  snakemake-storage-plugin-s3 =
+    callPackage ../development/python-modules/snakemake-storage-plugin-s3
+      { };
 
-  snakemake-storage-plugin-xrootd = callPackage ../development/python-modules/snakemake-storage-plugin-xrootd { };
+  snakemake-storage-plugin-xrootd =
+    callPackage ../development/python-modules/snakemake-storage-plugin-xrootd
+      { };
 
   snakebite = callPackage ../development/python-modules/snakebite { };
 
@@ -15523,7 +15848,9 @@ self: super: with self; {
 
   snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
 
-  snowflake-connector-python = callPackage ../development/python-modules/snowflake-connector-python { };
+  snowflake-connector-python =
+    callPackage ../development/python-modules/snowflake-connector-python
+      { };
 
   snowflake-sqlalchemy = callPackage ../development/python-modules/snowflake-sqlalchemy { };
 
@@ -15533,15 +15860,19 @@ self: super: with self; {
 
   snuggs = callPackage ../development/python-modules/snuggs { };
 
-  soapysdr = toPythonModule (pkgs.soapysdr.override {
-    inherit (self) python;
-    usePython = true;
-  });
+  soapysdr = toPythonModule (
+    pkgs.soapysdr.override {
+      inherit (self) python;
+      usePython = true;
+    }
+  );
 
-  soapysdr-with-plugins = toPythonModule (pkgs.soapysdr-with-plugins.override {
-    inherit (self) python;
-    usePython = true;
-  });
+  soapysdr-with-plugins = toPythonModule (
+    pkgs.soapysdr-with-plugins.override {
+      inherit (self) python;
+      usePython = true;
+    }
+  );
 
   socketio-client = callPackage ../development/python-modules/socketio-client { };
 
@@ -15551,7 +15882,7 @@ self: super: with self; {
 
   socialscan = callPackage ../development/python-modules/socialscan { };
 
-  socid-extractor =  callPackage ../development/python-modules/socid-extractor { };
+  socid-extractor = callPackage ../development/python-modules/socid-extractor { };
 
   sockio = callPackage ../development/python-modules/sockio { };
 
@@ -15575,7 +15906,9 @@ self: super: with self; {
 
   solidpython2 = callPackage ../development/python-modules/solidpython2 { };
 
-  solo-python = disabledIf (!pythonAtLeast "3.6") (callPackage ../development/python-modules/solo-python { });
+  solo-python = disabledIf (!pythonAtLeast "3.6") (
+    callPackage ../development/python-modules/solo-python { }
+  );
 
   somajo = callPackage ../development/python-modules/somajo { };
 
@@ -15607,9 +15940,7 @@ self: super: with self; {
 
   sourmash = callPackage ../development/python-modules/sourmash { };
 
-  soxr = callPackage ../development/python-modules/soxr {
-    libsoxr = pkgs.soxr;
-  };
+  soxr = callPackage ../development/python-modules/soxr { libsoxr = pkgs.soxr; };
 
   spacy = callPackage ../development/python-modules/spacy {
     # fix error: ‘_PyCFrame’ has no member named ‘use_tracing’
@@ -15626,7 +15957,9 @@ self: super: with self; {
 
   spacy-alignments = callPackage ../development/python-modules/spacy-alignments { };
 
-  spacy-curated-transformers = callPackage ../development/python-modules/spacy-curated-transformers { };
+  spacy-curated-transformers =
+    callPackage ../development/python-modules/spacy-curated-transformers
+      { };
 
   spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
 
@@ -15634,9 +15967,7 @@ self: super: with self; {
 
   spacy-lookups-data = callPackage ../development/python-modules/spacy/lookups-data.nix { };
 
-  spacy-models = callPackage ../development/python-modules/spacy/models.nix {
-      inherit (pkgs) jq;
-  };
+  spacy-models = callPackage ../development/python-modules/spacy/models.nix { inherit (pkgs) jq; };
 
   spacy-pkuseg = callPackage ../development/python-modules/spacy-pkuseg { };
 
@@ -15758,7 +16089,9 @@ self: super: with self; {
 
   sphinxcontrib-blockdiag = callPackage ../development/python-modules/sphinxcontrib-blockdiag { };
 
-  sphinxcontrib-confluencebuilder = callPackage ../development/python-modules/sphinxcontrib-confluencebuilder { };
+  sphinxcontrib-confluencebuilder =
+    callPackage ../development/python-modules/sphinxcontrib-confluencebuilder
+      { };
 
   sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp { };
 
@@ -15786,7 +16119,9 @@ self: super: with self; {
 
   sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
 
-  sphinxcontrib-moderncmakedomain = callPackage ../development/python-modules/sphinxcontrib-moderncmakedomain { };
+  sphinxcontrib-moderncmakedomain =
+    callPackage ../development/python-modules/sphinxcontrib-moderncmakedomain
+      { };
 
   sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
 
@@ -15798,17 +16133,23 @@ self: super: with self; {
     inherit (pkgs) plantuml;
   };
 
-  sphinxcontrib-programoutput = callPackage ../development/python-modules/sphinxcontrib-programoutput { };
+  sphinxcontrib-programoutput =
+    callPackage ../development/python-modules/sphinxcontrib-programoutput
+      { };
 
   sphinxcontrib-qthelp = callPackage ../development/python-modules/sphinxcontrib-qthelp { };
 
-  sphinxcontrib-serializinghtml = callPackage ../development/python-modules/sphinxcontrib-serializinghtml { };
+  sphinxcontrib-serializinghtml =
+    callPackage ../development/python-modules/sphinxcontrib-serializinghtml
+      { };
 
   sphinxcontrib-seqdiag = callPackage ../development/python-modules/sphinxcontrib-seqdiag { };
 
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 
-  sphinxcontrib-svg2pdfconverter = callPackage ../development/python-modules/sphinxcontrib-svg2pdfconverter { };
+  sphinxcontrib-svg2pdfconverter =
+    callPackage ../development/python-modules/sphinxcontrib-svg2pdfconverter
+      { };
 
   sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz { };
 
@@ -15914,9 +16255,9 @@ self: super: with self; {
 
   sqlbag = callPackage ../development/python-modules/sqlbag { };
 
-  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 {};
-  sqlcipher3-binary = callPackage ../development/python-modules/sqlcipher3-binary {};
-  sqlcipher3-wheels = callPackage ../development/python-modules/sqlcipher3-wheels {};
+  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 { };
+  sqlcipher3-binary = callPackage ../development/python-modules/sqlcipher3-binary { };
+  sqlcipher3-wheels = callPackage ../development/python-modules/sqlcipher3-wheels { };
 
   sqlfmt = callPackage ../development/python-modules/sqlfmt { };
 
@@ -15960,9 +16301,7 @@ self: super: with self; {
 
   srvlookup = callPackage ../development/python-modules/srvlookup { };
 
-  ssdeep = callPackage ../development/python-modules/ssdeep {
-    inherit (pkgs) ssdeep;
-  };
+  ssdeep = callPackage ../development/python-modules/ssdeep { inherit (pkgs) ssdeep; };
 
   ssdp = callPackage ../development/python-modules/ssdp { };
 
@@ -16062,17 +16401,29 @@ self: super: with self; {
 
   stm32loader = callPackage ../development/python-modules/stm32loader { };
 
-  standard-aifc = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-aifc { } else null;
+  standard-aifc =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-aifc { } else null;
 
-  standard-chunk = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-chunk { } else null;
+  standard-chunk =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-chunk { } else null;
 
-  standard-imghdr = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-imghdr { } else null;
+  standard-imghdr =
+    if pythonAtLeast "3.13" then
+      callPackage ../development/python-modules/standard-imghdr { }
+    else
+      null;
 
-  standard-pipes = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-pipes { } else null;
+  standard-pipes =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-pipes { } else null;
 
-  standard-sunau = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-sunau { } else null;
+  standard-sunau =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-sunau { } else null;
 
-  standard-telnetlib = if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-telnetlib { } else null;
+  standard-telnetlib =
+    if pythonAtLeast "3.13" then
+      callPackage ../development/python-modules/standard-telnetlib { }
+    else
+      null;
 
   standardwebhooks = callPackage ../development/python-modules/standardwebhooks { };
 
@@ -16086,9 +16437,7 @@ self: super: with self; {
 
   stop-words = callPackage ../development/python-modules/stop-words { };
 
-  stp = toPythonModule (pkgs.stp.override {
-    python3 = self.python;
-  });
+  stp = toPythonModule (pkgs.stp.override { python3 = self.python; });
 
   stransi = callPackage ../development/python-modules/stransi { };
 
@@ -16104,7 +16453,9 @@ self: super: with self; {
 
   strct = callPackage ../development/python-modules/strct { };
 
-  streamcontroller-plugin-tools = callPackage ../development/python-modules/streamcontroller-plugin-tools { };
+  streamcontroller-plugin-tools =
+    callPackage ../development/python-modules/streamcontroller-plugin-tools
+      { };
 
   streamdeck = callPackage ../development/python-modules/streamdeck { };
 
@@ -16116,7 +16467,7 @@ self: super: with self; {
 
   streamz = callPackage ../development/python-modules/streamz { };
 
-  strenum =  callPackage ../development/python-modules/strenum { };
+  strenum = callPackage ../development/python-modules/strenum { };
 
   strict-rfc3339 = callPackage ../development/python-modules/strict-rfc3339 { };
 
@@ -16254,9 +16605,7 @@ self: super: with self; {
 
   symbolic = callPackage ../development/python-modules/symbolic { };
 
-  symengine = callPackage ../development/python-modules/symengine {
-    inherit (pkgs) symengine;
-  };
+  symengine = callPackage ../development/python-modules/symengine { inherit (pkgs) symengine; };
 
   symfc = callPackage ../development/python-modules/symfc { };
 
@@ -16268,10 +16617,12 @@ self: super: with self; {
 
   syncer = callPackage ../development/python-modules/syncer { };
 
-  syndication-domination = toPythonModule (pkgs.syndication-domination.override {
-    enablePython = true;
-    python3Packages = self;
-  });
+  syndication-domination = toPythonModule (
+    pkgs.syndication-domination.override {
+      enablePython = true;
+      python3Packages = self;
+    }
+  );
 
   synergy = callPackage ../development/python-modules/synergy { };
 
@@ -16285,9 +16636,7 @@ self: super: with self; {
 
   systembridgemodels = callPackage ../development/python-modules/systembridgemodels { };
 
-  systemd = callPackage ../development/python-modules/systemd {
-    inherit (pkgs) systemd;
-  };
+  systemd = callPackage ../development/python-modules/systemd { inherit (pkgs) systemd; };
 
   systemdunitparser = callPackage ../development/python-modules/systemdunitparser { };
 
@@ -16313,10 +16662,12 @@ self: super: with self; {
 
   tabview = callPackage ../development/python-modules/tabview { };
 
-  taco = toPythonModule (pkgs.taco.override {
-    inherit (self) python;
-    enablePython = true;
-  });
+  taco = toPythonModule (
+    pkgs.taco.override {
+      inherit (self) python;
+      enablePython = true;
+    }
+  );
 
   tadasets = callPackage ../development/python-modules/tadasets { };
 
@@ -16378,11 +16729,11 @@ self: super: with self; {
 
   telepath = callPackage ../development/python-modules/telepath { };
 
-  telethon = callPackage ../development/python-modules/telethon {
-    inherit (pkgs) openssl;
-  };
+  telethon = callPackage ../development/python-modules/telethon { inherit (pkgs) openssl; };
 
-  telethon-session-sqlalchemy = callPackage ../development/python-modules/telethon-session-sqlalchemy { };
+  telethon-session-sqlalchemy =
+    callPackage ../development/python-modules/telethon-session-sqlalchemy
+      { };
 
   teletype = callPackage ../development/python-modules/teletype { };
 
@@ -16412,7 +16763,9 @@ self: super: with self; {
 
   tensorboard-data-server = callPackage ../development/python-modules/tensorboard-data-server { };
 
-  tensorboard-plugin-profile = callPackage ../development/python-modules/tensorboard-plugin-profile { };
+  tensorboard-plugin-profile =
+    callPackage ../development/python-modules/tensorboard-plugin-profile
+      { };
 
   tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit { };
 
@@ -16428,71 +16781,66 @@ self: super: with self; {
     cudaPackages = pkgs.cudaPackages_12;
   };
 
-  tensorflow-build = let
-    compat = rec {
-      protobufTF = pkgs.protobuf_21.override {
-        abseil-cpp = pkgs.abseil-cpp_202301;
+  tensorflow-build =
+    let
+      compat = rec {
+        protobufTF = pkgs.protobuf_21.override { abseil-cpp = pkgs.abseil-cpp_202301; };
+        # https://www.tensorflow.org/install/source#gpu
+        cudaPackagesTF = pkgs.cudaPackages_11;
+        grpcTF =
+          (pkgs.grpc.overrideAttrs (oldAttrs: rec {
+            # nvcc fails on recent grpc versions, so we use the latest patch level
+            #  of the grpc version bundled by upstream tensorflow to allow CUDA
+            #  support
+            version = "1.27.3";
+            src = pkgs.fetchFromGitHub {
+              owner = "grpc";
+              repo = "grpc";
+              rev = "v${version}";
+              hash = "sha256-PpiOT4ZJe1uMp5j+ReQulC9jpT0xoR2sAl6vRYKA0AA=";
+              fetchSubmodules = true;
+            };
+            patches = [ ];
+            postPatch = ''
+              sed -i "s/-std=c++11/-std=c++17/" CMakeLists.txt
+              echo "set(CMAKE_CXX_STANDARD 17)" >> CMakeLists.txt
+            '';
+          })).override
+            { protobuf = protobufTF; };
+        protobuf-pythonTF = self.protobuf4.override { protobuf = protobufTF; };
+        grpcioTF = self.grpcio.override { protobuf = protobufTF; };
+        tensorboardTF = self.tensorboard.override {
+          grpcio = grpcioTF;
+          protobuf = protobuf-pythonTF;
+        };
       };
-      # https://www.tensorflow.org/install/source#gpu
-      cudaPackagesTF = pkgs.cudaPackages_11;
-      grpcTF = (pkgs.grpc.overrideAttrs (
-        oldAttrs: rec {
-          # nvcc fails on recent grpc versions, so we use the latest patch level
-          #  of the grpc version bundled by upstream tensorflow to allow CUDA
-          #  support
-          version = "1.27.3";
-          src = pkgs.fetchFromGitHub {
-            owner = "grpc";
-            repo = "grpc";
-            rev = "v${version}";
-            hash = "sha256-PpiOT4ZJe1uMp5j+ReQulC9jpT0xoR2sAl6vRYKA0AA=";
-            fetchSubmodules = true;
-          };
-          patches = [ ];
-          postPatch = ''
-            sed -i "s/-std=c++11/-std=c++17/" CMakeLists.txt
-            echo "set(CMAKE_CXX_STANDARD 17)" >> CMakeLists.txt
-          '';
-        })
-      ).override {
-        protobuf = protobufTF;
-      };
-      protobuf-pythonTF = self.protobuf4.override {
-        protobuf = protobufTF;
-      };
-      grpcioTF = self.grpcio.override {
-        protobuf = protobufTF;
-      };
-      tensorboardTF = self.tensorboard.override {
-        grpcio = grpcioTF;
-        protobuf = protobuf-pythonTF;
-      };
-    };
-  in
-  callPackage ../development/python-modules/tensorflow {
-    inherit (pkgs.config) cudaSupport;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
-    flatbuffers-core = pkgs.flatbuffers;
-    flatbuffers-python = self.flatbuffers;
-    cudaPackages = compat.cudaPackagesTF;
-    protobuf-core = compat.protobufTF;
-    protobuf-python = compat.protobuf-pythonTF;
-    grpc = compat.grpcTF;
-    grpcio = compat.grpcioTF;
-    tensorboard = compat.tensorboardTF;
-    abseil-cpp = pkgs.abseil-cpp_202301;
+    in
+    callPackage ../development/python-modules/tensorflow {
+      inherit (pkgs.config) cudaSupport;
+      inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
+      flatbuffers-core = pkgs.flatbuffers;
+      flatbuffers-python = self.flatbuffers;
+      cudaPackages = compat.cudaPackagesTF;
+      protobuf-core = compat.protobufTF;
+      protobuf-python = compat.protobuf-pythonTF;
+      grpc = compat.grpcTF;
+      grpcio = compat.grpcioTF;
+      tensorboard = compat.tensorboardTF;
+      abseil-cpp = pkgs.abseil-cpp_202301;
 
-    # Tensorflow 2.13 doesn't support gcc13:
-    # https://github.com/tensorflow/tensorflow/issues/61289
-    #
-    # We use the nixpkgs' default libstdc++ to stay compatible with other
-    # python modules
-    stdenv = pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv;
-  };
+      # Tensorflow 2.13 doesn't support gcc13:
+      # https://github.com/tensorflow/tensorflow/issues/61289
+      #
+      # We use the nixpkgs' default libstdc++ to stay compatible with other
+      # python modules
+      stdenv = pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv;
+    };
 
   tensorflow-datasets = callPackage ../development/python-modules/tensorflow-datasets { };
 
-  tensorflow-estimator-bin = callPackage ../development/python-modules/tensorflow-estimator/bin.nix { };
+  tensorflow-estimator-bin =
+    callPackage ../development/python-modules/tensorflow-estimator/bin.nix
+      { };
 
   tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
 
@@ -16500,17 +16848,15 @@ self: super: with self; {
 
   tensorflow = self.tensorflow-bin;
 
-  tensorflowWithCuda = self.tensorflow.override {
-    cudaSupport = true;
-  };
+  tensorflowWithCuda = self.tensorflow.override { cudaSupport = true; };
 
-  tensorflowWithoutCuda = self.tensorflow.override {
-    cudaSupport = false;
-  };
+  tensorflowWithoutCuda = self.tensorflow.override { cudaSupport = false; };
 
   tensorly = callPackage ../development/python-modules/tensorly { };
 
-  tensorrt = callPackage ../development/python-modules/tensorrt { cudaPackages = pkgs.cudaPackages_11; };
+  tensorrt = callPackage ../development/python-modules/tensorrt {
+    cudaPackages = pkgs.cudaPackages_11;
+  };
 
   tensorstore = callPackage ../development/python-modules/tensorstore { };
 
@@ -16582,7 +16928,9 @@ self: super: with self; {
 
   textual-slider = callPackage ../development/python-modules/textual-slider { };
 
-  textual-universal-directorytree = callPackage ../development/python-modules/textual-universal-directorytree { };
+  textual-universal-directorytree =
+    callPackage ../development/python-modules/textual-universal-directorytree
+      { };
 
   textualeffects = callPackage ../development/python-modules/textualeffects { };
 
@@ -16645,7 +16993,12 @@ self: super: with self; {
   thespian = callPackage ../development/python-modules/thespian { };
 
   thinc = callPackage ../development/python-modules/thinc {
-    inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate CoreFoundation CoreGraphics CoreVideo;
+    inherit (pkgs.darwin.apple_sdk.frameworks)
+      Accelerate
+      CoreFoundation
+      CoreGraphics
+      CoreVideo
+      ;
   };
 
   thinqconnect = callPackage ../development/python-modules/thinqconnect { };
@@ -16692,9 +17045,7 @@ self: super: with self; {
 
   tikzplotlib = callPackage ../development/python-modules/tikzplotlib { };
 
-  tiledb = callPackage ../development/python-modules/tiledb {
-    inherit (pkgs) tiledb;
-  };
+  tiledb = callPackage ../development/python-modules/tiledb { inherit (pkgs) tiledb; };
 
   tilequant = callPackage ../development/python-modules/tilequant { };
 
@@ -16726,11 +17077,13 @@ self: super: with self; {
 
   timy = callPackage ../development/python-modules/timy { };
 
-  tiny-cuda-nn = toPythonModule (pkgs.tiny-cuda-nn.override {
-    cudaPackages = self.torch.cudaPackages;
-    python3Packages = self;
-    pythonSupport = true;
-  });
+  tiny-cuda-nn = toPythonModule (
+    pkgs.tiny-cuda-nn.override {
+      cudaPackages = self.torch.cudaPackages;
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
 
   tiny-proxy = callPackage ../development/python-modules/tiny-proxy { };
 
@@ -16825,9 +17178,7 @@ self: super: with self; {
 
   torch-pitch-shift = callPackage ../development/python-modules/torch-pitch-shift { };
 
-  torch-bin = callPackage ../development/python-modules/torch/bin.nix {
-    triton = self.triton-bin;
-  };
+  torch-bin = callPackage ../development/python-modules/torch/bin.nix { triton = self.triton-bin; };
 
   torchbench = callPackage ../development/python-modules/torchbench { };
 
@@ -16839,9 +17190,7 @@ self: super: with self; {
     rocmSupport = false;
   };
 
-  torchWithoutCuda = self.torch.override {
-    cudaSupport = false;
-  };
+  torchWithoutCuda = self.torch.override { cudaSupport = false; };
 
   torchWithRocm = self.torch.override {
     triton = self.triton-no-cuda;
@@ -16849,13 +17198,9 @@ self: super: with self; {
     cudaSupport = false;
   };
 
-  torchWithoutRocm = self.torch.override {
-    rocmSupport = false;
-  };
+  torchWithoutRocm = self.torch.override { rocmSupport = false; };
 
-  torchWithVulkan = self.torch.override {
-    vulkanSupport = true;
-  };
+  torchWithVulkan = self.torch.override { vulkanSupport = true; };
 
   torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
 
@@ -16907,9 +17252,7 @@ self: super: with self; {
 
   total-connect-client = callPackage ../development/python-modules/total-connect-client { };
 
-  towncrier = callPackage ../development/python-modules/towncrier {
-    inherit (pkgs) git;
-  };
+  towncrier = callPackage ../development/python-modules/towncrier { inherit (pkgs) git; };
 
   tox = callPackage ../development/python-modules/tox { };
 
@@ -16935,9 +17278,9 @@ self: super: with self; {
 
   trafilatura = callPackage ../development/python-modules/trafilatura { };
 
-  trailrunner = callPackage ../development/python-modules/trailrunner {};
+  trailrunner = callPackage ../development/python-modules/trailrunner { };
 
-  trainer = callPackage ../development/python-modules/trainer {};
+  trainer = callPackage ../development/python-modules/trainer { };
 
   traitlets = callPackage ../development/python-modules/traitlets { };
 
@@ -17019,23 +17362,22 @@ self: super: with self; {
 
   trio-websocket = callPackage ../development/python-modules/trio-websocket { };
 
-  triton = callPackage ../development/python-modules/triton {
-    llvm = pkgs.triton-llvm;
-  };
+  triton = callPackage ../development/python-modules/triton { llvm = pkgs.triton-llvm; };
 
-  triton-cuda = self.triton.override {
-    cudaSupport = true;
-  };
+  triton-cuda = self.triton.override { cudaSupport = true; };
 
-  triton-no-cuda = self.triton.override {
-    cudaSupport = false;
-  };
+  triton-no-cuda = self.triton.override { cudaSupport = false; };
 
   triton-bin = callPackage ../development/python-modules/triton/bin.nix { };
 
   tritonclient = callPackage ../development/python-modules/tritonclient { };
 
-  trlib = toPythonModule (pkgs.trlib.override { pythonSupport = true; python3Packages = self;});
+  trlib = toPythonModule (
+    pkgs.trlib.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   troposphere = callPackage ../development/python-modules/troposphere { };
 
@@ -17059,10 +17401,12 @@ self: super: with self; {
 
   tsfresh = callPackage ../development/python-modules/tsfresh { };
 
-  tsid = toPythonModule (pkgs.tsid.override {
-    pythonSupport = true;
-    python3Packages = self;
-  });
+  tsid = toPythonModule (
+    pkgs.tsid.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
 
   tskit = callPackage ../development/python-modules/tskit { };
 
@@ -17880,7 +18224,7 @@ self: super: with self; {
 
     types-aiobotocore-xray
 
-  ;
+    ;
 
   types-appdirs = callPackage ../development/python-modules/types-appdirs { };
 
@@ -18092,9 +18436,7 @@ self: super: with self; {
 
   unicode-slugify = callPackage ../development/python-modules/unicode-slugify { };
 
-  unicorn = callPackage ../development/python-modules/unicorn {
-    inherit (pkgs) unicorn;
-  };
+  unicorn = callPackage ../development/python-modules/unicorn { inherit (pkgs) unicorn; };
 
   unicorn-angr = callPackage ../development/python-modules/unicorn-angr {
     inherit (pkgs) unicorn-angr;
@@ -18260,7 +18602,9 @@ self: super: with self; {
 
   vacuum-map-parser-base = callPackage ../development/python-modules/vacuum-map-parser-base { };
 
-  vacuum-map-parser-roborock = callPackage ../development/python-modules/vacuum-map-parser-roborock { };
+  vacuum-map-parser-roborock =
+    callPackage ../development/python-modules/vacuum-map-parser-roborock
+      { };
 
   validate-email = callPackage ../development/python-modules/validate-email { };
 
@@ -18272,9 +18616,7 @@ self: super: with self; {
 
   vallox-websocket-api = callPackage ../development/python-modules/vallox-websocket-api { };
 
-  vapoursynth = callPackage ../development/python-modules/vapoursynth {
-    inherit (pkgs) vapoursynth;
-  };
+  vapoursynth = callPackage ../development/python-modules/vapoursynth { inherit (pkgs) vapoursynth; };
 
   variants = callPackage ../development/python-modules/variants { };
 
@@ -18342,9 +18684,7 @@ self: super: with self; {
 
   vidstab = callPackage ../development/python-modules/vidstab { };
 
-  viennarna = toPythonModule (pkgs.viennarna.override {
-    python3 = self.python;
-  });
+  viennarna = toPythonModule (pkgs.viennarna.override { python3 = self.python; });
 
   viewstate = callPackage ../development/python-modules/viewstate { };
 
@@ -18426,10 +18766,12 @@ self: super: with self; {
 
   vtjp = callPackage ../development/python-modules/vtjp { };
 
-  vtk = toPythonModule (pkgs.vtk_9.override {
-    inherit python;
-    enablePython = true;
-  });
+  vtk = toPythonModule (
+    pkgs.vtk_9.override {
+      inherit python;
+      enablePython = true;
+    }
+  );
 
   vttlib = callPackage ../development/python-modules/vttlib { };
 
@@ -18496,7 +18838,12 @@ self: super: with self; {
   wasserstein = callPackage ../development/python-modules/wasserstein { };
 
   wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
-  inherit (self.wasmerPackages) wasmer wasmer-compiler-cranelift wasmer-compiler-llvm wasmer-compiler-singlepass;
+  inherit (self.wasmerPackages)
+    wasmer
+    wasmer-compiler-cranelift
+    wasmer-compiler-llvm
+    wasmer-compiler-singlepass
+    ;
 
   wat = callPackage ../development/python-modules/wat { };
 
@@ -18522,7 +18869,7 @@ self: super: with self; {
 
   wavinsentio = callPackage ../development/python-modules/wavinsentio { };
 
-  waybackpy = callPackage ../development/python-modules/waybackpy {};
+  waybackpy = callPackage ../development/python-modules/waybackpy { };
 
   wazeroutecalculator = callPackage ../development/python-modules/wazeroutecalculator { };
 
@@ -18602,7 +18949,7 @@ self: super: with self; {
 
   weconnect-mqtt = callPackage ../development/python-modules/weconnect-mqtt { };
 
-  weheat =  callPackage ../development/python-modules/weheat { };
+  weheat = callPackage ../development/python-modules/weheat { };
 
   werkzeug = callPackage ../development/python-modules/werkzeug { };
 
@@ -18747,9 +19094,7 @@ self: super: with self; {
   wurlitzer = callPackage ../development/python-modules/wurlitzer { };
 
   wxpython = callPackage ../development/python-modules/wxpython/4.2.nix {
-    wxGTK = pkgs.wxGTK32.override {
-      withWebKit = true;
-    };
+    wxGTK = pkgs.wxGTK32.override { withWebKit = true; };
   };
 
   wyoming = callPackage ../development/python-modules/wyoming { };
@@ -18762,9 +19107,7 @@ self: super: with self; {
 
   x256 = callPackage ../development/python-modules/x256 { };
 
-  xapian = callPackage ../development/python-modules/xapian {
-    inherit (pkgs) xapian;
-  };
+  xapian = callPackage ../development/python-modules/xapian { inherit (pkgs) xapian; };
 
   xarray = callPackage ../development/python-modules/xarray { };
 
@@ -18788,19 +19131,13 @@ self: super: with self; {
 
   xdoctest = callPackage ../development/python-modules/xdoctest { };
 
-  xdot = callPackage ../development/python-modules/xdot {
-    inherit (pkgs) graphviz;
-  };
+  xdot = callPackage ../development/python-modules/xdot { inherit (pkgs) graphviz; };
 
-  xen = toPythonModule (pkgs.xen.override {
-    python3Packages = self;
-  });
+  xen = toPythonModule (pkgs.xen.override { python3Packages = self; });
 
   xformers = callPackage ../development/python-modules/xformers { };
 
-  xgboost = callPackage ../development/python-modules/xgboost {
-    inherit (pkgs) xgboost;
-  };
+  xgboost = callPackage ../development/python-modules/xgboost { inherit (pkgs) xgboost; };
 
   xgrammar = callPackage ../development/python-modules/xgrammar { };
 
@@ -18837,7 +19174,13 @@ self: super: with self; {
   xmlschema = callPackage ../development/python-modules/xmlschema { };
 
   xmlsec = callPackage ../development/python-modules/xmlsec {
-    inherit (pkgs) libxslt libxml2 libtool pkg-config xmlsec;
+    inherit (pkgs)
+      libxslt
+      libxml2
+      libtool
+      pkg-config
+      xmlsec
+      ;
   };
 
   xmltodict = callPackage ../development/python-modules/xmltodict { };
@@ -18860,9 +19203,7 @@ self: super: with self; {
 
   xpybutil = callPackage ../development/python-modules/xpybutil { };
 
-  xrootd = callPackage ../development/python-modules/xrootd {
-    inherit (pkgs) xrootd;
-  };
+  xrootd = callPackage ../development/python-modules/xrootd { inherit (pkgs) xrootd; };
 
   xsdata = callPackage ../development/python-modules/xsdata { };
 
@@ -18878,7 +19219,9 @@ self: super: with self; {
 
   xstatic-jquery = callPackage ../development/python-modules/xstatic-jquery { };
 
-  xstatic-jquery-file-upload = callPackage ../development/python-modules/xstatic-jquery-file-upload { };
+  xstatic-jquery-file-upload =
+    callPackage ../development/python-modules/xstatic-jquery-file-upload
+      { };
 
   xstatic-jquery-ui = callPackage ../development/python-modules/xstatic-jquery-ui { };
 
@@ -18886,7 +19229,7 @@ self: super: with self; {
 
   xtensor-python = callPackage ../development/python-modules/xtensor-python { };
 
-  xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper {};
+  xvfbwrapper = callPackage ../development/python-modules/xvfbwrapper { };
 
   xxhash = callPackage ../development/python-modules/xxhash { };
 
@@ -18956,9 +19299,7 @@ self: super: with self; {
 
   yolink-api = callPackage ../development/python-modules/yolink-api { };
 
-  yosys = toPythonModule (pkgs.yosys.override {
-    python3 = python;
-  });
+  yosys = toPythonModule (pkgs.yosys.override { python3 = python; });
 
   yoto-api = callPackage ../development/python-modules/yoto-api { };
 
@@ -18970,21 +19311,15 @@ self: super: with self; {
 
   youtube-dl = callPackage ../tools/misc/youtube-dl { };
 
-  youtube-dl-light = callPackage ../tools/misc/youtube-dl {
-    ffmpegSupport = false;
-  };
+  youtube-dl-light = callPackage ../tools/misc/youtube-dl { ffmpegSupport = false; };
 
   youtubeaio = callPackage ../development/python-modules/youtubeaio { };
 
   yoyo-migrations = callPackage ../development/python-modules/yoyo-migrations { };
 
-  yt-dlp = toPythonModule (pkgs.yt-dlp.override {
-    python3Packages = self;
-  });
+  yt-dlp = toPythonModule (pkgs.yt-dlp.override { python3Packages = self; });
 
-  yt-dlp-light = toPythonModule (pkgs.yt-dlp-light.override {
-    python3Packages = self;
-  });
+  yt-dlp-light = toPythonModule (pkgs.yt-dlp-light.override { python3Packages = self; });
 
   yt-dlp-dearrow = callPackage ../development/python-modules/yt-dlp-dearrow { };
 
@@ -18998,9 +19333,7 @@ self: super: with self; {
 
   ypy-websocket = callPackage ../development/python-modules/ypy-websocket { };
 
-  yq = callPackage ../development/python-modules/yq {
-    inherit (pkgs) jq;
-  };
+  yq = callPackage ../development/python-modules/yq { inherit (pkgs) jq; };
 
   yte = callPackage ../development/python-modules/yte { };
 
@@ -19012,11 +19345,12 @@ self: super: with self; {
 
   z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };
 
-  z3-solver = (toPythonModule ((pkgs.z3.override {
-    inherit python;
-  }).overrideAttrs (_: {
-    pname = "z3-solver";
-  }))).python;
+  z3-solver =
+    (toPythonModule (
+      (pkgs.z3.override { inherit python; }).overrideAttrs (_: {
+        pname = "z3-solver";
+      })
+    )).python;
 
   zabbix-utils = callPackage ../development/python-modules/zabbix-utils { };
 
@@ -19038,15 +19372,11 @@ self: super: with self; {
 
   zebrafy = callPackage ../development/python-modules/zebrafy { };
 
-  zeek = (toPythonModule (pkgs.zeek.broker.override {
-    python3 = python;
-  })).py;
+  zeek = (toPythonModule (pkgs.zeek.broker.override { python3 = python; })).py;
 
   zeep = callPackage ../development/python-modules/zeep { };
 
-  zeitgeist = (toPythonModule (pkgs.zeitgeist.override {
-    python3 = python;
-  })).py;
+  zeitgeist = (toPythonModule (pkgs.zeitgeist.override { python3 = python; })).py;
 
   zenoh = callPackage ../development/python-modules/zenoh { };
 
@@ -19102,9 +19432,7 @@ self: super: with self; {
 
   zipstream-ng = callPackage ../development/python-modules/zipstream-ng { };
 
-  zlib-ng = callPackage ../development/python-modules/zlib-ng {
-    inherit (pkgs) zlib-ng;
-  };
+  zlib-ng = callPackage ../development/python-modules/zlib-ng { inherit (pkgs) zlib-ng; };
 
   zm-py = callPackage ../development/python-modules/zm-py { };
 
@@ -19158,17 +19486,13 @@ self: super: with self; {
 
   zope-testrunner = callPackage ../development/python-modules/zope-testrunner { };
 
-  zopfli = callPackage ../development/python-modules/zopfli {
-    inherit (pkgs) zopfli;
-  };
+  zopfli = callPackage ../development/python-modules/zopfli { inherit (pkgs) zopfli; };
 
   zpp = callPackage ../development/python-modules/zpp { };
 
   zstandard = callPackage ../development/python-modules/zstandard { };
 
-  zstd = callPackage ../development/python-modules/zstd {
-    inherit (pkgs) zstd;
-  };
+  zstd = callPackage ../development/python-modules/zstd { inherit (pkgs) zstd; };
 
   zulip = callPackage ../development/python-modules/zulip { };
 
@@ -19182,7 +19506,5 @@ self: super: with self; {
 
   zxcvbn-rs-py = callPackage ../development/python-modules/zxcvbn-rs-py { };
 
-  zxing-cpp = callPackage ../development/python-modules/zxing-cpp {
-    libzxing-cpp = pkgs.zxing-cpp;
-  };
+  zxing-cpp = callPackage ../development/python-modules/zxing-cpp { libzxing-cpp = pkgs.zxing-cpp; };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -28,12 +28,9 @@ self: super: with self; {
   setuptools = callPackage ../development/python-modules/setuptools { };
 
   # keep-sorted start block=yes newline_separated=yes
-
   a2wsgi = callPackage ../development/python-modules/a2wsgi { };
 
   aafigure = callPackage ../development/python-modules/aafigure { };
-
-  airportsdata = callPackage ../development/python-modules/airportsdata { };
 
   aardwolf = callPackage ../development/python-modules/aardwolf { };
 
@@ -43,13 +40,13 @@ self: super: with self; {
 
   absl-py = callPackage ../development/python-modules/absl-py { };
 
-  accessible-pygments = callPackage ../development/python-modules/accessible-pygments { };
-
   accelerate = callPackage ../development/python-modules/accelerate { };
 
-  accuweather = callPackage ../development/python-modules/accuweather { };
+  accessible-pygments = callPackage ../development/python-modules/accessible-pygments { };
 
   accupy = callPackage ../development/python-modules/accupy { };
+
+  accuweather = callPackage ../development/python-modules/accuweather { };
 
   acme = callPackage ../development/python-modules/acme { };
 
@@ -63,9 +60,9 @@ self: super: with self; {
 
   acunetix = callPackage ../development/python-modules/acunetix { };
 
-  adafruit-io = callPackage ../development/python-modules/adafruit-io { };
-
   adafruit-board-toolkit = callPackage ../development/python-modules/adafruit-board-toolkit { };
+
+  adafruit-io = callPackage ../development/python-modules/adafruit-io { };
 
   adafruit-platformdetect = callPackage ../development/python-modules/adafruit-platformdetect { };
 
@@ -131,11 +128,11 @@ self: super: with self; {
 
   agent-py = callPackage ../development/python-modules/agent-py { };
 
+  aggdraw = callPackage ../development/python-modules/aggdraw { };
+
   aggregate6 = callPackage ../development/python-modules/aggregate6 { };
 
   ago = callPackage ../development/python-modules/ago { };
-
-  aggdraw = callPackage ../development/python-modules/aggdraw { };
 
   ahocorapy = callPackage ../development/python-modules/ahocorapy { };
 
@@ -144,6 +141,8 @@ self: super: with self; {
   aider-chat = callPackage ../development/python-modules/aider-chat { };
 
   aigpy = callPackage ../development/python-modules/aigpy { };
+
+  ailment = callPackage ../development/python-modules/ailment { };
 
   aio-geojson-client = callPackage ../development/python-modules/aio-geojson-client { };
 
@@ -173,29 +172,25 @@ self: super: with self; {
 
   aio-pika = callPackage ../development/python-modules/aio-pika { };
 
+  aioacaia = callPackage ../development/python-modules/aioacaia { };
+
   aioairctrl = callPackage ../development/python-modules/aioairctrl { };
 
-  aioacaia = callPackage ../development/python-modules/aioacaia { };
+  aioairq = callPackage ../development/python-modules/aioairq { };
 
   aioairzone = callPackage ../development/python-modules/aioairzone { };
 
   aioairzone-cloud = callPackage ../development/python-modules/aioairzone-cloud { };
 
-  aioairq = callPackage ../development/python-modules/aioairq { };
-
   aioambient = callPackage ../development/python-modules/aioambient { };
+
+  aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   aioapcaccess = callPackage ../development/python-modules/aioapcaccess { };
 
   aioapns = callPackage ../development/python-modules/aioapns { };
 
   aioaquacell = callPackage ../development/python-modules/aioaquacell { };
-
-  aiocron = callPackage ../development/python-modules/aiocron { };
-
-  ailment = callPackage ../development/python-modules/ailment { };
-
-  aioamqp = callPackage ../development/python-modules/aioamqp { };
 
   aioaseko = callPackage ../development/python-modules/aioaseko { };
 
@@ -209,9 +204,15 @@ self: super: with self; {
 
   aiobafi6 = callPackage ../development/python-modules/aiobafi6 { };
 
-  aioboto3 = callPackage ../development/python-modules/aioboto3 { };
+  aiobiketrax = callPackage ../development/python-modules/aiobiketrax { };
 
   aioblescan = callPackage ../development/python-modules/aioblescan { };
+
+  aioboto3 = callPackage ../development/python-modules/aioboto3 { };
+
+  aiobotocore = callPackage ../development/python-modules/aiobotocore { };
+
+  aiobroadlink = callPackage ../development/python-modules/aiobroadlink { };
 
   aiocache = callPackage ../development/python-modules/aiocache { };
 
@@ -222,6 +223,8 @@ self: super: with self; {
   aioconsole = callPackage ../development/python-modules/aioconsole { };
 
   aiocontextvars = callPackage ../development/python-modules/aiocontextvars { };
+
+  aiocron = callPackage ../development/python-modules/aiocron { };
 
   aiocsv = callPackage ../development/python-modules/aiocsv { };
 
@@ -259,11 +262,11 @@ self: super: with self; {
 
   aioftp = callPackage ../development/python-modules/aioftp { };
 
-  aioguardian = callPackage ../development/python-modules/aioguardian { };
-
   aiogithubapi = callPackage ../development/python-modules/aiogithubapi { };
 
   aiogram = callPackage ../development/python-modules/aiogram { };
+
+  aioguardian = callPackage ../development/python-modules/aioguardian { };
 
   aiohappyeyeballs = callPackage ../development/python-modules/aiohappyeyeballs { };
 
@@ -313,14 +316,6 @@ self: super: with self; {
 
   aiohttp-wsgi = callPackage ../development/python-modules/aiohttp-wsgi { };
 
-  aioitertools = callPackage ../development/python-modules/aioitertools { };
-
-  aiobiketrax = callPackage ../development/python-modules/aiobiketrax { };
-
-  aiobotocore = callPackage ../development/python-modules/aiobotocore { };
-
-  aiobroadlink = callPackage ../development/python-modules/aiobroadlink { };
-
   aiohue = callPackage ../development/python-modules/aiohue { };
 
   aiohwenergy = callPackage ../development/python-modules/aiohwenergy { };
@@ -329,6 +324,8 @@ self: super: with self; {
 
   aioinflux = callPackage ../development/python-modules/aioinflux { };
 
+  aioitertools = callPackage ../development/python-modules/aioitertools { };
+
   aiojellyfin = callPackage ../development/python-modules/aiojellyfin { };
 
   aiojobs = callPackage ../development/python-modules/aiojobs { };
@@ -336,8 +333,6 @@ self: super: with self; {
   aiokafka = callPackage ../development/python-modules/aiokafka { };
 
   aiokef = callPackage ../development/python-modules/aiokef { };
-
-  aiolookin = callPackage ../development/python-modules/aiolookin { };
 
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
@@ -348,6 +343,8 @@ self: super: with self; {
   aiolifx-themes = callPackage ../development/python-modules/aiolifx-themes { };
 
   aiolimiter = callPackage ../development/python-modules/aiolimiter { };
+
+  aiolookin = callPackage ../development/python-modules/aiolookin { };
 
   aiolyric = callPackage ../development/python-modules/aiolyric { };
 
@@ -431,23 +428,15 @@ self: super: with self; {
 
   aioruckus = callPackage ../development/python-modules/aioruckus { };
 
-  aiorussound = callPackage ../development/python-modules/aiorussound { };
-
   aiorun = callPackage ../development/python-modules/aiorun { };
+
+  aiorussound = callPackage ../development/python-modules/aiorussound { };
 
   aioruuvigateway = callPackage ../development/python-modules/aioruuvigateway { };
 
   aiorwlock = callPackage ../development/python-modules/aiorwlock { };
 
   aiosasl = callPackage ../development/python-modules/aiosasl { };
-
-  aiosonic = callPackage ../development/python-modules/aiosonic { };
-
-  aiosonos = callPackage ../development/python-modules/aiosonos { };
-
-  aiosql = callPackage ../development/python-modules/aiosql { };
-
-  aiosseclient = callPackage ../development/python-modules/aiosseclient { };
 
   aiosenz = callPackage ../development/python-modules/aiosenz { };
 
@@ -457,9 +446,9 @@ self: super: with self; {
 
   aioshutil = callPackage ../development/python-modules/aioshutil { };
 
-  aioskybell = callPackage ../development/python-modules/aioskybell { };
-
   aiosignal = callPackage ../development/python-modules/aiosignal { };
+
+  aioskybell = callPackage ../development/python-modules/aioskybell { };
 
   aioslimproto = callPackage ../development/python-modules/aioslimproto { };
 
@@ -473,7 +462,15 @@ self: super: with self; {
 
   aiosomecomfort = callPackage ../development/python-modules/aiosomecomfort { };
 
+  aiosonic = callPackage ../development/python-modules/aiosonic { };
+
+  aiosonos = callPackage ../development/python-modules/aiosonos { };
+
+  aiosql = callPackage ../development/python-modules/aiosql { };
+
   aiosqlite = callPackage ../development/python-modules/aiosqlite { };
+
+  aiosseclient = callPackage ../development/python-modules/aiosseclient { };
 
   aiosteamist = callPackage ../development/python-modules/aiosteamist { };
 
@@ -501,21 +498,21 @@ self: super: with self; {
 
   aiovodafone = callPackage ../development/python-modules/aiovodafone { };
 
-  aiowatttime = callPackage ../development/python-modules/aiowatttime { };
-
   aiowaqi = callPackage ../development/python-modules/aiowaqi { };
 
-  aioweenect = callPackage ../development/python-modules/aioweenect { };
+  aiowatttime = callPackage ../development/python-modules/aiowatttime { };
 
   aiowebdav2 = callPackage ../development/python-modules/aiowebdav2 { };
 
   aiowebostv = callPackage ../development/python-modules/aiowebostv { };
 
-  aiowmi = callPackage ../development/python-modules/aiowmi { };
+  aioweenect = callPackage ../development/python-modules/aioweenect { };
 
   aiowinreg = callPackage ../development/python-modules/aiowinreg { };
 
   aiowithings = callPackage ../development/python-modules/aiowithings { };
+
+  aiowmi = callPackage ../development/python-modules/aiowmi { };
 
   aioxmpp = callPackage ../development/python-modules/aioxmpp { };
 
@@ -530,6 +527,8 @@ self: super: with self; {
   airium = callPackage ../development/python-modules/airium { };
 
   airly = callPackage ../development/python-modules/airly { };
+
+  airportsdata = callPackage ../development/python-modules/airportsdata { };
 
   airthings-ble = callPackage ../development/python-modules/airthings-ble { };
 
@@ -590,13 +589,13 @@ self: super: with self; {
 
   allure-behave = callPackage ../development/python-modules/allure-behave { };
 
+  allure-pytest = callPackage ../development/python-modules/allure-pytest { };
+
   allure-python-commons = callPackage ../development/python-modules/allure-python-commons { };
 
   allure-python-commons-test =
     callPackage ../development/python-modules/allure-python-commons-test
       { };
-
-  allure-pytest = callPackage ../development/python-modules/allure-pytest { };
 
   alpha-vantage = callPackage ../development/python-modules/alpha-vantage { };
 
@@ -605,6 +604,12 @@ self: super: with self; {
   altcha = callPackage ../development/python-modules/altcha { };
 
   altgraph = callPackage ../development/python-modules/altgraph { };
+
+  amaranth = callPackage ../development/python-modules/amaranth { };
+
+  amaranth-boards = callPackage ../development/python-modules/amaranth-boards { };
+
+  amaranth-soc = callPackage ../development/python-modules/amaranth-soc { };
 
   amarna = callPackage ../development/python-modules/amarna { };
 
@@ -626,19 +631,17 @@ self: super: with self; {
 
   amshan = callPackage ../development/python-modules/amshan { };
 
-  anonymizeip = callPackage ../development/python-modules/anonymizeip { };
-
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };
 
   ancp-bids = callPackage ../development/python-modules/ancp-bids { };
+
+  androguard = callPackage ../development/python-modules/androguard { };
 
   android-backup = callPackage ../development/python-modules/android-backup { };
 
   androidtv = callPackage ../development/python-modules/androidtv { };
 
   androidtvremote2 = callPackage ../development/python-modules/androidtvremote2 { };
-
-  androguard = callPackage ../development/python-modules/androguard { };
 
   anel-pwrctrl-homeassistant =
     callPackage ../development/python-modules/anel-pwrctrl-homeassistant
@@ -664,7 +667,11 @@ self: super: with self; {
 
   anonip = callPackage ../development/python-modules/anonip { };
 
+  anonymizeip = callPackage ../development/python-modules/anonymizeip { };
+
   anova-wifi = callPackage ../development/python-modules/anova-wifi { };
+
+  ansi = callPackage ../development/python-modules/ansi { };
 
   ansi2html = callPackage ../development/python-modules/ansi2html { };
 
@@ -685,8 +692,6 @@ self: super: with self; {
   ansible-runner = callPackage ../development/python-modules/ansible-runner { };
 
   ansible-vault-rw = callPackage ../development/python-modules/ansible-vault-rw { };
-
-  ansi = callPackage ../development/python-modules/ansi { };
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
@@ -768,11 +773,11 @@ self: super: with self; {
 
   approvaltests = callPackage ../development/python-modules/approvaltests { };
 
-  apptools = callPackage ../development/python-modules/apptools { };
-
   appthreat-vulnerability-db =
     callPackage ../development/python-modules/appthreat-vulnerability-db
       { };
+
+  apptools = callPackage ../development/python-modules/apptools { };
 
   apricot-select = callPackage ../development/python-modules/apricot-select { };
 
@@ -780,9 +785,9 @@ self: super: with self; {
 
   apscheduler = callPackage ../development/python-modules/apscheduler { };
 
-  apsystems-ez1 = callPackage ../development/python-modules/apsystems-ez1 { };
-
   apsw = callPackage ../development/python-modules/apsw { };
+
+  apsystems-ez1 = callPackage ../development/python-modules/apsystems-ez1 { };
 
   apt-repo = callPackage ../development/python-modules/apt-repo { };
 
@@ -826,11 +831,11 @@ self: super: with self; {
 
   argon2-cffi-bindings = callPackage ../development/python-modules/argon2-cffi-bindings { };
 
+  argos-translate-files = callPackage ../development/python-modules/argos-translate-files { };
+
   argostranslate = callPackage ../development/python-modules/argostranslate {
     ctranslate2-cpp = pkgs.ctranslate2;
   };
-
-  argos-translate-files = callPackage ../development/python-modules/argos-translate-files { };
 
   argparse-addons = callPackage ../development/python-modules/argparse-addons { };
 
@@ -843,6 +848,8 @@ self: super: with self; {
   aria2p = callPackage ../development/python-modules/aria2p { };
 
   ariadne = callPackage ../development/python-modules/ariadne { };
+
+  arpeggio = callPackage ../development/python-modules/arpeggio { };
 
   arpy = callPackage ../development/python-modules/arpy { };
 
@@ -924,9 +931,9 @@ self: super: with self; {
 
   assay = callPackage ../development/python-modules/assay { };
 
-  asserts = callPackage ../development/python-modules/asserts { };
-
   assertpy = callPackage ../development/python-modules/assertpy { };
+
+  asserts = callPackage ../development/python-modules/asserts { };
 
   asterisk-mbox = callPackage ../development/python-modules/asterisk-mbox { };
 
@@ -942,13 +949,13 @@ self: super: with self; {
 
   astropy = callPackage ../development/python-modules/astropy { };
 
+  astropy-extension-helpers = callPackage ../development/python-modules/astropy-extension-helpers { };
+
   astropy-healpix = callPackage ../development/python-modules/astropy-healpix { };
 
   astropy-helpers = callPackage ../development/python-modules/astropy-helpers { };
 
   astropy-iers-data = callPackage ../development/python-modules/astropy-iers-data { };
-
-  astropy-extension-helpers = callPackage ../development/python-modules/astropy-extension-helpers { };
 
   astroquery = callPackage ../development/python-modules/astroquery { };
 
@@ -957,8 +964,6 @@ self: super: with self; {
   astunparse = callPackage ../development/python-modules/astunparse { };
 
   asyauth = callPackage ../development/python-modules/asyauth { };
-
-  asyncarve = callPackage ../development/python-modules/asyncarve { };
 
   async-cache = callPackage ../development/python-modules/async-cache { };
 
@@ -972,6 +977,16 @@ self: super: with self; {
 
   async-modbus = callPackage ../development/python-modules/async-modbus { };
 
+  async-stagger = callPackage ../development/python-modules/async-stagger { };
+
+  async-timeout = callPackage ../development/python-modules/async-timeout { };
+
+  async-tkinter-loop = callPackage ../development/python-modules/async-tkinter-loop { };
+
+  async-upnp-client = callPackage ../development/python-modules/async-upnp-client { };
+
+  asyncarve = callPackage ../development/python-modules/asyncarve { };
+
   asyncclick = callPackage ../development/python-modules/asyncclick { };
 
   asynccmd = callPackage ../development/python-modules/asynccmd { };
@@ -982,9 +997,9 @@ self: super: with self; {
 
   asyncio-rlock = callPackage ../development/python-modules/asyncio-rlock { };
 
-  asyncmy = callPackage ../development/python-modules/asyncmy { };
-
   asyncio-throttle = callPackage ../development/python-modules/asyncio-throttle { };
+
+  asyncmy = callPackage ../development/python-modules/asyncmy { };
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
@@ -996,17 +1011,9 @@ self: super: with self; {
 
   asyncstdlib = callPackage ../development/python-modules/asyncstdlib { };
 
-  async-stagger = callPackage ../development/python-modules/async-stagger { };
-
   asynctest = callPackage ../development/python-modules/asynctest { };
 
-  async-timeout = callPackage ../development/python-modules/async-timeout { };
-
-  async-tkinter-loop = callPackage ../development/python-modules/async-tkinter-loop { };
-
   asyncua = callPackage ../development/python-modules/asyncua { };
-
-  async-upnp-client = callPackage ../development/python-modules/async-upnp-client { };
 
   asyncwhois = callPackage ../development/python-modules/asyncwhois { };
 
@@ -1028,9 +1035,9 @@ self: super: with self; {
     callPackage ../development/python-modules/atomicwrites-homeassistant
       { };
 
-  atopile = callPackage ../development/python-modules/atopile { };
-
   atomman = callPackage ../development/python-modules/atomman { };
+
+  atopile = callPackage ../development/python-modules/atopile { };
 
   atproto = callPackage ../development/python-modules/atproto { };
 
@@ -1124,6 +1131,8 @@ self: super: with self; {
 
   autoslot = callPackage ../development/python-modules/autoslot { };
 
+  av = callPackage ../development/python-modules/av { };
+
   avahi = toPythonModule (
     pkgs.avahi.override {
       inherit python;
@@ -1131,19 +1140,17 @@ self: super: with self; {
     }
   );
 
-  av = callPackage ../development/python-modules/av { };
-
   avea = callPackage ../development/python-modules/avea { };
 
   avidtools = callPackage ../development/python-modules/avidtools { };
 
   avion = callPackage ../development/python-modules/avion { };
 
-  avro3k = callPackage ../development/python-modules/avro3k { };
-
   avro = callPackage ../development/python-modules/avro { };
 
   avro-python3 = callPackage ../development/python-modules/avro-python3 { };
+
+  avro3k = callPackage ../development/python-modules/avro3k { };
 
   avwx-engine = callPackage ../development/python-modules/avwx-engine { };
 
@@ -1285,9 +1292,9 @@ self: super: with self; {
 
   azure-mgmt-automation = callPackage ../development/python-modules/azure-mgmt-automation { };
 
-  azure-mgmt-batchai = callPackage ../development/python-modules/azure-mgmt-batchai { };
-
   azure-mgmt-batch = callPackage ../development/python-modules/azure-mgmt-batch { };
+
+  azure-mgmt-batchai = callPackage ../development/python-modules/azure-mgmt-batchai { };
 
   azure-mgmt-billing = callPackage ../development/python-modules/azure-mgmt-billing { };
 
@@ -1435,12 +1442,12 @@ self: super: with self; {
 
   azure-mgmt-rdbms = callPackage ../development/python-modules/azure-mgmt-rdbms { };
 
-  azure-mgmt-recoveryservicesbackup =
-    callPackage ../development/python-modules/azure-mgmt-recoveryservicesbackup
-      { };
-
   azure-mgmt-recoveryservices =
     callPackage ../development/python-modules/azure-mgmt-recoveryservices
+      { };
+
+  azure-mgmt-recoveryservicesbackup =
+    callPackage ../development/python-modules/azure-mgmt-recoveryservicesbackup
       { };
 
   azure-mgmt-redhatopenshift =
@@ -1560,38 +1567,6 @@ self: super: with self; {
     }
   );
 
-  baize = callPackage ../development/python-modules/baize { };
-
-  bambi = callPackage ../development/python-modules/bambi { };
-
-  pad4pi = callPackage ../development/python-modules/pad4pi { };
-
-  paddle-bfloat = callPackage ../development/python-modules/paddle-bfloat { };
-
-  paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
-
-  paddleocr = callPackage ../development/python-modules/paddleocr { };
-
-  paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
-
-  pcffont = callPackage ../development/python-modules/pcffont { };
-
-  pueblo = callPackage ../development/python-modules/pueblo { };
-
-  pulumi = callPackage ../development/python-modules/pulumi { };
-
-  pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
-
-  pulumi-aws-native = pkgs.pulumiPackages.pulumi-aws-native.sdks.python;
-
-  pulumi-azure-native = pkgs.pulumiPackages.pulumi-azure-native.sdks.python;
-
-  pulumi-command = pkgs.pulumiPackages.pulumi-command.sdks.python;
-
-  pulumi-hcloud = pkgs.pulumiPackages.pulumi-hcloud.sdks.python;
-
-  pulumi-random = pkgs.pulumiPackages.pulumi-random.sdks.python;
-
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };
@@ -1613,6 +1588,10 @@ self: super: with self; {
   bacpypes = callPackage ../development/python-modules/bacpypes { };
 
   bagit = callPackage ../development/python-modules/bagit { };
+
+  baize = callPackage ../development/python-modules/baize { };
+
+  bambi = callPackage ../development/python-modules/bambi { };
 
   banal = callPackage ../development/python-modules/banal { };
 
@@ -1640,9 +1619,9 @@ self: super: with self; {
 
   base64io = callPackage ../development/python-modules/base64io { };
 
-  basedtyping = callPackage ../development/python-modules/basedtyping { };
-
   basedmypy = callPackage ../development/python-modules/basedmypy { };
+
+  basedtyping = callPackage ../development/python-modules/basedtyping { };
 
   baseline = callPackage ../development/python-modules/baseline { };
 
@@ -1676,13 +1655,13 @@ self: super: with self; {
 
   bbox = callPackage ../development/python-modules/bbox { };
 
-  bcc = toPythonModule (pkgs.bcc.override { python3Packages = self; });
-
   bc-detect-secrets = callPackage ../development/python-modules/bc-detect-secrets { };
 
   bc-jsonpath-ng = callPackage ../development/python-modules/bc-jsonpath-ng { };
 
   bc-python-hcl2 = callPackage ../development/python-modules/bc-python-hcl2 { };
+
+  bcc = toPythonModule (pkgs.bcc.override { python3Packages = self; });
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };
 
@@ -1704,19 +1683,17 @@ self: super: with self; {
 
   beaker = callPackage ../development/python-modules/beaker { };
 
-  before-after = callPackage ../development/python-modules/before-after { };
-
   beancount = callPackage ../development/python-modules/beancount { };
-
-  beancount_2 = callPackage ../development/python-modules/beancount/2.nix { };
 
   beancount-black = callPackage ../development/python-modules/beancount-black { };
 
-  beancount-parser = callPackage ../development/python-modules/beancount-parser { };
-
   beancount-docverif = callPackage ../development/python-modules/beancount-docverif { };
 
+  beancount-parser = callPackage ../development/python-modules/beancount-parser { };
+
   beancount-plugin-utils = callPackage ../development/python-modules/beancount-plugin-utils { };
+
+  beancount_2 = callPackage ../development/python-modules/beancount/2.nix { };
 
   beangulp = callPackage ../development/python-modules/beangulp { };
 
@@ -1745,6 +1722,8 @@ self: super: with self; {
   beautysh = callPackage ../development/python-modules/beautysh { };
 
   bech32 = callPackage ../development/python-modules/bech32 { };
+
+  before-after = callPackage ../development/python-modules/before-after { };
 
   behave = callPackage ../development/python-modules/behave { };
 
@@ -1820,19 +1799,17 @@ self: super: with self; {
 
   biothings-client = callPackage ../development/python-modules/biothings-client { };
 
-  biplist = callPackage ../development/python-modules/biplist { };
-
   bip-utils = callPackage ../development/python-modules/bip-utils { };
 
   bip32 = callPackage ../development/python-modules/bip32 { };
+
+  biplist = callPackage ../development/python-modules/biplist { };
 
   birch = callPackage ../development/python-modules/birch { };
 
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitbox02 = callPackage ../development/python-modules/bitbox02 { };
-
-  python-bitcoinlib = callPackage ../development/python-modules/python-bitcoinlib { };
 
   bitcoin-utils-fork-minimal =
     callPackage ../development/python-modules/bitcoin-utils-fork-minimal
@@ -1866,11 +1843,11 @@ self: super: with self; {
 
   black = callPackage ../development/python-modules/black { };
 
+  black-macchiato = callPackage ../development/python-modules/black-macchiato { };
+
   blacken-docs = callPackage ../development/python-modules/blacken-docs { };
 
   blackjax = callPackage ../development/python-modules/blackjax { };
-
-  black-macchiato = callPackage ../development/python-modules/black-macchiato { };
 
   blackrenderer = callPackage ../development/python-modules/blackrenderer { };
 
@@ -1904,11 +1881,11 @@ self: super: with self; {
 
   blobfile = callPackage ../development/python-modules/blobfile { };
 
+  block-io = callPackage ../development/python-modules/block-io { };
+
   blockchain = callPackage ../development/python-modules/blockchain { };
 
   blockdiag = callPackage ../development/python-modules/blockdiag { };
-
-  block-io = callPackage ../development/python-modules/block-io { };
 
   blockfrost-python = callPackage ../development/python-modules/blockfrost-python { };
 
@@ -1970,9 +1947,9 @@ self: super: with self; {
 
   bonsai = callPackage ../development/python-modules/bonsai { };
 
-  booleanoperations = callPackage ../development/python-modules/booleanoperations { };
-
   boolean-py = callPackage ../development/python-modules/boolean-py { };
+
+  booleanoperations = callPackage ../development/python-modules/booleanoperations { };
 
   # Build boost for this specific Python version
   # TODO: use separate output for libboost_python.so
@@ -1983,17 +1960,15 @@ self: super: with self; {
     }
   );
 
+  boost-histogram = callPackage ../development/python-modules/boost-histogram {
+    inherit (pkgs) boost;
+  };
+
   borb = callPackage ../development/python-modules/borb { };
 
   bork = callPackage ../development/python-modules/bork { };
 
   boschshcpy = callPackage ../development/python-modules/boschshcpy { };
-
-  bottombar = callPackage ../development/python-modules/bottombar { };
-
-  boost-histogram = callPackage ../development/python-modules/boost-histogram {
-    inherit (pkgs) boost;
-  };
 
   boto3 = callPackage ../development/python-modules/boto3 { };
 
@@ -2008,6 +1983,8 @@ self: super: with self; {
   bottle = callPackage ../development/python-modules/bottle { };
 
   bottleneck = callPackage ../development/python-modules/bottleneck { };
+
+  bottombar = callPackage ../development/python-modules/bottombar { };
 
   bpemb = callPackage ../development/python-modules/bpemb { };
 
@@ -2075,6 +2052,8 @@ self: super: with self; {
 
   bsuite = callPackage ../development/python-modules/bsuite { };
 
+  bt-proximity = callPackage ../development/python-modules/bt-proximity { };
+
   btchip-python = callPackage ../development/python-modules/btchip-python { };
 
   btest = callPackage ../development/python-modules/btest { };
@@ -2082,8 +2061,6 @@ self: super: with self; {
   bthome-ble = callPackage ../development/python-modules/bthome-ble { };
 
   bthomehub5-devicelist = callPackage ../development/python-modules/bthomehub5-devicelist { };
-
-  bt-proximity = callPackage ../development/python-modules/bt-proximity { };
 
   btrees = callPackage ../development/python-modules/btrees { };
 
@@ -2109,9 +2086,9 @@ self: super: with self; {
 
   buildcatrust = callPackage ../development/python-modules/buildcatrust { };
 
-  bump2version = callPackage ../development/python-modules/bump2version { };
-
   bump-my-version = callPackage ../development/python-modules/bump-my-version { };
+
+  bump2version = callPackage ../development/python-modules/bump2version { };
 
   bumpfontversion = callPackage ../development/python-modules/bumpfontversion { };
 
@@ -2131,11 +2108,11 @@ self: super: with self; {
 
   busypie = callPackage ../development/python-modules/busypie { };
 
+  bwapy = callPackage ../development/python-modules/bwapy { };
+
   bx-py-utils = callPackage ../development/python-modules/bx-py-utils { };
 
   bx-python = callPackage ../development/python-modules/bx-python { };
-
-  bwapy = callPackage ../development/python-modules/bwapy { };
 
   bytecode = callPackage ../development/python-modules/bytecode { };
 
@@ -2178,8 +2155,6 @@ self: super: with self; {
 
   caldav = callPackage ../development/python-modules/caldav { };
 
-  calver = callPackage ../development/python-modules/calver { };
-
   callee = callPackage ../development/python-modules/callee { };
 
   calmjs = callPackage ../development/python-modules/calmjs { };
@@ -2188,11 +2163,15 @@ self: super: with self; {
 
   calmjs-types = callPackage ../development/python-modules/calmjs-types { };
 
+  calver = callPackage ../development/python-modules/calver { };
+
   calysto = callPackage ../development/python-modules/calysto { };
 
   calysto-scheme = callPackage ../development/python-modules/calysto-scheme { };
 
   camel-converter = callPackage ../development/python-modules/camel-converter { };
+
+  camelot = callPackage ../development/python-modules/camelot { };
 
   can-isotp = callPackage ../development/python-modules/can-isotp { };
 
@@ -2206,9 +2185,8 @@ self: super: with self; {
 
   cantools = callPackage ../development/python-modules/cantools { };
 
-  camelot = callPackage ../development/python-modules/camelot { };
-
   capstone = callPackage ../development/python-modules/capstone { inherit (pkgs) capstone; };
+
   capstone_4 = callPackage ../development/python-modules/capstone/4.nix {
     inherit (pkgs) capstone_4;
   };
@@ -2269,9 +2247,9 @@ self: super: with self; {
 
   causal-conv1d = callPackage ../development/python-modules/causal-conv1d { };
 
-  cbor2 = callPackage ../development/python-modules/cbor2 { };
-
   cbor = callPackage ../development/python-modules/cbor { };
+
+  cbor2 = callPackage ../development/python-modules/cbor2 { };
 
   cccolutils = callPackage ../development/python-modules/cccolutils { krb5-c = pkgs.krb5; };
 
@@ -2292,43 +2270,6 @@ self: super: with self; {
   cemm = callPackage ../development/python-modules/cemm { };
 
   censys = callPackage ../development/python-modules/censys { };
-
-  cexprtk = callPackage ../development/python-modules/cexprtk { };
-
-  coal = toPythonModule (
-    pkgs.coal.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  coffea = callPackage ../development/python-modules/coffea { };
-
-  cohere = callPackage ../development/python-modules/cohere { };
-
-  coincurve = callPackage ../development/python-modules/coincurve { inherit (pkgs) secp256k1; };
-
-  comicapi = callPackage ../development/python-modules/comicapi { };
-
-  comicon = callPackage ../development/python-modules/comicon { };
-
-  command-runner = callPackage ../development/python-modules/command-runner { };
-
-  commitizen = callPackage ../development/python-modules/commitizen { };
-
-  consolekit = callPackage ../development/python-modules/consolekit { };
-
-  connect-box = callPackage ../development/python-modules/connect-box { };
-
-  connection-pool = callPackage ../development/python-modules/connection-pool { };
-
-  connio = callPackage ../development/python-modules/connio { };
-
-  conway-polynomials = callPackage ../development/python-modules/conway-polynomials { };
-
-  correctionlib = callPackage ../development/python-modules/correctionlib { };
-
-  coqpit = callPackage ../development/python-modules/coqpit { };
 
   cerberus = callPackage ../development/python-modules/cerberus { };
 
@@ -2359,6 +2300,8 @@ self: super: with self; {
   certomancer = callPackage ../development/python-modules/certomancer { };
 
   certvalidator = callPackage ../development/python-modules/certvalidator { };
+
+  cexprtk = callPackage ../development/python-modules/cexprtk { };
 
   cf-xarray = callPackage ../development/python-modules/cf-xarray { };
 
@@ -2408,9 +2351,9 @@ self: super: with self; {
 
   channels-redis = callPackage ../development/python-modules/channels-redis { };
 
-  characteristic = callPackage ../development/python-modules/characteristic { };
-
   character-encoding-utils = callPackage ../development/python-modules/character-encoding-utils { };
+
+  characteristic = callPackage ../development/python-modules/characteristic { };
 
   chardet = callPackage ../development/python-modules/chardet { };
 
@@ -2468,13 +2411,13 @@ self: super: with self; {
 
   cirq-core = callPackage ../development/python-modules/cirq-core { };
 
-  cirq-ionq = callPackage ../development/python-modules/cirq-ionq { };
-
   cirq-google = callPackage ../development/python-modules/cirq-google { };
 
-  cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };
+  cirq-ionq = callPackage ../development/python-modules/cirq-ionq { };
 
   cirq-pasqal = callPackage ../development/python-modules/cirq-pasqal { };
+
+  cirq-rigetti = callPackage ../development/python-modules/cirq-rigetti { };
 
   cirq-web = callPackage ../development/python-modules/cirq-web { };
 
@@ -2502,6 +2445,8 @@ self: super: with self; {
 
   claripy = callPackage ../development/python-modules/claripy { };
 
+  class-doc = callPackage ../development/python-modules/class-doc { };
+
   classify-imports = callPackage ../development/python-modules/classify-imports { };
 
   cle = callPackage ../development/python-modules/cle { };
@@ -2520,25 +2465,13 @@ self: super: with self; {
 
   clf = callPackage ../development/python-modules/clf { };
 
+  cli-helpers = callPackage ../development/python-modules/cli-helpers { };
+
   cli-ui = callPackage ../development/python-modules/cli-ui { };
-
-  clip = callPackage ../development/python-modules/clip { };
-
-  clip-anytorch = callPackage ../development/python-modules/clip-anytorch { };
-
-  clr-loader = callPackage ../development/python-modules/clr-loader { };
-
-  cock = callPackage ../development/python-modules/cock { };
-
-  cobs = callPackage ../development/python-modules/cobs { };
-
-  class-doc = callPackage ../development/python-modules/class-doc { };
 
   cliche = callPackage ../development/python-modules/cliche { };
 
   click = callPackage ../development/python-modules/click { };
-
-  clickclick = callPackage ../development/python-modules/clickclick { };
 
   click-aliases = callPackage ../development/python-modules/click-aliases { };
 
@@ -2566,13 +2499,15 @@ self: super: with self; {
 
   click-plugins = callPackage ../development/python-modules/click-plugins { };
 
+  click-repl = callPackage ../development/python-modules/click-repl { };
+
   click-shell = callPackage ../development/python-modules/click-shell { };
 
   click-spinner = callPackage ../development/python-modules/click-spinner { };
 
-  click-repl = callPackage ../development/python-modules/click-repl { };
-
   click-threading = callPackage ../development/python-modules/click-threading { };
+
+  clickclick = callPackage ../development/python-modules/clickclick { };
 
   clickgen = callPackage ../development/python-modules/clickgen { };
 
@@ -2590,13 +2525,15 @@ self: super: with self; {
 
   cligj = callPackage ../development/python-modules/cligj { };
 
-  cli-helpers = callPackage ../development/python-modules/cli-helpers { };
-
   clikit = callPackage ../development/python-modules/clikit { };
 
   clint = callPackage ../development/python-modules/clint { };
 
   clintermission = callPackage ../development/python-modules/clintermission { };
+
+  clip = callPackage ../development/python-modules/clip { };
+
+  clip-anytorch = callPackage ../development/python-modules/clip-anytorch { };
 
   clize = callPackage ../development/python-modules/clize { };
 
@@ -2617,6 +2554,8 @@ self: super: with self; {
   cloudsplaining = callPackage ../development/python-modules/cloudsplaining { };
 
   cloup = callPackage ../development/python-modules/cloup { };
+
+  clr-loader = callPackage ../development/python-modules/clr-loader { };
 
   cltk = callPackage ../development/python-modules/cltk { };
 
@@ -2652,9 +2591,20 @@ self: super: with self; {
 
   co2signal = callPackage ../development/python-modules/co2signal { };
 
+  coal = toPythonModule (
+    pkgs.coal.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
   coapthon3 = callPackage ../development/python-modules/coapthon3 { };
 
   cobble = callPackage ../development/python-modules/cobble { };
+
+  cobs = callPackage ../development/python-modules/cobs { };
+
+  cock = callPackage ../development/python-modules/cock { };
 
   coconut = callPackage ../development/python-modules/coconut { };
 
@@ -2664,15 +2614,21 @@ self: super: with self; {
 
   codepy = callPackage ../development/python-modules/codepy { };
 
+  coffea = callPackage ../development/python-modules/coffea { };
+
   cogapp = callPackage ../development/python-modules/cogapp { };
+
+  cohere = callPackage ../development/python-modules/cohere { };
 
   coiled = callPackage ../development/python-modules/coiled { };
 
+  coincurve = callPackage ../development/python-modules/coincurve { inherit (pkgs) secp256k1; };
+
   coinmetrics-api-client = callPackage ../development/python-modules/coinmetrics-api-client { };
 
-  colanderalchemy = callPackage ../development/python-modules/colanderalchemy { };
-
   colander = callPackage ../development/python-modules/colander { };
+
+  colanderalchemy = callPackage ../development/python-modules/colanderalchemy { };
 
   colbert-ai = callPackage ../development/python-modules/colbert-ai { };
 
@@ -2716,13 +2672,21 @@ self: super: with self; {
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
+  comicapi = callPackage ../development/python-modules/comicapi { };
+
+  comicon = callPackage ../development/python-modules/comicon { };
+
   comm = callPackage ../development/python-modules/comm { };
+
+  command-runner = callPackage ../development/python-modules/command-runner { };
 
   commandlines = callPackage ../development/python-modules/commandlines { };
 
   commandparse = callPackage ../development/python-modules/commandparse { };
 
   commentjson = callPackage ../development/python-modules/commentjson { };
+
+  commitizen = callPackage ../development/python-modules/commitizen { };
 
   commoncode = callPackage ../development/python-modules/commoncode { };
 
@@ -2764,6 +2728,8 @@ self: super: with self; {
 
   configclass = callPackage ../development/python-modules/configclass { };
 
+  confight = callPackage ../development/python-modules/confight { };
+
   configobj = callPackage ../development/python-modules/configobj { };
 
   configparser = callPackage ../development/python-modules/configparser { };
@@ -2774,15 +2740,21 @@ self: super: with self; {
 
   confluent-kafka = callPackage ../development/python-modules/confluent-kafka { };
 
-  confuse = callPackage ../development/python-modules/confuse { };
-
   confusable-homoglyphs = callPackage ../development/python-modules/confusable-homoglyphs { };
 
-  confight = callPackage ../development/python-modules/confight { };
+  confuse = callPackage ../development/python-modules/confuse { };
+
+  connect-box = callPackage ../development/python-modules/connect-box { };
+
+  connection-pool = callPackage ../development/python-modules/connection-pool { };
 
   connexion = callPackage ../development/python-modules/connexion { };
 
+  connio = callPackage ../development/python-modules/connio { };
+
   cons = callPackage ../development/python-modules/cons { };
+
+  consolekit = callPackage ../development/python-modules/consolekit { };
 
   consonance = callPackage ../development/python-modules/consonance { };
 
@@ -2812,6 +2784,8 @@ self: super: with self; {
 
   convertertools = callPackage ../development/python-modules/convertertools { };
 
+  conway-polynomials = callPackage ../development/python-modules/conway-polynomials { };
+
   cookidoo-api = callPackage ../development/python-modules/cookidoo-api { };
 
   cookiecutter = callPackage ../development/python-modules/cookiecutter { };
@@ -2824,6 +2798,8 @@ self: super: with self; {
 
   copykitten = callPackage ../development/python-modules/copykitten { };
 
+  coqpit = callPackage ../development/python-modules/coqpit { };
+
   coreapi = callPackage ../development/python-modules/coreapi { };
 
   coredis = callPackage ../development/python-modules/coredis { };
@@ -2833,6 +2809,8 @@ self: super: with self; {
   corner = callPackage ../development/python-modules/corner { };
 
   cornice = callPackage ../development/python-modules/cornice { };
+
+  correctionlib = callPackage ../development/python-modules/correctionlib { };
 
   corsair-scan = callPackage ../development/python-modules/corsair-scan { };
 
@@ -2947,12 +2925,6 @@ self: super: with self; {
 
   csrmesh = callPackage ../development/python-modules/csrmesh { };
 
-  cssbeautifier = callPackage ../development/python-modules/cssbeautifier { };
-
-  csscompressor = callPackage ../development/python-modules/csscompressor { };
-
-  cssmin = callPackage ../development/python-modules/cssmin { };
-
   css-html-js-minify = callPackage ../development/python-modules/css-html-js-minify { };
 
   css-inline = callPackage ../development/python-modules/css-inline {
@@ -2961,9 +2933,15 @@ self: super: with self; {
 
   css-parser = callPackage ../development/python-modules/css-parser { };
 
-  cssselect2 = callPackage ../development/python-modules/cssselect2 { };
+  cssbeautifier = callPackage ../development/python-modules/cssbeautifier { };
+
+  csscompressor = callPackage ../development/python-modules/csscompressor { };
+
+  cssmin = callPackage ../development/python-modules/cssmin { };
 
   cssselect = callPackage ../development/python-modules/cssselect { };
+
+  cssselect2 = callPackage ../development/python-modules/cssselect2 { };
 
   cssutils = callPackage ../development/python-modules/cssutils { };
 
@@ -2983,12 +2961,6 @@ self: super: with self; {
 
   cu2qu = callPackage ../development/python-modules/cu2qu { };
 
-  curated-tokenizers = callPackage ../development/python-modules/curated-tokenizers { };
-
-  curated-transformers = callPackage ../development/python-modules/curated-transformers { };
-
-  customtkinter = callPackage ../development/python-modules/customtkinter { };
-
   cucumber-tag-expressions = callPackage ../development/python-modules/cucumber-tag-expressions { };
 
   cupy = callPackage ../development/python-modules/cupy {
@@ -3001,19 +2973,25 @@ self: super: with self; {
     );
   };
 
+  curated-tokenizers = callPackage ../development/python-modules/curated-tokenizers { };
+
+  curated-transformers = callPackage ../development/python-modules/curated-transformers { };
+
   curio = callPackage ../development/python-modules/curio { };
 
   curio-compat = callPackage ../development/python-modules/curio-compat { };
 
-  curlify = callPackage ../development/python-modules/curlify { };
-
   curl-cffi = callPackage ../development/python-modules/curl-cffi { };
+
+  curlify = callPackage ../development/python-modules/curlify { };
 
   curtsies = callPackage ../development/python-modules/curtsies { };
 
   curve25519-donna = callPackage ../development/python-modules/curve25519-donna { };
 
   curvefitgui = callPackage ../development/python-modules/curvefitgui { };
+
+  customtkinter = callPackage ../development/python-modules/customtkinter { };
 
   cvelib = callPackage ../development/python-modules/cvelib { };
 
@@ -3067,11 +3045,11 @@ self: super: with self; {
 
   cython = callPackage ../development/python-modules/cython { };
 
-  cython_0 = callPackage ../development/python-modules/cython/0.nix { };
-
   cython-test-exception-raiser =
     callPackage ../development/python-modules/cython-test-exception-raiser
       { };
+
+  cython_0 = callPackage ../development/python-modules/cython/0.nix { };
 
   cytoolz = callPackage ../development/python-modules/cytoolz { };
 
@@ -3141,9 +3119,9 @@ self: super: with self; {
 
   databricks-connect = callPackage ../development/python-modules/databricks-connect { };
 
-  databricks-sql-connector = callPackage ../development/python-modules/databricks-sql-connector { };
-
   databricks-sdk = callPackage ../development/python-modules/databricks-sdk { };
+
+  databricks-sql-connector = callPackage ../development/python-modules/databricks-sql-connector { };
 
   dataclass-factory = callPackage ../development/python-modules/dataclass-factory { };
 
@@ -3214,6 +3192,8 @@ self: super: with self; {
 
   dazl = callPackage ../development/python-modules/dazl { };
 
+  db-dtypes = callPackage ../development/python-modules/db-dtypes { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };
@@ -3254,8 +3234,6 @@ self: super: with self; {
 
   dbutils = callPackage ../development/python-modules/dbutils { };
 
-  db-dtypes = callPackage ../development/python-modules/db-dtypes { };
-
   dcmstack = callPackage ../development/python-modules/dcmstack { };
 
   dctorch = callPackage ../development/python-modules/dctorch { };
@@ -3268,29 +3246,31 @@ self: super: with self; {
 
   deap = callPackage ../development/python-modules/deap { };
 
-  debianbts = callPackage ../development/python-modules/debianbts { };
-
   debian-inspector = callPackage ../development/python-modules/debian-inspector { };
+
+  debianbts = callPackage ../development/python-modules/debianbts { };
 
   debtcollector = callPackage ../development/python-modules/debtcollector { };
 
   debts = callPackage ../development/python-modules/debts { };
 
-  debugpy = callPackage ../development/python-modules/debugpy { };
-
   debuglater = callPackage ../development/python-modules/debuglater { };
+
+  debugpy = callPackage ../development/python-modules/debugpy { };
 
   decli = callPackage ../development/python-modules/decli { };
 
-  decorator = callPackage ../development/python-modules/decorator { };
-
   decopatch = callPackage ../development/python-modules/decopatch { };
+
+  decorator = callPackage ../development/python-modules/decorator { };
 
   deebot-client = callPackage ../development/python-modules/deebot-client { };
 
   deemix = callPackage ../development/python-modules/deemix { };
 
   deep-chainmap = callPackage ../development/python-modules/deep-chainmap { };
+
+  deep-translator = callPackage ../development/python-modules/deep-translator { };
 
   deepdiff = callPackage ../development/python-modules/deepdiff { };
 
@@ -3311,8 +3291,6 @@ self: super: with self; {
   deeptoolsintervals = callPackage ../development/python-modules/deeptoolsintervals { };
 
   deepwave = callPackage ../development/python-modules/deepwave { };
-
-  deep-translator = callPackage ../development/python-modules/deep-translator { };
 
   deezer-py = callPackage ../development/python-modules/deezer-py { };
 
@@ -3408,9 +3386,9 @@ self: super: with self; {
 
   diceware = callPackage ../development/python-modules/diceware { };
 
-  dicom2nifti = callPackage ../development/python-modules/dicom2nifti { };
-
   dicom-numpy = callPackage ../development/python-modules/dicom-numpy { };
+
+  dicom2nifti = callPackage ../development/python-modules/dicom2nifti { };
 
   dicomweb-client = callPackage ../development/python-modules/dicomweb-client { };
 
@@ -3440,9 +3418,9 @@ self: super: with self; {
 
   dill = callPackage ../development/python-modules/dill { };
 
-  dingz = callPackage ../development/python-modules/dingz { };
-
   dinghy = callPackage ../development/python-modules/dinghy { };
+
+  dingz = callPackage ../development/python-modules/dingz { };
 
   dio-chacon-wifi-api = callPackage ../development/python-modules/dio-chacon-wifi-api { };
 
@@ -3488,12 +3466,6 @@ self: super: with self; {
 
   dissect-cstruct = callPackage ../development/python-modules/dissect-cstruct { };
 
-  dissect-fat = callPackage ../development/python-modules/dissect-fat { };
-
-  dissect-ffs = callPackage ../development/python-modules/dissect-ffs { };
-
-  dissect-fve = callPackage ../development/python-modules/dissect-fve { };
-
   dissect-esedb = callPackage ../development/python-modules/dissect-esedb { };
 
   dissect-etl = callPackage ../development/python-modules/dissect-etl { };
@@ -3505,6 +3477,12 @@ self: super: with self; {
   dissect-executable = callPackage ../development/python-modules/dissect-executable { };
 
   dissect-extfs = callPackage ../development/python-modules/dissect-extfs { };
+
+  dissect-fat = callPackage ../development/python-modules/dissect-fat { };
+
+  dissect-ffs = callPackage ../development/python-modules/dissect-ffs { };
+
+  dissect-fve = callPackage ../development/python-modules/dissect-fve { };
 
   dissect-hypervisor = callPackage ../development/python-modules/dissect-hypervisor { };
 
@@ -3518,9 +3496,9 @@ self: super: with self; {
 
   dissect-shellitem = callPackage ../development/python-modules/dissect-shellitem { };
 
-  dissect-squashfs = callPackage ../development/python-modules/dissect-squashfs { };
-
   dissect-sql = callPackage ../development/python-modules/dissect-sql { };
+
+  dissect-squashfs = callPackage ../development/python-modules/dissect-squashfs { };
 
   dissect-target = callPackage ../development/python-modules/dissect-target { };
 
@@ -3553,21 +3531,20 @@ self: super: with self; {
 
   distutils-extra = callPackage ../development/python-modules/distutils-extra { };
 
-  # LTS in extended support phase
-  django_3 = callPackage ../development/python-modules/django/3.nix { };
+  dj-database-url = callPackage ../development/python-modules/dj-database-url { };
+
+  dj-email-url = callPackage ../development/python-modules/dj-email-url { };
+
+  dj-rest-auth = callPackage ../development/python-modules/dj-rest-auth { };
+
+  dj-search-url = callPackage ../development/python-modules/dj-search-url { };
+
+  dj-static = callPackage ../development/python-modules/dj-static { };
+
+  dj-stripe = callPackage ../development/python-modules/dj-stripe { };
 
   # LTS with mainsteam support
   django = self.django_4;
-  django_4 = callPackage ../development/python-modules/django/4.nix { };
-
-  # Pre-release
-  django_5 = callPackage ../development/python-modules/django/5.nix { };
-
-  djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
-
-  djangocms-text-ckeditor = callPackage ../development/python-modules/djangocms-text-ckeditor { };
-
-  djangocms-alias = callPackage ../development/python-modules/djangocms-alias { };
 
   django-admin-datta = callPackage ../development/python-modules/django-admin-datta { };
 
@@ -3575,13 +3552,13 @@ self: super: with self; {
 
   django-allauth = callPackage ../development/python-modules/django-allauth { };
 
-  django-anymail = callPackage ../development/python-modules/django-anymail { };
-
   django-annoying = callPackage ../development/python-modules/django-annoying { };
 
-  django-appconf = callPackage ../development/python-modules/django-appconf { };
+  django-anymail = callPackage ../development/python-modules/django-anymail { };
 
   django-app-helper = callPackage ../development/python-modules/django-app-helper { };
+
+  django-appconf = callPackage ../development/python-modules/django-appconf { };
 
   django-apscheduler = callPackage ../development/python-modules/django-apscheduler { };
 
@@ -3627,11 +3604,11 @@ self: super: with self; {
 
   django-colorful = callPackage ../development/python-modules/django-colorful { };
 
-  django-compressor = callPackage ../development/python-modules/django-compressor { };
-
   django-compression-middleware =
     callPackage ../development/python-modules/django-compression-middleware
       { };
+
+  django-compressor = callPackage ../development/python-modules/django-compressor { };
 
   django-configurations = callPackage ../development/python-modules/django-configurations { };
 
@@ -3683,23 +3660,23 @@ self: super: with self; {
 
   django-filter = callPackage ../development/python-modules/django-filter { };
 
-  django-formtools = callPackage ../development/python-modules/django-formtools { };
-
   django-formset-js-improved =
     callPackage ../development/python-modules/django-formset-js-improved
       { };
 
+  django-formtools = callPackage ../development/python-modules/django-formtools { };
+
   django-fsm = callPackage ../development/python-modules/django-fsm { };
+
+  django-google-analytics-app =
+    callPackage ../development/python-modules/django-google-analytics-app
+      { };
 
   django-graphiql-debug-toolbar =
     callPackage ../development/python-modules/django-graphiql-debug-toolbar
       { };
 
   django-gravatar2 = callPackage ../development/python-modules/django-gravatar2 { };
-
-  django-google-analytics-app =
-    callPackage ../development/python-modules/django-google-analytics-app
-      { };
 
   django-guardian = callPackage ../development/python-modules/django-guardian { };
 
@@ -3725,15 +3702,17 @@ self: super: with self; {
 
   django-jquery-js = callPackage ../development/python-modules/django-jquery-js { };
 
-  django-json-widget = callPackage ../development/python-modules/django-json-widget { };
-
   django-js-asset = callPackage ../development/python-modules/django-js-asset { };
 
   django-js-reverse = callPackage ../development/python-modules/django-js-reverse { };
 
-  django-libsass = callPackage ../development/python-modules/django-libsass { };
+  django-json-widget = callPackage ../development/python-modules/django-json-widget { };
 
   django-leaflet = callPackage ../development/python-modules/django-leaflet { };
+
+  django-libsass = callPackage ../development/python-modules/django-libsass { };
+
+  django-localflavor = callPackage ../development/python-modules/django-localflavor { };
 
   django-logentry-admin = callPackage ../development/python-modules/django-logentry-admin { };
 
@@ -3741,13 +3720,15 @@ self: super: with self; {
     callPackage ../development/python-modules/django-login-required-middleware
       { };
 
-  django-localflavor = callPackage ../development/python-modules/django-localflavor { };
-
   django-mailman3 = callPackage ../development/python-modules/django-mailman3 { };
+
+  django-maintenance-mode = callPackage ../development/python-modules/django-maintenance-mode { };
+
+  django-markdownx = callPackage ../development/python-modules/django-markdownx { };
 
   django-markup = callPackage ../development/python-modules/django-markup { };
 
-  django-markdownx = callPackage ../development/python-modules/django-markdownx { };
+  django-mdeditor = callPackage ../development/python-modules/django-mdeditor { };
 
   django-mfa3 = callPackage ../development/python-modules/django-mfa3 { };
 
@@ -3757,13 +3738,9 @@ self: super: with self; {
 
   django-modeltranslation = callPackage ../development/python-modules/django-modeltranslation { };
 
-  django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };
-
-  django-maintenance-mode = callPackage ../development/python-modules/django-maintenance-mode { };
-
-  django-mdeditor = callPackage ../development/python-modules/django-mdeditor { };
-
   django-mptt = callPackage ../development/python-modules/django-mptt { };
+
+  django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };
 
   django-ninja = callPackage ../development/python-modules/django-ninja { };
 
@@ -3805,27 +3782,15 @@ self: super: with self; {
 
   django-q2 = callPackage ../development/python-modules/django-q2 { };
 
-  django-registration = callPackage ../development/python-modules/django-registration { };
-
-  django-scheduler = callPackage ../development/python-modules/django-scheduler { };
-
-  django-scim2 = callPackage ../development/python-modules/django-scim2 { };
-
-  django-shortuuidfield = callPackage ../development/python-modules/django-shortuuidfield { };
-
-  django-scopes = callPackage ../development/python-modules/django-scopes { };
-
-  django-split-settings = callPackage ../development/python-modules/django-split-settings { };
-
-  djangoql = callPackage ../development/python-modules/djangoql { };
-
   django-ranged-response = callPackage ../development/python-modules/django-ranged-response { };
-
-  django-ratelimit = callPackage ../development/python-modules/django-ratelimit { };
 
   django-raster = callPackage ../development/python-modules/django-raster { };
 
+  django-ratelimit = callPackage ../development/python-modules/django-ratelimit { };
+
   django-redis = callPackage ../development/python-modules/django-redis { };
+
+  django-registration = callPackage ../development/python-modules/django-registration { };
 
   django-rest-auth = callPackage ../development/python-modules/django-rest-auth { };
 
@@ -3833,49 +3798,23 @@ self: super: with self; {
 
   django-rest-registration = callPackage ../development/python-modules/django-rest-registration { };
 
+  django-reversion = callPackage ../development/python-modules/django-reversion { };
+
   django-rosetta = callPackage ../development/python-modules/django-rosetta { };
 
   django-rq = callPackage ../development/python-modules/django-rq { };
 
-  djangorestframework = callPackage ../development/python-modules/djangorestframework { };
+  django-scheduler = callPackage ../development/python-modules/django-scheduler { };
 
-  djangorestframework-dataclasses =
-    callPackage ../development/python-modules/djangorestframework-dataclasses
-      { };
+  django-scim2 = callPackage ../development/python-modules/django-scim2 { };
 
-  djangorestframework-camel-case =
-    callPackage ../development/python-modules/djangorestframework-camel-case
-      { };
-
-  djangorestframework-csv = callPackage ../development/python-modules/djangorestframework-csv { };
-
-  djangorestframework-guardian =
-    callPackage ../development/python-modules/djangorestframework-guardian
-      { };
-
-  djangorestframework-guardian2 =
-    callPackage ../development/python-modules/djangorestframework-guardian2
-      { };
-
-  djangorestframework-jsonp = callPackage ../development/python-modules/djangorestframework-jsonp { };
-
-  djangorestframework-recursive =
-    callPackage ../development/python-modules/djangorestframework-recursive
-      { };
-
-  djangorestframework-simplejwt =
-    callPackage ../development/python-modules/djangorestframework-simplejwt
-      { };
-
-  djangorestframework-stubs = callPackage ../development/python-modules/djangorestframework-stubs { };
-
-  django-reversion = callPackage ../development/python-modules/django-reversion { };
-
-  djangosaml2 = callPackage ../development/python-modules/djangosaml2 { };
+  django-scopes = callPackage ../development/python-modules/django-scopes { };
 
   django-sekizai = callPackage ../development/python-modules/django-sekizai { };
 
   django-sesame = callPackage ../development/python-modules/django-sesame { };
+
+  django-shortuuidfield = callPackage ../development/python-modules/django-shortuuidfield { };
 
   django-silk = callPackage ../development/python-modules/django-silk { };
 
@@ -3886,6 +3825,8 @@ self: super: with self; {
   django-sites = callPackage ../development/python-modules/django-sites { };
 
   django-soft-delete = callPackage ../development/python-modules/django-soft-delete { };
+
+  django-split-settings = callPackage ../development/python-modules/django-split-settings { };
 
   django-sql-utils = callPackage ../development/python-modules/django-sql-utils { };
 
@@ -3931,19 +3872,57 @@ self: super: with self; {
 
   django-widget-tweaks = callPackage ../development/python-modules/django-widget-tweaks { };
 
-  dj-database-url = callPackage ../development/python-modules/dj-database-url { };
+  # LTS in extended support phase
+  django_3 = callPackage ../development/python-modules/django/3.nix { };
 
-  dj-email-url = callPackage ../development/python-modules/dj-email-url { };
+  django_4 = callPackage ../development/python-modules/django/4.nix { };
+
+  # Pre-release
+  django_5 = callPackage ../development/python-modules/django/5.nix { };
+
+  djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
+
+  djangocms-alias = callPackage ../development/python-modules/djangocms-alias { };
+
+  djangocms-text-ckeditor = callPackage ../development/python-modules/djangocms-text-ckeditor { };
+
+  djangoql = callPackage ../development/python-modules/djangoql { };
+
+  djangorestframework = callPackage ../development/python-modules/djangorestframework { };
+
+  djangorestframework-camel-case =
+    callPackage ../development/python-modules/djangorestframework-camel-case
+      { };
+
+  djangorestframework-csv = callPackage ../development/python-modules/djangorestframework-csv { };
+
+  djangorestframework-dataclasses =
+    callPackage ../development/python-modules/djangorestframework-dataclasses
+      { };
+
+  djangorestframework-guardian =
+    callPackage ../development/python-modules/djangorestframework-guardian
+      { };
+
+  djangorestframework-guardian2 =
+    callPackage ../development/python-modules/djangorestframework-guardian2
+      { };
+
+  djangorestframework-jsonp = callPackage ../development/python-modules/djangorestframework-jsonp { };
+
+  djangorestframework-recursive =
+    callPackage ../development/python-modules/djangorestframework-recursive
+      { };
+
+  djangorestframework-simplejwt =
+    callPackage ../development/python-modules/djangorestframework-simplejwt
+      { };
+
+  djangorestframework-stubs = callPackage ../development/python-modules/djangorestframework-stubs { };
+
+  djangosaml2 = callPackage ../development/python-modules/djangosaml2 { };
 
   djmail = callPackage ../development/python-modules/djmail { };
-
-  dj-rest-auth = callPackage ../development/python-modules/dj-rest-auth { };
-
-  dj-search-url = callPackage ../development/python-modules/dj-search-url { };
-
-  dj-static = callPackage ../development/python-modules/dj-static { };
-
-  dj-stripe = callPackage ../development/python-modules/dj-stripe { };
 
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
@@ -3957,12 +3936,6 @@ self: super: with self; {
 
   dlx = callPackage ../development/python-modules/dlx { };
 
-  dmenu-python = callPackage ../development/python-modules/dmenu { };
-
-  dmgbuild = callPackage ../development/python-modules/dmgbuild { };
-
-  dmt-core = callPackage ../development/python-modules/dmt-core { };
-
   dm-control = callPackage ../development/python-modules/dm-control { };
 
   dm-env = callPackage ../development/python-modules/dm-env { };
@@ -3975,6 +3948,12 @@ self: super: with self; {
     abseil-cpp = pkgs.abseil-cpp.override { cxxStandard = "14"; };
   };
 
+  dmenu-python = callPackage ../development/python-modules/dmenu { };
+
+  dmgbuild = callPackage ../development/python-modules/dmgbuild { };
+
+  dmt-core = callPackage ../development/python-modules/dmt-core { };
+
   dnachisel = callPackage ../development/python-modules/dnachisel { };
 
   dncil = callPackage ../development/python-modules/dncil { };
@@ -3985,11 +3964,11 @@ self: super: with self; {
 
   dnfile = callPackage ../development/python-modules/dnfile { };
 
+  dns-lexicon = callPackage ../development/python-modules/dns-lexicon { };
+
   dnslib = callPackage ../development/python-modules/dnslib { };
 
   dnspython = callPackage ../development/python-modules/dnspython { };
-
-  dns-lexicon = callPackage ../development/python-modules/dns-lexicon { };
 
   doc8 = callPackage ../development/python-modules/doc8 { };
 
@@ -3997,11 +3976,11 @@ self: super: with self; {
 
   docker = callPackage ../development/python-modules/docker { };
 
+  docker-pycreds = callPackage ../development/python-modules/docker-pycreds { };
+
   dockerfile-parse = callPackage ../development/python-modules/dockerfile-parse { };
 
   dockerpty = callPackage ../development/python-modules/dockerpty { };
-
-  docker-pycreds = callPackage ../development/python-modules/docker-pycreds { };
 
   dockerspawner = callPackage ../development/python-modules/dockerspawner { };
 
@@ -4017,12 +3996,6 @@ self: super: with self; {
 
   docloud = callPackage ../development/python-modules/docloud { };
 
-  docstr-coverage = callPackage ../development/python-modules/docstr-coverage { };
-
-  docstring-to-markdown = callPackage ../development/python-modules/docstring-to-markdown { };
-
-  docstring-parser = callPackage ../development/python-modules/docstring-parser { };
-
   docopt = callPackage ../development/python-modules/docopt { };
 
   docopt-ng = callPackage ../development/python-modules/docopt-ng { };
@@ -4032,6 +4005,12 @@ self: super: with self; {
   docplex = callPackage ../development/python-modules/docplex { };
 
   docrep = callPackage ../development/python-modules/docrep { };
+
+  docstr-coverage = callPackage ../development/python-modules/docstr-coverage { };
+
+  docstring-parser = callPackage ../development/python-modules/docstring-parser { };
+
+  docstring-to-markdown = callPackage ../development/python-modules/docstring-to-markdown { };
 
   docutils = callPackage ../development/python-modules/docutils { };
 
@@ -4069,13 +4048,13 @@ self: super: with self; {
 
   dopy = callPackage ../development/python-modules/dopy { };
 
-  dotty-dict = callPackage ../development/python-modules/dotty-dict { };
-
   dot2tex = callPackage ../development/python-modules/dot2tex { inherit (pkgs) graphviz; };
 
-  dotwiz = callPackage ../development/python-modules/dotwiz { };
-
   dotmap = callPackage ../development/python-modules/dotmap { };
+
+  dotty-dict = callPackage ../development/python-modules/dotty-dict { };
+
+  dotwiz = callPackage ../development/python-modules/dotwiz { };
 
   downloader-cli = callPackage ../development/python-modules/downloader-cli { };
 
@@ -4139,13 +4118,15 @@ self: super: with self; {
 
   dropmqttapi = callPackage ../development/python-modules/dropmqttapi { };
 
-  dscribe = callPackage ../development/python-modules/dscribe { };
-
   ds-store = callPackage ../development/python-modules/ds-store { };
 
   ds4drv = callPackage ../development/python-modules/ds4drv { };
 
+  dscribe = callPackage ../development/python-modules/dscribe { };
+
   dsinternals = callPackage ../development/python-modules/dsinternals { };
+
+  dsl2html = callPackage ../development/python-modules/dsl2html { };
 
   dsmr-parser = callPackage ../development/python-modules/dsmr-parser { };
 
@@ -4235,13 +4216,13 @@ self: super: with self; {
 
   dynd = callPackage ../development/python-modules/dynd { };
 
-  dsl2html = callPackage ../development/python-modules/dsl2html { };
-
   e3-core = callPackage ../development/python-modules/e3-core { };
 
   e3-testsuite = callPackage ../development/python-modules/e3-testsuite { };
 
   eagle100 = callPackage ../development/python-modules/eagle100 { };
+
+  easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
 
   easydict = callPackage ../development/python-modules/easydict { };
 
@@ -4255,8 +4236,6 @@ self: super: with self; {
 
   easyprocess = callPackage ../development/python-modules/easyprocess { };
 
-  easy-thumbnails = callPackage ../development/python-modules/easy-thumbnails { };
-
   easywatch = callPackage ../development/python-modules/easywatch { };
 
   ebaysdk = callPackage ../development/python-modules/ebaysdk { };
@@ -4265,9 +4244,9 @@ self: super: with self; {
 
   ebooklib = callPackage ../development/python-modules/ebooklib { };
 
-  ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };
-
   ec2-metadata = callPackage ../development/python-modules/ec2-metadata { };
+
+  ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };
 
   eccodes = toPythonModule (
     pkgs.eccodes.override {
@@ -4330,19 +4309,15 @@ self: super: with self; {
 
   eiswarnung = callPackage ../development/python-modules/eiswarnung { };
 
-  elgato = callPackage ../development/python-modules/elgato { };
-
-  elkm1-lib = callPackage ../development/python-modules/elkm1-lib { };
-
   elastic-apm = callPackage ../development/python-modules/elastic-apm { };
 
   elastic-transport = callPackage ../development/python-modules/elastic-transport { };
 
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
-  elasticsearch8 = callPackage ../development/python-modules/elasticsearch8 { };
-
   elasticsearch-dsl = callPackage ../development/python-modules/elasticsearch-dsl { };
+
+  elasticsearch8 = callPackage ../development/python-modules/elasticsearch8 { };
 
   elasticsearchdsl = self.elasticsearch-dsl;
 
@@ -4354,27 +4329,29 @@ self: super: with self; {
 
   elevenlabs = callPackage ../development/python-modules/elevenlabs { };
 
+  elgato = callPackage ../development/python-modules/elgato { };
+
   eliot = callPackage ../development/python-modules/eliot { };
 
   eliqonline = callPackage ../development/python-modules/eliqonline { };
+
+  elkm1-lib = callPackage ../development/python-modules/elkm1-lib { };
 
   elmax = callPackage ../development/python-modules/elmax { };
 
   elmax-api = callPackage ../development/python-modules/elmax-api { };
 
-  emailthreads = callPackage ../development/python-modules/emailthreads { };
-
   email-validator = callPackage ../development/python-modules/email-validator { };
+
+  emailthreads = callPackage ../development/python-modules/emailthreads { };
 
   embedding-reader = callPackage ../development/python-modules/embedding-reader { };
 
-  embrace = callPackage ../development/python-modules/embrace { };
-
   emborg = callPackage ../development/python-modules/emborg { };
 
-  emcee = callPackage ../development/python-modules/emcee { };
+  embrace = callPackage ../development/python-modules/embrace { };
 
-  emv = callPackage ../development/python-modules/emv { };
+  emcee = callPackage ../development/python-modules/emcee { };
 
   emoji = callPackage ../development/python-modules/emoji { };
 
@@ -4383,6 +4360,8 @@ self: super: with self; {
   empy = callPackage ../development/python-modules/empy { };
 
   emulated-roku = callPackage ../development/python-modules/emulated-roku { };
+
+  emv = callPackage ../development/python-modules/emv { };
 
   enaml = callPackage ../development/python-modules/enaml { };
 
@@ -4428,11 +4407,11 @@ self: super: with self; {
 
   envisage = callPackage ../development/python-modules/envisage { };
 
-  envs = callPackage ../development/python-modules/envs { };
-
   envoy-reader = callPackage ../development/python-modules/envoy-reader { };
 
   envoy-utils = callPackage ../development/python-modules/envoy-utils { };
+
+  envs = callPackage ../development/python-modules/envs { };
 
   enzyme = callPackage ../development/python-modules/enzyme { };
 
@@ -4460,6 +4439,8 @@ self: super: with self; {
 
   es-client = callPackage ../development/python-modules/es-client { };
 
+  escapism = callPackage ../development/python-modules/escapism { };
+
   eseries = callPackage ../development/python-modules/eseries { };
 
   esig = callPackage ../development/python-modules/esig { };
@@ -4474,11 +4455,11 @@ self: super: with self; {
 
   esprima = callPackage ../development/python-modules/esprima { };
 
-  escapism = callPackage ../development/python-modules/escapism { };
-
   essentials = callPackage ../development/python-modules/essentials { };
 
   essentials-openapi = callPackage ../development/python-modules/essentials-openapi { };
+
+  et-xmlfile = callPackage ../development/python-modules/et-xmlfile { };
 
   etcd = callPackage ../development/python-modules/etcd { };
 
@@ -4486,11 +4467,11 @@ self: super: with self; {
 
   ete3 = callPackage ../development/python-modules/ete3 { };
 
-  etelemetry = callPackage ../development/python-modules/etelemetry { };
-
   etebase = callPackage ../development/python-modules/etebase {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
+
+  etelemetry = callPackage ../development/python-modules/etelemetry { };
 
   eternalegypt = callPackage ../development/python-modules/eternalegypt { };
 
@@ -4521,8 +4502,6 @@ self: super: with self; {
   etils = callPackage ../development/python-modules/etils { };
 
   etuples = callPackage ../development/python-modules/etuples { };
-
-  et-xmlfile = callPackage ../development/python-modules/et-xmlfile { };
 
   euclid3 = callPackage ../development/python-modules/euclid3 { };
 
@@ -4563,11 +4542,11 @@ self: super: with self; {
     }
   );
 
-  exdown = callPackage ../development/python-modules/exdown { };
-
   exceptiongroup = callPackage ../development/python-modules/exceptiongroup { };
 
   exchangelib = callPackage ../development/python-modules/exchangelib { };
+
+  exdown = callPackage ../development/python-modules/exdown { };
 
   execnb = callPackage ../development/python-modules/execnb { };
 
@@ -4580,6 +4559,8 @@ self: super: with self; {
   exif = callPackage ../development/python-modules/exif { };
 
   exifread = callPackage ../development/python-modules/exifread { };
+
+  exitcode = callPackage ../development/python-modules/exitcode { };
 
   exiv2 = callPackage ../development/python-modules/exiv2 { inherit (pkgs) exiv2; };
 
@@ -4598,8 +4579,6 @@ self: super: with self; {
   explorerscript = callPackage ../development/python-modules/explorerscript { };
 
   exrex = callPackage ../development/python-modules/exrex { };
-
-  exitcode = callPackage ../development/python-modules/exitcode { };
 
   extension-helpers = callPackage ../development/python-modules/extension-helpers { };
 
@@ -4654,25 +4633,25 @@ self: super: with self; {
 
   f90nml = callPackage ../development/python-modules/f90nml { };
 
+  faadelays = callPackage ../development/python-modules/faadelays { };
+
   fabio = callPackage ../development/python-modules/fabio { };
 
   fabric = callPackage ../development/python-modules/fabric { };
 
-  faadelays = callPackage ../development/python-modules/faadelays { };
-
   fabulous = callPackage ../development/python-modules/fabulous { };
-
-  facebook-sdk = callPackage ../development/python-modules/facebook-sdk { };
 
   face = callPackage ../development/python-modules/face { };
 
-  facedancer = callPackage ../development/python-modules/facedancer { };
-
   face-recognition = callPackage ../development/python-modules/face-recognition { };
 
-  facenet-pytorch = callPackage ../development/python-modules/facenet-pytorch { };
-
   face-recognition-models = callPackage ../development/python-modules/face-recognition/models.nix { };
+
+  facebook-sdk = callPackage ../development/python-modules/facebook-sdk { };
+
+  facedancer = callPackage ../development/python-modules/facedancer { };
+
+  facenet-pytorch = callPackage ../development/python-modules/facenet-pytorch { };
 
   factory-boy = callPackage ../development/python-modules/factory-boy { };
 
@@ -4707,6 +4686,8 @@ self: super: with self; {
 
   farama-notifications = callPackage ../development/python-modules/farama-notifications { };
 
+  fast-histogram = callPackage ../development/python-modules/fast-histogram { };
+
   fastai = callPackage ../development/python-modules/fastai { };
 
   fastapi = callPackage ../development/python-modules/fastapi { };
@@ -4717,10 +4698,6 @@ self: super: with self; {
 
   fastapi-sso = callPackage ../development/python-modules/fastapi-sso { };
 
-  fastcrc = callPackage ../development/python-modules/fastcrc { };
-
-  fast-histogram = callPackage ../development/python-modules/fast-histogram { };
-
   fastavro = callPackage ../development/python-modules/fastavro { };
 
   fastbencode = callPackage ../development/python-modules/fastbencode { };
@@ -4728,6 +4705,8 @@ self: super: with self; {
   fastcache = callPackage ../development/python-modules/fastcache { };
 
   fastcore = callPackage ../development/python-modules/fastcore { };
+
+  fastcrc = callPackage ../development/python-modules/fastcrc { };
 
   fastdiff = callPackage ../development/python-modules/fastdiff { };
 
@@ -4753,14 +4732,14 @@ self: super: with self; {
 
   fastjsonschema = callPackage ../development/python-modules/fastjsonschema { };
 
+  fastmri = callPackage ../development/python-modules/fastmri { };
+
   fastnlo-toolkit = toPythonModule (
     pkgs.fastnlo-toolkit.override {
       withPython = true;
       inherit (self) python;
     }
   );
-
-  fastmri = callPackage ../development/python-modules/fastmri { };
 
   fastnumbers = callPackage ../development/python-modules/fastnumbers { };
 
@@ -4809,9 +4788,9 @@ self: super: with self; {
 
   ffcv = callPackage ../development/python-modules/ffcv { };
 
-  ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
-
   ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };
+
+  ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
@@ -4845,9 +4824,9 @@ self: super: with self; {
 
   finalfusion = callPackage ../development/python-modules/finalfusion { };
 
-  findimports = callPackage ../development/python-modules/findimports { };
-
   find-libpython = callPackage ../development/python-modules/find-libpython { };
+
+  findimports = callPackage ../development/python-modules/findimports { };
 
   findpython = callPackage ../development/python-modules/findpython { };
 
@@ -4867,9 +4846,9 @@ self: super: with self; {
 
   fire = callPackage ../development/python-modules/fire { };
 
-  firebase-messaging = callPackage ../development/python-modules/firebase-messaging { };
-
   firebase-admin = callPackage ../development/python-modules/firebase-admin { };
+
+  firebase-messaging = callPackage ../development/python-modules/firebase-messaging { };
 
   firecrawl-py = callPackage ../development/python-modules/firecrawl-py { };
 
@@ -4893,13 +4872,11 @@ self: super: with self; {
 
   fjaraskupan = callPackage ../development/python-modules/fjaraskupan { };
 
+  flake8 = callPackage ../development/python-modules/flake8 { };
+
   flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };
 
   flake8-bugbear = callPackage ../development/python-modules/flake8-bugbear { };
-
-  flake8 = callPackage ../development/python-modules/flake8 { };
-
-  flake8-length = callPackage ../development/python-modules/flake8-length { };
 
   flake8-class-newline = callPackage ../development/python-modules/flake8-class-newline { };
 
@@ -4912,6 +4889,8 @@ self: super: with self; {
   flake8-future-import = callPackage ../development/python-modules/flake8-future-import { };
 
   flake8-import-order = callPackage ../development/python-modules/flake8-import-order { };
+
+  flake8-length = callPackage ../development/python-modules/flake8-length { };
 
   flake8-polyfill = callPackage ../development/python-modules/flake8-polyfill { };
 
@@ -4926,6 +4905,8 @@ self: super: with self; {
   flasgger = callPackage ../development/python-modules/flasgger { };
 
   flashtext = callPackage ../development/python-modules/flashtext { };
+
+  flask = callPackage ../development/python-modules/flask { };
 
   flask-admin = callPackage ../development/python-modules/flask-admin { };
 
@@ -4944,8 +4925,6 @@ self: super: with self; {
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };
 
   flask-caching = callPackage ../development/python-modules/flask-caching { };
-
-  flask = callPackage ../development/python-modules/flask { };
 
   flask-compress = callPackage ../development/python-modules/flask-compress { };
 
@@ -5001,11 +4980,11 @@ self: super: with self; {
 
   flask-seasurf = callPackage ../development/python-modules/flask-seasurf { };
 
+  flask-security = callPackage ../development/python-modules/flask-security { };
+
   flask-session = callPackage ../development/python-modules/flask-session { };
 
   flask-session-captcha = callPackage ../development/python-modules/flask-session-captcha { };
-
-  flask-security = callPackage ../development/python-modules/flask-security { };
 
   flask-silk = callPackage ../development/python-modules/flask-silk { };
 
@@ -5113,11 +5092,15 @@ self: super: with self; {
 
   flynt = callPackage ../development/python-modules/flynt { };
 
+  fnllm = callPackage ../development/python-modules/fnllm { };
+
   fnv-hash-fast = callPackage ../development/python-modules/fnv-hash-fast { };
 
   fnvhash = callPackage ../development/python-modules/fnvhash { };
 
   folium = callPackage ../development/python-modules/folium { };
+
+  font-v = callPackage ../development/python-modules/font-v { };
 
   fontawesomefree = callPackage ../development/python-modules/fontawesomefree { };
 
@@ -5134,6 +5117,8 @@ self: super: with self; {
     )
   );
 
+  fontmake = callPackage ../development/python-modules/fontmake { };
+
   fontmath = callPackage ../development/python-modules/fontmath { };
 
   fontparts = callPackage ../development/python-modules/fontparts { };
@@ -5141,34 +5126,6 @@ self: super: with self; {
   fontpens = callPackage ../development/python-modules/fontpens { };
 
   fonttools = callPackage ../development/python-modules/fonttools { };
-
-  fontmake = callPackage ../development/python-modules/fontmake { };
-
-  font-v = callPackage ../development/python-modules/font-v { };
-
-  free-proxy = callPackage ../development/python-modules/free-proxy { };
-
-  freenub = callPackage ../development/python-modules/freenub { };
-
-  skia-pathops = callPackage ../development/python-modules/skia-pathops {
-    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL;
-  };
-
-  oelint-parser = callPackage ../development/python-modules/oelint-parser { };
-
-  ohme = callPackage ../development/python-modules/ohme { };
-
-  openstep-parser = callPackage ../development/python-modules/openstep-parser { };
-
-  openstep-plist = callPackage ../development/python-modules/openstep-plist { };
-
-  glyphsets = callPackage ../development/python-modules/glyphsets { };
-
-  glyphslib = callPackage ../development/python-modules/glyphslib { };
-
-  glyphtools = callPackage ../development/python-modules/glyphtools { };
-
-  fnllm = callPackage ../development/python-modules/fnllm { };
 
   foobot-async = callPackage ../development/python-modules/foobot-async { };
 
@@ -5180,13 +5137,13 @@ self: super: with self; {
 
   formbox = callPackage ../development/python-modules/formbox { };
 
-  formulae = callPackage ../development/python-modules/formulae { };
-
-  fortiosapi = callPackage ../development/python-modules/fortiosapi { };
-
   formencode = callPackage ../development/python-modules/formencode { };
 
+  formulae = callPackage ../development/python-modules/formulae { };
+
   formulaic = callPackage ../development/python-modules/formulaic { };
+
+  fortiosapi = callPackage ../development/python-modules/fortiosapi { };
 
   foundationdb73 = callPackage ../servers/foundationdb/python.nix {
     foundationdb = pkgs.foundationdb73;
@@ -5206,7 +5163,11 @@ self: super: with self; {
 
   fqdn = callPackage ../development/python-modules/fqdn { };
 
+  free-proxy = callPackage ../development/python-modules/free-proxy { };
+
   freebox-api = callPackage ../development/python-modules/freebox-api { };
+
+  freenub = callPackage ../development/python-modules/freenub { };
 
   freertos-gdb = callPackage ../development/python-modules/freertos-gdb { };
 
@@ -5244,9 +5205,9 @@ self: super: with self; {
 
   fslpy = callPackage ../development/python-modules/fslpy { };
 
-  fsspec-xrootd = callPackage ../development/python-modules/fsspec-xrootd { };
-
   fsspec = callPackage ../development/python-modules/fsspec { };
+
+  fsspec-xrootd = callPackage ../development/python-modules/fsspec-xrootd { };
 
   fst-pso = callPackage ../development/python-modules/fst-pso { };
 
@@ -5317,9 +5278,9 @@ self: super: with self; {
 
   gardena-bluetooth = callPackage ../development/python-modules/gardena-bluetooth { };
 
-  garminconnect-aio = callPackage ../development/python-modules/garminconnect-aio { };
-
   garminconnect = callPackage ../development/python-modules/garminconnect { };
+
+  garminconnect-aio = callPackage ../development/python-modules/garminconnect-aio { };
 
   garth = callPackage ../development/python-modules/garth { };
 
@@ -5420,11 +5381,11 @@ self: super: with self; {
 
   geoarrow-c = callPackage ../development/python-modules/geoarrow-c { };
 
-  geoarrow-types = callPackage ../development/python-modules/geoarrow-types { };
-
   geoarrow-pandas = callPackage ../development/python-modules/geoarrow-pandas { };
 
   geoarrow-pyarrow = callPackage ../development/python-modules/geoarrow-pyarrow { };
+
+  geoarrow-types = callPackage ../development/python-modules/geoarrow-types { };
 
   geocachingapi = callPackage ../development/python-modules/geocachingapi { };
 
@@ -5434,9 +5395,9 @@ self: super: with self; {
 
   geographiclib = callPackage ../development/python-modules/geographiclib { };
 
-  geoip2 = callPackage ../development/python-modules/geoip2 { };
-
   geoip = callPackage ../development/python-modules/geoip { libgeoip = pkgs.geoip; };
+
+  geoip2 = callPackage ../development/python-modules/geoip2 { };
 
   geojson = callPackage ../development/python-modules/geojson { };
 
@@ -5480,29 +5441,29 @@ self: super: with self; {
 
   gepetto-gui = toPythonModule (gepetto-viewer.withPlugins [ gepetto-viewer-corba ]);
 
+  gepetto-viewer = toPythonModule (pkgs.gepetto-viewer.override { python3Packages = self; });
+
   gepetto-viewer-corba = toPythonModule (
     pkgs.gepetto-viewer-corba.override { python3Packages = self; }
   );
 
-  gepetto-viewer = toPythonModule (pkgs.gepetto-viewer.override { python3Packages = self; });
-
   gerbonara = callPackage ../development/python-modules/gerbonara { };
-
-  getjump = callPackage ../development/python-modules/getjump { };
-
-  getmac = callPackage ../development/python-modules/getmac { };
-
-  getkey = callPackage ../development/python-modules/getkey { };
 
   get-video-properties = callPackage ../development/python-modules/get-video-properties { };
 
-  gevent = callPackage ../development/python-modules/gevent { };
+  getjump = callPackage ../development/python-modules/getjump { };
 
-  geventhttpclient = callPackage ../development/python-modules/geventhttpclient { };
+  getkey = callPackage ../development/python-modules/getkey { };
+
+  getmac = callPackage ../development/python-modules/getmac { };
+
+  gevent = callPackage ../development/python-modules/gevent { };
 
   gevent-socketio = callPackage ../development/python-modules/gevent-socketio { };
 
   gevent-websocket = callPackage ../development/python-modules/gevent-websocket { };
+
+  geventhttpclient = callPackage ../development/python-modules/geventhttpclient { };
 
   gfal2-python = callPackage ../development/python-modules/gfal2-python { };
 
@@ -5546,6 +5507,8 @@ self: super: with self; {
 
   git-annex-adapter = callPackage ../development/python-modules/git-annex-adapter { };
 
+  git-dummy = callPackage ../development/python-modules/git-dummy { };
+
   git-filter-repo = callPackage ../development/python-modules/git-filter-repo { };
 
   git-find-repos = callPackage ../development/python-modules/git-find-repos { };
@@ -5556,11 +5519,9 @@ self: super: with self; {
 
   git-url-parse = callPackage ../development/python-modules/git-url-parse { };
 
-  git-dummy = callPackage ../development/python-modules/git-dummy { };
+  git-versioner = callPackage ../development/python-modules/git-versioner { };
 
   gitdb = callPackage ../development/python-modules/gitdb { };
-
-  githubkit = callPackage ../development/python-modules/githubkit { };
 
   github-to-sqlite = callPackage ../development/python-modules/github-to-sqlite { };
 
@@ -5568,15 +5529,15 @@ self: super: with self; {
 
   github3-py = callPackage ../development/python-modules/github3-py { };
 
-  gitingest = callPackage ../development/python-modules/gitingest { };
+  githubkit = callPackage ../development/python-modules/githubkit { };
 
   gitignore-parser = callPackage ../development/python-modules/gitignore-parser { };
+
+  gitingest = callPackage ../development/python-modules/gitingest { };
 
   gitlike-commands = callPackage ../development/python-modules/gitlike-commands { };
 
   gitpython = callPackage ../development/python-modules/gitpython { };
-
-  git-versioner = callPackage ../development/python-modules/git-versioner { };
 
   glad = callPackage ../development/python-modules/glad { };
 
@@ -5604,9 +5565,17 @@ self: super: with self; {
 
   glymur = callPackage ../development/python-modules/glymur { };
 
-  gmpy2 = callPackage ../development/python-modules/gmpy2 { };
+  glyphsets = callPackage ../development/python-modules/glyphsets { };
+
+  glyphslib = callPackage ../development/python-modules/glyphslib { };
+
+  glyphtools = callPackage ../development/python-modules/glyphtools { };
 
   gmpy = callPackage ../development/python-modules/gmpy { };
+
+  gmpy2 = callPackage ../development/python-modules/gmpy2 { };
+
+  gmqtt = callPackage ../development/python-modules/gmqtt { };
 
   gmsh = toPythonModule (
     pkgs.gmsh.override {
@@ -5614,8 +5583,6 @@ self: super: with self; {
       enablePython = true;
     }
   );
-
-  gmqtt = callPackage ../development/python-modules/gmqtt { };
 
   gntp = callPackage ../development/python-modules/gntp { };
 
@@ -5633,8 +5600,6 @@ self: super: with self; {
 
   goodwe = callPackage ../development/python-modules/goodwe { };
 
-  gophish = callPackage ../development/python-modules/gophish { };
-
   google = callPackage ../development/python-modules/google { };
 
   google-ai-generativelanguage =
@@ -5644,8 +5609,6 @@ self: super: with self; {
   google-api-core = callPackage ../development/python-modules/google-api-core { };
 
   google-api-python-client = callPackage ../development/python-modules/google-api-python-client { };
-
-  googleapis-common-protos = callPackage ../development/python-modules/googleapis-common-protos { };
 
   google-auth = callPackage ../development/python-modules/google-auth { };
 
@@ -5801,11 +5764,9 @@ self: super: with self; {
 
   google-nest-sdm = callPackage ../development/python-modules/google-nest-sdm { };
 
-  google-photos-library-api = callPackage ../development/python-modules/google-photos-library-api { };
-
-  googlemaps = callPackage ../development/python-modules/googlemaps { };
-
   google-pasta = callPackage ../development/python-modules/google-pasta { };
+
+  google-photos-library-api = callPackage ../development/python-modules/google-photos-library-api { };
 
   google-re2 = callPackage ../development/python-modules/google-re2 { };
 
@@ -5813,15 +5774,21 @@ self: super: with self; {
 
   google-search-results = callPackage ../development/python-modules/google-search-results { };
 
+  googleapis-common-protos = callPackage ../development/python-modules/googleapis-common-protos { };
+
+  googlemaps = callPackage ../development/python-modules/googlemaps { };
+
   googletrans = callPackage ../development/python-modules/googletrans { };
 
-  gotailwind = callPackage ../development/python-modules/gotailwind { };
-
-  gotenberg-client = callPackage ../development/python-modules/gotenberg-client { };
+  gophish = callPackage ../development/python-modules/gophish { };
 
   gorilla = callPackage ../development/python-modules/gorilla { };
 
   goslide-api = callPackage ../development/python-modules/goslide-api { };
+
+  gotailwind = callPackage ../development/python-modules/gotailwind { };
+
+  gotenberg-client = callPackage ../development/python-modules/gotenberg-client { };
 
   govee-ble = callPackage ../development/python-modules/govee-ble { };
 
@@ -5837,21 +5804,25 @@ self: super: with self; {
 
   gpaw = callPackage ../development/python-modules/gpaw { };
 
+  gpgme = callPackage ../development/python-modules/gpgme { inherit (pkgs) gpgme; };
+
+  gphoto2 = callPackage ../development/python-modules/gphoto2 { };
+
   gpib-ctypes = callPackage ../development/python-modules/gpib-ctypes { };
 
   gpiozero = callPackage ../development/python-modules/gpiozero { };
 
   gplaycli = callPackage ../development/python-modules/gplaycli { };
 
-  gpgme = callPackage ../development/python-modules/gpgme { inherit (pkgs) gpgme; };
-
-  gphoto2 = callPackage ../development/python-modules/gphoto2 { };
-
   gprof2dot = callPackage ../development/python-modules/gprof2dot { inherit (pkgs) graphviz; };
 
   gps3 = callPackage ../development/python-modules/gps3 { };
 
   gpsoauth = callPackage ../development/python-modules/gpsoauth { };
+
+  gpt-2-simple = callPackage ../development/python-modules/gpt-2-simple { };
+
+  gptcache = callPackage ../development/python-modules/gptcache { };
 
   gpuctypes = callPackage ../development/python-modules/gpuctypes { };
 
@@ -5863,19 +5834,15 @@ self: super: with self; {
 
   gpytorch = callPackage ../development/python-modules/gpytorch { };
 
-  gpt-2-simple = callPackage ../development/python-modules/gpt-2-simple { };
-
-  gptcache = callPackage ../development/python-modules/gptcache { };
-
   gql = callPackage ../development/python-modules/gql { };
 
   grad-cam = callPackage ../development/python-modules/grad-cam { };
 
   gradient = callPackage ../development/python-modules/gradient { };
 
-  gradient-utils = callPackage ../development/python-modules/gradient-utils { };
-
   gradient-statsd = callPackage ../development/python-modules/gradient-statsd { };
+
+  gradient-utils = callPackage ../development/python-modules/gradient-utils { };
 
   gradio = callPackage ../development/python-modules/gradio { };
 
@@ -5889,17 +5856,17 @@ self: super: with self; {
 
   grandalf = callPackage ../development/python-modules/grandalf { };
 
-  grapheme = callPackage ../development/python-modules/grapheme { };
+  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal; };
 
-  graphite-web = callPackage ../development/python-modules/graphite-web { };
+  grapheme = callPackage ../development/python-modules/grapheme { };
 
   graphene = callPackage ../development/python-modules/graphene { };
 
   graphene-django = callPackage ../development/python-modules/graphene-django { };
 
-  graphlib-backport = callPackage ../development/python-modules/graphlib-backport { };
+  graphite-web = callPackage ../development/python-modules/graphite-web { };
 
-  graphqlclient = callPackage ../development/python-modules/graphqlclient { };
+  graphlib-backport = callPackage ../development/python-modules/graphlib-backport { };
 
   graphql-core = callPackage ../development/python-modules/graphql-core { };
 
@@ -5911,9 +5878,9 @@ self: super: with self; {
     callPackage ../development/python-modules/graphql-subscription-manager
       { };
 
-  graphrag = callPackage ../development/python-modules/graphrag { };
+  graphqlclient = callPackage ../development/python-modules/graphqlclient { };
 
-  graph-tool = callPackage ../development/python-modules/graph-tool { inherit (pkgs) cgal; };
+  graphrag = callPackage ../development/python-modules/graphrag { };
 
   graphtage = callPackage ../development/python-modules/graphtage { };
 
@@ -5925,11 +5892,11 @@ self: super: with self; {
 
   graspologic-native = callPackage ../development/python-modules/graspologic-native { };
 
-  greatfet = callPackage ../development/python-modules/greatfet { };
-
   great-expectations = callPackage ../development/python-modules/great-expectations { };
 
   great-tables = callPackage ../development/python-modules/great-tables { };
+
+  greatfet = callPackage ../development/python-modules/greatfet { };
 
   greeclimate = callPackage ../development/python-modules/greeclimate { };
 
@@ -5942,17 +5909,13 @@ self: super: with self; {
   # built-in for pypi
   greenlet = if isPyPy then null else callPackage ../development/python-modules/greenlet { };
 
-  grequests = callPackage ../development/python-modules/grequests { };
-
   gremlinpython = callPackage ../development/python-modules/gremlinpython { };
 
   grep-ast = callPackage ../development/python-modules/grep-ast { };
 
+  grequests = callPackage ../development/python-modules/grequests { };
+
   greynoise = callPackage ../development/python-modules/greynoise { };
-
-  groq = callPackage ../development/python-modules/groq { };
-
-  growattserver = callPackage ../development/python-modules/growattserver { };
 
   gridnet = callPackage ../development/python-modules/gridnet { };
 
@@ -5963,6 +5926,10 @@ self: super: with self; {
   groestlcoin-hash = callPackage ../development/python-modules/groestlcoin-hash { };
 
   groovy = callPackage ../development/python-modules/groovy { };
+
+  groq = callPackage ../development/python-modules/groq { };
+
+  growattserver = callPackage ../development/python-modules/growattserver { };
 
   grpc-google-iam-v1 = callPackage ../development/python-modules/grpc-google-iam-v1 { };
 
@@ -5980,9 +5947,9 @@ self: super: with self; {
 
   grpcio-status = callPackage ../development/python-modules/grpcio-status { };
 
-  grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
-
   grpcio-testing = callPackage ../development/python-modules/grpcio-testing { };
+
+  grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
 
   grpclib = callPackage ../development/python-modules/grpclib { };
 
@@ -6016,11 +5983,11 @@ self: super: with self; {
 
   gtts-token = callPackage ../development/python-modules/gtts-token { };
 
+  gudhi = callPackage ../development/python-modules/gudhi { inherit (pkgs) cgal; };
+
   guessit = callPackage ../development/python-modules/guessit { };
 
   guestfs = callPackage ../development/python-modules/guestfs { qemu = pkgs.qemu; };
-
-  gudhi = callPackage ../development/python-modules/gudhi { inherit (pkgs) cgal; };
 
   guidance = callPackage ../development/python-modules/guidance { };
 
@@ -6038,9 +6005,9 @@ self: super: with self; {
 
   guzzle-sphinx-theme = callPackage ../development/python-modules/guzzle-sphinx-theme { };
 
-  gvm-tools = callPackage ../development/python-modules/gvm-tools { };
-
   gviz-api = callPackage ../development/python-modules/gviz-api { };
+
+  gvm-tools = callPackage ../development/python-modules/gvm-tools { };
 
   gwcs = callPackage ../development/python-modules/gwcs { };
 
@@ -6066,27 +6033,23 @@ self: super: with self; {
 
   h5py-mpi = self.h5py.override { hdf5 = pkgs.hdf5-mpi; };
 
-  habanero = callPackage ../development/python-modules/habanero { };
-
-  habluetooth = callPackage ../development/python-modules/habluetooth { };
-
-  habitipy = callPackage ../development/python-modules/habitipy { };
-
-  habiticalib = callPackage ../development/python-modules/habiticalib { };
-
-  hachoir = callPackage ../development/python-modules/hachoir { };
-
-  hacking = callPackage ../development/python-modules/hacking { };
-
-  hdate = callPackage ../development/python-modules/hdate { };
-
-  hdf5plugin = callPackage ../development/python-modules/hdf5plugin { };
-
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
   ha-mqtt-discoverable = callPackage ../development/python-modules/ha-mqtt-discoverable { };
 
   ha-philipsjs = callPackage ../development/python-modules/ha-philipsjs { };
+
+  habanero = callPackage ../development/python-modules/habanero { };
+
+  habiticalib = callPackage ../development/python-modules/habiticalib { };
+
+  habitipy = callPackage ../development/python-modules/habitipy { };
+
+  habluetooth = callPackage ../development/python-modules/habluetooth { };
+
+  hachoir = callPackage ../development/python-modules/hachoir { };
+
+  hacking = callPackage ../development/python-modules/hacking { };
 
   hahomematic = callPackage ../development/python-modules/hahomematic { };
 
@@ -6105,9 +6068,9 @@ self: super: with self; {
 
   handout = callPackage ../development/python-modules/handout { };
 
-  hankel = callPackage ../development/python-modules/hankel { };
-
   handy-archives = callPackage ../development/python-modules/handy-archives { };
+
+  hankel = callPackage ../development/python-modules/hankel { };
 
   hanzidentifier = callPackage ../development/python-modules/hanzidentifier { };
 
@@ -6127,23 +6090,23 @@ self: super: with self; {
 
   hatasmota = callPackage ../development/python-modules/hatasmota { };
 
-  hatchling = callPackage ../development/python-modules/hatchling { };
-
   hatch-babel = callPackage ../development/python-modules/hatch-babel { };
 
   hatch-fancy-pypi-readme = callPackage ../development/python-modules/hatch-fancy-pypi-readme { };
 
   hatch-jupyter-builder = callPackage ../development/python-modules/hatch-jupyter-builder { };
 
-  hatch-odoo = callPackage ../development/python-modules/hatch-odoo { };
-
-  hatch-vcs = callPackage ../development/python-modules/hatch-vcs { };
-
   hatch-nodejs-version = callPackage ../development/python-modules/hatch-nodejs-version { };
+
+  hatch-odoo = callPackage ../development/python-modules/hatch-odoo { };
 
   hatch-regex-commit = callPackage ../development/python-modules/hatch-regex-commit { };
 
   hatch-requirements-txt = callPackage ../development/python-modules/hatch-requirements-txt { };
+
+  hatch-vcs = callPackage ../development/python-modules/hatch-vcs { };
+
+  hatchling = callPackage ../development/python-modules/hatchling { };
 
   haversine = callPackage ../development/python-modules/haversine { };
 
@@ -6155,7 +6118,11 @@ self: super: with self; {
 
   hcs-utils = callPackage ../development/python-modules/hcs-utils { };
 
+  hdate = callPackage ../development/python-modules/hdate { };
+
   hdbscan = callPackage ../development/python-modules/hdbscan { };
+
+  hdf5plugin = callPackage ../development/python-modules/hdf5plugin { };
 
   hdfs = callPackage ../development/python-modules/hdfs { };
 
@@ -6197,9 +6164,9 @@ self: super: with self; {
 
   hexdump = callPackage ../development/python-modules/hexdump { };
 
-  hfst = callPackage ../development/python-modules/hfst { };
-
   hf-transfer = callPackage ../development/python-modules/hf-transfer { };
+
+  hfst = callPackage ../development/python-modules/hfst { };
 
   hg-commitsigs = callPackage ../development/python-modules/hg-commitsigs { };
 
@@ -6209,21 +6176,21 @@ self: super: with self; {
 
   hickle = callPackage ../development/python-modules/hickle { };
 
+  hid = callPackage ../development/python-modules/hid { inherit (pkgs) hidapi; };
+
+  hid-parser = callPackage ../development/python-modules/hid-parser { };
+
+  hidapi = callPackage ../development/python-modules/hidapi { inherit (pkgs) hidapi udev; };
+
+  hier-config = callPackage ../development/python-modules/hier-config { };
+
+  hieroglyph = callPackage ../development/python-modules/hieroglyph { };
+
   highdicom = callPackage ../development/python-modules/highdicom { };
 
   highspy = callPackage ../development/python-modules/highspy { };
 
   hightime = callPackage ../development/python-modules/hightime { };
-
-  hid = callPackage ../development/python-modules/hid { inherit (pkgs) hidapi; };
-
-  hidapi = callPackage ../development/python-modules/hidapi { inherit (pkgs) hidapi udev; };
-
-  hid-parser = callPackage ../development/python-modules/hid-parser { };
-
-  hier-config = callPackage ../development/python-modules/hier-config { };
-
-  hieroglyph = callPackage ../development/python-modules/hieroglyph { };
 
   hijri-converter = callPackage ../development/python-modules/hijri-converter { };
 
@@ -6255,9 +6222,9 @@ self: super: with self; {
 
   hlk-sw16 = callPackage ../development/python-modules/hlk-sw16 { };
 
-  hnswlib = callPackage ../development/python-modules/hnswlib { inherit (pkgs) hnswlib; };
-
   hmmlearn = callPackage ../development/python-modules/hmmlearn { };
+
+  hnswlib = callPackage ../development/python-modules/hnswlib { inherit (pkgs) hnswlib; };
 
   hocr-tools = callPackage ../development/python-modules/hocr-tools { };
 
@@ -6271,15 +6238,15 @@ self: super: with self; {
 
   home-assistant-bluetooth = callPackage ../development/python-modules/home-assistant-bluetooth { };
 
-  home-assistant-chip-wheels = toPythonModule (
-    callPackage ../development/python-modules/home-assistant-chip-wheels { }
-  );
-
   home-assistant-chip-clusters =
     callPackage ../development/python-modules/home-assistant-chip-clusters
       { };
 
   home-assistant-chip-core = callPackage ../development/python-modules/home-assistant-chip-core { };
+
+  home-assistant-chip-wheels = toPythonModule (
+    callPackage ../development/python-modules/home-assistant-chip-wheels { }
+  );
 
   homeassistant-stubs = callPackage ../servers/home-assistant/stubs.nix { };
 
@@ -6313,15 +6280,25 @@ self: super: with self; {
 
   hstspreload = callPackage ../development/python-modules/hstspreload { };
 
+  html-sanitizer = callPackage ../development/python-modules/html-sanitizer { };
+
+  html-table-parser-python3 = callPackage ../development/python-modules/html-table-parser-python3 { };
+
+  html-tag-names = callPackage ../development/python-modules/html-tag-names { };
+
+  html-text = callPackage ../development/python-modules/html-text { };
+
+  html-void-elements = callPackage ../development/python-modules/html-void-elements { };
+
   html2image = callPackage ../development/python-modules/html2image { };
 
   html2text = callPackage ../development/python-modules/html2text { };
 
+  html5-parser = callPackage ../development/python-modules/html5-parser { };
+
   html5lib = callPackage ../development/python-modules/html5lib { };
 
   html5tagger = callPackage ../development/python-modules/html5tagger { };
-
-  html5-parser = callPackage ../development/python-modules/html5-parser { };
 
   htmldate = callPackage ../development/python-modules/htmldate { };
 
@@ -6333,19 +6310,19 @@ self: super: with self; {
 
   htmltools = callPackage ../development/python-modules/htmltools { };
 
-  html-sanitizer = callPackage ../development/python-modules/html-sanitizer { };
-
-  html-table-parser-python3 = callPackage ../development/python-modules/html-table-parser-python3 { };
-
-  html-tag-names = callPackage ../development/python-modules/html-tag-names { };
-
-  html-text = callPackage ../development/python-modules/html-text { };
-
-  html-void-elements = callPackage ../development/python-modules/html-void-elements { };
-
   htseq = callPackage ../development/python-modules/htseq { };
 
   httmock = callPackage ../development/python-modules/httmock { };
+
+  http-ece = callPackage ../development/python-modules/http-ece { };
+
+  http-message-signatures = callPackage ../development/python-modules/http-message-signatures { };
+
+  http-parser = callPackage ../development/python-modules/http-parser { };
+
+  http-sf = callPackage ../development/python-modules/http-sf { };
+
+  http-sfv = callPackage ../development/python-modules/http-sfv { };
 
   httpagentparser = callPackage ../development/python-modules/httpagentparser { };
 
@@ -6357,19 +6334,9 @@ self: super: with self; {
 
   httpie = callPackage ../development/python-modules/httpie { };
 
-  http-ece = callPackage ../development/python-modules/http-ece { };
-
   httpie-ntlm = callPackage ../development/python-modules/httpie-ntlm { };
 
   httplib2 = callPackage ../development/python-modules/httplib2 { };
-
-  http-message-signatures = callPackage ../development/python-modules/http-message-signatures { };
-
-  http-parser = callPackage ../development/python-modules/http-parser { };
-
-  http-sf = callPackage ../development/python-modules/http-sf { };
-
-  http-sfv = callPackage ../development/python-modules/http-sfv { };
 
   httpretty = callPackage ../development/python-modules/httpretty { };
 
@@ -6403,11 +6370,11 @@ self: super: with self; {
 
   huisbaasje-client = callPackage ../development/python-modules/huisbaasje-client { };
 
+  human-readable = callPackage ../development/python-modules/human-readable { };
+
   humanfriendly = callPackage ../development/python-modules/humanfriendly { };
 
   humanize = callPackage ../development/python-modules/humanize { };
-
-  human-readable = callPackage ../development/python-modules/human-readable { };
 
   humblewx = callPackage ../development/python-modules/humblewx { };
 
@@ -6441,8 +6408,6 @@ self: super: with self; {
 
   hyperframe = callPackage ../development/python-modules/hyperframe { };
 
-  hyperscan = callPackage ../development/python-modules/hyperscan { };
-
   hyperion-py = callPackage ../development/python-modules/hyperion-py { };
 
   hyperlink = callPackage ../development/python-modules/hyperlink { };
@@ -6451,9 +6416,11 @@ self: super: with self; {
 
   hyperpyyaml = callPackage ../development/python-modules/hyperpyyaml { };
 
-  hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
+  hyperscan = callPackage ../development/python-modules/hyperscan { };
 
   hypothesis = callPackage ../development/python-modules/hypothesis { };
+
+  hypothesis-auto = callPackage ../development/python-modules/hypothesis-auto { };
 
   hypothesmith = callPackage ../development/python-modules/hypothesmith { };
 
@@ -6461,13 +6428,15 @@ self: super: with self; {
 
   hyrule = callPackage ../development/python-modules/hyrule { };
 
+  i-pi = callPackage ../development/python-modules/i-pi { };
+
   i2c-tools = callPackage ../development/python-modules/i2c-tools { inherit (pkgs) i2c-tools; };
 
   i2csense = callPackage ../development/python-modules/i2csense { };
 
-  i3ipc = callPackage ../development/python-modules/i3ipc { };
-
   i3-py = callPackage ../development/python-modules/i3-py { };
+
+  i3ipc = callPackage ../development/python-modules/i3ipc { };
 
   iammeter = callPackage ../development/python-modules/iammeter { };
 
@@ -6501,17 +6470,17 @@ self: super: with self; {
 
   icnsutil = callPackage ../development/python-modules/icnsutil { };
 
-  ics = callPackage ../development/python-modules/ics { };
-
-  idasen = callPackage ../development/python-modules/idasen { };
-
-  idasen-ha = callPackage ../development/python-modules/idasen-ha { };
-
   icoextract = toPythonModule (pkgs.icoextract.override { python3Packages = self; });
 
   icontract = callPackage ../development/python-modules/icontract { };
 
+  ics = callPackage ../development/python-modules/ics { };
+
   id = callPackage ../development/python-modules/id { };
+
+  idasen = callPackage ../development/python-modules/idasen { };
+
+  idasen-ha = callPackage ../development/python-modules/idasen-ha { };
 
   idbutils = callPackage ../development/python-modules/idbutils { };
 
@@ -6545,9 +6514,13 @@ self: super: with self; {
 
   ijson = callPackage ../development/python-modules/ijson { };
 
+  ilcli = callPackage ../development/python-modules/ilcli { };
+
   ilua = callPackage ../development/python-modules/ilua { };
 
-  ilcli = callPackage ../development/python-modules/ilcli { };
+  image-diff = callPackage ../development/python-modules/image-diff { };
+
+  image-go-nord = callPackage ../development/python-modules/image-go-nord { };
 
   imagecodecs-lite = callPackage ../development/python-modules/imagecodecs-lite { };
 
@@ -6561,19 +6534,15 @@ self: super: with self; {
 
   imageio-ffmpeg = callPackage ../development/python-modules/imageio-ffmpeg { };
 
-  image-diff = callPackage ../development/python-modules/image-diff { };
-
-  image-go-nord = callPackage ../development/python-modules/image-go-nord { };
-
   imagesize = callPackage ../development/python-modules/imagesize { };
 
   imantics = callPackage ../development/python-modules/imantics { };
 
+  imap-tools = callPackage ../development/python-modules/imap-tools { };
+
   imapclient = callPackage ../development/python-modules/imapclient { };
 
   imaplib2 = callPackage ../development/python-modules/imaplib2 { };
-
-  imap-tools = callPackage ../development/python-modules/imap-tools { };
 
   imbalanced-learn = callPackage ../development/python-modules/imbalanced-learn { };
 
@@ -6651,2518 +6620,6 @@ self: super: with self; {
   influxdb3-python = callPackage ../development/python-modules/influxdb3-python { };
 
   inform = callPackage ../development/python-modules/inform { };
-
-  iniconfig = callPackage ../development/python-modules/iniconfig { };
-
-  inifile = callPackage ../development/python-modules/inifile { };
-
-  iniparse = callPackage ../development/python-modules/iniparse { };
-
-  inject = callPackage ../development/python-modules/inject { };
-
-  injector = callPackage ../development/python-modules/injector { };
-
-  inkbird-ble = callPackage ../development/python-modules/inkbird-ble { };
-
-  inkex = callPackage ../development/python-modules/inkex { };
-
-  inline-snapshot = callPackage ../development/python-modules/inline-snapshot { };
-
-  inlinestyler = callPackage ../development/python-modules/inlinestyler { };
-
-  inotify = callPackage ../development/python-modules/inotify { };
-
-  inotify-simple = callPackage ../development/python-modules/inotify-simple { };
-
-  inotifyrecursive = callPackage ../development/python-modules/inotifyrecursive { };
-
-  inquirer = callPackage ../development/python-modules/inquirer { };
-
-  inquirerpy = callPackage ../development/python-modules/inquirerpy { };
-
-  inscriptis = callPackage ../development/python-modules/inscriptis { };
-
-  insegel = callPackage ../development/python-modules/insegel { };
-
-  insightface = callPackage ../development/python-modules/insightface { };
-
-  installer = callPackage ../development/python-modules/installer { };
-
-  insteon-frontend-home-assistant =
-    callPackage ../development/python-modules/insteon-frontend-home-assistant
-      { };
-
-  instructor = callPackage ../development/python-modules/instructor { };
-
-  intake = callPackage ../development/python-modules/intake { };
-
-  intake-parquet = callPackage ../development/python-modules/intake-parquet { };
-
-  intbitset = callPackage ../development/python-modules/intbitset { };
-
-  intelhex = callPackage ../development/python-modules/intelhex { };
-
-  intellifire4py = callPackage ../development/python-modules/intellifire4py { };
-
-  intensity-normalization = callPackage ../development/python-modules/intensity-normalization { };
-
-  interegular = callPackage ../development/python-modules/interegular { };
-
-  interface-meta = callPackage ../development/python-modules/interface-meta { };
-
-  internetarchive = callPackage ../development/python-modules/internetarchive { };
-
-  interruptingcow = callPackage ../development/python-modules/interruptingcow { };
-
-  intervaltree = callPackage ../development/python-modules/intervaltree { };
-
-  into-dbus-python = callPackage ../development/python-modules/into-dbus-python { };
-
-  invisible-watermark = callPackage ../development/python-modules/invisible-watermark { };
-
-  invocations = callPackage ../development/python-modules/invocations { };
-
-  invoke = callPackage ../development/python-modules/invoke { };
-
-  iocsearcher = callPackage ../development/python-modules/iocsearcher { };
-
-  iodata = callPackage ../development/python-modules/iodata { };
-
-  iocapture = callPackage ../development/python-modules/iocapture { };
-
-  iocextract = callPackage ../development/python-modules/iocextract { };
-
-  ioctl-opt = callPackage ../development/python-modules/ioctl-opt { };
-
-  iometer = callPackage ../development/python-modules/iometer { };
-
-  ionhash = callPackage ../development/python-modules/ionhash { };
-
-  ionoscloud = callPackage ../development/python-modules/ionoscloud { };
-
-  iopath = callPackage ../development/python-modules/iopath { };
-
-  iosbackup = callPackage ../development/python-modules/iosbackup { };
-
-  iotawattpy = callPackage ../development/python-modules/iotawattpy { };
-
-  iottycloud = callPackage ../development/python-modules/iottycloud { };
-
-  iowait = callPackage ../development/python-modules/iowait { };
-
-  ipadic = callPackage ../development/python-modules/ipadic { };
-
-  ipaddr = callPackage ../development/python-modules/ipaddr { };
-
-  ipdb = callPackage ../development/python-modules/ipdb { };
-
-  ipfshttpclient = callPackage ../development/python-modules/ipfshttpclient { };
-
-  i-pi = callPackage ../development/python-modules/i-pi { };
-
-  iptools = callPackage ../development/python-modules/iptools { };
-
-  ipwhl = callPackage ../development/python-modules/ipwhl { };
-
-  ipwhois = callPackage ../development/python-modules/ipwhois { };
-
-  ipy = callPackage ../development/python-modules/ipy { };
-
-  ipycanvas = callPackage ../development/python-modules/ipycanvas { };
-
-  ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };
-
-  ipylab = callPackage ../development/python-modules/ipylab { };
-
-  ipynbname = callPackage ../development/python-modules/ipynbname { };
-
-  ipyniivue = callPackage ../development/python-modules/ipyniivue { };
-
-  ipykernel = callPackage ../development/python-modules/ipykernel { };
-
-  ipymarkup = callPackage ../development/python-modules/ipymarkup { };
-
-  ipympl = callPackage ../development/python-modules/ipympl { };
-
-  ipyparallel = callPackage ../development/python-modules/ipyparallel { };
-
-  ipytablewidgets = callPackage ../development/python-modules/ipytablewidgets { };
-
-  ipython-genutils = callPackage ../development/python-modules/ipython-genutils { };
-
-  ipython-pygments-lexers = callPackage ../development/python-modules/ipython-pygments-lexers { };
-
-  ipython = callPackage ../development/python-modules/ipython { };
-
-  ipython-sql = callPackage ../development/python-modules/ipython-sql { };
-
-  ipyvue = callPackage ../development/python-modules/ipyvue { };
-
-  ipyvuetify = callPackage ../development/python-modules/ipyvuetify { };
-
-  ipywidgets = callPackage ../development/python-modules/ipywidgets { };
-
-  ipyxact = callPackage ../development/python-modules/ipyxact { };
-
-  irc = callPackage ../development/python-modules/irc { };
-
-  ircrobots = callPackage ../development/python-modules/ircrobots { };
-
-  ircstates = callPackage ../development/python-modules/ircstates { };
-
-  irctokens = callPackage ../development/python-modules/irctokens { };
-
-  isal = callPackage ../development/python-modules/isal { };
-
-  isbnlib = callPackage ../development/python-modules/isbnlib { };
-
-  islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_24; };
-
-  iso3166 = callPackage ../development/python-modules/iso3166 { };
-
-  ismartgate = callPackage ../development/python-modules/ismartgate { };
-
-  iso-639 = callPackage ../development/python-modules/iso-639 { };
-
-  iso4217 = callPackage ../development/python-modules/iso4217 { };
-
-  iso8601 = callPackage ../development/python-modules/iso8601 { };
-
-  isodate = callPackage ../development/python-modules/isodate { };
-
-  isoduration = callPackage ../development/python-modules/isoduration { };
-
-  isort = callPackage ../development/python-modules/isort { };
-
-  isosurfaces = callPackage ../development/python-modules/isosurfaces { };
-
-  isounidecode = callPackage ../development/python-modules/isounidecode { };
-
-  isoweek = callPackage ../development/python-modules/isoweek { };
-
-  israel-rail-api = callPackage ../development/python-modules/israel-rail-api { };
-
-  itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
-
-  itk = toPythonModule (
-    pkgs.itk.override {
-      inherit python numpy;
-      enablePython = true;
-      enableRtk = false;
-      stdenv =
-        if stdenv.cc.isGNU then pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv else stdenv;
-    }
-  );
-
-  item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };
-
-  itemadapter = callPackage ../development/python-modules/itemadapter { };
-
-  itemdb = callPackage ../development/python-modules/itemdb { };
-
-  itemloaders = callPackage ../development/python-modules/itemloaders { };
-
-  iterable-io = callPackage ../development/python-modules/iterable-io { };
-
-  iteration-utilities = callPackage ../development/python-modules/iteration-utilities { };
-
-  iterative-telemetry = callPackage ../development/python-modules/iterative-telemetry { };
-
-  iterfzf = callPackage ../development/python-modules/iterfzf { };
-
-  iterm2 = callPackage ../development/python-modules/iterm2 { };
-
-  itsdangerous = callPackage ../development/python-modules/itsdangerous { };
-
-  itunespy = callPackage ../development/python-modules/itunespy { };
-
-  itypes = callPackage ../development/python-modules/itypes { };
-
-  iwlib = callPackage ../development/python-modules/iwlib { };
-
-  ixia = callPackage ../development/python-modules/ixia { };
-
-  j2cli = callPackage ../development/python-modules/j2cli { };
-
-  jaconv = callPackage ../development/python-modules/jaconv { };
-
-  jalali-core = callPackage ../development/python-modules/jalali-core { };
-
-  jamo = callPackage ../development/python-modules/jamo { };
-
-  janus = callPackage ../development/python-modules/janus { };
-
-  jaraco-abode = callPackage ../development/python-modules/jaraco-abode { };
-
-  jaraco-classes = callPackage ../development/python-modules/jaraco-classes { };
-
-  jaraco-collections = callPackage ../development/python-modules/jaraco-collections { };
-
-  jaraco-email = callPackage ../development/python-modules/jaraco-email { };
-
-  jaraco-envs = callPackage ../development/python-modules/jaraco-envs { };
-
-  jaraco-context = callPackage ../development/python-modules/jaraco-context { };
-
-  jaraco-functools = callPackage ../development/python-modules/jaraco-functools { };
-
-  jaraco-itertools = callPackage ../development/python-modules/jaraco-itertools { };
-
-  jaraco-logging = callPackage ../development/python-modules/jaraco-logging { };
-
-  jaraco-net = callPackage ../development/python-modules/jaraco-net { };
-
-  jaraco-path = callPackage ../development/python-modules/jaraco-path { };
-
-  jaraco-stream = callPackage ../development/python-modules/jaraco-stream { };
-
-  jaraco-test = callPackage ../development/python-modules/jaraco-test { };
-
-  jaraco-text = callPackage ../development/python-modules/jaraco-text { };
-
-  jarowinkler = callPackage ../development/python-modules/jarowinkler { };
-
-  javaobj-py3 = callPackage ../development/python-modules/javaobj-py3 { };
-
-  javaproperties = callPackage ../development/python-modules/javaproperties { };
-
-  jax = callPackage ../development/python-modules/jax { };
-
-  jax-cuda12-pjrt = callPackage ../development/python-modules/jax-cuda12-pjrt { };
-
-  jax-cuda12-plugin = callPackage ../development/python-modules/jax-cuda12-plugin { };
-
-  jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
-
-  jaxlib-bin = callPackage ../development/python-modules/jaxlib/bin.nix { };
-
-  jaxlib-build = callPackage ../development/python-modules/jaxlib { };
-
-  jaxlib = jaxlib-bin;
-
-  jaxopt = callPackage ../development/python-modules/jaxopt { };
-
-  jaxtyping = callPackage ../development/python-modules/jaxtyping { };
-
-  jaydebeapi = callPackage ../development/python-modules/jaydebeapi { };
-
-  jc = callPackage ../development/python-modules/jc { };
-
-  jdatetime = callPackage ../development/python-modules/jdatetime { };
-
-  jdcal = callPackage ../development/python-modules/jdcal { };
-
-  jedi = callPackage ../development/python-modules/jedi { };
-
-  jedi-language-server = callPackage ../development/python-modules/jedi-language-server { };
-
-  jeepney = callPackage ../development/python-modules/jeepney { };
-
-  jello = callPackage ../development/python-modules/jello { };
-
-  jellyfin-apiclient-python = callPackage ../development/python-modules/jellyfin-apiclient-python { };
-
-  jellyfish = callPackage ../development/python-modules/jellyfish { };
-
-  jenkinsapi = callPackage ../development/python-modules/jenkinsapi { };
-
-  jenkins-job-builder = callPackage ../development/python-modules/jenkins-job-builder { };
-
-  jh2 = callPackage ../development/python-modules/jh2 { };
-
-  jfx-bridge = callPackage ../development/python-modules/jfx-bridge { };
-
-  jianpu-ly = callPackage ../development/python-modules/jianpu-ly { };
-
-  jieba = callPackage ../development/python-modules/jieba { };
-
-  jinja2 = callPackage ../development/python-modules/jinja2 { };
-
-  jinja2-ansible-filters = callPackage ../development/python-modules/jinja2-ansible-filters { };
-
-  jinja2-git = callPackage ../development/python-modules/jinja2-git { };
-
-  jinja2-humanize-extension = callPackage ../development/python-modules/jinja2-humanize-extension { };
-
-  jinja2-pluralize = callPackage ../development/python-modules/jinja2-pluralize { };
-
-  jinja2-strcase = callPackage ../development/python-modules/jinja2-strcase { };
-
-  jinja2-time = callPackage ../development/python-modules/jinja2-time { };
-
-  jira = callPackage ../development/python-modules/jira { };
-
-  jishaku = callPackage ../development/python-modules/jishaku { };
-
-  jiter = callPackage ../development/python-modules/jiter { };
-
-  jiwer = callPackage ../development/python-modules/jiwer { };
-
-  jmespath = callPackage ../development/python-modules/jmespath { };
-
-  jmp = callPackage ../development/python-modules/jmp { };
-
-  joblib = callPackage ../development/python-modules/joblib { };
-
-  jobspy = callPackage ../development/python-modules/jobspy { };
-
-  johnnycanencrypt = callPackage ../development/python-modules/johnnycanencrypt {
-    inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
-  };
-
-  josepy = callPackage ../development/python-modules/josepy { };
-
-  joserfc = callPackage ../development/python-modules/joserfc { };
-
-  jplephem = callPackage ../development/python-modules/jplephem { };
-
-  jproperties = callPackage ../development/python-modules/jproperties { };
-
-  jpylyzer = callPackage ../development/python-modules/jpylyzer { };
-
-  jpype1 = callPackage ../development/python-modules/jpype1 { };
-
-  jq = callPackage ../development/python-modules/jq { inherit (pkgs) jq; };
-
-  jsbeautifier = callPackage ../development/python-modules/jsbeautifier { };
-
-  jschema-to-python = callPackage ../development/python-modules/jschema-to-python { };
-
-  jschon = callPackage ../development/python-modules/jschon { };
-
-  jsmin = callPackage ../development/python-modules/jsmin { };
-
-  json2html = callPackage ../development/python-modules/json2html { };
-
-  json5 = callPackage ../development/python-modules/json5 { };
-
-  jsonxs = callPackage ../development/python-modules/jsonxs { };
-
-  jsonargparse = callPackage ../development/python-modules/jsonargparse { };
-
-  jsonconversion = callPackage ../development/python-modules/jsonconversion { };
-
-  jsondate = callPackage ../development/python-modules/jsondate { };
-
-  jsondiff = callPackage ../development/python-modules/jsondiff { };
-
-  jsonfeed = callPackage ../development/python-modules/jsonfeed { };
-
-  jsonfield = callPackage ../development/python-modules/jsonfield { };
-
-  jsonlines = callPackage ../development/python-modules/jsonlines { };
-
-  json-api-doc = callPackage ../development/python-modules/json-api-doc { };
-
-  json-logging = callPackage ../development/python-modules/json-logging { };
-
-  jsonmerge = callPackage ../development/python-modules/jsonmerge { };
-
-  json-home-client = callPackage ../development/python-modules/json-home-client { };
-
-  json-merge-patch = callPackage ../development/python-modules/json-merge-patch { };
-
-  json-repair = callPackage ../development/python-modules/json-repair { };
-
-  json-schema-for-humans = callPackage ../development/python-modules/json-schema-for-humans { };
-
-  json-stream = callPackage ../development/python-modules/json-stream { };
-
-  json-stream-rs-tokenizer = callPackage ../development/python-modules/json-stream-rs-tokenizer { };
-
-  jsonable = callPackage ../development/python-modules/jsonable { };
-
-  jsonformatter = callPackage ../development/python-modules/jsonformatter { };
-
-  jsonnet = buildPythonPackage { inherit (pkgs.jsonnet) name src; };
-
-  jsonpatch = callPackage ../development/python-modules/jsonpatch { };
-
-  jsonpath = callPackage ../development/python-modules/jsonpath { };
-
-  jsonpath-rw = callPackage ../development/python-modules/jsonpath-rw { };
-
-  jsonpath-ng = callPackage ../development/python-modules/jsonpath-ng { };
-
-  jsonpath-python = callPackage ../development/python-modules/jsonpath-python { };
-
-  jsonpickle = callPackage ../development/python-modules/jsonpickle { };
-
-  jsonpointer = callPackage ../development/python-modules/jsonpointer { };
-
-  jsonref = callPackage ../development/python-modules/jsonref { };
-
-  json-rpc = callPackage ../development/python-modules/json-rpc { };
-
-  jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
-
-  jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };
-
-  jsonrpclib-pelix = callPackage ../development/python-modules/jsonrpclib-pelix { };
-
-  jsonrpc-websocket = callPackage ../development/python-modules/jsonrpc-websocket { };
-
-  jsons = callPackage ../development/python-modules/jsons { };
-
-  jsonschema = callPackage ../development/python-modules/jsonschema { };
-
-  jsonschema-path = callPackage ../development/python-modules/jsonschema-path { };
-
-  jsonschema-rs = callPackage ../development/python-modules/jsonschema-rs { };
-
-  jsonschema-spec = callPackage ../development/python-modules/jsonschema-spec { };
-
-  jsonschema-specifications = callPackage ../development/python-modules/jsonschema-specifications { };
-
-  jsonslicer = callPackage ../development/python-modules/jsonslicer { };
-
-  jsonstreams = callPackage ../development/python-modules/jsonstreams { };
-
-  json-tricks = callPackage ../development/python-modules/json-tricks { };
-
-  jstyleson = callPackage ../development/python-modules/jstyleson { };
-
-  jug = callPackage ../development/python-modules/jug { };
-
-  juliandate = callPackage ../development/python-modules/juliandate { };
-
-  julius = callPackage ../development/python-modules/julius { };
-
-  junitparser = callPackage ../development/python-modules/junitparser { };
-
-  junit2html = callPackage ../development/python-modules/junit2html { };
-
-  junit-xml = callPackage ../development/python-modules/junit-xml { };
-
-  junos-eznc = callPackage ../development/python-modules/junos-eznc { };
-
-  jupysql-plugin = callPackage ../development/python-modules/jupysql-plugin { };
-
-  jupysql = callPackage ../development/python-modules/jupysql { };
-
-  jupyter = callPackage ../development/python-modules/jupyter { };
-
-  jupyter-book = callPackage ../development/python-modules/jupyter-book { };
-
-  jupyter-c-kernel = callPackage ../development/python-modules/jupyter-c-kernel { };
-
-  jupyter-cache = callPackage ../development/python-modules/jupyter-cache { };
-
-  jupyter-client = callPackage ../development/python-modules/jupyter-client { };
-
-  jupyter-collaboration = callPackage ../development/python-modules/jupyter-collaboration { };
-
-  jupyter-collaboration-ui = callPackage ../development/python-modules/jupyter-collaboration-ui { };
-
-  jupyter-contrib-core = callPackage ../development/python-modules/jupyter-contrib-core { };
-
-  jupyter-console = callPackage ../development/python-modules/jupyter-console { };
-
-  jupyter-core = callPackage ../development/python-modules/jupyter-core { };
-
-  jupyter-docprovider = callPackage ../development/python-modules/jupyter-docprovider { };
-
-  jupyter-events = callPackage ../development/python-modules/jupyter-events { };
-
-  jupyter-highlight-selected-word =
-    callPackage ../development/python-modules/jupyter-highlight-selected-word
-      { };
-
-  jupyter-lsp = callPackage ../development/python-modules/jupyter-lsp { };
-
-  jupyter-nbextensions-configurator =
-    callPackage ../development/python-modules/jupyter-nbextensions-configurator
-      { };
-
-  jupyter-server = callPackage ../development/python-modules/jupyter-server { };
-
-  jupyter-server-fileid = callPackage ../development/python-modules/jupyter-server-fileid { };
-
-  jupyter-server-terminals = callPackage ../development/python-modules/jupyter-server-terminals { };
-
-  jupyter-server-ydoc = callPackage ../development/python-modules/jupyter-server-ydoc { };
-
-  jupyter-ui-poll = callPackage ../development/python-modules/jupyter-ui-poll { };
-
-  jupyter-ydoc = callPackage ../development/python-modules/jupyter-ydoc { };
-
-  jupyterhub = callPackage ../development/python-modules/jupyterhub { };
-
-  jupyterhub-ldapauthenticator =
-    callPackage ../development/python-modules/jupyterhub-ldapauthenticator
-      { };
-
-  jupyterhub-systemdspawner = callPackage ../development/python-modules/jupyterhub-systemdspawner { };
-
-  jupyterhub-tmpauthenticator =
-    callPackage ../development/python-modules/jupyterhub-tmpauthenticator
-      { };
-
-  jupyterlab = callPackage ../development/python-modules/jupyterlab { };
-
-  jupyterlab-execute-time = callPackage ../development/python-modules/jupyterlab-execute-time { };
-
-  jupyterlab-git = callPackage ../development/python-modules/jupyterlab-git { };
-
-  jupyterlab-pygments = callPackage ../development/python-modules/jupyterlab-pygments { };
-
-  jupyterlab-server = callPackage ../development/python-modules/jupyterlab-server { };
-
-  jupyterlab-widgets = callPackage ../development/python-modules/jupyterlab-widgets { };
-
-  jupyterlab-lsp = callPackage ../development/python-modules/jupyterlab-lsp { };
-
-  jupyter-packaging = callPackage ../development/python-modules/jupyter-packaging { };
-
-  jupyter-repo2docker = callPackage ../development/python-modules/jupyter-repo2docker {
-    pkgs-docker = pkgs.docker;
-  };
-
-  jupyter-server-mathjax = callPackage ../development/python-modules/jupyter-server-mathjax { };
-
-  jupyter-sphinx = callPackage ../development/python-modules/jupyter-sphinx { };
-
-  jupyter-telemetry = callPackage ../development/python-modules/jupyter-telemetry { };
-
-  jupytext = callPackage ../development/python-modules/jupytext { };
-
-  justbackoff = callPackage ../development/python-modules/justbackoff { };
-
-  justbases = callPackage ../development/python-modules/justbases { };
-
-  justbytes = callPackage ../development/python-modules/justbytes { };
-
-  justext = callPackage ../development/python-modules/justext { };
-
-  justnimbus = callPackage ../development/python-modules/justnimbus { };
-
-  jwcrypto = callPackage ../development/python-modules/jwcrypto { };
-
-  jwt = callPackage ../development/python-modules/jwt { };
-
-  jxlpy = callPackage ../development/python-modules/jxlpy { };
-
-  jxmlease = callPackage ../development/python-modules/jxmlease { };
-
-  k-diffusion = callPackage ../development/python-modules/k-diffusion { };
-
-  k5test = callPackage ../development/python-modules/k5test {
-    inherit (pkgs) findutils;
-    krb5-c = pkgs.krb5;
-  };
-
-  kaa-base = callPackage ../development/python-modules/kaa-base { };
-
-  kaa-metadata = callPackage ../development/python-modules/kaa-metadata { };
-
-  kafka-python-ng = callPackage ../development/python-modules/kafka-python-ng { };
-
-  kaggle = callPackage ../development/python-modules/kaggle { };
-
-  kaitaistruct = callPackage ../development/python-modules/kaitaistruct { };
-
-  kajiki = callPackage ../development/python-modules/kajiki { };
-
-  kaldi-active-grammar = callPackage ../development/python-modules/kaldi-active-grammar { };
-
-  kaleido = callPackage ../development/python-modules/kaleido { };
-
-  kalshi-python = callPackage ../development/python-modules/kalshi-python { };
-
-  kanidm = callPackage ../development/python-modules/kanidm { };
-
-  kaptan = callPackage ../development/python-modules/kaptan { };
-
-  karton-asciimagic = callPackage ../development/python-modules/karton-asciimagic { };
-
-  karton-autoit-ripper = callPackage ../development/python-modules/karton-autoit-ripper { };
-
-  karton-classifier = callPackage ../development/python-modules/karton-classifier { };
-
-  karton-config-extractor = callPackage ../development/python-modules/karton-config-extractor { };
-
-  karton-core = callPackage ../development/python-modules/karton-core { };
-
-  karton-dashboard = callPackage ../development/python-modules/karton-dashboard { };
-
-  karton-mwdb-reporter = callPackage ../development/python-modules/karton-mwdb-reporter { };
-
-  karton-yaramatcher = callPackage ../development/python-modules/karton-yaramatcher { };
-
-  kasa-crypt = callPackage ../development/python-modules/kasa-crypt { };
-
-  kazoo = callPackage ../development/python-modules/kazoo { };
-
-  kbcstorage = callPackage ../development/python-modules/kbcstorage { };
-
-  kconfiglib = callPackage ../development/python-modules/kconfiglib { };
-
-  kde-material-you-colors = callPackage ../development/python-modules/kde-material-you-colors { };
-
-  kdl-py = callPackage ../development/python-modules/kdl-py { };
-
-  keba-kecontact = callPackage ../development/python-modules/keba-kecontact { };
-
-  keep = callPackage ../development/python-modules/keep { };
-
-  keepalive = callPackage ../development/python-modules/keepalive { };
-
-  keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };
-
-  keepkey = callPackage ../development/python-modules/keepkey { };
-
-  kegtron-ble = callPackage ../development/python-modules/kegtron-ble { };
-
-  keke = callPackage ../development/python-modules/keke { };
-
-  keras = callPackage ../development/python-modules/keras { };
-
-  kerberos = callPackage ../development/python-modules/kerberos { };
-
-  kestra = callPackage ../development/python-modules/kestra { };
-
-  keyboard = callPackage ../development/python-modules/keyboard { };
-
-  keyring = callPackage ../development/python-modules/keyring { };
-
-  keyring-pass = callPackage ../development/python-modules/keyring-pass { };
-
-  keyrings-cryptfile = callPackage ../development/python-modules/keyrings-cryptfile { };
-
-  keyrings-google-artifactregistry-auth =
-    callPackage ../development/python-modules/keyrings-google-artifactregistry-auth
-      { };
-
-  keyrings-alt = callPackage ../development/python-modules/keyrings-alt { };
-
-  keystone-engine = callPackage ../development/python-modules/keystone-engine { };
-
-  keyrings-passwordstore = callPackage ../development/python-modules/keyrings-passwordstore { };
-
-  keystoneauth1 = callPackage ../development/python-modules/keystoneauth1 { };
-
-  keyutils = callPackage ../development/python-modules/keyutils { inherit (pkgs) keyutils; };
-
-  kfactory = callPackage ../development/python-modules/kfactory { };
-
-  khanaa = callPackage ../development/python-modules/khanaa { };
-
-  kicad = toPythonModule (pkgs.kicad.override { python3 = python; }).src;
-
-  kinparse = callPackage ../development/python-modules/kinparse { };
-
-  kiss-headers = callPackage ../development/python-modules/kiss-headers { };
-
-  kitchen = callPackage ../development/python-modules/kitchen { };
-
-  kivy = callPackage ../development/python-modules/kivy { };
-
-  kivy-garden = callPackage ../development/python-modules/kivy-garden { };
-
-  kivy-garden-modernmenu = callPackage ../development/python-modules/kivy-garden-modernmenu { };
-
-  kiwiki-client = callPackage ../development/python-modules/kiwiki-client { };
-
-  kiwisolver = callPackage ../development/python-modules/kiwisolver { };
-
-  klaus = callPackage ../development/python-modules/klaus { };
-
-  klayout = callPackage ../development/python-modules/klayout { };
-
-  klein = callPackage ../development/python-modules/klein { };
-
-  kmapper = callPackage ../development/python-modules/kmapper { };
-
-  kml2geojson = callPackage ../development/python-modules/kml2geojson { };
-
-  kmsxx = toPythonModule (
-    pkgs.kmsxx.override {
-      withPython = true;
-      python3Packages = self;
-    }
-  );
-
-  knack = callPackage ../development/python-modules/knack { };
-
-  kneaddata = callPackage ../development/python-modules/kneaddata { };
-
-  kneed = callPackage ../development/python-modules/kneed { };
-
-  knocki = callPackage ../development/python-modules/knocki { };
-
-  knx-frontend = callPackage ../development/python-modules/knx-frontend { };
-
-  kombu = callPackage ../development/python-modules/kombu { };
-
-  konnected = callPackage ../development/python-modules/konnected { };
-
-  kotsu = callPackage ../development/python-modules/kotsu { };
-
-  korean-lunar-calendar = callPackage ../development/python-modules/korean-lunar-calendar { };
-
-  kornia = callPackage ../development/python-modules/kornia { };
-
-  kornia-rs = callPackage ../development/python-modules/kornia-rs { };
-
-  krakenex = callPackage ../development/python-modules/krakenex { };
-
-  krb5 = callPackage ../development/python-modules/krb5 { krb5-c = pkgs.krb5; };
-
-  krfzf-py = callPackage ../development/python-modules/krfzf-py { };
-
-  kserve = callPackage ../development/python-modules/kserve { };
-
-  kubernetes = callPackage ../development/python-modules/kubernetes { };
-
-  kubernetes-asyncio = callPackage ../development/python-modules/kubernetes-asyncio { };
-
-  kubernetes-validate = callPackage ../by-name/ku/kubernetes-validate/unwrapped.nix { };
-
-  kurbopy = callPackage ../development/python-modules/kurbopy { };
-
-  l18n = callPackage ../development/python-modules/l18n { };
-
-  labelbox = callPackage ../development/python-modules/labelbox { };
-
-  labgrid = callPackage ../development/python-modules/labgrid { };
-
-  labmath = callPackage ../development/python-modules/labmath { };
-
-  laces = callPackage ../development/python-modules/laces { };
-
-  lacuscore = callPackage ../development/python-modules/lacuscore { };
-
-  lakeside = callPackage ../development/python-modules/lakeside { };
-
-  lammps = callPackage ../development/python-modules/lammps { inherit (pkgs) lammps; };
-
-  lancedb = callPackage ../development/python-modules/lancedb { inherit (pkgs) protobuf; };
-
-  langchain = callPackage ../development/python-modules/langchain { };
-
-  langchain-aws = callPackage ../development/python-modules/langchain-aws { };
-
-  langchain-azure-dynamic-sessions =
-    callPackage ../development/python-modules/langchain-azure-dynamic-sessions
-      { };
-
-  langchain-chroma = callPackage ../development/python-modules/langchain-chroma { };
-
-  langchain-community = callPackage ../development/python-modules/langchain-community { };
-
-  langchain-core = callPackage ../development/python-modules/langchain-core { };
-
-  langchain-groq = callPackage ../development/python-modules/langchain-groq { };
-
-  langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };
-
-  langchain-mongodb = callPackage ../development/python-modules/langchain-mongodb { };
-
-  langchain-ollama = callPackage ../development/python-modules/langchain-ollama { };
-
-  langchain-openai = callPackage ../development/python-modules/langchain-openai { };
-
-  langchain-tests = callPackage ../development/python-modules/langchain-tests { };
-
-  langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };
-
-  langcodes = callPackage ../development/python-modules/langcodes { };
-
-  langdetect = callPackage ../development/python-modules/langdetect { };
-
-  langfuse = callPackage ../development/python-modules/langfuse { };
-
-  langgraph = callPackage ../development/python-modules/langgraph { };
-
-  langgraph-checkpoint = callPackage ../development/python-modules/langgraph-checkpoint { };
-
-  langgraph-checkpoint-postgres =
-    callPackage ../development/python-modules/langgraph-checkpoint-postgres
-      { };
-
-  langgraph-checkpoint-duckdb =
-    callPackage ../development/python-modules/langgraph-checkpoint-duckdb
-      { };
-
-  langgraph-checkpoint-sqlite =
-    callPackage ../development/python-modules/langgraph-checkpoint-sqlite
-      { };
-
-  langgraph-cli = callPackage ../development/python-modules/langgraph-cli { };
-
-  langgraph-sdk = callPackage ../development/python-modules/langgraph-sdk { };
-
-  langid = callPackage ../development/python-modules/langid { };
-
-  langsmith = callPackage ../development/python-modules/langsmith { };
-
-  language-data = callPackage ../development/python-modules/language-data { };
-
-  language-tags = callPackage ../development/python-modules/language-tags { };
-
-  language-tool-python = callPackage ../development/python-modules/language-tool-python { };
-
-  lanms-neo = callPackage ../development/python-modules/lanms-neo { };
-
-  lark = callPackage ../development/python-modules/lark { };
-
-  laspy = callPackage ../development/python-modules/laspy { };
-
-  lastversion = callPackage ../development/python-modules/lastversion { };
-
-  laszip = callPackage ../development/python-modules/laszip {
-    inherit (pkgs) cmake ninja;
-    inherit (pkgs.__splicedPackages) laszip;
-  };
-
-  lap = callPackage ../development/python-modules/lap { };
-
-  latex2mathml = callPackage ../development/python-modules/latex2mathml { };
-
-  latex2pydata = callPackage ../development/python-modules/latex2pydata { };
-
-  latexcodec = callPackage ../development/python-modules/latexcodec { };
-
-  latexify-py = callPackage ../development/python-modules/latexify-py { };
-
-  latexrestricted = callPackage ../development/python-modules/latexrestricted { };
-
-  launchpadlib = callPackage ../development/python-modules/launchpadlib { };
-
-  laundrify-aio = callPackage ../development/python-modules/laundrify-aio { };
-
-  layoutparser = callPackage ../development/python-modules/layoutparser { };
-
-  lazr-config = callPackage ../development/python-modules/lazr-config { };
-
-  lazr-delegates = callPackage ../development/python-modules/lazr-delegates { };
-
-  lazr-restfulclient = callPackage ../development/python-modules/lazr-restfulclient { };
-
-  lazr-uri = callPackage ../development/python-modules/lazr-uri { };
-
-  lazy = callPackage ../development/python-modules/lazy { };
-
-  lazy-imports = callPackage ../development/python-modules/lazy-imports { };
-
-  lazy-loader = callPackage ../development/python-modules/lazy-loader { };
-
-  lazy-object-proxy = callPackage ../development/python-modules/lazy-object-proxy { };
-
-  lc7001 = callPackage ../development/python-modules/lc7001 { };
-
-  lcd-i2c = callPackage ../development/python-modules/lcd-i2c { };
-
-  lcgit = callPackage ../development/python-modules/lcgit { };
-
-  lcn-frontend = callPackage ../development/python-modules/lcn-frontend { };
-
-  lcov-cobertura = callPackage ../development/python-modules/lcov-cobertura { };
-
-  ld2410-ble = callPackage ../development/python-modules/ld2410-ble { };
-
-  ldap3 = callPackage ../development/python-modules/ldap3 { };
-
-  ldap3-bleeding-edge = callPackage ../development/python-modules/ldap3-bleeding-edge { };
-
-  ldapdomaindump = callPackage ../development/python-modules/ldapdomaindump { };
-
-  ldappool = callPackage ../development/python-modules/ldappool { };
-
-  ldaptor = callPackage ../development/python-modules/ldaptor { };
-
-  ldfparser = callPackage ../development/python-modules/ldfparser { };
-
-  leather = callPackage ../development/python-modules/leather { };
-
-  leanblueprint = callPackage ../development/python-modules/leanblueprint { };
-
-  leaone-ble = callPackage ../development/python-modules/leaone-ble { };
-
-  leb128 = callPackage ../development/python-modules/leb128 { };
-
-  led-ble = callPackage ../development/python-modules/led-ble { };
-
-  ledger =
-    (toPythonModule (
-      pkgs.ledger.override {
-        usePython = true;
-        python3 = python;
-      }
-    )).py;
-
-  ledger-agent = callPackage ../development/python-modules/ledger-agent { };
-
-  ledger-bitcoin = callPackage ../development/python-modules/ledger-bitcoin { };
-
-  ledgerblue = callPackage ../development/python-modules/ledgerblue { };
-
-  ledgercomm = callPackage ../development/python-modules/ledgercomm { };
-
-  ledgerwallet = callPackage ../development/python-modules/ledgerwallet {
-    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
-  };
-
-  legacy-cgi = callPackage ../development/python-modules/legacy-cgi { };
-
-  leidenalg = callPackage ../development/python-modules/leidenalg { igraph-c = pkgs.igraph; };
-
-  lektricowifi = callPackage ../development/python-modules/lektricowifi { };
-
-  letpot = callPackage ../development/python-modules/letpot { };
-
-  leveldb = callPackage ../development/python-modules/leveldb { };
-
-  levenshtein = callPackage ../development/python-modules/levenshtein { };
-
-  lexid = callPackage ../development/python-modules/lexid { };
-
-  lexilang = callPackage ../development/python-modules/lexilang { };
-
-  lhapdf = toPythonModule (pkgs.lhapdf.override { inherit python; });
-
-  lib4package = callPackage ../development/python-modules/lib4package { };
-
-  libagent = callPackage ../development/python-modules/libagent { };
-
-  libbs = callPackage ../development/python-modules/libbs { };
-
-  pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };
-
-  lib4sbom = callPackage ../development/python-modules/lib4sbom { };
-
-  libais = callPackage ../development/python-modules/libais { };
-
-  libarchive-c = callPackage ../development/python-modules/libarchive-c {
-    inherit (pkgs) libarchive;
-  };
-
-  libarcus = callPackage ../development/python-modules/libarcus { protobuf = pkgs.protobuf_21; };
-
-  libasyncns = callPackage ../development/python-modules/libasyncns { inherit (pkgs) libasyncns; };
-
-  libclang = callPackage ../development/python-modules/libclang { };
-
-  libcloud = callPackage ../development/python-modules/libcloud { };
-
-  libcomps = lib.pipe pkgs.libcomps [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ];
-        };
-      })
-    )
-    (p: p.override { inherit python; })
-    (p: p.py)
-  ];
-
-  libcst = callPackage ../development/python-modules/libcst { };
-
-  libdnf = lib.pipe pkgs.libdnf [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ];
-        };
-      })
-    )
-    (p: p.override { inherit python; })
-    (p: p.py)
-  ];
-
-  libevdev = callPackage ../development/python-modules/libevdev { };
-
-  libfdt = toPythonModule (
-    pkgs.dtc.override {
-      inherit python;
-      pythonSupport = true;
-    }
-  );
-
-  libfive = toPythonModule (pkgs.libfive.override { inherit python; });
-
-  libgpiod = callPackage ../development/python-modules/libgpiod { inherit (pkgs) libgpiod; };
-
-  libgravatar = callPackage ../development/python-modules/libgravatar { };
-
-  libiio =
-    (toPythonModule (
-      pkgs.libiio.override {
-        pythonSupport = true;
-        inherit python;
-      }
-    )).python;
-
-  libipld = callPackage ../development/python-modules/libipld { };
-
-  libkeepass = callPackage ../development/python-modules/libkeepass { };
-
-  libknot = callPackage ../development/python-modules/libknot { };
-
-  liblarch = callPackage ../development/python-modules/liblarch { };
-
-  liblzfse = callPackage ../development/python-modules/liblzfse { inherit (pkgs) lzfse; };
-
-  libmambapy = callPackage ../development/python-modules/libmambapy { };
-
-  libmodulemd = lib.pipe pkgs.libmodulemd [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ]; # The package always builds python3 bindings
-          broken = (super.meta.broken or false) || !isPy3k;
-        };
-      })
-    )
-    (p: p.override { python3 = python; })
-    (p: p.py)
-  ];
-
-  libmr = callPackage ../development/python-modules/libmr { };
-
-  libnacl = callPackage ../development/python-modules/libnacl { inherit (pkgs) libsodium; };
-
-  libnbd = toPythonModule (
-    pkgs.libnbd.override {
-      buildPythonBindings = true;
-      python3 = python;
-    }
-  );
-
-  libpcap = callPackage ../development/python-modules/libpcap {
-    pkgsLibpcap = pkgs.libpcap; # Needs the C library
-  };
-
-  libpurecool = callPackage ../development/python-modules/libpurecool { };
-
-  libpyfoscam = callPackage ../development/python-modules/libpyfoscam { };
-
-  libpysal = callPackage ../development/python-modules/libpysal { };
-
-  libpyvivotek = callPackage ../development/python-modules/libpyvivotek { };
-
-  libpwquality = lib.pipe pkgs.libpwquality [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ];
-        };
-      })
-    )
-    (
-      p:
-      p.override {
-        enablePython = true;
-        inherit python;
-      }
-    )
-    (p: p.py)
-  ];
-
-  libredwg = toPythonModule (
-    pkgs.libredwg.override {
-      enablePython = true;
-      inherit (self) python libxml2;
-    }
-  );
-
-  librepo = lib.pipe pkgs.librepo [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ];
-        };
-      })
-    )
-    (p: p.override { inherit python; })
-    (p: p.py)
-  ];
-
-  librespot = callPackage ../development/python-modules/librespot { };
-
-  libretranslate = callPackage ../development/python-modules/libretranslate { };
-
-  librosa = callPackage ../development/python-modules/librosa { };
-
-  librouteros = callPackage ../development/python-modules/librouteros { };
-
-  libsass = callPackage ../development/python-modules/libsass { inherit (pkgs) libsass; };
-
-  libsavitar = callPackage ../development/python-modules/libsavitar { };
-
-  libsbml = toPythonModule (
-    pkgs.libsbml.override {
-      withPython = true;
-      inherit (self) python;
-    }
-  );
-
-  libsixel = callPackage ../development/python-modules/libsixel { inherit (pkgs) libsixel; };
-
-  libselinux = lib.pipe pkgs.libselinux [
-    toPythonModule
-    (
-      p:
-      p.overrideAttrs (super: {
-        meta = super.meta // {
-          outputsToInstall = [ "py" ];
-          broken = super.meta.broken or isPy27;
-        };
-      })
-    )
-    (
-      p:
-      p.override {
-        enablePython = true;
-        python3 = python;
-        python3Packages = pythonPackages;
-      }
-    )
-    (p: p.py)
-  ];
-
-  libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
-
-  libthumbor = callPackage ../development/python-modules/libthumbor { };
-
-  libtmux = callPackage ../development/python-modules/libtmux { };
-
-  libtorrent-rasterbar =
-    (toPythonModule (pkgs.libtorrent-rasterbar.override { python3 = python; })).python;
-
-  libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };
-
-  libusbsio = callPackage ../development/python-modules/libusbsio { inherit (pkgs) libusbsio; };
-
-  libuuu = callPackage ../development/python-modules/libuuu { };
-
-  libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion; };
-
-  libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };
-
-  libxml2 =
-    (toPythonModule (
-      pkgs.libxml2.override {
-        pythonSupport = true;
-        inherit python;
-      }
-    )).py;
-
-  libxslt =
-    (toPythonModule (
-      pkgs.libxslt.override {
-        pythonSupport = true;
-        inherit (self) python libxml2;
-      }
-    )).py;
-
-  liccheck = callPackage ../development/python-modules/liccheck { };
-
-  license-expression = callPackage ../development/python-modules/license-expression { };
-
-  lida = callPackage ../development/python-modules/lida { };
-
-  lief = (toPythonModule (pkgs.lief.override { inherit python; })).py;
-
-  life360 = callPackage ../development/python-modules/life360 { };
-
-  lifelines = callPackage ../development/python-modules/lifelines { };
-
-  lightgbm = callPackage ../development/python-modules/lightgbm { };
-
-  lightify = callPackage ../development/python-modules/lightify { };
-
-  lightning-utilities = callPackage ../development/python-modules/lightning-utilities { };
-
-  lightparam = callPackage ../development/python-modules/lightparam { };
-
-  lightwave = callPackage ../development/python-modules/lightwave { };
-
-  lightwave2 = callPackage ../development/python-modules/lightwave2 { };
-
-  lima = callPackage ../development/python-modules/lima { };
-
-  lime = callPackage ../development/python-modules/lime { };
-
-  limiter = callPackage ../development/python-modules/limiter { };
-
-  limitlessled = callPackage ../development/python-modules/limitlessled { };
-
-  limits = callPackage ../development/python-modules/limits { };
-
-  limnoria = callPackage ../development/python-modules/limnoria { };
-
-  linear-garage-door = callPackage ../development/python-modules/linear-garage-door { };
-
-  linear-operator = callPackage ../development/python-modules/linear-operator { };
-
-  lineax = callPackage ../development/python-modules/lineax { };
-
-  linecache2 = callPackage ../development/python-modules/linecache2 { };
-
-  lineedit = callPackage ../development/python-modules/lineedit { };
-
-  line-profiler = callPackage ../development/python-modules/line-profiler { };
-
-  linetable = callPackage ../development/python-modules/linetable { };
-
-  lingua = callPackage ../development/python-modules/lingua { };
-
-  lingva = callPackage ../development/python-modules/lingva { };
-
-  linien-client = callPackage ../development/python-modules/linien-client { };
-
-  linien-common = callPackage ../development/python-modules/linien-common { };
-
-  linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
-
-  linknlink = callPackage ../development/python-modules/linknlink { };
-
-  linode-api = callPackage ../development/python-modules/linode-api { };
-
-  linode-metadata = callPackage ../development/python-modules/linode-metadata { };
-
-  linode = callPackage ../development/python-modules/linode { };
-
-  linuxfd = callPackage ../development/python-modules/linuxfd { };
-
-  linuxpy = callPackage ../development/python-modules/linuxpy { };
-
-  lion-pytorch = callPackage ../development/python-modules/lion-pytorch { };
-
-  liquidctl = callPackage ../development/python-modules/liquidctl { };
-
-  lirc = toPythonModule (pkgs.lirc.override { python3 = python; });
-
-  lit = callPackage ../development/python-modules/lit { };
-
-  litellm = callPackage ../development/python-modules/litellm { };
-
-  litemapy = callPackage ../development/python-modules/litemapy { };
-
-  litestar-htmx = callPackage ../development/python-modules/litestar-htmx { };
-
-  litestar = callPackage ../development/python-modules/litestar { };
-
-  littleutils = callPackage ../development/python-modules/littleutils { };
-
-  livelossplot = callPackage ../development/python-modules/livelossplot { };
-
-  livereload = callPackage ../development/python-modules/livereload { };
-
-  livisi = callPackage ../development/python-modules/livisi { };
-
-  lizard = callPackage ../development/python-modules/lizard { };
-
-  llama-cpp-python = callPackage ../development/python-modules/llama-cpp-python { };
-
-  llama-cloud = callPackage ../development/python-modules/llama-cloud { };
-
-  llama-index = callPackage ../development/python-modules/llama-index { };
-
-  llama-index-agent-openai = callPackage ../development/python-modules/llama-index-agent-openai { };
-
-  llama-index-cli = callPackage ../development/python-modules/llama-index-cli { };
-
-  llama-index-core = callPackage ../development/python-modules/llama-index-core { };
-
-  llama-index-embeddings-gemini =
-    callPackage ../development/python-modules/llama-index-embeddings-gemini
-      { };
-
-  llama-index-embeddings-google =
-    callPackage ../development/python-modules/llama-index-embeddings-google
-      { };
-
-  llama-index-embeddings-huggingface =
-    callPackage ../development/python-modules/llama-index-embeddings-huggingface
-      { };
-
-  llama-index-embeddings-ollama =
-    callPackage ../development/python-modules/llama-index-embeddings-ollama
-      { };
-
-  llama-index-embeddings-openai =
-    callPackage ../development/python-modules/llama-index-embeddings-openai
-      { };
-
-  llama-index-graph-stores-nebula =
-    callPackage ../development/python-modules/llama-index-graph-stores-nebula
-      { };
-
-  llama-index-graph-stores-neo4j =
-    callPackage ../development/python-modules/llama-index-graph-stores-neo4j
-      { };
-
-  llama-index-graph-stores-neptune =
-    callPackage ../development/python-modules/llama-index-graph-stores-neptune
-      { };
-
-  llama-index-indices-managed-llama-cloud =
-    callPackage ../development/python-modules/llama-index-indices-managed-llama-cloud
-      { };
-
-  llama-index-legacy = callPackage ../development/python-modules/llama-index-legacy { };
-
-  llama-index-llms-ollama = callPackage ../development/python-modules/llama-index-llms-ollama { };
-
-  llama-index-llms-openai = callPackage ../development/python-modules/llama-index-llms-openai { };
-
-  llama-index-llms-openai-like =
-    callPackage ../development/python-modules/llama-index-llms-openai-like
-      { };
-
-  llama-index-multi-modal-llms-openai =
-    callPackage ../development/python-modules/llama-index-multi-modal-llms-openai
-      { };
-
-  llama-index-program-openai =
-    callPackage ../development/python-modules/llama-index-program-openai
-      { };
-
-  llama-index-question-gen-openai =
-    callPackage ../development/python-modules/llama-index-question-gen-openai
-      { };
-
-  llama-index-readers-database =
-    callPackage ../development/python-modules/llama-index-readers-database
-      { };
-
-  llama-index-readers-file = callPackage ../development/python-modules/llama-index-readers-file { };
-
-  llama-index-readers-json = callPackage ../development/python-modules/llama-index-readers-json { };
-
-  llama-index-readers-llama-parse =
-    callPackage ../development/python-modules/llama-index-readers-llama-parse
-      { };
-
-  llama-index-readers-s3 = callPackage ../development/python-modules/llama-index-readers-s3 { };
-
-  llama-index-readers-twitter =
-    callPackage ../development/python-modules/llama-index-readers-twitter
-      { };
-
-  llama-index-readers-txtai = callPackage ../development/python-modules/llama-index-readers-txtai { };
-
-  llama-index-readers-weather =
-    callPackage ../development/python-modules/llama-index-readers-weather
-      { };
-
-  llama-index-vector-stores-chroma =
-    callPackage ../development/python-modules/llama-index-vector-stores-chroma
-      { };
-
-  llama-index-vector-stores-google =
-    callPackage ../development/python-modules/llama-index-vector-stores-google
-      { };
-
-  llama-index-vector-stores-postgres =
-    callPackage ../development/python-modules/llama-index-vector-stores-postgres
-      { };
-
-  llama-index-vector-stores-qdrant =
-    callPackage ../development/python-modules/llama-index-vector-stores-qdrant
-      { };
-
-  llama-parse = callPackage ../development/python-modules/llama-parse { };
-
-  llamaindex-py-client = callPackage ../development/python-modules/llamaindex-py-client { };
-
-  llfuse = callPackage ../development/python-modules/llfuse { inherit (pkgs) fuse; };
-
-  llguidance = callPackage ../development/python-modules/llguidance { };
-
-  llm = callPackage ../development/python-modules/llm { };
-
-  llm-anthropic = callPackage ../development/python-modules/llm-anthropic { };
-
-  llm-cmd = callPackage ../development/python-modules/llm-cmd { };
-
-  llm-gemini = callPackage ../development/python-modules/llm-gemini { };
-
-  llm-gguf = callPackage ../development/python-modules/llm-gguf { };
-
-  llm-jq = callPackage ../development/python-modules/llm-jq { };
-
-  llm-ollama = callPackage ../development/python-modules/llm-ollama { };
-
-  llmx = callPackage ../development/python-modules/llmx { };
-
-  llvmlite = callPackage ../development/python-modules/llvmlite {
-    # llvmlite always requires a specific version of llvm.
-    llvm = pkgs.llvm_15;
-  };
-
-  lm-eval = callPackage ../development/python-modules/lm-eval { };
-
-  lm-format-enforcer = callPackage ../development/python-modules/lm-format-enforcer { };
-
-  lmdb = callPackage ../development/python-modules/lmdb { inherit (pkgs) lmdb; };
-
-  lmfit = callPackage ../development/python-modules/lmfit { };
-
-  lml = callPackage ../development/python-modules/lml { };
-
-  lmnotify = callPackage ../development/python-modules/lmnotify { };
-
-  lmtpd = callPackage ../development/python-modules/lmtpd { };
-
-  lnkparse3 = callPackage ../development/python-modules/lnkparse3 { };
-
-  loca = callPackage ../development/python-modules/loca { };
-
-  localimport = callPackage ../development/python-modules/localimport { };
-
-  localstack-client = callPackage ../development/python-modules/localstack-client { };
-
-  localstack-ext = callPackage ../development/python-modules/localstack-ext { };
-
-  localzone = callPackage ../development/python-modules/localzone { };
-
-  locationsharinglib = callPackage ../development/python-modules/locationsharinglib { };
-
-  locket = callPackage ../development/python-modules/locket { };
-
-  lockfile = callPackage ../development/python-modules/lockfile { };
-
-  locust = callPackage ../development/python-modules/locust { };
-
-  log-symbols = callPackage ../development/python-modules/log-symbols { };
-
-  logassert = callPackage ../development/python-modules/logassert { };
-
-  logbook = callPackage ../development/python-modules/logbook { };
-
-  logfury = callPackage ../development/python-modules/logfury { };
-
-  logging-journald = callPackage ../development/python-modules/logging-journald { };
-
-  logi-circle = callPackage ../development/python-modules/logi-circle { };
-
-  logical-unification = callPackage ../development/python-modules/logical-unification { };
-
-  logilab-common = callPackage ../development/python-modules/logilab/common.nix {
-    pytestCheckHook = pytest7CheckHook;
-  };
-
-  logilab-constraint = callPackage ../development/python-modules/logilab/constraint.nix { };
-
-  logmatic-python = callPackage ../development/python-modules/logmatic-python { };
-
-  logster = callPackage ../development/python-modules/logster { };
-
-  loguru = callPackage ../development/python-modules/loguru { };
-
-  loguru-logging-intercept = callPackage ../development/python-modules/loguru-logging-intercept { };
-
-  logutils = callPackage ../development/python-modules/logutils { };
-
-  logzero = callPackage ../development/python-modules/logzero { };
-
-  lomond = callPackage ../development/python-modules/lomond { };
-
-  loompy = callPackage ../development/python-modules/loompy { };
-
-  loopy = callPackage ../development/python-modules/loopy { };
-
-  looseversion = callPackage ../development/python-modules/looseversion { };
-
-  loqedapi = callPackage ../development/python-modules/loqedapi { };
-
-  losant-rest = callPackage ../development/python-modules/losant-rest { };
-
-  lottie = callPackage ../development/python-modules/lottie { };
-
-  lox = callPackage ../development/python-modules/lox { };
-
-  lpc-checksum = callPackage ../development/python-modules/lpc-checksum { };
-
-  lrcalc-python = callPackage ../development/python-modules/lrcalc-python { };
-
-  lrclibapi = callPackage ../development/python-modules/lrclibapi { };
-
-  lru-dict = callPackage ../development/python-modules/lru-dict { };
-
-  lsassy = callPackage ../development/python-modules/lsassy { };
-
-  lsprotocol = callPackage ../development/python-modules/lsprotocol { };
-
-  lsp-tree-sitter = callPackage ../development/python-modules/lsp-tree-sitter { };
-
-  ltpycld2 = callPackage ../development/python-modules/ltpycld2 { };
-
-  lttng = callPackage ../development/python-modules/lttng { };
-
-  luddite = callPackage ../development/python-modules/luddite { };
-
-  luftdaten = callPackage ../development/python-modules/luftdaten { };
-
-  luhn = callPackage ../development/python-modules/luhn { };
-
-  lunarcalendar = callPackage ../development/python-modules/lunarcalendar { };
-
-  luna-soc = callPackage ../development/python-modules/luna-soc { };
-
-  luna-usb = callPackage ../development/python-modules/luna-usb { };
-
-  luqum = callPackage ../development/python-modules/luqum { };
-
-  luxtronik = callPackage ../development/python-modules/luxtronik { };
-
-  lupa = callPackage ../development/python-modules/lupa { };
-
-  lupupy = callPackage ../development/python-modules/lupupy { };
-
-  lxmf = callPackage ../development/python-modules/lxmf { };
-
-  lxml = callPackage ../development/python-modules/lxml { inherit (pkgs) libxml2 libxslt zlib; };
-
-  lxml-html-clean = callPackage ../development/python-modules/lxml-html-clean { };
-
-  lxml-stubs = callPackage ../development/python-modules/lxml-stubs { };
-
-  lyricwikia = callPackage ../development/python-modules/lyricwikia { };
-
-  lz4 = callPackage ../development/python-modules/lz4 { };
-
-  lzallright = callPackage ../development/python-modules/lzallright { };
-
-  lzstring = callPackage ../development/python-modules/lzstring { };
-
-  m2crypto = callPackage ../development/python-modules/m2crypto { };
-
-  m2r = callPackage ../development/python-modules/m2r { };
-
-  m3u8 = callPackage ../development/python-modules/m3u8 { };
-
-  mac-alias = callPackage ../development/python-modules/mac-alias { };
-
-  mac-vendor-lookup = callPackage ../development/python-modules/mac-vendor-lookup { };
-
-  macaddress = callPackage ../development/python-modules/macaddress { };
-
-  macfsevents = callPackage ../development/python-modules/macfsevents {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
-  };
-
-  macholib = callPackage ../development/python-modules/macholib { };
-
-  macropy = callPackage ../development/python-modules/macropy { };
-
-  maec = callPackage ../development/python-modules/maec { };
-
-  maestral = callPackage ../development/python-modules/maestral { };
-
-  magic = callPackage ../development/python-modules/magic { };
-
-  magicgui = callPackage ../development/python-modules/magicgui { };
-
-  magic-filter = callPackage ../development/python-modules/magic-filter { };
-
-  magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
-
-  magic-wormhole-mailbox-server =
-    callPackage ../development/python-modules/magic-wormhole-mailbox-server
-      { };
-
-  magic-wormhole-transit-relay =
-    callPackage ../development/python-modules/magic-wormhole-transit-relay
-      { };
-
-  magika = callPackage ../development/python-modules/magika { };
-
-  mahotas = callPackage ../development/python-modules/mahotas { };
-
-  mailcap-fix = callPackage ../development/python-modules/mailcap-fix { };
-
-  mailchecker = callPackage ../development/python-modules/mailchecker { };
-
-  mailchimp = callPackage ../development/python-modules/mailchimp { };
-
-  mailmanclient = callPackage ../development/python-modules/mailmanclient { };
-
-  rtfde = callPackage ../development/python-modules/rtfde { };
-
-  rtfunicode = callPackage ../development/python-modules/rtfunicode { };
-
-  rtmixer = callPackage ../development/python-modules/rtmixer { };
-
-  regress = callPackage ../development/python-modules/regress { };
-
-  macaroonbakery = callPackage ../development/python-modules/macaroonbakery { };
-
-  mail-parser = callPackage ../development/python-modules/mail-parser { };
-
-  makefun = callPackage ../development/python-modules/makefun { };
-
-  mailsuite = callPackage ../development/python-modules/mailsuite { };
-
-  maison = callPackage ../development/python-modules/maison { };
-
-  mako = callPackage ../development/python-modules/mako { };
-
-  malduck = callPackage ../development/python-modules/malduck { };
-
-  mallard-ducktype = callPackage ../development/python-modules/mallard-ducktype { };
-
-  mammoth = callPackage ../development/python-modules/mammoth { };
-
-  mamba-ssm = callPackage ../development/python-modules/mamba-ssm { };
-
-  managesieve = callPackage ../development/python-modules/managesieve { };
-
-  mando = callPackage ../development/python-modules/mando { };
-
-  mandown = callPackage ../development/python-modules/mandown { };
-
-  manga-ocr = callPackage ../development/python-modules/manga-ocr { };
-
-  manhole = callPackage ../development/python-modules/manhole { };
-
-  manim = callPackage ../development/python-modules/manim { };
-
-  manimpango = callPackage ../development/python-modules/manimpango {
-    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
-  };
-
-  manim-slides = callPackage ../development/python-modules/manim-slides { };
-
-  manifest-ml = callPackage ../development/python-modules/manifest-ml { };
-
-  manifold3d = callPackage ../development/python-modules/manifold3d { };
-
-  manifestoo = callPackage ../development/python-modules/manifestoo { };
-
-  manifestoo-core = callPackage ../development/python-modules/manifestoo-core { };
-
-  manifestparser =
-    callPackage ../development/python-modules/marionette-harness/manifestparser.nix
-      { };
-
-  manuel = callPackage ../development/python-modules/manuel { };
-
-  manuf = callPackage ../development/python-modules/manuf { };
-
-  mapbox-earcut = callPackage ../development/python-modules/mapbox-earcut { };
-
-  mapclassify = callPackage ../development/python-modules/mapclassify { };
-
-  mariadb = callPackage ../development/python-modules/mariadb { };
-
-  marimo = callPackage ../development/python-modules/marimo { };
-
-  marisa = callPackage ../development/python-modules/marisa { inherit (pkgs) marisa; };
-
-  marisa-trie = callPackage ../development/python-modules/marisa-trie { };
-
-  markdown2 = callPackage ../development/python-modules/markdown2 { };
-
-  markdown = callPackage ../development/python-modules/markdown { };
-
-  markdown-include = callPackage ../development/python-modules/markdown-include { };
-
-  markdown-it-py = callPackage ../development/python-modules/markdown-it-py { };
-
-  markdown-macros = callPackage ../development/python-modules/markdown-macros { };
-
-  markdownify = callPackage ../development/python-modules/markdownify { };
-
-  markitdown = callPackage ../development/python-modules/markitdown { };
-
-  marko = callPackage ../development/python-modules/marko { };
-
-  markupsafe = callPackage ../development/python-modules/markupsafe { };
-
-  markuppy = callPackage ../development/python-modules/markuppy { };
-
-  markups = callPackage ../development/python-modules/markups { };
-
-  marqo = callPackage ../development/python-modules/marqo { };
-
-  marshmallow = callPackage ../development/python-modules/marshmallow { };
-
-  marshmallow-dataclass = callPackage ../development/python-modules/marshmallow-dataclass { };
-
-  marshmallow-oneofschema = callPackage ../development/python-modules/marshmallow-oneofschema { };
-
-  marshmallow-polyfield = callPackage ../development/python-modules/marshmallow-polyfield { };
-
-  marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
-
-  mashumaro = callPackage ../development/python-modules/mashumaro { };
-
-  masky = callPackage ../development/python-modules/masky { };
-
-  mastodon-py = callPackage ../development/python-modules/mastodon-py { };
-
-  mat2 = callPackage ../development/python-modules/mat2 { };
-
-  material-color-utilities = callPackage ../development/python-modules/material-color-utilities { };
-
-  materialx = callPackage ../development/python-modules/materialx { };
-
-  materialyoucolor = callPackage ../development/python-modules/materialyoucolor { };
-
-  matchpy = callPackage ../development/python-modules/matchpy { };
-
-  mathlibtools = callPackage ../development/python-modules/mathlibtools { };
-
-  mathutils = callPackage ../development/python-modules/mathutils { };
-
-  matlink-gpapi = callPackage ../development/python-modules/matlink-gpapi { };
-
-  matplotlib = callPackage ../development/python-modules/matplotlib {
-    stdenv = if stdenv.hostPlatform.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
-    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
-    ghostscript = pkgs.ghostscript_headless;
-  };
-
-  matplotlib-inline = callPackage ../development/python-modules/matplotlib-inline { };
-
-  matplotlib-sixel = callPackage ../development/python-modules/matplotlib-sixel { };
-
-  matplotlib-venn = callPackage ../development/python-modules/matplotlib-venn { };
-
-  matplotx = callPackage ../development/python-modules/matplotx { };
-
-  matrix-client = callPackage ../development/python-modules/matrix-client { };
-
-  matrix-common = callPackage ../development/python-modules/matrix-common { };
-
-  matrix-nio = callPackage ../development/python-modules/matrix-nio { };
-
-  mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
-
-  maubot = callPackage ../tools/networking/maubot { };
-
-  mautrix = callPackage ../development/python-modules/mautrix { };
-
-  mautrix-appservice = self.mautrix; # alias 2019-12-28
-
-  maxcube-api = callPackage ../development/python-modules/maxcube-api { };
-
-  maxminddb = callPackage ../development/python-modules/maxminddb { };
-
-  maya = callPackage ../development/python-modules/maya { };
-
-  mayavi = pkgs.libsForQt5.callPackage ../development/python-modules/mayavi {
-    inherit buildPythonPackage pythonOlder pythonAtLeast;
-    # when next release contains numpy2 support unpin
-    # https://github.com/enthought/mayavi/pull/1315
-    inherit (self)
-      pyface
-      pygments
-      numpy_1
-      packaging
-      vtk
-      traitsui
-      envisage
-      apptools
-      pyqt5
-      ;
-  };
-
-  mayim = callPackage ../development/python-modules/mayim { };
-
-  mbddns = callPackage ../development/python-modules/mbddns { };
-
-  mbstrdecoder = callPackage ../development/python-modules/mbstrdecoder { };
-
-  mccabe = callPackage ../development/python-modules/mccabe { };
-
-  mcdreforged = callPackage ../development/python-modules/mcdreforged { };
-
-  mcp = callPackage ../development/python-modules/mcp { };
-
-  mcpadapt = callPackage ../development/python-modules/mcpadapt { };
-
-  mcstatus = callPackage ../development/python-modules/mcstatus { };
-
-  mcuuid = callPackage ../development/python-modules/mcuuid { };
-
-  md-toc = callPackage ../development/python-modules/md-toc { };
-
-  mdx-truly-sane-lists = callPackage ../development/python-modules/mdx-truly-sane-lists { };
-
-  md2gemini = callPackage ../development/python-modules/md2gemini { };
-
-  md2pdf = callPackage ../development/python-modules/md2pdf { };
-
-  mdformat = callPackage ../development/python-modules/mdformat { };
-  mdformat-admon = callPackage ../development/python-modules/mdformat-admon { };
-  mdformat-beautysh = callPackage ../development/python-modules/mdformat-beautysh { };
-  mdformat-footnote = callPackage ../development/python-modules/mdformat-footnote { };
-  mdformat-frontmatter = callPackage ../development/python-modules/mdformat-frontmatter { };
-  mdformat-gfm = callPackage ../development/python-modules/mdformat-gfm { };
-  mdformat-gfm-alerts = callPackage ../development/python-modules/mdformat-gfm-alerts { };
-  mdformat-mkdocs = callPackage ../development/python-modules/mdformat-mkdocs { };
-  mdformat-myst = callPackage ../development/python-modules/mdformat-myst { };
-  mdformat-nix-alejandra = callPackage ../development/python-modules/mdformat-nix-alejandra { };
-  mdformat-simple-breaks = callPackage ../development/python-modules/mdformat-simple-breaks { };
-  mdformat-tables = callPackage ../development/python-modules/mdformat-tables { };
-  mdformat-toc = callPackage ../development/python-modules/mdformat-toc { };
-  mdformat-wikilink = callPackage ../development/python-modules/mdformat-wikilink { };
-
-  mdit-py-plugins = callPackage ../development/python-modules/mdit-py-plugins { };
-
-  mdtraj = callPackage ../development/python-modules/mdtraj { };
-
-  mdurl = callPackage ../development/python-modules/mdurl { };
-
-  mdutils = callPackage ../development/python-modules/mdutils { };
-
-  mean-average-precision = callPackage ../development/python-modules/mean-average-precision { };
-
-  measurement = callPackage ../development/python-modules/measurement { };
-
-  meater-python = callPackage ../development/python-modules/meater-python { };
-
-  mecab-python3 = callPackage ../development/python-modules/mecab-python3 { };
-
-  mechanicalsoup = callPackage ../development/python-modules/mechanicalsoup { };
-
-  mechanize = callPackage ../development/python-modules/mechanize { };
-
-  medallion = callPackage ../development/python-modules/medallion { };
-
-  mediafile = callPackage ../development/python-modules/mediafile { };
-
-  mediafire-dl = callPackage ../development/python-modules/mediafire-dl { };
-
-  mediapy = callPackage ../development/python-modules/mediapy { };
-
-  medpy = callPackage ../development/python-modules/medpy { };
-
-  medvol = callPackage ../development/python-modules/medvol { };
-
-  meeko = callPackage ../development/python-modules/meeko { };
-
-  meep = callPackage ../development/python-modules/meep { };
-
-  meilisearch = callPackage ../development/python-modules/meilisearch { };
-
-  meinheld = callPackage ../development/python-modules/meinheld { };
-
-  meld3 = callPackage ../development/python-modules/meld3 { };
-
-  melnor-bluetooth = callPackage ../development/python-modules/melnor-bluetooth { };
-
-  memestra = callPackage ../development/python-modules/memestra { };
-
-  memory-allocator = callPackage ../development/python-modules/memory-allocator { };
-
-  memory-profiler = callPackage ../development/python-modules/memory-profiler { };
-
-  memory-tempfile = callPackage ../development/python-modules/memory-tempfile { };
-
-  meraki = callPackage ../development/python-modules/meraki { };
-
-  mercadopago = callPackage ../development/python-modules/mercadopago { };
-
-  mercantile = callPackage ../development/python-modules/mercantile { };
-
-  mercurial = toPythonModule (pkgs.mercurial.override { python3Packages = self; });
-
-  merge3 = callPackage ../development/python-modules/merge3 { };
-
-  mergecal = callPackage ../development/python-modules/mergecal { };
-
-  mergedb = callPackage ../development/python-modules/mergedb { };
-
-  mergedeep = callPackage ../development/python-modules/mergedeep { };
-
-  mergedict = callPackage ../development/python-modules/mergedict { };
-
-  merkletools = callPackage ../development/python-modules/merkletools { };
-
-  meross-iot = callPackage ../development/python-modules/meross-iot { };
-
-  mesa = callPackage ../development/python-modules/mesa { };
-
-  meshcat = callPackage ../development/python-modules/meshcat { };
-
-  meshio = callPackage ../development/python-modules/meshio { };
-
-  meshlabxml = callPackage ../development/python-modules/meshlabxml { };
-
-  meshtastic = callPackage ../development/python-modules/meshtastic { };
-
-  meson = toPythonModule (
-    (pkgs.meson.override { python3 = python; }).overridePythonAttrs (oldAttrs: {
-      # We do not want the setup hook in Python packages because the build is performed differently.
-      setupHook = null;
-    })
-  );
-
-  mesonpep517 = callPackage ../development/python-modules/mesonpep517 { };
-
-  meson-python = callPackage ../development/python-modules/meson-python { inherit (pkgs) ninja; };
-
-  messagebird = callPackage ../development/python-modules/messagebird { };
-
-  metaflow = callPackage ../development/python-modules/metaflow { };
-
-  metakernel = callPackage ../development/python-modules/metakernel { };
-
-  metar = callPackage ../development/python-modules/metar { };
-
-  metawear = callPackage ../development/python-modules/metawear { };
-
-  meteoalertapi = callPackage ../development/python-modules/meteoalertapi { };
-
-  meteocalc = callPackage ../development/python-modules/meteocalc { };
-
-  meteofrance-api = callPackage ../development/python-modules/meteofrance-api { };
-
-  meteoswiss-async = callPackage ../development/python-modules/meteoswiss-async { };
-
-  methodtools = callPackage ../development/python-modules/methodtools { };
-
-  mezzanine = callPackage ../development/python-modules/mezzanine { };
-
-  mf2py = callPackage ../development/python-modules/mf2py { };
-
-  mficlient = callPackage ../development/python-modules/mficlient { };
-
-  mhcflurry = callPackage ../development/python-modules/mhcflurry { };
-
-  mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };
-
-  miasm = callPackage ../development/python-modules/miasm { };
-
-  miauth = callPackage ../development/python-modules/miauth { };
-
-  micawber = callPackage ../development/python-modules/micawber { };
-
-  microdata = callPackage ../development/python-modules/microdata { };
-
-  microsoft-kiota-abstractions =
-    callPackage ../development/python-modules/microsoft-kiota-abstractions
-      { };
-
-  microsoft-kiota-authentication-azure =
-    callPackage ../development/python-modules/microsoft-kiota-authentication-azure
-      { };
-
-  microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
-
-  microsoft-kiota-serialization-form =
-    callPackage ../development/python-modules/microsoft-kiota-serialization-form
-      { };
-
-  microsoft-kiota-serialization-json =
-    callPackage ../development/python-modules/microsoft-kiota-serialization-json
-      { };
-
-  microsoft-kiota-serialization-multipart =
-    callPackage ../development/python-modules/microsoft-kiota-serialization-multipart
-      { };
-
-  microsoft-kiota-serialization-text =
-    callPackage ../development/python-modules/microsoft-kiota-serialization-text
-      { };
-
-  microsoft-security-utilities-secret-masker =
-    callPackage ../development/python-modules/microsoft-security-utilities-secret-masker
-      { };
-
-  midea-beautiful-air = callPackage ../development/python-modules/midea-beautiful-air { };
-
-  midea-local = callPackage ../development/python-modules/midea-local { };
-
-  midiutil = callPackage ../development/python-modules/midiutil { };
-
-  mido = callPackage ../development/python-modules/mido { };
-
-  migen = callPackage ../development/python-modules/migen { };
-
-  mike = callPackage ../development/python-modules/mike { };
-
-  milc = callPackage ../development/python-modules/milc { };
-
-  milksnake = callPackage ../development/python-modules/milksnake { };
-
-  mill-local = callPackage ../development/python-modules/mill-local { };
-
-  millheater = callPackage ../development/python-modules/millheater { };
-
-  mim-solvers = toPythonModule (
-    pkgs.mim-solvers.override {
-      python3Packages = self;
-      pythonSupport = true;
-    }
-  );
-
-  minari = callPackage ../development/python-modules/minari { };
-
-  mindsdb-evaluator = callPackage ../development/python-modules/mindsdb-evaluator { };
-
-  minexr = callPackage ../development/python-modules/minexr { };
-
-  miniaudio = callPackage ../development/python-modules/miniaudio {
-    inherit (pkgs) miniaudio;
-    inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox CoreAudio;
-  };
-
-  minichain = callPackage ../development/python-modules/minichain { };
-
-  minidb = callPackage ../development/python-modules/minidb { };
-
-  minidump = callPackage ../development/python-modules/minidump { };
-
-  miniful = callPackage ../development/python-modules/miniful { };
-
-  minify-html = callPackage ../development/python-modules/minify-html { };
-
-  minikanren = callPackage ../development/python-modules/minikanren { };
-
-  minikerberos = callPackage ../development/python-modules/minikerberos { };
-
-  minimal-snowplow-tracker = callPackage ../development/python-modules/minimal-snowplow-tracker { };
-
-  minimock = callPackage ../development/python-modules/minimock { };
-
-  mininet-python = (toPythonModule (pkgs.mininet.override { python3 = python; })).py;
-
-  minio = callPackage ../development/python-modules/minio { };
-
-  miniupnpc = callPackage ../development/python-modules/miniupnpc { };
-
-  mip = callPackage ../development/python-modules/mip { };
-
-  mir-eval = callPackage ../development/python-modules/mir-eval { };
-
-  mirakuru = callPackage ../development/python-modules/mirakuru { };
-
-  misaka = callPackage ../development/python-modules/misaka { };
-
-  misoc = callPackage ../development/python-modules/misoc { };
-
-  miss-hit = callPackage ../development/python-modules/miss-hit { };
-
-  miss-hit-core = callPackage ../development/python-modules/miss-hit-core { };
-
-  mistletoe = callPackage ../development/python-modules/mistletoe { };
-
-  mistral-common = callPackage ../development/python-modules/mistral-common { };
-
-  mistune = callPackage ../development/python-modules/mistune { };
-
-  mitmproxy = callPackage ../development/python-modules/mitmproxy { };
-
-  mitmproxy-linux = callPackage ../development/python-modules/mitmproxy-linux { };
-
-  mitmproxy-macos = callPackage ../development/python-modules/mitmproxy-macos { };
-
-  mitmproxy-rs = callPackage ../development/python-modules/mitmproxy-rs { };
-
-  mitogen = callPackage ../development/python-modules/mitogen { };
-
-  mixbox = callPackage ../development/python-modules/mixbox { };
-
-  mixins = callPackage ../development/python-modules/mixins { };
-
-  mixpanel = callPackage ../development/python-modules/mixpanel { };
-
-  mizani = callPackage ../development/python-modules/mizani { };
-
-  mkdocs = callPackage ../development/python-modules/mkdocs { };
-
-  mkdocs-autolinks-plugin = callPackage ../development/python-modules/mkdocs-autolinks-plugin { };
-
-  mkdocs-autorefs = callPackage ../development/python-modules/mkdocs-autorefs { };
-  mkdocs-awesome-nav = callPackage ../development/python-modules/mkdocs-awesome-nav { };
-
-  mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
-
-  mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
-
-  mkdocs-get-deps = callPackage ../development/python-modules/mkdocs-get-deps { };
-
-  mkdocs-git-authors-plugin = callPackage ../development/python-modules/mkdocs-git-authors-plugin { };
-
-  mkdocs-git-committers-plugin-2 =
-    callPackage ../development/python-modules/mkdocs-git-committers-plugin-2
-      { };
-
-  mkdocs-git-revision-date-localized-plugin =
-    callPackage ../development/python-modules/mkdocs-git-revision-date-localized-plugin
-      { };
-
-  mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };
-
-  mkdocs-glightbox = callPackage ../development/python-modules/mkdocs-glightbox { };
-
-  mkdocs-jupyter = callPackage ../development/python-modules/mkdocs-jupyter { };
-
-  mkdocs-linkcheck = callPackage ../development/python-modules/mkdocs-linkcheck { };
-
-  mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
-
-  mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
-
-  mkdocs-material-extensions =
-    callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
-      { };
-
-  mkdocs-mermaid2-plugin = callPackage ../development/python-modules/mkdocs-mermaid2-plugin { };
-
-  mkdocs-minify-plugin = callPackage ../development/python-modules/mkdocs-minify-plugin { };
-
-  mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
-
-  mkdocs-redoc-tag = callPackage ../development/python-modules/mkdocs-redoc-tag { };
-
-  mkdocs-rss-plugin = callPackage ../development/python-modules/mkdocs-rss-plugin { };
-
-  mkdocs-swagger-ui-tag = callPackage ../development/python-modules/mkdocs-swagger-ui-tag { };
-
-  mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
-
-  mkdocstrings-python = callPackage ../development/python-modules/mkdocstrings-python { };
-
-  mkl-service = callPackage ../development/python-modules/mkl-service { };
-
-  mktestdocs = callPackage ../development/python-modules/mktestdocs { };
-
-  ml-collections = callPackage ../development/python-modules/ml-collections { };
-
-  ml-dtypes = callPackage ../development/python-modules/ml-dtypes { };
-
-  mlflow = callPackage ../development/python-modules/mlflow { };
-
-  mlrose = callPackage ../development/python-modules/mlrose { };
-
-  mlx = callPackage ../development/python-modules/mlx { };
-
-  mlxtend = callPackage ../development/python-modules/mlxtend { };
-
-  mlt = toPythonModule (
-    pkgs.mlt.override {
-      python3 = python;
-      enablePython = true;
-    }
-  );
-
-  mmcif-pdbx = callPackage ../development/python-modules/mmcif-pdbx { };
-
-  mmcv = callPackage ../development/python-modules/mmcv { };
-
-  mmengine = callPackage ../development/python-modules/mmengine { };
-
-  mmh3 = callPackage ../development/python-modules/mmh3 { };
-
-  mmpython = callPackage ../development/python-modules/mmpython { };
-
-  mmtf-python = callPackage ../development/python-modules/mmtf-python { };
-
-  mnemonic = callPackage ../development/python-modules/mnemonic { };
-
-  mne-python = callPackage ../development/python-modules/mne-python { };
-
-  mnist = callPackage ../development/python-modules/mnist { };
-
-  moat-ble = callPackage ../development/python-modules/moat-ble { };
-
-  mobi = callPackage ../development/python-modules/mobi { };
-
-  mobly = callPackage ../development/python-modules/mobly { };
-
-  mocket = callPackage ../development/python-modules/mocket { };
-
-  mock = callPackage ../development/python-modules/mock { };
-
-  mockfs = callPackage ../development/python-modules/mockfs { };
-
-  mockito = callPackage ../development/python-modules/mockito { };
-
-  mock-django = callPackage ../development/python-modules/mock-django { };
-
-  mock-open = callPackage ../development/python-modules/mock-open { };
-
-  mock-services = callPackage ../development/python-modules/mock-services { };
-
-  mock-ssh-server = callPackage ../development/python-modules/mock-ssh-server { };
-
-  mockupdb = callPackage ../development/python-modules/mockupdb { };
-
-  modbus-tk = callPackage ../development/python-modules/modbus-tk { };
-
-  moddb = callPackage ../development/python-modules/moddb { };
-
-  model-bakery = callPackage ../development/python-modules/model-bakery { };
-
-  model-checker = callPackage ../development/python-modules/model-checker { };
-
-  modelcif = callPackage ../development/python-modules/modelcif { };
-
-  modeled = callPackage ../development/python-modules/modeled { };
-
-  moderngl = callPackage ../development/python-modules/moderngl { };
-
-  moderngl-window = callPackage ../development/python-modules/moderngl-window { };
-
-  modestmaps = callPackage ../development/python-modules/modestmaps { };
-
-  mohawk = callPackage ../development/python-modules/mohawk { };
-
-  molbar = callPackage ../development/python-modules/molbar { };
-
-  molecule = callPackage ../development/python-modules/molecule { };
-
-  molecule-plugins = callPackage ../development/python-modules/molecule/plugins.nix { };
-
-  momepy = callPackage ../development/python-modules/momepy { };
-
-  monai = callPackage ../development/python-modules/monai { };
-
-  monai-deploy = callPackage ../development/python-modules/monai-deploy { };
-
-  monero = callPackage ../development/python-modules/monero { };
-
-  mongomock = callPackage ../development/python-modules/mongomock { };
-
-  mongodict = callPackage ../development/python-modules/mongodict { };
-
-  mongoengine = callPackage ../development/python-modules/mongoengine { };
-
-  mongoquery = callPackage ../development/python-modules/mongoquery { };
-
-  monitorcontrol = callPackage ../development/python-modules/monitorcontrol { };
-
-  monkeyhex = callPackage ../development/python-modules/monkeyhex { };
-
-  monkeytype = callPackage ../development/python-modules/monkeytype { };
-
-  monosat = pkgs.monosat.python {
-    inherit buildPythonPackage;
-    inherit (self) cython pytestCheckHook;
-  };
-
-  monotonic = callPackage ../development/python-modules/monotonic { };
-
-  monotonic-alignment-search =
-    callPackage ../development/python-modules/monotonic-alignment-search
-      { };
-
-  monty = callPackage ../development/python-modules/monty { };
-
-  monzopy = callPackage ../development/python-modules/monzopy { };
-
-  moonraker-api = callPackage ../development/python-modules/moonraker-api { };
-
-  mopeka-iot-ble = callPackage ../development/python-modules/mopeka-iot-ble { };
-
-  more-itertools = callPackage ../development/python-modules/more-itertools { };
-
-  more-properties = callPackage ../development/python-modules/more-properties { };
-
-  morecantile = callPackage ../development/python-modules/morecantile { };
-
-  moreorless = callPackage ../development/python-modules/moreorless { };
-
-  moretools = callPackage ../development/python-modules/moretools { };
-
-  morfessor = callPackage ../development/python-modules/morfessor { };
-
-  morphys = callPackage ../development/python-modules/morphys { };
-
-  mortgage = callPackage ../development/python-modules/mortgage { };
-
-  motmetrics = callPackage ../development/python-modules/motmetrics { };
-
-  motionblinds = callPackage ../development/python-modules/motionblinds { };
-
-  motionblindsble = callPackage ../development/python-modules/motionblindsble { };
-
-  motioneye-client = callPackage ../development/python-modules/motioneye-client { };
-
-  moto = callPackage ../development/python-modules/moto { };
-
-  motor = callPackage ../development/python-modules/motor { };
-
-  mouseinfo = callPackage ../development/python-modules/mouseinfo { };
-
-  moviepy = callPackage ../development/python-modules/moviepy { };
-
-  mozart-api = callPackage ../development/python-modules/mozart-api { };
-
-  mozilla-django-oidc = callPackage ../development/python-modules/mozilla-django-oidc { };
-
-  mpd2 = callPackage ../development/python-modules/mpd2 { };
-
-  mpegdash = callPackage ../development/python-modules/mpegdash { };
-
-  mpi4py = callPackage ../development/python-modules/mpi4py { };
-
-  mpire = callPackage ../development/python-modules/mpire { };
-
-  mpldatacursor = callPackage ../development/python-modules/mpldatacursor { };
-
-  mplcursors = callPackage ../development/python-modules/mplcursors { };
-
-  mplfinance = callPackage ../development/python-modules/mplfinance { };
-
-  mplhep = callPackage ../development/python-modules/mplhep { };
-
-  mplhep-data = callPackage ../development/python-modules/mplhep-data { };
-
-  mplleaflet = callPackage ../development/python-modules/mplleaflet { };
-
-  mpl-scatter-density = callPackage ../development/python-modules/mpl-scatter-density { };
-
-  mpl-typst = callPackage ../development/python-modules/mpl-typst { };
-
-  mpmath = callPackage ../development/python-modules/mpmath { };
-
-  mpris-server = callPackage ../development/python-modules/mpris-server { };
-
-  mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };
-
-  mpyq = callPackage ../development/python-modules/mpyq { };
-
-  mrjob = callPackage ../development/python-modules/mrjob { };
-
-  mrsqm = callPackage ../development/python-modules/mrsqm { };
-
-  ms-active-directory = callPackage ../development/python-modules/ms-active-directory { };
-
-  ms-cv = callPackage ../development/python-modules/ms-cv { };
-
-  msal = callPackage ../development/python-modules/msal { };
-
-  msal-extensions = callPackage ../development/python-modules/msal-extensions { };
-
-  mscerts = callPackage ../development/python-modules/mscerts { };
-
-  msgpack = callPackage ../development/python-modules/msgpack { };
-
-  msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
-
-  msg-parser = callPackage ../development/python-modules/msg-parser { };
-
-  msgspec = callPackage ../development/python-modules/msgspec { };
-
-  msldap = callPackage ../development/python-modules/msldap { };
-
-  msmart-ng = callPackage ../development/python-modules/msmart-ng { };
-
-  msoffcrypto-tool = callPackage ../development/python-modules/msoffcrypto-tool { };
-
-  msprime = callPackage ../development/python-modules/msprime { };
-
-  mss = callPackage ../development/python-modules/mss { };
-
-  msticpy = callPackage ../development/python-modules/msticpy { };
-
-  msrestazure = callPackage ../development/python-modules/msrestazure { };
-
-  msrest = callPackage ../development/python-modules/msrest { };
-
-  mtcnn = callPackage ../development/python-modules/mtcnn { };
-
-  mt-940 = callPackage ../development/python-modules/mt-940 { };
-
-  mullvad-api = callPackage ../development/python-modules/mullvad-api { };
-
-  mullvad-closest = callPackage ../development/python-modules/mullvad-closest { };
-
-  mulpyplexer = callPackage ../development/python-modules/mulpyplexer { };
-
-  multidict = callPackage ../development/python-modules/multidict { };
-
-  multi-key-dict = callPackage ../development/python-modules/multi-key-dict { };
-
-  multimethod = callPackage ../development/python-modules/multimethod { };
-
-  multipledispatch = callPackage ../development/python-modules/multipledispatch { };
-
-  multiprocess = callPackage ../development/python-modules/multiprocess { };
-
-  multiscale-spatial-image = callPackage ../development/python-modules/multiscale-spatial-image { };
-
-  multiset = callPackage ../development/python-modules/multiset { };
-
-  multitasking = callPackage ../development/python-modules/multitasking { };
-
-  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
-
-  munch = callPackage ../development/python-modules/munch { };
-
-  mung = callPackage ../development/python-modules/mung { };
-
-  munkres = callPackage ../development/python-modules/munkres { };
-
-  murmurhash = callPackage ../development/python-modules/murmurhash { };
-
-  muscima = callPackage ../development/python-modules/muscima { };
-
-  music-assistant-client = callPackage ../development/python-modules/music-assistant-client { };
-
-  music-assistant-models = callPackage ../development/python-modules/music-assistant-models { };
-
-  musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };
-
-  music-tag = callPackage ../development/python-modules/music-tag { };
-
-  mutag = callPackage ../development/python-modules/mutag { };
-
-  mutagen = callPackage ../development/python-modules/mutagen { };
-
-  mutatormath = callPackage ../development/python-modules/mutatormath { };
-
-  mutesync = callPackage ../development/python-modules/mutesync { };
-
-  mutf8 = callPackage ../development/python-modules/mutf8 { };
-
-  mujoco = callPackage ../development/python-modules/mujoco { inherit (pkgs) mujoco; };
-
-  mujson = callPackage ../development/python-modules/mujson { };
-
-  mwcli = callPackage ../development/python-modules/mwcli { };
-
-  mwclient = callPackage ../development/python-modules/mwclient { };
-
-  mwdblib = callPackage ../development/python-modules/mwdblib { };
-
-  mwoauth = callPackage ../development/python-modules/mwoauth { };
-
-  mwparserfromhell = callPackage ../development/python-modules/mwparserfromhell { };
-
-  mwtypes = callPackage ../development/python-modules/mwtypes { };
-
-  mwxml = callPackage ../development/python-modules/mwxml { };
-
-  mxnet = callPackage ../development/python-modules/mxnet { };
-
-  myfitnesspal = callPackage ../development/python-modules/myfitnesspal { };
-
-  mygene = callPackage ../development/python-modules/mygene { };
-
-  mygpoclient = callPackage ../development/python-modules/mygpoclient { };
-
-  myhdl = callPackage ../development/python-modules/myhdl { inherit (pkgs) ghdl iverilog; };
-
-  myhome = callPackage ../development/python-modules/myhome { };
-
-  myjwt = callPackage ../development/python-modules/myjwt { };
-
-  mypermobil = callPackage ../development/python-modules/mypermobil { };
-
-  mypy = callPackage ../development/python-modules/mypy { };
-
-  mypy-boto3-builder = callPackage ../development/python-modules/mypy-boto3-builder { };
 
   inherit (callPackage ../development/python-modules/mypy-boto3 { })
     mypy-boto3-accessanalyzer
@@ -9514,8007 +6971,6 @@ self: super: with self; {
     mypy-boto3-workspaces-web
     mypy-boto3-xray
     ;
-
-  mypy-extensions = callPackage ../development/python-modules/mypy/extensions.nix { };
-
-  mypy-protobuf = callPackage ../development/python-modules/mypy-protobuf { };
-
-  mysqlclient = callPackage ../development/python-modules/mysqlclient { };
-
-  mysql-connector = callPackage ../development/python-modules/mysql-connector { };
-
-  myst-docutils = callPackage ../development/python-modules/myst-docutils { };
-
-  myst-nb = callPackage ../development/python-modules/myst-nb { };
-
-  myst-parser = callPackage ../development/python-modules/myst-parser { };
-
-  myuplink = callPackage ../development/python-modules/myuplink { };
-
-  nad-receiver = callPackage ../development/python-modules/nad-receiver { };
-
-  nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };
-
-  naked = callPackage ../development/python-modules/naked { };
-
-  namedlist = callPackage ../development/python-modules/namedlist { };
-
-  nameparser = callPackage ../development/python-modules/nameparser { };
-
-  names = callPackage ../development/python-modules/names { };
-
-  namex = callPackage ../development/python-modules/namex { };
-
-  name-that-hash = callPackage ../development/python-modules/name-that-hash { };
-
-  nameko = callPackage ../development/python-modules/nameko { };
-
-  nampa = callPackage ../development/python-modules/nampa { };
-
-  nanobind = callPackage ../development/python-modules/nanobind { };
-
-  nanoemoji = callPackage ../development/python-modules/nanoemoji { };
-
-  nanoid = callPackage ../development/python-modules/nanoid { };
-
-  nanoleaf = callPackage ../development/python-modules/nanoleaf { };
-
-  navec = callPackage ../development/python-modules/navec { };
-
-  narwhals = callPackage ../development/python-modules/narwhals { };
-
-  natasha = callPackage ../development/python-modules/natasha { };
-
-  natural = callPackage ../development/python-modules/natural { };
-
-  ndcurves = toPythonModule (
-    pkgs.ndcurves.override {
-      python3Packages = self;
-      pythonSupport = true;
-    }
-  );
-
-  nglview = callPackage ../development/python-modules/nglview { };
-
-  nomadnet = callPackage ../development/python-modules/nomadnet { };
-
-  nonbloat-db = callPackage ../development/python-modules/nonbloat-db { };
-
-  noneprompt = callPackage ../development/python-modules/noneprompt { };
-
-  nox = callPackage ../development/python-modules/nox { };
-
-  nanomsg-python = callPackage ../development/python-modules/nanomsg-python {
-    inherit (pkgs) nanomsg;
-  };
-
-  nanotime = callPackage ../development/python-modules/nanotime { };
-
-  napalm = callPackage ../development/python-modules/napalm { };
-
-  napalm-hp-procurve = callPackage ../development/python-modules/napalm/hp-procurve.nix { };
-
-  napalm-ros = callPackage ../development/python-modules/napalm/ros.nix { };
-
-  napari = callPackage ../development/python-modules/napari {
-    inherit (pkgs.libsForQt5) mkDerivationWith wrapQtAppsHook;
-  };
-
-  napari-console = callPackage ../development/python-modules/napari-console { };
-
-  napari-nifti = callPackage ../development/python-modules/napari-nifti { };
-
-  napari-npe2 = callPackage ../development/python-modules/napari-npe2 { };
-
-  napari-plugin-engine = callPackage ../development/python-modules/napari-plugin-engine { };
-
-  napari-svg = callPackage ../development/python-modules/napari-svg { };
-
-  nasdaq-data-link = callPackage ../development/python-modules/nasdaq-data-link { };
-
-  nats-py = callPackage ../development/python-modules/nats-py { };
-
-  nats-python = callPackage ../development/python-modules/nats-python { };
-
-  natsort = callPackage ../development/python-modules/natsort { };
-
-  naturalsort = callPackage ../development/python-modules/naturalsort { };
-
-  nbclassic = callPackage ../development/python-modules/nbclassic { };
-
-  nbclient = callPackage ../development/python-modules/nbclient { };
-
-  nbconflux = callPackage ../development/python-modules/nbconflux { };
-
-  nbconvert = callPackage ../development/python-modules/nbconvert { };
-
-  nbdev = callPackage ../development/python-modules/nbdev { };
-
-  nbdime = callPackage ../development/python-modules/nbdime { };
-
-  nbexec = callPackage ../development/python-modules/nbexec { };
-
-  nbformat = callPackage ../development/python-modules/nbformat { };
-
-  nbmake = callPackage ../development/python-modules/nbmake { };
-
-  nbsmoke = callPackage ../development/python-modules/nbsmoke { };
-
-  nbsphinx = callPackage ../development/python-modules/nbsphinx { };
-
-  nbtlib = callPackage ../development/python-modules/nbtlib { };
-
-  nbval = callPackage ../development/python-modules/nbval { };
-
-  nbxmpp = callPackage ../development/python-modules/nbxmpp { };
-
-  nc-dnsapi = callPackage ../development/python-modules/nc-dnsapi { };
-
-  ncclient = callPackage ../development/python-modules/ncclient { };
-
-  nclib = callPackage ../development/python-modules/nclib { };
-
-  ndeflib = callPackage ../development/python-modules/ndeflib { };
-
-  ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
-
-  ndindex = callPackage ../development/python-modules/ndindex { };
-
-  ndjson = callPackage ../development/python-modules/ndjson { };
-
-  ndms2-client = callPackage ../development/python-modules/ndms2-client { };
-
-  ndspy = callPackage ../development/python-modules/ndspy { };
-
-  ndtypes = callPackage ../development/python-modules/ndtypes { };
-
-  nebula3-python = callPackage ../development/python-modules/nebula3-python { };
-
-  nemosis = callPackage ../development/python-modules/nemosis { };
-
-  nengo = callPackage ../development/python-modules/nengo { };
-
-  neo = callPackage ../development/python-modules/neo { };
-
-  neo4j = callPackage ../development/python-modules/neo4j { };
-
-  neoteroi-mkdocs = callPackage ../development/python-modules/neoteroi-mkdocs { };
-
-  nessclient = callPackage ../development/python-modules/nessclient { };
-
-  nest = toPythonModule (
-    pkgs.nest-mpi.override {
-      withPython = true;
-      python3 = python;
-    }
-  );
-
-  nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
-
-  nested-lookup = callPackage ../development/python-modules/nested-lookup { };
-
-  nestedtext = callPackage ../development/python-modules/nestedtext { };
-
-  netaddr = callPackage ../development/python-modules/netaddr { };
-
-  netapp-lib = callPackage ../development/python-modules/netapp-lib { };
-
-  netapp-ontap = callPackage ../development/python-modules/netapp-ontap { };
-
-  netbox-bgp = callPackage ../development/python-modules/netbox-bgp { };
-
-  netbox-contract = callPackage ../development/python-modules/netbox-contract { };
-
-  netbox-dns = callPackage ../development/python-modules/netbox-dns { };
-
-  netbox-documents = callPackage ../development/python-modules/netbox-documents { };
-
-  netbox-floorplan-plugin = callPackage ../development/python-modules/netbox-floorplan-plugin { };
-
-  netbox-interface-synchronization =
-    callPackage ../development/python-modules/netbox-interface-synchronization
-      { };
-
-  netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };
-
-  netbox-plugin-prometheus-sd =
-    callPackage ../development/python-modules/netbox-plugin-prometheus-sd
-      { };
-
-  netbox-qrcode = callPackage ../development/python-modules/netbox-qrcode { };
-
-  netbox-reorder-rack = callPackage ../development/python-modules/netbox-reorder-rack { };
-
-  netbox-routing = callPackage ../development/python-modules/netbox-routing { };
-
-  netbox-topology-views = callPackage ../development/python-modules/netbox-topology-views { };
-
-  netcdf4 = callPackage ../development/python-modules/netcdf4 { };
-
-  netdata = callPackage ../development/python-modules/netdata { };
-
-  netdata-pandas = callPackage ../development/python-modules/netdata-pandas { };
-
-  netdisco = callPackage ../development/python-modules/netdisco { };
-
-  netgen-mesher = toPythonModule (pkgs.netgen.override { python3Packages = self; });
-
-  nethsm = callPackage ../development/python-modules/nethsm { };
-
-  netifaces = callPackage ../development/python-modules/netifaces { };
-
-  netifaces2 = callPackage ../development/python-modules/netifaces2 { };
-
-  netifaces-plus = callPackage ../development/python-modules/netifaces-plus { };
-
-  netmiko = callPackage ../development/python-modules/netmiko { };
-
-  netio = callPackage ../development/python-modules/netio { };
-
-  nettigo-air-monitor = callPackage ../development/python-modules/nettigo-air-monitor { };
-
-  netutils = callPackage ../development/python-modules/netutils { };
-
-  networkx = callPackage ../development/python-modules/networkx { };
-
-  neuralfoil = callPackage ../development/python-modules/neuralfoil { };
-
-  neurokit2 = callPackage ../development/python-modules/neurokit2 { };
-
-  neuron-full = pkgs.neuron-full.override { python3 = python; };
-
-  neuronpy = toPythonModule neuron-full;
-
-  nevow = callPackage ../development/python-modules/nevow { };
-
-  newversion = callPackage ../development/python-modules/newversion { };
-
-  newick = callPackage ../development/python-modules/newick { };
-
-  nexia = callPackage ../development/python-modules/nexia { };
-
-  nextcloudmonitor = callPackage ../development/python-modules/nextcloudmonitor { };
-
-  nextcord = callPackage ../development/python-modules/nextcord { };
-
-  nextdns = callPackage ../development/python-modules/nextdns { };
-
-  nexusformat = callPackage ../development/python-modules/nexusformat { };
-
-  nfcpy = callPackage ../development/python-modules/nfcpy { };
-
-  nftables = callPackage ../os-specific/linux/nftables/python.nix { inherit (pkgs) nftables; };
-
-  nh3 = callPackage ../development/python-modules/nh3 { };
-
-  nhc = callPackage ../development/python-modules/nhc { };
-
-  niaaml = callPackage ../development/python-modules/niaaml { };
-
-  nianet = callPackage ../development/python-modules/nianet { };
-
-  niaarm = callPackage ../development/python-modules/niaarm { };
-
-  niaclass = callPackage ../development/python-modules/niaclass { };
-
-  niapy = callPackage ../development/python-modules/niapy { };
-
-  nibabel = callPackage ../development/python-modules/nibabel { };
-
-  nibe = callPackage ../development/python-modules/nibe { };
-
-  nice-go = callPackage ../development/python-modules/nice-go { };
-
-  nicegui = callPackage ../development/python-modules/nicegui { };
-
-  nicegui-highcharts = callPackage ../development/python-modules/nicegui-highcharts { };
-
-  nidaqmx = callPackage ../development/python-modules/nidaqmx { };
-
-  nifty8 = callPackage ../development/python-modules/nifty8 { };
-
-  nikola = callPackage ../development/python-modules/nikola { };
-
-  nilearn = callPackage ../development/python-modules/nilearn { };
-
-  niluclient = callPackage ../development/python-modules/niluclient { };
-
-  nimfa = callPackage ../development/python-modules/nimfa { };
-
-  nine = callPackage ../development/python-modules/nine { };
-
-  ninebot-ble = callPackage ../development/python-modules/ninebot-ble { };
-
-  ninja = callPackage ../development/python-modules/ninja { inherit (pkgs) ninja; };
-
-  nipreps-versions = callPackage ../development/python-modules/nipreps-versions { };
-
-  nipy = callPackage ../development/python-modules/nipy { };
-
-  nipype = callPackage ../development/python-modules/nipype { inherit (pkgs) which; };
-
-  nitime = callPackage ../development/python-modules/nitime { };
-
-  nitpick = callPackage ../applications/version-management/nitpick { };
-
-  nitransforms = callPackage ../development/python-modules/nitransforms { };
-
-  nitrokey = callPackage ../development/python-modules/nitrokey { };
-
-  niworkflows = callPackage ../development/python-modules/niworkflows { };
-
-  nix-kernel = callPackage ../development/python-modules/nix-kernel { inherit (pkgs) nix; };
-
-  nixpkgs = callPackage ../development/python-modules/nixpkgs { };
-
-  nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };
-
-  nixpkgs-updaters-library = callPackage ../development/python-modules/nixpkgs-updaters-library { };
-
-  nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
-
-  nkdfu = callPackage ../development/python-modules/nkdfu { };
-
-  nlpcloud = callPackage ../development/python-modules/nlpcloud { };
-
-  nlpo3 = callPackage ../development/python-modules/nlpo3 { };
-
-  nltk = callPackage ../development/python-modules/nltk { };
-
-  nnpdf = toPythonModule (pkgs.nnpdf.override { python3 = python; });
-
-  nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };
-
-  amaranth-boards = callPackage ../development/python-modules/amaranth-boards { };
-
-  amaranth = callPackage ../development/python-modules/amaranth { };
-
-  amaranth-soc = callPackage ../development/python-modules/amaranth-soc { };
-
-  nocasedict = callPackage ../development/python-modules/nocasedict { };
-
-  nocaselist = callPackage ../development/python-modules/nocaselist { };
-
-  nocturne = callPackage ../development/python-modules/nocturne { };
-
-  nodeenv = callPackage ../development/python-modules/nodeenv { };
-
-  nodepy-runtime = callPackage ../development/python-modules/nodepy-runtime { };
-
-  node-semver = callPackage ../development/python-modules/node-semver { };
-
-  nodriver = callPackage ../development/python-modules/nodriver { };
-
-  noise = callPackage ../development/python-modules/noise { };
-
-  noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
-
-  norfair = callPackage ../development/python-modules/norfair { };
-
-  normality = callPackage ../development/python-modules/normality { };
-
-  nose2 = callPackage ../development/python-modules/nose2 { };
-
-  nose2pytest = callPackage ../development/python-modules/nose2pytest { };
-
-  notebook = callPackage ../development/python-modules/notebook { };
-
-  notebook-shim = callPackage ../development/python-modules/notebook-shim { };
-
-  notedown = callPackage ../development/python-modules/notedown { };
-
-  notifications-android-tv = callPackage ../development/python-modules/notifications-android-tv { };
-
-  notifications-python-client =
-    callPackage ../development/python-modules/notifications-python-client
-      { };
-
-  notify-events = callPackage ../development/python-modules/notify-events { };
-
-  notify-py = callPackage ../development/python-modules/notify-py { };
-
-  notify2 = callPackage ../development/python-modules/notify2 { };
-
-  notion-client = callPackage ../development/python-modules/notion-client { };
-
-  notmuch = callPackage ../development/python-modules/notmuch { inherit (pkgs) notmuch; };
-
-  notmuch2 = callPackage ../development/python-modules/notmuch2 { inherit (pkgs) notmuch; };
-
-  notobuilder = callPackage ../development/python-modules/notobuilder { };
-
-  nototools = callPackage ../development/python-modules/nototools { };
-
-  notus-scanner = callPackage ../development/python-modules/notus-scanner { };
-
-  nplusone = callPackage ../development/python-modules/nplusone { };
-
-  nptyping = callPackage ../development/python-modules/nptyping { };
-
-  npyscreen = callPackage ../development/python-modules/npyscreen { };
-
-  nsapi = callPackage ../development/python-modules/nsapi { };
-
-  nskeyedunarchiver = callPackage ../development/python-modules/nskeyedunarchiver { };
-
-  ntc-templates = callPackage ../development/python-modules/ntc-templates { };
-
-  ntplib = callPackage ../development/python-modules/ntplib { };
-
-  nuclear = callPackage ../development/python-modules/nuclear { };
-
-  nuitka = callPackage ../development/python-modules/nuitka { };
-
-  nuheat = callPackage ../development/python-modules/nuheat { };
-
-  nulltype = callPackage ../development/python-modules/nulltype { };
-
-  num2words = callPackage ../development/python-modules/num2words { };
-
-  numba = callPackage ../development/python-modules/numba { inherit (pkgs.config) cudaSupport; };
-
-  numbaWithCuda = self.numba.override { cudaSupport = true; };
-
-  numba-scipy = callPackage ../development/python-modules/numba-scipy { };
-
-  numcodecs = callPackage ../development/python-modules/numcodecs { };
-
-  numdifftools = callPackage ../development/python-modules/numdifftools { };
-
-  numericalunits = callPackage ../development/python-modules/numericalunits { };
-
-  numexpr = callPackage ../development/python-modules/numexpr { };
-
-  numpydoc = callPackage ../development/python-modules/numpydoc { };
-
-  numpy_1 = callPackage ../development/python-modules/numpy/1.nix { };
-  numpy_2 = callPackage ../development/python-modules/numpy/2.nix { };
-  numpy = numpy_2;
-
-  numpy-groupies = callPackage ../development/python-modules/numpy-groupies { };
-
-  numpy-stl = callPackage ../development/python-modules/numpy-stl { };
-
-  numpyro = callPackage ../development/python-modules/numpyro { };
-
-  nunavut = callPackage ../development/python-modules/nunavut { };
-
-  nutils = callPackage ../development/python-modules/nutils { };
-
-  nutils-poly = callPackage ../development/python-modules/nutils-poly { };
-
-  nutpie = callPackage ../development/python-modules/nutpie { };
-
-  nvchecker = callPackage ../development/python-modules/nvchecker { };
-
-  nvdlib = callPackage ../development/python-modules/nvdlib { };
-
-  nvidia-ml-py = callPackage ../development/python-modules/nvidia-ml-py { };
-
-  nsz = callPackage ../development/python-modules/nsz { };
-
-  nxt-python = callPackage ../development/python-modules/nxt-python { };
-
-  nyt-games = callPackage ../development/python-modules/nyt-games { };
-
-  petl = callPackage ../development/python-modules/petl { };
-
-  plugp100 = callPackage ../development/python-modules/plugp100 { };
-
-  python-bugzilla = callPackage ../development/python-modules/python-bugzilla { };
-
-  python-debian = callPackage ../development/python-modules/python-debian { };
-
-  python-google-drive-api = callPackage ../development/python-modules/python-google-drive-api { };
-
-  python-hcl2 = callPackage ../development/python-modules/python-hcl2 { };
-
-  python-lorem = callPackage ../development/python-modules/python-lorem { };
-
-  python-ndn = callPackage ../development/python-modules/python-ndn { };
-
-  python-nvd3 = callPackage ../development/python-modules/python-nvd3 { };
-
-  python-qt = toPythonModule (pkgs.python-qt.override { python3 = self.python; });
-
-  python-secp256k1-cardano = callPackage ../development/python-modules/python-secp256k1-cardano { };
-
-  python-tds = callPackage ../development/python-modules/python-tds { };
-
-  python-yate = callPackage ../development/python-modules/python-yate { };
-
-  python-youtube = callPackage ../development/python-modules/python-youtube { };
-
-  py-aosmith = callPackage ../development/python-modules/py-aosmith { };
-
-  py-ccm15 = callPackage ../development/python-modules/py-ccm15 { };
-
-  py-datastruct = callPackage ../development/python-modules/py-datastruct { };
-
-  py-deprecate = callPackage ../development/python-modules/py-deprecate { };
-
-  py-ecc = callPackage ../development/python-modules/py-ecc { };
-
-  py-eth-sig-utils = callPackage ../development/python-modules/py-eth-sig-utils { };
-
-  py-evm = callPackage ../development/python-modules/py-evm { };
-
-  py-expression-eval = callPackage ../development/python-modules/py-expression-eval { };
-
-  py-improv-ble-client = callPackage ../development/python-modules/py-improv-ble-client { };
-
-  py-machineid = callPackage ../development/python-modules/py-machineid { };
-
-  py-ocsf-models = callPackage ../development/python-modules/py-ocsf-models { };
-
-  py-opensonic = callPackage ../development/python-modules/py-opensonic { };
-
-  py-radix-sr = callPackage ../development/python-modules/py-radix-sr { };
-
-  py-rust-stemmers = callPackage ../development/python-modules/py-rust-stemmers { };
-
-  py-sucks = callPackage ../development/python-modules/py-sucks { };
-
-  nwdiag = callPackage ../development/python-modules/nwdiag { };
-
-  oasatelematics = callPackage ../development/python-modules/oasatelematics { };
-
-  oath = callPackage ../development/python-modules/oath { };
-
-  oauth2 = callPackage ../development/python-modules/oauth2 { };
-
-  oauth2client = callPackage ../development/python-modules/oauth2client { };
-
-  oauth = callPackage ../development/python-modules/oauth { };
-
-  oauthenticator = callPackage ../development/python-modules/oauthenticator { };
-
-  oauthlib = callPackage ../development/python-modules/oauthlib { };
-
-  obfsproxy = callPackage ../development/python-modules/obfsproxy { };
-
-  objax = callPackage ../development/python-modules/objax { };
-
-  objexplore = callPackage ../development/python-modules/objexplore { };
-
-  objprint = callPackage ../development/python-modules/objprint { };
-
-  objsize = callPackage ../development/python-modules/objsize { };
-
-  objgraph = callPackage ../development/python-modules/objgraph {
-    # requires both the graphviz package and python package
-    graphvizPkgs = pkgs.graphviz;
-  };
-
-  obspy = callPackage ../development/python-modules/obspy { };
-
-  oca-port = callPackage ../development/python-modules/oca-port { };
-
-  ochre = callPackage ../development/python-modules/ochre { };
-
-  oci = callPackage ../development/python-modules/oci { };
-
-  ocifs = callPackage ../development/python-modules/ocifs { };
-
-  ocrmypdf = callPackage ../development/python-modules/ocrmypdf { tesseract = pkgs.tesseract5; };
-
-  od = callPackage ../development/python-modules/od { };
-
-  odc-geo = callPackage ../development/python-modules/odc-geo { };
-
-  odc-stac = callPackage ../development/python-modules/odc-stac { };
-
-  oddsprout = callPackage ../development/python-modules/oddsprout { };
-
-  odfpy = callPackage ../development/python-modules/odfpy { };
-
-  odp-amsterdam = callPackage ../development/python-modules/odp-amsterdam { };
-
-  offtrac = callPackage ../development/python-modules/offtrac { };
-
-  ofxclient = callPackage ../development/python-modules/ofxclient { };
-
-  ofxhome = callPackage ../development/python-modules/ofxhome { };
-
-  ofxparse = callPackage ../development/python-modules/ofxparse { };
-
-  ofxtools = callPackage ../development/python-modules/ofxtools { };
-
-  oemthermostat = callPackage ../development/python-modules/oemthermostat { };
-
-  ogmios = callPackage ../development/python-modules/ogmios { };
-
-  okonomiyaki = callPackage ../development/python-modules/okonomiyaki { };
-
-  okta = callPackage ../development/python-modules/okta { };
-
-  oldest-supported-numpy = callPackage ../development/python-modules/oldest-supported-numpy { };
-
-  olefile = callPackage ../development/python-modules/olefile { };
-
-  oletools = callPackage ../development/python-modules/oletools { };
-
-  ollama = callPackage ../development/python-modules/ollama { };
-
-  omegaconf = callPackage ../development/python-modules/omegaconf { };
-
-  omemo-dr = callPackage ../development/python-modules/omemo-dr { };
-
-  ome-zarr = callPackage ../development/python-modules/ome-zarr { };
-
-  omnikinverter = callPackage ../development/python-modules/omnikinverter { };
-
-  omnilogic = callPackage ../development/python-modules/omnilogic { };
-
-  omniorb = toPythonModule (pkgs.omniorb.override { python3 = self.python; });
-
-  omniorbpy = callPackage ../development/python-modules/omniorbpy { };
-
-  omorfi = callPackage ../development/python-modules/omorfi { };
-
-  omrdatasettools = callPackage ../development/python-modules/omrdatasettools { };
-
-  oncalendar = callPackage ../development/python-modules/oncalendar { };
-
-  ondilo = callPackage ../development/python-modules/ondilo { };
-
-  onecache = callPackage ../development/python-modules/onecache { };
-
-  onedrive-personal-sdk = callPackage ../development/python-modules/onedrive-personal-sdk { };
-
-  onetimepass = callPackage ../development/python-modules/onetimepass { };
-
-  onigurumacffi = callPackage ../development/python-modules/onigurumacffi { };
-
-  onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
-
-  online-judge-api-client = callPackage ../development/python-modules/online-judge-api-client { };
-
-  online-judge-tools = callPackage ../development/python-modules/online-judge-tools { };
-
-  onlykey-solo-python = callPackage ../development/python-modules/onlykey-solo-python { };
-
-  onnx = callPackage ../development/python-modules/onnx { };
-
-  onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };
-
-  onnxmltools = callPackage ../development/python-modules/onnxmltools { };
-
-  onnxruntime = callPackage ../development/python-modules/onnxruntime {
-    onnxruntime = pkgs.onnxruntime.override {
-      python3Packages = self;
-      pythonSupport = true;
-    };
-  };
-
-  onnxruntime-tools = callPackage ../development/python-modules/onnxruntime-tools { };
-
-  onvif-zeep = callPackage ../development/python-modules/onvif-zeep { };
-
-  onvif-zeep-async = callPackage ../development/python-modules/onvif-zeep-async { };
-
-  oocsi = callPackage ../development/python-modules/oocsi { };
-
-  opcua-widgets = callPackage ../development/python-modules/opcua-widgets { };
-
-  open-clip-torch = callPackage ../development/python-modules/open-clip-torch { };
-
-  open-garage = callPackage ../development/python-modules/open-garage { };
-
-  open-hypergraphs = callPackage ../development/python-modules/open-hypergraphs { };
-
-  open-interpreter = callPackage ../development/python-modules/open-interpreter { };
-
-  open-meteo = callPackage ../development/python-modules/open-meteo { };
-
-  openai-whisper = callPackage ../development/python-modules/openai-whisper { };
-
-  openant = callPackage ../development/python-modules/openant { };
-
-  openapi-schema-validator = callPackage ../development/python-modules/openapi-schema-validator { };
-
-  openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };
-
-  openapi3 = callPackage ../development/python-modules/openapi3 { };
-
-  openbabel-bindings = callPackage ../development/python-modules/openbabel-bindings {
-    openbabel = callPackage ../development/libraries/openbabel { inherit (self) python; };
-  };
-
-  opencensus = callPackage ../development/python-modules/opencensus { };
-
-  opencensus-context = callPackage ../development/python-modules/opencensus-context { };
-
-  opencensus-ext-azure = callPackage ../development/python-modules/opencensus-ext-azure { };
-
-  opencontainers = callPackage ../development/python-modules/opencontainers { };
-
-  opencv4 = toPythonModule (
-    pkgs.opencv4.override {
-      enablePython = true;
-      pythonPackages = self;
-    }
-  );
-
-  opencv-python = callPackage ../development/python-modules/opencv-python { };
-
-  opencv-python-headless = callPackage ../development/python-modules/opencv-python-headless { };
-
-  openerz-api = callPackage ../development/python-modules/openerz-api { };
-
-  openevsewifi = callPackage ../development/python-modules/openevsewifi { };
-
-  openhomedevice = callPackage ../development/python-modules/openhomedevice { };
-
-  openidc-client = callPackage ../development/python-modules/openidc-client { };
-
-  openmm = toPythonModule (
-    pkgs.openmm.override {
-      python3Packages = self;
-      enablePython = true;
-    }
-  );
-
-  openpyxl = callPackage ../development/python-modules/openpyxl { };
-
-  openrazer = callPackage ../development/python-modules/openrazer/pylib.nix { };
-
-  openrazer-daemon = callPackage ../development/python-modules/openrazer/daemon.nix { };
-
-  openrgb-python = callPackage ../development/python-modules/openrgb-python { };
-
-  openrouteservice = callPackage ../development/python-modules/openrouteservice { };
-
-  opensearch-py = callPackage ../development/python-modules/opensearch-py { };
-
-  opensensemap-api = callPackage ../development/python-modules/opensensemap-api { };
-
-  opensfm = callPackage ../development/python-modules/opensfm { };
-
-  openshift = callPackage ../development/python-modules/openshift { };
-
-  opensimplex = callPackage ../development/python-modules/opensimplex { };
-
-  openslide = callPackage ../development/python-modules/openslide { inherit (pkgs) openslide; };
-
-  openstackdocstheme = callPackage ../development/python-modules/openstackdocstheme { };
-
-  openstacksdk = callPackage ../development/python-modules/openstacksdk { };
-
-  opentimestamps = callPackage ../development/python-modules/opentimestamps { };
-
-  opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
-
-  opentelemetry-exporter-otlp =
-    callPackage ../development/python-modules/opentelemetry-exporter-otlp
-      { };
-
-  opentelemetry-exporter-otlp-proto-common =
-    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common
-      { };
-
-  opentelemetry-exporter-otlp-proto-grpc =
-    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc
-      { };
-
-  opentelemetry-exporter-otlp-proto-http =
-    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-http
-      { };
-
-  opentelemetry-exporter-prometheus =
-    callPackage ../development/python-modules/opentelemetry-exporter-prometheus
-      { };
-
-  opentelemetry-instrumentation =
-    callPackage ../development/python-modules/opentelemetry-instrumentation
-      { };
-
-  opentelemetry-instrumentation-aiohttp-client =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-aiohttp-client
-      { };
-
-  opentelemetry-instrumentation-asgi =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-asgi
-      { };
-
-  opentelemetry-instrumentation-celery =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-celery
-      { };
-
-  opentelemetry-instrumentation-botocore =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-botocore
-      { };
-
-  opentelemetry-instrumentation-dbapi =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-dbapi
-      { };
-
-  opentelemetry-instrumentation-django =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-django
-      { };
-
-  opentelemetry-instrumentation-fastapi =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-fastapi
-      { };
-
-  opentelemetry-instrumentation-flask =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-flask
-      { };
-
-  opentelemetry-instrumentation-grpc =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-grpc
-      { };
-
-  opentelemetry-instrumentation-logging =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-logging
-      { };
-
-  opentelemetry-instrumentation-psycopg2 =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-psycopg2
-      { };
-
-  opentelemetry-instrumentation-requests =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-requests
-      { };
-
-  opentelemetry-instrumentation-redis =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-redis
-      { };
-
-  opentelemetry-instrumentation-wsgi =
-    callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi
-      { };
-
-  opentelemetry-propagator-aws-xray =
-    callPackage ../development/python-modules/opentelemetry-propagator-aws-xray
-      { };
-
-  opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
-
-  opentelemetry-semantic-conventions =
-    callPackage ../development/python-modules/opentelemetry-semantic-conventions
-      { };
-
-  opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
-
-  opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
-
-  opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };
-
-  openturns = toPythonModule (
-    pkgs.openturns.override {
-      python3Packages = self;
-      enablePython = true;
-    }
-  );
-
-  opentsne = callPackage ../development/python-modules/opentsne { };
-
-  opentypespec = callPackage ../development/python-modules/opentypespec { };
-
-  openvino = callPackage ../development/python-modules/openvino {
-    openvino-native = pkgs.openvino.override { python3Packages = self; };
-  };
-
-  openwebifpy = callPackage ../development/python-modules/openwebifpy { };
-
-  openwrt-luci-rpc = callPackage ../development/python-modules/openwrt-luci-rpc { };
-
-  openwrt-ubus-rpc = callPackage ../development/python-modules/openwrt-ubus-rpc { };
-
-  opower = callPackage ../development/python-modules/opower { };
-
-  opsdroid-get-image-size = callPackage ../development/python-modules/opsdroid-get-image-size { };
-
-  opt-einsum = callPackage ../development/python-modules/opt-einsum { };
-
-  optax = callPackage ../development/python-modules/optax { };
-
-  optimistix = callPackage ../development/python-modules/optimistix { };
-
-  optimum = callPackage ../development/python-modules/optimum { };
-
-  optree = callPackage ../development/python-modules/optree { };
-
-  optuna = callPackage ../development/python-modules/optuna { };
-
-  opuslib = callPackage ../development/python-modules/opuslib { };
-
-  opytimark = callPackage ../development/python-modules/opytimark { };
-
-  oracledb = callPackage ../development/python-modules/oracledb { };
-
-  oralb-ble = callPackage ../development/python-modules/oralb-ble { };
-
-  orange3 = callPackage ../development/python-modules/orange3 { };
-
-  orange-canvas-core = callPackage ../development/python-modules/orange-canvas-core { };
-
-  orange-widget-base = callPackage ../development/python-modules/orange-widget-base { };
-
-  oras = callPackage ../development/python-modules/oras { };
-
-  orbax-checkpoint = callPackage ../development/python-modules/orbax-checkpoint { };
-
-  orderedmultidict = callPackage ../development/python-modules/orderedmultidict { };
-
-  ordered-set = callPackage ../development/python-modules/ordered-set { };
-
-  orderly-set = callPackage ../development/python-modules/orderly-set { };
-
-  orderedset = callPackage ../development/python-modules/orderedset { };
-
-  orgparse = callPackage ../development/python-modules/orgparse { };
-
-  orjson = callPackage ../development/python-modules/orjson { };
-
-  orm = callPackage ../development/python-modules/orm { };
-
-  ormar = callPackage ../development/python-modules/ormar { };
-
-  ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;
-
-  orvibo = callPackage ../development/python-modules/orvibo { };
-
-  oryx = callPackage ../development/python-modules/oryx { };
-
-  os-client-config = callPackage ../development/python-modules/os-client-config { };
-
-  os-service-types = callPackage ../development/python-modules/os-service-types { };
-
-  osc = callPackage ../development/python-modules/osc { };
-
-  osc-diagram = callPackage ../development/python-modules/osc-diagram { };
-
-  osc-lib = callPackage ../development/python-modules/osc-lib { };
-
-  osc-placement = callPackage ../development/python-modules/osc-placement { };
-
-  osc-sdk-python = callPackage ../development/python-modules/osc-sdk-python { };
-
-  oschmod = callPackage ../development/python-modules/oschmod { };
-
-  oscpy = callPackage ../development/python-modules/oscpy { };
-
-  oscrypto = callPackage ../development/python-modules/oscrypto { };
-
-  oscscreen = callPackage ../development/python-modules/oscscreen { };
-
-  oset = callPackage ../development/python-modules/oset { };
-
-  osmnx = callPackage ../development/python-modules/osmnx { };
-
-  osmpythontools = callPackage ../development/python-modules/osmpythontools { };
-
-  oslo-concurrency = callPackage ../development/python-modules/oslo-concurrency { };
-
-  oslo-config = callPackage ../development/python-modules/oslo-config { };
-
-  oslo-context = callPackage ../development/python-modules/oslo-context { };
-
-  oslo-db = callPackage ../development/python-modules/oslo-db { };
-
-  oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
-
-  oslo-log = callPackage ../development/python-modules/oslo-log { };
-
-  oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
-
-  oslo-utils = callPackage ../development/python-modules/oslo-utils { };
-
-  oslotest = callPackage ../development/python-modules/oslotest { };
-
-  ospd = callPackage ../development/python-modules/ospd { };
-
-  osprofiler = callPackage ../development/python-modules/osprofiler { };
-
-  osqp = callPackage ../development/python-modules/osqp { };
-
-  oss2 = callPackage ../development/python-modules/oss2 { };
-
-  ossfs = callPackage ../development/python-modules/ossfs { };
-
-  osxphotos = callPackage ../development/python-modules/osxphotos { };
-
-  otpauth = callPackage ../development/python-modules/otpauth { };
-
-  ots-python = callPackage ../development/python-modules/ots-python { };
-
-  ourgroceries = callPackage ../development/python-modules/ourgroceries { };
-
-  outcome = callPackage ../development/python-modules/outcome { };
-
-  outdated = callPackage ../development/python-modules/outdated { };
-
-  outspin = callPackage ../development/python-modules/outspin { };
-
-  ovh = callPackage ../development/python-modules/ovh { };
-
-  ovmfvartool = callPackage ../development/python-modules/ovmfvartool { };
-
-  ovoenergy = callPackage ../development/python-modules/ovoenergy { };
-
-  owslib = callPackage ../development/python-modules/owslib { };
-
-  oyaml = callPackage ../development/python-modules/oyaml { };
-
-  p1monitor = callPackage ../development/python-modules/p1monitor { };
-
-  packageurl-python = callPackage ../development/python-modules/packageurl-python { };
-
-  packaging = callPackage ../development/python-modules/packaging { };
-
-  packaging-legacy = callPackage ../development/python-modules/packaging-legacy { };
-
-  packbits = callPackage ../development/python-modules/packbits { };
-
-  packet-python = callPackage ../development/python-modules/packet-python { };
-
-  packvers = callPackage ../development/python-modules/packvers { };
-
-  pagelabels = callPackage ../development/python-modules/pagelabels { };
-
-  paginate = callPackage ../development/python-modules/paginate { };
-
-  paho-mqtt = callPackage ../development/python-modules/paho-mqtt/default.nix { };
-
-  paintcompiler = callPackage ../development/python-modules/paintcompiler { };
-
-  palace = callPackage ../development/python-modules/palace { };
-
-  palettable = callPackage ../development/python-modules/palettable { };
-
-  pallets-sphinx-themes = callPackage ../development/python-modules/pallets-sphinx-themes { };
-
-  python-docs-theme = callPackage ../development/python-modules/python-docs-theme { };
-
-  pamela = callPackage ../development/python-modules/pamela { };
-
-  pamqp = callPackage ../development/python-modules/pamqp { };
-
-  panacotta = callPackage ../development/python-modules/panacotta { };
-
-  panasonic-viera = callPackage ../development/python-modules/panasonic-viera { };
-
-  pandantic = callPackage ../development/python-modules/pandantic { };
-
-  pandas = callPackage ../development/python-modules/pandas { inherit (pkgs.darwin) adv_cmds; };
-
-  pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
-
-  pandas-ta = callPackage ../development/python-modules/pandas-ta { };
-
-  pandera = callPackage ../development/python-modules/pandera { };
-
-  pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
-
-  pandoc-latex-environment = callPackage ../development/python-modules/pandoc-latex-environment { };
-
-  pandoc-xnos = callPackage ../development/python-modules/pandoc-xnos { };
-
-  pandocfilters = callPackage ../development/python-modules/pandocfilters { };
-
-  panel = callPackage ../development/python-modules/panel { };
-
-  panflute = callPackage ../development/python-modules/panflute { };
-
-  panphon = callPackage ../development/python-modules/panphon { };
-
-  paperbush = callPackage ../development/python-modules/paperbush { };
-
-  papermill = callPackage ../development/python-modules/papermill { };
-
-  openpaperwork-core = callPackage ../applications/office/paperwork/openpaperwork-core.nix { };
-  openpaperwork-gtk = callPackage ../applications/office/paperwork/openpaperwork-gtk.nix { };
-  paperwork-backend = callPackage ../applications/office/paperwork/paperwork-backend.nix { };
-  paperwork-shell = callPackage ../applications/office/paperwork/paperwork-shell.nix { };
-
-  papis = callPackage ../development/python-modules/papis { };
-
-  papis-python-rofi = callPackage ../development/python-modules/papis-python-rofi { };
-
-  para = callPackage ../development/python-modules/para { };
-
-  paragraphs = callPackage ../development/python-modules/paragraphs { };
-
-  parallel-ssh = callPackage ../development/python-modules/parallel-ssh { };
-
-  param = callPackage ../development/python-modules/param { };
-
-  paramax = callPackage ../development/python-modules/paramax { };
-
-  parameter-expansion-patched =
-    callPackage ../development/python-modules/parameter-expansion-patched
-      { };
-
-  parameterized = callPackage ../development/python-modules/parameterized { };
-
-  parametrize-from-file = callPackage ../development/python-modules/parametrize-from-file { };
-
-  paramiko = callPackage ../development/python-modules/paramiko { };
-
-  paramz = callPackage ../development/python-modules/paramz { };
-
-  paranoid-crypto = callPackage ../development/python-modules/paranoid-crypto { };
-
-  parfive = callPackage ../development/python-modules/parfive { };
-
-  parquet = callPackage ../development/python-modules/parquet { };
-
-  parse = callPackage ../development/python-modules/parse { };
-
-  parsedatetime = callPackage ../development/python-modules/parsedatetime { };
-
-  parsedmarc = callPackage ../development/python-modules/parsedmarc { };
-
-  parsel = callPackage ../development/python-modules/parsel { };
-
-  parselmouth = callPackage ../development/python-modules/parselmouth { };
-
-  parse-type = callPackage ../development/python-modules/parse-type { };
-
-  parsimonious = callPackage ../development/python-modules/parsimonious { };
-
-  parsley = callPackage ../development/python-modules/parsley { };
-
-  parso = callPackage ../development/python-modules/parso { };
-
-  parsy = callPackage ../development/python-modules/parsy { };
-
-  partd = callPackage ../development/python-modules/partd { };
-
-  partial-json-parser = callPackage ../development/python-modules/partial-json-parser { };
-
-  parts = callPackage ../development/python-modules/parts { };
-
-  particle = callPackage ../development/python-modules/particle { };
-
-  parver = callPackage ../development/python-modules/parver { };
-  arpeggio = callPackage ../development/python-modules/arpeggio { };
-
-  pasimple = callPackage ../development/python-modules/pasimple { };
-
-  passlib = callPackage ../development/python-modules/passlib { };
-
-  paste = callPackage ../development/python-modules/paste { };
-
-  pastedeploy = callPackage ../development/python-modules/pastedeploy { };
-
-  pastel = callPackage ../development/python-modules/pastel { };
-
-  pastescript = callPackage ../development/python-modules/pastescript { };
-
-  patator = callPackage ../development/python-modules/patator { };
-
-  patch = callPackage ../development/python-modules/patch { };
-
-  patch-ng = callPackage ../development/python-modules/patch-ng { };
-
-  patchpy = callPackage ../development/python-modules/patchpy { };
-
-  path = callPackage ../development/python-modules/path { };
-
-  path-and-address = callPackage ../development/python-modules/path-and-address { };
-
-  pathable = callPackage ../development/python-modules/pathable { };
-
-  pathlib2 = callPackage ../development/python-modules/pathlib2 { };
-
-  pathlib-abc = callPackage ../development/python-modules/pathlib-abc { };
-
-  pathos = callPackage ../development/python-modules/pathos { };
-
-  pathspec = callPackage ../development/python-modules/pathspec { };
-
-  pathtools = callPackage ../development/python-modules/pathtools { };
-
-  pathvalidate = callPackage ../development/python-modules/pathvalidate { };
-
-  pathy = callPackage ../development/python-modules/pathy { };
-
-  patiencediff = callPackage ../development/python-modules/patiencediff { };
-
-  patool = callPackage ../development/python-modules/patool { };
-
-  patsy = callPackage ../development/python-modules/patsy { };
-
-  patrowl4py = callPackage ../development/python-modules/patrowl4py { };
-
-  paver = callPackage ../development/python-modules/paver { };
-
-  paypal-checkout-serversdk = callPackage ../development/python-modules/paypal-checkout-serversdk { };
-
-  paypalhttp = callPackage ../development/python-modules/paypalhttp { };
-
-  paypalrestsdk = callPackage ../development/python-modules/paypalrestsdk { };
-
-  pbar = callPackage ../development/python-modules/pbar { };
-
-  pbkdf2 = callPackage ../development/python-modules/pbkdf2 { };
-
-  pbr = callPackage ../development/python-modules/pbr { };
-
-  pbs-installer = callPackage ../development/python-modules/pbs-installer { };
-
-  pbxproj = callPackage ../development/python-modules/pbxproj { };
-
-  pcapy-ng = callPackage ../development/python-modules/pcapy-ng {
-    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
-  };
-
-  pcbnewtransition = callPackage ../development/python-modules/pcbnewtransition { };
-
-  pcodedmp = callPackage ../development/python-modules/pcodedmp { };
-
-  pcpp = callPackage ../development/python-modules/pcpp { };
-
-  pcre2-py = callPackage ../development/python-modules/pcre2-py { };
-
-  pdb2pqr = callPackage ../development/python-modules/pdb2pqr { };
-
-  pdbfixer = callPackage ../development/python-modules/pdbfixer { };
-
-  pdf2docx = callPackage ../development/python-modules/pdf2docx { };
-
-  pdf2image = callPackage ../development/python-modules/pdf2image { };
-
-  pdfkit = callPackage ../development/python-modules/pdfkit { };
-
-  pdfminer-six = callPackage ../development/python-modules/pdfminer-six { };
-
-  pdfplumber = callPackage ../development/python-modules/pdfplumber { };
-
-  pdfrw = callPackage ../development/python-modules/pdfrw { };
-
-  pdfrw2 = callPackage ../development/python-modules/pdfrw2 { };
-
-  pdftotext = callPackage ../development/python-modules/pdftotext { };
-
-  pdm-backend = callPackage ../development/python-modules/pdm-backend { };
-
-  pdm-build-locked = callPackage ../development/python-modules/pdm-build-locked { };
-
-  pdm-pep517 = callPackage ../development/python-modules/pdm-pep517 { };
-
-  pdoc = callPackage ../development/python-modules/pdoc { };
-
-  pdoc-pyo3-sample-library = callPackage ../development/python-modules/pdoc-pyo3-sample-library { };
-
-  pdoc3 = callPackage ../development/python-modules/pdoc3 { };
-
-  peacasso = callPackage ../development/python-modules/peacasso { };
-
-  peaqevcore = callPackage ../development/python-modules/peaqevcore { };
-
-  pegen = callPackage ../development/python-modules/pegen { };
-
-  pebble = callPackage ../development/python-modules/pebble { };
-
-  peblar = callPackage ../development/python-modules/peblar { };
-
-  pecan = callPackage ../development/python-modules/pecan { };
-
-  peco = callPackage ../development/python-modules/peco { };
-
-  pettingzoo = callPackage ../development/python-modules/pettingzoo { };
-
-  peewee = callPackage ../development/python-modules/peewee { };
-
-  peewee-migrate = callPackage ../development/python-modules/peewee-migrate { };
-
-  pefile = callPackage ../development/python-modules/pefile { };
-
-  peft = callPackage ../development/python-modules/peft { };
-
-  pelican = callPackage ../development/python-modules/pelican { inherit (pkgs) glibcLocales git; };
-
-  pem = callPackage ../development/python-modules/pem { };
-
-  pendulum = callPackage ../development/python-modules/pendulum { };
-
-  pep440 = callPackage ../development/python-modules/pep440 { };
-
-  pep517 = callPackage ../development/python-modules/pep517 { };
-
-  pep8 = callPackage ../development/python-modules/pep8 { };
-
-  pep8-naming = callPackage ../development/python-modules/pep8-naming { };
-
-  pepit = callPackage ../development/python-modules/pepit { };
-
-  peppercorn = callPackage ../development/python-modules/peppercorn { };
-
-  percol = callPackage ../development/python-modules/percol { };
-
-  perfplot = callPackage ../development/python-modules/perfplot { };
-
-  periodictable = callPackage ../development/python-modules/periodictable { };
-
-  periodiq = callPackage ../development/python-modules/periodiq { };
-
-  permissionedforms = callPackage ../development/python-modules/permissionedforms { };
-
-  persim = callPackage ../development/python-modules/persim { };
-
-  persist-queue = callPackage ../development/python-modules/persist-queue { };
-
-  persistent = callPackage ../development/python-modules/persistent { };
-
-  persisting-theory = callPackage ../development/python-modules/persisting-theory { };
-
-  pescea = callPackage ../development/python-modules/pescea { };
-
-  pesq = callPackage ../development/python-modules/pesq { };
-
-  petsc4py = toPythonModule (
-    pkgs.petsc.override {
-      python3 = python;
-      python3Packages = self;
-      pythonSupport = true;
-    }
-  );
-
-  pex = callPackage ../development/python-modules/pex { };
-
-  pexif = callPackage ../development/python-modules/pexif { };
-
-  pexpect = callPackage ../development/python-modules/pexpect { };
-
-  pfzy = callPackage ../development/python-modules/pfzy { };
-
-  ping3 = callPackage ../development/python-modules/ping3 { };
-
-  pins = callPackage ../development/python-modules/pins { };
-
-  pipetools = callPackage ../development/python-modules/pipetools { };
-
-  piqp = callPackage ../development/python-modules/piqp { };
-
-  pg8000 = callPackage ../development/python-modules/pg8000 { };
-
-  pgcli = callPackage ../development/python-modules/pgcli { };
-
-  pglast = callPackage ../development/python-modules/pglast { };
-
-  pglive = callPackage ../development/python-modules/pglive { };
-
-  pgpdump = callPackage ../development/python-modules/pgpdump { };
-
-  pgpy = callPackage ../development/python-modules/pgpy { };
-
-  pgpy-dtc = callPackage ../development/python-modules/pgpy-dtc { };
-
-  pgsanity = callPackage ../development/python-modules/pgsanity { };
-
-  pgspecial = callPackage ../development/python-modules/pgspecial { };
-
-  pgvector = callPackage ../development/python-modules/pgvector { };
-
-  phe = callPackage ../development/python-modules/phe { };
-
-  phply = callPackage ../development/python-modules/phply { };
-
-  phik = callPackage ../development/python-modules/phik { };
-
-  philipstv = callPackage ../development/python-modules/philipstv { };
-
-  phone-modem = callPackage ../development/python-modules/phone-modem { };
-
-  phonenumbers = callPackage ../development/python-modules/phonenumbers { };
-
-  phonenumberslite = callPackage ../development/python-modules/phonenumberslite { };
-
-  photutils = callPackage ../development/python-modules/photutils { };
-
-  pkgutil-resolve-name = callPackage ../development/python-modules/pkgutil-resolve-name { };
-
-  pkg-about = callPackage ../development/python-modules/pkg-about { };
-
-  micloud = callPackage ../development/python-modules/micloud { };
-
-  mqtt2influxdb = callPackage ../development/python-modules/mqtt2influxdb { };
-
-  msgraph-core = callPackage ../development/python-modules/msgraph-core { };
-
-  msgraph-sdk = callPackage ../development/python-modules/msgraph-sdk { };
-
-  multipart = callPackage ../development/python-modules/multipart { };
-
-  netmap = callPackage ../development/python-modules/netmap { };
-
-  onetimepad = callPackage ../development/python-modules/onetimepad { };
-
-  openai = callPackage ../development/python-modules/openai { };
-
-  openaiauth = callPackage ../development/python-modules/openaiauth { };
-
-  openapi-core = callPackage ../development/python-modules/openapi-core { };
-
-  opentype-feature-freezer = callPackage ../development/python-modules/opentype-feature-freezer { };
-
-  openusd = callPackage ../development/python-modules/openusd { alembic = pkgs.alembic; };
-
-  outlines = callPackage ../development/python-modules/outlines { };
-
-  outlines-core = callPackage ../development/python-modules/outlines-core { };
-
-  overly = callPackage ../development/python-modules/overly { };
-
-  overpy = callPackage ../development/python-modules/overpy { };
-
-  overrides = callPackage ../development/python-modules/overrides { };
-
-  pandas-stubs = callPackage ../development/python-modules/pandas-stubs { };
-
-  pdunehd = callPackage ../development/python-modules/pdunehd { };
-
-  pencompy = callPackage ../development/python-modules/pencompy { };
-
-  pgmpy = callPackage ../development/python-modules/pgmpy { };
-
-  phonopy = callPackage ../development/python-modules/phonopy { };
-
-  pixcat = callPackage ../development/python-modules/pixcat { };
-
-  pinecone-client = callPackage ../development/python-modules/pinecone-client { };
-
-  pinecone-plugin-interface = callPackage ../development/python-modules/pinecone-plugin-interface { };
-
-  pinecone-plugin-inference = callPackage ../development/python-modules/pinecone-plugin-inference { };
-
-  psrpcore = callPackage ../development/python-modules/psrpcore { };
-
-  pyaprilaire = callPackage ../development/python-modules/pyaprilaire { };
-
-  pwinput = callPackage ../development/python-modules/pwinput { };
-
-  pybars3 = callPackage ../development/python-modules/pybars3 { };
-
-  pyembroidery = callPackage ../development/python-modules/pyembroidery { };
-
-  pymeta3 = callPackage ../development/python-modules/pymeta3 { };
-
-  pypemicro = callPackage ../development/python-modules/pypemicro { };
-
-  pymeshlab = toPythonModule (pkgs.libsForQt5.callPackage ../applications/graphics/pymeshlab { });
-
-  pypglab = callPackage ../development/python-modules/pypglab { };
-
-  pyprecice = callPackage ../development/python-modules/pyprecice { };
-
-  pyprobables = callPackage ../development/python-modules/pyprobables { };
-
-  pyproject-api = callPackage ../development/python-modules/pyproject-api { };
-
-  pyproject-hooks = callPackage ../development/python-modules/pyproject-hooks { };
-
-  pyproject-parser = callPackage ../development/python-modules/pyproject-parser { };
-
-  pypsrp = callPackage ../development/python-modules/pypsrp { };
-
-  phpserialize = callPackage ../development/python-modules/phpserialize { };
-
-  phunspell = callPackage ../development/python-modules/phunspell { };
-
-  phx-class-registry = callPackage ../development/python-modules/phx-class-registry { };
-
-  pi1wire = callPackage ../development/python-modules/pi1wire { };
-
-  piano-transcription-inference =
-    callPackage ../development/python-modules/piano-transcription-inference
-      { };
-
-  piccata = callPackage ../development/python-modules/piccata { };
-
-  pick = callPackage ../development/python-modules/pick { };
-
-  pickpack = callPackage ../development/python-modules/pickpack { };
-
-  pickleshare = callPackage ../development/python-modules/pickleshare { };
-
-  picobox = callPackage ../development/python-modules/picobox { };
-
-  picologging = callPackage ../development/python-modules/picologging { };
-
-  picos = callPackage ../development/python-modules/picos { };
-
-  picosvg = callPackage ../development/python-modules/picosvg { };
-
-  piccolo-theme = callPackage ../development/python-modules/piccolo-theme { };
-
-  pid = callPackage ../development/python-modules/pid { };
-
-  piep = callPackage ../development/python-modules/piep { };
-
-  piexif = callPackage ../development/python-modules/piexif { };
-
-  pijuice = callPackage ../development/python-modules/pijuice { };
-
-  pika = callPackage ../development/python-modules/pika { };
-
-  pika-pool = callPackage ../development/python-modules/pika-pool { };
-
-  pikepdf = callPackage ../development/python-modules/pikepdf { };
-
-  pilkit = callPackage ../development/python-modules/pilkit { };
-
-  pillowfight = callPackage ../development/python-modules/pillowfight { };
-
-  pillow = callPackage ../development/python-modules/pillow {
-    inherit (pkgs)
-      freetype
-      lcms2
-      libimagequant
-      libjpeg
-      libraqm
-      libtiff
-      libwebp
-      openjpeg
-      zlib
-      ;
-    inherit (pkgs.xorg) libxcb;
-  };
-
-  pillow-heif = callPackage ../development/python-modules/pillow-heif { };
-
-  pillow-jpls = callPackage ../development/python-modules/pillow-jpls { };
-
-  pims = callPackage ../development/python-modules/pims { };
-
-  pinboard = callPackage ../development/python-modules/pinboard { };
-
-  pinocchio = toPythonModule (
-    pkgs.pinocchio.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  pint = callPackage ../development/python-modules/pint { };
-
-  pint-pandas = callPackage ../development/python-modules/pint-pandas { };
-
-  pint-xarray = callPackage ../development/python-modules/pint-xarray { };
-
-  pip = callPackage ../development/python-modules/pip { };
-
-  pipdate = callPackage ../development/python-modules/pipdate { };
-
-  pipdeptree = callPackage ../development/python-modules/pipdeptree { };
-
-  pipe = callPackage ../development/python-modules/pipe { };
-
-  piper-phonemize = callPackage ../development/python-modules/piper-phonemize {
-    onnxruntime-native = pkgs.onnxruntime;
-    piper-phonemize-native = pkgs.piper-phonemize;
-  };
-
-  pip-api = callPackage ../development/python-modules/pip-api { };
-
-  pip-chill = callPackage ../development/python-modules/pip-chill { };
-
-  pip-tools = callPackage ../development/python-modules/pip-tools { };
-
-  pip-requirements-parser = callPackage ../development/python-modules/pip-requirements-parser { };
-
-  pip-system-certs = callPackage ../development/python-modules/pip-system-certs { };
-
-  pipx = callPackage ../development/python-modules/pipx { };
-
-  pivy = callPackage ../development/python-modules/pivy {
-    inherit (pkgs.qt5) qtbase qmake;
-    inherit (pkgs.libsForQt5) soqt;
-  };
-
-  pixel-font-builder = callPackage ../development/python-modules/pixel-font-builder { };
-
-  pixel-font-knife = callPackage ../development/python-modules/pixel-font-knife { };
-
-  pixel-ring = callPackage ../development/python-modules/pixel-ring { };
-
-  pjsua2 =
-    (toPythonModule (
-      pkgs.pjsip.override {
-        pythonSupport = true;
-        python3 = self.python;
-      }
-    )).py;
-
-  pkce = callPackage ../development/python-modules/pkce { };
-
-  pkgconfig = callPackage ../development/python-modules/pkgconfig { };
-
-  pkginfo = callPackage ../development/python-modules/pkginfo { };
-
-  pkginfo2 = callPackage ../development/python-modules/pkginfo2 { };
-
-  pkuseg = callPackage ../development/python-modules/pkuseg { };
-
-  playwright = callPackage ../development/python-modules/playwright { };
-
-  playwright-stealth = callPackage ../development/python-modules/playwright-stealth { };
-
-  playwrightcapture = callPackage ../development/python-modules/playwrightcapture { };
-
-  pmsensor = callPackage ../development/python-modules/pmsensor { };
-
-  ppdeep = callPackage ../development/python-modules/ppdeep { };
-
-  ppk2-api = callPackage ../development/python-modules/ppk2-api { };
-
-  precisely = callPackage ../development/python-modules/precisely { };
-
-  primp = callPackage ../development/python-modules/primp {
-    inherit (pkgs.darwin.apple_sdk.frameworks) SystemConfiguration;
-  };
-
-  print-color = callPackage ../development/python-modules/print-color { };
-
-  private-gpt = callPackage ../development/python-modules/private-gpt { };
-
-  prodict = callPackage ../development/python-modules/prodict { };
-
-  prometheus-async = callPackage ../development/python-modules/prometheus-async { };
-
-  prometheus-pandas = callPackage ../development/python-modules/prometheus-pandas { };
-
-  propcache = callPackage ../development/python-modules/propcache { };
-
-  prophet = callPackage ../development/python-modules/prophet { };
-
-  propka = callPackage ../development/python-modules/propka { };
-
-  prosemirror = callPackage ../development/python-modules/prosemirror { };
-
-  proxsuite = toPythonModule (
-    pkgs.proxsuite.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  proxsuite-nlp = toPythonModule (
-    pkgs.proxsuite-nlp.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  proxy-tools = callPackage ../development/python-modules/proxy-tools { };
-
-  proxy-db = callPackage ../development/python-modules/proxy-db { };
-
-  py-deviceid = callPackage ../development/python-modules/py-deviceid { };
-
-  py-nextbusnext = callPackage ../development/python-modules/py-nextbusnext { };
-
-  py65 = callPackage ../development/python-modules/py65 { };
-
-  py7zr = callPackage ../development/python-modules/py7zr { };
-
-  pyabpoa = toPythonModule (
-    pkgs.abpoa.override {
-      enablePython = true;
-      python3Packages = self;
-    }
-  );
-
-  pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
-
-  pyalsaaudio = callPackage ../development/python-modules/pyalsaaudio { };
-
-  pyatag = callPackage ../development/python-modules/pyatag { };
-
-  pyatem = callPackage ../development/python-modules/pyatem { };
-
-  pyatome = callPackage ../development/python-modules/pyatome { };
-
-  pybcj = callPackage ../development/python-modules/pybcj { };
-
-  pycketcasts = callPackage ../development/python-modules/pycketcasts { };
-
-  pycolorecho = callPackage ../development/python-modules/pycolorecho { };
-
-  pycomm3 = callPackage ../development/python-modules/pycomm3 { };
-
-  pycompliance = callPackage ../development/python-modules/pycompliance { };
-
-  pycomposefile = callPackage ../development/python-modules/pycomposefile { };
-  pycontrol4 = callPackage ../development/python-modules/pycontrol4 { };
-
-  pycookiecheat = callPackage ../development/python-modules/pycookiecheat { };
-
-  pycoolmasternet-async = callPackage ../development/python-modules/pycoolmasternet-async { };
-
-  pycrdt = callPackage ../development/python-modules/pycrdt { };
-
-  pycrdt-websocket = callPackage ../development/python-modules/pycrdt-websocket { };
-
-  pycycling = callPackage ../development/python-modules/pycycling { };
-
-  pyfibaro = callPackage ../development/python-modules/pyfibaro { };
-
-  pyfireservicerota = callPackage ../development/python-modules/pyfireservicerota { };
-
-  pyflexit = callPackage ../development/python-modules/pyflexit { };
-
-  pyflick = callPackage ../development/python-modules/pyflick { };
-
-  pyfluidsynth = callPackage ../development/python-modules/pyfluidsynth { };
-
-  pyformlang = callPackage ../development/python-modules/pyformlang { };
-
-  pyfreedompro = callPackage ../development/python-modules/pyfreedompro { };
-
-  pygelf = callPackage ../development/python-modules/pygelf { };
-
-  pygerber = callPackage ../development/python-modules/pygerber { };
-
-  pygments-style-github = callPackage ../development/python-modules/pygments-style-github { };
-
-  pygnmi = callPackage ../development/python-modules/pygnmi { };
-
-  pygount = callPackage ../development/python-modules/pygount { };
-
-  pygti = callPackage ../development/python-modules/pygti { };
-
-  pyheck = callPackage ../development/python-modules/pyheck { };
-
-  pyheos = callPackage ../development/python-modules/pyheos { };
-
-  pyhepmc = callPackage ../development/python-modules/pyhepmc { };
-
-  pyhidra = callPackage ../development/python-modules/pyhidra { };
-
-  pyhive-integration = callPackage ../development/python-modules/pyhive-integration { };
-
-  pyhumps = callPackage ../development/python-modules/pyhumps { };
-
-  pyindego = callPackage ../development/python-modules/pyindego { };
-
-  pyinstaller = callPackage ../development/python-modules/pyinstaller { };
-
-  pyinstaller-hooks-contrib = callPackage ../development/python-modules/pyinstaller-hooks-contrib { };
-
-  pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };
-
-  pyisemail = callPackage ../development/python-modules/pyisemail { };
-
-  pyiskra = callPackage ../development/python-modules/pyiskra { };
-
-  pyisy = callPackage ../development/python-modules/pyisy { };
-
-  pyituran = callPackage ../development/python-modules/pyituran { };
-
-  pyixapi = callPackage ../development/python-modules/pyixapi { };
-
-  pykcs11 = callPackage ../development/python-modules/pykcs11 { };
-
-  pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
-
-  pylance = callPackage ../development/python-modules/pylance { };
-
-  pyldavis = callPackage ../development/python-modules/pyldavis { };
-
-  pylddwrap = callPackage ../development/python-modules/pylddwrap { };
-
-  pyloadapi = callPackage ../development/python-modules/pyloadapi { };
-
-  pylibrespot-java = callPackage ../development/python-modules/pylibrespot-java { };
-
-  pylsl = callPackage ../development/python-modules/pylsl { };
-
-  pynfsclient = callPackage ../development/python-modules/pynfsclient { };
-
-  pyngo = callPackage ../development/python-modules/pyngo { };
-
-  pyngrok = callPackage ../development/python-modules/pyngrok { };
-
-  pynitrokey = callPackage ../development/python-modules/pynitrokey { };
-
-  pynndescent = callPackage ../development/python-modules/pynndescent { };
-
-  pynobo = callPackage ../development/python-modules/pynobo { };
-
-  pynotifier = callPackage ../development/python-modules/pynotifier { };
-
-  pynordpool = callPackage ../development/python-modules/pynordpool { };
-
-  pynslookup = callPackage ../development/python-modules/pynslookup { };
-
-  pynuki = callPackage ../development/python-modules/pynuki { };
-
-  pynut2 = callPackage ../development/python-modules/pynut2 { };
-
-  pynws = callPackage ../development/python-modules/pynws { };
-
-  pynx584 = callPackage ../development/python-modules/pynx584 { };
-
-  pyogrio = callPackage ../development/python-modules/pyogrio { };
-
-  pyorthanc = callPackage ../development/python-modules/pyorthanc { };
-
-  pyoutbreaksnearme = callPackage ../development/python-modules/pyoutbreaksnearme { };
-
-  pyoverkiz = callPackage ../development/python-modules/pyoverkiz { };
-
-  pyownet = callPackage ../development/python-modules/pyownet { };
-
-  pypoint = callPackage ../development/python-modules/pypoint { };
-
-  pypoolstation = callPackage ../development/python-modules/pypoolstation { };
-
-  pyppmd = callPackage ../development/python-modules/pyppmd { };
-
-  pyrail = callPackage ../development/python-modules/pyrail { };
-
-  pyrdfa3 = callPackage ../development/python-modules/pyrdfa3 { };
-
-  pyre-extensions = callPackage ../development/python-modules/pyre-extensions { };
-
-  pyrender = callPackage ../development/python-modules/pyrender { };
-
-  pyrevolve = callPackage ../development/python-modules/pyrevolve { };
-
-  pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };
-
-  pyrogram = callPackage ../development/python-modules/pyrogram { };
-
-  pyrympro = callPackage ../development/python-modules/pyrympro { };
-
-  pysabnzbd = callPackage ../development/python-modules/pysabnzbd { };
-
-  pysbd = callPackage ../development/python-modules/pysbd { };
-
-  pysequoia = callPackage ../development/python-modules/pysequoia { };
-
-  pyseries = callPackage ../development/python-modules/pyseries { };
-
-  pyschemes = callPackage ../development/python-modules/pyschemes { };
-
-  pyschlage = callPackage ../development/python-modules/pyschlage { };
-
-  pyshark = callPackage ../development/python-modules/pyshark { };
-
-  pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };
-
-  pysilero-vad = callPackage ../development/python-modules/pysilero-vad { };
-
-  pysimplesoap = callPackage ../development/python-modules/pysimplesoap { };
-
-  pyskyqhub = callPackage ../development/python-modules/pyskyqhub { };
-
-  pyskyqremote = callPackage ../development/python-modules/pyskyqremote { };
-
-  pysmhi = callPackage ../development/python-modules/pysmhi { };
-
-  pysolcast = callPackage ../development/python-modules/pysolcast { };
-
-  pystac = callPackage ../development/python-modules/pystac { };
-
-  pystac-client = callPackage ../development/python-modules/pystac-client { };
-
-  pysubs2 = callPackage ../development/python-modules/pysubs2 { };
-
-  pysuezv2 = callPackage ../development/python-modules/pysuezv2 { };
-
-  pysqlitecipher = callPackage ../development/python-modules/pysqlitecipher { };
-
-  pysyncthru = callPackage ../development/python-modules/pysyncthru { };
-
-  pytask = callPackage ../development/python-modules/pytask { };
-
-  pytest-lsp = callPackage ../development/python-modules/pytest-lsp { };
-
-  pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };
-
-  pytest-pook = callPackage ../development/python-modules/pytest-pook { };
-
-  pytest-pudb = callPackage ../development/python-modules/pytest-pudb { };
-
-  pytest-ruff = callPackage ../development/python-modules/pytest-ruff { };
-
-  pytlv = callPackage ../development/python-modules/pytlv { };
-
-  pywebcopy = callPackage ../development/python-modules/pywebcopy { };
-
-  python-calamine = callPackage ../development/python-modules/python-calamine { };
-
-  python-can = callPackage ../development/python-modules/python-can { };
-
-  python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
-
-  python-creole = callPackage ../development/python-modules/python-creole { };
-
-  python-crfsuite = callPackage ../development/python-modules/python-crfsuite { };
-
-  python-csxcad = callPackage ../development/python-modules/python-csxcad { };
-
-  python-djvulibre = callPackage ../development/python-modules/python-djvulibre { };
-
-  python-ecobee-api = callPackage ../development/python-modules/python-ecobee-api { };
-
-  python-escpos = callPackage ../development/python-modules/python-escpos { };
-
-  python-ffmpeg = callPackage ../development/python-modules/python-ffmpeg { };
-
-  python-flirt = callPackage ../development/python-modules/python-flirt { };
-
-  python-fullykiosk = callPackage ../development/python-modules/python-fullykiosk { };
-
-  python-fx = callPackage ../development/python-modules/python-fx { };
-
-  python-glanceclient = callPackage ../development/python-modules/python-glanceclient { };
-
-  python-google-nest = callPackage ../development/python-modules/python-google-nest { };
-
-  python-heatclient = callPackage ../development/python-modules/python-heatclient { };
-
-  python-hl7 = callPackage ../development/python-modules/python-hl7 { };
-
-  python-ipmi = callPackage ../development/python-modules/python-ipmi { };
-
-  python-ipware = callPackage ../development/python-modules/python-ipware { };
-
-  python-ironicclient = callPackage ../development/python-modules/python-ironicclient { };
-
-  python-izone = callPackage ../development/python-modules/python-izone { };
-
-  python-juicenet = callPackage ../development/python-modules/python-juicenet { };
-
-  python-kadmin-rs = callPackage ../development/python-modules/python-kadmin-rs { };
-
-  python-kasa = callPackage ../development/python-modules/python-kasa { };
-
-  python-keycloak = callPackage ../development/python-modules/python-keycloak { };
-
-  python-keystoneclient = callPackage ../development/python-modules/python-keystoneclient { };
-
-  python-linkplay = callPackage ../development/python-modules/python-linkplay { };
-
-  python-lsp-black = callPackage ../development/python-modules/python-lsp-black { };
-
-  python-mbedtls = callPackage ../development/python-modules/python-mbedtls { };
-
-  python-memcached = callPackage ../development/python-modules/python-memcached {
-    inherit (pkgs) memcached;
-  };
-
-  python-motionmount = callPackage ../development/python-modules/python-motionmount { };
-
-  python-octaviaclient = callPackage ../development/python-modules/python-octaviaclient { };
-
-  python-otbr-api = callPackage ../development/python-modules/python-otbr-api { };
-
-  python-openems = callPackage ../development/python-modules/python-openems { };
-
-  python-opensky = callPackage ../development/python-modules/python-opensky { };
-
-  python-overseerr = callPackage ../development/python-modules/python-overseerr { };
-
-  python-owasp-zap-v2-4 = callPackage ../development/python-modules/python-owasp-zap-v2-4 { };
-
-  python-poppler = callPackage ../development/python-modules/python-poppler { };
-
-  python-pptx = callPackage ../development/python-modules/python-pptx { };
-
-  python-snoo = callPackage ../development/python-modules/python-snoo { };
-
-  python-songpal = callPackage ../development/python-modules/python-songpal { };
-
-  python-swiftclient = callPackage ../development/python-modules/python-swiftclient { };
-
-  python-xapp = callPackage ../development/python-modules/python-xapp {
-    inherit (pkgs.buildPackages) meson;
-    inherit (pkgs)
-      gtk3
-      gobject-introspection
-      polkit
-      xapp
-      ;
-  };
-
-  python-tado = callPackage ../development/python-modules/python-tado { };
-
-  python-troveclient = callPackage ../development/python-modules/python-troveclient { };
-
-  python-idzip = callPackage ../development/python-modules/python-idzip { };
-
-  python-yakh = callPackage ../development/python-modules/python-yakh { };
-
-  pythonfinder = callPackage ../development/python-modules/pythonfinder { };
-
-  pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };
-
-  pytorch3d = callPackage ../development/python-modules/pytorch3d { };
-
-  pytouchline-extended = callPackage ../development/python-modules/pytouchline-extended { };
-
-  pytouchlinesl = callPackage ../development/python-modules/pytouchlinesl { };
-
-  pyuca = callPackage ../development/python-modules/pyuca { };
-
-  pyunpack = callPackage ../development/python-modules/pyunpack { };
-
-  pyunormalize = callPackage ../development/python-modules/pyunormalize { };
-
-  pyutil = callPackage ../development/python-modules/pyutil { };
-
-  pyzbar = callPackage ../development/python-modules/pyzbar { };
-
-  pyzipper = callPackage ../development/python-modules/pyzipper { };
-
-  pyzstd = callPackage ../development/python-modules/pyzstd { zstd-c = pkgs.zstd; };
-
-  plac = callPackage ../development/python-modules/plac { };
-
-  plaid-python = callPackage ../development/python-modules/plaid-python { };
-
-  planetary-computer = callPackage ../development/python-modules/planetary-computer { };
-
-  plantuml = callPackage ../development/python-modules/plantuml { };
-
-  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown {
-    inherit (pkgs) plantuml;
-  };
-
-  plaster = callPackage ../development/python-modules/plaster { };
-
-  plasTeX = callPackage ../development/python-modules/plasTeX { };
-
-  plastexdepgraph = callPackage ../development/python-modules/plastexdepgraph { };
-
-  plastexshowmore = callPackage ../development/python-modules/plastexshowmore { };
-
-  plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy { };
-
-  platformdirs = callPackage ../development/python-modules/platformdirs { };
-
-  playsound = callPackage ../development/python-modules/playsound { };
-
-  plexapi = callPackage ../development/python-modules/plexapi { };
-
-  plexauth = callPackage ../development/python-modules/plexauth { };
-
-  plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
-
-  plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
-
-  plone-testing = callPackage ../development/python-modules/plone-testing { };
-
-  ploomber-core = callPackage ../development/python-modules/ploomber-core { };
-
-  ploomber-extension = callPackage ../development/python-modules/ploomber-extension { };
-
-  plotext = callPackage ../development/python-modules/plotext { };
-
-  plotly = callPackage ../development/python-modules/plotly { };
-
-  plotpy = callPackage ../development/python-modules/plotpy { };
-
-  plotnine = callPackage ../development/python-modules/plotnine { };
-
-  pluggy = callPackage ../development/python-modules/pluggy { };
-
-  plugincode = callPackage ../development/python-modules/plugincode { };
-
-  pluginbase = callPackage ../development/python-modules/pluginbase { };
-
-  plugnplay = callPackage ../development/python-modules/plugnplay { };
-
-  plugwise = callPackage ../development/python-modules/plugwise { };
-
-  plum-py = callPackage ../development/python-modules/plum-py { };
-
-  plumbum = callPackage ../development/python-modules/plumbum { };
-
-  pluthon = callPackage ../development/python-modules/pluthon { };
-
-  plux = callPackage ../development/python-modules/plux { };
-
-  ply = callPackage ../development/python-modules/ply { };
-
-  plyara = callPackage ../development/python-modules/plyara { };
-
-  plyer = callPackage ../development/python-modules/plyer { };
-
-  plyfile = callPackage ../development/python-modules/plyfile { };
-
-  plyplus = callPackage ../development/python-modules/plyplus { };
-
-  plyvel = callPackage ../development/python-modules/plyvel { };
-
-  pmw = callPackage ../development/python-modules/pmw { };
-
-  pmdarima = callPackage ../development/python-modules/pmdarima { };
-
-  pmdsky-debug-py = callPackage ../development/python-modules/pmdsky-debug-py { };
-
-  pnglatex = callPackage ../development/python-modules/pnglatex { };
-
-  pocket = callPackage ../development/python-modules/pocket { };
-
-  pocketsphinx = callPackage ../development/python-modules/pocketsphinx {
-    inherit (pkgs) pocketsphinx;
-  };
-
-  podcastparser = callPackage ../development/python-modules/podcastparser { };
-
-  podcats = callPackage ../development/python-modules/podcats { };
-
-  podgen = callPackage ../development/python-modules/podgen { };
-
-  podman = callPackage ../development/python-modules/podman { };
-
-  poetry-core = callPackage ../development/python-modules/poetry-core { };
-
-  poetry-dynamic-versioning = callPackage ../development/python-modules/poetry-dynamic-versioning { };
-
-  poetry-semver = callPackage ../development/python-modules/poetry-semver { };
-
-  polars = callPackage ../development/python-modules/polars { };
-
-  polarizationsolver = callPackage ../development/python-modules/polarizationsolver { };
-
-  polling = callPackage ../development/python-modules/polling { };
-
-  polib = callPackage ../development/python-modules/polib { };
-
-  policy-sentry = callPackage ../development/python-modules/policy-sentry { };
-
-  policyuniverse = callPackage ../development/python-modules/policyuniverse { };
-
-  polyline = callPackage ../development/python-modules/polyline { };
-
-  polyfactory = callPackage ../development/python-modules/polyfactory { };
-
-  polygon3 = callPackage ../development/python-modules/polygon3 { };
-
-  polyswarm-api = callPackage ../development/python-modules/polyswarm-api { };
-
-  pomegranate = callPackage ../development/python-modules/pomegranate { };
-
-  pontos = callPackage ../development/python-modules/pontos { };
-
-  pony = callPackage ../development/python-modules/pony { };
-
-  ponywhoosh = callPackage ../development/python-modules/ponywhoosh { };
-
-  pooch = callPackage ../development/python-modules/pooch { };
-
-  pook = callPackage ../development/python-modules/pook { };
-
-  poolsense = callPackage ../development/python-modules/poolsense { };
-
-  poppler-qt5 = callPackage ../development/python-modules/poppler-qt5 {
-    inherit (pkgs.qt5) qtbase qmake;
-    inherit (pkgs.libsForQt5) poppler;
-  };
-
-  portalocker = callPackage ../development/python-modules/portalocker { };
-
-  portend = callPackage ../development/python-modules/portend { };
-
-  portion = callPackage ../development/python-modules/portion { };
-
-  port-for = callPackage ../development/python-modules/port-for { };
-
-  portpicker = callPackage ../development/python-modules/portpicker { };
-
-  posix-ipc = callPackage ../development/python-modules/posix-ipc { };
-
-  posthog = callPackage ../development/python-modules/posthog { };
-
-  pot = callPackage ../development/python-modules/pot { };
-
-  potentials = callPackage ../development/python-modules/potentials { };
-
-  potr = callPackage ../development/python-modules/potr { };
-
-  power = callPackage ../development/python-modules/power { };
-
-  powerapi = callPackage ../development/python-modules/powerapi { };
-
-  powerfox = callPackage ../development/python-modules/powerfox { };
-
-  powerline = callPackage ../development/python-modules/powerline { };
-
-  powerline-mem-segment = callPackage ../development/python-modules/powerline-mem-segment { };
-
-  pox = callPackage ../development/python-modules/pox { };
-
-  poyo = callPackage ../development/python-modules/poyo { };
-
-  ppft = callPackage ../development/python-modules/ppft { };
-
-  pplpy = callPackage ../development/python-modules/pplpy { };
-
-  pprintpp = callPackage ../development/python-modules/pprintpp { };
-
-  pproxy = callPackage ../development/python-modules/pproxy { };
-
-  ppscore = callPackage ../development/python-modules/ppscore { };
-
-  pq = callPackage ../development/python-modules/pq { };
-
-  prance = callPackage ../development/python-modules/prance { };
-
-  prawcore = callPackage ../development/python-modules/prawcore { };
-
-  praw = callPackage ../development/python-modules/praw { };
-
-  prayer-times-calculator-offline =
-    callPackage ../development/python-modules/prayer-times-calculator-offline
-      { };
-
-  precis-i18n = callPackage ../development/python-modules/precis-i18n { };
-
-  prefixed = callPackage ../development/python-modules/prefixed { };
-
-  pre-commit-hooks = callPackage ../development/python-modules/pre-commit-hooks { };
-
-  pre-commit-po-hooks = callPackage ../development/python-modules/pre-commit-po-hooks { };
-
-  preggy = callPackage ../development/python-modules/preggy { };
-
-  preprocess-cancellation = callPackage ../development/python-modules/preprocess-cancellation { };
-
-  preshed = callPackage ../development/python-modules/preshed { };
-
-  presenterm-export = callPackage ../development/python-modules/presenterm-export { };
-
-  pretend = callPackage ../development/python-modules/pretend { };
-
-  pretty-errors = callPackage ../development/python-modules/pretty-errors { };
-
-  prettytable = callPackage ../development/python-modules/prettytable { };
-
-  primecountpy = callPackage ../development/python-modules/primecountpy { };
-
-  primepy = callPackage ../development/python-modules/primepy { };
-
-  primer3 = callPackage ../development/python-modules/primer3 { };
-
-  priority = callPackage ../development/python-modules/priority { };
-
-  prisma = callPackage ../development/python-modules/prisma { };
-
-  prison = callPackage ../development/python-modules/prison { };
-
-  process-tests = callPackage ../development/python-modules/process-tests { };
-
-  procmon-parser = callPackage ../development/python-modules/procmon-parser { };
-
-  proglog = callPackage ../development/python-modules/proglog { };
-
-  progressbar2 = callPackage ../development/python-modules/progressbar2 { };
-
-  progressbar33 = callPackage ../development/python-modules/progressbar33 { };
-
-  progressbar = callPackage ../development/python-modules/progressbar { };
-
-  progress = callPackage ../development/python-modules/progress { };
-
-  prometheus-api-client = callPackage ../development/python-modules/prometheus-api-client { };
-
-  prometheus-client = callPackage ../development/python-modules/prometheus-client { };
-
-  prometheus-fastapi-instrumentator =
-    callPackage ../development/python-modules/prometheus-fastapi-instrumentator
-      { };
-
-  prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
-
-  prometrix = callPackage ../development/python-modules/prometrix { };
-
-  promise = callPackage ../development/python-modules/promise { };
-
-  prompt-toolkit = callPackage ../development/python-modules/prompt-toolkit { };
-
-  prompthub-py = callPackage ../development/python-modules/prompthub-py { };
-
-  property-manager = callPackage ../development/python-modules/property-manager { };
-
-  protego = callPackage ../development/python-modules/protego { };
-
-  proto-plus = callPackage ../development/python-modules/proto-plus { };
-
-  # Protobuf 4.x
-  protobuf4 = callPackage ../development/python-modules/protobuf/4.nix {
-    protobuf = pkgs.protobuf_25;
-  };
-
-  # Protobuf 5.x
-  protobuf5 = callPackage ../development/python-modules/protobuf/default.nix {
-    inherit (pkgs.__splicedPackages) protobuf;
-  };
-
-  # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
-  protobuf = protobuf5;
-
-  protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
-
-  proton-client = callPackage ../development/python-modules/proton-client { };
-
-  proton-core = callPackage ../development/python-modules/proton-core { };
-
-  proton-keyring-linux = callPackage ../development/python-modules/proton-keyring-linux { };
-
-  proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
-
-  proton-vpn-network-manager =
-    callPackage ../development/python-modules/proton-vpn-network-manager
-      { };
-
-  protonup-ng = callPackage ../development/python-modules/protonup-ng { };
-
-  protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {
-    pkgs-systemd = pkgs.systemd;
-  };
-
-  prov = callPackage ../development/python-modules/prov { };
-
-  prox-tv = callPackage ../development/python-modules/prox-tv { };
-
-  proxmoxer = callPackage ../development/python-modules/proxmoxer { };
-
-  proxy-py = callPackage ../development/python-modules/proxy-py { };
-
-  psautohint = callPackage ../development/python-modules/psautohint { };
-
-  pscript = callPackage ../development/python-modules/pscript { };
-
-  psd-tools = callPackage ../development/python-modules/psd-tools { };
-
-  psutil = callPackage ../development/python-modules/psutil {
-    stdenv =
-      if pkgs.stdenv.hostPlatform.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation IOKit;
-  };
-
-  psutil-home-assistant = callPackage ../development/python-modules/psutil-home-assistant { };
-
-  psychrolib = callPackage ../development/python-modules/psychrolib { };
-
-  psycopg = callPackage ../development/python-modules/psycopg { };
-  psycopg-pool = psycopg.pool;
-  psycopg-c = psycopg.c;
-
-  psycopg2 = callPackage ../development/python-modules/psycopg2 { };
-
-  psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi { };
-
-  psycopg2-binary = callPackage ../development/python-modules/psycopg2-binary { };
-
-  psygnal = callPackage ../development/python-modules/psygnal { };
-
-  ptable = callPackage ../development/python-modules/ptable { };
-
-  ptest = callPackage ../development/python-modules/ptest { };
-
-  ptpython = callPackage ../development/python-modules/ptpython { };
-
-  ptyprocess = callPackage ../development/python-modules/ptyprocess { };
-
-  publicsuffix2 = callPackage ../development/python-modules/publicsuffix2 { };
-
-  publicsuffix = callPackage ../development/python-modules/publicsuffix { };
-
-  publicsuffixlist = callPackage ../development/python-modules/publicsuffixlist { };
-
-  pubnub = callPackage ../development/python-modules/pubnub { };
-
-  pubnubsub-handler = callPackage ../development/python-modules/pubnubsub-handler { };
-
-  pudb = callPackage ../development/python-modules/pudb { };
-
-  pulp = callPackage ../development/python-modules/pulp { };
-
-  pulsar-client = callPackage ../development/python-modules/pulsar-client { };
-
-  pulsectl-asyncio = callPackage ../development/python-modules/pulsectl-asyncio { };
-
-  pulsar = callPackage ../development/python-modules/pulsar { };
-
-  pulsectl = callPackage ../development/python-modules/pulsectl { };
-
-  pure-cdb = callPackage ../development/python-modules/pure-cdb { };
-
-  pure-eval = callPackage ../development/python-modules/pure-eval { };
-
-  pure-pcapy3 = callPackage ../development/python-modules/pure-pcapy3 { };
-
-  purepng = callPackage ../development/python-modules/purepng { };
-
-  pure-protobuf = callPackage ../development/python-modules/pure-protobuf { };
-
-  pure-python-adb = callPackage ../development/python-modules/pure-python-adb { };
-
-  pure-python-adb-homeassistant =
-    callPackage ../development/python-modules/pure-python-adb-homeassistant
-      { };
-
-  puremagic = callPackage ../development/python-modules/puremagic { };
-
-  purl = callPackage ../development/python-modules/purl { };
-
-  push-receiver = callPackage ../development/python-modules/push-receiver { };
-
-  pushbullet-py = callPackage ../development/python-modules/pushbullet-py { };
-
-  pushover-complete = callPackage ../development/python-modules/pushover-complete { };
-
-  pvextractor = callPackage ../development/python-modules/pvextractor { };
-
-  pvlib = callPackage ../development/python-modules/pvlib { };
-
-  pvo = callPackage ../development/python-modules/pvo { };
-
-  pweave = callPackage ../development/python-modules/pweave { };
-
-  pwkit = callPackage ../development/python-modules/pwkit { };
-
-  pwlf = callPackage ../development/python-modules/pwlf { };
-
-  pwntools = callPackage ../development/python-modules/pwntools { debugger = pkgs.gdb; };
-
-  py-air-control = callPackage ../development/python-modules/py-air-control { };
-
-  py-air-control-exporter = callPackage ../development/python-modules/py-air-control-exporter { };
-
-  py-bip39-bindings = callPackage ../development/python-modules/py-bip39-bindings { };
-
-  py-dmidecode = callPackage ../development/python-modules/py-dmidecode { };
-
-  py-dormakaba-dkey = callPackage ../development/python-modules/py-dormakaba-dkey { };
-
-  py-madvr2 = callPackage ../development/python-modules/py-madvr2 { };
-
-  py-nightscout = callPackage ../development/python-modules/py-nightscout { };
-
-  py-partiql-parser = callPackage ../development/python-modules/py-partiql-parser { };
-
-  py-pdf-parser = callPackage ../development/python-modules/py-pdf-parser { };
-
-  py-serializable = callPackage ../development/python-modules/py-serializable { };
-
-  py-synologydsm-api = callPackage ../development/python-modules/py-synologydsm-api { };
-
-  py-sneakers = callPackage ../development/python-modules/py-sneakers { };
-
-  py-sr25519-bindings = callPackage ../development/python-modules/py-sr25519-bindings { };
-
-  py-tes = callPackage ../development/python-modules/py-tes { };
-
-  py-ubjson = callPackage ../development/python-modules/py-ubjson { };
-
-  py-zabbix = callPackage ../development/python-modules/py-zabbix { };
-
-  py2bit = callPackage ../development/python-modules/py2bit { };
-
-  py3buddy = callPackage ../development/python-modules/py3buddy { };
-
-  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { inherit (pkgs) exiv2; };
-
-  py3langid = callPackage ../development/python-modules/py3langid { };
-
-  py3nvml = callPackage ../development/python-modules/py3nvml { };
-
-  py3rijndael = callPackage ../development/python-modules/py3rijndael { };
-
-  py3status = callPackage ../development/python-modules/py3status { };
-
-  py4j = callPackage ../development/python-modules/py4j { };
-
-  pyacaia-async = callPackage ../development/python-modules/pyacaia-async { };
-
-  pyacoustid = callPackage ../development/python-modules/pyacoustid { };
-
-  pyads = callPackage ../development/python-modules/pyads { };
-
-  pyaes = callPackage ../development/python-modules/pyaes { };
-
-  pyaftership = callPackage ../development/python-modules/pyaftership { };
-
-  pyahocorasick = callPackage ../development/python-modules/pyahocorasick { };
-
-  pyairnow = callPackage ../development/python-modules/pyairnow { };
-
-  pyairports = callPackage ../development/python-modules/pyairports { };
-
-  pyairvisual = callPackage ../development/python-modules/pyairvisual { };
-
-  pyais = callPackage ../development/python-modules/pyais { };
-
-  pyalgotrade = callPackage ../development/python-modules/pyalgotrade { };
-
-  pyamg = callPackage ../development/python-modules/pyamg { };
-
-  pyaml = callPackage ../development/python-modules/pyaml { };
-
-  pyaml-env = callPackage ../development/python-modules/pyaml-env { };
-
-  pyannotate = callPackage ../development/python-modules/pyannotate { };
-
-  pyannote-audio = callPackage ../development/python-modules/pyannote-audio { };
-
-  pyannote-pipeline = callPackage ../development/python-modules/pyannote-pipeline { };
-
-  pyannote-metrics = callPackage ../development/python-modules/pyannote-metrics { };
-
-  pyannote-database = callPackage ../development/python-modules/pyannote-database { };
-
-  pyannote-core = callPackage ../development/python-modules/pyannote-core { };
-
-  pyarlo = callPackage ../development/python-modules/pyarlo { };
-
-  pyarr = callPackage ../development/python-modules/pyarr { };
-
-  pyarrow = callPackage ../development/python-modules/pyarrow { inherit (pkgs) arrow-cpp cmake; };
-
-  pyarrow-hotfix = callPackage ../development/python-modules/pyarrow-hotfix { };
-
-  pyasn = callPackage ../development/python-modules/pyasn { };
-
-  pyasn1 = callPackage ../development/python-modules/pyasn1 { };
-
-  pyasn1-modules = callPackage ../development/python-modules/pyasn1-modules { };
-
-  pyasuswrt = callPackage ../development/python-modules/pyasuswrt { };
-
-  pyasynchat = callPackage ../development/python-modules/pyasynchat { };
-
-  pyasyncore = callPackage ../development/python-modules/pyasyncore { };
-
-  pyathena = callPackage ../development/python-modules/pyathena { };
-
-  pyatmo = callPackage ../development/python-modules/pyatmo { };
-
-  pyatspi = callPackage ../development/python-modules/pyatspi { };
-
-  pyatv = callPackage ../development/python-modules/pyatv { };
-
-  pyaudio = callPackage ../development/python-modules/pyaudio { };
-
-  pyaussiebb = callPackage ../development/python-modules/pyaussiebb { };
-
-  pyautogui = callPackage ../development/python-modules/pyautogui { };
-
-  pyavm = callPackage ../development/python-modules/pyavm { };
-
-  pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
-
-  pybalboa = callPackage ../development/python-modules/pybalboa { };
-
-  pybase64 = callPackage ../development/python-modules/pybase64 { };
-
-  pybids = callPackage ../development/python-modules/pybids { };
-
-  pybigwig = callPackage ../development/python-modules/pybigwig { };
-
-  pybind11 = callPackage ../development/python-modules/pybind11 { };
-
-  pybind11-abseil = callPackage ../development/python-modules/pybind11-abseil { };
-
-  pybind11-protobuf = callPackage ../development/python-modules/pybind11-protobuf { };
-
-  pybind11-stubgen = callPackage ../development/python-modules/pybind11-stubgen { };
-
-  pybindgen = callPackage ../development/python-modules/pybindgen { };
-
-  pyblackbird = callPackage ../development/python-modules/pyblackbird { };
-
-  pybloom-live = callPackage ../development/python-modules/pybloom-live { };
-
-  pyblu = callPackage ../development/python-modules/pyblu { };
-
-  pybluez = callPackage ../development/python-modules/pybluez { inherit (pkgs) bluez; };
-
-  pybotvac = callPackage ../development/python-modules/pybotvac { };
-
-  pybox2d = callPackage ../development/python-modules/pybox2d { };
-
-  pybravia = callPackage ../development/python-modules/pybravia { };
-
-  pybrowsers = callPackage ../development/python-modules/pybrowsers { };
-
-  pybrowserid = callPackage ../development/python-modules/pybrowserid { };
-
-  pybtex = callPackage ../development/python-modules/pybtex { };
-
-  pybtex-docutils = callPackage ../development/python-modules/pybtex-docutils { };
-
-  pybullet = callPackage ../development/python-modules/pybullet { };
-
-  pycairo = callPackage ../development/python-modules/pycairo { inherit (pkgs.buildPackages) meson; };
-
-  py = callPackage ../development/python-modules/py { };
-
-  pycangjie = callPackage ../development/python-modules/pycangjie {
-    inherit (pkgs.buildPackages) meson;
-  };
-
-  pycapnp = callPackage ../development/python-modules/pycapnp { };
-
-  pycaption = callPackage ../development/python-modules/pycaption { };
-
-  pycares = callPackage ../development/python-modules/pycares { };
-
-  pycarwings2 = callPackage ../development/python-modules/pycarwings2 { };
-
-  pycatch22 = callPackage ../development/python-modules/pycatch22 { };
-
-  pycategories = callPackage ../development/python-modules/pycategories { };
-
-  pycddl = callPackage ../development/python-modules/pycddl { };
-
-  pycdio = callPackage ../development/python-modules/pycdio { };
-
-  pycec = callPackage ../development/python-modules/pycec { };
-
-  pycep-parser = callPackage ../development/python-modules/pycep-parser { };
-
-  pycfdns = callPackage ../development/python-modules/pycfdns { };
-
-  pycflow2dot = callPackage ../development/python-modules/pycflow2dot { inherit (pkgs) graphviz; };
-
-  pycfmodel = callPackage ../development/python-modules/pycfmodel { };
-
-  pychannels = callPackage ../development/python-modules/pychannels { };
-
-  pychart = callPackage ../development/python-modules/pychart { };
-
-  pychm = callPackage ../development/python-modules/pychm { };
-
-  pychromecast = callPackage ../development/python-modules/pychromecast { };
-
-  pyclimacell = callPackage ../development/python-modules/pyclimacell { };
-
-  pyclip = callPackage ../development/python-modules/pyclip { };
-
-  pyclipper = callPackage ../development/python-modules/pyclipper { };
-
-  pycm = callPackage ../development/python-modules/pycm { };
-
-  pycmarkgfm = callPackage ../development/python-modules/pycmarkgfm { };
-
-  pycocotools = callPackage ../development/python-modules/pycocotools { };
-
-  pycodestyle = callPackage ../development/python-modules/pycodestyle { };
-
-  pycognito = callPackage ../development/python-modules/pycognito { };
-
-  pycoin = callPackage ../development/python-modules/pycoin { };
-
-  pycollada = callPackage ../development/python-modules/pycollada { };
-
-  pycomfoconnect = callPackage ../development/python-modules/pycomfoconnect { };
-
-  pycosat = callPackage ../development/python-modules/pycosat { };
-
-  pycotap = callPackage ../development/python-modules/pycotap { };
-
-  pycountry = callPackage ../development/python-modules/pycountry { };
-
-  pycountry-convert = callPackage ../development/python-modules/pycountry-convert { };
-
-  pycparser = callPackage ../development/python-modules/pycparser { };
-
-  py-canary = callPackage ../development/python-modules/py-canary { };
-
-  py-cid = callPackage ../development/python-modules/py-cid { };
-
-  py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
-
-  pycardano = callPackage ../development/python-modules/pycardano { };
-
-  pycrc = callPackage ../development/python-modules/pycrc { };
-
-  pycritty = callPackage ../development/python-modules/pycritty { };
-
-  pycron = callPackage ../development/python-modules/pycron { };
-
-  pycrypto = callPackage ../development/python-modules/pycrypto { };
-
-  pycryptodome = callPackage ../development/python-modules/pycryptodome { };
-
-  pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
-
-  pycsdr = callPackage ../development/python-modules/pycsdr { };
-
-  pyct = callPackage ../development/python-modules/pyct { };
-
-  pyctr = callPackage ../development/python-modules/pyctr { };
-
-  pycuda = callPackage ../development/python-modules/pycuda { inherit (pkgs.stdenv) mkDerivation; };
-
-  pycups = callPackage ../development/python-modules/pycups { };
-
-  pycurl = callPackage ../development/python-modules/pycurl { };
-
-  pycxx = callPackage ../development/python-modules/pycxx { };
-
-  pycyphal = callPackage ../development/python-modules/pycyphal { };
-
-  pydaikin = callPackage ../development/python-modules/pydaikin { };
-
-  pydal = callPackage ../development/python-modules/pydal { };
-
-  pydanfossair = callPackage ../development/python-modules/pydanfossair { };
-
-  pydantic = callPackage ../development/python-modules/pydantic { };
-
-  pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };
-
-  pydantic-argparse-extensible =
-    callPackage ../development/python-modules/pydantic-argparse-extensible
-      { };
-
-  pydantic-compat = callPackage ../development/python-modules/pydantic-compat { };
-
-  pydantic-core = callPackage ../development/python-modules/pydantic-core { };
-
-  pydantic-extra-types = callPackage ../development/python-modules/pydantic-extra-types { };
-
-  pydantic-scim = callPackage ../development/python-modules/pydantic-scim { };
-
-  pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };
-
-  pydantic-yaml = callPackage ../development/python-modules/pydantic-yaml { };
-
-  pydash = callPackage ../development/python-modules/pydash { };
-
-  pydata-google-auth = callPackage ../development/python-modules/pydata-google-auth { };
-
-  pydata-sphinx-theme = callPackage ../development/python-modules/pydata-sphinx-theme { };
-
-  pydateinfer = callPackage ../development/python-modules/pydateinfer { };
-
-  pydbus = callPackage ../development/python-modules/pydbus { };
-
-  pydeako = callPackage ../development/python-modules/pydeako { };
-
-  pydeck = callPackage ../development/python-modules/pydeck { };
-
-  pydeconz = callPackage ../development/python-modules/pydeconz { };
-
-  pydelijn = callPackage ../development/python-modules/pydelijn { };
-
-  pydenticon = callPackage ../development/python-modules/pydenticon { };
-
-  pydemumble = callPackage ../development/python-modules/pydemumble { };
-
-  pydeps = callPackage ../development/python-modules/pydeps { inherit (pkgs) graphviz; };
-
-  pydes = callPackage ../development/python-modules/pydes { };
-
-  py-desmume = callPackage ../development/python-modules/py-desmume {
-    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
-  };
-
-  pydevccu = callPackage ../development/python-modules/pydevccu { };
-
-  pydevd = callPackage ../development/python-modules/pydevd { };
-
-  pydevtool = callPackage ../development/python-modules/pydevtool { };
-
-  pydexcom = callPackage ../development/python-modules/pydexcom { };
-
-  pydicom = callPackage ../development/python-modules/pydicom { };
-
-  pydicom-seg = callPackage ../development/python-modules/pydicom-seg { };
-
-  pydigiham = callPackage ../development/python-modules/pydigiham { };
-
-  pydiscourse = callPackage ../development/python-modules/pydiscourse { };
-
-  pydiscovergy = callPackage ../development/python-modules/pydiscovergy { };
-
-  pydispatcher = callPackage ../development/python-modules/pydispatcher { };
-
-  pydmd = callPackage ../development/python-modules/pydmd { };
-
-  py3dns = callPackage ../development/python-modules/py3dns { };
-
-  pydocstyle = callPackage ../development/python-modules/pydocstyle { };
-
-  pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
-
-  pydoods = callPackage ../development/python-modules/pydoods { };
-
-  pydoe = callPackage ../development/python-modules/pydoe { };
-
-  pydot = callPackage ../development/python-modules/pydot { inherit (pkgs) graphviz; };
-
-  pydrawise = callPackage ../development/python-modules/pydrawise { };
-
-  pydrive2 = callPackage ../development/python-modules/pydrive2 { };
-
-  pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam { };
-
-  pydruid = callPackage ../development/python-modules/pydruid { };
-
-  pydsdl = callPackage ../development/python-modules/pydsdl { };
-
-  pydub = callPackage ../development/python-modules/pydub { };
-
-  pyduke-energy = callPackage ../development/python-modules/pyduke-energy { };
-
-  pyduotecno = callPackage ../development/python-modules/pyduotecno { };
-
-  pydy = callPackage ../development/python-modules/pydy { };
-
-  pydyf = callPackage ../development/python-modules/pydyf { };
-
-  pyebus = callPackage ../development/python-modules/pyebus { };
-
-  pyecharts = callPackage ../development/python-modules/pyecharts { };
-
-  pyechonest = callPackage ../development/python-modules/pyechonest { };
-
-  pyeclib = callPackage ../development/python-modules/pyeclib { };
-
-  pyecoforest = callPackage ../development/python-modules/pyecoforest { };
-
-  pyeconet = callPackage ../development/python-modules/pyeconet { };
-
-  pyecotrend-ista = callPackage ../development/python-modules/pyecotrend-ista { };
-
-  pyecowitt = callPackage ../development/python-modules/pyecowitt { };
-
-  pyedflib = callPackage ../development/python-modules/pyedflib { };
-
-  pyedimax = callPackage ../development/python-modules/pyedimax { };
-
-  pyee = callPackage ../development/python-modules/pyee { };
-
-  pyefergy = callPackage ../development/python-modules/pyefergy { };
-
-  pyegps = callPackage ../development/python-modules/pyegps { };
-
-  pyeight = callPackage ../development/python-modules/pyeight { };
-
-  pyeiscp = callPackage ../development/python-modules/pyeiscp { };
-
-  pyelectra = callPackage ../development/python-modules/pyelectra { };
-
-  pyelftools = callPackage ../development/python-modules/pyelftools { };
-
-  pyemby = callPackage ../development/python-modules/pyemby { };
-
-  pyemd = callPackage ../development/python-modules/pyemd { };
-
-  pyemoncms = callPackage ../development/python-modules/pyemoncms { };
-
-  pyemvue = callPackage ../development/python-modules/pyemvue { };
-
-  pyenchant = callPackage ../development/python-modules/pyenchant { inherit (pkgs) enchant2; };
-
-  pyenphase = callPackage ../development/python-modules/pyenphase { };
-
-  pyenvisalink = callPackage ../development/python-modules/pyenvisalink { };
-
-  pyephember = callPackage ../development/python-modules/pyephember { };
-
-  pyepsg = callPackage ../development/python-modules/pyepsg { };
-
-  pyerfa = callPackage ../development/python-modules/pyerfa { };
-
-  pyevmasm = callPackage ../development/python-modules/pyevmasm { };
-
-  pyevilgenius = callPackage ../development/python-modules/pyevilgenius { };
-
-  pyevtk = callPackage ../development/python-modules/pyevtk { };
-
-  pyexcel = callPackage ../development/python-modules/pyexcel { };
-
-  pyexcel-io = callPackage ../development/python-modules/pyexcel-io { };
-
-  pyexcel-ods = callPackage ../development/python-modules/pyexcel-ods { };
-
-  pyexcel-xls = callPackage ../development/python-modules/pyexcel-xls { };
-
-  pyexiftool = callPackage ../development/python-modules/pyexiftool { };
-
-  pyexpect = callPackage ../development/python-modules/pyexpect { };
-
-  pyexploitdb = callPackage ../development/python-modules/pyexploitdb { };
-
-  pyezviz = callPackage ../development/python-modules/pyezviz { };
-
-  pyezvizapi = callPackage ../development/python-modules/pyezvizapi { };
-
-  pyface = callPackage ../development/python-modules/pyface { };
-
-  pyfaidx = callPackage ../development/python-modules/pyfaidx { };
-
-  pyfakefs = callPackage ../development/python-modules/pyfakefs { };
-
-  pyfakewebcam = callPackage ../development/python-modules/pyfakewebcam { };
-
-  pyfantom = callPackage ../development/python-modules/pyfantom { };
-
-  pyfatfs = callPackage ../development/python-modules/pyfatfs { };
-
-  pyfcm = callPackage ../development/python-modules/pyfcm { };
-
-  pyfido = callPackage ../development/python-modules/pyfido { };
-
-  pyfiglet = callPackage ../development/python-modules/pyfiglet { };
-
-  pyfnip = callPackage ../development/python-modules/pyfnip { };
-
-  pyflakes = callPackage ../development/python-modules/pyflakes { };
-
-  pyflic = callPackage ../development/python-modules/pyflic { };
-
-  pyflume = callPackage ../development/python-modules/pyflume { };
-
-  pyflipper = callPackage ../development/python-modules/pyflipper { };
-
-  pyfma = callPackage ../development/python-modules/pyfma { };
-
-  pyfribidi = callPackage ../development/python-modules/pyfribidi { };
-
-  pyfritzhome = callPackage ../development/python-modules/pyfritzhome { };
-
-  pyfronius = callPackage ../development/python-modules/pyfronius { };
-
-  pyftdi = callPackage ../development/python-modules/pyftdi { };
-
-  pyftgl = callPackage ../development/python-modules/pyftgl { };
-
-  pyftpdlib = callPackage ../development/python-modules/pyftpdlib { };
-
-  pyfttt = callPackage ../development/python-modules/pyfttt { };
-
-  pyfume = callPackage ../development/python-modules/pyfume { };
-
-  pyfunctional = callPackage ../development/python-modules/pyfunctional { };
-
-  pyfuse3 = callPackage ../development/python-modules/pyfuse3 { };
-
-  pyfwup = callPackage ../development/python-modules/pyfwup { inherit (pkgs) libusb1; };
-
-  pyfxa = callPackage ../development/python-modules/pyfxa { };
-
-  pyfzf = callPackage ../development/python-modules/pyfzf { inherit (pkgs) fzf; };
-
-  pygal = callPackage ../development/python-modules/pygal { };
-
-  pygame = callPackage ../development/python-modules/pygame { SDL2_image = pkgs.SDL2_image_2_0; };
-
-  pygame-ce = callPackage ../development/python-modules/pygame-ce {
-    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
-    SDL2_image = pkgs.SDL2_image_2_0;
-    SDL2_mixer = pkgs.SDL2_mixer_2_0;
-  };
-
-  pygame-sdl2 = callPackage ../development/python-modules/pygame-sdl2 { };
-
-  pygame-gui = callPackage ../development/python-modules/pygame-gui { };
-
-  pygatt = callPackage ../development/python-modules/pygatt { };
-
-  pygccxml = callPackage ../development/python-modules/pygccxml { };
-
-  pygdbmi = callPackage ../development/python-modules/pygdbmi { };
-
-  pygeocodio = callPackage ../development/python-modules/pygeocodio { };
-
-  pygetwindow = callPackage ../development/python-modules/pygetwindow { };
-
-  pygit2 = callPackage ../development/python-modules/pygit2 { };
-
-  pygitguardian = callPackage ../development/python-modules/pygitguardian { };
-
-  pygithub = callPackage ../development/python-modules/pygithub { };
-
-  pyglet = callPackage ../development/python-modules/pyglet { };
-
-  pyglm = callPackage ../development/python-modules/pyglm { };
-
-  pygls = callPackage ../development/python-modules/pygls { };
-
-  pygltflib = callPackage ../development/python-modules/pygltflib { };
-
-  pygmars = callPackage ../development/python-modules/pygmars { };
-
-  pygments-better-html = callPackage ../development/python-modules/pygments-better-html { };
-
-  pygments = callPackage ../development/python-modules/pygments { };
-
-  pygments-markdown-lexer = callPackage ../development/python-modules/pygments-markdown-lexer { };
-
-  pygmo = callPackage ../development/python-modules/pygmo { };
-
-  pygmt = callPackage ../development/python-modules/pygmt { };
-
-  pygobject3 = callPackage ../development/python-modules/pygobject/3.nix {
-    # inherit (pkgs) meson won't work because it won't be spliced
-    inherit (pkgs.buildPackages) meson;
-  };
-
-  pygobject-stubs = callPackage ../development/python-modules/pygobject-stubs { };
-
-  pygpgme = callPackage ../development/python-modules/pygpgme { };
-
-  pygraphviz = callPackage ../development/python-modules/pygraphviz { inherit (pkgs) graphviz; };
-
-  pygreat = callPackage ../development/python-modules/pygreat { };
-
-  pygrok = callPackage ../development/python-modules/pygrok { };
-
-  pygsl = callPackage ../development/python-modules/pygsl { inherit (pkgs) gsl swig; };
-
-  pygtfs = callPackage ../development/python-modules/pygtfs { };
-
-  pygtail = callPackage ../development/python-modules/pygtail { };
-
-  pygtkspellcheck = callPackage ../development/python-modules/pygtkspellcheck { };
-
-  pygtrie = callPackage ../development/python-modules/pygtrie { };
-
-  pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };
-
-  pyhanko = callPackage ../development/python-modules/pyhanko { };
-
-  pyhanko-certvalidator = callPackage ../development/python-modules/pyhanko-certvalidator { };
-
-  pyhaversion = callPackage ../development/python-modules/pyhaversion { };
-
-  pyhcl = callPackage ../development/python-modules/pyhcl { };
-
-  pyhocon = callPackage ../development/python-modules/pyhocon { };
-
-  pyhomee = callPackage ../development/python-modules/pyhomee { };
-
-  pyhomematic = callPackage ../development/python-modules/pyhomematic { };
-
-  pyhomepilot = callPackage ../development/python-modules/pyhomepilot { };
-
-  pyhomeworks = callPackage ../development/python-modules/pyhomeworks { };
-
-  pyheif = callPackage ../development/python-modules/pyheif { };
-
-  pyi2cflash = callPackage ../development/python-modules/pyi2cflash { };
-
-  pyialarm = callPackage ../development/python-modules/pyialarm { };
-
-  pyiceberg = callPackage ../development/python-modules/pyiceberg { };
-
-  pyicloud = callPackage ../development/python-modules/pyicloud { };
-
-  pyicu = callPackage ../development/python-modules/pyicu { };
-
-  pyicumessageformat = callPackage ../development/python-modules/pyicumessageformat { };
-
-  pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy { inherit (pkgs) ssdeep; };
-
-  pyinotify = callPackage ../development/python-modules/pyinotify { };
-
-  pyinputevent = callPackage ../development/python-modules/pyinputevent { };
-
-  pyinsteon = callPackage ../development/python-modules/pyinsteon { };
-
-  pyinstrument = callPackage ../development/python-modules/pyinstrument { };
-
-  pyintesishome = callPackage ../development/python-modules/pyintesishome { };
-
-  pyipma = callPackage ../development/python-modules/pyipma { };
-
-  pyipp = callPackage ../development/python-modules/pyipp { };
-
-  pyipv8 = callPackage ../development/python-modules/pyipv8 { };
-
-  pyiqvia = callPackage ../development/python-modules/pyiqvia { };
-
-  pyisbn = callPackage ../development/python-modules/pyisbn { };
-
-  pyjks = callPackage ../development/python-modules/pyjks { };
-
-  pyjnius = callPackage ../development/python-modules/pyjnius { };
-
-  pyjson5 = callPackage ../development/python-modules/pyjson5 { };
-
-  pyjsparser = callPackage ../development/python-modules/pyjsparser { };
-
-  pyjvcprojector = callPackage ../development/python-modules/pyjvcprojector { };
-
-  pyjwkest = callPackage ../development/python-modules/pyjwkest { };
-
-  pyjwt = callPackage ../development/python-modules/pyjwt { };
-
-  pykakasi = callPackage ../development/python-modules/pykakasi { };
-
-  pykaleidescape = callPackage ../development/python-modules/pykaleidescape { };
-
-  pykalman = callPackage ../development/python-modules/pykalman { };
-
-  pykdl = callPackage ../development/python-modules/pykdl { };
-
-  pykdtree = callPackage ../development/python-modules/pykdtree {
-    inherit (pkgs.llvmPackages) openmp;
-  };
-
-  pykeepass = callPackage ../development/python-modules/pykeepass { };
-
-  pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };
-
-  pykeyatome = callPackage ../development/python-modules/pykeyatome { };
-
-  pykira = callPackage ../development/python-modules/pykira { };
-
-  pykka = callPackage ../development/python-modules/pykka { };
-
-  pykmtronic = callPackage ../development/python-modules/pykmtronic { };
-
-  pykodi = callPackage ../development/python-modules/pykodi { };
-
-  pykoplenti = callPackage ../development/python-modules/pykoplenti { };
-
-  pykostalpiko = callPackage ../development/python-modules/pykostalpiko { };
-
-  pykulersky = callPackage ../development/python-modules/pykulersky { };
-
-  pykwalify = callPackage ../development/python-modules/pykwalify { };
-
-  pykwb = callPackage ../development/python-modules/pykwb { };
-
-  pylacrosse = callPackage ../development/python-modules/pylacrosse { };
-
-  pylacus = callPackage ../development/python-modules/pylacus { };
-
-  pylama = callPackage ../development/python-modules/pylama { };
-
-  pylamarzocco = callPackage ../development/python-modules/pylamarzocco { };
-
-  pylast = callPackage ../development/python-modules/pylast { };
-
-  pylatex = callPackage ../development/python-modules/pylatex { };
-
-  pylatexenc = callPackage ../development/python-modules/pylatexenc { };
-
-  pylaunches = callPackage ../development/python-modules/pylaunches { };
-
-  pyld = callPackage ../development/python-modules/pyld { };
-
-  pyleri = callPackage ../development/python-modules/pyleri { };
-
-  pylette = callPackage ../development/python-modules/pylette { };
-
-  pylev = callPackage ../development/python-modules/pylev { };
-
-  pylgnetcast = callPackage ../development/python-modules/pylgnetcast { };
-
-  pylibacl = callPackage ../development/python-modules/pylibacl { };
-
-  pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
-
-  pylibdmtx = callPackage ../development/python-modules/pylibdmtx { };
-
-  pylibftdi = callPackage ../development/python-modules/pylibftdi { inherit (pkgs) libusb1; };
-
-  pylibjpeg = callPackage ../development/python-modules/pylibjpeg { };
-
-  pylibjpeg-data = callPackage ../development/python-modules/pylibjpeg-data { };
-
-  pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
-
-  pylibjpeg-openjpeg = callPackage ../development/python-modules/pylibjpeg-openjpeg { };
-
-  pyliblo = callPackage ../development/python-modules/pyliblo { };
-
-  pylibmc = callPackage ../development/python-modules/pylibmc { };
-
-  pylink-square = callPackage ../development/python-modules/pylink-square { };
-
-  pylint = callPackage ../development/python-modules/pylint { };
-
-  pylint-celery = callPackage ../development/python-modules/pylint-celery { };
-
-  pylint-django = callPackage ../development/python-modules/pylint-django { };
-
-  pylint-flask = callPackage ../development/python-modules/pylint-flask { };
-
-  pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
-
-  pylint-venv = callPackage ../development/python-modules/pylint-venv { };
-
-  pylion = callPackage ../development/python-modules/pylion { };
-
-  pylitejet = callPackage ../development/python-modules/pylitejet { };
-
-  pylitterbot = callPackage ../development/python-modules/pylitterbot { };
-
-  py-libzfs = callPackage ../development/python-modules/py-libzfs { };
-
-  pyloggermanager = callPackage ../development/python-modules/pyloggermanager { };
-
-  py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
-
-  pylnk3 = callPackage ../development/python-modules/pylnk3 { };
-
-  pylru = callPackage ../development/python-modules/pylru { };
-
-  pylsqpack = callPackage ../development/python-modules/pylsqpack { };
-
-  pyls-flake8 = callPackage ../development/python-modules/pyls-flake8 { };
-
-  pyls-isort = callPackage ../development/python-modules/pyls-isort { };
-
-  pyls-memestra = callPackage ../development/python-modules/pyls-memestra { };
-
-  pyls-spyder = callPackage ../development/python-modules/pyls-spyder { };
-
-  pylsp-mypy = callPackage ../development/python-modules/pylsp-mypy { };
-
-  pylsp-rope = callPackage ../development/python-modules/pylsp-rope { };
-
-  pylpsd = callPackage ../development/python-modules/pylpsd { };
-
-  pylutron = callPackage ../development/python-modules/pylutron { };
-
-  pylutron-caseta = callPackage ../development/python-modules/pylutron-caseta { };
-
-  pylyrics = callPackage ../development/python-modules/pylyrics { };
-
-  pylxd = callPackage ../development/python-modules/pylxd { };
-
-  pylzma = callPackage ../development/python-modules/pylzma { };
-
-  pym3u8downloader = callPackage ../development/python-modules/pym3u8downloader { };
-
-  pymacaroons = callPackage ../development/python-modules/pymacaroons { };
-
-  pymailgunner = callPackage ../development/python-modules/pymailgunner { };
-
-  pymanopt = callPackage ../development/python-modules/pymanopt { };
-
-  pymarshal = callPackage ../development/python-modules/pymarshal { };
-
-  pymata-express = callPackage ../development/python-modules/pymata-express { };
-
-  pymatgen = callPackage ../development/python-modules/pymatgen { };
-
-  pymatreader = callPackage ../development/python-modules/pymatreader { };
-
-  pymatting = callPackage ../development/python-modules/pymatting { };
-
-  pymaven-patch = callPackage ../development/python-modules/pymaven-patch { };
-
-  pymavlink = callPackage ../development/python-modules/pymavlink { };
-
-  pymbolic = callPackage ../development/python-modules/pymbolic { };
-
-  pymc = callPackage ../development/python-modules/pymc { };
-
-  pymdstat = callPackage ../development/python-modules/pymdstat { };
-
-  pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
-
-  pymediainfo = callPackage ../development/python-modules/pymediainfo { };
-
-  pymediaroom = callPackage ../development/python-modules/pymediaroom { };
-
-  pymedio = callPackage ../development/python-modules/pymedio { };
-
-  pymee = callPackage ../development/python-modules/pymee { };
-
-  pymeeus = callPackage ../development/python-modules/pymeeus { };
-
-  pymelcloud = callPackage ../development/python-modules/pymelcloud { };
-
-  pymemcache = callPackage ../development/python-modules/pymemcache { };
-
-  pymemoize = callPackage ../development/python-modules/pymemoize { };
-
-  pyment = callPackage ../development/python-modules/pyment { };
-
-  pymetar = callPackage ../development/python-modules/pymetar { };
-
-  pymeteireann = callPackage ../development/python-modules/pymeteireann { };
-
-  pymeteoclimatic = callPackage ../development/python-modules/pymeteoclimatic { };
-
-  pymetno = callPackage ../development/python-modules/pymetno { };
-
-  pymicro-vad = callPackage ../development/python-modules/pymicro-vad { };
-
-  pymicrobot = callPackage ../development/python-modules/pymicrobot { };
-
-  pymiele = callPackage ../development/python-modules/pymiele { };
-
-  pymilter = callPackage ../development/python-modules/pymilter { };
-
-  pymilvus = callPackage ../development/python-modules/pymilvus { };
-
-  pymitv = callPackage ../development/python-modules/pymitv { };
-
-  pymfy = callPackage ../development/python-modules/pymfy { };
-
-  pymodbus = callPackage ../development/python-modules/pymodbus { };
-
-  pymonctl = callPackage ../development/python-modules/pymonctl { };
-
-  pymongo = callPackage ../development/python-modules/pymongo { };
-
-  pymongo-inmemory = callPackage ../development/python-modules/pymongo-inmemory { };
-
-  pymoo = callPackage ../development/python-modules/pymoo { };
-
-  pymorphy2 = callPackage ../development/python-modules/pymorphy2 { };
-
-  pymorphy2-dicts-ru = callPackage ../development/python-modules/pymorphy2/dicts-ru.nix { };
-
-  pymorphy3 = callPackage ../development/python-modules/pymorphy3 { };
-
-  pymorphy3-dicts-ru = callPackage ../development/python-modules/pymorphy3/dicts-ru.nix { };
-
-  pymorphy3-dicts-uk = callPackage ../development/python-modules/pymorphy3/dicts-uk.nix { };
-
-  pympler = callPackage ../development/python-modules/pympler { };
-
-  pymsgbox = callPackage ../development/python-modules/pymsgbox { };
-
-  pymssql = callPackage ../development/python-modules/pymssql { krb5-c = pkgs.krb5; };
-
-  pymsteams = callPackage ../development/python-modules/pymsteams { };
-
-  py-multiaddr = callPackage ../development/python-modules/py-multiaddr { };
-
-  py-multibase = callPackage ../development/python-modules/py-multibase { };
-
-  py-multicodec = callPackage ../development/python-modules/py-multicodec { };
-
-  py-multihash = callPackage ../development/python-modules/py-multihash { };
-
-  pymumble = callPackage ../development/python-modules/pymumble { };
-
-  pymunk = callPackage ../development/python-modules/pymunk {
-    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
-  };
-
-  pymupdf = callPackage ../development/python-modules/pymupdf { };
-  pymupdf-fonts = callPackage ../development/python-modules/pymupdf-fonts { };
-
-  pymvglive = callPackage ../development/python-modules/pymvglive { };
-
-  pymysensors = callPackage ../development/python-modules/pymysensors { };
-
-  pymysql = callPackage ../development/python-modules/pymysql { };
-
-  pymysqlsa = callPackage ../development/python-modules/pymysqlsa { };
-
-  pymystem3 = callPackage ../development/python-modules/pymystem3 { };
-
-  pynac = callPackage ../development/python-modules/pynac { };
-
-  pynacl = callPackage ../development/python-modules/pynacl { };
-
-  pynamecheap = callPackage ../development/python-modules/pynamecheap { };
-
-  pynamodb = callPackage ../development/python-modules/pynamodb { };
-
-  pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
-
-  pync = callPackage ../development/python-modules/pync { inherit (pkgs) which; };
-
-  pynecil = callPackage ../development/python-modules/pynecil { };
-
-  pynello = callPackage ../development/python-modules/pynello { };
-
-  pynest2d = callPackage ../development/python-modules/pynest2d { };
-
-  pynetbox = callPackage ../development/python-modules/pynetbox { };
-
-  pynetdicom = callPackage ../development/python-modules/pynetdicom { };
-
-  pynetgear = callPackage ../development/python-modules/pynetgear { };
-
-  pynina = callPackage ../development/python-modules/pynina { };
-
-  pynisher = callPackage ../development/python-modules/pynisher { };
-
-  pynmea2 = callPackage ../development/python-modules/pynmea2 { };
-
-  pynmeagps = callPackage ../development/python-modules/pynmeagps { };
-
-  pynput = callPackage ../development/python-modules/pynput { };
-
-  pynrrd = callPackage ../development/python-modules/pynrrd { };
-
-  pynvim = callPackage ../development/python-modules/pynvim { };
-
-  pynvim-pp = callPackage ../development/python-modules/pynvim-pp { };
-
-  pynvml = callPackage ../development/python-modules/pynvml { };
-
-  pynzb = callPackage ../development/python-modules/pynzb { };
-
-  pyobihai = callPackage ../development/python-modules/pyobihai { };
-
-  pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
-
-  pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
-
-  pyocd = callPackage ../development/python-modules/pyocd { };
-
-  pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };
-
-  pyocr = callPackage ../development/python-modules/pyocr { tesseract = pkgs.tesseract4; };
-
-  pyoctoprintapi = callPackage ../development/python-modules/pyoctoprintapi { };
-
-  pyodbc = callPackage ../development/python-modules/pyodbc { };
-
-  pyogg = callPackage ../development/python-modules/pyogg { };
-
-  pyombi = callPackage ../development/python-modules/pyombi { };
-
-  pyomo = callPackage ../development/python-modules/pyomo { };
-
-  pypng = callPackage ../development/python-modules/pypng { };
-
-  phonemizer = callPackage ../development/python-modules/phonemizer { };
-
-  pyopencl = callPackage ../development/python-modules/pyopencl { };
-
-  pyopengl = callPackage ../development/python-modules/pyopengl { };
-
-  pyopengl-accelerate = callPackage ../development/python-modules/pyopengl-accelerate { };
-
-  pyopengltk = callPackage ../development/python-modules/pyopengltk { };
-
-  pyopenssl = callPackage ../development/python-modules/pyopenssl { };
-
-  pyopenuv = callPackage ../development/python-modules/pyopenuv { };
-
-  pyopenweathermap = callPackage ../development/python-modules/pyopenweathermap { };
-
-  pyopnsense = callPackage ../development/python-modules/pyopnsense { };
-
-  pyoppleio = callPackage ../development/python-modules/pyoppleio { };
-
-  pyosf = callPackage ../development/python-modules/pyosf { };
-
-  pyosmium = callPackage ../development/python-modules/pyosmium { inherit (pkgs) lz4; };
-
-  pyosohotwaterapi = callPackage ../development/python-modules/pyosohotwaterapi { };
-
-  pyotgw = callPackage ../development/python-modules/pyotgw { };
-
-  pyotp = callPackage ../development/python-modules/pyotp { };
-
-  pyowm = callPackage ../development/python-modules/pyowm { };
-
-  pyoxigraph = callPackage ../development/python-modules/pyoxigraph { };
-
-  pypager = callPackage ../development/python-modules/pypager { };
-
-  pypamtest = toPythonModule (
-    pkgs.libpam-wrapper.override {
-      enablePython = true;
-      inherit python;
-    }
-  );
-
-  pypalazzetti = callPackage ../development/python-modules/pypalazzetti { };
-
-  pypandoc = callPackage ../development/python-modules/pypandoc { };
-
-  pyparser = callPackage ../development/python-modules/pyparser { };
-
-  pyparsing = callPackage ../development/python-modules/pyparsing { };
-
-  pyparted = callPackage ../development/python-modules/pyparted { };
-
-  pypass = callPackage ../development/python-modules/pypass { };
-
-  pypblib = callPackage ../development/python-modules/pypblib { };
-
-  pypca = callPackage ../development/python-modules/pypca { };
-
-  pypcap = callPackage ../development/python-modules/pypcap {
-    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
-  };
-
-  pypck = callPackage ../development/python-modules/pypck { };
-
-  pypdf = callPackage ../development/python-modules/pypdf { };
-
-  pypdf2 = callPackage ../development/python-modules/pypdf2 { };
-
-  pypdf3 = callPackage ../development/python-modules/pypdf3 { };
-
-  pypdfium2 = callPackage ../development/python-modules/pypdfium2 { };
-
-  pypeg2 = callPackage ../development/python-modules/pypeg2 { };
-
-  pyperclip = callPackage ../development/python-modules/pyperclip { };
-
-  pyperclipfix = callPackage ../development/python-modules/pyperclipfix { };
-
-  pyperscan = callPackage ../development/python-modules/pyperscan { };
-
-  pyperf = callPackage ../development/python-modules/pyperf { };
-
-  pyphen = callPackage ../development/python-modules/pyphen { };
-
-  pyphotonfile = callPackage ../development/python-modules/pyphotonfile { };
-
-  pypika = callPackage ../development/python-modules/pypika { };
-
-  pypillowfight = callPackage ../development/python-modules/pypillowfight { };
-
-  pypinyin = callPackage ../development/python-modules/pypinyin { };
-
-  pypiserver = callPackage ../development/python-modules/pypiserver { };
-
-  pypitoken = callPackage ../development/python-modules/pypitoken { };
-
-  pyplaato = callPackage ../development/python-modules/pyplaato { };
-
-  pyplatec = callPackage ../development/python-modules/pyplatec { };
-
-  pyppeteer = callPackage ../development/python-modules/pyppeteer { };
-
-  pypresence = callPackage ../development/python-modules/pypresence { };
-
-  pyprind = callPackage ../development/python-modules/pyprind { };
-
-  pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
-
-  pyproj = callPackage ../development/python-modules/pyproj { };
-
-  pyproject-metadata = callPackage ../development/python-modules/pyproject-metadata { };
-
-  pyprosegur = callPackage ../development/python-modules/pyprosegur { };
-
-  pyprusalink = callPackage ../development/python-modules/pyprusalink { };
-
-  pyptlib = callPackage ../development/python-modules/pyptlib { };
-
-  pypubsub = callPackage ../development/python-modules/pypubsub { };
-
-  pypugjs = callPackage ../development/python-modules/pypugjs { };
-
-  pypykatz = callPackage ../development/python-modules/pypykatz { };
-
-  pypytools = callPackage ../development/python-modules/pypytools { };
-
-  pyqldb = callPackage ../development/python-modules/pyqldb { };
-
-  pyqrcode = callPackage ../development/python-modules/pyqrcode { };
-
-  pyqt-builder = callPackage ../development/python-modules/pyqt-builder { };
-
-  pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { inherit (pkgs) mesa; };
-
-  pyqt5-stubs = callPackage ../development/python-modules/pyqt5-stubs { };
-
-  pyqt5-sip = callPackage ../development/python-modules/pyqt/sip.nix { };
-
-  pyqt5-multimedia = self.pyqt5.override { withMultimedia = true; };
-
-  # `pyqt5-webkit` should not be used by python libraries in
-  # pkgs/development/python-modules/*. Putting this attribute in
-  # `propagatedBuildInputs` may cause collisions.
-  pyqt5-webkit = self.pyqt5.override { withWebKit = true; };
-
-  pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
-
-  pyqt6-charts = callPackage ../development/python-modules/pyqt6-charts { };
-
-  pyqt6-sip = callPackage ../development/python-modules/pyqt/pyqt6-sip.nix { };
-
-  pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine { };
-
-  pyqt3d = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt3d {
-    inherit (self)
-      buildPythonPackage
-      pyqt5
-      pyqt-builder
-      python
-      pythonOlder
-      setuptools
-      sip
-      ;
-  };
-
-  pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
-    inherit (self)
-      buildPythonPackage
-      pyqt5
-      pyqt-builder
-      python
-      pythonOlder
-      setuptools
-      sip
-      ;
-  };
-
-  pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
-
-  pyqtdatavisualization =
-    pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization
-      {
-        inherit (self)
-          buildPythonPackage
-          pyqt5
-          pyqt-builder
-          python
-          pythonOlder
-          setuptools
-          sip
-          ;
-      };
-
-  pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
-
-  pyqtwebengine = callPackage ../development/python-modules/pyqtwebengine { };
-
-  pyquery = callPackage ../development/python-modules/pyquery { };
-
-  pyquerylist = callPackage ../development/python-modules/pyquerylist { };
-
-  pyquaternion = callPackage ../development/python-modules/pyquaternion { };
-
-  pyquil = callPackage ../development/python-modules/pyquil { };
-
-  pyqvrpro = callPackage ../development/python-modules/pyqvrpro { };
-
-  pyqwikswitch = callPackage ../development/python-modules/pyqwikswitch { };
-
-  pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
-
-  pyrad = callPackage ../development/python-modules/pyrad { };
-
-  pyradiomics = callPackage ../development/python-modules/pyradiomics { };
-
-  pyradios = callPackage ../development/python-modules/pyradios { };
-
-  pyrainbird = callPackage ../development/python-modules/pyrainbird { };
-
-  pyramid-beaker = callPackage ../development/python-modules/pyramid-beaker { };
-
-  pyramid = callPackage ../development/python-modules/pyramid { };
-
-  pyramid-chameleon = callPackage ../development/python-modules/pyramid-chameleon { };
-
-  pyramid-exclog = callPackage ../development/python-modules/pyramid-exclog { };
-
-  pyramid-jinja2 = callPackage ../development/python-modules/pyramid-jinja2 { };
-
-  pyramid-mako = callPackage ../development/python-modules/pyramid-mako { };
-
-  pyramid-multiauth = callPackage ../development/python-modules/pyramid-multiauth { };
-
-  pyrate-limiter = callPackage ../development/python-modules/pyrate-limiter { };
-
-  pyreaderwriterlock = callPackage ../development/python-modules/pyreaderwriterlock { };
-
-  pyreadstat = callPackage ../development/python-modules/pyreadstat { };
-
-  pyrealsense2 = toPythonModule (
-    pkgs.librealsense.override {
-      enablePython = true;
-      pythonPackages = self;
-    }
-  );
-
-  pyrealsense2WithCuda = toPythonModule (
-    pkgs.librealsenseWithCuda.override {
-      cudaSupport = true;
-      enablePython = true;
-      pythonPackages = self;
-    }
-  );
-
-  pyrealsense2WithoutCuda = toPythonModule (
-    pkgs.librealsenseWithoutCuda.override {
-      enablePython = true;
-      pythonPackages = self;
-    }
-  );
-
-  pyrect = callPackage ../development/python-modules/pyrect { };
-
-  pyregion = callPackage ../development/python-modules/pyregion { };
-
-  pyric = callPackage ../development/python-modules/pyric { };
-
-  pyring-buffer = callPackage ../development/python-modules/pyring-buffer { };
-
-  pyrisco = callPackage ../development/python-modules/pyrisco { };
-
-  pyrituals = callPackage ../development/python-modules/pyrituals { };
-
-  pyrfc3339 = callPackage ../development/python-modules/pyrfc3339 { };
-
-  pyrmvtransport = callPackage ../development/python-modules/pyrmvtransport { };
-
-  pyro4 = callPackage ../development/python-modules/pyro4 { };
-
-  pyro5 = callPackage ../development/python-modules/pyro5 { };
-
-  pyroma = callPackage ../development/python-modules/pyroma { };
-
-  pyro-api = callPackage ../development/python-modules/pyro-api { };
-
-  pyro-ppl = callPackage ../development/python-modules/pyro-ppl { };
-
-  pyroute2 = callPackage ../development/python-modules/pyroute2 { };
-
-  pyrr = callPackage ../development/python-modules/pyrr { };
-
-  pyrsistent = callPackage ../development/python-modules/pyrsistent { };
-
-  pyrss2gen = callPackage ../development/python-modules/pyrss2gen { };
-
-  pyrtlsdr = callPackage ../development/python-modules/pyrtlsdr { };
-
-  pysaj = callPackage ../development/python-modules/pysaj { };
-
-  pysam = callPackage ../development/python-modules/pysam { };
-
-  pysaml2 = callPackage ../development/python-modules/pysaml2 { inherit (pkgs) xmlsec; };
-
-  pysatochip = callPackage ../development/python-modules/pysatochip { };
-
-  pysc2 = callPackage ../development/python-modules/pysc2 { };
-
-  pyscard = callPackage ../development/python-modules/pyscard {
-    inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
-  };
-
-  pyscaffold = callPackage ../development/python-modules/pyscaffold { };
-
-  pyscaffoldext-cookiecutter =
-    callPackage ../development/python-modules/pyscaffoldext-cookiecutter
-      { };
-
-  pyscaffoldext-custom-extension =
-    callPackage ../development/python-modules/pyscaffoldext-custom-extension
-      { };
-
-  pyscaffoldext-django = callPackage ../development/python-modules/pyscaffoldext-django { };
-
-  pyscaffoldext-dsproject = callPackage ../development/python-modules/pyscaffoldext-dsproject { };
-
-  pyscaffoldext-markdown = callPackage ../development/python-modules/pyscaffoldext-markdown { };
-
-  pyscaffoldext-travis = callPackage ../development/python-modules/pyscaffoldext-travis { };
-
-  pyscf = callPackage ../development/python-modules/pyscf { };
-
-  pyschedule = callPackage ../development/python-modules/pyschedule { };
-
-  pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };
-
-  pyscreeze = callPackage ../development/python-modules/pyscreeze { };
-
-  py-scrypt = callPackage ../development/python-modules/py-scrypt { };
-
-  pyscrypt = callPackage ../development/python-modules/pyscrypt { };
-
-  pyscss = callPackage ../development/python-modules/pyscss { };
-
-  pysdcp = callPackage ../development/python-modules/pysdcp { };
-
-  pysdl2 = callPackage ../development/python-modules/pysdl2 { };
-
-  pysearpc = toPythonModule (pkgs.libsearpc.override { python3 = self.python; });
-
-  pysecuritas = callPackage ../development/python-modules/pysecuritas { };
-
-  pysendfile = callPackage ../development/python-modules/pysendfile { };
-
-  pysensibo = callPackage ../development/python-modules/pysensibo { };
-
-  pysensors = callPackage ../development/python-modules/pysensors { };
-
-  pyserial-asyncio = callPackage ../development/python-modules/pyserial-asyncio { };
-
-  pyserial-asyncio-fast = callPackage ../development/python-modules/pyserial-asyncio-fast { };
-
-  pyserial = callPackage ../development/python-modules/pyserial { };
-
-  pyseventeentrack = callPackage ../development/python-modules/pyseventeentrack { };
-
-  pysftp = callPackage ../development/python-modules/pysftp { };
-
-  pyshp = callPackage ../development/python-modules/pyshp { };
-
-  pyside2-tools = toPythonModule (
-    callPackage ../development/python-modules/pyside2-tools { inherit (pkgs) cmake qt5; }
-  );
-
-  pyside2 = toPythonModule (
-    callPackage ../development/python-modules/pyside2 { inherit (pkgs) cmake ninja qt5; }
-  );
-
-  pyside6 = toPythonModule (
-    callPackage ../development/python-modules/pyside6 { inherit (pkgs) cmake ninja; }
-  );
-
-  pyside6-qtads = callPackage ../development/python-modules/pyside6-qtads { };
-
-  pysigma = callPackage ../development/python-modules/pysigma { };
-
-  pysigma-backend-elasticsearch =
-    callPackage ../development/python-modules/pysigma-backend-elasticsearch
-      { };
-
-  pysigma-backend-opensearch =
-    callPackage ../development/python-modules/pysigma-backend-opensearch
-      { };
-
-  pysigma-backend-qradar = callPackage ../development/python-modules/pysigma-backend-qradar { };
-
-  pysigma-backend-splunk = callPackage ../development/python-modules/pysigma-backend-splunk { };
-
-  pysigma-backend-sqlite = callPackage ../development/python-modules/pysigma-backend-sqlite { };
-
-  pysigma-backend-insightidr =
-    callPackage ../development/python-modules/pysigma-backend-insightidr
-      { };
-
-  pysigma-backend-loki = callPackage ../development/python-modules/pysigma-backend-loki { };
-
-  pysigma-pipeline-crowdstrike =
-    callPackage ../development/python-modules/pysigma-pipeline-crowdstrike
-      { };
-
-  pysigma-pipeline-sysmon = callPackage ../development/python-modules/pysigma-pipeline-sysmon { };
-
-  pysigma-pipeline-windows = callPackage ../development/python-modules/pysigma-pipeline-windows { };
-
-  pysignalclirestapi = callPackage ../development/python-modules/pysignalclirestapi { };
-
-  pysigset = callPackage ../development/python-modules/pysigset { };
-
-  pysim = callPackage ../development/python-modules/pysim { };
-
-  pysingleton = callPackage ../development/python-modules/pysingleton { };
-
-  pyslim = callPackage ../development/python-modules/pyslim { };
-
-  pyslurm = callPackage ../development/python-modules/pyslurm { inherit (pkgs) slurm; };
-
-  pysma = callPackage ../development/python-modules/pysma { };
-
-  pysmappee = callPackage ../development/python-modules/pysmappee { };
-
-  pysmart = callPackage ../development/python-modules/pysmart { };
-
-  pysmartapp = callPackage ../development/python-modules/pysmartapp { };
-
-  pysmartdl = callPackage ../development/python-modules/pysmartdl { };
-
-  pysmartthings = callPackage ../development/python-modules/pysmartthings { };
-
-  pysmb = callPackage ../development/python-modules/pysmb { };
-
-  pysmbc = callPackage ../development/python-modules/pysmbc { };
-
-  pysmf = callPackage ../development/python-modules/pysmf { };
-
-  pysmi = callPackage ../development/python-modules/pysmi { };
-
-  pysml = callPackage ../development/python-modules/pysml { };
-
-  pysmlight = callPackage ../development/python-modules/pysmlight { };
-
-  pysmt = callPackage ../development/python-modules/pysmt { };
-
-  pysnmp = callPackage ../development/python-modules/pysnmp { };
-
-  pysnmpcrypto = callPackage ../development/python-modules/pysnmpcrypto { };
-
-  pysnmp-pyasn1 = callPackage ../development/python-modules/pysnmp-pyasn1 { };
-
-  pysnmp-pysmi = callPackage ../development/python-modules/pysnmp-pysmi { };
-
-  pysnmplib = callPackage ../development/python-modules/pysnmplib { };
-
-  pysnooper = callPackage ../development/python-modules/pysnooper { };
-
-  pysnooz = callPackage ../development/python-modules/pysnooz { };
-
-  pysnow = callPackage ../development/python-modules/pysnow { };
-
-  pysocks = callPackage ../development/python-modules/pysocks { };
-
-  pysol-cards = callPackage ../development/python-modules/pysol-cards { };
-
-  pysolr = callPackage ../development/python-modules/pysolr { };
-
-  pysoma = callPackage ../development/python-modules/pysoma { };
-
-  py-sonic = callPackage ../development/python-modules/py-sonic { };
-
-  pysonos = callPackage ../development/python-modules/pysonos { };
-
-  pysoundfile = self.soundfile; # Alias added 23-06-2019
-
-  pyspark = callPackage ../development/python-modules/pyspark { };
-
-  pyspcwebgw = callPackage ../development/python-modules/pyspcwebgw { };
-
-  pyspeex-noise = callPackage ../development/python-modules/pyspeex-noise { };
-
-  pyspellchecker = callPackage ../development/python-modules/pyspellchecker { };
-
-  pyspf = callPackage ../development/python-modules/pyspf { };
-
-  pyspice = callPackage ../development/python-modules/pyspice { };
-
-  pyspiflash = callPackage ../development/python-modules/pyspiflash { };
-
-  pyspinel = callPackage ../development/python-modules/pyspinel { };
-
-  pyspnego = callPackage ../development/python-modules/pyspnego { };
-
-  pysptk = callPackage ../development/python-modules/pysptk { };
-
-  pyspx = callPackage ../development/python-modules/pyspx { };
-
-  pysqlcipher3 = callPackage ../development/python-modules/pysqlcipher3 { inherit (pkgs) sqlcipher; };
-
-  pysqueezebox = callPackage ../development/python-modules/pysqueezebox { };
-
-  pysrim = callPackage ../development/python-modules/pysrim { };
-
-  pysrt = callPackage ../development/python-modules/pysrt { };
-
-  pyssim = callPackage ../development/python-modules/pyssim { };
-
-  pystache = callPackage ../development/python-modules/pystache { };
-
-  pystardict = callPackage ../development/python-modules/pystardict { };
-
-  pystatgrab = callPackage ../development/python-modules/pystatgrab { };
-
-  pystemd = callPackage ../development/python-modules/pystemd { inherit (pkgs) systemd; };
-
-  pystemmer = callPackage ../development/python-modules/pystemmer { };
-
-  pystray = callPackage ../development/python-modules/pystray { };
-
-  py-stringmatching = callPackage ../development/python-modules/py-stringmatching { };
-
-  pysvg-py3 = callPackage ../development/python-modules/pysvg-py3 { };
-
-  pysvn = callPackage ../development/python-modules/pysvn {
-    inherit (pkgs)
-      bash
-      subversion
-      apr
-      aprutil
-      ;
-  };
-
-  pyswitchbee = callPackage ../development/python-modules/pyswitchbee { };
-
-  pyswitchbot = callPackage ../development/python-modules/pyswitchbot { };
-
-  pysychonaut = callPackage ../development/python-modules/pysychonaut { };
-
-  pysyncobj = callPackage ../development/python-modules/pysyncobj { };
-
-  pytabix = callPackage ../development/python-modules/pytabix { };
-
-  pytablewriter = callPackage ../development/python-modules/pytablewriter { };
-
-  pytaglib = callPackage ../development/python-modules/pytaglib { };
-
-  pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
-
-  pytap2 = callPackage ../development/python-modules/pytap2 { };
-
-  pytapo = callPackage ../development/python-modules/pytapo { };
-
-  pytautulli = callPackage ../development/python-modules/pytautulli { };
-
-  pyte = callPackage ../development/python-modules/pyte { };
-
-  pytedee-async = callPackage ../development/python-modules/pytedee-async { };
-
-  pytenable = callPackage ../development/python-modules/pytenable { };
-
-  pytensor = callPackage ../development/python-modules/pytensor { };
-
-  pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
-
-  pytesseract = callPackage ../development/python-modules/pytesseract { };
-
-  pytest = callPackage ../development/python-modules/pytest { };
-
-  pytest_7 = callPackage ../development/python-modules/pytest/7.nix { };
-
-  pytest7CheckHook = pytestCheckHook.override { pytest = pytest_7; };
-
-  pytest-aio = callPackage ../development/python-modules/pytest-aio { };
-
-  pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
-
-  pytest-annotate = callPackage ../development/python-modules/pytest-annotate { };
-
-  pytest-ansible = callPackage ../development/python-modules/pytest-ansible { };
-
-  pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
-
-  pytest-astropy = callPackage ../development/python-modules/pytest-astropy { };
-
-  pytest-astropy-header = callPackage ../development/python-modules/pytest-astropy-header { };
-
-  pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
-
-  pytest-asyncio_0_21 = pytest-asyncio.overridePythonAttrs (old: rec {
-    version = "0.21.2";
-    src = pkgs.fetchFromGitHub {
-      owner = "pytest-dev";
-      repo = "pytest-asyncio";
-      rev = "refs/tags/v${version}";
-      hash = "sha256-AVVvdo/CDF9IU6l779sLc7wKz5h3kzMttdDNTPLYxtQ=";
-    };
-  });
-
-  pytest-bdd = callPackage ../development/python-modules/pytest-bdd { };
-
-  pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
-
-  pytest-black = callPackage ../development/python-modules/pytest-black { };
-
-  pytest-cache = self.pytestcache; # added 2021-01-04
-  pytestcache = callPackage ../development/python-modules/pytestcache { };
-
-  pytest-base-url = callPackage ../development/python-modules/pytest-base-url { };
-
-  pytest-cases = callPackage ../development/python-modules/pytest-cases { };
-
-  pytest-catchlog = callPackage ../development/python-modules/pytest-catchlog { };
-
-  pytest-celery = callPackage ../development/python-modules/pytest-celery { };
-
-  pytest-check = callPackage ../development/python-modules/pytest-check { };
-
-  pytest-cid = callPackage ../development/python-modules/pytest-cid { };
-
-  pytest-click = callPackage ../development/python-modules/pytest-click { };
-
-  pytest-codspeed = callPackage ../development/python-modules/pytest-codspeed { };
-
-  pytest-console-scripts = callPackage ../development/python-modules/pytest-console-scripts { };
-
-  pytest-cov = callPackage ../development/python-modules/pytest-cov { };
-
-  pytest-cov-stub = callPackage ../development/python-modules/pytest-cov-stub { };
-
-  pytest-cram = callPackage ../development/python-modules/pytest-cram { };
-
-  pytest-datadir = callPackage ../development/python-modules/pytest-datadir { };
-
-  pytest-datafiles = callPackage ../development/python-modules/pytest-datafiles { };
-
-  pytest-dependency = callPackage ../development/python-modules/pytest-dependency { };
-
-  pytest-describe = callPackage ../development/python-modules/pytest-describe { };
-
-  pytest-django = callPackage ../development/python-modules/pytest-django { };
-
-  pytest-docker-tools = callPackage ../development/python-modules/pytest-docker-tools { };
-
-  pytest-doctestplus = callPackage ../development/python-modules/pytest-doctestplus { };
-
-  pytest-dotenv = callPackage ../development/python-modules/pytest-dotenv { };
-
-  pytest-emoji = callPackage ../development/python-modules/pytest-emoji { };
-
-  pytest-env = callPackage ../development/python-modules/pytest-env { };
-
-  pytest-error-for-skips = callPackage ../development/python-modules/pytest-error-for-skips { };
-
-  pytest-examples = callPackage ../development/python-modules/pytest-examples { };
-
-  pytest-expect = callPackage ../development/python-modules/pytest-expect { };
-
-  pytest-factoryboy = callPackage ../development/python-modules/pytest-factoryboy { };
-
-  pytest-filter-subpackage = callPackage ../development/python-modules/pytest-filter-subpackage { };
-
-  pytest-fixture-config = callPackage ../development/python-modules/pytest-fixture-config { };
-
-  pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };
-
-  pytest-flakes = callPackage ../development/python-modules/pytest-flakes { };
-
-  pytest-flask = callPackage ../development/python-modules/pytest-flask { };
-
-  pytest-forked = callPackage ../development/python-modules/pytest-forked { };
-
-  pytest-freezegun = callPackage ../development/python-modules/pytest-freezegun { };
-
-  pytest-freezer = callPackage ../development/python-modules/pytest-freezer { };
-
-  pytest-golden = callPackage ../development/python-modules/pytest-golden { };
-
-  pytest-grpc = callPackage ../development/python-modules/pytest-grpc { };
-
-  pytest-harvest = callPackage ../development/python-modules/pytest-harvest { };
-
-  pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
-
-  pytest-html = callPackage ../development/python-modules/pytest-html { };
-
-  pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
-
-  pytest-httpserver = callPackage ../development/python-modules/pytest-httpserver { };
-
-  pytest-httpx = callPackage ../development/python-modules/pytest-httpx { };
-
-  pytest-image-diff = callPackage ../development/python-modules/pytest-image-diff { };
-
-  pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
-
-  pytest-isort = callPackage ../development/python-modules/pytest-isort { };
-
-  pytest-json-report = callPackage ../development/python-modules/pytest-json-report { };
-
-  pytest-jupyter = callPackage ../development/python-modules/pytest-jupyter { };
-
-  pytest-lazy-fixture = callPackage ../development/python-modules/pytest-lazy-fixture { };
-
-  pytest-lazy-fixtures = callPackage ../development/python-modules/pytest-lazy-fixtures { };
-
-  pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };
-
-  pytest-logdog = callPackage ../development/python-modules/pytest-logdog { };
-
-  pytest-markdown-docs = callPackage ../development/python-modules/pytest-markdown-docs { };
-
-  pytest-md-report = callPackage ../development/python-modules/pytest-md-report { };
-
-  pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
-
-  pytest-mock = callPackage ../development/python-modules/pytest-mock { };
-
-  pytest-mockservers = callPackage ../development/python-modules/pytest-mockservers { };
-
-  pytest-mpi = callPackage ../development/python-modules/pytest-mpi { };
-
-  pytest-mpl = callPackage ../development/python-modules/pytest-mpl { };
-
-  pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
-
-  pytest-mypy-plugins = callPackage ../development/python-modules/pytest-mypy-plugins { };
-
-  pytest-notebook = callPackage ../development/python-modules/pytest-notebook { };
-
-  pytest-order = callPackage ../development/python-modules/pytest-order { };
-
-  pytest-param-files = callPackage ../development/python-modules/pytest-param-files { };
-
-  pytest-parallel = callPackage ../development/python-modules/pytest-parallel { };
-
-  pytest-playwright = callPackage ../development/python-modules/pytest-playwright { };
-
-  pytest-plt = callPackage ../development/python-modules/pytest-plt { };
-
-  pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };
-
-  pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
-
-  pytest-pytestrail = callPackage ../development/python-modules/pytest-pytestrail { };
-
-  pytest-qt = callPackage ../development/python-modules/pytest-qt { };
-
-  pytest-quickcheck = callPackage ../development/python-modules/pytest-quickcheck { };
-
-  pytest-raises = callPackage ../development/python-modules/pytest-raises { };
-
-  pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
-
-  pytest-raisin = callPackage ../development/python-modules/pytest-raisin { };
-
-  pytest-randomly = callPackage ../development/python-modules/pytest-randomly { };
-
-  pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
-
-  pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
-
-  pytest-recording = callPackage ../development/python-modules/pytest-recording { };
-
-  pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };
-
-  pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };
-
-  pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
-
-  pytest-repeat = callPackage ../development/python-modules/pytest-repeat { };
-
-  pytest-rerunfailures = callPackage ../development/python-modules/pytest-rerunfailures { };
-
-  pytest-resource-path = callPackage ../development/python-modules/pytest-resource-path { };
-
-  pytest-responses = callPackage ../development/python-modules/pytest-responses { };
-
-  pytest-selenium = callPackage ../development/python-modules/pytest-selenium { };
-
-  pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
-
-  pytest-services = callPackage ../development/python-modules/pytest-services { };
-
-  pytest-snapshot = callPackage ../development/python-modules/pytest-snapshot { };
-
-  pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
-
-  pytest-smtpd = callPackage ../development/python-modules/pytest-smtpd { };
-
-  pytest-spec = callPackage ../development/python-modules/pytest-spec { };
-
-  python-status = callPackage ../development/python-modules/python-status { };
-
-  python-string-utils = callPackage ../development/python-modules/python-string-utils { };
-
-  pytest-socket = callPackage ../development/python-modules/pytest-socket { };
-
-  pytest-subprocess = callPackage ../development/python-modules/pytest-subprocess { };
-
-  pytest-subtesthack = callPackage ../development/python-modules/pytest-subtesthack { };
-
-  pytest-subtests = callPackage ../development/python-modules/pytest-subtests { };
-
-  pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
-
-  pytest-tap = callPackage ../development/python-modules/pytest-tap { };
-
-  pytest-test-utils = callPackage ../development/python-modules/pytest-test-utils { };
-
-  pytest-testinfra = callPackage ../development/python-modules/pytest-testinfra { };
-
-  pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
-
-  pytest-textual-snapshot = callPackage ../development/python-modules/pytest-textual-snapshot { };
-
-  pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
-
-  pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
-
-  pytest-tornasync = callPackage ../development/python-modules/pytest-tornasync { };
-
-  pytest-trio = callPackage ../development/python-modules/pytest-trio { };
-
-  pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };
-
-  pytest-unordered = callPackage ../development/python-modules/pytest-unordered { };
-
-  pytest-variables = callPackage ../development/python-modules/pytest-variables { };
-
-  pytest-vcr = callPackage ../development/python-modules/pytest-vcr { };
-
-  pytest-virtualenv = callPackage ../development/python-modules/pytest-virtualenv { };
-
-  pytest-voluptuous = callPackage ../development/python-modules/pytest-voluptuous { };
-
-  pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
-
-  pytest-watch = callPackage ../development/python-modules/pytest-watch { };
-
-  pytest-xdist = callPackage ../development/python-modules/pytest-xdist { };
-
-  pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
-
-  pytest-xvfb = callPackage ../development/python-modules/pytest-xvfb { };
-
-  python3-application = callPackage ../development/python-modules/python3-application { };
-
-  python3-eventlib = callPackage ../development/python-modules/python3-eventlib { };
-
-  python3-gnutls = callPackage ../development/python-modules/python3-gnutls { };
-
-  python3-openid = callPackage ../development/python-modules/python3-openid { };
-
-  python-aodhclient = callPackage ../development/python-modules/python-aodhclient { };
-
-  python-apt = callPackage ../development/python-modules/python-apt { };
-
-  python-arango = callPackage ../development/python-modules/python-arango { };
-
-  python-awair = callPackage ../development/python-modules/python-awair { };
-
-  python3-saml = callPackage ../development/python-modules/python3-saml { };
-
-  python-axolotl = callPackage ../development/python-modules/python-axolotl { };
-
-  python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };
-
-  python-barbicanclient = callPackage ../development/python-modules/python-barbicanclient { };
-
-  python-barcode = callPackage ../development/python-modules/python-barcode { };
-
-  python-baseconv = callPackage ../development/python-modules/python-baseconv { };
-
-  python-benedict = callPackage ../development/python-modules/python-benedict { };
-
-  python-bidi = callPackage ../development/python-modules/python-bidi { };
-
-  python-binance = callPackage ../development/python-modules/python-binance { };
-
-  python-box = callPackage ../development/python-modules/python-box { };
-
-  python-bring-api = callPackage ../development/python-modules/python-bring-api { };
-
-  python-bsblan = callPackage ../development/python-modules/python-bsblan { };
-
-  python-cinderclient = callPackage ../development/python-modules/python-cinderclient { };
-
-  python-constraint = callPackage ../development/python-modules/python-constraint { };
-
-  python-crontab = callPackage ../development/python-modules/python-crontab { };
-
-  python-ctags3 = callPackage ../development/python-modules/python-ctags3 { };
-
-  python-daemon = callPackage ../development/python-modules/python-daemon { };
-
-  python-datemath = callPackage ../development/python-modules/python-datemath { };
-
-  python-dateutil = callPackage ../development/python-modules/python-dateutil { };
-
-  python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };
-
-  python-decouple = callPackage ../development/python-modules/python-decouple { };
-
-  python-designateclient = callPackage ../development/python-modules/python-designateclient { };
-
-  pythondialog = callPackage ../development/python-modules/pythondialog { };
-
-  python-didl-lite = callPackage ../development/python-modules/python-didl-lite { };
-
-  python-digitalocean = callPackage ../development/python-modules/python-digitalocean { };
-
-  python-docx = callPackage ../development/python-modules/python-docx { };
-
-  python-doi = callPackage ../development/python-modules/python-doi { };
-
-  python-dotenv = callPackage ../development/python-modules/python-dotenv { };
-
-  python-editor = callPackage ../development/python-modules/python-editor { };
-
-  python-family-hub-local = callPackage ../development/python-modules/python-family-hub-local { };
-
-  python-fsutil = callPackage ../development/python-modules/python-fsutil { };
-
-  pythonefl = callPackage ../development/python-modules/python-efl { };
-
-  pythonegardia = callPackage ../development/python-modules/pythonegardia { };
-
-  python-engineio = callPackage ../development/python-modules/python-engineio { };
-
-  python-engineio-v3 = callPackage ../development/python-modules/python-engineio-v3 { };
-
-  python-etcd = callPackage ../development/python-modules/python-etcd { };
-
-  python-ev3dev2 = callPackage ../development/python-modules/python-ev3dev2 { };
-
-  python-fedora = callPackage ../development/python-modules/python-fedora { };
-
-  python-fontconfig = callPackage ../development/python-modules/python-fontconfig { };
-
-  python-frontmatter = callPackage ../development/python-modules/python-frontmatter { };
-
-  python-gammu = callPackage ../development/python-modules/python-gammu { };
-
-  python-gitlab = callPackage ../development/python-modules/python-gitlab { };
-
-  python-gnupg = callPackage ../development/python-modules/python-gnupg { };
-
-  python-gvm = callPackage ../development/python-modules/python-gvm { };
-
-  python-hglib = callPackage ../development/python-modules/python-hglib { };
-
-  python-homeassistant-analytics =
-    callPackage ../development/python-modules/python-homeassistant-analytics
-      { };
-
-  python-homewizard-energy = callPackage ../development/python-modules/python-homewizard-energy { };
-
-  python-hosts = callPackage ../development/python-modules/python-hosts { };
-
-  python-hpilo = callPackage ../development/python-modules/python-hpilo { };
-
-  python-http-client = callPackage ../development/python-modules/python-http-client { };
-
-  python-i18n = callPackage ../development/python-modules/python-i18n { };
-
-  pythonix = callPackage ../development/python-modules/pythonix {
-    nix = pkgs.nixVersions.nix_2_3;
-    meson = pkgs.meson.override { python3 = self.python; };
-  };
-
-  python-jenkins = callPackage ../development/python-modules/python-jenkins { };
-
-  python-jose = callPackage ../development/python-modules/python-jose { };
-
-  python-json-logger = callPackage ../development/python-modules/python-json-logger { };
-
-  python-jsonrpc-server = callPackage ../development/python-modules/python-jsonrpc-server { };
-
-  python-ldap = callPackage ../development/python-modules/python-ldap {
-    inherit (pkgs) openldap cyrus_sasl;
-  };
-
-  python-ldap-test = callPackage ../development/python-modules/python-ldap-test { };
-
-  python-libnmap = callPackage ../development/python-modules/python-libnmap { };
-
-  python-linux-procfs = callPackage ../development/python-modules/python-linux-procfs { };
-
-  python-logging-loki = callPackage ../development/python-modules/python-logging-loki { };
-
-  python-logstash = callPackage ../development/python-modules/python-logstash { };
-
-  python-louvain = callPackage ../development/python-modules/python-louvain { };
-
-  python-lsp-jsonrpc = callPackage ../development/python-modules/python-lsp-jsonrpc { };
-
-  python-lsp-ruff = callPackage ../development/python-modules/python-lsp-ruff { };
-
-  python-lsp-server = callPackage ../development/python-modules/python-lsp-server { };
-
-  python-ly = callPackage ../development/python-modules/python-ly { };
-
-  python-lzf = callPackage ../development/python-modules/python-lzf { };
-
-  python-lzo = callPackage ../development/python-modules/python-lzo { inherit (pkgs) lzo; };
-
-  python-magic = callPackage ../development/python-modules/python-magic { };
-
-  python-magnumclient = callPackage ../development/python-modules/python-magnumclient { };
-
-  python-manilaclient = callPackage ../development/python-modules/python-manilaclient { };
-
-  python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
-    inherit (pkgs)
-      pkg-config
-      cairo
-      icu
-      libjpeg
-      libpng
-      libtiff
-      libwebp
-      proj
-      zlib
-      ;
-    boost = pkgs.boost.override {
-      enablePython = true;
-      inherit python;
-    };
-    harfbuzz = pkgs.harfbuzz.override { withIcu = true; };
-    mapnik = pkgs.mapnik.override { inherit boost harfbuzz; };
-  };
-
-  python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
-
-  python-matter-server = callPackage ../development/python-modules/python-matter-server { };
-
-  python-miio = callPackage ../development/python-modules/python-miio { };
-
-  python-mimeparse = callPackage ../development/python-modules/python-mimeparse { };
-
-  python-mistralclient = callPackage ../development/python-modules/python-mistralclient { };
-
-  python-mnist = callPackage ../development/python-modules/python-mnist { };
-
-  python-mpv-jsonipc = callPackage ../development/python-modules/python-mpv-jsonipc { };
-
-  python-multipart = callPackage ../development/python-modules/python-multipart { };
-
-  python-musicpd = callPackage ../development/python-modules/python-musicpd { };
-
-  python-mystrom = callPackage ../development/python-modules/python-mystrom { };
-
-  python-neutronclient = callPackage ../development/python-modules/python-neutronclient { };
-
-  python-nest = callPackage ../development/python-modules/python-nest { };
-
-  pythonnet = callPackage ../development/python-modules/pythonnet { };
-
-  python-nmap = callPackage ../development/python-modules/python-nmap { };
-
-  python-nomad = callPackage ../development/python-modules/python-nomad { };
-
-  python-novaclient = callPackage ../development/python-modules/python-novaclient { };
-
-  python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
-
-  pythonocc-core = toPythonModule (
-    callPackage ../development/python-modules/pythonocc-core {
-      inherit (pkgs) fontconfig rapidjson;
-      inherit (pkgs.xorg)
-        libX11
-        libXi
-        libXmu
-        libXext
-        ;
-      inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
-    }
-  );
-
-  python-olm = callPackage ../development/python-modules/python-olm { };
-
-  python-on-whales = callPackage ../development/python-modules/python-on-whales { };
-
-  python-opendata-transport = callPackage ../development/python-modules/python-opendata-transport { };
-
-  python-openstackclient = callPackage ../development/python-modules/python-openstackclient { };
-
-  python-openzwave = callPackage ../development/python-modules/python-openzwave { };
-
-  python-osc = callPackage ../development/python-modules/python-osc { };
-
-  python-packer = callPackage ../development/python-modules/python-packer { };
-
-  python-pae = callPackage ../development/python-modules/python-pae { };
-
-  python-pam = callPackage ../development/python-modules/python-pam { inherit (pkgs) pam; };
-
-  python-periphery = callPackage ../development/python-modules/python-periphery { };
-
-  python-picnic-api2 = callPackage ../development/python-modules/python-picnic-api2 { };
-
-  python-pidfile = callPackage ../development/python-modules/python-pidfile { };
-
-  python-pipedrive = callPackage ../development/python-modules/python-pipedrive { };
-
-  python-pkcs11 = callPackage ../development/python-modules/python-pkcs11 { };
-
-  python-prctl = callPackage ../development/python-modules/python-prctl { };
-
-  python-ptrace = callPackage ../development/python-modules/python-ptrace { };
-
-  python-rapidjson = callPackage ../development/python-modules/python-rapidjson { };
-
-  python-rabbitair = callPackage ../development/python-modules/python-rabbitair { };
-
-  python-redis-lock = callPackage ../development/python-modules/python-redis-lock { };
-
-  python-registry = callPackage ../development/python-modules/python-registry { };
-
-  python-roborock = callPackage ../development/python-modules/python-roborock { };
-
-  python-rtmidi = callPackage ../development/python-modules/python-rtmidi {
-    inherit (pkgs.darwin.apple_sdk.frameworks)
-      CoreAudio
-      CoreMIDI
-      CoreServices
-      Foundation
-      ;
-  };
-
-  python-sat = callPackage ../development/python-modules/python-sat { };
-
-  python-simple-hipchat = callPackage ../development/python-modules/python-simple-hipchat { };
-
-  python-slugify = callPackage ../development/python-modules/python-slugify { };
-
-  python-smarttub = callPackage ../development/python-modules/python-smarttub { };
-
-  python-snap7 = callPackage ../development/python-modules/python-snap7 { inherit (pkgs) snap7; };
-
-  python-snappy = callPackage ../development/python-modules/python-snappy { inherit (pkgs) snappy; };
-
-  python-socketio = callPackage ../development/python-modules/python-socketio { };
-
-  python-socketio-v4 = callPackage ../development/python-modules/python-socketio-v4 { };
-
-  python-socks = callPackage ../development/python-modules/python-socks { };
-
-  python-sql = callPackage ../development/python-modules/python-sql { };
-
-  python-stdnum = callPackage ../development/python-modules/python-stdnum { };
-
-  python-technove = callPackage ../development/python-modules/python-technove { };
-
-  python-telegram = callPackage ../development/python-modules/python-telegram { };
-
-  python-telegram-bot = callPackage ../development/python-modules/python-telegram-bot { };
-
-  python-toolbox = callPackage ../development/python-modules/python-toolbox { };
-
-  python-trovo = callPackage ../development/python-modules/python-trovo { };
-
-  python-twitch-client = callPackage ../development/python-modules/python-twitch-client { };
-
-  python-twitter = callPackage ../development/python-modules/python-twitter { };
-
-  python-u2flib-host = callPackage ../development/python-modules/python-u2flib-host { };
-
-  python-u2flib-server = callPackage ../development/python-modules/python-u2flib-server { };
-
-  python-uinput = callPackage ../development/python-modules/python-uinput { };
-
-  python-ulid = callPackage ../development/python-modules/python-ulid { };
-
-  python-unshare = callPackage ../development/python-modules/python-unshare { };
-
-  python-utils = callPackage ../development/python-modules/python-utils { };
-
-  python-vagrant = callPackage ../development/python-modules/python-vagrant { };
-
-  python-velbus = callPackage ../development/python-modules/python-velbus { };
-
-  python-vipaccess = callPackage ../development/python-modules/python-vipaccess { };
-
-  python-vlc = callPackage ../development/python-modules/python-vlc { };
-
-  python-watcherclient = callPackage ../development/python-modules/python-watcherclient { };
-
-  python-whois = callPackage ../development/python-modules/python-whois { };
-
-  python-wifi = callPackage ../development/python-modules/python-wifi { };
-
-  python-wink = callPackage ../development/python-modules/python-wink { };
-
-  python-xmp-toolkit = callPackage ../development/python-modules/python-xmp-toolkit { };
-
-  python-xz = callPackage ../development/python-modules/python-xz { };
-
-  python-zaqarclient = callPackage ../development/python-modules/python-zaqarclient { };
-
-  python-zbar = callPackage ../development/python-modules/python-zbar { };
-
-  python-zunclient = callPackage ../development/python-modules/python-zunclient { };
-
-  pythran = callPackage ../development/python-modules/pythran { inherit (pkgs.llvmPackages) openmp; };
-
-  pyeapi = callPackage ../development/python-modules/pyeapi { };
-
-  pyeverlights = callPackage ../development/python-modules/pyeverlights { };
-
-  pyinfra = callPackage ../development/python-modules/pyinfra { };
-
-  pymodes = callPackage ../development/python-modules/pymodes { };
-
-  pytibber = callPackage ../development/python-modules/pytibber { };
-
-  pytile = callPackage ../development/python-modules/pytile { };
-
-  pytimeparse = callPackage ../development/python-modules/pytimeparse { };
-
-  pytimeparse2 = callPackage ../development/python-modules/pytimeparse2 { };
-
-  pytikz-allefeld = callPackage ../development/python-modules/pytikz-allefeld { };
-
-  pytm = callPackage ../development/python-modules/pytm { };
-
-  pytmx = callPackage ../development/python-modules/pytmx { };
-
-  pytomlpp = callPackage ../development/python-modules/pytomlpp { };
-
-  pytoolconfig = callPackage ../development/python-modules/pytoolconfig { };
-
-  pytools = callPackage ../development/python-modules/pytools { };
-
-  pytorch-bench = callPackage ../development/python-modules/pytorch-bench { };
-
-  pytorch-lightning = callPackage ../development/python-modules/pytorch-lightning { };
-
-  pytorch-metric-learning = callPackage ../development/python-modules/pytorch-metric-learning { };
-
-  pytorch-msssim = callPackage ../development/python-modules/pytorch-msssim { };
-
-  pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
-
-  pytraccar = callPackage ../development/python-modules/pytraccar { };
-
-  pytradfri = callPackage ../development/python-modules/pytradfri { };
-
-  pytrafikverket = callPackage ../development/python-modules/pytrafikverket { };
-
-  pytransportnsw = callPackage ../development/python-modules/pytransportnsw { };
-
-  pytransportnswv2 = callPackage ../development/python-modules/pytransportnswv2 { };
-
-  pytricia = callPackage ../development/python-modules/pytricia { };
-
-  pytrydan = callPackage ../development/python-modules/pytrydan { };
-
-  pyttsx3 = callPackage ../development/python-modules/pyttsx3 { };
-
-  pytube = callPackage ../development/python-modules/pytube { };
-
-  pytubefix = callPackage ../development/python-modules/pytubefix { };
-
-  pytun = callPackage ../development/python-modules/pytun { };
-
-  pyturbojpeg = callPackage ../development/python-modules/pyturbojpeg { };
-
-  pytweening = callPackage ../development/python-modules/pytweening { };
-
-  pytz = callPackage ../development/python-modules/pytz { };
-
-  pytz-deprecation-shim = callPackage ../development/python-modules/pytz-deprecation-shim { };
-
-  pyu2f = callPackage ../development/python-modules/pyu2f { };
-
-  pyudev = callPackage ../development/python-modules/pyudev { inherit (pkgs) udev; };
-
-  pyunbound = callPackage ../development/python-modules/pyunbound { };
-
-  pyunifi = callPackage ../development/python-modules/pyunifi { };
-
-  pyupdate = callPackage ../development/python-modules/pyupdate { };
-
-  pyupgrade = callPackage ../development/python-modules/pyupgrade { };
-
-  pyuptimerobot = callPackage ../development/python-modules/pyuptimerobot { };
-
-  pyusb = callPackage ../development/python-modules/pyusb { inherit (pkgs) libusb1; };
-
-  pyuseragents = callPackage ../development/python-modules/pyuseragents { };
-
-  pyuv = callPackage ../development/python-modules/pyuv { };
-
-  py-vapid = callPackage ../development/python-modules/py-vapid { };
-
-  pyvcd = callPackage ../development/python-modules/pyvcd { };
-
-  pyvera = callPackage ../development/python-modules/pyvera { };
-
-  pyverilog = callPackage ../development/python-modules/pyverilog { };
-
-  pyversasense = callPackage ../development/python-modules/pyversasense { };
-
-  pyvesync = callPackage ../development/python-modules/pyvesync { };
-
-  pyvex = callPackage ../development/python-modules/pyvex { };
-
-  pyvicare = callPackage ../development/python-modules/pyvicare { };
-
-  pyvirtualdisplay = callPackage ../development/python-modules/pyvirtualdisplay { };
-
-  pyvis = callPackage ../development/python-modules/pyvis { };
-
-  pyvisa = callPackage ../development/python-modules/pyvisa { };
-
-  pyvisa-py = callPackage ../development/python-modules/pyvisa-py { };
-
-  pyvisa-sim = callPackage ../development/python-modules/pyvisa-sim { };
-
-  pyvista = callPackage ../development/python-modules/pyvista { };
-
-  pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
-
-  pyvizio = callPackage ../development/python-modules/pyvizio { };
-
-  pyvips = callPackage ../development/python-modules/pyvips { inherit (pkgs) vips glib; };
-
-  pyvlx = callPackage ../development/python-modules/pyvlx { };
-
-  pyvmomi = callPackage ../development/python-modules/pyvmomi { };
-
-  pyvo = callPackage ../development/python-modules/pyvo { };
-
-  pyvolumio = callPackage ../development/python-modules/pyvolumio { };
-
-  pyvoro = callPackage ../development/python-modules/pyvoro { };
-
-  pyvows = callPackage ../development/python-modules/pyvows { };
-
-  pywal = callPackage ../development/python-modules/pywal { };
-
-  pywatchman = callPackage ../development/python-modules/pywatchman { };
-
-  pywaterkotte = callPackage ../development/python-modules/pywaterkotte { };
-
-  pywavefront = callPackage ../development/python-modules/pywavefront { };
-
-  pywavelets = callPackage ../development/python-modules/pywavelets { };
-
-  pywayland = callPackage ../development/python-modules/pywayland { };
-
-  pywaze = callPackage ../development/python-modules/pywaze { };
-
-  pywbem = callPackage ../development/python-modules/pywbem { inherit (pkgs) libxml2; };
-
-  pyweatherflowrest = callPackage ../development/python-modules/pyweatherflowrest { };
-
-  pyweatherflowudp = callPackage ../development/python-modules/pyweatherflowudp { };
-
-  pywebpush = callPackage ../development/python-modules/pywebpush { };
-
-  pywebview = callPackage ../development/python-modules/pywebview { };
-
-  pywemo = callPackage ../development/python-modules/pywemo { };
-
-  pywerview = callPackage ../development/python-modules/pywerview { };
-
-  pywfa = callPackage ../development/python-modules/pywfa { };
-
-  pywikibot = callPackage ../development/python-modules/pywikibot { };
-
-  pywilight = callPackage ../development/python-modules/pywilight { };
-
-  pywinbox = callPackage ../development/python-modules/pywinbox { };
-
-  pywinctl = callPackage ../development/python-modules/pywinctl { };
-
-  pywinrm = callPackage ../development/python-modules/pywinrm { };
-
-  pywizlight = callPackage ../development/python-modules/pywizlight { };
-
-  pywlroots = callPackage ../development/python-modules/pywlroots { wlroots = pkgs.wlroots_0_17; };
-
-  pyws66i = callPackage ../development/python-modules/pyws66i { };
-
-  pyxattr = callPackage ../development/python-modules/pyxattr { };
-
-  pyxlsb = callPackage ../development/python-modules/pyxlsb { };
-
-  pyworld = callPackage ../development/python-modules/pyworld { };
-
-  pyx = callPackage ../development/python-modules/pyx { };
-
-  pyxbe = callPackage ../development/python-modules/pyxbe { };
-
-  pyxdg = callPackage ../development/python-modules/pyxdg { };
-
-  pyxeoma = callPackage ../development/python-modules/pyxeoma { };
-
-  pyxiaomigateway = callPackage ../development/python-modules/pyxiaomigateway { };
-
-  pyxl3 = callPackage ../development/python-modules/pyxl3 { };
-
-  pyxnat = callPackage ../development/python-modules/pyxnat { };
-
-  pyyaml = callPackage ../development/python-modules/pyyaml { };
-
-  pyyaml-env-tag = callPackage ../development/python-modules/pyyaml-env-tag { };
-
-  pyyaml-include = callPackage ../development/python-modules/pyyaml-include { };
-
-  pyyardian = callPackage ../development/python-modules/pyyardian { };
-
-  pyytlounge = callPackage ../development/python-modules/pyytlounge { };
-
-  pyzabbix = callPackage ../development/python-modules/pyzabbix { };
-
-  pyzerproc = callPackage ../development/python-modules/pyzerproc { };
-
-  pyzmq = callPackage ../development/python-modules/pyzmq { };
-
-  pyzx = callPackage ../development/python-modules/pyzx { };
-
-  qbittorrent-api = callPackage ../development/python-modules/qbittorrent-api { };
-
-  qasync = callPackage ../development/python-modules/qasync { };
-
-  qbusmqttapi = callPackage ../development/python-modules/qbusmqttapi { };
-
-  qcelemental = callPackage ../development/python-modules/qcelemental { };
-
-  qcengine = callPackage ../development/python-modules/qcengine { };
-
-  qcodes = callPackage ../development/python-modules/qcodes { };
-
-  qcodes-contrib-drivers = callPackage ../development/python-modules/qcodes-contrib-drivers { };
-
-  qcs-api-client = callPackage ../development/python-modules/qcs-api-client { };
-
-  qcs-api-client-common = callPackage ../development/python-modules/qcs-api-client-common { };
-
-  qcs-sdk-python = callPackage ../development/python-modules/qcs-sdk-python { };
-
-  qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
-
-  qdldl = callPackage ../development/python-modules/qdldl { };
-
-  qdrant-client = callPackage ../development/python-modules/qdrant-client { };
-
-  qgrid = callPackage ../development/python-modules/qgrid { };
-
-  qemu = callPackage ../development/python-modules/qemu { qemu = pkgs.qemu; };
-
-  qiling = callPackage ../development/python-modules/qiling { };
-
-  qimage2ndarray = callPackage ../development/python-modules/qimage2ndarray { };
-
-  qingping-ble = callPackage ../development/python-modules/qingping-ble { };
-
-  qiskit = callPackage ../development/python-modules/qiskit { };
-
-  qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
-
-  qiskit-finance = callPackage ../development/python-modules/qiskit-finance { };
-
-  qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
-
-  qiskit-ignis = callPackage ../development/python-modules/qiskit-ignis { };
-
-  qiskit-machine-learning = callPackage ../development/python-modules/qiskit-machine-learning { };
-
-  qiskit-nature = callPackage ../development/python-modules/qiskit-nature { };
-
-  qiskit-optimization = callPackage ../development/python-modules/qiskit-optimization { };
-
-  qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
-
-  qnap-qsw = callPackage ../development/python-modules/qnap-qsw { };
-
-  qnapstats = callPackage ../development/python-modules/qnapstats { };
-
-  qpageview = callPackage ../development/python-modules/qpageview { };
-
-  qpsolvers = callPackage ../development/python-modules/qpsolvers { };
-
-  qrcode = callPackage ../development/python-modules/qrcode { };
-
-  qrcode-terminal = callPackage ../development/python-modules/qrcode-terminal { };
-
-  qreactor = callPackage ../development/python-modules/qreactor { };
-
-  qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {
-    pythonPackages = self;
-  };
-
-  qscintilla = self.qscintilla-qt5;
-
-  qstylizer = callPackage ../development/python-modules/qstylizer { };
-
-  qt-material = callPackage ../development/python-modules/qt-material { };
-
-  qt5reactor = callPackage ../development/python-modules/qt5reactor { };
-
-  qt6 = pkgs.qt6.override { python3 = self.python; };
-
-  qtawesome = callPackage ../development/python-modules/qtawesome { };
-
-  qtconsole = callPackage ../development/python-modules/qtconsole { };
-
-  qtile = callPackage ../development/python-modules/qtile { wlroots = pkgs.wlroots_0_17; };
-  qtile-extras = callPackage ../development/python-modules/qtile-extras { };
-
-  qtile-bonsai = callPackage ../development/python-modules/qtile-bonsai { };
-
-  qtpy = callPackage ../development/python-modules/qtpy { };
-
-  quadprog = callPackage ../development/python-modules/quadprog { };
-
-  qualysclient = callPackage ../development/python-modules/qualysclient { };
-
-  quandl = callPackage ../development/python-modules/quandl { };
-
-  quantile-forest = callPackage ../development/python-modules/quantile-forest { };
-
-  quantities = callPackage ../development/python-modules/quantities { };
-
-  quantiphy = callPackage ../development/python-modules/quantiphy { };
-
-  quantile-python = callPackage ../development/python-modules/quantile-python { };
-
-  quantiphy-eval = callPackage ../development/python-modules/quantiphy-eval { };
-
-  quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
-
-  quantulum3 = callPackage ../development/python-modules/quantulum3 { };
-
-  quart = callPackage ../development/python-modules/quart { };
-
-  quart-cors = callPackage ../development/python-modules/quart-cors { };
-
-  quart-schema = callPackage ../development/python-modules/quart-schema { };
-
-  quaternion = callPackage ../development/python-modules/quaternion { };
-
-  qudida = callPackage ../development/python-modules/qudida { };
-
-  querystring-parser = callPackage ../development/python-modules/querystring-parser { };
-
-  questo = callPackage ../development/python-modules/questo { };
-
-  questionary = callPackage ../development/python-modules/questionary { };
-
-  queuelib = callPackage ../development/python-modules/queuelib { };
-
-  quil = callPackage ../development/python-modules/quil { };
-
-  quixote = callPackage ../development/python-modules/quixote { };
-
-  qutip = callPackage ../development/python-modules/qutip { };
-
-  pythonqwt = callPackage ../development/python-modules/pythonqwt { };
-
-  r2pipe = callPackage ../development/python-modules/r2pipe { };
-
-  rachiopy = callPackage ../development/python-modules/rachiopy { };
-
-  radicale-infcloud = callPackage ../development/python-modules/radicale-infcloud {
-    radicale = pkgs.radicale.override { python3 = python; };
-  };
-
-  radian = callPackage ../development/python-modules/radian { };
-
-  radio-beam = callPackage ../development/python-modules/radio-beam { };
-
-  radios = callPackage ../development/python-modules/radios { };
-
-  radiotherm = callPackage ../development/python-modules/radiotherm { };
-
-  radish-bdd = callPackage ../development/python-modules/radish-bdd { };
-
-  radon = callPackage ../development/python-modules/radon { };
-
-  railroad-diagrams = callPackage ../development/python-modules/railroad-diagrams { };
-
-  rainbowstream = callPackage ../development/python-modules/rainbowstream { };
-
-  raincloudy = callPackage ../development/python-modules/raincloudy { };
-
-  ramlfications = callPackage ../development/python-modules/ramlfications { };
-
-  random-user-agent = callPackage ../development/python-modules/random-user-agent { };
-
-  random2 = callPackage ../development/python-modules/random2 { };
-
-  randomfiletree = callPackage ../development/python-modules/randomfiletree { };
-
-  range-typed-integers = callPackage ../development/python-modules/range-typed-integers { };
-
-  rangehttpserver = callPackage ../development/python-modules/rangehttpserver { };
-
-  rangeparser = callPackage ../development/python-modules/rangeparser { };
-
-  rank-bm25 = callPackage ../development/python-modules/rank-bm25 { };
-
-  rapidfuzz = callPackage ../development/python-modules/rapidfuzz { };
-
-  rapidfuzz-capi = callPackage ../development/python-modules/rapidfuzz-capi { };
-
-  rapidgzip = callPackage ../development/python-modules/rapidgzip { inherit (pkgs) nasm; };
-
-  rapidocr-onnxruntime = callPackage ../development/python-modules/rapidocr-onnxruntime { };
-
-  rapt-ble = callPackage ../development/python-modules/rapt-ble { };
-
-  rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
-
-  rasterio = callPackage ../development/python-modules/rasterio { };
-
-  ratarmountcore = callPackage ../development/python-modules/ratarmountcore { inherit (pkgs) zstd; };
-
-  ratarmount = callPackage ../development/python-modules/ratarmount { };
-
-  ratelim = callPackage ../development/python-modules/ratelim { };
-
-  ratelimit = callPackage ../development/python-modules/ratelimit { };
-
-  raven = callPackage ../development/python-modules/raven { };
-
-  rawkit = callPackage ../development/python-modules/rawkit { };
-
-  rawpy = callPackage ../development/python-modules/rawpy { };
-
-  ray = callPackage ../development/python-modules/ray { };
-
-  raylib-python-cffi = callPackage ../development/python-modules/raylib-python-cffi { };
-
-  razdel = callPackage ../development/python-modules/razdel { };
-
-  rbtools = callPackage ../development/python-modules/rbtools { };
-
-  rchitect = callPackage ../development/python-modules/rchitect { };
-
-  rclone-python = callPackage ../development/python-modules/rclone-python { };
-
-  rcssmin = callPackage ../development/python-modules/rcssmin { };
-
-  rdflib = callPackage ../development/python-modules/rdflib { };
-
-  rdkit = callPackage ../development/python-modules/rdkit {
-    boost = pkgs.boost.override {
-      enablePython = true;
-      inherit python;
-    };
-  };
-
-  re-assert = callPackage ../development/python-modules/re-assert { };
-
-  readability-lxml = callPackage ../development/python-modules/readability-lxml { };
-
-  readabilipy = callPackage ../development/python-modules/readabilipy { };
-
-  readchar = callPackage ../development/python-modules/readchar { };
-
-  readlike = callPackage ../development/python-modules/readlike { };
-
-  readmdict = callPackage ../development/python-modules/readmdict { };
-
-  readme = callPackage ../development/python-modules/readme { };
-
-  readme-renderer = callPackage ../development/python-modules/readme-renderer { };
-
-  readthedocs-sphinx-ext = callPackage ../development/python-modules/readthedocs-sphinx-ext { };
-
-  reactivex = callPackage ../development/python-modules/reactivex { };
-
-  rebulk = callPackage ../development/python-modules/rebulk { };
-
-  recipe-scrapers = callPackage ../development/python-modules/recipe-scrapers { };
-
-  recline = callPackage ../development/python-modules/recline { };
-
-  recoll = toPythonModule (pkgs.recoll.override { python3Packages = self; });
-
-  recommonmark = callPackage ../development/python-modules/recommonmark { };
-
-  reconplogger = callPackage ../development/python-modules/reconplogger { };
-
-  recordlinkage = callPackage ../development/python-modules/recordlinkage { };
-
-  rectpack = callPackage ../development/python-modules/rectpack { };
-
-  rectangle-packer = callPackage ../development/python-modules/rectangle-packer { };
-
-  recurring-ical-events = callPackage ../development/python-modules/recurring-ical-events { };
-
-  recursive-pth-loader = toPythonModule (
-    callPackage ../development/python-modules/recursive-pth-loader { }
-  );
-
-  red-black-tree-mod = callPackage ../development/python-modules/red-black-tree-mod { };
-
-  redbaron = callPackage ../development/python-modules/redbaron { };
-
-  redis = callPackage ../development/python-modules/redis { };
-
-  redis-om = callPackage ../development/python-modules/redis-om { };
-
-  redshift-connector = callPackage ../development/python-modules/redshift-connector { };
-
-  reedsolo = callPackage ../development/python-modules/reedsolo { };
-
-  referencing = callPackage ../development/python-modules/referencing { };
-
-  refery = callPackage ../development/python-modules/refery { };
-
-  reflex = callPackage ../development/python-modules/reflex { };
-
-  reflex-chakra = callPackage ../development/python-modules/reflex-chakra { };
-
-  reflex-hosting-cli = callPackage ../development/python-modules/reflex-hosting-cli { };
-
-  reflink = callPackage ../development/python-modules/reflink { };
-
-  refoss-ha = callPackage ../development/python-modules/refoss-ha { };
-
-  regenmaschine = callPackage ../development/python-modules/regenmaschine { };
-
-  regex = callPackage ../development/python-modules/regex { };
-
-  regional = callPackage ../development/python-modules/regional { };
-
-  reikna = callPackage ../development/python-modules/reikna { };
-
-  related = callPackage ../development/python-modules/related { };
-
-  relatorio = callPackage ../development/python-modules/relatorio { };
-
-  releases = callPackage ../development/python-modules/releases { };
-
-  remarshal = callPackage ../development/python-modules/remarshal { };
-
-  remctl = callPackage ../development/python-modules/remctl { remctl-c = pkgs.remctl; };
-
-  remi = callPackage ../development/python-modules/remi { };
-
-  remote-pdb = callPackage ../development/python-modules/remote-pdb { };
-
-  remotezip = callPackage ../development/python-modules/remotezip { };
-
-  renault-api = callPackage ../development/python-modules/renault-api { };
-
-  rencode = callPackage ../development/python-modules/rencode { };
-
-  reno = callPackage ../development/python-modules/reno { };
-
-  renson-endura-delta = callPackage ../development/python-modules/renson-endura-delta { };
-
-  reorder-python-imports = callPackage ../development/python-modules/reorder-python-imports { };
-
-  reolink = callPackage ../development/python-modules/reolink { };
-
-  reolink-aio = callPackage ../development/python-modules/reolink-aio { };
-
-  reparser = callPackage ../development/python-modules/reparser { };
-
-  repath = callPackage ../development/python-modules/repath { };
-
-  repeated-test = callPackage ../development/python-modules/repeated-test { };
-
-  repl-python-wakatime = callPackage ../development/python-modules/repl-python-wakatime { };
-
-  replicate = callPackage ../development/python-modules/replicate { };
-
-  reportlab = callPackage ../development/python-modules/reportlab { };
-
-  reportlab-qrcode = callPackage ../development/python-modules/reportlab-qrcode { };
-
-  repoze-lru = callPackage ../development/python-modules/repoze-lru { };
-
-  repoze-sphinx-autointerface =
-    callPackage ../development/python-modules/repoze-sphinx-autointerface
-      { };
-
-  repoze-who = callPackage ../development/python-modules/repoze-who { };
-
-  reproject = callPackage ../development/python-modules/reproject { };
-
-  reprint = callPackage ../development/python-modules/reprint { };
-
-  reprshed = callPackage ../development/python-modules/reprshed { };
-
-  reptor = callPackage ../development/python-modules/reptor { };
-
-  reqif = callPackage ../development/python-modules/reqif { };
-
-  requests-aws4auth = callPackage ../development/python-modules/requests-aws4auth { };
-
-  requests-cache = callPackage ../development/python-modules/requests-cache { };
-
-  requests-credssp = callPackage ../development/python-modules/requests-credssp { };
-
-  requests-gssapi = callPackage ../development/python-modules/requests-gssapi { };
-
-  requests-hawk = callPackage ../development/python-modules/requests-hawk { };
-
-  requests = callPackage ../development/python-modules/requests { };
-
-  requests-download = callPackage ../development/python-modules/requests-download { };
-
-  requestsexceptions = callPackage ../development/python-modules/requestsexceptions { };
-
-  requests-file = callPackage ../development/python-modules/requests-file { };
-
-  requests-futures = callPackage ../development/python-modules/requests-futures { };
-
-  requests-http-signature = callPackage ../development/python-modules/requests-http-signature { };
-
-  requests-kerberos = callPackage ../development/python-modules/requests-kerberos { };
-
-  requests-mock = callPackage ../development/python-modules/requests-mock { };
-
-  requests-ntlm = callPackage ../development/python-modules/requests-ntlm { };
-
-  requests-oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
-
-  requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };
-
-  requests-ratelimiter = callPackage ../development/python-modules/requests-ratelimiter { };
-
-  requests-toolbelt = callPackage ../development/python-modules/requests-toolbelt { };
-
-  requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket { };
-
-  requests-unixsocket2 = callPackage ../development/python-modules/requests-unixsocket2 { };
-
-  requests-wsgi-adapter = callPackage ../development/python-modules/requests-wsgi-adapter { };
-
-  requirements-detector = callPackage ../development/python-modules/requirements-detector { };
-
-  requirements-parser = callPackage ../development/python-modules/requirements-parser { };
-
-  reretry = callPackage ../development/python-modules/reretry { };
-
-  rerun-sdk = callPackage ../development/python-modules/rerun-sdk { };
-
-  resampy = callPackage ../development/python-modules/resampy { };
-
-  resend = callPackage ../development/python-modules/resend { };
-
-  resize-right = callPackage ../development/python-modules/resize-right { };
-
-  resolvelib = callPackage ../development/python-modules/resolvelib { };
-
-  responses = callPackage ../development/python-modules/responses { };
-
-  respx = callPackage ../development/python-modules/respx { };
-
-  restfly = callPackage ../development/python-modules/restfly { };
-
-  restrictedpython = callPackage ../development/python-modules/restrictedpython { };
-
-  restructuredtext-lint = callPackage ../development/python-modules/restructuredtext-lint { };
-
-  restview = callPackage ../development/python-modules/restview { };
-
-  result = callPackage ../development/python-modules/result { };
-
-  rethinkdb = callPackage ../development/python-modules/rethinkdb { };
-
-  retinaface = callPackage ../development/python-modules/retinaface { };
-
-  retry = callPackage ../development/python-modules/retry { };
-
-  retry-decorator = callPackage ../development/python-modules/retry-decorator { };
-
-  retry2 = callPackage ../development/python-modules/retry2 { };
-
-  retrying = callPackage ../development/python-modules/retrying { };
-
-  returns = callPackage ../development/python-modules/returns { };
-
-  reuse = callPackage ../development/python-modules/reuse { };
-
-  reverse-geocode = callPackage ../development/python-modules/reverse-geocode { };
-
-  rfc3161-client = callPackage ../development/python-modules/rfc3161-client { };
-
-  rfc3339 = callPackage ../development/python-modules/rfc3339 { };
-
-  rfc3339-validator = callPackage ../development/python-modules/rfc3339-validator { };
-
-  rfc3986 = callPackage ../development/python-modules/rfc3986 { };
-
-  rfc3986-validator = callPackage ../development/python-modules/rfc3986-validator { };
-
-  rfc3987 = callPackage ../development/python-modules/rfc3987 { };
-
-  rfc6555 = callPackage ../development/python-modules/rfc6555 { };
-
-  rfc7464 = callPackage ../development/python-modules/rfc7464 { };
-
-  rfc8785 = callPackage ../development/python-modules/rfc8785 { };
-
-  rfcat = callPackage ../development/python-modules/rfcat { };
-
-  rflink = callPackage ../development/python-modules/rflink { };
-
-  rich = callPackage ../development/python-modules/rich { };
-
-  rich-argparse = callPackage ../development/python-modules/rich-argparse { };
-
-  rich-argparse-plus = callPackage ../development/python-modules/rich-argparse-plus { };
-
-  rich-click = callPackage ../development/python-modules/rich-click { };
-
-  rich-pixels = callPackage ../development/python-modules/rich-pixels { };
-
-  rich-rst = callPackage ../development/python-modules/rich-rst { };
-
-  rich-theme-manager = callPackage ../development/python-modules/rich-theme-manager { };
-
-  rich-toolkit = callPackage ../development/python-modules/rich-toolkit { };
-
-  riden = callPackage ../development/python-modules/riden { };
-
-  rigour = callPackage ../development/python-modules/rigour { };
-
-  ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
-
-  rio-tiler = callPackage ../development/python-modules/rio-tiler { };
-
-  rioxarray = callPackage ../development/python-modules/rioxarray { };
-
-  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
-
-  ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
-
-  riprova = callPackage ../development/python-modules/riprova { };
-
-  ripser = callPackage ../development/python-modules/ripser { };
-
-  riscof = callPackage ../development/python-modules/riscof { };
-
-  riscv-config = callPackage ../development/python-modules/riscv-config { };
-
-  riscv-isac = callPackage ../development/python-modules/riscv-isac { };
-
-  ritassist = callPackage ../development/python-modules/ritassist { };
-
-  rivet = toPythonModule (pkgs.rivet.override { python3 = python; });
-
-  rjpl = callPackage ../development/python-modules/rjpl { };
-
-  rjsmin = callPackage ../development/python-modules/rjsmin { };
-
-  rki-covid-parser = callPackage ../development/python-modules/rki-covid-parser { };
-
-  rkm-codes = callPackage ../development/python-modules/rkm-codes { };
-
-  rlax = callPackage ../development/python-modules/rlax { };
-
-  rlcard = callPackage ../development/python-modules/rlcard { };
-
-  rlp = callPackage ../development/python-modules/rlp { };
-
-  rmcl = callPackage ../development/python-modules/rmcl { };
-
-  rmrl = callPackage ../development/python-modules/rmrl { };
-
-  rmscene = callPackage ../development/python-modules/rmscene { };
-
-  rmsd = callPackage ../development/python-modules/rmsd { };
-
-  rnc2rng = callPackage ../development/python-modules/rnc2rng { };
-
-  rnginline = callPackage ../development/python-modules/rnginline { };
-
-  rns = callPackage ../development/python-modules/rns { };
-
-  roadlib = callPackage ../development/python-modules/roadlib { };
-
-  roadrecon = callPackage ../development/python-modules/roadrecon { };
-
-  roadtools = callPackage ../development/python-modules/roadtools { };
-
-  roadtx = callPackage ../development/python-modules/roadtx { };
-
-  robomachine = callPackage ../development/python-modules/robomachine { };
-
-  robot-detection = callPackage ../development/python-modules/robot-detection { };
-
-  robotframework = callPackage ../development/python-modules/robotframework { };
-
-  robotframework-databaselibrary =
-    callPackage ../development/python-modules/robotframework-databaselibrary
-      { };
-
-  robotframework-excellib = callPackage ../development/python-modules/robotframework-excellib { };
-
-  robotframework-pythonlibcore =
-    callPackage ../development/python-modules/robotframework-pythonlibcore
-      { };
-
-  robotframework-requests = callPackage ../development/python-modules/robotframework-requests { };
-
-  robotframework-selenium2library =
-    callPackage ../development/python-modules/robotframework-selenium2library
-      { };
-
-  robotframework-seleniumlibrary =
-    callPackage ../development/python-modules/robotframework-seleniumlibrary
-      { };
-
-  robotframework-sshlibrary = callPackage ../development/python-modules/robotframework-sshlibrary { };
-
-  robotframework-tools = callPackage ../development/python-modules/robotframework-tools { };
-
-  robotstatuschecker = callPackage ../development/python-modules/robotstatuschecker { };
-
-  robotsuite = callPackage ../development/python-modules/robotsuite { };
-
-  rocket-errbot = callPackage ../development/python-modules/rocket-errbot { };
-
-  rocketchat-api = callPackage ../development/python-modules/rocketchat-api { };
-
-  roku = callPackage ../development/python-modules/roku { };
-
-  rokuecp = callPackage ../development/python-modules/rokuecp { };
-
-  rollbar = callPackage ../development/python-modules/rollbar { };
-
-  roma = callPackage ../development/python-modules/roma { };
-
-  roman-numerals-py = callPackage ../development/python-modules/roman-numerals-py { };
-
-  roman = callPackage ../development/python-modules/roman { };
-
-  romy = callPackage ../development/python-modules/romy { };
-
-  roombapy = callPackage ../development/python-modules/roombapy { };
-
-  roonapi = callPackage ../development/python-modules/roonapi { };
-
-  rope = callPackage ../development/python-modules/rope { };
-
-  ropgadget = callPackage ../development/python-modules/ropgadget { };
-
-  ropper = callPackage ../development/python-modules/ropper { };
-
-  rotary-embedding-torch = callPackage ../development/python-modules/rotary-embedding-torch { };
-
-  rouge-score = callPackage ../development/python-modules/rouge-score { };
-
-  routeros-api = callPackage ../development/python-modules/routeros-api { };
-
-  routes = callPackage ../development/python-modules/routes { };
-
-  rova = callPackage ../development/python-modules/rova { };
-
-  rowan = callPackage ../development/python-modules/rowan { };
-
-  rpcq = callPackage ../development/python-modules/rpcq { };
-
-  rpdb = callPackage ../development/python-modules/rpdb { };
-
-  rpds-py = callPackage ../development/python-modules/rpds-py { };
-
-  rpi-bad-power = callPackage ../development/python-modules/rpi-bad-power { };
-
-  rpi-gpio = callPackage ../development/python-modules/rpi-gpio { };
-
-  rplcd = callPackage ../development/python-modules/rplcd { };
-
-  rply = callPackage ../development/python-modules/rply { };
-
-  rpm = toPythonModule (pkgs.rpm.override { python3 = self.python; });
-
-  rpmfile = callPackage ../development/python-modules/rpmfile { };
-
-  rpmfluff = callPackage ../development/python-modules/rpmfluff { };
-
-  rpy2 = callPackage ../development/python-modules/rpy2 { };
-
-  rpyc = callPackage ../development/python-modules/rpyc { };
-
-  rq = callPackage ../development/python-modules/rq { };
-
-  rsa = callPackage ../development/python-modules/rsa { };
-
-  rsskey = callPackage ../development/python-modules/rsskey { };
-
-  rst2ansi = callPackage ../development/python-modules/rst2ansi { };
-
-  rst2pdf = callPackage ../development/python-modules/rst2pdf { };
-
-  rstcheck = callPackage ../development/python-modules/rstcheck { };
-
-  rstcheck-core = callPackage ../development/python-modules/rstcheck-core { };
-
-  rstr = callPackage ../development/python-modules/rstr { };
-
-  rtmidi-python = callPackage ../development/python-modules/rtmidi-python {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices;
-  };
-
-  rtoml = callPackage ../development/python-modules/rtoml { };
-
-  rtb-data = callPackage ../development/python-modules/rtb-data { };
-
-  rtp = callPackage ../development/python-modules/rtp { };
-
-  rtree = callPackage ../development/python-modules/rtree { inherit (pkgs) libspatialindex; };
-
-  rtslib-fb = callPackage ../development/python-modules/rtslib-fb { };
-
-  rtsp-to-webrtc = callPackage ../development/python-modules/rtsp-to-webrtc { };
-
-  ruamel-base = callPackage ../development/python-modules/ruamel-base { };
-
-  ruamel-yaml = callPackage ../development/python-modules/ruamel-yaml { };
-
-  ruamel-yaml-clib = callPackage ../development/python-modules/ruamel-yaml-clib { };
-
-  ruamel-yaml-string = callPackage ../development/python-modules/ruamel-yaml-string { };
-
-  rubicon-objc = callPackage ../development/python-modules/rubicon-objc { };
-
-  rubymarshal = callPackage ../development/python-modules/rubymarshal { };
-
-  ruff = callPackage ../development/python-modules/ruff { inherit (pkgs) ruff; };
-
-  ruff-api = callPackage ../development/python-modules/ruff-api { };
-
-  ruffus = callPackage ../development/python-modules/ruffus { };
-
-  rules = callPackage ../development/python-modules/rules { };
-
-  rumps = callPackage ../development/python-modules/rumps { };
-
-  runs = callPackage ../development/python-modules/runs { };
-
-  runstats = callPackage ../development/python-modules/runstats { };
-
-  ruuvitag-ble = callPackage ../development/python-modules/ruuvitag-ble { };
-
-  ruyaml = callPackage ../development/python-modules/ruyaml { };
-
-  rx = callPackage ../development/python-modules/rx { };
-
-  rxv = callPackage ../development/python-modules/rxv { };
-
-  ryd-client = callPackage ../development/python-modules/ryd-client { };
-
-  rzpipe = callPackage ../development/python-modules/rzpipe { };
-
-  s2clientprotocol = callPackage ../development/python-modules/s2clientprotocol { };
-
-  s3fs = callPackage ../development/python-modules/s3fs { };
-
-  s3transfer = callPackage ../development/python-modules/s3transfer { };
-
-  s3-credentials = callPackage ../development/python-modules/s3-credentials { };
-
-  sabctools = callPackage ../development/python-modules/sabctools { };
-
-  sabyenc3 = callPackage ../development/python-modules/sabyenc3 { };
-
-  sabyenc = callPackage ../development/python-modules/sabyenc { };
-
-  sacn = callPackage ../development/python-modules/sacn { };
-
-  sacrebleu = callPackage ../development/python-modules/sacrebleu { };
-
-  sacremoses = callPackage ../development/python-modules/sacremoses { };
-
-  safe-pysha3 = callPackage ../development/python-modules/safe-pysha3 { };
-
-  safehttpx = callPackage ../development/python-modules/safehttpx { };
-
-  safeio = callPackage ../development/python-modules/safeio { };
-
-  safetensors = callPackage ../development/python-modules/safetensors { };
-
-  safety = callPackage ../development/python-modules/safety { };
-
-  safety-schemas = callPackage ../development/python-modules/safety-schemas { };
-
-  sagemaker = callPackage ../development/python-modules/sagemaker { };
-
-  sagemaker-core = callPackage ../development/python-modules/sagemaker-core { };
-
-  sagemaker-mlflow = callPackage ../development/python-modules/sagemaker-mlflow { };
-
-  salib = callPackage ../development/python-modules/salib { };
-
-  salmon-mail = callPackage ../development/python-modules/salmon-mail { };
-
-  sane = callPackage ../development/python-modules/sane { inherit (pkgs) sane-backends; };
-
-  saneyaml = callPackage ../development/python-modules/saneyaml { };
-
-  samarium = callPackage ../development/python-modules/samarium { };
-
-  samplerate = callPackage ../development/python-modules/samplerate { inherit (pkgs) libsamplerate; };
-
-  samsungctl = callPackage ../development/python-modules/samsungctl { };
-
-  samsungtvws = callPackage ../development/python-modules/samsungtvws { };
-
-  sanic = callPackage ../development/python-modules/sanic {
-    # Don't pass any `sanic` to avoid dependency loops.  `sanic-testing`
-    # has special logic to disable tests when this is the case.
-    sanic-testing = self.sanic-testing.override { sanic = null; };
-  };
-
-  sanic-auth = callPackage ../development/python-modules/sanic-auth { };
-
-  sanic-routing = callPackage ../development/python-modules/sanic-routing { };
-
-  sanic-testing = callPackage ../development/python-modules/sanic-testing { };
-
-  sanix = callPackage ../development/python-modules/sanix { };
-
-  sansio-multipart = callPackage ../development/python-modules/sansio-multipart { };
-
-  sarif-om = callPackage ../development/python-modules/sarif-om { };
-
-  sarif-tools = callPackage ../development/python-modules/sarif-tools { };
-
-  sarge = callPackage ../development/python-modules/sarge { };
-
-  sasmodels = callPackage ../development/python-modules/sasmodels { };
-
-  sbom2dot = callPackage ../development/python-modules/sbom2dot { };
-
-  sbom4files = callPackage ../development/python-modules/sbom4files { };
-
-  scalene = callPackage ../development/python-modules/scalene { };
-
-  scales = callPackage ../development/python-modules/scales { };
-
-  scancode-toolkit = callPackage ../development/python-modules/scancode-toolkit { };
-
-  scapy = callPackage ../development/python-modules/scapy {
-    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
-  };
-
-  schedule = callPackage ../development/python-modules/schedule { };
-
-  schema = callPackage ../development/python-modules/schema { };
-
-  schemainspect = callPackage ../development/python-modules/schemainspect { };
-
-  schema-salad = callPackage ../development/python-modules/schema-salad { };
-
-  schemdraw = callPackage ../development/python-modules/schemdraw { };
-
-  schiene = callPackage ../development/python-modules/schiene { };
-
-  scholarly = callPackage ../development/python-modules/scholarly { };
-
-  schwifty = callPackage ../development/python-modules/schwifty { };
-
-  scienceplots = callPackage ../development/python-modules/scienceplots { };
-
-  sciform = callPackage ../development/python-modules/sciform { };
-
-  scim2-client = callPackage ../development/python-modules/scim2-client { };
-
-  scim2-filter-parser = callPackage ../development/python-modules/scim2-filter-parser { };
-
-  scim2-models = callPackage ../development/python-modules/scim2-models { };
-
-  scim2-server = callPackage ../development/python-modules/scim2-server { };
-
-  scim2-tester = callPackage ../development/python-modules/scim2-tester { };
-
-  scikit-base = callPackage ../development/python-modules/scikit-base { };
-
-  scikit-bio = callPackage ../development/python-modules/scikit-bio { };
-
-  scikit-build = callPackage ../development/python-modules/scikit-build { };
-
-  scikit-build-core = callPackage ../development/python-modules/scikit-build-core { };
-
-  scikit-fmm = callPackage ../development/python-modules/scikit-fmm { };
-
-  scikit-fuzzy = callPackage ../development/python-modules/scikit-fuzzy { };
-
-  scikit-hep-testdata = callPackage ../development/python-modules/scikit-hep-testdata { };
-
-  scikit-image = callPackage ../development/python-modules/scikit-image { };
-
-  scikit-learn = callPackage ../development/python-modules/scikit-learn {
-    inherit (pkgs) gfortran glibcLocales;
-  };
-
-  scikit-learn-extra = callPackage ../development/python-modules/scikit-learn-extra { };
-
-  scikit-misc = callPackage ../development/python-modules/scikit-misc { };
-
-  scikit-posthocs = callPackage ../development/python-modules/scikit-posthocs { };
-
-  scikit-rf = callPackage ../development/python-modules/scikit-rf { };
-
-  scikits-odes = callPackage ../development/python-modules/scikits-odes { };
-
-  scikits-odes-core = callPackage ../development/python-modules/scikits-odes-core { };
-
-  scikits-odes-daepack = callPackage ../development/python-modules/scikits-odes-daepack { };
-
-  scikits-odes-sundials = callPackage ../development/python-modules/scikits-odes-sundials { };
-
-  scikit-tda = callPackage ../development/python-modules/scikit-tda { };
-
-  scipy = callPackage ../development/python-modules/scipy { };
-
-  scmrepo = callPackage ../development/python-modules/scmrepo { };
-
-  scour = callPackage ../development/python-modules/scour { };
-
-  scooby = callPackage ../development/python-modules/scooby { };
-
-  scp = callPackage ../development/python-modules/scp { };
-
-  scramp = callPackage ../development/python-modules/scramp { };
-
-  scrap-engine = callPackage ../development/python-modules/scrap-engine { };
-
-  scrapy = callPackage ../development/python-modules/scrapy { };
-
-  scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };
-
-  scrapy-fake-useragent = callPackage ../development/python-modules/scrapy-fake-useragent { };
-
-  scrapy-splash = callPackage ../development/python-modules/scrapy-splash { };
-
-  screed = callPackage ../development/python-modules/screed { };
-
-  screeninfo = callPackage ../development/python-modules/screeninfo { };
-
-  screenlogicpy = callPackage ../development/python-modules/screenlogicpy { };
-
-  scripttest = callPackage ../development/python-modules/scripttest { };
-
-  scrypt = callPackage ../development/python-modules/scrypt { };
-
-  scikit-survival = callPackage ../development/python-modules/scikit-survival { };
-
-  scs = callPackage ../development/python-modules/scs {
-    inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate;
-  };
-
-  sdds = callPackage ../development/python-modules/sdds { };
-
-  sdjson = callPackage ../development/python-modules/sdjson { };
-
-  sdkmanager = callPackage ../development/python-modules/sdkmanager { };
-
-  sdnotify = callPackage ../development/python-modules/sdnotify { };
-
-  seaborn = callPackage ../development/python-modules/seaborn { };
-
-  seabreeze = callPackage ../development/python-modules/seabreeze { };
-
-  seaserv = toPythonModule (pkgs.seafile-server.override { python3 = self.python; });
-
-  seasonal = callPackage ../development/python-modules/seasonal { };
-
-  seatconnect = callPackage ../development/python-modules/seatconnect { };
-
-  seccomp = callPackage ../development/python-modules/seccomp { };
-
-  secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1; };
-
-  secretstorage = callPackage ../development/python-modules/secretstorage { };
-
-  secure = callPackage ../development/python-modules/secure { };
-
-  securesystemslib = callPackage ../development/python-modules/securesystemslib { };
-
-  securetar = callPackage ../development/python-modules/securetar { };
-
-  securityreporter = callPackage ../development/python-modules/securityreporter { };
-
-  sectools = callPackage ../development/python-modules/sectools { };
-
-  sectxt = callPackage ../development/python-modules/sectxt { };
-
-  seedir = callPackage ../development/python-modules/seedir { };
-
-  seekpath = callPackage ../development/python-modules/seekpath { };
-
-  segments = callPackage ../development/python-modules/segments { };
-
-  segno = callPackage ../development/python-modules/segno { };
-
-  segyio = callPackage ../development/python-modules/segyio { inherit (pkgs) cmake ninja; };
-
-  selenium = callPackage ../development/python-modules/selenium { };
-
-  selenium-wire = callPackage ../development/python-modules/selenium-wire { };
-
-  semantic-version = callPackage ../development/python-modules/semantic-version { };
-
-  semchunk = callPackage ../development/python-modules/semchunk { };
-
-  semgrep = callPackage ../development/python-modules/semgrep {
-    semgrep-core = callPackage ../development/python-modules/semgrep/semgrep-core.nix { };
-  };
-
-  semaphore-bot = callPackage ../development/python-modules/semaphore-bot { };
-
-  semver = callPackage ../development/python-modules/semver { };
-
-  send2trash = callPackage ../development/python-modules/send2trash { };
-
-  sendgrid = callPackage ../development/python-modules/sendgrid { };
-
-  senf = callPackage ../development/python-modules/senf { };
-
-  sensai-utils = callPackage ../development/python-modules/sensai-utils { };
-
-  sense-energy = callPackage ../development/python-modules/sense-energy { };
-
-  sensirion-ble = callPackage ../development/python-modules/sensirion-ble { };
-
-  sensor-state-data = callPackage ../development/python-modules/sensor-state-data { };
-
-  sensorpro-ble = callPackage ../development/python-modules/sensorpro-ble { };
-
-  sensorpush-api = callPackage ../development/python-modules/sensorpush-api { };
-
-  sensorpush-ble = callPackage ../development/python-modules/sensorpush-ble { };
-
-  sensorpush-ha = callPackage ../development/python-modules/sensorpush-ha { };
-
-  sensoterra = callPackage ../development/python-modules/sensoterra { };
-
-  sentencepiece = callPackage ../development/python-modules/sentencepiece {
-    inherit (pkgs) sentencepiece;
-  };
-
-  sentence-splitter = callPackage ../development/python-modules/sentence-splitter { };
-
-  sentence-transformers = callPackage ../development/python-modules/sentence-transformers { };
-
-  sentinel = callPackage ../development/python-modules/sentinel { };
-
-  sentinels = callPackage ../development/python-modules/sentinels { };
-
-  sentry-sdk_1 = callPackage ../development/python-modules/sentry-sdk/1.nix { };
-  sentry-sdk_2 = callPackage ../development/python-modules/sentry-sdk/default.nix { };
-  sentry-sdk = sentry-sdk_1;
-
-  sepaxml = callPackage ../development/python-modules/sepaxml { };
-
-  seqdiag = callPackage ../development/python-modules/seqdiag { };
-
-  seqeval = callPackage ../development/python-modules/seqeval { };
-
-  serialio = callPackage ../development/python-modules/serialio { };
-
-  serializable = callPackage ../development/python-modules/serializable { };
-
-  serpent = callPackage ../development/python-modules/serpent { };
-
-  serpy = callPackage ../development/python-modules/serpy { };
-
-  servefile = callPackage ../development/python-modules/servefile { };
-
-  serverfiles = callPackage ../development/python-modules/serverfiles { };
-
-  serverlessrepo = callPackage ../development/python-modules/serverlessrepo { };
-
-  service-identity = callPackage ../development/python-modules/service-identity { };
-
-  setproctitle = callPackage ../development/python-modules/setproctitle { };
-
-  setupmeta = callPackage ../development/python-modules/setupmeta { };
-
-  setuptools-changelog-shortener =
-    callPackage ../development/python-modules/setuptools-changelog-shortener
-      { };
-
-  setuptools-declarative-requirements =
-    callPackage ../development/python-modules/setuptools-declarative-requirements
-      { };
-
-  setuptools-dso = callPackage ../development/python-modules/setuptools-dso { };
-
-  setuptools-generate = callPackage ../development/python-modules/setuptools-generate { };
-
-  setuptools-gettext = callPackage ../development/python-modules/setuptools-gettext { };
-
-  setuptools-git = callPackage ../development/python-modules/setuptools-git { };
-
-  setuptools-git-versioning = callPackage ../development/python-modules/setuptools-git-versioning { };
-
-  setuptools-lint = callPackage ../development/python-modules/setuptools-lint { };
-
-  setuptools-odoo = callPackage ../development/python-modules/setuptools-odoo { };
-
-  setuptools-rust = callPackage ../development/python-modules/setuptools-rust { };
-
-  setuptools-scm = callPackage ../development/python-modules/setuptools-scm { };
-
-  setuptools-scm-git-archive =
-    callPackage ../development/python-modules/setuptools-scm-git-archive
-      { };
-
-  setuptools-trial = callPackage ../development/python-modules/setuptools-trial { };
-
-  seventeentrack = callPackage ../development/python-modules/seventeentrack { };
-
-  sev-snp-measure = callPackage ../development/python-modules/sev-snp-measure { };
-
-  sexpdata = callPackage ../development/python-modules/sexpdata { };
-
-  sfepy = callPackage ../development/python-modules/sfepy { };
-
-  sfrbox-api = callPackage ../development/python-modules/sfrbox-api { };
-
-  sgmllib3k = callPackage ../development/python-modules/sgmllib3k { };
-
-  sgp4 = callPackage ../development/python-modules/sgp4 { };
-
-  shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
-
-  shap = callPackage ../development/python-modules/shap { };
-
-  shapely = callPackage ../development/python-modules/shapely { };
-
-  shaperglot = callPackage ../development/python-modules/shaperglot { };
-
-  sharedmem = callPackage ../development/python-modules/sharedmem { };
-
-  sharkiq = callPackage ../development/python-modules/sharkiq { };
-
-  sharp-aquos-rc = callPackage ../development/python-modules/sharp-aquos-rc { };
-
-  shazamio = callPackage ../development/python-modules/shazamio { };
-
-  sh = callPackage ../development/python-modules/sh { };
-
-  shlib = callPackage ../development/python-modules/shlib { };
-
-  shellescape = callPackage ../development/python-modules/shellescape { };
-
-  shellingham = callPackage ../development/python-modules/shellingham { };
-
-  shiboken2 = toPythonModule (
-    callPackage ../development/python-modules/shiboken2 { inherit (pkgs) cmake llvmPackages_15 qt5; }
-  );
-
-  shiboken6 = toPythonModule (
-    callPackage ../development/python-modules/shiboken6 { inherit (pkgs) cmake llvmPackages; }
-  );
-
-  shimmy = callPackage ../development/python-modules/shimmy { };
-
-  shiny = callPackage ../development/python-modules/shiny { };
-
-  shippai = callPackage ../development/python-modules/shippai { };
-
-  shippinglabel = callPackage ../development/python-modules/shippinglabel { };
-
-  shiv = callPackage ../development/python-modules/shiv { };
-
-  shodan = callPackage ../development/python-modules/shodan { };
-
-  shortuuid = callPackage ../development/python-modules/shortuuid { };
-
-  should-dsl = callPackage ../development/python-modules/should-dsl { };
-
-  show-in-file-manager = callPackage ../development/python-modules/show-in-file-manager { };
-
-  showit = callPackage ../development/python-modules/showit { };
-
-  shtab = callPackage ../development/python-modules/shtab { };
-
-  shutilwhich = callPackage ../development/python-modules/shutilwhich { };
-
-  sievelib = callPackage ../development/python-modules/sievelib { };
-
-  signalslot = callPackage ../development/python-modules/signalslot { };
-
-  signedjson = callPackage ../development/python-modules/signedjson { };
-
-  signxml = callPackage ../development/python-modules/signxml { };
-
-  sigparse = callPackage ../development/python-modules/sigparse { };
-
-  sigrok = callPackage ../development/python-modules/sigrok { };
-
-  sigstore = callPackage ../development/python-modules/sigstore { };
-
-  sigstore-protobuf-specs = callPackage ../development/python-modules/sigstore-protobuf-specs { };
-
-  sigstore-rekor-types = callPackage ../development/python-modules/sigstore-rekor-types { };
-
-  sigtools = callPackage ../development/python-modules/sigtools { };
-
-  simanneal = callPackage ../development/python-modules/simanneal { };
-
-  simber = callPackage ../development/python-modules/simber { };
-
-  simple-parsing = callPackage ../development/python-modules/simple-parsing { };
-
-  simple-term-menu = callPackage ../development/python-modules/simple-term-menu { };
-
-  simpleaudio = callPackage ../development/python-modules/simpleaudio { };
-
-  simplebayes = callPackage ../development/python-modules/simplebayes { };
-
-  simpleeval = callPackage ../development/python-modules/simpleeval { };
-
-  simplefin4py = callPackage ../development/python-modules/simplefin4py { };
-
-  simplefix = callPackage ../development/python-modules/simplefix { };
-
-  simplegeneric = callPackage ../development/python-modules/simplegeneric { };
-
-  simplehound = callPackage ../development/python-modules/simplehound { };
-
-  simpleitk = callPackage ../development/python-modules/simpleitk { inherit (pkgs) itk simpleitk; };
-
-  simplejson = callPackage ../development/python-modules/simplejson { };
-
-  simplekml = callPackage ../development/python-modules/simplekml { };
-
-  simplekv = callPackage ../development/python-modules/simplekv { };
-
-  simplemma = callPackage ../development/python-modules/simplemma { };
-
-  simplenote = callPackage ../development/python-modules/simplenote { };
-
-  simplepush = callPackage ../development/python-modules/simplepush { };
-
-  simplesat = callPackage ../development/python-modules/simplesat { };
-
-  simplesqlite = callPackage ../development/python-modules/simplesqlite { };
-
-  simple-dftd3 = callPackage ../development/libraries/science/chemistry/simple-dftd3/python.nix {
-    inherit (pkgs) simple-dftd3;
-  };
-
-  simple-di = callPackage ../development/python-modules/simple-di { };
-
-  simple-rest-client = callPackage ../development/python-modules/simple-rest-client { };
-
-  simple-rlp = callPackage ../development/python-modules/simple-rlp { };
-
-  simple-salesforce = callPackage ../development/python-modules/simple-salesforce { };
-
-  simple-websocket = callPackage ../development/python-modules/simple-websocket { };
-
-  simple-websocket-server = callPackage ../development/python-modules/simple-websocket-server { };
-
-  simplisafe-python = callPackage ../development/python-modules/simplisafe-python { };
-
-  simpful = callPackage ../development/python-modules/simpful { };
-
-  simpy = callPackage ../development/python-modules/simpy { };
-
-  simsimd = callPackage ../development/python-modules/simsimd { };
-
-  single-source = callPackage ../development/python-modules/single-source { };
-
-  single-version = callPackage ../development/python-modules/single-version { };
-
-  signify = callPackage ../development/python-modules/signify { };
-
-  siobrultech-protocols = callPackage ../development/python-modules/siobrultech-protocols { };
-
-  siosocks = callPackage ../development/python-modules/siosocks { };
-
-  sip = callPackage ../development/python-modules/sip { };
-
-  sip4 = callPackage ../development/python-modules/sip/4.x.nix { };
-
-  siphash24 = callPackage ../development/python-modules/siphash24 { };
-
-  siphashc = callPackage ../development/python-modules/siphashc { };
-
-  sipyco = callPackage ../development/python-modules/sipyco { };
-
-  sirius = toPythonModule (
-    pkgs.sirius.override {
-      enablePython = true;
-      pythonPackages = self;
-    }
-  );
-
-  sismic = callPackage ../development/python-modules/sismic { };
-
-  sisyphus-control = callPackage ../development/python-modules/sisyphus-control { };
-
-  siuba = callPackage ../development/python-modules/siuba { };
-
-  six = callPackage ../development/python-modules/six { };
-
-  sjcl = callPackage ../development/python-modules/sjcl { };
-
-  skein = callPackage ../development/python-modules/skein { };
-
-  skidl = callPackage ../development/python-modules/skidl { };
-
-  skl2onnx = callPackage ../development/python-modules/skl2onnx { };
-
-  sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
-
-  skodaconnect = callPackage ../development/python-modules/skodaconnect { };
-
-  skops = callPackage ../development/python-modules/skops { };
-
-  skorch = callPackage ../development/python-modules/skorch { };
-
-  skrl = callPackage ../development/python-modules/skrl { };
-
-  skybellpy = callPackage ../development/python-modules/skybellpy { };
-
-  skyboxremote = callPackage ../development/python-modules/skyboxremote { };
-
-  skyfield = callPackage ../development/python-modules/skyfield { };
-
-  skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
-
-  skytemple-eventserver = callPackage ../development/python-modules/skytemple-eventserver { };
-
-  skytemple-files = callPackage ../development/python-modules/skytemple-files { };
-
-  skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };
-
-  skytemple-rust = callPackage ../development/python-modules/skytemple-rust {
-    inherit (pkgs.darwin.apple_sdk.frameworks) Foundation;
-  };
-
-  skytemple-ssb-debugger = callPackage ../development/python-modules/skytemple-ssb-debugger { };
-
-  skytemple-ssb-emulator = callPackage ../development/python-modules/skytemple-ssb-emulator { };
-
-  slack-bolt = callPackage ../development/python-modules/slack-bolt { };
-
-  slack-sdk = callPackage ../development/python-modules/slack-sdk { };
-
-  slapd = callPackage ../development/python-modules/slapd { };
-
-  sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };
-
-  sleekxmppfs = callPackage ../development/python-modules/sleekxmppfs { };
-
-  sleepyq = callPackage ../development/python-modules/sleepyq { };
-
-  slepc4py = toPythonModule (
-    pkgs.slepc.override {
-      pythonSupport = true;
-      python3 = self.python;
-      python3Packages = self;
-      petsc = petsc4py;
-    }
-  );
-
-  sleqp = toPythonModule (
-    pkgs.sleqp.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  slicedimage = callPackage ../development/python-modules/slicedimage { };
-
-  slicer = callPackage ../development/python-modules/slicer { };
-
-  slicerator = callPackage ../development/python-modules/slicerator { };
-
-  slip10 = callPackage ../development/python-modules/slip10 { };
-
-  slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };
-
-  slimit = callPackage ../development/python-modules/slimit { };
-
-  slixmpp = callPackage ../development/python-modules/slixmpp { inherit (pkgs) gnupg; };
-
-  slob = callPackage ../development/python-modules/slob { };
-
-  slovnet = callPackage ../development/python-modules/slovnet { };
-
-  slowapi = callPackage ../development/python-modules/slowapi { };
-
-  slpp = callPackage ../development/python-modules/slpp { };
-
-  slugid = callPackage ../development/python-modules/slugid { };
-
-  py-slvs = callPackage ../development/python-modules/py-slvs { };
-
-  sly = callPackage ../development/python-modules/sly { };
-
-  smart-meter-texas = callPackage ../development/python-modules/smart-meter-texas { };
-
-  smart-open = callPackage ../development/python-modules/smart-open { };
-
-  smarthab = callPackage ../development/python-modules/smarthab { };
-
-  smartypants = callPackage ../development/python-modules/smartypants { };
-
-  smbprotocol = callPackage ../development/python-modules/smbprotocol { };
-
-  smbus-cffi = callPackage ../development/python-modules/smbus-cffi { };
-
-  smbus2 = callPackage ../development/python-modules/smbus2 { };
-
-  smdebug-rulesconfig = callPackage ../development/python-modules/smdebug-rulesconfig { };
-
-  smhi-pkg = callPackage ../development/python-modules/smhi-pkg { };
-
-  smmap = callPackage ../development/python-modules/smmap { };
-
-  smoke-zephyr = callPackage ../development/python-modules/smoke-zephyr { };
-
-  smolagents = callPackage ../development/python-modules/smolagents { };
-
-  smpplib = callPackage ../development/python-modules/smpplib { };
-
-  smpp-pdu = callPackage ../development/python-modules/smpp-pdu { };
-
-  smtpdfix = callPackage ../development/python-modules/smtpdfix { };
-
-  snack = toPythonModule (pkgs.newt.override { inherit (self) python; });
-
-  snakemake = toPythonModule (pkgs.snakemake.override { python3Packages = self; });
-
-  snakemake-executor-plugin-cluster-generic =
-    callPackage ../development/python-modules/snakemake-executor-plugin-cluster-generic
-      { };
-
-  snakemake-interface-common =
-    callPackage ../development/python-modules/snakemake-interface-common
-      { };
-
-  snakemake-interface-executor-plugins =
-    callPackage ../development/python-modules/snakemake-interface-executor-plugins
-      { };
-
-  snakemake-interface-report-plugins =
-    callPackage ../development/python-modules/snakemake-interface-report-plugins
-      { };
-
-  snakemake-interface-storage-plugins =
-    callPackage ../development/python-modules/snakemake-interface-storage-plugins
-      { };
-
-  snakemake-storage-plugin-fs =
-    callPackage ../development/python-modules/snakemake-storage-plugin-fs
-      { };
-
-  snakemake-storage-plugin-s3 =
-    callPackage ../development/python-modules/snakemake-storage-plugin-s3
-      { };
-
-  snakemake-storage-plugin-xrootd =
-    callPackage ../development/python-modules/snakemake-storage-plugin-xrootd
-      { };
-
-  snakebite = callPackage ../development/python-modules/snakebite { };
-
-  snakeviz = callPackage ../development/python-modules/snakeviz { };
-
-  snap-helpers = callPackage ../development/python-modules/snap-helpers { };
-
-  snapcast = callPackage ../development/python-modules/snapcast { };
-
-  snapshottest = callPackage ../development/python-modules/snapshottest { };
-
-  snaptime = callPackage ../development/python-modules/snaptime { };
-
-  sniffio = callPackage ../development/python-modules/sniffio { };
-
-  snitun = callPackage ../development/python-modules/snitun { };
-
-  snorkel = callPackage ../development/python-modules/snorkel { };
-
-  snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
-
-  snowflake-connector-python =
-    callPackage ../development/python-modules/snowflake-connector-python
-      { };
-
-  snowflake-sqlalchemy = callPackage ../development/python-modules/snowflake-sqlalchemy { };
-
-  snowplow-tracker = callPackage ../development/python-modules/snowplow-tracker { };
-
-  snscrape = callPackage ../development/python-modules/snscrape { };
-
-  snuggs = callPackage ../development/python-modules/snuggs { };
-
-  soapysdr = toPythonModule (
-    pkgs.soapysdr.override {
-      inherit (self) python;
-      usePython = true;
-    }
-  );
-
-  soapysdr-with-plugins = toPythonModule (
-    pkgs.soapysdr-with-plugins.override {
-      inherit (self) python;
-      usePython = true;
-    }
-  );
-
-  socketio-client = callPackage ../development/python-modules/socketio-client { };
-
-  social-auth-app-django = callPackage ../development/python-modules/social-auth-app-django { };
-
-  social-auth-core = callPackage ../development/python-modules/social-auth-core { };
-
-  socialscan = callPackage ../development/python-modules/socialscan { };
-
-  socid-extractor = callPackage ../development/python-modules/socid-extractor { };
-
-  sockio = callPackage ../development/python-modules/sockio { };
-
-  sockjs = callPackage ../development/python-modules/sockjs { };
-
-  sockjs-tornado = callPackage ../development/python-modules/sockjs-tornado { };
-
-  socksio = callPackage ../development/python-modules/socksio { };
-
-  socksipy-branch = callPackage ../development/python-modules/socksipy-branch { };
-
-  soco = callPackage ../development/python-modules/soco { };
-
-  softlayer = callPackage ../development/python-modules/softlayer { };
-
-  solarlog-cli = callPackage ../development/python-modules/solarlog-cli { };
-
-  solax = callPackage ../development/python-modules/solax { };
-
-  solc-select = callPackage ../development/python-modules/solc-select { };
-
-  solidpython2 = callPackage ../development/python-modules/solidpython2 { };
-
-  solo-python = disabledIf (!pythonAtLeast "3.6") (
-    callPackage ../development/python-modules/solo-python { }
-  );
-
-  somajo = callPackage ../development/python-modules/somajo { };
-
-  somfy-mylink-synergy = callPackage ../development/python-modules/somfy-mylink-synergy { };
-
-  somweb = callPackage ../development/python-modules/somweb { };
-
-  sonos-websocket = callPackage ../development/python-modules/sonos-websocket { };
-
-  sopel = callPackage ../development/python-modules/sopel { };
-
-  sorl-thumbnail = callPackage ../development/python-modules/sorl-thumbnail { };
-
-  sortedcollections = callPackage ../development/python-modules/sortedcollections { };
-
-  sortedcontainers = callPackage ../development/python-modules/sortedcontainers { };
-
-  sotabenchapi = callPackage ../development/python-modules/sotabenchapi { };
-
-  soundcard = callPackage ../development/python-modules/soundcard { };
-
-  soundcloud-v2 = callPackage ../development/python-modules/soundcloud-v2 { };
-
-  sounddevice = callPackage ../development/python-modules/sounddevice { };
-
-  soundfile = callPackage ../development/python-modules/soundfile { };
-
-  soupsieve = callPackage ../development/python-modules/soupsieve { };
-
-  sourmash = callPackage ../development/python-modules/sourmash { };
-
-  soxr = callPackage ../development/python-modules/soxr { libsoxr = pkgs.soxr; };
-
-  spacy = callPackage ../development/python-modules/spacy {
-    # fix error: ‘_PyCFrame’ has no member named ‘use_tracing’
-    # see: https://aur.archlinux.org/packages/python-spacy
-    cython_0 = cython_0.overridePythonAttrs (old: rec {
-      version = "0.29.37";
-      src = pkgs.fetchPypi {
-        pname = "Cython";
-        inherit version;
-        hash = "sha256-+BPUpt2Ure5dT/JmGR0dlb9tQWSk+sxTVCLAIbJQTPs=";
-      };
-    });
-  };
-
-  spacy-alignments = callPackage ../development/python-modules/spacy-alignments { };
-
-  spacy-curated-transformers =
-    callPackage ../development/python-modules/spacy-curated-transformers
-      { };
-
-  spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
-
-  spacy-loggers = callPackage ../development/python-modules/spacy-loggers { };
-
-  spacy-lookups-data = callPackage ../development/python-modules/spacy/lookups-data.nix { };
-
-  spacy-models = callPackage ../development/python-modules/spacy/models.nix { inherit (pkgs) jq; };
-
-  spacy-pkuseg = callPackage ../development/python-modules/spacy-pkuseg { };
-
-  spacy-transformers = callPackage ../development/python-modules/spacy-transformers { };
-
-  spake2 = callPackage ../development/python-modules/spake2 { };
-
-  spark-parser = callPackage ../development/python-modules/spark-parser { };
-
-  sparklines = callPackage ../development/python-modules/sparklines { };
-
-  sparqlwrapper = callPackage ../development/python-modules/sparqlwrapper { };
-
-  sparse = callPackage ../development/python-modules/sparse { };
-
-  sparsezoo = callPackage ../development/python-modules/sparsezoo { };
-
-  spatial-image = callPackage ../development/python-modules/spatial-image { };
-
-  spatialmath-python = callPackage ../development/python-modules/spatialmath-python { };
-
-  spdx = callPackage ../development/python-modules/spdx { };
-
-  spdx-lookup = callPackage ../development/python-modules/spdx-lookup { };
-
-  spdx-tools = callPackage ../development/python-modules/spdx-tools { };
-
-  speaklater = callPackage ../development/python-modules/speaklater { };
-
-  speaklater3 = callPackage ../development/python-modules/speaklater3 { };
-
-  spectra = callPackage ../development/python-modules/spectra { };
-
-  spectral-cube = callPackage ../development/python-modules/spectral-cube { };
-
-  speechbrain = callPackage ../development/python-modules/speechbrain { };
-
-  speechrecognition = callPackage ../development/python-modules/speechrecognition { };
-
-  speedtest-cli = callPackage ../development/python-modules/speedtest-cli { };
-
-  speg = callPackage ../development/python-modules/speg { };
-
-  spglib = callPackage ../development/python-modules/spglib { };
-
-  sphfile = callPackage ../development/python-modules/sphfile { };
-
-  spiderpy = callPackage ../development/python-modules/spiderpy { };
-
-  spinners = callPackage ../development/python-modules/spinners { };
-
-  sphinx-automodapi = callPackage ../development/python-modules/sphinx-automodapi {
-    graphviz = pkgs.graphviz;
-  };
-
-  sphinx-better-theme = callPackage ../development/python-modules/sphinx-better-theme { };
-
-  sphinx-book-theme = callPackage ../development/python-modules/sphinx-book-theme { };
-
-  sphinx-click = callPackage ../development/python-modules/sphinx-click { };
-
-  sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
-
-  sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };
-
-  sphinxcontrib-images = callPackage ../development/python-modules/sphinxcontrib-images { };
-
-  sphinx-design = callPackage ../development/python-modules/sphinx-design { };
-
-  sphinx-external-toc = callPackage ../development/python-modules/sphinx-external-toc { };
-
-  sphinx-favicon = callPackage ../development/python-modules/sphinx-favicon { };
-
-  sphinx-fortran = callPackage ../development/python-modules/sphinx-fortran { };
-
-  sphinx-hoverxref = callPackage ../development/python-modules/sphinx-hoverxref { };
-
-  sphinx-intl = callPackage ../development/python-modules/sphinx-intl { };
-
-  sphinx-jupyterbook-latex = callPackage ../development/python-modules/sphinx-jupyterbook-latex { };
-
-  sphinx-lv2-theme = callPackage ../development/python-modules/sphinx-lv2-theme { };
-
-  sphinx-multitoc-numbering = callPackage ../development/python-modules/sphinx-multitoc-numbering { };
-
-  sphinx-multiversion = callPackage ../development/python-modules/sphinx-multiversion { };
-
-  sphinx-notfound-page = callPackage ../development/python-modules/sphinx-notfound-page { };
-
-  sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
-
-  sphinx-prompt = callPackage ../development/python-modules/sphinx-prompt { };
-
-  sphinx-sitemap = callPackage ../development/python-modules/sphinx-sitemap { };
-
-  sphinx-thebe = callPackage ../development/python-modules/sphinx-thebe { };
-
-  sphinx-tabs = callPackage ../development/python-modules/sphinx-tabs { };
-
-  sphinx-togglebutton = callPackage ../development/python-modules/sphinx-togglebutton { };
-
-  sphinx-versions = callPackage ../development/python-modules/sphinx-versions { };
-
-  sphinxawesome-theme = callPackage ../development/python-modules/sphinxawesome-theme { };
-
-  sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };
-
-  sphinxcontrib-apidoc = callPackage ../development/python-modules/sphinxcontrib-apidoc { };
-
-  sphinxcontrib-applehelp = callPackage ../development/python-modules/sphinxcontrib-applehelp { };
-
-  sphinxcontrib-asyncio = callPackage ../development/python-modules/sphinxcontrib-asyncio { };
-
-  sphinx-autoapi = callPackage ../development/python-modules/sphinx-autoapi { };
-
-  sphinxcontrib-bayesnet = callPackage ../development/python-modules/sphinxcontrib-bayesnet { };
-
-  sphinxcontrib-bibtex = callPackage ../development/python-modules/sphinxcontrib-bibtex { };
-
-  sphinxcontrib-blockdiag = callPackage ../development/python-modules/sphinxcontrib-blockdiag { };
-
-  sphinxcontrib-confluencebuilder =
-    callPackage ../development/python-modules/sphinxcontrib-confluencebuilder
-      { };
-
-  sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp { };
-
-  sphinxcontrib-ditaa = callPackage ../development/python-modules/sphinxcontrib-ditaa { };
-
-  sphinxcontrib-excel-table = callPackage ../development/python-modules/sphinxcontrib-excel-table { };
-
-  sphinxcontrib-fulltoc = callPackage ../development/python-modules/sphinxcontrib-fulltoc { };
-
-  sphinxcontrib-htmlhelp = callPackage ../development/python-modules/sphinxcontrib-htmlhelp { };
-
-  sphinxcontrib-httpdomain = callPackage ../development/python-modules/sphinxcontrib-httpdomain { };
-
-  sphinxcontrib-jinjadomain = callPackage ../development/python-modules/sphinxcontrib-jinjadomain { };
-
-  sphinxcontrib-jquery = callPackage ../development/python-modules/sphinxcontrib-jquery { };
-
-  sphinxcontrib-jsmath = callPackage ../development/python-modules/sphinxcontrib-jsmath { };
-
-  sphinxcontrib-katex = callPackage ../development/python-modules/sphinxcontrib-katex { };
-
-  sphinxcontrib-mscgen = callPackage ../development/python-modules/sphinxcontrib-mscgen {
-    inherit (pkgs) mscgen;
-  };
-
-  sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
-
-  sphinxcontrib-moderncmakedomain =
-    callPackage ../development/python-modules/sphinxcontrib-moderncmakedomain
-      { };
-
-  sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
-
-  sphinxcontrib-newsfeed = callPackage ../development/python-modules/sphinxcontrib-newsfeed { };
-
-  sphinxcontrib-openapi = callPackage ../development/python-modules/sphinxcontrib-openapi { };
-
-  sphinxcontrib-plantuml = callPackage ../development/python-modules/sphinxcontrib-plantuml {
-    inherit (pkgs) plantuml;
-  };
-
-  sphinxcontrib-programoutput =
-    callPackage ../development/python-modules/sphinxcontrib-programoutput
-      { };
-
-  sphinxcontrib-qthelp = callPackage ../development/python-modules/sphinxcontrib-qthelp { };
-
-  sphinxcontrib-serializinghtml =
-    callPackage ../development/python-modules/sphinxcontrib-serializinghtml
-      { };
-
-  sphinxcontrib-seqdiag = callPackage ../development/python-modules/sphinxcontrib-seqdiag { };
-
-  sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
-
-  sphinxcontrib-svg2pdfconverter =
-    callPackage ../development/python-modules/sphinxcontrib-svg2pdfconverter
-      { };
-
-  sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz { };
-
-  sphinxcontrib-wavedrom = callPackage ../development/python-modules/sphinxcontrib-wavedrom { };
-
-  sphinxcontrib-websupport = callPackage ../development/python-modules/sphinxcontrib-websupport { };
-
-  sphinxcontrib-youtube = callPackage ../development/python-modules/sphinxcontrib-youtube { };
-
-  sphinx = callPackage ../development/python-modules/sphinx { };
-
-  sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
-
-  sphinx-autobuild = callPackage ../development/python-modules/sphinx-autobuild { };
-
-  sphinx-autodoc-typehints = callPackage ../development/python-modules/sphinx-autodoc-typehints { };
-
-  sphinx-autodoc2 = callPackage ../development/python-modules/sphinx-autodoc2 { };
-
-  sphinx-basic-ng = callPackage ../development/python-modules/sphinx-basic-ng { };
-
-  sphinx-copybutton = callPackage ../development/python-modules/sphinx-copybutton { };
-
-  sphinxemoji = callPackage ../development/python-modules/sphinxemoji { };
-
-  sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
-
-  sphinx-issues = callPackage ../development/python-modules/sphinx-issues { };
-
-  sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
-
-  sphinx-markdown-builder = callPackage ../development/python-modules/sphinx-markdown-builder { };
-
-  sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };
-
-  sphinx-markdown-tables = callPackage ../development/python-modules/sphinx-markdown-tables { };
-
-  sphinx-material = callPackage ../development/python-modules/sphinx-material { };
-
-  sphinx-mdinclude = callPackage ../development/python-modules/sphinx-mdinclude { };
-
-  sphinx-rtd-dark-mode = callPackage ../development/python-modules/sphinx-rtd-dark-mode { };
-
-  sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };
-
-  sphinx-serve = callPackage ../development/python-modules/sphinx-serve { };
-
-  sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
-
-  sphinx-version-warning = callPackage ../development/python-modules/sphinx-version-warning { };
-
-  sphinxext-opengraph = callPackage ../development/python-modules/sphinxext-opengraph { };
-
-  sphinxext-rediraffe = callPackage ../development/python-modules/sphinxext-rediraffe { };
-
-  spidev = callPackage ../development/python-modules/spidev { };
-
-  splinter = callPackage ../development/python-modules/splinter { };
-
-  splunk-sdk = callPackage ../development/python-modules/splunk-sdk { };
-
-  spotifyaio = callPackage ../development/python-modules/spotifyaio { };
-
-  spotipy = callPackage ../development/python-modules/spotipy { };
-
-  spsdk = callPackage ../development/python-modules/spsdk { };
-
-  spur = callPackage ../development/python-modules/spur { };
-
-  spyder = callPackage ../development/python-modules/spyder { };
-
-  spyder-kernels = callPackage ../development/python-modules/spyder-kernels { };
-
-  spylls = callPackage ../development/python-modules/spylls { };
-
-  spyse-python = callPackage ../development/python-modules/spyse-python { };
-
-  spython = callPackage ../development/python-modules/spython { };
-
-  sqids = callPackage ../development/python-modules/sqids { };
-
-  sqlalchemy = callPackage ../development/python-modules/sqlalchemy { };
-
-  sqlalchemy_1_4 = callPackage ../development/python-modules/sqlalchemy/1_4.nix { };
-
-  sqlalchemy-citext = callPackage ../development/python-modules/sqlalchemy-citext { };
-
-  sqlalchemy-continuum = callPackage ../development/python-modules/sqlalchemy-continuum { };
-
-  sqlalchemy-file = callPackage ../development/python-modules/sqlalchemy-file { };
-
-  sqlalchemy-i18n = callPackage ../development/python-modules/sqlalchemy-i18n { };
-
-  sqlalchemy-json = callPackage ../development/python-modules/sqlalchemy-json { };
-
-  sqlalchemy-jsonfield = callPackage ../development/python-modules/sqlalchemy-jsonfield { };
-
-  sqlalchemy-mixins = callPackage ../development/python-modules/sqlalchemy-mixins { };
-
-  sqlalchemy-utils = callPackage ../development/python-modules/sqlalchemy-utils { };
-
-  sqlalchemy-views = callPackage ../development/python-modules/sqlalchemy-views { };
-
-  sqlbag = callPackage ../development/python-modules/sqlbag { };
-
-  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 { };
-  sqlcipher3-binary = callPackage ../development/python-modules/sqlcipher3-binary { };
-  sqlcipher3-wheels = callPackage ../development/python-modules/sqlcipher3-wheels { };
-
-  sqlfmt = callPackage ../development/python-modules/sqlfmt { };
-
-  sqlglot = callPackage ../development/python-modules/sqlglot { };
-
-  sqlite-anyio = callPackage ../development/python-modules/sqlite-anyio { };
-
-  sqlitedict = callPackage ../development/python-modules/sqlitedict { };
-
-  sqlite-migrate = callPackage ../development/python-modules/sqlite-migrate { };
-
-  sqlite-fts4 = callPackage ../development/python-modules/sqlite-fts4 { };
-
-  sqlite-utils = callPackage ../development/python-modules/sqlite-utils { };
-
-  sqliteschema = callPackage ../development/python-modules/sqliteschema { };
-
-  sqlmap = callPackage ../development/python-modules/sqlmap { };
-
-  sqlmodel = callPackage ../development/python-modules/sqlmodel { };
-
-  sqlobject = callPackage ../development/python-modules/sqlobject { };
-
-  sqlparse = callPackage ../development/python-modules/sqlparse { };
-
-  sqltrie = callPackage ../development/python-modules/sqltrie { };
-
-  squarify = callPackage ../development/python-modules/squarify { };
-
-  sre-yield = callPackage ../development/python-modules/sre-yield { };
-
-  srp = callPackage ../development/python-modules/srp { };
-
-  srpenergy = callPackage ../development/python-modules/srpenergy { };
-
-  srptools = callPackage ../development/python-modules/srptools { };
-
-  srsly = callPackage ../development/python-modules/srsly { };
-
-  srt = callPackage ../development/python-modules/srt { };
-
-  srvlookup = callPackage ../development/python-modules/srvlookup { };
-
-  ssdeep = callPackage ../development/python-modules/ssdeep { inherit (pkgs) ssdeep; };
-
-  ssdp = callPackage ../development/python-modules/ssdp { };
-
-  ssdpy = callPackage ../development/python-modules/ssdpy { };
-
-  sseclient = callPackage ../development/python-modules/sseclient { };
-
-  sseclient-py = callPackage ../development/python-modules/sseclient-py { };
-
-  sse-starlette = callPackage ../development/python-modules/sse-starlette { };
-
-  sshfs = callPackage ../development/python-modules/sshfs { };
-
-  sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
-
-  sshtunnel = callPackage ../development/python-modules/sshtunnel { };
-
-  ssh-python = callPackage ../development/python-modules/ssh-python { };
-
-  ssh2-python = callPackage ../development/python-modules/ssh2-python { };
-
-  sslib = callPackage ../development/python-modules/sslib { };
-
-  ssg = callPackage ../development/python-modules/ssg { };
-
-  ssort = callPackage ../development/python-modules/ssort { };
-
-  stable-baselines3 = callPackage ../development/python-modules/stable-baselines3 { };
-
-  stack-data = callPackage ../development/python-modules/stack-data { };
-
-  stamina = callPackage ../development/python-modules/stamina { };
-
-  stanio = callPackage ../development/python-modules/stanio { };
-
-  stanza = callPackage ../development/python-modules/stanza { };
-
-  starlette = callPackage ../development/python-modules/starlette { };
-
-  starlette-admin = callPackage ../development/python-modules/starlette-admin { };
-
-  starlette-context = callPackage ../development/python-modules/starlette-context { };
-
-  starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };
-
-  starkbank-ecdsa = callPackage ../development/python-modules/starkbank-ecdsa { };
-
-  starline = callPackage ../development/python-modules/starline { };
-
-  stashy = callPackage ../development/python-modules/stashy { };
-
-  static3 = callPackage ../development/python-modules/static3 { };
-
-  staticmap = callPackage ../development/python-modules/staticmap { };
-
-  staticjinja = callPackage ../development/python-modules/staticjinja { };
-
-  statistics = callPackage ../development/python-modules/statistics { };
-
-  statmake = callPackage ../development/python-modules/statmake { };
-
-  statsd = callPackage ../development/python-modules/statsd { };
-
-  statsmodels = callPackage ../development/python-modules/statsmodels { };
-
-  std-uritemplate = callPackage ../development/python-modules/std-uritemplate { };
-
-  std2 = callPackage ../development/python-modules/std2 { };
-
-  stdiomask = callPackage ../development/python-modules/stdiomask { };
-
-  stdlib-list = callPackage ../development/python-modules/stdlib-list { };
-
-  stdlibs = callPackage ../development/python-modules/stdlibs { };
-
-  steamodd = callPackage ../development/python-modules/steamodd { };
-
-  steamship = callPackage ../development/python-modules/steamship { };
-
-  stem = callPackage ../development/python-modules/stem { };
-
-  stemming = callPackage ../development/python-modules/stemming { };
-
-  stestr = callPackage ../development/python-modules/stestr { };
-
-  stevedore = callPackage ../development/python-modules/stevedore { };
-
-  stickytape = callPackage ../development/python-modules/stickytape { };
-
-  stim = callPackage ../development/python-modules/stim { };
-
-  stix2 = callPackage ../development/python-modules/stix2 { };
-
-  stix2-patterns = callPackage ../development/python-modules/stix2-patterns { };
-
-  stix2-validator = callPackage ../development/python-modules/stix2-validator { };
-
-  stm32loader = callPackage ../development/python-modules/stm32loader { };
-
-  standard-aifc =
-    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-aifc { } else null;
-
-  standard-chunk =
-    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-chunk { } else null;
-
-  standard-imghdr =
-    if pythonAtLeast "3.13" then
-      callPackage ../development/python-modules/standard-imghdr { }
-    else
-      null;
-
-  standard-pipes =
-    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-pipes { } else null;
-
-  standard-sunau =
-    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-sunau { } else null;
-
-  standard-telnetlib =
-    if pythonAtLeast "3.13" then
-      callPackage ../development/python-modules/standard-telnetlib { }
-    else
-      null;
-
-  standardwebhooks = callPackage ../development/python-modules/standardwebhooks { };
-
-  stone = callPackage ../development/python-modules/stone { };
-
-  stookalert = callPackage ../development/python-modules/stookalert { };
-
-  stookwijzer = callPackage ../development/python-modules/stookwijzer { };
-
-  stopit = callPackage ../development/python-modules/stopit { };
-
-  stop-words = callPackage ../development/python-modules/stop-words { };
-
-  stp = toPythonModule (pkgs.stp.override { python3 = self.python; });
-
-  stransi = callPackage ../development/python-modules/stransi { };
-
-  strategies = callPackage ../development/python-modules/strategies { };
-
-  stravalib = callPackage ../development/python-modules/stravalib { };
-
-  stravaweblib = callPackage ../development/python-modules/stravaweblib { };
-
-  strawberry-graphql = callPackage ../development/python-modules/strawberry-graphql { };
-
-  strawberry-django = callPackage ../development/python-modules/strawberry-django { };
-
-  strct = callPackage ../development/python-modules/strct { };
-
-  streamcontroller-plugin-tools =
-    callPackage ../development/python-modules/streamcontroller-plugin-tools
-      { };
-
-  streamdeck = callPackage ../development/python-modules/streamdeck { };
-
-  streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
-
-  streamlabswater = callPackage ../development/python-modules/streamlabswater { };
-
-  streamlit = callPackage ../development/python-modules/streamlit { };
-
-  streamz = callPackage ../development/python-modules/streamz { };
-
-  strenum = callPackage ../development/python-modules/strenum { };
-
-  strict-rfc3339 = callPackage ../development/python-modules/strict-rfc3339 { };
-
-  strictyaml = callPackage ../development/python-modules/strictyaml { };
-
-  stringbrewer = callPackage ../development/python-modules/stringbrewer { };
-
-  stringcase = callPackage ../development/python-modules/stringcase { };
-
-  stringly = callPackage ../development/python-modules/stringly { };
-
-  stringparser = callPackage ../development/python-modules/stringparser { };
-
-  stringzilla = callPackage ../development/python-modules/stringzilla { };
-
-  strip-ansi = callPackage ../development/python-modules/strip-ansi { };
-
-  stripe = callPackage ../development/python-modules/stripe { };
-
-  striprtf = callPackage ../development/python-modules/striprtf { };
-
-  strpdatetime = callPackage ../development/python-modules/strpdatetime { };
-
-  structlog = callPackage ../development/python-modules/structlog { };
-
-  stubserver = callPackage ../development/python-modules/stubserver { };
-
-  stumpy = callPackage ../development/python-modules/stumpy { };
-
-  stupidartnet = callPackage ../development/python-modules/stupidartnet { };
-
-  stups-cli-support = callPackage ../development/python-modules/stups-cli-support { };
-
-  stups-fullstop = callPackage ../development/python-modules/stups-fullstop { };
-
-  stups-pierone = callPackage ../development/python-modules/stups-pierone { };
-
-  stups-tokens = callPackage ../development/python-modules/stups-tokens { };
-
-  stups-zign = callPackage ../development/python-modules/stups-zign { };
-
-  stytra = callPackage ../development/python-modules/stytra { };
-
-  subarulink = callPackage ../development/python-modules/subarulink { };
-
-  subliminal = callPackage ../development/python-modules/subliminal { };
-
-  submitit = callPackage ../development/python-modules/submitit { };
-
-  subprocess-tee = callPackage ../development/python-modules/subprocess-tee { };
-
-  subunit = callPackage ../development/python-modules/subunit {
-    inherit (pkgs) subunit cppunit check;
-  };
-
-  subunit2sql = callPackage ../development/python-modules/subunit2sql { };
-
-  subzerod = callPackage ../development/python-modules/subzerod { };
-
-  succulent = callPackage ../development/python-modules/succulent { };
-
-  sudachidict-core = callPackage ../development/python-modules/sudachidict { };
-
-  sudachidict-full = callPackage ../development/python-modules/sudachidict {
-    sudachidict = pkgs.sudachidict.override { dict-type = "full"; };
-  };
-
-  sudachidict-small = callPackage ../development/python-modules/sudachidict {
-    sudachidict = pkgs.sudachidict.override { dict-type = "small"; };
-  };
-
-  sudachipy = callPackage ../development/python-modules/sudachipy { };
-
-  suds = callPackage ../development/python-modules/suds { };
-
-  suds-community = callPackage ../development/python-modules/suds-community { };
-
-  sumo = callPackage ../development/python-modules/sumo { };
-
-  sumtypes = callPackage ../development/python-modules/sumtypes { };
-
-  summarytools = callPackage ../development/python-modules/summarytools { };
-
-  sunpy = callPackage ../development/python-modules/sunpy { };
-
-  sunwatcher = callPackage ../development/python-modules/sunwatcher { };
-
-  sunweg = callPackage ../development/python-modules/sunweg { };
-
-  supervise-api = callPackage ../development/python-modules/supervise-api { };
-
-  supervisor = callPackage ../development/python-modules/supervisor { };
-
-  superqt = callPackage ../development/python-modules/superqt { };
-
-  sure = callPackage ../development/python-modules/sure { };
-
-  surepy = callPackage ../development/python-modules/surepy { };
-
-  surt = callPackage ../development/python-modules/surt { };
-
-  survey = callPackage ../development/python-modules/survey { };
-
-  svg2tikz = callPackage ../development/python-modules/svg2tikz { };
-
-  svglib = callPackage ../development/python-modules/svglib { };
-
-  svg-path = callPackage ../development/python-modules/svg-path { };
-
-  svg-py = callPackage ../development/python-modules/svg-py { };
-
-  svgelements = callPackage ../development/python-modules/svgelements { };
-
-  svgutils = callPackage ../development/python-modules/svgutils { };
-
-  svgwrite = callPackage ../development/python-modules/svgwrite { };
-
-  sv-ttk = callPackage ../development/python-modules/sv-ttk { };
-
-  swagger-spec-validator = callPackage ../development/python-modules/swagger-spec-validator { };
-
-  swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
-
-  switchbot-api = callPackage ../development/python-modules/switchbot-api { };
-
-  swift = callPackage ../development/python-modules/swift { };
-
-  swifter = callPackage ../development/python-modules/swifter { };
-
-  swisshydrodata = callPackage ../development/python-modules/swisshydrodata { };
-
-  swspotify = callPackage ../development/python-modules/swspotify { };
-
-  sybil = callPackage ../development/python-modules/sybil { };
-
-  symbolic = callPackage ../development/python-modules/symbolic { };
-
-  symengine = callPackage ../development/python-modules/symengine { inherit (pkgs) symengine; };
-
-  symfc = callPackage ../development/python-modules/symfc { };
-
-  sympy = callPackage ../development/python-modules/sympy { };
-
-  symspellpy = callPackage ../development/python-modules/symspellpy { };
-
-  syncedlyrics = callPackage ../development/python-modules/syncedlyrics { };
-
-  syncer = callPackage ../development/python-modules/syncer { };
-
-  syndication-domination = toPythonModule (
-    pkgs.syndication-domination.override {
-      enablePython = true;
-      python3Packages = self;
-    }
-  );
-
-  synergy = callPackage ../development/python-modules/synergy { };
-
-  syslog-rfc5424-formatter = callPackage ../development/python-modules/syslog-rfc5424-formatter { };
-
-  sysrsync = callPackage ../development/python-modules/sysrsync { };
-
-  systembridge = callPackage ../development/python-modules/systembridge { };
-
-  systembridgeconnector = callPackage ../development/python-modules/systembridgeconnector { };
-
-  systembridgemodels = callPackage ../development/python-modules/systembridgemodels { };
-
-  systemd = callPackage ../development/python-modules/systemd { inherit (pkgs) systemd; };
-
-  systemdunitparser = callPackage ../development/python-modules/systemdunitparser { };
-
-  sysv-ipc = callPackage ../development/python-modules/sysv-ipc { };
-
-  syrupy = callPackage ../development/python-modules/syrupy { };
-
-  tabcmd = callPackage ../development/python-modules/tabcmd { };
-
-  tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
-
-  tableauserverclient = callPackage ../development/python-modules/tableauserverclient { };
-
-  tabledata = callPackage ../development/python-modules/tabledata { };
-
-  tables = callPackage ../development/python-modules/tables { };
-
-  tablib = callPackage ../development/python-modules/tablib { };
-
-  tabula-py = callPackage ../development/python-modules/tabula-py { };
-
-  tabulate = callPackage ../development/python-modules/tabulate { };
-
-  tabview = callPackage ../development/python-modules/tabview { };
-
-  taco = toPythonModule (
-    pkgs.taco.override {
-      inherit (self) python;
-      enablePython = true;
-    }
-  );
-
-  tadasets = callPackage ../development/python-modules/tadasets { };
-
-  tag-expressions = callPackage ../development/python-modules/tag-expressions { };
-
-  tago = callPackage ../development/python-modules/tago { };
-
-  tagoio-sdk = callPackage ../development/python-modules/tagoio-sdk { };
-
-  tahoma-api = callPackage ../development/python-modules/tahoma-api { };
-
-  tailer = callPackage ../development/python-modules/tailer { };
-
-  tailscale = callPackage ../development/python-modules/tailscale { };
-
-  takethetime = callPackage ../development/python-modules/takethetime { };
-
-  tank-utility = callPackage ../development/python-modules/tank-utility { };
-
-  tappy = callPackage ../development/python-modules/tappy { };
-
-  tasklib = callPackage ../development/python-modules/tasklib { };
-
-  taskw = callPackage ../development/python-modules/taskw { };
-
-  taskw-ng = callPackage ../development/python-modules/taskw-ng { };
-
-  tatsu = callPackage ../development/python-modules/tatsu { };
-
-  tatsu-lts = callPackage ../development/python-modules/tatsu-lts { };
-
-  taxi = callPackage ../development/python-modules/taxi { };
-
-  taxii2-client = callPackage ../development/python-modules/taxii2-client { };
-
-  tbats = callPackage ../development/python-modules/tbats { };
-
-  tblib = callPackage ../development/python-modules/tblib { };
-
-  tblite = callPackage ../development/libraries/science/chemistry/tblite/python.nix {
-    inherit (pkgs) tblite meson simple-dftd3;
-  };
-
-  tbm-utils = callPackage ../development/python-modules/tbm-utils { };
-
-  tcolorpy = callPackage ../development/python-modules/tcolorpy { };
-
-  tcxfile = callPackage ../development/python-modules/tcxfile { };
-
-  tcxparser = callPackage ../development/python-modules/tcxparser { };
-
-  tcxreader = callPackage ../development/python-modules/tcxreader { };
-
-  tdir = callPackage ../development/python-modules/tdir { };
-
-  teamcity-messages = callPackage ../development/python-modules/teamcity-messages { };
-
-  telegraph = callPackage ../development/python-modules/telegraph { };
-
-  telepath = callPackage ../development/python-modules/telepath { };
-
-  telethon = callPackage ../development/python-modules/telethon { inherit (pkgs) openssl; };
-
-  telethon-session-sqlalchemy =
-    callPackage ../development/python-modules/telethon-session-sqlalchemy
-      { };
-
-  teletype = callPackage ../development/python-modules/teletype { };
-
-  telfhash = callPackage ../development/python-modules/telfhash { };
-
-  telegram-text = callPackage ../development/python-modules/telegram-text { };
-
-  temescal = callPackage ../development/python-modules/temescal { };
-
-  temperusb = callPackage ../development/python-modules/temperusb { };
-
-  tempest = callPackage ../development/python-modules/tempest { };
-
-  templateflow = callPackage ../development/python-modules/templateflow { };
-
-  tempman = callPackage ../development/python-modules/tempman { };
-
-  tempora = callPackage ../development/python-modules/tempora { };
-
-  tenacity = callPackage ../development/python-modules/tenacity { };
-
-  tenant-schemas-celery = callPackage ../development/python-modules/tenant-schemas-celery { };
-
-  tencentcloud-sdk-python = callPackage ../development/python-modules/tencentcloud-sdk-python { };
-
-  tendo = callPackage ../development/python-modules/tendo { };
-
-  tensorboard-data-server = callPackage ../development/python-modules/tensorboard-data-server { };
-
-  tensorboard-plugin-profile =
-    callPackage ../development/python-modules/tensorboard-plugin-profile
-      { };
-
-  tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit { };
-
-  tensorboard = callPackage ../development/python-modules/tensorboard { };
-
-  tensorboardx = callPackage ../development/python-modules/tensorboardx { };
-
-  tensordict = callPackage ../development/python-modules/tensordict { };
-
-  tensorflow-bin = callPackage ../development/python-modules/tensorflow/bin.nix {
-    inherit (pkgs.config) cudaSupport;
-    # https://www.tensorflow.org/install/source#gpu
-    cudaPackages = pkgs.cudaPackages_12;
-  };
-
-  tensorflow-build =
-    let
-      compat = rec {
-        protobufTF = pkgs.protobuf_21.override { abseil-cpp = pkgs.abseil-cpp_202301; };
-        # https://www.tensorflow.org/install/source#gpu
-        cudaPackagesTF = pkgs.cudaPackages_11;
-        grpcTF =
-          (pkgs.grpc.overrideAttrs (oldAttrs: rec {
-            # nvcc fails on recent grpc versions, so we use the latest patch level
-            #  of the grpc version bundled by upstream tensorflow to allow CUDA
-            #  support
-            version = "1.27.3";
-            src = pkgs.fetchFromGitHub {
-              owner = "grpc";
-              repo = "grpc";
-              rev = "v${version}";
-              hash = "sha256-PpiOT4ZJe1uMp5j+ReQulC9jpT0xoR2sAl6vRYKA0AA=";
-              fetchSubmodules = true;
-            };
-            patches = [ ];
-            postPatch = ''
-              sed -i "s/-std=c++11/-std=c++17/" CMakeLists.txt
-              echo "set(CMAKE_CXX_STANDARD 17)" >> CMakeLists.txt
-            '';
-          })).override
-            { protobuf = protobufTF; };
-        protobuf-pythonTF = self.protobuf4.override { protobuf = protobufTF; };
-        grpcioTF = self.grpcio.override { protobuf = protobufTF; };
-        tensorboardTF = self.tensorboard.override {
-          grpcio = grpcioTF;
-          protobuf = protobuf-pythonTF;
-        };
-      };
-    in
-    callPackage ../development/python-modules/tensorflow {
-      inherit (pkgs.config) cudaSupport;
-      inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
-      flatbuffers-core = pkgs.flatbuffers;
-      flatbuffers-python = self.flatbuffers;
-      cudaPackages = compat.cudaPackagesTF;
-      protobuf-core = compat.protobufTF;
-      protobuf-python = compat.protobuf-pythonTF;
-      grpc = compat.grpcTF;
-      grpcio = compat.grpcioTF;
-      tensorboard = compat.tensorboardTF;
-      abseil-cpp = pkgs.abseil-cpp_202301;
-
-      # Tensorflow 2.13 doesn't support gcc13:
-      # https://github.com/tensorflow/tensorflow/issues/61289
-      #
-      # We use the nixpkgs' default libstdc++ to stay compatible with other
-      # python modules
-      stdenv = pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv;
-    };
-
-  tensorflow-datasets = callPackage ../development/python-modules/tensorflow-datasets { };
-
-  tensorflow-estimator-bin =
-    callPackage ../development/python-modules/tensorflow-estimator/bin.nix
-      { };
-
-  tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
-
-  tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
-
-  tensorflow = self.tensorflow-bin;
-
-  tensorflowWithCuda = self.tensorflow.override { cudaSupport = true; };
-
-  tensorflowWithoutCuda = self.tensorflow.override { cudaSupport = false; };
-
-  tensorly = callPackage ../development/python-modules/tensorly { };
-
-  tensorrt = callPackage ../development/python-modules/tensorrt {
-    cudaPackages = pkgs.cudaPackages_11;
-  };
-
-  tensorstore = callPackage ../development/python-modules/tensorstore { };
-
-  tellduslive = callPackage ../development/python-modules/tellduslive { };
-
-  term-image = callPackage ../development/python-modules/term-image { };
-
-  termcolor = callPackage ../development/python-modules/termcolor { };
-
-  termgraph = callPackage ../development/python-modules/termgraph { };
-
-  terminado = callPackage ../development/python-modules/terminado { };
-
-  terminaltables = callPackage ../development/python-modules/terminaltables { };
-
-  terminaltables3 = callPackage ../development/python-modules/terminaltables3 { };
-
-  terminaltexteffects = callPackage ../development/python-modules/terminaltexteffects { };
-
-  termplotlib = callPackage ../development/python-modules/termplotlib { };
-
-  termstyle = callPackage ../development/python-modules/termstyle { };
-
-  tern = callPackage ../development/python-modules/tern { };
-
-  tesla-fleet-api = callPackage ../development/python-modules/tesla-fleet-api { };
-
-  tesla-powerwall = callPackage ../development/python-modules/tesla-powerwall { };
-
-  tesla-wall-connector = callPackage ../development/python-modules/tesla-wall-connector { };
-
-  teslajsonpy = callPackage ../development/python-modules/teslajsonpy { };
-
-  teslemetry-stream = callPackage ../development/python-modules/teslemetry-stream { };
-
-  tess = callPackage ../development/python-modules/tess { };
-
-  tesserocr = callPackage ../development/python-modules/tesserocr { };
-
-  test-results-parser = callPackage ../development/python-modules/test-results-parser { };
-
-  testcontainers = callPackage ../development/python-modules/testcontainers { };
-
-  testfixtures = callPackage ../development/python-modules/testfixtures { };
-
-  texsoup = callPackage ../development/python-modules/texsoup { };
-
-  text2digits = callPackage ../development/python-modules/text2digits { };
-
-  textblob = callPackage ../development/python-modules/textblob { };
-
-  textfsm = callPackage ../development/python-modules/textfsm { };
-
-  textile = callPackage ../development/python-modules/textile { };
-
-  textparser = callPackage ../development/python-modules/textparser { };
-
-  textstat = callPackage ../development/python-modules/textstat { };
-
-  textual = callPackage ../development/python-modules/textual { };
-
-  textual-autocomplete = callPackage ../development/python-modules/textual-autocomplete { };
-
-  textual-dev = callPackage ../development/python-modules/textual-dev { };
-
-  textual-fastdatatable = callPackage ../development/python-modules/textual-fastdatatable { };
-
-  textual-serve = callPackage ../development/python-modules/textual-serve { };
-
-  textual-slider = callPackage ../development/python-modules/textual-slider { };
-
-  textual-universal-directorytree =
-    callPackage ../development/python-modules/textual-universal-directorytree
-      { };
-
-  textualeffects = callPackage ../development/python-modules/textualeffects { };
-
-  textual-textarea = callPackage ../development/python-modules/textual-textarea { };
-
-  testbook = callPackage ../development/python-modules/testbook { };
-
-  testing-common-database = callPackage ../development/python-modules/testing-common-database { };
-
-  testing-postgresql = callPackage ../development/python-modules/testing-postgresql { };
-
-  testpath = callPackage ../development/python-modules/testpath { };
-
-  testrail-api = callPackage ../development/python-modules/testrail-api { };
-
-  testrepository = callPackage ../development/python-modules/testrepository { };
-
-  testresources = callPackage ../development/python-modules/testresources { };
-
-  testscenarios = callPackage ../development/python-modules/testscenarios { };
-
-  testtools = callPackage ../development/python-modules/testtools { };
-
-  test-tube = callPackage ../development/python-modules/test-tube { };
-
-  textdistance = callPackage ../development/python-modules/textdistance { };
-
-  textacy = callPackage ../development/python-modules/textacy { };
-
-  textnets = callPackage ../development/python-modules/textnets {
-    en_core_web_sm = spacy-models.en_core_web_sm;
-  };
-
-  texttable = callPackage ../development/python-modules/texttable { };
-
-  text-unidecode = callPackage ../development/python-modules/text-unidecode { };
-
-  textwrap3 = callPackage ../development/python-modules/textwrap3 { };
-
-  textx = callPackage ../development/python-modules/textx { };
-
-  tf-keras = callPackage ../development/python-modules/tf-keras { };
-
-  tf2onnx = callPackage ../development/python-modules/tf2onnx { };
-
-  tflearn = callPackage ../development/python-modules/tflearn { };
-
-  tftpy = callPackage ../development/python-modules/tftpy { };
-
-  tgcrypto = callPackage ../development/python-modules/tgcrypto { };
-
-  thefuzz = callPackage ../development/python-modules/thefuzz { };
-
-  thelogrus = callPackage ../development/python-modules/thelogrus { };
-
-  thermobeacon-ble = callPackage ../development/python-modules/thermobeacon-ble { };
-
-  thermopro-ble = callPackage ../development/python-modules/thermopro-ble { };
-
-  thespian = callPackage ../development/python-modules/thespian { };
-
-  thinc = callPackage ../development/python-modules/thinc {
-    inherit (pkgs.darwin.apple_sdk.frameworks)
-      Accelerate
-      CoreFoundation
-      CoreGraphics
-      CoreVideo
-      ;
-  };
-
-  thinqconnect = callPackage ../development/python-modules/thinqconnect { };
-
-  thorlabspm100 = callPackage ../development/python-modules/thorlabspm100 { };
-
-  threadloop = callPackage ../development/python-modules/threadloop { };
-
-  threadpool = callPackage ../development/python-modules/threadpool { };
-
-  threadpoolctl = callPackage ../development/python-modules/threadpoolctl { };
-
-  threat9-test-bed = callPackage ../development/python-modules/threat9-test-bed { };
-
-  three-merge = callPackage ../development/python-modules/three-merge { };
-
-  thrift = callPackage ../development/python-modules/thrift { };
-
-  thriftpy2 = callPackage ../development/python-modules/thriftpy2 { };
-
-  throttler = callPackage ../development/python-modules/throttler { };
-
-  thttp = callPackage ../development/python-modules/thttp { };
-
-  tkinter = callPackage ../development/python-modules/tkinter {
-    py = python.override (lib.optionalAttrs (!python.isPyPy) { x11Support = true; });
-  };
-
-  tianshou = callPackage ../development/python-modules/tianshou { };
-
-  tidalapi = callPackage ../development/python-modules/tidalapi { };
-
-  tidyexc = callPackage ../development/python-modules/tidyexc { };
-
-  tidylib = callPackage ../development/python-modules/pytidylib { };
-
-  tifffile = callPackage ../development/python-modules/tifffile { };
-
-  tika = callPackage ../development/python-modules/tika { };
-
-  tika-client = callPackage ../development/python-modules/tika-client { };
-
-  tiktoken = callPackage ../development/python-modules/tiktoken { };
-
-  tikzplotlib = callPackage ../development/python-modules/tikzplotlib { };
-
-  tiledb = callPackage ../development/python-modules/tiledb { inherit (pkgs) tiledb; };
-
-  tilequant = callPackage ../development/python-modules/tilequant { };
-
-  tiler = callPackage ../development/python-modules/tiler { };
-
-  tilestache = callPackage ../development/python-modules/tilestache { };
-
-  tilt-ble = callPackage ../development/python-modules/tilt-ble { };
-
-  timeago = callPackage ../development/python-modules/timeago { };
-
-  timecop = callPackage ../development/python-modules/timecop { };
-
-  timelib = callPackage ../development/python-modules/timelib { };
-
-  time-machine = callPackage ../development/python-modules/time-machine { };
-
-  timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };
-
-  timeslot = callPackage ../development/python-modules/timeslot { };
-
-  timetagger = callPackage ../development/python-modules/timetagger { };
-
-  timezonefinder = callPackage ../development/python-modules/timezonefinder { };
-
-  timing-asgi = callPackage ../development/python-modules/timing-asgi { };
-
-  timm = callPackage ../development/python-modules/timm { };
-
-  timy = callPackage ../development/python-modules/timy { };
-
-  tiny-cuda-nn = toPythonModule (
-    pkgs.tiny-cuda-nn.override {
-      cudaPackages = self.torch.cudaPackages;
-      python3Packages = self;
-      pythonSupport = true;
-    }
-  );
-
-  tiny-proxy = callPackage ../development/python-modules/tiny-proxy { };
-
-  tinycss2 = callPackage ../development/python-modules/tinycss2 { };
-
-  tinycss = callPackage ../development/python-modules/tinycss { };
-
-  tinydb = callPackage ../development/python-modules/tinydb { };
-
-  tinygrad = callPackage ../development/python-modules/tinygrad { };
-
-  tinyhtml5 = callPackage ../development/python-modules/tinyhtml5 { };
-
-  tinyobjloader-py = callPackage ../development/python-modules/tinyobjloader-py { };
-
-  tinyrecord = callPackage ../development/python-modules/tinyrecord { };
-
-  tinysegmenter = callPackage ../development/python-modules/tinysegmenter { };
-
-  tinytag = callPackage ../development/python-modules/tinytag { };
-
-  tinytuya = callPackage ../development/python-modules/tinytuya { };
-
-  tiptapy = callPackage ../development/python-modules/tiptapy { };
-
-  titlecase = callPackage ../development/python-modules/titlecase { };
-
-  tivars = callPackage ../development/python-modules/tivars { };
-
-  tld = callPackage ../development/python-modules/tld { };
-
-  tlds = callPackage ../development/python-modules/tlds { };
-
-  tldextract = callPackage ../development/python-modules/tldextract { };
-
-  tlsh = callPackage ../development/python-modules/tlsh { };
-
-  tlslite-ng = callPackage ../development/python-modules/tlslite-ng { };
-
-  tls-client = callPackage ../development/python-modules/tls-client { };
-
-  tls-parser = callPackage ../development/python-modules/tls-parser { };
-
-  tlv8 = callPackage ../development/python-modules/tlv8 { };
-
-  tmb = callPackage ../development/python-modules/tmb { };
-
-  todoist = callPackage ../development/python-modules/todoist { };
-
-  todoist-api-python = callPackage ../development/python-modules/todoist-api-python { };
-
-  toggl-cli = callPackage ../development/python-modules/toggl-cli { };
-
-  token-bucket = callPackage ../development/python-modules/token-bucket { };
-
-  tokenizers = callPackage ../development/python-modules/tokenizers { };
-
-  tokenize-rt = callPackage ../development/python-modules/tokenize-rt { };
-
-  tokenlib = callPackage ../development/python-modules/tokenlib { };
-
-  tokentrim = callPackage ../development/python-modules/tokentrim { };
-
-  tololib = callPackage ../development/python-modules/tololib { };
-
-  toml = callPackage ../development/python-modules/toml { };
-
-  toml-adapt = callPackage ../development/python-modules/toml-adapt { };
-
-  tomli = callPackage ../development/python-modules/tomli { };
-
-  tomli-w = callPackage ../development/python-modules/tomli-w { };
-
-  tomlkit = callPackage ../development/python-modules/tomlkit { };
-
-  toolz = callPackage ../development/python-modules/toolz { };
-
-  toonapi = callPackage ../development/python-modules/toonapi { };
-
-  toposort = callPackage ../development/python-modules/toposort { };
-
-  toptica-lasersdk = callPackage ../development/python-modules/toptica-lasersdk { };
-
-  torch = callPackage ../development/python-modules/torch { };
-
-  # Required to test triton
-  torch-no-triton = self.torch.override { tritonSupport = false; };
-
-  torch-audiomentations = callPackage ../development/python-modules/torch-audiomentations { };
-
-  torch-geometric = callPackage ../development/python-modules/torch-geometric { };
-
-  torch-pitch-shift = callPackage ../development/python-modules/torch-pitch-shift { };
-
-  torch-bin = callPackage ../development/python-modules/torch/bin.nix { triton = self.triton-bin; };
-
-  torchbench = callPackage ../development/python-modules/torchbench { };
-
-  torchsnapshot = callPackage ../development/python-modules/torchsnapshot { };
-
-  torchWithCuda = self.torch.override {
-    triton = self.triton-cuda;
-    cudaSupport = true;
-    rocmSupport = false;
-  };
-
-  torchWithoutCuda = self.torch.override { cudaSupport = false; };
-
-  torchWithRocm = self.torch.override {
-    triton = self.triton-no-cuda;
-    rocmSupport = true;
-    cudaSupport = false;
-  };
-
-  torchWithoutRocm = self.torch.override { rocmSupport = false; };
-
-  torchWithVulkan = self.torch.override { vulkanSupport = true; };
-
-  torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
-
-  torchaudio = callPackage ../development/python-modules/torchaudio { };
-
-  torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix {
-    cudaPackages = pkgs.cudaPackages_12;
-  };
-
-  torchcrepe = callPackage ../development/python-modules/torchcrepe { };
-
-  torchdiffeq = callPackage ../development/python-modules/torchdiffeq { };
-
-  torcheval = callPackage ../development/python-modules/torcheval { };
-
-  torchmetrics = callPackage ../development/python-modules/torchmetrics { };
-
-  torchio = callPackage ../development/python-modules/torchio { };
-
-  torchinfo = callPackage ../development/python-modules/torchinfo { };
-
-  torchlibrosa = callPackage ../development/python-modules/torchlibrosa { };
-
-  torchrl = callPackage ../development/python-modules/torchrl { };
-
-  torchsde = callPackage ../development/python-modules/torchsde { };
-
-  torchsummary = callPackage ../development/python-modules/torchsummary { };
-
-  torchtnt = callPackage ../development/python-modules/torchtnt { };
-
-  torchtnt-nightly = callPackage ../development/python-modules/torchtnt-nightly { };
-
-  torchvision = callPackage ../development/python-modules/torchvision { };
-
-  torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix {
-    cudaPackages = pkgs.cudaPackages_12;
-  };
-
-  tornado = callPackage ../development/python-modules/tornado { };
-
-  torchprofile = callPackage ../development/python-modules/torchprofile { };
-
-  torpy = callPackage ../development/python-modules/torpy { };
-
-  torrent-parser = callPackage ../development/python-modules/torrent-parser { };
-
-  torrequest = callPackage ../development/python-modules/torrequest { };
-
-  total-connect-client = callPackage ../development/python-modules/total-connect-client { };
-
-  towncrier = callPackage ../development/python-modules/towncrier { inherit (pkgs) git; };
-
-  tox = callPackage ../development/python-modules/tox { };
-
-  tplink-omada-client = callPackage ../development/python-modules/tplink-omada-client { };
-
-  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
-
-  tqdm = callPackage ../development/python-modules/tqdm { };
-
-  tqdm-multiprocess = callPackage ../development/python-modules/tqdm-multiprocess { };
-
-  traceback2 = callPackage ../development/python-modules/traceback2 { };
-
-  tracerite = callPackage ../development/python-modules/tracerite { };
-
-  tracing = callPackage ../development/python-modules/tracing { };
-
-  translate-toolkit = callPackage ../development/python-modules/translate-toolkit { };
-
-  translation-finder = callPackage ../development/python-modules/translation-finder { };
-
-  trackpy = callPackage ../development/python-modules/trackpy { };
-
-  trafilatura = callPackage ../development/python-modules/trafilatura { };
-
-  trailrunner = callPackage ../development/python-modules/trailrunner { };
-
-  trainer = callPackage ../development/python-modules/trainer { };
-
-  traitlets = callPackage ../development/python-modules/traitlets { };
-
-  traits = callPackage ../development/python-modules/traits { };
-
-  traitsui = callPackage ../development/python-modules/traitsui { };
-
-  traittypes = callPackage ../development/python-modules/traittypes { };
-
-  trakit = callPackage ../development/python-modules/trakit { };
-
-  trampoline = callPackage ../development/python-modules/trampoline { };
-
-  transaction = callPackage ../development/python-modules/transaction { };
-
-  transformers = callPackage ../development/python-modules/transformers { };
-
-  transforms3d = callPackage ../development/python-modules/transforms3d { };
-
-  transitions = callPackage ../development/python-modules/transitions { };
-
-  translatehtml = callPackage ../development/python-modules/translatehtml { };
-
-  translatepy = callPackage ../development/python-modules/translatepy { };
-
-  translationstring = callPackage ../development/python-modules/translationstring { };
-
-  translitcodec = callPackage ../development/python-modules/translitcodec { };
-
-  transmission-rpc = callPackage ../development/python-modules/transmission-rpc { };
-
-  trectools = callPackage ../development/python-modules/trectools { };
-
-  tree-sitter = callPackage ../development/python-modules/tree-sitter { };
-
-  tree-sitter_0_21 = callPackage ../development/python-modules/tree-sitter/0_21.nix { };
-
-  tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
-
-  tree-sitter-python = callPackage ../development/python-modules/tree-sitter-python { };
-
-  tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };
-
-  tree-sitter-javascript = callPackage ../development/python-modules/tree-sitter-javascript { };
-
-  tree-sitter-json = callPackage ../development/python-modules/tree-sitter-json { };
-
-  tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
-
-  tree-sitter-languages = callPackage ../development/python-modules/tree-sitter-languages { };
-
-  treelib = callPackage ../development/python-modules/treelib { };
-
-  treelog = callPackage ../development/python-modules/treelog { };
-
-  treeo = callPackage ../development/python-modules/treeo { };
-
-  treescope = callPackage ../development/python-modules/treescope { };
-
-  treex = callPackage ../development/python-modules/treex { };
-
-  treq = callPackage ../development/python-modules/treq { };
-
-  trezor-agent = callPackage ../development/python-modules/trezor-agent {
-    pinentry = pkgs.pinentry-curses;
-  };
-
-  trezor = callPackage ../development/python-modules/trezor { };
-
-  trie = callPackage ../development/python-modules/trie { };
-
-  trimesh = callPackage ../development/python-modules/trimesh { };
-
-  trino-python-client = callPackage ../development/python-modules/trino-python-client { };
-
-  trio = callPackage ../development/python-modules/trio { };
-
-  trio-asyncio = callPackage ../development/python-modules/trio-asyncio { };
-
-  trio-websocket = callPackage ../development/python-modules/trio-websocket { };
-
-  triton = callPackage ../development/python-modules/triton { llvm = pkgs.triton-llvm; };
-
-  triton-cuda = self.triton.override { cudaSupport = true; };
-
-  triton-no-cuda = self.triton.override { cudaSupport = false; };
-
-  triton-bin = callPackage ../development/python-modules/triton/bin.nix { };
-
-  tritonclient = callPackage ../development/python-modules/tritonclient { };
-
-  trlib = toPythonModule (
-    pkgs.trlib.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  troposphere = callPackage ../development/python-modules/troposphere { };
-
-  trove-classifiers = callPackage ../development/python-modules/trove-classifiers { };
-
-  trubar = callPackage ../development/python-modules/trubar { };
-
-  trueskill = callPackage ../development/python-modules/trueskill { };
-
-  truncnorm = callPackage ../development/python-modules/truncnorm { };
-
-  trustme = callPackage ../development/python-modules/trustme { };
-
-  truststore = callPackage ../development/python-modules/truststore { };
-
-  trx-python = callPackage ../development/python-modules/trx-python { };
-
-  trytond = callPackage ../development/python-modules/trytond { };
-
-  ts1-signatures = callPackage ../development/python-modules/ts1-signatures { };
-
-  tsfresh = callPackage ../development/python-modules/tsfresh { };
-
-  tsid = toPythonModule (
-    pkgs.tsid.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
-  tskit = callPackage ../development/python-modules/tskit { };
-
-  ttach = callPackage ../development/python-modules/ttach { };
-
-  ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };
-
-  ttls = callPackage ../development/python-modules/ttls { };
-
-  ttn-client = callPackage ../development/python-modules/ttn-client { };
-
-  ttp = callPackage ../development/python-modules/ttp { };
-
-  ttp-templates = callPackage ../development/python-modules/ttp-templates { };
-
-  ttstokenizer = callPackage ../development/python-modules/ttstokenizer { };
-
-  tubes = callPackage ../development/python-modules/tubes { };
-
-  tuf = callPackage ../development/python-modules/tuf { };
-
-  tunigo = callPackage ../development/python-modules/tunigo { };
-
-  tubeup = callPackage ../development/python-modules/tubeup { };
-
-  turnt = callPackage ../development/python-modules/turnt { };
-
-  turrishw = callPackage ../development/python-modules/turrishw { };
-
-  tuya-device-sharing-sdk = callPackage ../development/python-modules/tuya-device-sharing-sdk { };
-
-  tuya-iot-py-sdk = callPackage ../development/python-modules/tuya-iot-py-sdk { };
-
-  tuyaha = callPackage ../development/python-modules/tuyaha { };
-
-  tvdb-api = callPackage ../development/python-modules/tvdb-api { };
-
-  tweedledum = callPackage ../development/python-modules/tweedledum { };
-
-  tweepy = callPackage ../development/python-modules/tweepy { };
-
-  twentemilieu = callPackage ../development/python-modules/twentemilieu { };
-
-  twiggy = callPackage ../development/python-modules/twiggy { };
-
-  twilio = callPackage ../development/python-modules/twilio { };
-
-  twill = callPackage ../development/python-modules/twill { };
-
-  twine = callPackage ../development/python-modules/twine { };
-
-  twinkly-client = callPackage ../development/python-modules/twinkly-client { };
-
-  twisted = callPackage ../development/python-modules/twisted { };
-
-  twitch-python = callPackage ../development/python-modules/twitch-python { };
-
-  twitchapi = callPackage ../development/python-modules/twitchapi { };
-
-  twitter = callPackage ../development/python-modules/twitter { };
-
-  twitterapi = callPackage ../development/python-modules/twitterapi { };
-
-  twofish = callPackage ../development/python-modules/twofish { };
-
-  txaio = callPackage ../development/python-modules/txaio { };
-
-  txamqp = callPackage ../development/python-modules/txamqp { };
-
-  txdbus = callPackage ../development/python-modules/txdbus { };
-
-  txgithub = callPackage ../development/python-modules/txgithub { };
-
-  txi2p-tahoe = callPackage ../development/python-modules/txi2p-tahoe { };
-
-  txredisapi = callPackage ../development/python-modules/txredisapi { };
-
-  txrequests = callPackage ../development/python-modules/txrequests { };
-
-  txtai = callPackage ../development/python-modules/txtai { };
-
-  txtorcon = callPackage ../development/python-modules/txtorcon { };
-
-  txzmq = callPackage ../development/python-modules/txzmq { };
-
-  typechecks = callPackage ../development/python-modules/typechecks { };
-
-  typecode = callPackage ../development/python-modules/typecode { };
-
-  typecode-libmagic = callPackage ../development/python-modules/typecode/libmagic.nix {
-    inherit (pkgs) file zlib;
-  };
-
-  typed-ast = callPackage ../development/python-modules/typed-ast { };
-
-  typed-settings = callPackage ../development/python-modules/typed-settings { };
-
-  typeguard = callPackage ../development/python-modules/typeguard { };
-
-  typepy = callPackage ../development/python-modules/typepy { };
-
-  typer = callPackage ../development/python-modules/typer { };
-
-  typer-shell = callPackage ../development/python-modules/typer-shell { };
-
-  type-infer = callPackage ../development/python-modules/type-infer { };
-
-  types-aiobotocore = callPackage ../development/python-modules/types-aiobotocore { };
 
   inherit (callPackage ../development/python-modules/types-aiobotocore-packages { })
 
@@ -18226,6 +7682,10590 @@ self: super: with self; {
 
     ;
 
+  inherit (self.wasmerPackages)
+    wasmer
+    wasmer-compiler-cranelift
+    wasmer-compiler-llvm
+    wasmer-compiler-singlepass
+    ;
+
+  iniconfig = callPackage ../development/python-modules/iniconfig { };
+
+  inifile = callPackage ../development/python-modules/inifile { };
+
+  iniparse = callPackage ../development/python-modules/iniparse { };
+
+  inject = callPackage ../development/python-modules/inject { };
+
+  injector = callPackage ../development/python-modules/injector { };
+
+  inkbird-ble = callPackage ../development/python-modules/inkbird-ble { };
+
+  inkex = callPackage ../development/python-modules/inkex { };
+
+  inline-snapshot = callPackage ../development/python-modules/inline-snapshot { };
+
+  inlinestyler = callPackage ../development/python-modules/inlinestyler { };
+
+  inotify = callPackage ../development/python-modules/inotify { };
+
+  inotify-simple = callPackage ../development/python-modules/inotify-simple { };
+
+  inotifyrecursive = callPackage ../development/python-modules/inotifyrecursive { };
+
+  inquirer = callPackage ../development/python-modules/inquirer { };
+
+  inquirerpy = callPackage ../development/python-modules/inquirerpy { };
+
+  inscriptis = callPackage ../development/python-modules/inscriptis { };
+
+  insegel = callPackage ../development/python-modules/insegel { };
+
+  insightface = callPackage ../development/python-modules/insightface { };
+
+  installer = callPackage ../development/python-modules/installer { };
+
+  insteon-frontend-home-assistant =
+    callPackage ../development/python-modules/insteon-frontend-home-assistant
+      { };
+
+  instructor = callPackage ../development/python-modules/instructor { };
+
+  intake = callPackage ../development/python-modules/intake { };
+
+  intake-parquet = callPackage ../development/python-modules/intake-parquet { };
+
+  intbitset = callPackage ../development/python-modules/intbitset { };
+
+  intelhex = callPackage ../development/python-modules/intelhex { };
+
+  intellifire4py = callPackage ../development/python-modules/intellifire4py { };
+
+  intensity-normalization = callPackage ../development/python-modules/intensity-normalization { };
+
+  interegular = callPackage ../development/python-modules/interegular { };
+
+  interface-meta = callPackage ../development/python-modules/interface-meta { };
+
+  internetarchive = callPackage ../development/python-modules/internetarchive { };
+
+  interruptingcow = callPackage ../development/python-modules/interruptingcow { };
+
+  intervaltree = callPackage ../development/python-modules/intervaltree { };
+
+  into-dbus-python = callPackage ../development/python-modules/into-dbus-python { };
+
+  invisible-watermark = callPackage ../development/python-modules/invisible-watermark { };
+
+  invocations = callPackage ../development/python-modules/invocations { };
+
+  invoke = callPackage ../development/python-modules/invoke { };
+
+  iocapture = callPackage ../development/python-modules/iocapture { };
+
+  iocextract = callPackage ../development/python-modules/iocextract { };
+
+  iocsearcher = callPackage ../development/python-modules/iocsearcher { };
+
+  ioctl-opt = callPackage ../development/python-modules/ioctl-opt { };
+
+  iodata = callPackage ../development/python-modules/iodata { };
+
+  iometer = callPackage ../development/python-modules/iometer { };
+
+  ionhash = callPackage ../development/python-modules/ionhash { };
+
+  ionoscloud = callPackage ../development/python-modules/ionoscloud { };
+
+  iopath = callPackage ../development/python-modules/iopath { };
+
+  iosbackup = callPackage ../development/python-modules/iosbackup { };
+
+  iotawattpy = callPackage ../development/python-modules/iotawattpy { };
+
+  iottycloud = callPackage ../development/python-modules/iottycloud { };
+
+  iowait = callPackage ../development/python-modules/iowait { };
+
+  ipaddr = callPackage ../development/python-modules/ipaddr { };
+
+  ipadic = callPackage ../development/python-modules/ipadic { };
+
+  ipdb = callPackage ../development/python-modules/ipdb { };
+
+  ipfshttpclient = callPackage ../development/python-modules/ipfshttpclient { };
+
+  iptools = callPackage ../development/python-modules/iptools { };
+
+  ipwhl = callPackage ../development/python-modules/ipwhl { };
+
+  ipwhois = callPackage ../development/python-modules/ipwhois { };
+
+  ipy = callPackage ../development/python-modules/ipy { };
+
+  ipycanvas = callPackage ../development/python-modules/ipycanvas { };
+
+  ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };
+
+  ipykernel = callPackage ../development/python-modules/ipykernel { };
+
+  ipylab = callPackage ../development/python-modules/ipylab { };
+
+  ipymarkup = callPackage ../development/python-modules/ipymarkup { };
+
+  ipympl = callPackage ../development/python-modules/ipympl { };
+
+  ipynbname = callPackage ../development/python-modules/ipynbname { };
+
+  ipyniivue = callPackage ../development/python-modules/ipyniivue { };
+
+  ipyparallel = callPackage ../development/python-modules/ipyparallel { };
+
+  ipytablewidgets = callPackage ../development/python-modules/ipytablewidgets { };
+
+  ipython = callPackage ../development/python-modules/ipython { };
+
+  ipython-genutils = callPackage ../development/python-modules/ipython-genutils { };
+
+  ipython-pygments-lexers = callPackage ../development/python-modules/ipython-pygments-lexers { };
+
+  ipython-sql = callPackage ../development/python-modules/ipython-sql { };
+
+  ipyvue = callPackage ../development/python-modules/ipyvue { };
+
+  ipyvuetify = callPackage ../development/python-modules/ipyvuetify { };
+
+  ipywidgets = callPackage ../development/python-modules/ipywidgets { };
+
+  ipyxact = callPackage ../development/python-modules/ipyxact { };
+
+  irc = callPackage ../development/python-modules/irc { };
+
+  ircrobots = callPackage ../development/python-modules/ircrobots { };
+
+  ircstates = callPackage ../development/python-modules/ircstates { };
+
+  irctokens = callPackage ../development/python-modules/irctokens { };
+
+  isal = callPackage ../development/python-modules/isal { };
+
+  isbnlib = callPackage ../development/python-modules/isbnlib { };
+
+  islpy = callPackage ../development/python-modules/islpy { isl = pkgs.isl_0_24; };
+
+  ismartgate = callPackage ../development/python-modules/ismartgate { };
+
+  iso-639 = callPackage ../development/python-modules/iso-639 { };
+
+  iso3166 = callPackage ../development/python-modules/iso3166 { };
+
+  iso4217 = callPackage ../development/python-modules/iso4217 { };
+
+  iso8601 = callPackage ../development/python-modules/iso8601 { };
+
+  isodate = callPackage ../development/python-modules/isodate { };
+
+  isoduration = callPackage ../development/python-modules/isoduration { };
+
+  isort = callPackage ../development/python-modules/isort { };
+
+  isosurfaces = callPackage ../development/python-modules/isosurfaces { };
+
+  isounidecode = callPackage ../development/python-modules/isounidecode { };
+
+  isoweek = callPackage ../development/python-modules/isoweek { };
+
+  israel-rail-api = callPackage ../development/python-modules/israel-rail-api { };
+
+  itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
+
+  item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };
+
+  itemadapter = callPackage ../development/python-modules/itemadapter { };
+
+  itemdb = callPackage ../development/python-modules/itemdb { };
+
+  itemloaders = callPackage ../development/python-modules/itemloaders { };
+
+  iterable-io = callPackage ../development/python-modules/iterable-io { };
+
+  iteration-utilities = callPackage ../development/python-modules/iteration-utilities { };
+
+  iterative-telemetry = callPackage ../development/python-modules/iterative-telemetry { };
+
+  iterfzf = callPackage ../development/python-modules/iterfzf { };
+
+  iterm2 = callPackage ../development/python-modules/iterm2 { };
+
+  itk = toPythonModule (
+    pkgs.itk.override {
+      inherit python numpy;
+      enablePython = true;
+      enableRtk = false;
+      stdenv =
+        if stdenv.cc.isGNU then pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv else stdenv;
+    }
+  );
+
+  itsdangerous = callPackage ../development/python-modules/itsdangerous { };
+
+  itunespy = callPackage ../development/python-modules/itunespy { };
+
+  itypes = callPackage ../development/python-modules/itypes { };
+
+  iwlib = callPackage ../development/python-modules/iwlib { };
+
+  ixia = callPackage ../development/python-modules/ixia { };
+
+  j2cli = callPackage ../development/python-modules/j2cli { };
+
+  jaconv = callPackage ../development/python-modules/jaconv { };
+
+  jalali-core = callPackage ../development/python-modules/jalali-core { };
+
+  jamo = callPackage ../development/python-modules/jamo { };
+
+  janus = callPackage ../development/python-modules/janus { };
+
+  jaraco-abode = callPackage ../development/python-modules/jaraco-abode { };
+
+  jaraco-classes = callPackage ../development/python-modules/jaraco-classes { };
+
+  jaraco-collections = callPackage ../development/python-modules/jaraco-collections { };
+
+  jaraco-context = callPackage ../development/python-modules/jaraco-context { };
+
+  jaraco-email = callPackage ../development/python-modules/jaraco-email { };
+
+  jaraco-envs = callPackage ../development/python-modules/jaraco-envs { };
+
+  jaraco-functools = callPackage ../development/python-modules/jaraco-functools { };
+
+  jaraco-itertools = callPackage ../development/python-modules/jaraco-itertools { };
+
+  jaraco-logging = callPackage ../development/python-modules/jaraco-logging { };
+
+  jaraco-net = callPackage ../development/python-modules/jaraco-net { };
+
+  jaraco-path = callPackage ../development/python-modules/jaraco-path { };
+
+  jaraco-stream = callPackage ../development/python-modules/jaraco-stream { };
+
+  jaraco-test = callPackage ../development/python-modules/jaraco-test { };
+
+  jaraco-text = callPackage ../development/python-modules/jaraco-text { };
+
+  jarowinkler = callPackage ../development/python-modules/jarowinkler { };
+
+  javaobj-py3 = callPackage ../development/python-modules/javaobj-py3 { };
+
+  javaproperties = callPackage ../development/python-modules/javaproperties { };
+
+  jax = callPackage ../development/python-modules/jax { };
+
+  jax-cuda12-pjrt = callPackage ../development/python-modules/jax-cuda12-pjrt { };
+
+  jax-cuda12-plugin = callPackage ../development/python-modules/jax-cuda12-plugin { };
+
+  jax-jumpy = callPackage ../development/python-modules/jax-jumpy { };
+
+  jaxlib = jaxlib-bin;
+
+  jaxlib-bin = callPackage ../development/python-modules/jaxlib/bin.nix { };
+
+  jaxlib-build = callPackage ../development/python-modules/jaxlib { };
+
+  jaxopt = callPackage ../development/python-modules/jaxopt { };
+
+  jaxtyping = callPackage ../development/python-modules/jaxtyping { };
+
+  jaydebeapi = callPackage ../development/python-modules/jaydebeapi { };
+
+  jc = callPackage ../development/python-modules/jc { };
+
+  jdatetime = callPackage ../development/python-modules/jdatetime { };
+
+  jdcal = callPackage ../development/python-modules/jdcal { };
+
+  jedi = callPackage ../development/python-modules/jedi { };
+
+  jedi-language-server = callPackage ../development/python-modules/jedi-language-server { };
+
+  jeepney = callPackage ../development/python-modules/jeepney { };
+
+  jello = callPackage ../development/python-modules/jello { };
+
+  jellyfin-apiclient-python = callPackage ../development/python-modules/jellyfin-apiclient-python { };
+
+  jellyfish = callPackage ../development/python-modules/jellyfish { };
+
+  jenkins-job-builder = callPackage ../development/python-modules/jenkins-job-builder { };
+
+  jenkinsapi = callPackage ../development/python-modules/jenkinsapi { };
+
+  jfx-bridge = callPackage ../development/python-modules/jfx-bridge { };
+
+  jh2 = callPackage ../development/python-modules/jh2 { };
+
+  jianpu-ly = callPackage ../development/python-modules/jianpu-ly { };
+
+  jieba = callPackage ../development/python-modules/jieba { };
+
+  jinja2 = callPackage ../development/python-modules/jinja2 { };
+
+  jinja2-ansible-filters = callPackage ../development/python-modules/jinja2-ansible-filters { };
+
+  jinja2-git = callPackage ../development/python-modules/jinja2-git { };
+
+  jinja2-humanize-extension = callPackage ../development/python-modules/jinja2-humanize-extension { };
+
+  jinja2-pluralize = callPackage ../development/python-modules/jinja2-pluralize { };
+
+  jinja2-strcase = callPackage ../development/python-modules/jinja2-strcase { };
+
+  jinja2-time = callPackage ../development/python-modules/jinja2-time { };
+
+  jira = callPackage ../development/python-modules/jira { };
+
+  jishaku = callPackage ../development/python-modules/jishaku { };
+
+  jiter = callPackage ../development/python-modules/jiter { };
+
+  jiwer = callPackage ../development/python-modules/jiwer { };
+
+  jmespath = callPackage ../development/python-modules/jmespath { };
+
+  jmp = callPackage ../development/python-modules/jmp { };
+
+  joblib = callPackage ../development/python-modules/joblib { };
+
+  jobspy = callPackage ../development/python-modules/jobspy { };
+
+  johnnycanencrypt = callPackage ../development/python-modules/johnnycanencrypt {
+    inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
+  };
+
+  josepy = callPackage ../development/python-modules/josepy { };
+
+  joserfc = callPackage ../development/python-modules/joserfc { };
+
+  jplephem = callPackage ../development/python-modules/jplephem { };
+
+  jproperties = callPackage ../development/python-modules/jproperties { };
+
+  jpylyzer = callPackage ../development/python-modules/jpylyzer { };
+
+  jpype1 = callPackage ../development/python-modules/jpype1 { };
+
+  jq = callPackage ../development/python-modules/jq { inherit (pkgs) jq; };
+
+  jsbeautifier = callPackage ../development/python-modules/jsbeautifier { };
+
+  jschema-to-python = callPackage ../development/python-modules/jschema-to-python { };
+
+  jschon = callPackage ../development/python-modules/jschon { };
+
+  jsmin = callPackage ../development/python-modules/jsmin { };
+
+  json-api-doc = callPackage ../development/python-modules/json-api-doc { };
+
+  json-home-client = callPackage ../development/python-modules/json-home-client { };
+
+  json-logging = callPackage ../development/python-modules/json-logging { };
+
+  json-merge-patch = callPackage ../development/python-modules/json-merge-patch { };
+
+  json-repair = callPackage ../development/python-modules/json-repair { };
+
+  json-rpc = callPackage ../development/python-modules/json-rpc { };
+
+  json-schema-for-humans = callPackage ../development/python-modules/json-schema-for-humans { };
+
+  json-stream = callPackage ../development/python-modules/json-stream { };
+
+  json-stream-rs-tokenizer = callPackage ../development/python-modules/json-stream-rs-tokenizer { };
+
+  json-tricks = callPackage ../development/python-modules/json-tricks { };
+
+  json2html = callPackage ../development/python-modules/json2html { };
+
+  json5 = callPackage ../development/python-modules/json5 { };
+
+  jsonable = callPackage ../development/python-modules/jsonable { };
+
+  jsonargparse = callPackage ../development/python-modules/jsonargparse { };
+
+  jsonconversion = callPackage ../development/python-modules/jsonconversion { };
+
+  jsondate = callPackage ../development/python-modules/jsondate { };
+
+  jsondiff = callPackage ../development/python-modules/jsondiff { };
+
+  jsonfeed = callPackage ../development/python-modules/jsonfeed { };
+
+  jsonfield = callPackage ../development/python-modules/jsonfield { };
+
+  jsonformatter = callPackage ../development/python-modules/jsonformatter { };
+
+  jsonlines = callPackage ../development/python-modules/jsonlines { };
+
+  jsonmerge = callPackage ../development/python-modules/jsonmerge { };
+
+  jsonnet = buildPythonPackage { inherit (pkgs.jsonnet) name src; };
+
+  jsonpatch = callPackage ../development/python-modules/jsonpatch { };
+
+  jsonpath = callPackage ../development/python-modules/jsonpath { };
+
+  jsonpath-ng = callPackage ../development/python-modules/jsonpath-ng { };
+
+  jsonpath-python = callPackage ../development/python-modules/jsonpath-python { };
+
+  jsonpath-rw = callPackage ../development/python-modules/jsonpath-rw { };
+
+  jsonpickle = callPackage ../development/python-modules/jsonpickle { };
+
+  jsonpointer = callPackage ../development/python-modules/jsonpointer { };
+
+  jsonref = callPackage ../development/python-modules/jsonref { };
+
+  jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
+
+  jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };
+
+  jsonrpc-websocket = callPackage ../development/python-modules/jsonrpc-websocket { };
+
+  jsonrpclib-pelix = callPackage ../development/python-modules/jsonrpclib-pelix { };
+
+  jsons = callPackage ../development/python-modules/jsons { };
+
+  jsonschema = callPackage ../development/python-modules/jsonschema { };
+
+  jsonschema-path = callPackage ../development/python-modules/jsonschema-path { };
+
+  jsonschema-rs = callPackage ../development/python-modules/jsonschema-rs { };
+
+  jsonschema-spec = callPackage ../development/python-modules/jsonschema-spec { };
+
+  jsonschema-specifications = callPackage ../development/python-modules/jsonschema-specifications { };
+
+  jsonslicer = callPackage ../development/python-modules/jsonslicer { };
+
+  jsonstreams = callPackage ../development/python-modules/jsonstreams { };
+
+  jsonxs = callPackage ../development/python-modules/jsonxs { };
+
+  jstyleson = callPackage ../development/python-modules/jstyleson { };
+
+  jug = callPackage ../development/python-modules/jug { };
+
+  juliandate = callPackage ../development/python-modules/juliandate { };
+
+  julius = callPackage ../development/python-modules/julius { };
+
+  junit-xml = callPackage ../development/python-modules/junit-xml { };
+
+  junit2html = callPackage ../development/python-modules/junit2html { };
+
+  junitparser = callPackage ../development/python-modules/junitparser { };
+
+  junos-eznc = callPackage ../development/python-modules/junos-eznc { };
+
+  jupysql = callPackage ../development/python-modules/jupysql { };
+
+  jupysql-plugin = callPackage ../development/python-modules/jupysql-plugin { };
+
+  jupyter = callPackage ../development/python-modules/jupyter { };
+
+  jupyter-book = callPackage ../development/python-modules/jupyter-book { };
+
+  jupyter-c-kernel = callPackage ../development/python-modules/jupyter-c-kernel { };
+
+  jupyter-cache = callPackage ../development/python-modules/jupyter-cache { };
+
+  jupyter-client = callPackage ../development/python-modules/jupyter-client { };
+
+  jupyter-collaboration = callPackage ../development/python-modules/jupyter-collaboration { };
+
+  jupyter-collaboration-ui = callPackage ../development/python-modules/jupyter-collaboration-ui { };
+
+  jupyter-console = callPackage ../development/python-modules/jupyter-console { };
+
+  jupyter-contrib-core = callPackage ../development/python-modules/jupyter-contrib-core { };
+
+  jupyter-core = callPackage ../development/python-modules/jupyter-core { };
+
+  jupyter-docprovider = callPackage ../development/python-modules/jupyter-docprovider { };
+
+  jupyter-events = callPackage ../development/python-modules/jupyter-events { };
+
+  jupyter-highlight-selected-word =
+    callPackage ../development/python-modules/jupyter-highlight-selected-word
+      { };
+
+  jupyter-lsp = callPackage ../development/python-modules/jupyter-lsp { };
+
+  jupyter-nbextensions-configurator =
+    callPackage ../development/python-modules/jupyter-nbextensions-configurator
+      { };
+
+  jupyter-packaging = callPackage ../development/python-modules/jupyter-packaging { };
+
+  jupyter-repo2docker = callPackage ../development/python-modules/jupyter-repo2docker {
+    pkgs-docker = pkgs.docker;
+  };
+
+  jupyter-server = callPackage ../development/python-modules/jupyter-server { };
+
+  jupyter-server-fileid = callPackage ../development/python-modules/jupyter-server-fileid { };
+
+  jupyter-server-mathjax = callPackage ../development/python-modules/jupyter-server-mathjax { };
+
+  jupyter-server-terminals = callPackage ../development/python-modules/jupyter-server-terminals { };
+
+  jupyter-server-ydoc = callPackage ../development/python-modules/jupyter-server-ydoc { };
+
+  jupyter-sphinx = callPackage ../development/python-modules/jupyter-sphinx { };
+
+  jupyter-telemetry = callPackage ../development/python-modules/jupyter-telemetry { };
+
+  jupyter-ui-poll = callPackage ../development/python-modules/jupyter-ui-poll { };
+
+  jupyter-ydoc = callPackage ../development/python-modules/jupyter-ydoc { };
+
+  jupyterhub = callPackage ../development/python-modules/jupyterhub { };
+
+  jupyterhub-ldapauthenticator =
+    callPackage ../development/python-modules/jupyterhub-ldapauthenticator
+      { };
+
+  jupyterhub-systemdspawner = callPackage ../development/python-modules/jupyterhub-systemdspawner { };
+
+  jupyterhub-tmpauthenticator =
+    callPackage ../development/python-modules/jupyterhub-tmpauthenticator
+      { };
+
+  jupyterlab = callPackage ../development/python-modules/jupyterlab { };
+
+  jupyterlab-execute-time = callPackage ../development/python-modules/jupyterlab-execute-time { };
+
+  jupyterlab-git = callPackage ../development/python-modules/jupyterlab-git { };
+
+  jupyterlab-lsp = callPackage ../development/python-modules/jupyterlab-lsp { };
+
+  jupyterlab-pygments = callPackage ../development/python-modules/jupyterlab-pygments { };
+
+  jupyterlab-server = callPackage ../development/python-modules/jupyterlab-server { };
+
+  jupyterlab-widgets = callPackage ../development/python-modules/jupyterlab-widgets { };
+
+  jupytext = callPackage ../development/python-modules/jupytext { };
+
+  justbackoff = callPackage ../development/python-modules/justbackoff { };
+
+  justbases = callPackage ../development/python-modules/justbases { };
+
+  justbytes = callPackage ../development/python-modules/justbytes { };
+
+  justext = callPackage ../development/python-modules/justext { };
+
+  justnimbus = callPackage ../development/python-modules/justnimbus { };
+
+  jwcrypto = callPackage ../development/python-modules/jwcrypto { };
+
+  jwt = callPackage ../development/python-modules/jwt { };
+
+  jxlpy = callPackage ../development/python-modules/jxlpy { };
+
+  jxmlease = callPackage ../development/python-modules/jxmlease { };
+
+  k-diffusion = callPackage ../development/python-modules/k-diffusion { };
+
+  k5test = callPackage ../development/python-modules/k5test {
+    inherit (pkgs) findutils;
+    krb5-c = pkgs.krb5;
+  };
+
+  kaa-base = callPackage ../development/python-modules/kaa-base { };
+
+  kaa-metadata = callPackage ../development/python-modules/kaa-metadata { };
+
+  kafka-python-ng = callPackage ../development/python-modules/kafka-python-ng { };
+
+  kaggle = callPackage ../development/python-modules/kaggle { };
+
+  kaitaistruct = callPackage ../development/python-modules/kaitaistruct { };
+
+  kajiki = callPackage ../development/python-modules/kajiki { };
+
+  kaldi-active-grammar = callPackage ../development/python-modules/kaldi-active-grammar { };
+
+  kaleido = callPackage ../development/python-modules/kaleido { };
+
+  kalshi-python = callPackage ../development/python-modules/kalshi-python { };
+
+  kanidm = callPackage ../development/python-modules/kanidm { };
+
+  kaptan = callPackage ../development/python-modules/kaptan { };
+
+  karton-asciimagic = callPackage ../development/python-modules/karton-asciimagic { };
+
+  karton-autoit-ripper = callPackage ../development/python-modules/karton-autoit-ripper { };
+
+  karton-classifier = callPackage ../development/python-modules/karton-classifier { };
+
+  karton-config-extractor = callPackage ../development/python-modules/karton-config-extractor { };
+
+  karton-core = callPackage ../development/python-modules/karton-core { };
+
+  karton-dashboard = callPackage ../development/python-modules/karton-dashboard { };
+
+  karton-mwdb-reporter = callPackage ../development/python-modules/karton-mwdb-reporter { };
+
+  karton-yaramatcher = callPackage ../development/python-modules/karton-yaramatcher { };
+
+  kasa-crypt = callPackage ../development/python-modules/kasa-crypt { };
+
+  kazoo = callPackage ../development/python-modules/kazoo { };
+
+  kbcstorage = callPackage ../development/python-modules/kbcstorage { };
+
+  kconfiglib = callPackage ../development/python-modules/kconfiglib { };
+
+  kde-material-you-colors = callPackage ../development/python-modules/kde-material-you-colors { };
+
+  kdl-py = callPackage ../development/python-modules/kdl-py { };
+
+  keba-kecontact = callPackage ../development/python-modules/keba-kecontact { };
+
+  keep = callPackage ../development/python-modules/keep { };
+
+  keepalive = callPackage ../development/python-modules/keepalive { };
+
+  keepkey = callPackage ../development/python-modules/keepkey { };
+
+  keepkey-agent = callPackage ../development/python-modules/keepkey-agent { };
+
+  kegtron-ble = callPackage ../development/python-modules/kegtron-ble { };
+
+  keke = callPackage ../development/python-modules/keke { };
+
+  keras = callPackage ../development/python-modules/keras { };
+
+  kerberos = callPackage ../development/python-modules/kerberos { };
+
+  kestra = callPackage ../development/python-modules/kestra { };
+
+  keyboard = callPackage ../development/python-modules/keyboard { };
+
+  keyring = callPackage ../development/python-modules/keyring { };
+
+  keyring-pass = callPackage ../development/python-modules/keyring-pass { };
+
+  keyrings-alt = callPackage ../development/python-modules/keyrings-alt { };
+
+  keyrings-cryptfile = callPackage ../development/python-modules/keyrings-cryptfile { };
+
+  keyrings-google-artifactregistry-auth =
+    callPackage ../development/python-modules/keyrings-google-artifactregistry-auth
+      { };
+
+  keyrings-passwordstore = callPackage ../development/python-modules/keyrings-passwordstore { };
+
+  keystone-engine = callPackage ../development/python-modules/keystone-engine { };
+
+  keystoneauth1 = callPackage ../development/python-modules/keystoneauth1 { };
+
+  keyutils = callPackage ../development/python-modules/keyutils { inherit (pkgs) keyutils; };
+
+  kfactory = callPackage ../development/python-modules/kfactory { };
+
+  khanaa = callPackage ../development/python-modules/khanaa { };
+
+  kicad = toPythonModule (pkgs.kicad.override { python3 = python; }).src;
+
+  kinparse = callPackage ../development/python-modules/kinparse { };
+
+  kiss-headers = callPackage ../development/python-modules/kiss-headers { };
+
+  kitchen = callPackage ../development/python-modules/kitchen { };
+
+  kivy = callPackage ../development/python-modules/kivy { };
+
+  kivy-garden = callPackage ../development/python-modules/kivy-garden { };
+
+  kivy-garden-modernmenu = callPackage ../development/python-modules/kivy-garden-modernmenu { };
+
+  kiwiki-client = callPackage ../development/python-modules/kiwiki-client { };
+
+  kiwisolver = callPackage ../development/python-modules/kiwisolver { };
+
+  klaus = callPackage ../development/python-modules/klaus { };
+
+  klayout = callPackage ../development/python-modules/klayout { };
+
+  klein = callPackage ../development/python-modules/klein { };
+
+  kmapper = callPackage ../development/python-modules/kmapper { };
+
+  kml2geojson = callPackage ../development/python-modules/kml2geojson { };
+
+  kmsxx = toPythonModule (
+    pkgs.kmsxx.override {
+      withPython = true;
+      python3Packages = self;
+    }
+  );
+
+  knack = callPackage ../development/python-modules/knack { };
+
+  kneaddata = callPackage ../development/python-modules/kneaddata { };
+
+  kneed = callPackage ../development/python-modules/kneed { };
+
+  knocki = callPackage ../development/python-modules/knocki { };
+
+  knx-frontend = callPackage ../development/python-modules/knx-frontend { };
+
+  kombu = callPackage ../development/python-modules/kombu { };
+
+  konnected = callPackage ../development/python-modules/konnected { };
+
+  korean-lunar-calendar = callPackage ../development/python-modules/korean-lunar-calendar { };
+
+  kornia = callPackage ../development/python-modules/kornia { };
+
+  kornia-rs = callPackage ../development/python-modules/kornia-rs { };
+
+  kotsu = callPackage ../development/python-modules/kotsu { };
+
+  krakenex = callPackage ../development/python-modules/krakenex { };
+
+  krb5 = callPackage ../development/python-modules/krb5 { krb5-c = pkgs.krb5; };
+
+  krfzf-py = callPackage ../development/python-modules/krfzf-py { };
+
+  kserve = callPackage ../development/python-modules/kserve { };
+
+  kubernetes = callPackage ../development/python-modules/kubernetes { };
+
+  kubernetes-asyncio = callPackage ../development/python-modules/kubernetes-asyncio { };
+
+  kubernetes-validate = callPackage ../by-name/ku/kubernetes-validate/unwrapped.nix { };
+
+  kurbopy = callPackage ../development/python-modules/kurbopy { };
+
+  l18n = callPackage ../development/python-modules/l18n { };
+
+  labelbox = callPackage ../development/python-modules/labelbox { };
+
+  labgrid = callPackage ../development/python-modules/labgrid { };
+
+  labmath = callPackage ../development/python-modules/labmath { };
+
+  laces = callPackage ../development/python-modules/laces { };
+
+  lacuscore = callPackage ../development/python-modules/lacuscore { };
+
+  lakeside = callPackage ../development/python-modules/lakeside { };
+
+  lammps = callPackage ../development/python-modules/lammps { inherit (pkgs) lammps; };
+
+  lancedb = callPackage ../development/python-modules/lancedb { inherit (pkgs) protobuf; };
+
+  langchain = callPackage ../development/python-modules/langchain { };
+
+  langchain-aws = callPackage ../development/python-modules/langchain-aws { };
+
+  langchain-azure-dynamic-sessions =
+    callPackage ../development/python-modules/langchain-azure-dynamic-sessions
+      { };
+
+  langchain-chroma = callPackage ../development/python-modules/langchain-chroma { };
+
+  langchain-community = callPackage ../development/python-modules/langchain-community { };
+
+  langchain-core = callPackage ../development/python-modules/langchain-core { };
+
+  langchain-groq = callPackage ../development/python-modules/langchain-groq { };
+
+  langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };
+
+  langchain-mongodb = callPackage ../development/python-modules/langchain-mongodb { };
+
+  langchain-ollama = callPackage ../development/python-modules/langchain-ollama { };
+
+  langchain-openai = callPackage ../development/python-modules/langchain-openai { };
+
+  langchain-tests = callPackage ../development/python-modules/langchain-tests { };
+
+  langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };
+
+  langcodes = callPackage ../development/python-modules/langcodes { };
+
+  langdetect = callPackage ../development/python-modules/langdetect { };
+
+  langfuse = callPackage ../development/python-modules/langfuse { };
+
+  langgraph = callPackage ../development/python-modules/langgraph { };
+
+  langgraph-checkpoint = callPackage ../development/python-modules/langgraph-checkpoint { };
+
+  langgraph-checkpoint-duckdb =
+    callPackage ../development/python-modules/langgraph-checkpoint-duckdb
+      { };
+
+  langgraph-checkpoint-postgres =
+    callPackage ../development/python-modules/langgraph-checkpoint-postgres
+      { };
+
+  langgraph-checkpoint-sqlite =
+    callPackage ../development/python-modules/langgraph-checkpoint-sqlite
+      { };
+
+  langgraph-cli = callPackage ../development/python-modules/langgraph-cli { };
+
+  langgraph-sdk = callPackage ../development/python-modules/langgraph-sdk { };
+
+  langid = callPackage ../development/python-modules/langid { };
+
+  langsmith = callPackage ../development/python-modules/langsmith { };
+
+  language-data = callPackage ../development/python-modules/language-data { };
+
+  language-tags = callPackage ../development/python-modules/language-tags { };
+
+  language-tool-python = callPackage ../development/python-modules/language-tool-python { };
+
+  lanms-neo = callPackage ../development/python-modules/lanms-neo { };
+
+  lap = callPackage ../development/python-modules/lap { };
+
+  lark = callPackage ../development/python-modules/lark { };
+
+  laspy = callPackage ../development/python-modules/laspy { };
+
+  lastversion = callPackage ../development/python-modules/lastversion { };
+
+  laszip = callPackage ../development/python-modules/laszip {
+    inherit (pkgs) cmake ninja;
+    inherit (pkgs.__splicedPackages) laszip;
+  };
+
+  latex2mathml = callPackage ../development/python-modules/latex2mathml { };
+
+  latex2pydata = callPackage ../development/python-modules/latex2pydata { };
+
+  latexcodec = callPackage ../development/python-modules/latexcodec { };
+
+  latexify-py = callPackage ../development/python-modules/latexify-py { };
+
+  latexrestricted = callPackage ../development/python-modules/latexrestricted { };
+
+  launchpadlib = callPackage ../development/python-modules/launchpadlib { };
+
+  laundrify-aio = callPackage ../development/python-modules/laundrify-aio { };
+
+  layoutparser = callPackage ../development/python-modules/layoutparser { };
+
+  lazr-config = callPackage ../development/python-modules/lazr-config { };
+
+  lazr-delegates = callPackage ../development/python-modules/lazr-delegates { };
+
+  lazr-restfulclient = callPackage ../development/python-modules/lazr-restfulclient { };
+
+  lazr-uri = callPackage ../development/python-modules/lazr-uri { };
+
+  lazy = callPackage ../development/python-modules/lazy { };
+
+  lazy-imports = callPackage ../development/python-modules/lazy-imports { };
+
+  lazy-loader = callPackage ../development/python-modules/lazy-loader { };
+
+  lazy-object-proxy = callPackage ../development/python-modules/lazy-object-proxy { };
+
+  lc7001 = callPackage ../development/python-modules/lc7001 { };
+
+  lcd-i2c = callPackage ../development/python-modules/lcd-i2c { };
+
+  lcgit = callPackage ../development/python-modules/lcgit { };
+
+  lcn-frontend = callPackage ../development/python-modules/lcn-frontend { };
+
+  lcov-cobertura = callPackage ../development/python-modules/lcov-cobertura { };
+
+  ld2410-ble = callPackage ../development/python-modules/ld2410-ble { };
+
+  ldap3 = callPackage ../development/python-modules/ldap3 { };
+
+  ldap3-bleeding-edge = callPackage ../development/python-modules/ldap3-bleeding-edge { };
+
+  ldapdomaindump = callPackage ../development/python-modules/ldapdomaindump { };
+
+  ldappool = callPackage ../development/python-modules/ldappool { };
+
+  ldaptor = callPackage ../development/python-modules/ldaptor { };
+
+  ldfparser = callPackage ../development/python-modules/ldfparser { };
+
+  leanblueprint = callPackage ../development/python-modules/leanblueprint { };
+
+  leaone-ble = callPackage ../development/python-modules/leaone-ble { };
+
+  leather = callPackage ../development/python-modules/leather { };
+
+  leb128 = callPackage ../development/python-modules/leb128 { };
+
+  led-ble = callPackage ../development/python-modules/led-ble { };
+
+  ledger =
+    (toPythonModule (
+      pkgs.ledger.override {
+        usePython = true;
+        python3 = python;
+      }
+    )).py;
+
+  ledger-agent = callPackage ../development/python-modules/ledger-agent { };
+
+  ledger-bitcoin = callPackage ../development/python-modules/ledger-bitcoin { };
+
+  ledgerblue = callPackage ../development/python-modules/ledgerblue { };
+
+  ledgercomm = callPackage ../development/python-modules/ledgercomm { };
+
+  ledgerwallet = callPackage ../development/python-modules/ledgerwallet {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+  };
+
+  legacy-cgi = callPackage ../development/python-modules/legacy-cgi { };
+
+  leidenalg = callPackage ../development/python-modules/leidenalg { igraph-c = pkgs.igraph; };
+
+  lektricowifi = callPackage ../development/python-modules/lektricowifi { };
+
+  letpot = callPackage ../development/python-modules/letpot { };
+
+  leveldb = callPackage ../development/python-modules/leveldb { };
+
+  levenshtein = callPackage ../development/python-modules/levenshtein { };
+
+  lexid = callPackage ../development/python-modules/lexid { };
+
+  lexilang = callPackage ../development/python-modules/lexilang { };
+
+  lhapdf = toPythonModule (pkgs.lhapdf.override { inherit python; });
+
+  lib4package = callPackage ../development/python-modules/lib4package { };
+
+  lib4sbom = callPackage ../development/python-modules/lib4sbom { };
+
+  libagent = callPackage ../development/python-modules/libagent { };
+
+  libais = callPackage ../development/python-modules/libais { };
+
+  libarchive-c = callPackage ../development/python-modules/libarchive-c {
+    inherit (pkgs) libarchive;
+  };
+
+  libarcus = callPackage ../development/python-modules/libarcus { protobuf = pkgs.protobuf_21; };
+
+  libasyncns = callPackage ../development/python-modules/libasyncns { inherit (pkgs) libasyncns; };
+
+  libbs = callPackage ../development/python-modules/libbs { };
+
+  libclang = callPackage ../development/python-modules/libclang { };
+
+  libcloud = callPackage ../development/python-modules/libcloud { };
+
+  libcomps = lib.pipe pkgs.libcomps [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
+    (p: p.override { inherit python; })
+    (p: p.py)
+  ];
+
+  libcst = callPackage ../development/python-modules/libcst { };
+
+  libdnf = lib.pipe pkgs.libdnf [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
+    (p: p.override { inherit python; })
+    (p: p.py)
+  ];
+
+  libevdev = callPackage ../development/python-modules/libevdev { };
+
+  libfdt = toPythonModule (
+    pkgs.dtc.override {
+      inherit python;
+      pythonSupport = true;
+    }
+  );
+
+  libfive = toPythonModule (pkgs.libfive.override { inherit python; });
+
+  libgpiod = callPackage ../development/python-modules/libgpiod { inherit (pkgs) libgpiod; };
+
+  libgravatar = callPackage ../development/python-modules/libgravatar { };
+
+  libiio =
+    (toPythonModule (
+      pkgs.libiio.override {
+        pythonSupport = true;
+        inherit python;
+      }
+    )).python;
+
+  libipld = callPackage ../development/python-modules/libipld { };
+
+  libkeepass = callPackage ../development/python-modules/libkeepass { };
+
+  libknot = callPackage ../development/python-modules/libknot { };
+
+  liblarch = callPackage ../development/python-modules/liblarch { };
+
+  liblzfse = callPackage ../development/python-modules/liblzfse { inherit (pkgs) lzfse; };
+
+  libmambapy = callPackage ../development/python-modules/libmambapy { };
+
+  libmodulemd = lib.pipe pkgs.libmodulemd [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ]; # The package always builds python3 bindings
+          broken = (super.meta.broken or false) || !isPy3k;
+        };
+      })
+    )
+    (p: p.override { python3 = python; })
+    (p: p.py)
+  ];
+
+  libmr = callPackage ../development/python-modules/libmr { };
+
+  libnacl = callPackage ../development/python-modules/libnacl { inherit (pkgs) libsodium; };
+
+  libnbd = toPythonModule (
+    pkgs.libnbd.override {
+      buildPythonBindings = true;
+      python3 = python;
+    }
+  );
+
+  libpcap = callPackage ../development/python-modules/libpcap {
+    pkgsLibpcap = pkgs.libpcap; # Needs the C library
+  };
+
+  libpurecool = callPackage ../development/python-modules/libpurecool { };
+
+  libpwquality = lib.pipe pkgs.libpwquality [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
+    (
+      p:
+      p.override {
+        enablePython = true;
+        inherit python;
+      }
+    )
+    (p: p.py)
+  ];
+
+  libpyfoscam = callPackage ../development/python-modules/libpyfoscam { };
+
+  libpysal = callPackage ../development/python-modules/libpysal { };
+
+  libpyvivotek = callPackage ../development/python-modules/libpyvivotek { };
+
+  libredwg = toPythonModule (
+    pkgs.libredwg.override {
+      enablePython = true;
+      inherit (self) python libxml2;
+    }
+  );
+
+  librepo = lib.pipe pkgs.librepo [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+        };
+      })
+    )
+    (p: p.override { inherit python; })
+    (p: p.py)
+  ];
+
+  librespot = callPackage ../development/python-modules/librespot { };
+
+  libretranslate = callPackage ../development/python-modules/libretranslate { };
+
+  librosa = callPackage ../development/python-modules/librosa { };
+
+  librouteros = callPackage ../development/python-modules/librouteros { };
+
+  libsass = callPackage ../development/python-modules/libsass { inherit (pkgs) libsass; };
+
+  libsavitar = callPackage ../development/python-modules/libsavitar { };
+
+  libsbml = toPythonModule (
+    pkgs.libsbml.override {
+      withPython = true;
+      inherit (self) python;
+    }
+  );
+
+  libselinux = lib.pipe pkgs.libselinux [
+    toPythonModule
+    (
+      p:
+      p.overrideAttrs (super: {
+        meta = super.meta // {
+          outputsToInstall = [ "py" ];
+          broken = super.meta.broken or isPy27;
+        };
+      })
+    )
+    (
+      p:
+      p.override {
+        enablePython = true;
+        python3 = python;
+        python3Packages = pythonPackages;
+      }
+    )
+    (p: p.py)
+  ];
+
+  libsixel = callPackage ../development/python-modules/libsixel { inherit (pkgs) libsixel; };
+
+  libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
+
+  libthumbor = callPackage ../development/python-modules/libthumbor { };
+
+  libtmux = callPackage ../development/python-modules/libtmux { };
+
+  libtorrent-rasterbar =
+    (toPythonModule (pkgs.libtorrent-rasterbar.override { python3 = python; })).python;
+
+  libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };
+
+  libusbsio = callPackage ../development/python-modules/libusbsio { inherit (pkgs) libusbsio; };
+
+  libuuu = callPackage ../development/python-modules/libuuu { };
+
+  libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion; };
+
+  libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };
+
+  libxml2 =
+    (toPythonModule (
+      pkgs.libxml2.override {
+        pythonSupport = true;
+        inherit python;
+      }
+    )).py;
+
+  libxslt =
+    (toPythonModule (
+      pkgs.libxslt.override {
+        pythonSupport = true;
+        inherit (self) python libxml2;
+      }
+    )).py;
+
+  liccheck = callPackage ../development/python-modules/liccheck { };
+
+  license-expression = callPackage ../development/python-modules/license-expression { };
+
+  lida = callPackage ../development/python-modules/lida { };
+
+  lief = (toPythonModule (pkgs.lief.override { inherit python; })).py;
+
+  life360 = callPackage ../development/python-modules/life360 { };
+
+  lifelines = callPackage ../development/python-modules/lifelines { };
+
+  lightgbm = callPackage ../development/python-modules/lightgbm { };
+
+  lightify = callPackage ../development/python-modules/lightify { };
+
+  lightning-utilities = callPackage ../development/python-modules/lightning-utilities { };
+
+  lightparam = callPackage ../development/python-modules/lightparam { };
+
+  lightwave = callPackage ../development/python-modules/lightwave { };
+
+  lightwave2 = callPackage ../development/python-modules/lightwave2 { };
+
+  lima = callPackage ../development/python-modules/lima { };
+
+  lime = callPackage ../development/python-modules/lime { };
+
+  limiter = callPackage ../development/python-modules/limiter { };
+
+  limitlessled = callPackage ../development/python-modules/limitlessled { };
+
+  limits = callPackage ../development/python-modules/limits { };
+
+  limnoria = callPackage ../development/python-modules/limnoria { };
+
+  line-profiler = callPackage ../development/python-modules/line-profiler { };
+
+  linear-garage-door = callPackage ../development/python-modules/linear-garage-door { };
+
+  linear-operator = callPackage ../development/python-modules/linear-operator { };
+
+  lineax = callPackage ../development/python-modules/lineax { };
+
+  linecache2 = callPackage ../development/python-modules/linecache2 { };
+
+  lineedit = callPackage ../development/python-modules/lineedit { };
+
+  linetable = callPackage ../development/python-modules/linetable { };
+
+  lingua = callPackage ../development/python-modules/lingua { };
+
+  lingva = callPackage ../development/python-modules/lingva { };
+
+  linien-client = callPackage ../development/python-modules/linien-client { };
+
+  linien-common = callPackage ../development/python-modules/linien-common { };
+
+  linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
+
+  linknlink = callPackage ../development/python-modules/linknlink { };
+
+  linode = callPackage ../development/python-modules/linode { };
+
+  linode-api = callPackage ../development/python-modules/linode-api { };
+
+  linode-metadata = callPackage ../development/python-modules/linode-metadata { };
+
+  linuxfd = callPackage ../development/python-modules/linuxfd { };
+
+  linuxpy = callPackage ../development/python-modules/linuxpy { };
+
+  lion-pytorch = callPackage ../development/python-modules/lion-pytorch { };
+
+  liquidctl = callPackage ../development/python-modules/liquidctl { };
+
+  lirc = toPythonModule (pkgs.lirc.override { python3 = python; });
+
+  lit = callPackage ../development/python-modules/lit { };
+
+  litellm = callPackage ../development/python-modules/litellm { };
+
+  litemapy = callPackage ../development/python-modules/litemapy { };
+
+  litestar = callPackage ../development/python-modules/litestar { };
+
+  litestar-htmx = callPackage ../development/python-modules/litestar-htmx { };
+
+  littleutils = callPackage ../development/python-modules/littleutils { };
+
+  livelossplot = callPackage ../development/python-modules/livelossplot { };
+
+  livereload = callPackage ../development/python-modules/livereload { };
+
+  livisi = callPackage ../development/python-modules/livisi { };
+
+  lizard = callPackage ../development/python-modules/lizard { };
+
+  llama-cloud = callPackage ../development/python-modules/llama-cloud { };
+
+  llama-cpp-python = callPackage ../development/python-modules/llama-cpp-python { };
+
+  llama-index = callPackage ../development/python-modules/llama-index { };
+
+  llama-index-agent-openai = callPackage ../development/python-modules/llama-index-agent-openai { };
+
+  llama-index-cli = callPackage ../development/python-modules/llama-index-cli { };
+
+  llama-index-core = callPackage ../development/python-modules/llama-index-core { };
+
+  llama-index-embeddings-gemini =
+    callPackage ../development/python-modules/llama-index-embeddings-gemini
+      { };
+
+  llama-index-embeddings-google =
+    callPackage ../development/python-modules/llama-index-embeddings-google
+      { };
+
+  llama-index-embeddings-huggingface =
+    callPackage ../development/python-modules/llama-index-embeddings-huggingface
+      { };
+
+  llama-index-embeddings-ollama =
+    callPackage ../development/python-modules/llama-index-embeddings-ollama
+      { };
+
+  llama-index-embeddings-openai =
+    callPackage ../development/python-modules/llama-index-embeddings-openai
+      { };
+
+  llama-index-graph-stores-nebula =
+    callPackage ../development/python-modules/llama-index-graph-stores-nebula
+      { };
+
+  llama-index-graph-stores-neo4j =
+    callPackage ../development/python-modules/llama-index-graph-stores-neo4j
+      { };
+
+  llama-index-graph-stores-neptune =
+    callPackage ../development/python-modules/llama-index-graph-stores-neptune
+      { };
+
+  llama-index-indices-managed-llama-cloud =
+    callPackage ../development/python-modules/llama-index-indices-managed-llama-cloud
+      { };
+
+  llama-index-legacy = callPackage ../development/python-modules/llama-index-legacy { };
+
+  llama-index-llms-ollama = callPackage ../development/python-modules/llama-index-llms-ollama { };
+
+  llama-index-llms-openai = callPackage ../development/python-modules/llama-index-llms-openai { };
+
+  llama-index-llms-openai-like =
+    callPackage ../development/python-modules/llama-index-llms-openai-like
+      { };
+
+  llama-index-multi-modal-llms-openai =
+    callPackage ../development/python-modules/llama-index-multi-modal-llms-openai
+      { };
+
+  llama-index-program-openai =
+    callPackage ../development/python-modules/llama-index-program-openai
+      { };
+
+  llama-index-question-gen-openai =
+    callPackage ../development/python-modules/llama-index-question-gen-openai
+      { };
+
+  llama-index-readers-database =
+    callPackage ../development/python-modules/llama-index-readers-database
+      { };
+
+  llama-index-readers-file = callPackage ../development/python-modules/llama-index-readers-file { };
+
+  llama-index-readers-json = callPackage ../development/python-modules/llama-index-readers-json { };
+
+  llama-index-readers-llama-parse =
+    callPackage ../development/python-modules/llama-index-readers-llama-parse
+      { };
+
+  llama-index-readers-s3 = callPackage ../development/python-modules/llama-index-readers-s3 { };
+
+  llama-index-readers-twitter =
+    callPackage ../development/python-modules/llama-index-readers-twitter
+      { };
+
+  llama-index-readers-txtai = callPackage ../development/python-modules/llama-index-readers-txtai { };
+
+  llama-index-readers-weather =
+    callPackage ../development/python-modules/llama-index-readers-weather
+      { };
+
+  llama-index-vector-stores-chroma =
+    callPackage ../development/python-modules/llama-index-vector-stores-chroma
+      { };
+
+  llama-index-vector-stores-google =
+    callPackage ../development/python-modules/llama-index-vector-stores-google
+      { };
+
+  llama-index-vector-stores-postgres =
+    callPackage ../development/python-modules/llama-index-vector-stores-postgres
+      { };
+
+  llama-index-vector-stores-qdrant =
+    callPackage ../development/python-modules/llama-index-vector-stores-qdrant
+      { };
+
+  llama-parse = callPackage ../development/python-modules/llama-parse { };
+
+  llamaindex-py-client = callPackage ../development/python-modules/llamaindex-py-client { };
+
+  llfuse = callPackage ../development/python-modules/llfuse { inherit (pkgs) fuse; };
+
+  llguidance = callPackage ../development/python-modules/llguidance { };
+
+  llm = callPackage ../development/python-modules/llm { };
+
+  llm-anthropic = callPackage ../development/python-modules/llm-anthropic { };
+
+  llm-cmd = callPackage ../development/python-modules/llm-cmd { };
+
+  llm-gemini = callPackage ../development/python-modules/llm-gemini { };
+
+  llm-gguf = callPackage ../development/python-modules/llm-gguf { };
+
+  llm-jq = callPackage ../development/python-modules/llm-jq { };
+
+  llm-ollama = callPackage ../development/python-modules/llm-ollama { };
+
+  llmx = callPackage ../development/python-modules/llmx { };
+
+  llvmlite = callPackage ../development/python-modules/llvmlite {
+    # llvmlite always requires a specific version of llvm.
+    llvm = pkgs.llvm_15;
+  };
+
+  lm-eval = callPackage ../development/python-modules/lm-eval { };
+
+  lm-format-enforcer = callPackage ../development/python-modules/lm-format-enforcer { };
+
+  lmdb = callPackage ../development/python-modules/lmdb { inherit (pkgs) lmdb; };
+
+  lmfit = callPackage ../development/python-modules/lmfit { };
+
+  lml = callPackage ../development/python-modules/lml { };
+
+  lmnotify = callPackage ../development/python-modules/lmnotify { };
+
+  lmtpd = callPackage ../development/python-modules/lmtpd { };
+
+  lnkparse3 = callPackage ../development/python-modules/lnkparse3 { };
+
+  loca = callPackage ../development/python-modules/loca { };
+
+  localimport = callPackage ../development/python-modules/localimport { };
+
+  localstack-client = callPackage ../development/python-modules/localstack-client { };
+
+  localstack-ext = callPackage ../development/python-modules/localstack-ext { };
+
+  localzone = callPackage ../development/python-modules/localzone { };
+
+  locationsharinglib = callPackage ../development/python-modules/locationsharinglib { };
+
+  locket = callPackage ../development/python-modules/locket { };
+
+  lockfile = callPackage ../development/python-modules/lockfile { };
+
+  locust = callPackage ../development/python-modules/locust { };
+
+  log-symbols = callPackage ../development/python-modules/log-symbols { };
+
+  logassert = callPackage ../development/python-modules/logassert { };
+
+  logbook = callPackage ../development/python-modules/logbook { };
+
+  logfury = callPackage ../development/python-modules/logfury { };
+
+  logging-journald = callPackage ../development/python-modules/logging-journald { };
+
+  logi-circle = callPackage ../development/python-modules/logi-circle { };
+
+  logical-unification = callPackage ../development/python-modules/logical-unification { };
+
+  logilab-common = callPackage ../development/python-modules/logilab/common.nix {
+    pytestCheckHook = pytest7CheckHook;
+  };
+
+  logilab-constraint = callPackage ../development/python-modules/logilab/constraint.nix { };
+
+  logmatic-python = callPackage ../development/python-modules/logmatic-python { };
+
+  logster = callPackage ../development/python-modules/logster { };
+
+  loguru = callPackage ../development/python-modules/loguru { };
+
+  loguru-logging-intercept = callPackage ../development/python-modules/loguru-logging-intercept { };
+
+  logutils = callPackage ../development/python-modules/logutils { };
+
+  logzero = callPackage ../development/python-modules/logzero { };
+
+  lomond = callPackage ../development/python-modules/lomond { };
+
+  loompy = callPackage ../development/python-modules/loompy { };
+
+  loopy = callPackage ../development/python-modules/loopy { };
+
+  looseversion = callPackage ../development/python-modules/looseversion { };
+
+  loqedapi = callPackage ../development/python-modules/loqedapi { };
+
+  losant-rest = callPackage ../development/python-modules/losant-rest { };
+
+  lottie = callPackage ../development/python-modules/lottie { };
+
+  lox = callPackage ../development/python-modules/lox { };
+
+  lpc-checksum = callPackage ../development/python-modules/lpc-checksum { };
+
+  lrcalc-python = callPackage ../development/python-modules/lrcalc-python { };
+
+  lrclibapi = callPackage ../development/python-modules/lrclibapi { };
+
+  lru-dict = callPackage ../development/python-modules/lru-dict { };
+
+  lsassy = callPackage ../development/python-modules/lsassy { };
+
+  lsp-tree-sitter = callPackage ../development/python-modules/lsp-tree-sitter { };
+
+  lsprotocol = callPackage ../development/python-modules/lsprotocol { };
+
+  ltpycld2 = callPackage ../development/python-modules/ltpycld2 { };
+
+  lttng = callPackage ../development/python-modules/lttng { };
+
+  luddite = callPackage ../development/python-modules/luddite { };
+
+  luftdaten = callPackage ../development/python-modules/luftdaten { };
+
+  luhn = callPackage ../development/python-modules/luhn { };
+
+  luna-soc = callPackage ../development/python-modules/luna-soc { };
+
+  luna-usb = callPackage ../development/python-modules/luna-usb { };
+
+  lunarcalendar = callPackage ../development/python-modules/lunarcalendar { };
+
+  lupa = callPackage ../development/python-modules/lupa { };
+
+  lupupy = callPackage ../development/python-modules/lupupy { };
+
+  luqum = callPackage ../development/python-modules/luqum { };
+
+  luxtronik = callPackage ../development/python-modules/luxtronik { };
+
+  lxmf = callPackage ../development/python-modules/lxmf { };
+
+  lxml = callPackage ../development/python-modules/lxml { inherit (pkgs) libxml2 libxslt zlib; };
+
+  lxml-html-clean = callPackage ../development/python-modules/lxml-html-clean { };
+
+  lxml-stubs = callPackage ../development/python-modules/lxml-stubs { };
+
+  lyricwikia = callPackage ../development/python-modules/lyricwikia { };
+
+  lz4 = callPackage ../development/python-modules/lz4 { };
+
+  lzallright = callPackage ../development/python-modules/lzallright { };
+
+  lzstring = callPackage ../development/python-modules/lzstring { };
+
+  m2crypto = callPackage ../development/python-modules/m2crypto { };
+
+  m2r = callPackage ../development/python-modules/m2r { };
+
+  m3u8 = callPackage ../development/python-modules/m3u8 { };
+
+  mac-alias = callPackage ../development/python-modules/mac-alias { };
+
+  mac-vendor-lookup = callPackage ../development/python-modules/mac-vendor-lookup { };
+
+  macaddress = callPackage ../development/python-modules/macaddress { };
+
+  macaroonbakery = callPackage ../development/python-modules/macaroonbakery { };
+
+  macfsevents = callPackage ../development/python-modules/macfsevents {
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
+  };
+
+  macholib = callPackage ../development/python-modules/macholib { };
+
+  macropy = callPackage ../development/python-modules/macropy { };
+
+  maec = callPackage ../development/python-modules/maec { };
+
+  maestral = callPackage ../development/python-modules/maestral { };
+
+  magic = callPackage ../development/python-modules/magic { };
+
+  magic-filter = callPackage ../development/python-modules/magic-filter { };
+
+  magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
+
+  magic-wormhole-mailbox-server =
+    callPackage ../development/python-modules/magic-wormhole-mailbox-server
+      { };
+
+  magic-wormhole-transit-relay =
+    callPackage ../development/python-modules/magic-wormhole-transit-relay
+      { };
+
+  magicgui = callPackage ../development/python-modules/magicgui { };
+
+  magika = callPackage ../development/python-modules/magika { };
+
+  mahotas = callPackage ../development/python-modules/mahotas { };
+
+  mail-parser = callPackage ../development/python-modules/mail-parser { };
+
+  mailcap-fix = callPackage ../development/python-modules/mailcap-fix { };
+
+  mailchecker = callPackage ../development/python-modules/mailchecker { };
+
+  mailchimp = callPackage ../development/python-modules/mailchimp { };
+
+  mailmanclient = callPackage ../development/python-modules/mailmanclient { };
+
+  mailsuite = callPackage ../development/python-modules/mailsuite { };
+
+  maison = callPackage ../development/python-modules/maison { };
+
+  makefun = callPackage ../development/python-modules/makefun { };
+
+  mako = callPackage ../development/python-modules/mako { };
+
+  malduck = callPackage ../development/python-modules/malduck { };
+
+  mallard-ducktype = callPackage ../development/python-modules/mallard-ducktype { };
+
+  mamba-ssm = callPackage ../development/python-modules/mamba-ssm { };
+
+  mammoth = callPackage ../development/python-modules/mammoth { };
+
+  managesieve = callPackage ../development/python-modules/managesieve { };
+
+  mando = callPackage ../development/python-modules/mando { };
+
+  mandown = callPackage ../development/python-modules/mandown { };
+
+  manga-ocr = callPackage ../development/python-modules/manga-ocr { };
+
+  manhole = callPackage ../development/python-modules/manhole { };
+
+  manifest-ml = callPackage ../development/python-modules/manifest-ml { };
+
+  manifestoo = callPackage ../development/python-modules/manifestoo { };
+
+  manifestoo-core = callPackage ../development/python-modules/manifestoo-core { };
+
+  manifestparser =
+    callPackage ../development/python-modules/marionette-harness/manifestparser.nix
+      { };
+
+  manifold3d = callPackage ../development/python-modules/manifold3d { };
+
+  manim = callPackage ../development/python-modules/manim { };
+
+  manim-slides = callPackage ../development/python-modules/manim-slides { };
+
+  manimpango = callPackage ../development/python-modules/manimpango {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+  };
+
+  manuel = callPackage ../development/python-modules/manuel { };
+
+  manuf = callPackage ../development/python-modules/manuf { };
+
+  mapbox-earcut = callPackage ../development/python-modules/mapbox-earcut { };
+
+  mapclassify = callPackage ../development/python-modules/mapclassify { };
+
+  mariadb = callPackage ../development/python-modules/mariadb { };
+
+  marimo = callPackage ../development/python-modules/marimo { };
+
+  marisa = callPackage ../development/python-modules/marisa { inherit (pkgs) marisa; };
+
+  marisa-trie = callPackage ../development/python-modules/marisa-trie { };
+
+  markdown = callPackage ../development/python-modules/markdown { };
+
+  markdown-include = callPackage ../development/python-modules/markdown-include { };
+
+  markdown-it-py = callPackage ../development/python-modules/markdown-it-py { };
+
+  markdown-macros = callPackage ../development/python-modules/markdown-macros { };
+
+  markdown2 = callPackage ../development/python-modules/markdown2 { };
+
+  markdownify = callPackage ../development/python-modules/markdownify { };
+
+  markitdown = callPackage ../development/python-modules/markitdown { };
+
+  marko = callPackage ../development/python-modules/marko { };
+
+  markuppy = callPackage ../development/python-modules/markuppy { };
+
+  markups = callPackage ../development/python-modules/markups { };
+
+  markupsafe = callPackage ../development/python-modules/markupsafe { };
+
+  marqo = callPackage ../development/python-modules/marqo { };
+
+  marshmallow = callPackage ../development/python-modules/marshmallow { };
+
+  marshmallow-dataclass = callPackage ../development/python-modules/marshmallow-dataclass { };
+
+  marshmallow-oneofschema = callPackage ../development/python-modules/marshmallow-oneofschema { };
+
+  marshmallow-polyfield = callPackage ../development/python-modules/marshmallow-polyfield { };
+
+  marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
+
+  mashumaro = callPackage ../development/python-modules/mashumaro { };
+
+  masky = callPackage ../development/python-modules/masky { };
+
+  mastodon-py = callPackage ../development/python-modules/mastodon-py { };
+
+  mat2 = callPackage ../development/python-modules/mat2 { };
+
+  matchpy = callPackage ../development/python-modules/matchpy { };
+
+  material-color-utilities = callPackage ../development/python-modules/material-color-utilities { };
+
+  materialx = callPackage ../development/python-modules/materialx { };
+
+  materialyoucolor = callPackage ../development/python-modules/materialyoucolor { };
+
+  mathlibtools = callPackage ../development/python-modules/mathlibtools { };
+
+  mathutils = callPackage ../development/python-modules/mathutils { };
+
+  matlink-gpapi = callPackage ../development/python-modules/matlink-gpapi { };
+
+  matplotlib = callPackage ../development/python-modules/matplotlib {
+    stdenv = if stdenv.hostPlatform.isDarwin then pkgs.clangStdenv else pkgs.stdenv;
+    inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+    ghostscript = pkgs.ghostscript_headless;
+  };
+
+  matplotlib-inline = callPackage ../development/python-modules/matplotlib-inline { };
+
+  matplotlib-sixel = callPackage ../development/python-modules/matplotlib-sixel { };
+
+  matplotlib-venn = callPackage ../development/python-modules/matplotlib-venn { };
+
+  matplotx = callPackage ../development/python-modules/matplotx { };
+
+  matrix-client = callPackage ../development/python-modules/matrix-client { };
+
+  matrix-common = callPackage ../development/python-modules/matrix-common { };
+
+  matrix-nio = callPackage ../development/python-modules/matrix-nio { };
+
+  mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
+
+  maubot = callPackage ../tools/networking/maubot { };
+
+  mautrix = callPackage ../development/python-modules/mautrix { };
+
+  mautrix-appservice = self.mautrix; # alias 2019-12-28
+
+  maxcube-api = callPackage ../development/python-modules/maxcube-api { };
+
+  maxminddb = callPackage ../development/python-modules/maxminddb { };
+
+  maya = callPackage ../development/python-modules/maya { };
+
+  mayavi = pkgs.libsForQt5.callPackage ../development/python-modules/mayavi {
+    inherit buildPythonPackage pythonOlder pythonAtLeast;
+    # when next release contains numpy2 support unpin
+    # https://github.com/enthought/mayavi/pull/1315
+    inherit (self)
+      pyface
+      pygments
+      numpy_1
+      packaging
+      vtk
+      traitsui
+      envisage
+      apptools
+      pyqt5
+      ;
+  };
+
+  mayim = callPackage ../development/python-modules/mayim { };
+
+  mbddns = callPackage ../development/python-modules/mbddns { };
+
+  mbstrdecoder = callPackage ../development/python-modules/mbstrdecoder { };
+
+  mccabe = callPackage ../development/python-modules/mccabe { };
+
+  mcdreforged = callPackage ../development/python-modules/mcdreforged { };
+
+  mcp = callPackage ../development/python-modules/mcp { };
+
+  mcpadapt = callPackage ../development/python-modules/mcpadapt { };
+
+  mcstatus = callPackage ../development/python-modules/mcstatus { };
+
+  mcuuid = callPackage ../development/python-modules/mcuuid { };
+
+  md-toc = callPackage ../development/python-modules/md-toc { };
+
+  md2gemini = callPackage ../development/python-modules/md2gemini { };
+
+  md2pdf = callPackage ../development/python-modules/md2pdf { };
+
+  mdformat = callPackage ../development/python-modules/mdformat { };
+
+  mdformat-admon = callPackage ../development/python-modules/mdformat-admon { };
+
+  mdformat-beautysh = callPackage ../development/python-modules/mdformat-beautysh { };
+
+  mdformat-footnote = callPackage ../development/python-modules/mdformat-footnote { };
+
+  mdformat-frontmatter = callPackage ../development/python-modules/mdformat-frontmatter { };
+
+  mdformat-gfm = callPackage ../development/python-modules/mdformat-gfm { };
+
+  mdformat-gfm-alerts = callPackage ../development/python-modules/mdformat-gfm-alerts { };
+
+  mdformat-mkdocs = callPackage ../development/python-modules/mdformat-mkdocs { };
+
+  mdformat-myst = callPackage ../development/python-modules/mdformat-myst { };
+
+  mdformat-nix-alejandra = callPackage ../development/python-modules/mdformat-nix-alejandra { };
+
+  mdformat-simple-breaks = callPackage ../development/python-modules/mdformat-simple-breaks { };
+
+  mdformat-tables = callPackage ../development/python-modules/mdformat-tables { };
+
+  mdformat-toc = callPackage ../development/python-modules/mdformat-toc { };
+
+  mdformat-wikilink = callPackage ../development/python-modules/mdformat-wikilink { };
+
+  mdit-py-plugins = callPackage ../development/python-modules/mdit-py-plugins { };
+
+  mdtraj = callPackage ../development/python-modules/mdtraj { };
+
+  mdurl = callPackage ../development/python-modules/mdurl { };
+
+  mdutils = callPackage ../development/python-modules/mdutils { };
+
+  mdx-truly-sane-lists = callPackage ../development/python-modules/mdx-truly-sane-lists { };
+
+  mean-average-precision = callPackage ../development/python-modules/mean-average-precision { };
+
+  measurement = callPackage ../development/python-modules/measurement { };
+
+  meater-python = callPackage ../development/python-modules/meater-python { };
+
+  mecab-python3 = callPackage ../development/python-modules/mecab-python3 { };
+
+  mechanicalsoup = callPackage ../development/python-modules/mechanicalsoup { };
+
+  mechanize = callPackage ../development/python-modules/mechanize { };
+
+  medallion = callPackage ../development/python-modules/medallion { };
+
+  mediafile = callPackage ../development/python-modules/mediafile { };
+
+  mediafire-dl = callPackage ../development/python-modules/mediafire-dl { };
+
+  mediapy = callPackage ../development/python-modules/mediapy { };
+
+  medpy = callPackage ../development/python-modules/medpy { };
+
+  medvol = callPackage ../development/python-modules/medvol { };
+
+  meeko = callPackage ../development/python-modules/meeko { };
+
+  meep = callPackage ../development/python-modules/meep { };
+
+  meilisearch = callPackage ../development/python-modules/meilisearch { };
+
+  meinheld = callPackage ../development/python-modules/meinheld { };
+
+  meld3 = callPackage ../development/python-modules/meld3 { };
+
+  melnor-bluetooth = callPackage ../development/python-modules/melnor-bluetooth { };
+
+  memestra = callPackage ../development/python-modules/memestra { };
+
+  memory-allocator = callPackage ../development/python-modules/memory-allocator { };
+
+  memory-profiler = callPackage ../development/python-modules/memory-profiler { };
+
+  memory-tempfile = callPackage ../development/python-modules/memory-tempfile { };
+
+  meraki = callPackage ../development/python-modules/meraki { };
+
+  mercadopago = callPackage ../development/python-modules/mercadopago { };
+
+  mercantile = callPackage ../development/python-modules/mercantile { };
+
+  mercurial = toPythonModule (pkgs.mercurial.override { python3Packages = self; });
+
+  merge3 = callPackage ../development/python-modules/merge3 { };
+
+  mergecal = callPackage ../development/python-modules/mergecal { };
+
+  mergedb = callPackage ../development/python-modules/mergedb { };
+
+  mergedeep = callPackage ../development/python-modules/mergedeep { };
+
+  mergedict = callPackage ../development/python-modules/mergedict { };
+
+  merkletools = callPackage ../development/python-modules/merkletools { };
+
+  meross-iot = callPackage ../development/python-modules/meross-iot { };
+
+  mesa = callPackage ../development/python-modules/mesa { };
+
+  meshcat = callPackage ../development/python-modules/meshcat { };
+
+  meshio = callPackage ../development/python-modules/meshio { };
+
+  meshlabxml = callPackage ../development/python-modules/meshlabxml { };
+
+  meshtastic = callPackage ../development/python-modules/meshtastic { };
+
+  meson = toPythonModule (
+    (pkgs.meson.override { python3 = python; }).overridePythonAttrs (oldAttrs: {
+      # We do not want the setup hook in Python packages because the build is performed differently.
+      setupHook = null;
+    })
+  );
+
+  meson-python = callPackage ../development/python-modules/meson-python { inherit (pkgs) ninja; };
+
+  mesonpep517 = callPackage ../development/python-modules/mesonpep517 { };
+
+  messagebird = callPackage ../development/python-modules/messagebird { };
+
+  metaflow = callPackage ../development/python-modules/metaflow { };
+
+  metakernel = callPackage ../development/python-modules/metakernel { };
+
+  metar = callPackage ../development/python-modules/metar { };
+
+  metawear = callPackage ../development/python-modules/metawear { };
+
+  meteoalertapi = callPackage ../development/python-modules/meteoalertapi { };
+
+  meteocalc = callPackage ../development/python-modules/meteocalc { };
+
+  meteofrance-api = callPackage ../development/python-modules/meteofrance-api { };
+
+  meteoswiss-async = callPackage ../development/python-modules/meteoswiss-async { };
+
+  methodtools = callPackage ../development/python-modules/methodtools { };
+
+  mezzanine = callPackage ../development/python-modules/mezzanine { };
+
+  mf2py = callPackage ../development/python-modules/mf2py { };
+
+  mficlient = callPackage ../development/python-modules/mficlient { };
+
+  mhcflurry = callPackage ../development/python-modules/mhcflurry { };
+
+  mhcgnomes = callPackage ../development/python-modules/mhcgnomes { };
+
+  miasm = callPackage ../development/python-modules/miasm { };
+
+  miauth = callPackage ../development/python-modules/miauth { };
+
+  micawber = callPackage ../development/python-modules/micawber { };
+
+  micloud = callPackage ../development/python-modules/micloud { };
+
+  microdata = callPackage ../development/python-modules/microdata { };
+
+  microsoft-kiota-abstractions =
+    callPackage ../development/python-modules/microsoft-kiota-abstractions
+      { };
+
+  microsoft-kiota-authentication-azure =
+    callPackage ../development/python-modules/microsoft-kiota-authentication-azure
+      { };
+
+  microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
+
+  microsoft-kiota-serialization-form =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-form
+      { };
+
+  microsoft-kiota-serialization-json =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-json
+      { };
+
+  microsoft-kiota-serialization-multipart =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-multipart
+      { };
+
+  microsoft-kiota-serialization-text =
+    callPackage ../development/python-modules/microsoft-kiota-serialization-text
+      { };
+
+  microsoft-security-utilities-secret-masker =
+    callPackage ../development/python-modules/microsoft-security-utilities-secret-masker
+      { };
+
+  midea-beautiful-air = callPackage ../development/python-modules/midea-beautiful-air { };
+
+  midea-local = callPackage ../development/python-modules/midea-local { };
+
+  midiutil = callPackage ../development/python-modules/midiutil { };
+
+  mido = callPackage ../development/python-modules/mido { };
+
+  migen = callPackage ../development/python-modules/migen { };
+
+  mike = callPackage ../development/python-modules/mike { };
+
+  milc = callPackage ../development/python-modules/milc { };
+
+  milksnake = callPackage ../development/python-modules/milksnake { };
+
+  mill-local = callPackage ../development/python-modules/mill-local { };
+
+  millheater = callPackage ../development/python-modules/millheater { };
+
+  mim-solvers = toPythonModule (
+    pkgs.mim-solvers.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
+  minari = callPackage ../development/python-modules/minari { };
+
+  mindsdb-evaluator = callPackage ../development/python-modules/mindsdb-evaluator { };
+
+  minexr = callPackage ../development/python-modules/minexr { };
+
+  miniaudio = callPackage ../development/python-modules/miniaudio {
+    inherit (pkgs) miniaudio;
+    inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox CoreAudio;
+  };
+
+  minichain = callPackage ../development/python-modules/minichain { };
+
+  minidb = callPackage ../development/python-modules/minidb { };
+
+  minidump = callPackage ../development/python-modules/minidump { };
+
+  miniful = callPackage ../development/python-modules/miniful { };
+
+  minify-html = callPackage ../development/python-modules/minify-html { };
+
+  minikanren = callPackage ../development/python-modules/minikanren { };
+
+  minikerberos = callPackage ../development/python-modules/minikerberos { };
+
+  minimal-snowplow-tracker = callPackage ../development/python-modules/minimal-snowplow-tracker { };
+
+  minimock = callPackage ../development/python-modules/minimock { };
+
+  mininet-python = (toPythonModule (pkgs.mininet.override { python3 = python; })).py;
+
+  minio = callPackage ../development/python-modules/minio { };
+
+  miniupnpc = callPackage ../development/python-modules/miniupnpc { };
+
+  mip = callPackage ../development/python-modules/mip { };
+
+  mir-eval = callPackage ../development/python-modules/mir-eval { };
+
+  mirakuru = callPackage ../development/python-modules/mirakuru { };
+
+  misaka = callPackage ../development/python-modules/misaka { };
+
+  misoc = callPackage ../development/python-modules/misoc { };
+
+  miss-hit = callPackage ../development/python-modules/miss-hit { };
+
+  miss-hit-core = callPackage ../development/python-modules/miss-hit-core { };
+
+  mistletoe = callPackage ../development/python-modules/mistletoe { };
+
+  mistral-common = callPackage ../development/python-modules/mistral-common { };
+
+  mistune = callPackage ../development/python-modules/mistune { };
+
+  mitmproxy = callPackage ../development/python-modules/mitmproxy { };
+
+  mitmproxy-linux = callPackage ../development/python-modules/mitmproxy-linux { };
+
+  mitmproxy-macos = callPackage ../development/python-modules/mitmproxy-macos { };
+
+  mitmproxy-rs = callPackage ../development/python-modules/mitmproxy-rs { };
+
+  mitogen = callPackage ../development/python-modules/mitogen { };
+
+  mixbox = callPackage ../development/python-modules/mixbox { };
+
+  mixins = callPackage ../development/python-modules/mixins { };
+
+  mixpanel = callPackage ../development/python-modules/mixpanel { };
+
+  mizani = callPackage ../development/python-modules/mizani { };
+
+  mkdocs = callPackage ../development/python-modules/mkdocs { };
+
+  mkdocs-autolinks-plugin = callPackage ../development/python-modules/mkdocs-autolinks-plugin { };
+
+  mkdocs-autorefs = callPackage ../development/python-modules/mkdocs-autorefs { };
+
+  mkdocs-awesome-nav = callPackage ../development/python-modules/mkdocs-awesome-nav { };
+
+  mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
+
+  mkdocs-exclude = callPackage ../development/python-modules/mkdocs-exclude { };
+
+  mkdocs-get-deps = callPackage ../development/python-modules/mkdocs-get-deps { };
+
+  mkdocs-git-authors-plugin = callPackage ../development/python-modules/mkdocs-git-authors-plugin { };
+
+  mkdocs-git-committers-plugin-2 =
+    callPackage ../development/python-modules/mkdocs-git-committers-plugin-2
+      { };
+
+  mkdocs-git-revision-date-localized-plugin =
+    callPackage ../development/python-modules/mkdocs-git-revision-date-localized-plugin
+      { };
+
+  mkdocs-gitlab = callPackage ../development/python-modules/mkdocs-gitlab-plugin { };
+
+  mkdocs-glightbox = callPackage ../development/python-modules/mkdocs-glightbox { };
+
+  mkdocs-jupyter = callPackage ../development/python-modules/mkdocs-jupyter { };
+
+  mkdocs-linkcheck = callPackage ../development/python-modules/mkdocs-linkcheck { };
+
+  mkdocs-macros = callPackage ../development/python-modules/mkdocs-macros { };
+
+  mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
+
+  mkdocs-material-extensions =
+    callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
+      { };
+
+  mkdocs-mermaid2-plugin = callPackage ../development/python-modules/mkdocs-mermaid2-plugin { };
+
+  mkdocs-minify-plugin = callPackage ../development/python-modules/mkdocs-minify-plugin { };
+
+  mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };
+
+  mkdocs-redoc-tag = callPackage ../development/python-modules/mkdocs-redoc-tag { };
+
+  mkdocs-rss-plugin = callPackage ../development/python-modules/mkdocs-rss-plugin { };
+
+  mkdocs-swagger-ui-tag = callPackage ../development/python-modules/mkdocs-swagger-ui-tag { };
+
+  mkdocstrings = callPackage ../development/python-modules/mkdocstrings { };
+
+  mkdocstrings-python = callPackage ../development/python-modules/mkdocstrings-python { };
+
+  mkl-service = callPackage ../development/python-modules/mkl-service { };
+
+  mktestdocs = callPackage ../development/python-modules/mktestdocs { };
+
+  ml-collections = callPackage ../development/python-modules/ml-collections { };
+
+  ml-dtypes = callPackage ../development/python-modules/ml-dtypes { };
+
+  mlflow = callPackage ../development/python-modules/mlflow { };
+
+  mlrose = callPackage ../development/python-modules/mlrose { };
+
+  mlt = toPythonModule (
+    pkgs.mlt.override {
+      python3 = python;
+      enablePython = true;
+    }
+  );
+
+  mlx = callPackage ../development/python-modules/mlx { };
+
+  mlxtend = callPackage ../development/python-modules/mlxtend { };
+
+  mmcif-pdbx = callPackage ../development/python-modules/mmcif-pdbx { };
+
+  mmcv = callPackage ../development/python-modules/mmcv { };
+
+  mmengine = callPackage ../development/python-modules/mmengine { };
+
+  mmh3 = callPackage ../development/python-modules/mmh3 { };
+
+  mmpython = callPackage ../development/python-modules/mmpython { };
+
+  mmtf-python = callPackage ../development/python-modules/mmtf-python { };
+
+  mne-python = callPackage ../development/python-modules/mne-python { };
+
+  mnemonic = callPackage ../development/python-modules/mnemonic { };
+
+  mnist = callPackage ../development/python-modules/mnist { };
+
+  moat-ble = callPackage ../development/python-modules/moat-ble { };
+
+  mobi = callPackage ../development/python-modules/mobi { };
+
+  mobly = callPackage ../development/python-modules/mobly { };
+
+  mock = callPackage ../development/python-modules/mock { };
+
+  mock-django = callPackage ../development/python-modules/mock-django { };
+
+  mock-open = callPackage ../development/python-modules/mock-open { };
+
+  mock-services = callPackage ../development/python-modules/mock-services { };
+
+  mock-ssh-server = callPackage ../development/python-modules/mock-ssh-server { };
+
+  mocket = callPackage ../development/python-modules/mocket { };
+
+  mockfs = callPackage ../development/python-modules/mockfs { };
+
+  mockito = callPackage ../development/python-modules/mockito { };
+
+  mockupdb = callPackage ../development/python-modules/mockupdb { };
+
+  modbus-tk = callPackage ../development/python-modules/modbus-tk { };
+
+  moddb = callPackage ../development/python-modules/moddb { };
+
+  model-bakery = callPackage ../development/python-modules/model-bakery { };
+
+  model-checker = callPackage ../development/python-modules/model-checker { };
+
+  modelcif = callPackage ../development/python-modules/modelcif { };
+
+  modeled = callPackage ../development/python-modules/modeled { };
+
+  moderngl = callPackage ../development/python-modules/moderngl { };
+
+  moderngl-window = callPackage ../development/python-modules/moderngl-window { };
+
+  modestmaps = callPackage ../development/python-modules/modestmaps { };
+
+  mohawk = callPackage ../development/python-modules/mohawk { };
+
+  molbar = callPackage ../development/python-modules/molbar { };
+
+  molecule = callPackage ../development/python-modules/molecule { };
+
+  molecule-plugins = callPackage ../development/python-modules/molecule/plugins.nix { };
+
+  momepy = callPackage ../development/python-modules/momepy { };
+
+  monai = callPackage ../development/python-modules/monai { };
+
+  monai-deploy = callPackage ../development/python-modules/monai-deploy { };
+
+  monero = callPackage ../development/python-modules/monero { };
+
+  mongodict = callPackage ../development/python-modules/mongodict { };
+
+  mongoengine = callPackage ../development/python-modules/mongoengine { };
+
+  mongomock = callPackage ../development/python-modules/mongomock { };
+
+  mongoquery = callPackage ../development/python-modules/mongoquery { };
+
+  monitorcontrol = callPackage ../development/python-modules/monitorcontrol { };
+
+  monkeyhex = callPackage ../development/python-modules/monkeyhex { };
+
+  monkeytype = callPackage ../development/python-modules/monkeytype { };
+
+  monosat = pkgs.monosat.python {
+    inherit buildPythonPackage;
+    inherit (self) cython pytestCheckHook;
+  };
+
+  monotonic = callPackage ../development/python-modules/monotonic { };
+
+  monotonic-alignment-search =
+    callPackage ../development/python-modules/monotonic-alignment-search
+      { };
+
+  monty = callPackage ../development/python-modules/monty { };
+
+  monzopy = callPackage ../development/python-modules/monzopy { };
+
+  moonraker-api = callPackage ../development/python-modules/moonraker-api { };
+
+  mopeka-iot-ble = callPackage ../development/python-modules/mopeka-iot-ble { };
+
+  more-itertools = callPackage ../development/python-modules/more-itertools { };
+
+  more-properties = callPackage ../development/python-modules/more-properties { };
+
+  morecantile = callPackage ../development/python-modules/morecantile { };
+
+  moreorless = callPackage ../development/python-modules/moreorless { };
+
+  moretools = callPackage ../development/python-modules/moretools { };
+
+  morfessor = callPackage ../development/python-modules/morfessor { };
+
+  morphys = callPackage ../development/python-modules/morphys { };
+
+  mortgage = callPackage ../development/python-modules/mortgage { };
+
+  motionblinds = callPackage ../development/python-modules/motionblinds { };
+
+  motionblindsble = callPackage ../development/python-modules/motionblindsble { };
+
+  motioneye-client = callPackage ../development/python-modules/motioneye-client { };
+
+  motmetrics = callPackage ../development/python-modules/motmetrics { };
+
+  moto = callPackage ../development/python-modules/moto { };
+
+  motor = callPackage ../development/python-modules/motor { };
+
+  mouseinfo = callPackage ../development/python-modules/mouseinfo { };
+
+  moviepy = callPackage ../development/python-modules/moviepy { };
+
+  mozart-api = callPackage ../development/python-modules/mozart-api { };
+
+  mozilla-django-oidc = callPackage ../development/python-modules/mozilla-django-oidc { };
+
+  mpd2 = callPackage ../development/python-modules/mpd2 { };
+
+  mpegdash = callPackage ../development/python-modules/mpegdash { };
+
+  mpi4py = callPackage ../development/python-modules/mpi4py { };
+
+  mpire = callPackage ../development/python-modules/mpire { };
+
+  mpl-scatter-density = callPackage ../development/python-modules/mpl-scatter-density { };
+
+  mpl-typst = callPackage ../development/python-modules/mpl-typst { };
+
+  mplcursors = callPackage ../development/python-modules/mplcursors { };
+
+  mpldatacursor = callPackage ../development/python-modules/mpldatacursor { };
+
+  mplfinance = callPackage ../development/python-modules/mplfinance { };
+
+  mplhep = callPackage ../development/python-modules/mplhep { };
+
+  mplhep-data = callPackage ../development/python-modules/mplhep-data { };
+
+  mplleaflet = callPackage ../development/python-modules/mplleaflet { };
+
+  mpmath = callPackage ../development/python-modules/mpmath { };
+
+  mpris-server = callPackage ../development/python-modules/mpris-server { };
+
+  mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };
+
+  mpyq = callPackage ../development/python-modules/mpyq { };
+
+  mqtt2influxdb = callPackage ../development/python-modules/mqtt2influxdb { };
+
+  mrjob = callPackage ../development/python-modules/mrjob { };
+
+  mrsqm = callPackage ../development/python-modules/mrsqm { };
+
+  ms-active-directory = callPackage ../development/python-modules/ms-active-directory { };
+
+  ms-cv = callPackage ../development/python-modules/ms-cv { };
+
+  msal = callPackage ../development/python-modules/msal { };
+
+  msal-extensions = callPackage ../development/python-modules/msal-extensions { };
+
+  mscerts = callPackage ../development/python-modules/mscerts { };
+
+  msg-parser = callPackage ../development/python-modules/msg-parser { };
+
+  msgpack = callPackage ../development/python-modules/msgpack { };
+
+  msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
+
+  msgraph-core = callPackage ../development/python-modules/msgraph-core { };
+
+  msgraph-sdk = callPackage ../development/python-modules/msgraph-sdk { };
+
+  msgspec = callPackage ../development/python-modules/msgspec { };
+
+  msldap = callPackage ../development/python-modules/msldap { };
+
+  msmart-ng = callPackage ../development/python-modules/msmart-ng { };
+
+  msoffcrypto-tool = callPackage ../development/python-modules/msoffcrypto-tool { };
+
+  msprime = callPackage ../development/python-modules/msprime { };
+
+  msrest = callPackage ../development/python-modules/msrest { };
+
+  msrestazure = callPackage ../development/python-modules/msrestazure { };
+
+  mss = callPackage ../development/python-modules/mss { };
+
+  msticpy = callPackage ../development/python-modules/msticpy { };
+
+  mt-940 = callPackage ../development/python-modules/mt-940 { };
+
+  mtcnn = callPackage ../development/python-modules/mtcnn { };
+
+  mujoco = callPackage ../development/python-modules/mujoco { inherit (pkgs) mujoco; };
+
+  mujson = callPackage ../development/python-modules/mujson { };
+
+  mullvad-api = callPackage ../development/python-modules/mullvad-api { };
+
+  mullvad-closest = callPackage ../development/python-modules/mullvad-closest { };
+
+  mulpyplexer = callPackage ../development/python-modules/mulpyplexer { };
+
+  multi-key-dict = callPackage ../development/python-modules/multi-key-dict { };
+
+  multidict = callPackage ../development/python-modules/multidict { };
+
+  multimethod = callPackage ../development/python-modules/multimethod { };
+
+  multipart = callPackage ../development/python-modules/multipart { };
+
+  multipledispatch = callPackage ../development/python-modules/multipledispatch { };
+
+  multiprocess = callPackage ../development/python-modules/multiprocess { };
+
+  multiscale-spatial-image = callPackage ../development/python-modules/multiscale-spatial-image { };
+
+  multiset = callPackage ../development/python-modules/multiset { };
+
+  multitasking = callPackage ../development/python-modules/multitasking { };
+
+  multivolumefile = callPackage ../development/python-modules/multivolumefile { };
+
+  munch = callPackage ../development/python-modules/munch { };
+
+  mung = callPackage ../development/python-modules/mung { };
+
+  munkres = callPackage ../development/python-modules/munkres { };
+
+  murmurhash = callPackage ../development/python-modules/murmurhash { };
+
+  muscima = callPackage ../development/python-modules/muscima { };
+
+  music-assistant-client = callPackage ../development/python-modules/music-assistant-client { };
+
+  music-assistant-models = callPackage ../development/python-modules/music-assistant-models { };
+
+  music-tag = callPackage ../development/python-modules/music-tag { };
+
+  musicbrainzngs = callPackage ../development/python-modules/musicbrainzngs { };
+
+  mutag = callPackage ../development/python-modules/mutag { };
+
+  mutagen = callPackage ../development/python-modules/mutagen { };
+
+  mutatormath = callPackage ../development/python-modules/mutatormath { };
+
+  mutesync = callPackage ../development/python-modules/mutesync { };
+
+  mutf8 = callPackage ../development/python-modules/mutf8 { };
+
+  mwcli = callPackage ../development/python-modules/mwcli { };
+
+  mwclient = callPackage ../development/python-modules/mwclient { };
+
+  mwdblib = callPackage ../development/python-modules/mwdblib { };
+
+  mwoauth = callPackage ../development/python-modules/mwoauth { };
+
+  mwparserfromhell = callPackage ../development/python-modules/mwparserfromhell { };
+
+  mwtypes = callPackage ../development/python-modules/mwtypes { };
+
+  mwxml = callPackage ../development/python-modules/mwxml { };
+
+  mxnet = callPackage ../development/python-modules/mxnet { };
+
+  myfitnesspal = callPackage ../development/python-modules/myfitnesspal { };
+
+  mygene = callPackage ../development/python-modules/mygene { };
+
+  mygpoclient = callPackage ../development/python-modules/mygpoclient { };
+
+  myhdl = callPackage ../development/python-modules/myhdl { inherit (pkgs) ghdl iverilog; };
+
+  myhome = callPackage ../development/python-modules/myhome { };
+
+  myjwt = callPackage ../development/python-modules/myjwt { };
+
+  mypermobil = callPackage ../development/python-modules/mypermobil { };
+
+  mypy = callPackage ../development/python-modules/mypy { };
+
+  mypy-boto3-builder = callPackage ../development/python-modules/mypy-boto3-builder { };
+
+  mypy-extensions = callPackage ../development/python-modules/mypy/extensions.nix { };
+
+  mypy-protobuf = callPackage ../development/python-modules/mypy-protobuf { };
+
+  mysql-connector = callPackage ../development/python-modules/mysql-connector { };
+
+  mysqlclient = callPackage ../development/python-modules/mysqlclient { };
+
+  myst-docutils = callPackage ../development/python-modules/myst-docutils { };
+
+  myst-nb = callPackage ../development/python-modules/myst-nb { };
+
+  myst-parser = callPackage ../development/python-modules/myst-parser { };
+
+  myuplink = callPackage ../development/python-modules/myuplink { };
+
+  nad-receiver = callPackage ../development/python-modules/nad-receiver { };
+
+  nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };
+
+  naked = callPackage ../development/python-modules/naked { };
+
+  name-that-hash = callPackage ../development/python-modules/name-that-hash { };
+
+  namedlist = callPackage ../development/python-modules/namedlist { };
+
+  nameko = callPackage ../development/python-modules/nameko { };
+
+  nameparser = callPackage ../development/python-modules/nameparser { };
+
+  names = callPackage ../development/python-modules/names { };
+
+  namex = callPackage ../development/python-modules/namex { };
+
+  nampa = callPackage ../development/python-modules/nampa { };
+
+  nanobind = callPackage ../development/python-modules/nanobind { };
+
+  nanoemoji = callPackage ../development/python-modules/nanoemoji { };
+
+  nanoid = callPackage ../development/python-modules/nanoid { };
+
+  nanoleaf = callPackage ../development/python-modules/nanoleaf { };
+
+  nanomsg-python = callPackage ../development/python-modules/nanomsg-python {
+    inherit (pkgs) nanomsg;
+  };
+
+  nanotime = callPackage ../development/python-modules/nanotime { };
+
+  napalm = callPackage ../development/python-modules/napalm { };
+
+  napalm-hp-procurve = callPackage ../development/python-modules/napalm/hp-procurve.nix { };
+
+  napalm-ros = callPackage ../development/python-modules/napalm/ros.nix { };
+
+  napari = callPackage ../development/python-modules/napari {
+    inherit (pkgs.libsForQt5) mkDerivationWith wrapQtAppsHook;
+  };
+
+  napari-console = callPackage ../development/python-modules/napari-console { };
+
+  napari-nifti = callPackage ../development/python-modules/napari-nifti { };
+
+  napari-npe2 = callPackage ../development/python-modules/napari-npe2 { };
+
+  napari-plugin-engine = callPackage ../development/python-modules/napari-plugin-engine { };
+
+  napari-svg = callPackage ../development/python-modules/napari-svg { };
+
+  narwhals = callPackage ../development/python-modules/narwhals { };
+
+  nasdaq-data-link = callPackage ../development/python-modules/nasdaq-data-link { };
+
+  natasha = callPackage ../development/python-modules/natasha { };
+
+  nats-py = callPackage ../development/python-modules/nats-py { };
+
+  nats-python = callPackage ../development/python-modules/nats-python { };
+
+  natsort = callPackage ../development/python-modules/natsort { };
+
+  natural = callPackage ../development/python-modules/natural { };
+
+  naturalsort = callPackage ../development/python-modules/naturalsort { };
+
+  navec = callPackage ../development/python-modules/navec { };
+
+  nbclassic = callPackage ../development/python-modules/nbclassic { };
+
+  nbclient = callPackage ../development/python-modules/nbclient { };
+
+  nbconflux = callPackage ../development/python-modules/nbconflux { };
+
+  nbconvert = callPackage ../development/python-modules/nbconvert { };
+
+  nbdev = callPackage ../development/python-modules/nbdev { };
+
+  nbdime = callPackage ../development/python-modules/nbdime { };
+
+  nbexec = callPackage ../development/python-modules/nbexec { };
+
+  nbformat = callPackage ../development/python-modules/nbformat { };
+
+  nbmake = callPackage ../development/python-modules/nbmake { };
+
+  nbsmoke = callPackage ../development/python-modules/nbsmoke { };
+
+  nbsphinx = callPackage ../development/python-modules/nbsphinx { };
+
+  nbtlib = callPackage ../development/python-modules/nbtlib { };
+
+  nbval = callPackage ../development/python-modules/nbval { };
+
+  nbxmpp = callPackage ../development/python-modules/nbxmpp { };
+
+  nc-dnsapi = callPackage ../development/python-modules/nc-dnsapi { };
+
+  ncclient = callPackage ../development/python-modules/ncclient { };
+
+  nclib = callPackage ../development/python-modules/nclib { };
+
+  ndcurves = toPythonModule (
+    pkgs.ndcurves.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
+  ndeflib = callPackage ../development/python-modules/ndeflib { };
+
+  ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
+
+  ndindex = callPackage ../development/python-modules/ndindex { };
+
+  ndjson = callPackage ../development/python-modules/ndjson { };
+
+  ndms2-client = callPackage ../development/python-modules/ndms2-client { };
+
+  ndspy = callPackage ../development/python-modules/ndspy { };
+
+  ndtypes = callPackage ../development/python-modules/ndtypes { };
+
+  nebula3-python = callPackage ../development/python-modules/nebula3-python { };
+
+  nemosis = callPackage ../development/python-modules/nemosis { };
+
+  nengo = callPackage ../development/python-modules/nengo { };
+
+  neo = callPackage ../development/python-modules/neo { };
+
+  neo4j = callPackage ../development/python-modules/neo4j { };
+
+  neoteroi-mkdocs = callPackage ../development/python-modules/neoteroi-mkdocs { };
+
+  nessclient = callPackage ../development/python-modules/nessclient { };
+
+  nest = toPythonModule (
+    pkgs.nest-mpi.override {
+      withPython = true;
+      python3 = python;
+    }
+  );
+
+  nest-asyncio = callPackage ../development/python-modules/nest-asyncio { };
+
+  nested-lookup = callPackage ../development/python-modules/nested-lookup { };
+
+  nestedtext = callPackage ../development/python-modules/nestedtext { };
+
+  netaddr = callPackage ../development/python-modules/netaddr { };
+
+  netapp-lib = callPackage ../development/python-modules/netapp-lib { };
+
+  netapp-ontap = callPackage ../development/python-modules/netapp-ontap { };
+
+  netbox-bgp = callPackage ../development/python-modules/netbox-bgp { };
+
+  netbox-contract = callPackage ../development/python-modules/netbox-contract { };
+
+  netbox-dns = callPackage ../development/python-modules/netbox-dns { };
+
+  netbox-documents = callPackage ../development/python-modules/netbox-documents { };
+
+  netbox-floorplan-plugin = callPackage ../development/python-modules/netbox-floorplan-plugin { };
+
+  netbox-interface-synchronization =
+    callPackage ../development/python-modules/netbox-interface-synchronization
+      { };
+
+  netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };
+
+  netbox-plugin-prometheus-sd =
+    callPackage ../development/python-modules/netbox-plugin-prometheus-sd
+      { };
+
+  netbox-qrcode = callPackage ../development/python-modules/netbox-qrcode { };
+
+  netbox-reorder-rack = callPackage ../development/python-modules/netbox-reorder-rack { };
+
+  netbox-routing = callPackage ../development/python-modules/netbox-routing { };
+
+  netbox-topology-views = callPackage ../development/python-modules/netbox-topology-views { };
+
+  netcdf4 = callPackage ../development/python-modules/netcdf4 { };
+
+  netdata = callPackage ../development/python-modules/netdata { };
+
+  netdata-pandas = callPackage ../development/python-modules/netdata-pandas { };
+
+  netdisco = callPackage ../development/python-modules/netdisco { };
+
+  netgen-mesher = toPythonModule (pkgs.netgen.override { python3Packages = self; });
+
+  nethsm = callPackage ../development/python-modules/nethsm { };
+
+  netifaces = callPackage ../development/python-modules/netifaces { };
+
+  netifaces-plus = callPackage ../development/python-modules/netifaces-plus { };
+
+  netifaces2 = callPackage ../development/python-modules/netifaces2 { };
+
+  netio = callPackage ../development/python-modules/netio { };
+
+  netmap = callPackage ../development/python-modules/netmap { };
+
+  netmiko = callPackage ../development/python-modules/netmiko { };
+
+  nettigo-air-monitor = callPackage ../development/python-modules/nettigo-air-monitor { };
+
+  netutils = callPackage ../development/python-modules/netutils { };
+
+  networkx = callPackage ../development/python-modules/networkx { };
+
+  neuralfoil = callPackage ../development/python-modules/neuralfoil { };
+
+  neurokit2 = callPackage ../development/python-modules/neurokit2 { };
+
+  neuron-full = pkgs.neuron-full.override { python3 = python; };
+
+  neuronpy = toPythonModule neuron-full;
+
+  nevow = callPackage ../development/python-modules/nevow { };
+
+  newick = callPackage ../development/python-modules/newick { };
+
+  newversion = callPackage ../development/python-modules/newversion { };
+
+  nexia = callPackage ../development/python-modules/nexia { };
+
+  nextcloudmonitor = callPackage ../development/python-modules/nextcloudmonitor { };
+
+  nextcord = callPackage ../development/python-modules/nextcord { };
+
+  nextdns = callPackage ../development/python-modules/nextdns { };
+
+  nexusformat = callPackage ../development/python-modules/nexusformat { };
+
+  nfcpy = callPackage ../development/python-modules/nfcpy { };
+
+  nftables = callPackage ../os-specific/linux/nftables/python.nix { inherit (pkgs) nftables; };
+
+  nglview = callPackage ../development/python-modules/nglview { };
+
+  nh3 = callPackage ../development/python-modules/nh3 { };
+
+  nhc = callPackage ../development/python-modules/nhc { };
+
+  niaaml = callPackage ../development/python-modules/niaaml { };
+
+  niaarm = callPackage ../development/python-modules/niaarm { };
+
+  niaclass = callPackage ../development/python-modules/niaclass { };
+
+  nianet = callPackage ../development/python-modules/nianet { };
+
+  niapy = callPackage ../development/python-modules/niapy { };
+
+  nibabel = callPackage ../development/python-modules/nibabel { };
+
+  nibe = callPackage ../development/python-modules/nibe { };
+
+  nice-go = callPackage ../development/python-modules/nice-go { };
+
+  nicegui = callPackage ../development/python-modules/nicegui { };
+
+  nicegui-highcharts = callPackage ../development/python-modules/nicegui-highcharts { };
+
+  nidaqmx = callPackage ../development/python-modules/nidaqmx { };
+
+  nifty8 = callPackage ../development/python-modules/nifty8 { };
+
+  nikola = callPackage ../development/python-modules/nikola { };
+
+  nilearn = callPackage ../development/python-modules/nilearn { };
+
+  niluclient = callPackage ../development/python-modules/niluclient { };
+
+  nimfa = callPackage ../development/python-modules/nimfa { };
+
+  nine = callPackage ../development/python-modules/nine { };
+
+  ninebot-ble = callPackage ../development/python-modules/ninebot-ble { };
+
+  ninja = callPackage ../development/python-modules/ninja { inherit (pkgs) ninja; };
+
+  nipreps-versions = callPackage ../development/python-modules/nipreps-versions { };
+
+  nipy = callPackage ../development/python-modules/nipy { };
+
+  nipype = callPackage ../development/python-modules/nipype { inherit (pkgs) which; };
+
+  nitime = callPackage ../development/python-modules/nitime { };
+
+  nitpick = callPackage ../applications/version-management/nitpick { };
+
+  nitransforms = callPackage ../development/python-modules/nitransforms { };
+
+  nitrokey = callPackage ../development/python-modules/nitrokey { };
+
+  niworkflows = callPackage ../development/python-modules/niworkflows { };
+
+  nix-kernel = callPackage ../development/python-modules/nix-kernel { inherit (pkgs) nix; };
+
+  nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
+
+  nixpkgs = callPackage ../development/python-modules/nixpkgs { };
+
+  nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };
+
+  nixpkgs-updaters-library = callPackage ../development/python-modules/nixpkgs-updaters-library { };
+
+  nkdfu = callPackage ../development/python-modules/nkdfu { };
+
+  nlpcloud = callPackage ../development/python-modules/nlpcloud { };
+
+  nlpo3 = callPackage ../development/python-modules/nlpo3 { };
+
+  nltk = callPackage ../development/python-modules/nltk { };
+
+  nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };
+
+  nnpdf = toPythonModule (pkgs.nnpdf.override { python3 = python; });
+
+  nocasedict = callPackage ../development/python-modules/nocasedict { };
+
+  nocaselist = callPackage ../development/python-modules/nocaselist { };
+
+  nocturne = callPackage ../development/python-modules/nocturne { };
+
+  node-semver = callPackage ../development/python-modules/node-semver { };
+
+  nodeenv = callPackage ../development/python-modules/nodeenv { };
+
+  nodepy-runtime = callPackage ../development/python-modules/nodepy-runtime { };
+
+  nodriver = callPackage ../development/python-modules/nodriver { };
+
+  noise = callPackage ../development/python-modules/noise { };
+
+  noiseprotocol = callPackage ../development/python-modules/noiseprotocol { };
+
+  nomadnet = callPackage ../development/python-modules/nomadnet { };
+
+  nonbloat-db = callPackage ../development/python-modules/nonbloat-db { };
+
+  noneprompt = callPackage ../development/python-modules/noneprompt { };
+
+  norfair = callPackage ../development/python-modules/norfair { };
+
+  normality = callPackage ../development/python-modules/normality { };
+
+  nose2 = callPackage ../development/python-modules/nose2 { };
+
+  nose2pytest = callPackage ../development/python-modules/nose2pytest { };
+
+  notebook = callPackage ../development/python-modules/notebook { };
+
+  notebook-shim = callPackage ../development/python-modules/notebook-shim { };
+
+  notedown = callPackage ../development/python-modules/notedown { };
+
+  notifications-android-tv = callPackage ../development/python-modules/notifications-android-tv { };
+
+  notifications-python-client =
+    callPackage ../development/python-modules/notifications-python-client
+      { };
+
+  notify-events = callPackage ../development/python-modules/notify-events { };
+
+  notify-py = callPackage ../development/python-modules/notify-py { };
+
+  notify2 = callPackage ../development/python-modules/notify2 { };
+
+  notion-client = callPackage ../development/python-modules/notion-client { };
+
+  notmuch = callPackage ../development/python-modules/notmuch { inherit (pkgs) notmuch; };
+
+  notmuch2 = callPackage ../development/python-modules/notmuch2 { inherit (pkgs) notmuch; };
+
+  notobuilder = callPackage ../development/python-modules/notobuilder { };
+
+  nototools = callPackage ../development/python-modules/nototools { };
+
+  notus-scanner = callPackage ../development/python-modules/notus-scanner { };
+
+  nox = callPackage ../development/python-modules/nox { };
+
+  nplusone = callPackage ../development/python-modules/nplusone { };
+
+  nptyping = callPackage ../development/python-modules/nptyping { };
+
+  npyscreen = callPackage ../development/python-modules/npyscreen { };
+
+  nsapi = callPackage ../development/python-modules/nsapi { };
+
+  nskeyedunarchiver = callPackage ../development/python-modules/nskeyedunarchiver { };
+
+  nsz = callPackage ../development/python-modules/nsz { };
+
+  ntc-templates = callPackage ../development/python-modules/ntc-templates { };
+
+  ntplib = callPackage ../development/python-modules/ntplib { };
+
+  nuclear = callPackage ../development/python-modules/nuclear { };
+
+  nuheat = callPackage ../development/python-modules/nuheat { };
+
+  nuitka = callPackage ../development/python-modules/nuitka { };
+
+  nulltype = callPackage ../development/python-modules/nulltype { };
+
+  num2words = callPackage ../development/python-modules/num2words { };
+
+  numba = callPackage ../development/python-modules/numba { inherit (pkgs.config) cudaSupport; };
+
+  numba-scipy = callPackage ../development/python-modules/numba-scipy { };
+
+  numbaWithCuda = self.numba.override { cudaSupport = true; };
+
+  numcodecs = callPackage ../development/python-modules/numcodecs { };
+
+  numdifftools = callPackage ../development/python-modules/numdifftools { };
+
+  numericalunits = callPackage ../development/python-modules/numericalunits { };
+
+  numexpr = callPackage ../development/python-modules/numexpr { };
+
+  numpy = numpy_2;
+
+  numpy-groupies = callPackage ../development/python-modules/numpy-groupies { };
+
+  numpy-stl = callPackage ../development/python-modules/numpy-stl { };
+
+  numpy_1 = callPackage ../development/python-modules/numpy/1.nix { };
+
+  numpy_2 = callPackage ../development/python-modules/numpy/2.nix { };
+
+  numpydoc = callPackage ../development/python-modules/numpydoc { };
+
+  numpyro = callPackage ../development/python-modules/numpyro { };
+
+  nunavut = callPackage ../development/python-modules/nunavut { };
+
+  nutils = callPackage ../development/python-modules/nutils { };
+
+  nutils-poly = callPackage ../development/python-modules/nutils-poly { };
+
+  nutpie = callPackage ../development/python-modules/nutpie { };
+
+  nvchecker = callPackage ../development/python-modules/nvchecker { };
+
+  nvdlib = callPackage ../development/python-modules/nvdlib { };
+
+  nvidia-ml-py = callPackage ../development/python-modules/nvidia-ml-py { };
+
+  nwdiag = callPackage ../development/python-modules/nwdiag { };
+
+  nxt-python = callPackage ../development/python-modules/nxt-python { };
+
+  nyt-games = callPackage ../development/python-modules/nyt-games { };
+
+  oasatelematics = callPackage ../development/python-modules/oasatelematics { };
+
+  oath = callPackage ../development/python-modules/oath { };
+
+  oauth = callPackage ../development/python-modules/oauth { };
+
+  oauth2 = callPackage ../development/python-modules/oauth2 { };
+
+  oauth2client = callPackage ../development/python-modules/oauth2client { };
+
+  oauthenticator = callPackage ../development/python-modules/oauthenticator { };
+
+  oauthlib = callPackage ../development/python-modules/oauthlib { };
+
+  obfsproxy = callPackage ../development/python-modules/obfsproxy { };
+
+  objax = callPackage ../development/python-modules/objax { };
+
+  objexplore = callPackage ../development/python-modules/objexplore { };
+
+  objgraph = callPackage ../development/python-modules/objgraph {
+    # requires both the graphviz package and python package
+    graphvizPkgs = pkgs.graphviz;
+  };
+
+  objprint = callPackage ../development/python-modules/objprint { };
+
+  objsize = callPackage ../development/python-modules/objsize { };
+
+  obspy = callPackage ../development/python-modules/obspy { };
+
+  oca-port = callPackage ../development/python-modules/oca-port { };
+
+  ochre = callPackage ../development/python-modules/ochre { };
+
+  oci = callPackage ../development/python-modules/oci { };
+
+  ocifs = callPackage ../development/python-modules/ocifs { };
+
+  ocrmypdf = callPackage ../development/python-modules/ocrmypdf { tesseract = pkgs.tesseract5; };
+
+  od = callPackage ../development/python-modules/od { };
+
+  odc-geo = callPackage ../development/python-modules/odc-geo { };
+
+  odc-stac = callPackage ../development/python-modules/odc-stac { };
+
+  oddsprout = callPackage ../development/python-modules/oddsprout { };
+
+  odfpy = callPackage ../development/python-modules/odfpy { };
+
+  odp-amsterdam = callPackage ../development/python-modules/odp-amsterdam { };
+
+  oelint-parser = callPackage ../development/python-modules/oelint-parser { };
+
+  oemthermostat = callPackage ../development/python-modules/oemthermostat { };
+
+  offtrac = callPackage ../development/python-modules/offtrac { };
+
+  ofxclient = callPackage ../development/python-modules/ofxclient { };
+
+  ofxhome = callPackage ../development/python-modules/ofxhome { };
+
+  ofxparse = callPackage ../development/python-modules/ofxparse { };
+
+  ofxtools = callPackage ../development/python-modules/ofxtools { };
+
+  ogmios = callPackage ../development/python-modules/ogmios { };
+
+  ohme = callPackage ../development/python-modules/ohme { };
+
+  okonomiyaki = callPackage ../development/python-modules/okonomiyaki { };
+
+  okta = callPackage ../development/python-modules/okta { };
+
+  oldest-supported-numpy = callPackage ../development/python-modules/oldest-supported-numpy { };
+
+  olefile = callPackage ../development/python-modules/olefile { };
+
+  oletools = callPackage ../development/python-modules/oletools { };
+
+  ollama = callPackage ../development/python-modules/ollama { };
+
+  ome-zarr = callPackage ../development/python-modules/ome-zarr { };
+
+  omegaconf = callPackage ../development/python-modules/omegaconf { };
+
+  omemo-dr = callPackage ../development/python-modules/omemo-dr { };
+
+  omnikinverter = callPackage ../development/python-modules/omnikinverter { };
+
+  omnilogic = callPackage ../development/python-modules/omnilogic { };
+
+  omniorb = toPythonModule (pkgs.omniorb.override { python3 = self.python; });
+
+  omniorbpy = callPackage ../development/python-modules/omniorbpy { };
+
+  omorfi = callPackage ../development/python-modules/omorfi { };
+
+  omrdatasettools = callPackage ../development/python-modules/omrdatasettools { };
+
+  oncalendar = callPackage ../development/python-modules/oncalendar { };
+
+  ondilo = callPackage ../development/python-modules/ondilo { };
+
+  onecache = callPackage ../development/python-modules/onecache { };
+
+  onedrive-personal-sdk = callPackage ../development/python-modules/onedrive-personal-sdk { };
+
+  onetimepad = callPackage ../development/python-modules/onetimepad { };
+
+  onetimepass = callPackage ../development/python-modules/onetimepass { };
+
+  onigurumacffi = callPackage ../development/python-modules/onigurumacffi { };
+
+  onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
+
+  online-judge-api-client = callPackage ../development/python-modules/online-judge-api-client { };
+
+  online-judge-tools = callPackage ../development/python-modules/online-judge-tools { };
+
+  onlykey-solo-python = callPackage ../development/python-modules/onlykey-solo-python { };
+
+  onnx = callPackage ../development/python-modules/onnx { };
+
+  onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };
+
+  onnxmltools = callPackage ../development/python-modules/onnxmltools { };
+
+  onnxruntime = callPackage ../development/python-modules/onnxruntime {
+    onnxruntime = pkgs.onnxruntime.override {
+      python3Packages = self;
+      pythonSupport = true;
+    };
+  };
+
+  onnxruntime-tools = callPackage ../development/python-modules/onnxruntime-tools { };
+
+  onvif-zeep = callPackage ../development/python-modules/onvif-zeep { };
+
+  onvif-zeep-async = callPackage ../development/python-modules/onvif-zeep-async { };
+
+  oocsi = callPackage ../development/python-modules/oocsi { };
+
+  opcua-widgets = callPackage ../development/python-modules/opcua-widgets { };
+
+  open-clip-torch = callPackage ../development/python-modules/open-clip-torch { };
+
+  open-garage = callPackage ../development/python-modules/open-garage { };
+
+  open-hypergraphs = callPackage ../development/python-modules/open-hypergraphs { };
+
+  open-interpreter = callPackage ../development/python-modules/open-interpreter { };
+
+  open-meteo = callPackage ../development/python-modules/open-meteo { };
+
+  openai = callPackage ../development/python-modules/openai { };
+
+  openai-whisper = callPackage ../development/python-modules/openai-whisper { };
+
+  openaiauth = callPackage ../development/python-modules/openaiauth { };
+
+  openant = callPackage ../development/python-modules/openant { };
+
+  openapi-core = callPackage ../development/python-modules/openapi-core { };
+
+  openapi-schema-validator = callPackage ../development/python-modules/openapi-schema-validator { };
+
+  openapi-spec-validator = callPackage ../development/python-modules/openapi-spec-validator { };
+
+  openapi3 = callPackage ../development/python-modules/openapi3 { };
+
+  openbabel-bindings = callPackage ../development/python-modules/openbabel-bindings {
+    openbabel = callPackage ../development/libraries/openbabel { inherit (self) python; };
+  };
+
+  opencensus = callPackage ../development/python-modules/opencensus { };
+
+  opencensus-context = callPackage ../development/python-modules/opencensus-context { };
+
+  opencensus-ext-azure = callPackage ../development/python-modules/opencensus-ext-azure { };
+
+  opencontainers = callPackage ../development/python-modules/opencontainers { };
+
+  opencv-python = callPackage ../development/python-modules/opencv-python { };
+
+  opencv-python-headless = callPackage ../development/python-modules/opencv-python-headless { };
+
+  opencv4 = toPythonModule (
+    pkgs.opencv4.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
+
+  openerz-api = callPackage ../development/python-modules/openerz-api { };
+
+  openevsewifi = callPackage ../development/python-modules/openevsewifi { };
+
+  openhomedevice = callPackage ../development/python-modules/openhomedevice { };
+
+  openidc-client = callPackage ../development/python-modules/openidc-client { };
+
+  openmm = toPythonModule (
+    pkgs.openmm.override {
+      python3Packages = self;
+      enablePython = true;
+    }
+  );
+
+  openpaperwork-core = callPackage ../applications/office/paperwork/openpaperwork-core.nix { };
+
+  openpaperwork-gtk = callPackage ../applications/office/paperwork/openpaperwork-gtk.nix { };
+
+  openpyxl = callPackage ../development/python-modules/openpyxl { };
+
+  openrazer = callPackage ../development/python-modules/openrazer/pylib.nix { };
+
+  openrazer-daemon = callPackage ../development/python-modules/openrazer/daemon.nix { };
+
+  openrgb-python = callPackage ../development/python-modules/openrgb-python { };
+
+  openrouteservice = callPackage ../development/python-modules/openrouteservice { };
+
+  opensearch-py = callPackage ../development/python-modules/opensearch-py { };
+
+  opensensemap-api = callPackage ../development/python-modules/opensensemap-api { };
+
+  opensfm = callPackage ../development/python-modules/opensfm { };
+
+  openshift = callPackage ../development/python-modules/openshift { };
+
+  opensimplex = callPackage ../development/python-modules/opensimplex { };
+
+  openslide = callPackage ../development/python-modules/openslide { inherit (pkgs) openslide; };
+
+  openstackdocstheme = callPackage ../development/python-modules/openstackdocstheme { };
+
+  openstacksdk = callPackage ../development/python-modules/openstacksdk { };
+
+  openstep-parser = callPackage ../development/python-modules/openstep-parser { };
+
+  openstep-plist = callPackage ../development/python-modules/openstep-plist { };
+
+  opentelemetry-api = callPackage ../development/python-modules/opentelemetry-api { };
+
+  opentelemetry-exporter-otlp =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp
+      { };
+
+  opentelemetry-exporter-otlp-proto-common =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-common
+      { };
+
+  opentelemetry-exporter-otlp-proto-grpc =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-grpc
+      { };
+
+  opentelemetry-exporter-otlp-proto-http =
+    callPackage ../development/python-modules/opentelemetry-exporter-otlp-proto-http
+      { };
+
+  opentelemetry-exporter-prometheus =
+    callPackage ../development/python-modules/opentelemetry-exporter-prometheus
+      { };
+
+  opentelemetry-instrumentation =
+    callPackage ../development/python-modules/opentelemetry-instrumentation
+      { };
+
+  opentelemetry-instrumentation-aiohttp-client =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-aiohttp-client
+      { };
+
+  opentelemetry-instrumentation-asgi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-asgi
+      { };
+
+  opentelemetry-instrumentation-botocore =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-botocore
+      { };
+
+  opentelemetry-instrumentation-celery =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-celery
+      { };
+
+  opentelemetry-instrumentation-dbapi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-dbapi
+      { };
+
+  opentelemetry-instrumentation-django =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-django
+      { };
+
+  opentelemetry-instrumentation-fastapi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-fastapi
+      { };
+
+  opentelemetry-instrumentation-flask =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-flask
+      { };
+
+  opentelemetry-instrumentation-grpc =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-grpc
+      { };
+
+  opentelemetry-instrumentation-logging =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-logging
+      { };
+
+  opentelemetry-instrumentation-psycopg2 =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-psycopg2
+      { };
+
+  opentelemetry-instrumentation-redis =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-redis
+      { };
+
+  opentelemetry-instrumentation-requests =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-requests
+      { };
+
+  opentelemetry-instrumentation-wsgi =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi
+      { };
+
+  opentelemetry-propagator-aws-xray =
+    callPackage ../development/python-modules/opentelemetry-propagator-aws-xray
+      { };
+
+  opentelemetry-proto = callPackage ../development/python-modules/opentelemetry-proto { };
+
+  opentelemetry-sdk = callPackage ../development/python-modules/opentelemetry-sdk { };
+
+  opentelemetry-semantic-conventions =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions
+      { };
+
+  opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
+
+  opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };
+
+  opentimestamps = callPackage ../development/python-modules/opentimestamps { };
+
+  opentsne = callPackage ../development/python-modules/opentsne { };
+
+  openturns = toPythonModule (
+    pkgs.openturns.override {
+      python3Packages = self;
+      enablePython = true;
+    }
+  );
+
+  opentype-feature-freezer = callPackage ../development/python-modules/opentype-feature-freezer { };
+
+  opentypespec = callPackage ../development/python-modules/opentypespec { };
+
+  openusd = callPackage ../development/python-modules/openusd { alembic = pkgs.alembic; };
+
+  openvino = callPackage ../development/python-modules/openvino {
+    openvino-native = pkgs.openvino.override { python3Packages = self; };
+  };
+
+  openwebifpy = callPackage ../development/python-modules/openwebifpy { };
+
+  openwrt-luci-rpc = callPackage ../development/python-modules/openwrt-luci-rpc { };
+
+  openwrt-ubus-rpc = callPackage ../development/python-modules/openwrt-ubus-rpc { };
+
+  opower = callPackage ../development/python-modules/opower { };
+
+  opsdroid-get-image-size = callPackage ../development/python-modules/opsdroid-get-image-size { };
+
+  opt-einsum = callPackage ../development/python-modules/opt-einsum { };
+
+  optax = callPackage ../development/python-modules/optax { };
+
+  optimistix = callPackage ../development/python-modules/optimistix { };
+
+  optimum = callPackage ../development/python-modules/optimum { };
+
+  optree = callPackage ../development/python-modules/optree { };
+
+  optuna = callPackage ../development/python-modules/optuna { };
+
+  opuslib = callPackage ../development/python-modules/opuslib { };
+
+  opytimark = callPackage ../development/python-modules/opytimark { };
+
+  oracledb = callPackage ../development/python-modules/oracledb { };
+
+  oralb-ble = callPackage ../development/python-modules/oralb-ble { };
+
+  orange-canvas-core = callPackage ../development/python-modules/orange-canvas-core { };
+
+  orange-widget-base = callPackage ../development/python-modules/orange-widget-base { };
+
+  orange3 = callPackage ../development/python-modules/orange3 { };
+
+  oras = callPackage ../development/python-modules/oras { };
+
+  orbax-checkpoint = callPackage ../development/python-modules/orbax-checkpoint { };
+
+  ordered-set = callPackage ../development/python-modules/ordered-set { };
+
+  orderedmultidict = callPackage ../development/python-modules/orderedmultidict { };
+
+  orderedset = callPackage ../development/python-modules/orderedset { };
+
+  orderly-set = callPackage ../development/python-modules/orderly-set { };
+
+  orgparse = callPackage ../development/python-modules/orgparse { };
+
+  orjson = callPackage ../development/python-modules/orjson { };
+
+  orm = callPackage ../development/python-modules/orm { };
+
+  ormar = callPackage ../development/python-modules/ormar { };
+
+  ortools = (toPythonModule (pkgs.or-tools.override { inherit (self) python; })).python;
+
+  orvibo = callPackage ../development/python-modules/orvibo { };
+
+  oryx = callPackage ../development/python-modules/oryx { };
+
+  os-client-config = callPackage ../development/python-modules/os-client-config { };
+
+  os-service-types = callPackage ../development/python-modules/os-service-types { };
+
+  osc = callPackage ../development/python-modules/osc { };
+
+  osc-diagram = callPackage ../development/python-modules/osc-diagram { };
+
+  osc-lib = callPackage ../development/python-modules/osc-lib { };
+
+  osc-placement = callPackage ../development/python-modules/osc-placement { };
+
+  osc-sdk-python = callPackage ../development/python-modules/osc-sdk-python { };
+
+  oschmod = callPackage ../development/python-modules/oschmod { };
+
+  oscpy = callPackage ../development/python-modules/oscpy { };
+
+  oscrypto = callPackage ../development/python-modules/oscrypto { };
+
+  oscscreen = callPackage ../development/python-modules/oscscreen { };
+
+  oset = callPackage ../development/python-modules/oset { };
+
+  oslo-concurrency = callPackage ../development/python-modules/oslo-concurrency { };
+
+  oslo-config = callPackage ../development/python-modules/oslo-config { };
+
+  oslo-context = callPackage ../development/python-modules/oslo-context { };
+
+  oslo-db = callPackage ../development/python-modules/oslo-db { };
+
+  oslo-i18n = callPackage ../development/python-modules/oslo-i18n { };
+
+  oslo-log = callPackage ../development/python-modules/oslo-log { };
+
+  oslo-serialization = callPackage ../development/python-modules/oslo-serialization { };
+
+  oslo-utils = callPackage ../development/python-modules/oslo-utils { };
+
+  oslotest = callPackage ../development/python-modules/oslotest { };
+
+  osmnx = callPackage ../development/python-modules/osmnx { };
+
+  osmpythontools = callPackage ../development/python-modules/osmpythontools { };
+
+  ospd = callPackage ../development/python-modules/ospd { };
+
+  osprofiler = callPackage ../development/python-modules/osprofiler { };
+
+  osqp = callPackage ../development/python-modules/osqp { };
+
+  oss2 = callPackage ../development/python-modules/oss2 { };
+
+  ossfs = callPackage ../development/python-modules/ossfs { };
+
+  osxphotos = callPackage ../development/python-modules/osxphotos { };
+
+  otpauth = callPackage ../development/python-modules/otpauth { };
+
+  ots-python = callPackage ../development/python-modules/ots-python { };
+
+  ourgroceries = callPackage ../development/python-modules/ourgroceries { };
+
+  outcome = callPackage ../development/python-modules/outcome { };
+
+  outdated = callPackage ../development/python-modules/outdated { };
+
+  outlines = callPackage ../development/python-modules/outlines { };
+
+  outlines-core = callPackage ../development/python-modules/outlines-core { };
+
+  outspin = callPackage ../development/python-modules/outspin { };
+
+  overly = callPackage ../development/python-modules/overly { };
+
+  overpy = callPackage ../development/python-modules/overpy { };
+
+  overrides = callPackage ../development/python-modules/overrides { };
+
+  ovh = callPackage ../development/python-modules/ovh { };
+
+  ovmfvartool = callPackage ../development/python-modules/ovmfvartool { };
+
+  ovoenergy = callPackage ../development/python-modules/ovoenergy { };
+
+  owslib = callPackage ../development/python-modules/owslib { };
+
+  oyaml = callPackage ../development/python-modules/oyaml { };
+
+  p1monitor = callPackage ../development/python-modules/p1monitor { };
+
+  pa-ringbuffer = callPackage ../development/python-modules/pa-ringbuffer { };
+
+  packageurl-python = callPackage ../development/python-modules/packageurl-python { };
+
+  packaging = callPackage ../development/python-modules/packaging { };
+
+  packaging-legacy = callPackage ../development/python-modules/packaging-legacy { };
+
+  packbits = callPackage ../development/python-modules/packbits { };
+
+  packet-python = callPackage ../development/python-modules/packet-python { };
+
+  packvers = callPackage ../development/python-modules/packvers { };
+
+  pad4pi = callPackage ../development/python-modules/pad4pi { };
+
+  paddle-bfloat = callPackage ../development/python-modules/paddle-bfloat { };
+
+  paddle2onnx = callPackage ../development/python-modules/paddle2onnx { };
+
+  paddleocr = callPackage ../development/python-modules/paddleocr { };
+
+  paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
+
+  pagelabels = callPackage ../development/python-modules/pagelabels { };
+
+  paginate = callPackage ../development/python-modules/paginate { };
+
+  paho-mqtt = callPackage ../development/python-modules/paho-mqtt/default.nix { };
+
+  paintcompiler = callPackage ../development/python-modules/paintcompiler { };
+
+  palace = callPackage ../development/python-modules/palace { };
+
+  palettable = callPackage ../development/python-modules/palettable { };
+
+  pallets-sphinx-themes = callPackage ../development/python-modules/pallets-sphinx-themes { };
+
+  pamela = callPackage ../development/python-modules/pamela { };
+
+  pamqp = callPackage ../development/python-modules/pamqp { };
+
+  panacotta = callPackage ../development/python-modules/panacotta { };
+
+  panasonic-viera = callPackage ../development/python-modules/panasonic-viera { };
+
+  pandantic = callPackage ../development/python-modules/pandantic { };
+
+  pandas = callPackage ../development/python-modules/pandas { inherit (pkgs.darwin) adv_cmds; };
+
+  pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
+
+  pandas-stubs = callPackage ../development/python-modules/pandas-stubs { };
+
+  pandas-ta = callPackage ../development/python-modules/pandas-ta { };
+
+  pandera = callPackage ../development/python-modules/pandera { };
+
+  pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
+
+  pandoc-latex-environment = callPackage ../development/python-modules/pandoc-latex-environment { };
+
+  pandoc-xnos = callPackage ../development/python-modules/pandoc-xnos { };
+
+  pandocfilters = callPackage ../development/python-modules/pandocfilters { };
+
+  panel = callPackage ../development/python-modules/panel { };
+
+  panflute = callPackage ../development/python-modules/panflute { };
+
+  panphon = callPackage ../development/python-modules/panphon { };
+
+  paperbush = callPackage ../development/python-modules/paperbush { };
+
+  papermill = callPackage ../development/python-modules/papermill { };
+
+  paperwork-backend = callPackage ../applications/office/paperwork/paperwork-backend.nix { };
+
+  paperwork-shell = callPackage ../applications/office/paperwork/paperwork-shell.nix { };
+
+  papis = callPackage ../development/python-modules/papis { };
+
+  papis-python-rofi = callPackage ../development/python-modules/papis-python-rofi { };
+
+  para = callPackage ../development/python-modules/para { };
+
+  paragraphs = callPackage ../development/python-modules/paragraphs { };
+
+  parallel-ssh = callPackage ../development/python-modules/parallel-ssh { };
+
+  param = callPackage ../development/python-modules/param { };
+
+  paramax = callPackage ../development/python-modules/paramax { };
+
+  parameter-expansion-patched =
+    callPackage ../development/python-modules/parameter-expansion-patched
+      { };
+
+  parameterized = callPackage ../development/python-modules/parameterized { };
+
+  parametrize-from-file = callPackage ../development/python-modules/parametrize-from-file { };
+
+  paramiko = callPackage ../development/python-modules/paramiko { };
+
+  paramz = callPackage ../development/python-modules/paramz { };
+
+  paranoid-crypto = callPackage ../development/python-modules/paranoid-crypto { };
+
+  parfive = callPackage ../development/python-modules/parfive { };
+
+  parquet = callPackage ../development/python-modules/parquet { };
+
+  parse = callPackage ../development/python-modules/parse { };
+
+  parse-type = callPackage ../development/python-modules/parse-type { };
+
+  parsedatetime = callPackage ../development/python-modules/parsedatetime { };
+
+  parsedmarc = callPackage ../development/python-modules/parsedmarc { };
+
+  parsel = callPackage ../development/python-modules/parsel { };
+
+  parselmouth = callPackage ../development/python-modules/parselmouth { };
+
+  parsimonious = callPackage ../development/python-modules/parsimonious { };
+
+  parsley = callPackage ../development/python-modules/parsley { };
+
+  parso = callPackage ../development/python-modules/parso { };
+
+  parsy = callPackage ../development/python-modules/parsy { };
+
+  partd = callPackage ../development/python-modules/partd { };
+
+  partial-json-parser = callPackage ../development/python-modules/partial-json-parser { };
+
+  particle = callPackage ../development/python-modules/particle { };
+
+  parts = callPackage ../development/python-modules/parts { };
+
+  parver = callPackage ../development/python-modules/parver { };
+
+  pasimple = callPackage ../development/python-modules/pasimple { };
+
+  passlib = callPackage ../development/python-modules/passlib { };
+
+  paste = callPackage ../development/python-modules/paste { };
+
+  pastedeploy = callPackage ../development/python-modules/pastedeploy { };
+
+  pastel = callPackage ../development/python-modules/pastel { };
+
+  pastescript = callPackage ../development/python-modules/pastescript { };
+
+  patator = callPackage ../development/python-modules/patator { };
+
+  patch = callPackage ../development/python-modules/patch { };
+
+  patch-ng = callPackage ../development/python-modules/patch-ng { };
+
+  patchpy = callPackage ../development/python-modules/patchpy { };
+
+  path = callPackage ../development/python-modules/path { };
+
+  path-and-address = callPackage ../development/python-modules/path-and-address { };
+
+  pathable = callPackage ../development/python-modules/pathable { };
+
+  pathlib-abc = callPackage ../development/python-modules/pathlib-abc { };
+
+  pathlib2 = callPackage ../development/python-modules/pathlib2 { };
+
+  pathos = callPackage ../development/python-modules/pathos { };
+
+  pathspec = callPackage ../development/python-modules/pathspec { };
+
+  pathtools = callPackage ../development/python-modules/pathtools { };
+
+  pathvalidate = callPackage ../development/python-modules/pathvalidate { };
+
+  pathy = callPackage ../development/python-modules/pathy { };
+
+  patiencediff = callPackage ../development/python-modules/patiencediff { };
+
+  patool = callPackage ../development/python-modules/patool { };
+
+  patrowl4py = callPackage ../development/python-modules/patrowl4py { };
+
+  patsy = callPackage ../development/python-modules/patsy { };
+
+  paver = callPackage ../development/python-modules/paver { };
+
+  paypal-checkout-serversdk = callPackage ../development/python-modules/paypal-checkout-serversdk { };
+
+  paypalhttp = callPackage ../development/python-modules/paypalhttp { };
+
+  paypalrestsdk = callPackage ../development/python-modules/paypalrestsdk { };
+
+  pbar = callPackage ../development/python-modules/pbar { };
+
+  pbkdf2 = callPackage ../development/python-modules/pbkdf2 { };
+
+  pbr = callPackage ../development/python-modules/pbr { };
+
+  pbs-installer = callPackage ../development/python-modules/pbs-installer { };
+
+  pbxproj = callPackage ../development/python-modules/pbxproj { };
+
+  pcapy-ng = callPackage ../development/python-modules/pcapy-ng {
+    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
+  };
+
+  pcbnewtransition = callPackage ../development/python-modules/pcbnewtransition { };
+
+  pcffont = callPackage ../development/python-modules/pcffont { };
+
+  pcodedmp = callPackage ../development/python-modules/pcodedmp { };
+
+  pcpp = callPackage ../development/python-modules/pcpp { };
+
+  pcre2-py = callPackage ../development/python-modules/pcre2-py { };
+
+  pdb2pqr = callPackage ../development/python-modules/pdb2pqr { };
+
+  pdbfixer = callPackage ../development/python-modules/pdbfixer { };
+
+  pdf2docx = callPackage ../development/python-modules/pdf2docx { };
+
+  pdf2image = callPackage ../development/python-modules/pdf2image { };
+
+  pdfkit = callPackage ../development/python-modules/pdfkit { };
+
+  pdfminer-six = callPackage ../development/python-modules/pdfminer-six { };
+
+  pdfplumber = callPackage ../development/python-modules/pdfplumber { };
+
+  pdfrw = callPackage ../development/python-modules/pdfrw { };
+
+  pdfrw2 = callPackage ../development/python-modules/pdfrw2 { };
+
+  pdftotext = callPackage ../development/python-modules/pdftotext { };
+
+  pdm-backend = callPackage ../development/python-modules/pdm-backend { };
+
+  pdm-build-locked = callPackage ../development/python-modules/pdm-build-locked { };
+
+  pdm-pep517 = callPackage ../development/python-modules/pdm-pep517 { };
+
+  pdoc = callPackage ../development/python-modules/pdoc { };
+
+  pdoc-pyo3-sample-library = callPackage ../development/python-modules/pdoc-pyo3-sample-library { };
+
+  pdoc3 = callPackage ../development/python-modules/pdoc3 { };
+
+  pdunehd = callPackage ../development/python-modules/pdunehd { };
+
+  peacasso = callPackage ../development/python-modules/peacasso { };
+
+  peaqevcore = callPackage ../development/python-modules/peaqevcore { };
+
+  pebble = callPackage ../development/python-modules/pebble { };
+
+  peblar = callPackage ../development/python-modules/peblar { };
+
+  pecan = callPackage ../development/python-modules/pecan { };
+
+  peco = callPackage ../development/python-modules/peco { };
+
+  peewee = callPackage ../development/python-modules/peewee { };
+
+  peewee-migrate = callPackage ../development/python-modules/peewee-migrate { };
+
+  pefile = callPackage ../development/python-modules/pefile { };
+
+  peft = callPackage ../development/python-modules/peft { };
+
+  pegen = callPackage ../development/python-modules/pegen { };
+
+  pelican = callPackage ../development/python-modules/pelican { inherit (pkgs) glibcLocales git; };
+
+  pem = callPackage ../development/python-modules/pem { };
+
+  pencompy = callPackage ../development/python-modules/pencompy { };
+
+  pendulum = callPackage ../development/python-modules/pendulum { };
+
+  pep440 = callPackage ../development/python-modules/pep440 { };
+
+  pep517 = callPackage ../development/python-modules/pep517 { };
+
+  pep8 = callPackage ../development/python-modules/pep8 { };
+
+  pep8-naming = callPackage ../development/python-modules/pep8-naming { };
+
+  pepit = callPackage ../development/python-modules/pepit { };
+
+  peppercorn = callPackage ../development/python-modules/peppercorn { };
+
+  percol = callPackage ../development/python-modules/percol { };
+
+  perfplot = callPackage ../development/python-modules/perfplot { };
+
+  periodictable = callPackage ../development/python-modules/periodictable { };
+
+  periodiq = callPackage ../development/python-modules/periodiq { };
+
+  permissionedforms = callPackage ../development/python-modules/permissionedforms { };
+
+  persim = callPackage ../development/python-modules/persim { };
+
+  persist-queue = callPackage ../development/python-modules/persist-queue { };
+
+  persistent = callPackage ../development/python-modules/persistent { };
+
+  persisting-theory = callPackage ../development/python-modules/persisting-theory { };
+
+  pescea = callPackage ../development/python-modules/pescea { };
+
+  pesq = callPackage ../development/python-modules/pesq { };
+
+  petl = callPackage ../development/python-modules/petl { };
+
+  petsc4py = toPythonModule (
+    pkgs.petsc.override {
+      python3 = python;
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
+  pettingzoo = callPackage ../development/python-modules/pettingzoo { };
+
+  pex = callPackage ../development/python-modules/pex { };
+
+  pexif = callPackage ../development/python-modules/pexif { };
+
+  pexpect = callPackage ../development/python-modules/pexpect { };
+
+  pfzy = callPackage ../development/python-modules/pfzy { };
+
+  pg8000 = callPackage ../development/python-modules/pg8000 { };
+
+  pgcli = callPackage ../development/python-modules/pgcli { };
+
+  pglast = callPackage ../development/python-modules/pglast { };
+
+  pglive = callPackage ../development/python-modules/pglive { };
+
+  pgmpy = callPackage ../development/python-modules/pgmpy { };
+
+  pgpdump = callPackage ../development/python-modules/pgpdump { };
+
+  pgpy = callPackage ../development/python-modules/pgpy { };
+
+  pgpy-dtc = callPackage ../development/python-modules/pgpy-dtc { };
+
+  pgsanity = callPackage ../development/python-modules/pgsanity { };
+
+  pgspecial = callPackage ../development/python-modules/pgspecial { };
+
+  pgvector = callPackage ../development/python-modules/pgvector { };
+
+  phe = callPackage ../development/python-modules/phe { };
+
+  phik = callPackage ../development/python-modules/phik { };
+
+  philipstv = callPackage ../development/python-modules/philipstv { };
+
+  phone-modem = callPackage ../development/python-modules/phone-modem { };
+
+  phonemizer = callPackage ../development/python-modules/phonemizer { };
+
+  phonenumbers = callPackage ../development/python-modules/phonenumbers { };
+
+  phonenumberslite = callPackage ../development/python-modules/phonenumberslite { };
+
+  phonopy = callPackage ../development/python-modules/phonopy { };
+
+  photutils = callPackage ../development/python-modules/photutils { };
+
+  phply = callPackage ../development/python-modules/phply { };
+
+  phpserialize = callPackage ../development/python-modules/phpserialize { };
+
+  phunspell = callPackage ../development/python-modules/phunspell { };
+
+  phx-class-registry = callPackage ../development/python-modules/phx-class-registry { };
+
+  pi1wire = callPackage ../development/python-modules/pi1wire { };
+
+  piano-transcription-inference =
+    callPackage ../development/python-modules/piano-transcription-inference
+      { };
+
+  piccata = callPackage ../development/python-modules/piccata { };
+
+  piccolo-theme = callPackage ../development/python-modules/piccolo-theme { };
+
+  pick = callPackage ../development/python-modules/pick { };
+
+  pickleshare = callPackage ../development/python-modules/pickleshare { };
+
+  pickpack = callPackage ../development/python-modules/pickpack { };
+
+  picobox = callPackage ../development/python-modules/picobox { };
+
+  picologging = callPackage ../development/python-modules/picologging { };
+
+  picos = callPackage ../development/python-modules/picos { };
+
+  picosvg = callPackage ../development/python-modules/picosvg { };
+
+  pid = callPackage ../development/python-modules/pid { };
+
+  piep = callPackage ../development/python-modules/piep { };
+
+  piexif = callPackage ../development/python-modules/piexif { };
+
+  pijuice = callPackage ../development/python-modules/pijuice { };
+
+  pika = callPackage ../development/python-modules/pika { };
+
+  pika-pool = callPackage ../development/python-modules/pika-pool { };
+
+  pikepdf = callPackage ../development/python-modules/pikepdf { };
+
+  pilkit = callPackage ../development/python-modules/pilkit { };
+
+  pillow = callPackage ../development/python-modules/pillow {
+    inherit (pkgs)
+      freetype
+      lcms2
+      libimagequant
+      libjpeg
+      libraqm
+      libtiff
+      libwebp
+      openjpeg
+      zlib
+      ;
+    inherit (pkgs.xorg) libxcb;
+  };
+
+  pillow-heif = callPackage ../development/python-modules/pillow-heif { };
+
+  pillow-jpls = callPackage ../development/python-modules/pillow-jpls { };
+
+  pillowfight = callPackage ../development/python-modules/pillowfight { };
+
+  pims = callPackage ../development/python-modules/pims { };
+
+  pinboard = callPackage ../development/python-modules/pinboard { };
+
+  pinecone-client = callPackage ../development/python-modules/pinecone-client { };
+
+  pinecone-plugin-inference = callPackage ../development/python-modules/pinecone-plugin-inference { };
+
+  pinecone-plugin-interface = callPackage ../development/python-modules/pinecone-plugin-interface { };
+
+  ping3 = callPackage ../development/python-modules/ping3 { };
+
+  pinocchio = toPythonModule (
+    pkgs.pinocchio.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  pins = callPackage ../development/python-modules/pins { };
+
+  pint = callPackage ../development/python-modules/pint { };
+
+  pint-pandas = callPackage ../development/python-modules/pint-pandas { };
+
+  pint-xarray = callPackage ../development/python-modules/pint-xarray { };
+
+  pip = callPackage ../development/python-modules/pip { };
+
+  pip-api = callPackage ../development/python-modules/pip-api { };
+
+  pip-chill = callPackage ../development/python-modules/pip-chill { };
+
+  pip-requirements-parser = callPackage ../development/python-modules/pip-requirements-parser { };
+
+  pip-system-certs = callPackage ../development/python-modules/pip-system-certs { };
+
+  pip-tools = callPackage ../development/python-modules/pip-tools { };
+
+  pipdate = callPackage ../development/python-modules/pipdate { };
+
+  pipdeptree = callPackage ../development/python-modules/pipdeptree { };
+
+  pipe = callPackage ../development/python-modules/pipe { };
+
+  piper-phonemize = callPackage ../development/python-modules/piper-phonemize {
+    onnxruntime-native = pkgs.onnxruntime;
+    piper-phonemize-native = pkgs.piper-phonemize;
+  };
+
+  pipetools = callPackage ../development/python-modules/pipetools { };
+
+  pipx = callPackage ../development/python-modules/pipx { };
+
+  piqp = callPackage ../development/python-modules/piqp { };
+
+  pivy = callPackage ../development/python-modules/pivy {
+    inherit (pkgs.qt5) qtbase qmake;
+    inherit (pkgs.libsForQt5) soqt;
+  };
+
+  pixcat = callPackage ../development/python-modules/pixcat { };
+
+  pixel-font-builder = callPackage ../development/python-modules/pixel-font-builder { };
+
+  pixel-font-knife = callPackage ../development/python-modules/pixel-font-knife { };
+
+  pixel-ring = callPackage ../development/python-modules/pixel-ring { };
+
+  pjsua2 =
+    (toPythonModule (
+      pkgs.pjsip.override {
+        pythonSupport = true;
+        python3 = self.python;
+      }
+    )).py;
+
+  pkce = callPackage ../development/python-modules/pkce { };
+
+  pkg-about = callPackage ../development/python-modules/pkg-about { };
+
+  pkgconfig = callPackage ../development/python-modules/pkgconfig { };
+
+  pkginfo = callPackage ../development/python-modules/pkginfo { };
+
+  pkginfo2 = callPackage ../development/python-modules/pkginfo2 { };
+
+  pkgutil-resolve-name = callPackage ../development/python-modules/pkgutil-resolve-name { };
+
+  pkuseg = callPackage ../development/python-modules/pkuseg { };
+
+  plac = callPackage ../development/python-modules/plac { };
+
+  plaid-python = callPackage ../development/python-modules/plaid-python { };
+
+  planetary-computer = callPackage ../development/python-modules/planetary-computer { };
+
+  plantuml = callPackage ../development/python-modules/plantuml { };
+
+  plantuml-markdown = callPackage ../development/python-modules/plantuml-markdown {
+    inherit (pkgs) plantuml;
+  };
+
+  plasTeX = callPackage ../development/python-modules/plasTeX { };
+
+  plaster = callPackage ../development/python-modules/plaster { };
+
+  plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy { };
+
+  plastexdepgraph = callPackage ../development/python-modules/plastexdepgraph { };
+
+  plastexshowmore = callPackage ../development/python-modules/plastexshowmore { };
+
+  platformdirs = callPackage ../development/python-modules/platformdirs { };
+
+  playsound = callPackage ../development/python-modules/playsound { };
+
+  playwright = callPackage ../development/python-modules/playwright { };
+
+  playwright-stealth = callPackage ../development/python-modules/playwright-stealth { };
+
+  playwrightcapture = callPackage ../development/python-modules/playwrightcapture { };
+
+  plexapi = callPackage ../development/python-modules/plexapi { };
+
+  plexauth = callPackage ../development/python-modules/plexauth { };
+
+  plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
+
+  plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
+
+  plone-testing = callPackage ../development/python-modules/plone-testing { };
+
+  ploomber-core = callPackage ../development/python-modules/ploomber-core { };
+
+  ploomber-extension = callPackage ../development/python-modules/ploomber-extension { };
+
+  plotext = callPackage ../development/python-modules/plotext { };
+
+  plotly = callPackage ../development/python-modules/plotly { };
+
+  plotnine = callPackage ../development/python-modules/plotnine { };
+
+  plotpy = callPackage ../development/python-modules/plotpy { };
+
+  pluggy = callPackage ../development/python-modules/pluggy { };
+
+  pluginbase = callPackage ../development/python-modules/pluginbase { };
+
+  plugincode = callPackage ../development/python-modules/plugincode { };
+
+  plugnplay = callPackage ../development/python-modules/plugnplay { };
+
+  plugp100 = callPackage ../development/python-modules/plugp100 { };
+
+  plugwise = callPackage ../development/python-modules/plugwise { };
+
+  plum-py = callPackage ../development/python-modules/plum-py { };
+
+  plumbum = callPackage ../development/python-modules/plumbum { };
+
+  pluthon = callPackage ../development/python-modules/pluthon { };
+
+  plux = callPackage ../development/python-modules/plux { };
+
+  ply = callPackage ../development/python-modules/ply { };
+
+  plyara = callPackage ../development/python-modules/plyara { };
+
+  plyer = callPackage ../development/python-modules/plyer { };
+
+  plyfile = callPackage ../development/python-modules/plyfile { };
+
+  plyplus = callPackage ../development/python-modules/plyplus { };
+
+  plyvel = callPackage ../development/python-modules/plyvel { };
+
+  pmdarima = callPackage ../development/python-modules/pmdarima { };
+
+  pmdsky-debug-py = callPackage ../development/python-modules/pmdsky-debug-py { };
+
+  pmsensor = callPackage ../development/python-modules/pmsensor { };
+
+  pmw = callPackage ../development/python-modules/pmw { };
+
+  pnglatex = callPackage ../development/python-modules/pnglatex { };
+
+  pocket = callPackage ../development/python-modules/pocket { };
+
+  pocketsphinx = callPackage ../development/python-modules/pocketsphinx {
+    inherit (pkgs) pocketsphinx;
+  };
+
+  podcastparser = callPackage ../development/python-modules/podcastparser { };
+
+  podcats = callPackage ../development/python-modules/podcats { };
+
+  podgen = callPackage ../development/python-modules/podgen { };
+
+  podman = callPackage ../development/python-modules/podman { };
+
+  poetry-core = callPackage ../development/python-modules/poetry-core { };
+
+  poetry-dynamic-versioning = callPackage ../development/python-modules/poetry-dynamic-versioning { };
+
+  poetry-semver = callPackage ../development/python-modules/poetry-semver { };
+
+  polarizationsolver = callPackage ../development/python-modules/polarizationsolver { };
+
+  polars = callPackage ../development/python-modules/polars { };
+
+  polib = callPackage ../development/python-modules/polib { };
+
+  policy-sentry = callPackage ../development/python-modules/policy-sentry { };
+
+  policyuniverse = callPackage ../development/python-modules/policyuniverse { };
+
+  polling = callPackage ../development/python-modules/polling { };
+
+  polyfactory = callPackage ../development/python-modules/polyfactory { };
+
+  polygon3 = callPackage ../development/python-modules/polygon3 { };
+
+  polyline = callPackage ../development/python-modules/polyline { };
+
+  polyswarm-api = callPackage ../development/python-modules/polyswarm-api { };
+
+  pomegranate = callPackage ../development/python-modules/pomegranate { };
+
+  pontos = callPackage ../development/python-modules/pontos { };
+
+  pony = callPackage ../development/python-modules/pony { };
+
+  ponywhoosh = callPackage ../development/python-modules/ponywhoosh { };
+
+  pooch = callPackage ../development/python-modules/pooch { };
+
+  pook = callPackage ../development/python-modules/pook { };
+
+  poolsense = callPackage ../development/python-modules/poolsense { };
+
+  poppler-qt5 = callPackage ../development/python-modules/poppler-qt5 {
+    inherit (pkgs.qt5) qtbase qmake;
+    inherit (pkgs.libsForQt5) poppler;
+  };
+
+  port-for = callPackage ../development/python-modules/port-for { };
+
+  portalocker = callPackage ../development/python-modules/portalocker { };
+
+  portend = callPackage ../development/python-modules/portend { };
+
+  portion = callPackage ../development/python-modules/portion { };
+
+  portpicker = callPackage ../development/python-modules/portpicker { };
+
+  posix-ipc = callPackage ../development/python-modules/posix-ipc { };
+
+  posthog = callPackage ../development/python-modules/posthog { };
+
+  pot = callPackage ../development/python-modules/pot { };
+
+  potentials = callPackage ../development/python-modules/potentials { };
+
+  potr = callPackage ../development/python-modules/potr { };
+
+  power = callPackage ../development/python-modules/power { };
+
+  powerapi = callPackage ../development/python-modules/powerapi { };
+
+  powerfox = callPackage ../development/python-modules/powerfox { };
+
+  powerline = callPackage ../development/python-modules/powerline { };
+
+  powerline-mem-segment = callPackage ../development/python-modules/powerline-mem-segment { };
+
+  pox = callPackage ../development/python-modules/pox { };
+
+  poyo = callPackage ../development/python-modules/poyo { };
+
+  ppdeep = callPackage ../development/python-modules/ppdeep { };
+
+  ppft = callPackage ../development/python-modules/ppft { };
+
+  ppk2-api = callPackage ../development/python-modules/ppk2-api { };
+
+  pplpy = callPackage ../development/python-modules/pplpy { };
+
+  pprintpp = callPackage ../development/python-modules/pprintpp { };
+
+  pproxy = callPackage ../development/python-modules/pproxy { };
+
+  ppscore = callPackage ../development/python-modules/ppscore { };
+
+  pq = callPackage ../development/python-modules/pq { };
+
+  prance = callPackage ../development/python-modules/prance { };
+
+  praw = callPackage ../development/python-modules/praw { };
+
+  prawcore = callPackage ../development/python-modules/prawcore { };
+
+  prayer-times-calculator-offline =
+    callPackage ../development/python-modules/prayer-times-calculator-offline
+      { };
+
+  pre-commit-hooks = callPackage ../development/python-modules/pre-commit-hooks { };
+
+  pre-commit-po-hooks = callPackage ../development/python-modules/pre-commit-po-hooks { };
+
+  precis-i18n = callPackage ../development/python-modules/precis-i18n { };
+
+  precisely = callPackage ../development/python-modules/precisely { };
+
+  prefixed = callPackage ../development/python-modules/prefixed { };
+
+  preggy = callPackage ../development/python-modules/preggy { };
+
+  preprocess-cancellation = callPackage ../development/python-modules/preprocess-cancellation { };
+
+  presenterm-export = callPackage ../development/python-modules/presenterm-export { };
+
+  preshed = callPackage ../development/python-modules/preshed { };
+
+  pretend = callPackage ../development/python-modules/pretend { };
+
+  pretty-errors = callPackage ../development/python-modules/pretty-errors { };
+
+  prettytable = callPackage ../development/python-modules/prettytable { };
+
+  primecountpy = callPackage ../development/python-modules/primecountpy { };
+
+  primepy = callPackage ../development/python-modules/primepy { };
+
+  primer3 = callPackage ../development/python-modules/primer3 { };
+
+  primp = callPackage ../development/python-modules/primp {
+    inherit (pkgs.darwin.apple_sdk.frameworks) SystemConfiguration;
+  };
+
+  print-color = callPackage ../development/python-modules/print-color { };
+
+  priority = callPackage ../development/python-modules/priority { };
+
+  prisma = callPackage ../development/python-modules/prisma { };
+
+  prison = callPackage ../development/python-modules/prison { };
+
+  private-gpt = callPackage ../development/python-modules/private-gpt { };
+
+  process-tests = callPackage ../development/python-modules/process-tests { };
+
+  procmon-parser = callPackage ../development/python-modules/procmon-parser { };
+
+  prodict = callPackage ../development/python-modules/prodict { };
+
+  proglog = callPackage ../development/python-modules/proglog { };
+
+  progress = callPackage ../development/python-modules/progress { };
+
+  progressbar = callPackage ../development/python-modules/progressbar { };
+
+  progressbar2 = callPackage ../development/python-modules/progressbar2 { };
+
+  progressbar33 = callPackage ../development/python-modules/progressbar33 { };
+
+  prometheus-api-client = callPackage ../development/python-modules/prometheus-api-client { };
+
+  prometheus-async = callPackage ../development/python-modules/prometheus-async { };
+
+  prometheus-client = callPackage ../development/python-modules/prometheus-client { };
+
+  prometheus-fastapi-instrumentator =
+    callPackage ../development/python-modules/prometheus-fastapi-instrumentator
+      { };
+
+  prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
+
+  prometheus-pandas = callPackage ../development/python-modules/prometheus-pandas { };
+
+  prometrix = callPackage ../development/python-modules/prometrix { };
+
+  promise = callPackage ../development/python-modules/promise { };
+
+  prompt-toolkit = callPackage ../development/python-modules/prompt-toolkit { };
+
+  prompthub-py = callPackage ../development/python-modules/prompthub-py { };
+
+  propcache = callPackage ../development/python-modules/propcache { };
+
+  property-manager = callPackage ../development/python-modules/property-manager { };
+
+  prophet = callPackage ../development/python-modules/prophet { };
+
+  propka = callPackage ../development/python-modules/propka { };
+
+  prosemirror = callPackage ../development/python-modules/prosemirror { };
+
+  protego = callPackage ../development/python-modules/protego { };
+
+  proto-plus = callPackage ../development/python-modules/proto-plus { };
+
+  # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
+  protobuf = protobuf5;
+
+  protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
+
+  # Protobuf 4.x
+  protobuf4 = callPackage ../development/python-modules/protobuf/4.nix {
+    protobuf = pkgs.protobuf_25;
+  };
+
+  # Protobuf 5.x
+  protobuf5 = callPackage ../development/python-modules/protobuf/default.nix {
+    inherit (pkgs.__splicedPackages) protobuf;
+  };
+
+  proton-client = callPackage ../development/python-modules/proton-client { };
+
+  proton-core = callPackage ../development/python-modules/proton-core { };
+
+  proton-keyring-linux = callPackage ../development/python-modules/proton-keyring-linux { };
+
+  proton-vpn-api-core = callPackage ../development/python-modules/proton-vpn-api-core { };
+
+  proton-vpn-network-manager =
+    callPackage ../development/python-modules/proton-vpn-network-manager
+      { };
+
+  protonup-ng = callPackage ../development/python-modules/protonup-ng { };
+
+  protonvpn-nm-lib = callPackage ../development/python-modules/protonvpn-nm-lib {
+    pkgs-systemd = pkgs.systemd;
+  };
+
+  prov = callPackage ../development/python-modules/prov { };
+
+  prox-tv = callPackage ../development/python-modules/prox-tv { };
+
+  proxmoxer = callPackage ../development/python-modules/proxmoxer { };
+
+  proxsuite = toPythonModule (
+    pkgs.proxsuite.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  proxsuite-nlp = toPythonModule (
+    pkgs.proxsuite-nlp.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  proxy-db = callPackage ../development/python-modules/proxy-db { };
+
+  proxy-py = callPackage ../development/python-modules/proxy-py { };
+
+  proxy-tools = callPackage ../development/python-modules/proxy-tools { };
+
+  psautohint = callPackage ../development/python-modules/psautohint { };
+
+  pscript = callPackage ../development/python-modules/pscript { };
+
+  psd-tools = callPackage ../development/python-modules/psd-tools { };
+
+  psrpcore = callPackage ../development/python-modules/psrpcore { };
+
+  psutil = callPackage ../development/python-modules/psutil {
+    stdenv =
+      if pkgs.stdenv.hostPlatform.isDarwin then pkgs.overrideSDK pkgs.stdenv "11.0" else pkgs.stdenv;
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation IOKit;
+  };
+
+  psutil-home-assistant = callPackage ../development/python-modules/psutil-home-assistant { };
+
+  psychrolib = callPackage ../development/python-modules/psychrolib { };
+
+  psycopg = callPackage ../development/python-modules/psycopg { };
+
+  psycopg-c = psycopg.c;
+
+  psycopg-pool = psycopg.pool;
+
+  psycopg2 = callPackage ../development/python-modules/psycopg2 { };
+
+  psycopg2-binary = callPackage ../development/python-modules/psycopg2-binary { };
+
+  psycopg2cffi = callPackage ../development/python-modules/psycopg2cffi { };
+
+  psygnal = callPackage ../development/python-modules/psygnal { };
+
+  ptable = callPackage ../development/python-modules/ptable { };
+
+  ptest = callPackage ../development/python-modules/ptest { };
+
+  ptpython = callPackage ../development/python-modules/ptpython { };
+
+  ptyprocess = callPackage ../development/python-modules/ptyprocess { };
+
+  publicsuffix = callPackage ../development/python-modules/publicsuffix { };
+
+  publicsuffix2 = callPackage ../development/python-modules/publicsuffix2 { };
+
+  publicsuffixlist = callPackage ../development/python-modules/publicsuffixlist { };
+
+  pubnub = callPackage ../development/python-modules/pubnub { };
+
+  pubnubsub-handler = callPackage ../development/python-modules/pubnubsub-handler { };
+
+  pudb = callPackage ../development/python-modules/pudb { };
+
+  pueblo = callPackage ../development/python-modules/pueblo { };
+
+  pulp = callPackage ../development/python-modules/pulp { };
+
+  pulsar = callPackage ../development/python-modules/pulsar { };
+
+  pulsar-client = callPackage ../development/python-modules/pulsar-client { };
+
+  pulsectl = callPackage ../development/python-modules/pulsectl { };
+
+  pulsectl-asyncio = callPackage ../development/python-modules/pulsectl-asyncio { };
+
+  pulumi = callPackage ../development/python-modules/pulumi { };
+
+  pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
+
+  pulumi-aws-native = pkgs.pulumiPackages.pulumi-aws-native.sdks.python;
+
+  pulumi-azure-native = pkgs.pulumiPackages.pulumi-azure-native.sdks.python;
+
+  pulumi-command = pkgs.pulumiPackages.pulumi-command.sdks.python;
+
+  pulumi-hcloud = pkgs.pulumiPackages.pulumi-hcloud.sdks.python;
+
+  pulumi-random = pkgs.pulumiPackages.pulumi-random.sdks.python;
+
+  pure-cdb = callPackage ../development/python-modules/pure-cdb { };
+
+  pure-eval = callPackage ../development/python-modules/pure-eval { };
+
+  pure-pcapy3 = callPackage ../development/python-modules/pure-pcapy3 { };
+
+  pure-protobuf = callPackage ../development/python-modules/pure-protobuf { };
+
+  pure-python-adb = callPackage ../development/python-modules/pure-python-adb { };
+
+  pure-python-adb-homeassistant =
+    callPackage ../development/python-modules/pure-python-adb-homeassistant
+      { };
+
+  puremagic = callPackage ../development/python-modules/puremagic { };
+
+  purepng = callPackage ../development/python-modules/purepng { };
+
+  purl = callPackage ../development/python-modules/purl { };
+
+  push-receiver = callPackage ../development/python-modules/push-receiver { };
+
+  pushbullet-py = callPackage ../development/python-modules/pushbullet-py { };
+
+  pushover-complete = callPackage ../development/python-modules/pushover-complete { };
+
+  pvextractor = callPackage ../development/python-modules/pvextractor { };
+
+  pvlib = callPackage ../development/python-modules/pvlib { };
+
+  pvo = callPackage ../development/python-modules/pvo { };
+
+  pweave = callPackage ../development/python-modules/pweave { };
+
+  pwinput = callPackage ../development/python-modules/pwinput { };
+
+  pwkit = callPackage ../development/python-modules/pwkit { };
+
+  pwlf = callPackage ../development/python-modules/pwlf { };
+
+  pwntools = callPackage ../development/python-modules/pwntools { debugger = pkgs.gdb; };
+
+  py = callPackage ../development/python-modules/py { };
+
+  py-air-control = callPackage ../development/python-modules/py-air-control { };
+
+  py-air-control-exporter = callPackage ../development/python-modules/py-air-control-exporter { };
+
+  py-aosmith = callPackage ../development/python-modules/py-aosmith { };
+
+  py-bip39-bindings = callPackage ../development/python-modules/py-bip39-bindings { };
+
+  py-canary = callPackage ../development/python-modules/py-canary { };
+
+  py-ccm15 = callPackage ../development/python-modules/py-ccm15 { };
+
+  py-cid = callPackage ../development/python-modules/py-cid { };
+
+  py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
+
+  py-datastruct = callPackage ../development/python-modules/py-datastruct { };
+
+  py-deprecate = callPackage ../development/python-modules/py-deprecate { };
+
+  py-desmume = callPackage ../development/python-modules/py-desmume {
+    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
+  };
+
+  py-deviceid = callPackage ../development/python-modules/py-deviceid { };
+
+  py-dmidecode = callPackage ../development/python-modules/py-dmidecode { };
+
+  py-dormakaba-dkey = callPackage ../development/python-modules/py-dormakaba-dkey { };
+
+  py-ecc = callPackage ../development/python-modules/py-ecc { };
+
+  py-eth-sig-utils = callPackage ../development/python-modules/py-eth-sig-utils { };
+
+  py-evm = callPackage ../development/python-modules/py-evm { };
+
+  py-expression-eval = callPackage ../development/python-modules/py-expression-eval { };
+
+  py-improv-ble-client = callPackage ../development/python-modules/py-improv-ble-client { };
+
+  py-libzfs = callPackage ../development/python-modules/py-libzfs { };
+
+  py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };
+
+  py-machineid = callPackage ../development/python-modules/py-machineid { };
+
+  py-madvr2 = callPackage ../development/python-modules/py-madvr2 { };
+
+  py-multiaddr = callPackage ../development/python-modules/py-multiaddr { };
+
+  py-multibase = callPackage ../development/python-modules/py-multibase { };
+
+  py-multicodec = callPackage ../development/python-modules/py-multicodec { };
+
+  py-multihash = callPackage ../development/python-modules/py-multihash { };
+
+  py-nextbusnext = callPackage ../development/python-modules/py-nextbusnext { };
+
+  py-nightscout = callPackage ../development/python-modules/py-nightscout { };
+
+  py-ocsf-models = callPackage ../development/python-modules/py-ocsf-models { };
+
+  py-opensonic = callPackage ../development/python-modules/py-opensonic { };
+
+  py-partiql-parser = callPackage ../development/python-modules/py-partiql-parser { };
+
+  py-pdf-parser = callPackage ../development/python-modules/py-pdf-parser { };
+
+  py-radix-sr = callPackage ../development/python-modules/py-radix-sr { };
+
+  py-rust-stemmers = callPackage ../development/python-modules/py-rust-stemmers { };
+
+  py-scrypt = callPackage ../development/python-modules/py-scrypt { };
+
+  py-serializable = callPackage ../development/python-modules/py-serializable { };
+
+  py-slvs = callPackage ../development/python-modules/py-slvs { };
+
+  py-sneakers = callPackage ../development/python-modules/py-sneakers { };
+
+  py-sonic = callPackage ../development/python-modules/py-sonic { };
+
+  py-sr25519-bindings = callPackage ../development/python-modules/py-sr25519-bindings { };
+
+  py-stringmatching = callPackage ../development/python-modules/py-stringmatching { };
+
+  py-sucks = callPackage ../development/python-modules/py-sucks { };
+
+  py-synologydsm-api = callPackage ../development/python-modules/py-synologydsm-api { };
+
+  py-tes = callPackage ../development/python-modules/py-tes { };
+
+  py-ubjson = callPackage ../development/python-modules/py-ubjson { };
+
+  py-vapid = callPackage ../development/python-modules/py-vapid { };
+
+  py-zabbix = callPackage ../development/python-modules/py-zabbix { };
+
+  py2bit = callPackage ../development/python-modules/py2bit { };
+
+  py3buddy = callPackage ../development/python-modules/py3buddy { };
+
+  py3dns = callPackage ../development/python-modules/py3dns { };
+
+  py3exiv2 = callPackage ../development/python-modules/py3exiv2 { inherit (pkgs) exiv2; };
+
+  py3langid = callPackage ../development/python-modules/py3langid { };
+
+  py3nvml = callPackage ../development/python-modules/py3nvml { };
+
+  py3rijndael = callPackage ../development/python-modules/py3rijndael { };
+
+  py3status = callPackage ../development/python-modules/py3status { };
+
+  py4j = callPackage ../development/python-modules/py4j { };
+
+  py65 = callPackage ../development/python-modules/py65 { };
+
+  py7zr = callPackage ../development/python-modules/py7zr { };
+
+  pyabpoa = toPythonModule (
+    pkgs.abpoa.override {
+      enablePython = true;
+      python3Packages = self;
+    }
+  );
+
+  pyacaia-async = callPackage ../development/python-modules/pyacaia-async { };
+
+  pyacoustid = callPackage ../development/python-modules/pyacoustid { };
+
+  pyads = callPackage ../development/python-modules/pyads { };
+
+  pyaehw4a1 = callPackage ../development/python-modules/pyaehw4a1 { };
+
+  pyaes = callPackage ../development/python-modules/pyaes { };
+
+  pyaftership = callPackage ../development/python-modules/pyaftership { };
+
+  pyahocorasick = callPackage ../development/python-modules/pyahocorasick { };
+
+  pyairnow = callPackage ../development/python-modules/pyairnow { };
+
+  pyairports = callPackage ../development/python-modules/pyairports { };
+
+  pyairvisual = callPackage ../development/python-modules/pyairvisual { };
+
+  pyais = callPackage ../development/python-modules/pyais { };
+
+  pyalgotrade = callPackage ../development/python-modules/pyalgotrade { };
+
+  pyalsaaudio = callPackage ../development/python-modules/pyalsaaudio { };
+
+  pyamg = callPackage ../development/python-modules/pyamg { };
+
+  pyaml = callPackage ../development/python-modules/pyaml { };
+
+  pyaml-env = callPackage ../development/python-modules/pyaml-env { };
+
+  pyannotate = callPackage ../development/python-modules/pyannotate { };
+
+  pyannote-audio = callPackage ../development/python-modules/pyannote-audio { };
+
+  pyannote-core = callPackage ../development/python-modules/pyannote-core { };
+
+  pyannote-database = callPackage ../development/python-modules/pyannote-database { };
+
+  pyannote-metrics = callPackage ../development/python-modules/pyannote-metrics { };
+
+  pyannote-pipeline = callPackage ../development/python-modules/pyannote-pipeline { };
+
+  pyaprilaire = callPackage ../development/python-modules/pyaprilaire { };
+
+  pyarlo = callPackage ../development/python-modules/pyarlo { };
+
+  pyarr = callPackage ../development/python-modules/pyarr { };
+
+  pyarrow = callPackage ../development/python-modules/pyarrow { inherit (pkgs) arrow-cpp cmake; };
+
+  pyarrow-hotfix = callPackage ../development/python-modules/pyarrow-hotfix { };
+
+  pyasn = callPackage ../development/python-modules/pyasn { };
+
+  pyasn1 = callPackage ../development/python-modules/pyasn1 { };
+
+  pyasn1-modules = callPackage ../development/python-modules/pyasn1-modules { };
+
+  pyasuswrt = callPackage ../development/python-modules/pyasuswrt { };
+
+  pyasynchat = callPackage ../development/python-modules/pyasynchat { };
+
+  pyasyncore = callPackage ../development/python-modules/pyasyncore { };
+
+  pyatag = callPackage ../development/python-modules/pyatag { };
+
+  pyatem = callPackage ../development/python-modules/pyatem { };
+
+  pyathena = callPackage ../development/python-modules/pyathena { };
+
+  pyatmo = callPackage ../development/python-modules/pyatmo { };
+
+  pyatome = callPackage ../development/python-modules/pyatome { };
+
+  pyatspi = callPackage ../development/python-modules/pyatspi { };
+
+  pyatv = callPackage ../development/python-modules/pyatv { };
+
+  pyaudio = callPackage ../development/python-modules/pyaudio { };
+
+  pyaussiebb = callPackage ../development/python-modules/pyaussiebb { };
+
+  pyautogui = callPackage ../development/python-modules/pyautogui { };
+
+  pyavm = callPackage ../development/python-modules/pyavm { };
+
+  pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
+
+  pybalboa = callPackage ../development/python-modules/pybalboa { };
+
+  pybars3 = callPackage ../development/python-modules/pybars3 { };
+
+  pybase64 = callPackage ../development/python-modules/pybase64 { };
+
+  pybcj = callPackage ../development/python-modules/pybcj { };
+
+  pybids = callPackage ../development/python-modules/pybids { };
+
+  pybigwig = callPackage ../development/python-modules/pybigwig { };
+
+  pybind11 = callPackage ../development/python-modules/pybind11 { };
+
+  pybind11-abseil = callPackage ../development/python-modules/pybind11-abseil { };
+
+  pybind11-protobuf = callPackage ../development/python-modules/pybind11-protobuf { };
+
+  pybind11-stubgen = callPackage ../development/python-modules/pybind11-stubgen { };
+
+  pybindgen = callPackage ../development/python-modules/pybindgen { };
+
+  pyblackbird = callPackage ../development/python-modules/pyblackbird { };
+
+  pybloom-live = callPackage ../development/python-modules/pybloom-live { };
+
+  pyblu = callPackage ../development/python-modules/pyblu { };
+
+  pybluez = callPackage ../development/python-modules/pybluez { inherit (pkgs) bluez; };
+
+  pybotvac = callPackage ../development/python-modules/pybotvac { };
+
+  pybox2d = callPackage ../development/python-modules/pybox2d { };
+
+  pybravia = callPackage ../development/python-modules/pybravia { };
+
+  pybrowserid = callPackage ../development/python-modules/pybrowserid { };
+
+  pybrowsers = callPackage ../development/python-modules/pybrowsers { };
+
+  pybtex = callPackage ../development/python-modules/pybtex { };
+
+  pybtex-docutils = callPackage ../development/python-modules/pybtex-docutils { };
+
+  pybullet = callPackage ../development/python-modules/pybullet { };
+
+  pycairo = callPackage ../development/python-modules/pycairo { inherit (pkgs.buildPackages) meson; };
+
+  pycangjie = callPackage ../development/python-modules/pycangjie {
+    inherit (pkgs.buildPackages) meson;
+  };
+
+  pycapnp = callPackage ../development/python-modules/pycapnp { };
+
+  pycaption = callPackage ../development/python-modules/pycaption { };
+
+  pycardano = callPackage ../development/python-modules/pycardano { };
+
+  pycares = callPackage ../development/python-modules/pycares { };
+
+  pycarwings2 = callPackage ../development/python-modules/pycarwings2 { };
+
+  pycatch22 = callPackage ../development/python-modules/pycatch22 { };
+
+  pycategories = callPackage ../development/python-modules/pycategories { };
+
+  pycddl = callPackage ../development/python-modules/pycddl { };
+
+  pycdio = callPackage ../development/python-modules/pycdio { };
+
+  pycec = callPackage ../development/python-modules/pycec { };
+
+  pycep-parser = callPackage ../development/python-modules/pycep-parser { };
+
+  pycfdns = callPackage ../development/python-modules/pycfdns { };
+
+  pycflow2dot = callPackage ../development/python-modules/pycflow2dot { inherit (pkgs) graphviz; };
+
+  pycfmodel = callPackage ../development/python-modules/pycfmodel { };
+
+  pychannels = callPackage ../development/python-modules/pychannels { };
+
+  pychart = callPackage ../development/python-modules/pychart { };
+
+  pychm = callPackage ../development/python-modules/pychm { };
+
+  pychromecast = callPackage ../development/python-modules/pychromecast { };
+
+  pycketcasts = callPackage ../development/python-modules/pycketcasts { };
+
+  pyclimacell = callPackage ../development/python-modules/pyclimacell { };
+
+  pyclip = callPackage ../development/python-modules/pyclip { };
+
+  pyclipper = callPackage ../development/python-modules/pyclipper { };
+
+  pycm = callPackage ../development/python-modules/pycm { };
+
+  pycmarkgfm = callPackage ../development/python-modules/pycmarkgfm { };
+
+  pycocotools = callPackage ../development/python-modules/pycocotools { };
+
+  pycodestyle = callPackage ../development/python-modules/pycodestyle { };
+
+  pycognito = callPackage ../development/python-modules/pycognito { };
+
+  pycoin = callPackage ../development/python-modules/pycoin { };
+
+  pycollada = callPackage ../development/python-modules/pycollada { };
+
+  pycolorecho = callPackage ../development/python-modules/pycolorecho { };
+
+  pycomfoconnect = callPackage ../development/python-modules/pycomfoconnect { };
+
+  pycomm3 = callPackage ../development/python-modules/pycomm3 { };
+
+  pycompliance = callPackage ../development/python-modules/pycompliance { };
+
+  pycomposefile = callPackage ../development/python-modules/pycomposefile { };
+
+  pycontrol4 = callPackage ../development/python-modules/pycontrol4 { };
+
+  pycookiecheat = callPackage ../development/python-modules/pycookiecheat { };
+
+  pycoolmasternet-async = callPackage ../development/python-modules/pycoolmasternet-async { };
+
+  pycosat = callPackage ../development/python-modules/pycosat { };
+
+  pycotap = callPackage ../development/python-modules/pycotap { };
+
+  pycountry = callPackage ../development/python-modules/pycountry { };
+
+  pycountry-convert = callPackage ../development/python-modules/pycountry-convert { };
+
+  pycparser = callPackage ../development/python-modules/pycparser { };
+
+  pycrc = callPackage ../development/python-modules/pycrc { };
+
+  pycrdt = callPackage ../development/python-modules/pycrdt { };
+
+  pycrdt-websocket = callPackage ../development/python-modules/pycrdt-websocket { };
+
+  pycritty = callPackage ../development/python-modules/pycritty { };
+
+  pycron = callPackage ../development/python-modules/pycron { };
+
+  pycrypto = callPackage ../development/python-modules/pycrypto { };
+
+  pycryptodome = callPackage ../development/python-modules/pycryptodome { };
+
+  pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
+
+  pycsdr = callPackage ../development/python-modules/pycsdr { };
+
+  pyct = callPackage ../development/python-modules/pyct { };
+
+  pyctr = callPackage ../development/python-modules/pyctr { };
+
+  pycuda = callPackage ../development/python-modules/pycuda { inherit (pkgs.stdenv) mkDerivation; };
+
+  pycups = callPackage ../development/python-modules/pycups { };
+
+  pycurl = callPackage ../development/python-modules/pycurl { };
+
+  pycxx = callPackage ../development/python-modules/pycxx { };
+
+  pycycling = callPackage ../development/python-modules/pycycling { };
+
+  pycyphal = callPackage ../development/python-modules/pycyphal { };
+
+  pydaikin = callPackage ../development/python-modules/pydaikin { };
+
+  pydal = callPackage ../development/python-modules/pydal { };
+
+  pydanfossair = callPackage ../development/python-modules/pydanfossair { };
+
+  pydantic = callPackage ../development/python-modules/pydantic { };
+
+  pydantic-argparse-extensible =
+    callPackage ../development/python-modules/pydantic-argparse-extensible
+      { };
+
+  pydantic-compat = callPackage ../development/python-modules/pydantic-compat { };
+
+  pydantic-core = callPackage ../development/python-modules/pydantic-core { };
+
+  pydantic-extra-types = callPackage ../development/python-modules/pydantic-extra-types { };
+
+  pydantic-scim = callPackage ../development/python-modules/pydantic-scim { };
+
+  pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };
+
+  pydantic-yaml = callPackage ../development/python-modules/pydantic-yaml { };
+
+  pydantic_1 = callPackage ../development/python-modules/pydantic/1.nix { };
+
+  pydash = callPackage ../development/python-modules/pydash { };
+
+  pydata-google-auth = callPackage ../development/python-modules/pydata-google-auth { };
+
+  pydata-sphinx-theme = callPackage ../development/python-modules/pydata-sphinx-theme { };
+
+  pydateinfer = callPackage ../development/python-modules/pydateinfer { };
+
+  pydbus = callPackage ../development/python-modules/pydbus { };
+
+  pydeako = callPackage ../development/python-modules/pydeako { };
+
+  pydeck = callPackage ../development/python-modules/pydeck { };
+
+  pydeconz = callPackage ../development/python-modules/pydeconz { };
+
+  pydelijn = callPackage ../development/python-modules/pydelijn { };
+
+  pydemumble = callPackage ../development/python-modules/pydemumble { };
+
+  pydenticon = callPackage ../development/python-modules/pydenticon { };
+
+  pydeps = callPackage ../development/python-modules/pydeps { inherit (pkgs) graphviz; };
+
+  pydes = callPackage ../development/python-modules/pydes { };
+
+  pydevccu = callPackage ../development/python-modules/pydevccu { };
+
+  pydevd = callPackage ../development/python-modules/pydevd { };
+
+  pydevtool = callPackage ../development/python-modules/pydevtool { };
+
+  pydexcom = callPackage ../development/python-modules/pydexcom { };
+
+  pydicom = callPackage ../development/python-modules/pydicom { };
+
+  pydicom-seg = callPackage ../development/python-modules/pydicom-seg { };
+
+  pydigiham = callPackage ../development/python-modules/pydigiham { };
+
+  pydiscourse = callPackage ../development/python-modules/pydiscourse { };
+
+  pydiscovergy = callPackage ../development/python-modules/pydiscovergy { };
+
+  pydispatcher = callPackage ../development/python-modules/pydispatcher { };
+
+  pydmd = callPackage ../development/python-modules/pydmd { };
+
+  pydocstyle = callPackage ../development/python-modules/pydocstyle { };
+
+  pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
+
+  pydoe = callPackage ../development/python-modules/pydoe { };
+
+  pydoods = callPackage ../development/python-modules/pydoods { };
+
+  pydot = callPackage ../development/python-modules/pydot { inherit (pkgs) graphviz; };
+
+  pydrawise = callPackage ../development/python-modules/pydrawise { };
+
+  pydrive2 = callPackage ../development/python-modules/pydrive2 { };
+
+  pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam { };
+
+  pydruid = callPackage ../development/python-modules/pydruid { };
+
+  pydsdl = callPackage ../development/python-modules/pydsdl { };
+
+  pydub = callPackage ../development/python-modules/pydub { };
+
+  pyduke-energy = callPackage ../development/python-modules/pyduke-energy { };
+
+  pyduotecno = callPackage ../development/python-modules/pyduotecno { };
+
+  pydy = callPackage ../development/python-modules/pydy { };
+
+  pydyf = callPackage ../development/python-modules/pydyf { };
+
+  pyeapi = callPackage ../development/python-modules/pyeapi { };
+
+  pyebus = callPackage ../development/python-modules/pyebus { };
+
+  pyecharts = callPackage ../development/python-modules/pyecharts { };
+
+  pyechonest = callPackage ../development/python-modules/pyechonest { };
+
+  pyeclib = callPackage ../development/python-modules/pyeclib { };
+
+  pyecoforest = callPackage ../development/python-modules/pyecoforest { };
+
+  pyeconet = callPackage ../development/python-modules/pyeconet { };
+
+  pyecotrend-ista = callPackage ../development/python-modules/pyecotrend-ista { };
+
+  pyecowitt = callPackage ../development/python-modules/pyecowitt { };
+
+  pyedflib = callPackage ../development/python-modules/pyedflib { };
+
+  pyedimax = callPackage ../development/python-modules/pyedimax { };
+
+  pyee = callPackage ../development/python-modules/pyee { };
+
+  pyefergy = callPackage ../development/python-modules/pyefergy { };
+
+  pyegps = callPackage ../development/python-modules/pyegps { };
+
+  pyeight = callPackage ../development/python-modules/pyeight { };
+
+  pyeiscp = callPackage ../development/python-modules/pyeiscp { };
+
+  pyelectra = callPackage ../development/python-modules/pyelectra { };
+
+  pyelftools = callPackage ../development/python-modules/pyelftools { };
+
+  pyembroidery = callPackage ../development/python-modules/pyembroidery { };
+
+  pyemby = callPackage ../development/python-modules/pyemby { };
+
+  pyemd = callPackage ../development/python-modules/pyemd { };
+
+  pyemoncms = callPackage ../development/python-modules/pyemoncms { };
+
+  pyemvue = callPackage ../development/python-modules/pyemvue { };
+
+  pyenchant = callPackage ../development/python-modules/pyenchant { inherit (pkgs) enchant2; };
+
+  pyenphase = callPackage ../development/python-modules/pyenphase { };
+
+  pyenvisalink = callPackage ../development/python-modules/pyenvisalink { };
+
+  pyephember = callPackage ../development/python-modules/pyephember { };
+
+  pyepsg = callPackage ../development/python-modules/pyepsg { };
+
+  pyerfa = callPackage ../development/python-modules/pyerfa { };
+
+  pyeverlights = callPackage ../development/python-modules/pyeverlights { };
+
+  pyevilgenius = callPackage ../development/python-modules/pyevilgenius { };
+
+  pyevmasm = callPackage ../development/python-modules/pyevmasm { };
+
+  pyevtk = callPackage ../development/python-modules/pyevtk { };
+
+  pyexcel = callPackage ../development/python-modules/pyexcel { };
+
+  pyexcel-io = callPackage ../development/python-modules/pyexcel-io { };
+
+  pyexcel-ods = callPackage ../development/python-modules/pyexcel-ods { };
+
+  pyexcel-xls = callPackage ../development/python-modules/pyexcel-xls { };
+
+  pyexiftool = callPackage ../development/python-modules/pyexiftool { };
+
+  pyexpect = callPackage ../development/python-modules/pyexpect { };
+
+  pyexploitdb = callPackage ../development/python-modules/pyexploitdb { };
+
+  pyezviz = callPackage ../development/python-modules/pyezviz { };
+
+  pyezvizapi = callPackage ../development/python-modules/pyezvizapi { };
+
+  pyface = callPackage ../development/python-modules/pyface { };
+
+  pyfaidx = callPackage ../development/python-modules/pyfaidx { };
+
+  pyfakefs = callPackage ../development/python-modules/pyfakefs { };
+
+  pyfakewebcam = callPackage ../development/python-modules/pyfakewebcam { };
+
+  pyfantom = callPackage ../development/python-modules/pyfantom { };
+
+  pyfatfs = callPackage ../development/python-modules/pyfatfs { };
+
+  pyfcm = callPackage ../development/python-modules/pyfcm { };
+
+  pyfibaro = callPackage ../development/python-modules/pyfibaro { };
+
+  pyfido = callPackage ../development/python-modules/pyfido { };
+
+  pyfiglet = callPackage ../development/python-modules/pyfiglet { };
+
+  pyfireservicerota = callPackage ../development/python-modules/pyfireservicerota { };
+
+  pyflakes = callPackage ../development/python-modules/pyflakes { };
+
+  pyflexit = callPackage ../development/python-modules/pyflexit { };
+
+  pyflic = callPackage ../development/python-modules/pyflic { };
+
+  pyflick = callPackage ../development/python-modules/pyflick { };
+
+  pyflipper = callPackage ../development/python-modules/pyflipper { };
+
+  pyfluidsynth = callPackage ../development/python-modules/pyfluidsynth { };
+
+  pyflume = callPackage ../development/python-modules/pyflume { };
+
+  pyfma = callPackage ../development/python-modules/pyfma { };
+
+  pyfnip = callPackage ../development/python-modules/pyfnip { };
+
+  pyformlang = callPackage ../development/python-modules/pyformlang { };
+
+  pyfreedompro = callPackage ../development/python-modules/pyfreedompro { };
+
+  pyfribidi = callPackage ../development/python-modules/pyfribidi { };
+
+  pyfritzhome = callPackage ../development/python-modules/pyfritzhome { };
+
+  pyfronius = callPackage ../development/python-modules/pyfronius { };
+
+  pyftdi = callPackage ../development/python-modules/pyftdi { };
+
+  pyftgl = callPackage ../development/python-modules/pyftgl { };
+
+  pyftpdlib = callPackage ../development/python-modules/pyftpdlib { };
+
+  pyfttt = callPackage ../development/python-modules/pyfttt { };
+
+  pyfume = callPackage ../development/python-modules/pyfume { };
+
+  pyfunctional = callPackage ../development/python-modules/pyfunctional { };
+
+  pyfuse3 = callPackage ../development/python-modules/pyfuse3 { };
+
+  pyfwup = callPackage ../development/python-modules/pyfwup { inherit (pkgs) libusb1; };
+
+  pyfxa = callPackage ../development/python-modules/pyfxa { };
+
+  pyfzf = callPackage ../development/python-modules/pyfzf { inherit (pkgs) fzf; };
+
+  pygal = callPackage ../development/python-modules/pygal { };
+
+  pygame = callPackage ../development/python-modules/pygame { SDL2_image = pkgs.SDL2_image_2_0; };
+
+  pygame-ce = callPackage ../development/python-modules/pygame-ce {
+    inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+    SDL2_image = pkgs.SDL2_image_2_0;
+    SDL2_mixer = pkgs.SDL2_mixer_2_0;
+  };
+
+  pygame-gui = callPackage ../development/python-modules/pygame-gui { };
+
+  pygame-sdl2 = callPackage ../development/python-modules/pygame-sdl2 { };
+
+  pygatt = callPackage ../development/python-modules/pygatt { };
+
+  pygccxml = callPackage ../development/python-modules/pygccxml { };
+
+  pygdbmi = callPackage ../development/python-modules/pygdbmi { };
+
+  pygelf = callPackage ../development/python-modules/pygelf { };
+
+  pygeocodio = callPackage ../development/python-modules/pygeocodio { };
+
+  pygerber = callPackage ../development/python-modules/pygerber { };
+
+  pygetwindow = callPackage ../development/python-modules/pygetwindow { };
+
+  pygit2 = callPackage ../development/python-modules/pygit2 { };
+
+  pygitguardian = callPackage ../development/python-modules/pygitguardian { };
+
+  pygithub = callPackage ../development/python-modules/pygithub { };
+
+  pyglet = callPackage ../development/python-modules/pyglet { };
+
+  pyglm = callPackage ../development/python-modules/pyglm { };
+
+  pygls = callPackage ../development/python-modules/pygls { };
+
+  pygltflib = callPackage ../development/python-modules/pygltflib { };
+
+  pygmars = callPackage ../development/python-modules/pygmars { };
+
+  pygments = callPackage ../development/python-modules/pygments { };
+
+  pygments-better-html = callPackage ../development/python-modules/pygments-better-html { };
+
+  pygments-markdown-lexer = callPackage ../development/python-modules/pygments-markdown-lexer { };
+
+  pygments-style-github = callPackage ../development/python-modules/pygments-style-github { };
+
+  pygmo = callPackage ../development/python-modules/pygmo { };
+
+  pygmt = callPackage ../development/python-modules/pygmt { };
+
+  pygnmi = callPackage ../development/python-modules/pygnmi { };
+
+  pygobject-stubs = callPackage ../development/python-modules/pygobject-stubs { };
+
+  pygobject3 = callPackage ../development/python-modules/pygobject/3.nix {
+    # inherit (pkgs) meson won't work because it won't be spliced
+    inherit (pkgs.buildPackages) meson;
+  };
+
+  pygount = callPackage ../development/python-modules/pygount { };
+
+  pygpgme = callPackage ../development/python-modules/pygpgme { };
+
+  pygraphviz = callPackage ../development/python-modules/pygraphviz { inherit (pkgs) graphviz; };
+
+  pygreat = callPackage ../development/python-modules/pygreat { };
+
+  pygrok = callPackage ../development/python-modules/pygrok { };
+
+  pygsl = callPackage ../development/python-modules/pygsl { inherit (pkgs) gsl swig; };
+
+  pygtail = callPackage ../development/python-modules/pygtail { };
+
+  pygtfs = callPackage ../development/python-modules/pygtfs { };
+
+  pygti = callPackage ../development/python-modules/pygti { };
+
+  pygtkspellcheck = callPackage ../development/python-modules/pygtkspellcheck { };
+
+  pygtrie = callPackage ../development/python-modules/pygtrie { };
+
+  pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };
+
+  pyhanko = callPackage ../development/python-modules/pyhanko { };
+
+  pyhanko-certvalidator = callPackage ../development/python-modules/pyhanko-certvalidator { };
+
+  pyhaversion = callPackage ../development/python-modules/pyhaversion { };
+
+  pyhcl = callPackage ../development/python-modules/pyhcl { };
+
+  pyheck = callPackage ../development/python-modules/pyheck { };
+
+  pyheif = callPackage ../development/python-modules/pyheif { };
+
+  pyheos = callPackage ../development/python-modules/pyheos { };
+
+  pyhepmc = callPackage ../development/python-modules/pyhepmc { };
+
+  pyhidra = callPackage ../development/python-modules/pyhidra { };
+
+  pyhive-integration = callPackage ../development/python-modules/pyhive-integration { };
+
+  pyhocon = callPackage ../development/python-modules/pyhocon { };
+
+  pyhomee = callPackage ../development/python-modules/pyhomee { };
+
+  pyhomematic = callPackage ../development/python-modules/pyhomematic { };
+
+  pyhomepilot = callPackage ../development/python-modules/pyhomepilot { };
+
+  pyhomeworks = callPackage ../development/python-modules/pyhomeworks { };
+
+  pyhumps = callPackage ../development/python-modules/pyhumps { };
+
+  pyi2cflash = callPackage ../development/python-modules/pyi2cflash { };
+
+  pyialarm = callPackage ../development/python-modules/pyialarm { };
+
+  pyiceberg = callPackage ../development/python-modules/pyiceberg { };
+
+  pyicloud = callPackage ../development/python-modules/pyicloud { };
+
+  pyicu = callPackage ../development/python-modules/pyicu { };
+
+  pyicumessageformat = callPackage ../development/python-modules/pyicumessageformat { };
+
+  pyimpfuzzy = callPackage ../development/python-modules/pyimpfuzzy { inherit (pkgs) ssdeep; };
+
+  pyindego = callPackage ../development/python-modules/pyindego { };
+
+  pyinfra = callPackage ../development/python-modules/pyinfra { };
+
+  pyinotify = callPackage ../development/python-modules/pyinotify { };
+
+  pyinputevent = callPackage ../development/python-modules/pyinputevent { };
+
+  pyinstaller = callPackage ../development/python-modules/pyinstaller { };
+
+  pyinstaller-hooks-contrib = callPackage ../development/python-modules/pyinstaller-hooks-contrib { };
+
+  pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };
+
+  pyinsteon = callPackage ../development/python-modules/pyinsteon { };
+
+  pyinstrument = callPackage ../development/python-modules/pyinstrument { };
+
+  pyintesishome = callPackage ../development/python-modules/pyintesishome { };
+
+  pyipma = callPackage ../development/python-modules/pyipma { };
+
+  pyipp = callPackage ../development/python-modules/pyipp { };
+
+  pyipv8 = callPackage ../development/python-modules/pyipv8 { };
+
+  pyiqvia = callPackage ../development/python-modules/pyiqvia { };
+
+  pyisbn = callPackage ../development/python-modules/pyisbn { };
+
+  pyisemail = callPackage ../development/python-modules/pyisemail { };
+
+  pyiskra = callPackage ../development/python-modules/pyiskra { };
+
+  pyisy = callPackage ../development/python-modules/pyisy { };
+
+  pyituran = callPackage ../development/python-modules/pyituran { };
+
+  pyixapi = callPackage ../development/python-modules/pyixapi { };
+
+  pyjks = callPackage ../development/python-modules/pyjks { };
+
+  pyjnius = callPackage ../development/python-modules/pyjnius { };
+
+  pyjson5 = callPackage ../development/python-modules/pyjson5 { };
+
+  pyjsparser = callPackage ../development/python-modules/pyjsparser { };
+
+  pyjvcprojector = callPackage ../development/python-modules/pyjvcprojector { };
+
+  pyjwkest = callPackage ../development/python-modules/pyjwkest { };
+
+  pyjwt = callPackage ../development/python-modules/pyjwt { };
+
+  pykakasi = callPackage ../development/python-modules/pykakasi { };
+
+  pykaleidescape = callPackage ../development/python-modules/pykaleidescape { };
+
+  pykalman = callPackage ../development/python-modules/pykalman { };
+
+  pykcs11 = callPackage ../development/python-modules/pykcs11 { };
+
+  pykdl = callPackage ../development/python-modules/pykdl { };
+
+  pykdtree = callPackage ../development/python-modules/pykdtree {
+    inherit (pkgs.llvmPackages) openmp;
+  };
+
+  pykeepass = callPackage ../development/python-modules/pykeepass { };
+
+  pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };
+
+  pykeyatome = callPackage ../development/python-modules/pykeyatome { };
+
+  pykira = callPackage ../development/python-modules/pykira { };
+
+  pykka = callPackage ../development/python-modules/pykka { };
+
+  pykmtronic = callPackage ../development/python-modules/pykmtronic { };
+
+  pykodi = callPackage ../development/python-modules/pykodi { };
+
+  pykoplenti = callPackage ../development/python-modules/pykoplenti { };
+
+  pykostalpiko = callPackage ../development/python-modules/pykostalpiko { };
+
+  pykrakenapi = callPackage ../development/python-modules/pykrakenapi { };
+
+  pykulersky = callPackage ../development/python-modules/pykulersky { };
+
+  pykwalify = callPackage ../development/python-modules/pykwalify { };
+
+  pykwb = callPackage ../development/python-modules/pykwb { };
+
+  pylacrosse = callPackage ../development/python-modules/pylacrosse { };
+
+  pylacus = callPackage ../development/python-modules/pylacus { };
+
+  pylama = callPackage ../development/python-modules/pylama { };
+
+  pylamarzocco = callPackage ../development/python-modules/pylamarzocco { };
+
+  pylance = callPackage ../development/python-modules/pylance { };
+
+  pylast = callPackage ../development/python-modules/pylast { };
+
+  pylatex = callPackage ../development/python-modules/pylatex { };
+
+  pylatexenc = callPackage ../development/python-modules/pylatexenc { };
+
+  pylaunches = callPackage ../development/python-modules/pylaunches { };
+
+  pyld = callPackage ../development/python-modules/pyld { };
+
+  pyldavis = callPackage ../development/python-modules/pyldavis { };
+
+  pylddwrap = callPackage ../development/python-modules/pylddwrap { };
+
+  pyleri = callPackage ../development/python-modules/pyleri { };
+
+  pylette = callPackage ../development/python-modules/pylette { };
+
+  pylev = callPackage ../development/python-modules/pylev { };
+
+  pylgnetcast = callPackage ../development/python-modules/pylgnetcast { };
+
+  pylibacl = callPackage ../development/python-modules/pylibacl { };
+
+  pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };
+
+  pylibdmtx = callPackage ../development/python-modules/pylibdmtx { };
+
+  pylibftdi = callPackage ../development/python-modules/pylibftdi { inherit (pkgs) libusb1; };
+
+  pylibjpeg = callPackage ../development/python-modules/pylibjpeg { };
+
+  pylibjpeg-data = callPackage ../development/python-modules/pylibjpeg-data { };
+
+  pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
+
+  pylibjpeg-openjpeg = callPackage ../development/python-modules/pylibjpeg-openjpeg { };
+
+  pyliblo = callPackage ../development/python-modules/pyliblo { };
+
+  pylibmc = callPackage ../development/python-modules/pylibmc { };
+
+  pylibrespot-java = callPackage ../development/python-modules/pylibrespot-java { };
+
+  pylink-square = callPackage ../development/python-modules/pylink-square { };
+
+  pylint = callPackage ../development/python-modules/pylint { };
+
+  pylint-celery = callPackage ../development/python-modules/pylint-celery { };
+
+  pylint-django = callPackage ../development/python-modules/pylint-django { };
+
+  pylint-flask = callPackage ../development/python-modules/pylint-flask { };
+
+  pylint-plugin-utils = callPackage ../development/python-modules/pylint-plugin-utils { };
+
+  pylint-venv = callPackage ../development/python-modules/pylint-venv { };
+
+  pylion = callPackage ../development/python-modules/pylion { };
+
+  pylitejet = callPackage ../development/python-modules/pylitejet { };
+
+  pylitterbot = callPackage ../development/python-modules/pylitterbot { };
+
+  pylnk3 = callPackage ../development/python-modules/pylnk3 { };
+
+  pyloadapi = callPackage ../development/python-modules/pyloadapi { };
+
+  pyloggermanager = callPackage ../development/python-modules/pyloggermanager { };
+
+  pylpsd = callPackage ../development/python-modules/pylpsd { };
+
+  pylru = callPackage ../development/python-modules/pylru { };
+
+  pyls-flake8 = callPackage ../development/python-modules/pyls-flake8 { };
+
+  pyls-isort = callPackage ../development/python-modules/pyls-isort { };
+
+  pyls-memestra = callPackage ../development/python-modules/pyls-memestra { };
+
+  pyls-spyder = callPackage ../development/python-modules/pyls-spyder { };
+
+  pylsl = callPackage ../development/python-modules/pylsl { };
+
+  pylsp-mypy = callPackage ../development/python-modules/pylsp-mypy { };
+
+  pylsp-rope = callPackage ../development/python-modules/pylsp-rope { };
+
+  pylsqpack = callPackage ../development/python-modules/pylsqpack { };
+
+  pylutron = callPackage ../development/python-modules/pylutron { };
+
+  pylutron-caseta = callPackage ../development/python-modules/pylutron-caseta { };
+
+  pylxd = callPackage ../development/python-modules/pylxd { };
+
+  pylyrics = callPackage ../development/python-modules/pylyrics { };
+
+  pylzma = callPackage ../development/python-modules/pylzma { };
+
+  pym3u8downloader = callPackage ../development/python-modules/pym3u8downloader { };
+
+  pymacaroons = callPackage ../development/python-modules/pymacaroons { };
+
+  pymailgunner = callPackage ../development/python-modules/pymailgunner { };
+
+  pymanopt = callPackage ../development/python-modules/pymanopt { };
+
+  pymarshal = callPackage ../development/python-modules/pymarshal { };
+
+  pymata-express = callPackage ../development/python-modules/pymata-express { };
+
+  pymatgen = callPackage ../development/python-modules/pymatgen { };
+
+  pymatreader = callPackage ../development/python-modules/pymatreader { };
+
+  pymatting = callPackage ../development/python-modules/pymatting { };
+
+  pymaven-patch = callPackage ../development/python-modules/pymaven-patch { };
+
+  pymavlink = callPackage ../development/python-modules/pymavlink { };
+
+  pymbolic = callPackage ../development/python-modules/pymbolic { };
+
+  pymc = callPackage ../development/python-modules/pymc { };
+
+  pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
+
+  pymdstat = callPackage ../development/python-modules/pymdstat { };
+
+  pymediainfo = callPackage ../development/python-modules/pymediainfo { };
+
+  pymediaroom = callPackage ../development/python-modules/pymediaroom { };
+
+  pymedio = callPackage ../development/python-modules/pymedio { };
+
+  pymee = callPackage ../development/python-modules/pymee { };
+
+  pymeeus = callPackage ../development/python-modules/pymeeus { };
+
+  pymelcloud = callPackage ../development/python-modules/pymelcloud { };
+
+  pymemcache = callPackage ../development/python-modules/pymemcache { };
+
+  pymemoize = callPackage ../development/python-modules/pymemoize { };
+
+  pyment = callPackage ../development/python-modules/pyment { };
+
+  pymeshlab = toPythonModule (pkgs.libsForQt5.callPackage ../applications/graphics/pymeshlab { });
+
+  pymeta3 = callPackage ../development/python-modules/pymeta3 { };
+
+  pymetar = callPackage ../development/python-modules/pymetar { };
+
+  pymeteireann = callPackage ../development/python-modules/pymeteireann { };
+
+  pymeteoclimatic = callPackage ../development/python-modules/pymeteoclimatic { };
+
+  pymetno = callPackage ../development/python-modules/pymetno { };
+
+  pymfy = callPackage ../development/python-modules/pymfy { };
+
+  pymicro-vad = callPackage ../development/python-modules/pymicro-vad { };
+
+  pymicrobot = callPackage ../development/python-modules/pymicrobot { };
+
+  pymiele = callPackage ../development/python-modules/pymiele { };
+
+  pymilter = callPackage ../development/python-modules/pymilter { };
+
+  pymilvus = callPackage ../development/python-modules/pymilvus { };
+
+  pymitv = callPackage ../development/python-modules/pymitv { };
+
+  pymodbus = callPackage ../development/python-modules/pymodbus { };
+
+  pymodes = callPackage ../development/python-modules/pymodes { };
+
+  pymonctl = callPackage ../development/python-modules/pymonctl { };
+
+  pymongo = callPackage ../development/python-modules/pymongo { };
+
+  pymongo-inmemory = callPackage ../development/python-modules/pymongo-inmemory { };
+
+  pymoo = callPackage ../development/python-modules/pymoo { };
+
+  pymorphy2 = callPackage ../development/python-modules/pymorphy2 { };
+
+  pymorphy2-dicts-ru = callPackage ../development/python-modules/pymorphy2/dicts-ru.nix { };
+
+  pymorphy3 = callPackage ../development/python-modules/pymorphy3 { };
+
+  pymorphy3-dicts-ru = callPackage ../development/python-modules/pymorphy3/dicts-ru.nix { };
+
+  pymorphy3-dicts-uk = callPackage ../development/python-modules/pymorphy3/dicts-uk.nix { };
+
+  pympler = callPackage ../development/python-modules/pympler { };
+
+  pymsgbox = callPackage ../development/python-modules/pymsgbox { };
+
+  pymssql = callPackage ../development/python-modules/pymssql { krb5-c = pkgs.krb5; };
+
+  pymsteams = callPackage ../development/python-modules/pymsteams { };
+
+  pymumble = callPackage ../development/python-modules/pymumble { };
+
+  pymunk = callPackage ../development/python-modules/pymunk {
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
+  };
+
+  pymupdf = callPackage ../development/python-modules/pymupdf { };
+
+  pymupdf-fonts = callPackage ../development/python-modules/pymupdf-fonts { };
+
+  pymvglive = callPackage ../development/python-modules/pymvglive { };
+
+  pymysensors = callPackage ../development/python-modules/pymysensors { };
+
+  pymysql = callPackage ../development/python-modules/pymysql { };
+
+  pymysqlsa = callPackage ../development/python-modules/pymysqlsa { };
+
+  pymystem3 = callPackage ../development/python-modules/pymystem3 { };
+
+  pynac = callPackage ../development/python-modules/pynac { };
+
+  pynacl = callPackage ../development/python-modules/pynacl { };
+
+  pynamecheap = callPackage ../development/python-modules/pynamecheap { };
+
+  pynamodb = callPackage ../development/python-modules/pynamodb { };
+
+  pynanoleaf = callPackage ../development/python-modules/pynanoleaf { };
+
+  pync = callPackage ../development/python-modules/pync { inherit (pkgs) which; };
+
+  pynecil = callPackage ../development/python-modules/pynecil { };
+
+  pynello = callPackage ../development/python-modules/pynello { };
+
+  pynest2d = callPackage ../development/python-modules/pynest2d { };
+
+  pynetbox = callPackage ../development/python-modules/pynetbox { };
+
+  pynetdicom = callPackage ../development/python-modules/pynetdicom { };
+
+  pynetgear = callPackage ../development/python-modules/pynetgear { };
+
+  pynfsclient = callPackage ../development/python-modules/pynfsclient { };
+
+  pyngo = callPackage ../development/python-modules/pyngo { };
+
+  pyngrok = callPackage ../development/python-modules/pyngrok { };
+
+  pynina = callPackage ../development/python-modules/pynina { };
+
+  pynisher = callPackage ../development/python-modules/pynisher { };
+
+  pynitrokey = callPackage ../development/python-modules/pynitrokey { };
+
+  pynmea2 = callPackage ../development/python-modules/pynmea2 { };
+
+  pynmeagps = callPackage ../development/python-modules/pynmeagps { };
+
+  pynndescent = callPackage ../development/python-modules/pynndescent { };
+
+  pynobo = callPackage ../development/python-modules/pynobo { };
+
+  pynordpool = callPackage ../development/python-modules/pynordpool { };
+
+  pynotifier = callPackage ../development/python-modules/pynotifier { };
+
+  pynput = callPackage ../development/python-modules/pynput { };
+
+  pynrrd = callPackage ../development/python-modules/pynrrd { };
+
+  pynslookup = callPackage ../development/python-modules/pynslookup { };
+
+  pynuki = callPackage ../development/python-modules/pynuki { };
+
+  pynut2 = callPackage ../development/python-modules/pynut2 { };
+
+  pynvim = callPackage ../development/python-modules/pynvim { };
+
+  pynvim-pp = callPackage ../development/python-modules/pynvim-pp { };
+
+  pynvml = callPackage ../development/python-modules/pynvml { };
+
+  pynws = callPackage ../development/python-modules/pynws { };
+
+  pynx584 = callPackage ../development/python-modules/pynx584 { };
+
+  pynzb = callPackage ../development/python-modules/pynzb { };
+
+  pyobihai = callPackage ../development/python-modules/pyobihai { };
+
+  pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
+
+  pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
+
+  pyocd = callPackage ../development/python-modules/pyocd { };
+
+  pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };
+
+  pyocr = callPackage ../development/python-modules/pyocr { tesseract = pkgs.tesseract4; };
+
+  pyoctoprintapi = callPackage ../development/python-modules/pyoctoprintapi { };
+
+  pyodbc = callPackage ../development/python-modules/pyodbc { };
+
+  pyogg = callPackage ../development/python-modules/pyogg { };
+
+  pyogrio = callPackage ../development/python-modules/pyogrio { };
+
+  pyombi = callPackage ../development/python-modules/pyombi { };
+
+  pyomo = callPackage ../development/python-modules/pyomo { };
+
+  pyopencl = callPackage ../development/python-modules/pyopencl { };
+
+  pyopengl = callPackage ../development/python-modules/pyopengl { };
+
+  pyopengl-accelerate = callPackage ../development/python-modules/pyopengl-accelerate { };
+
+  pyopengltk = callPackage ../development/python-modules/pyopengltk { };
+
+  pyopenssl = callPackage ../development/python-modules/pyopenssl { };
+
+  pyopenuv = callPackage ../development/python-modules/pyopenuv { };
+
+  pyopenweathermap = callPackage ../development/python-modules/pyopenweathermap { };
+
+  pyopnsense = callPackage ../development/python-modules/pyopnsense { };
+
+  pyoppleio = callPackage ../development/python-modules/pyoppleio { };
+
+  pyorthanc = callPackage ../development/python-modules/pyorthanc { };
+
+  pyosf = callPackage ../development/python-modules/pyosf { };
+
+  pyosmium = callPackage ../development/python-modules/pyosmium { inherit (pkgs) lz4; };
+
+  pyosohotwaterapi = callPackage ../development/python-modules/pyosohotwaterapi { };
+
+  pyotgw = callPackage ../development/python-modules/pyotgw { };
+
+  pyotp = callPackage ../development/python-modules/pyotp { };
+
+  pyoutbreaksnearme = callPackage ../development/python-modules/pyoutbreaksnearme { };
+
+  pyoverkiz = callPackage ../development/python-modules/pyoverkiz { };
+
+  pyowm = callPackage ../development/python-modules/pyowm { };
+
+  pyownet = callPackage ../development/python-modules/pyownet { };
+
+  pyoxigraph = callPackage ../development/python-modules/pyoxigraph { };
+
+  pypager = callPackage ../development/python-modules/pypager { };
+
+  pypalazzetti = callPackage ../development/python-modules/pypalazzetti { };
+
+  pypamtest = toPythonModule (
+    pkgs.libpam-wrapper.override {
+      enablePython = true;
+      inherit python;
+    }
+  );
+
+  pypandoc = callPackage ../development/python-modules/pypandoc { };
+
+  pyparser = callPackage ../development/python-modules/pyparser { };
+
+  pyparsing = callPackage ../development/python-modules/pyparsing { };
+
+  pyparted = callPackage ../development/python-modules/pyparted { };
+
+  pypass = callPackage ../development/python-modules/pypass { };
+
+  pypblib = callPackage ../development/python-modules/pypblib { };
+
+  pypca = callPackage ../development/python-modules/pypca { };
+
+  pypcap = callPackage ../development/python-modules/pypcap {
+    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
+  };
+
+  pypck = callPackage ../development/python-modules/pypck { };
+
+  pypdf = callPackage ../development/python-modules/pypdf { };
+
+  pypdf2 = callPackage ../development/python-modules/pypdf2 { };
+
+  pypdf3 = callPackage ../development/python-modules/pypdf3 { };
+
+  pypdfium2 = callPackage ../development/python-modules/pypdfium2 { };
+
+  pypeg2 = callPackage ../development/python-modules/pypeg2 { };
+
+  pypemicro = callPackage ../development/python-modules/pypemicro { };
+
+  pyperclip = callPackage ../development/python-modules/pyperclip { };
+
+  pyperclipfix = callPackage ../development/python-modules/pyperclipfix { };
+
+  pyperf = callPackage ../development/python-modules/pyperf { };
+
+  pyperscan = callPackage ../development/python-modules/pyperscan { };
+
+  pypglab = callPackage ../development/python-modules/pypglab { };
+
+  pyphen = callPackage ../development/python-modules/pyphen { };
+
+  pyphotonfile = callPackage ../development/python-modules/pyphotonfile { };
+
+  pypika = callPackage ../development/python-modules/pypika { };
+
+  pypillowfight = callPackage ../development/python-modules/pypillowfight { };
+
+  pypinyin = callPackage ../development/python-modules/pypinyin { };
+
+  pypiserver = callPackage ../development/python-modules/pypiserver { };
+
+  pypitoken = callPackage ../development/python-modules/pypitoken { };
+
+  pyplaato = callPackage ../development/python-modules/pyplaato { };
+
+  pyplatec = callPackage ../development/python-modules/pyplatec { };
+
+  pypng = callPackage ../development/python-modules/pypng { };
+
+  pypoint = callPackage ../development/python-modules/pypoint { };
+
+  pypoolstation = callPackage ../development/python-modules/pypoolstation { };
+
+  pyppeteer = callPackage ../development/python-modules/pyppeteer { };
+
+  pyppmd = callPackage ../development/python-modules/pyppmd { };
+
+  pyprecice = callPackage ../development/python-modules/pyprecice { };
+
+  pypresence = callPackage ../development/python-modules/pypresence { };
+
+  pyprind = callPackage ../development/python-modules/pyprind { };
+
+  pyprobables = callPackage ../development/python-modules/pyprobables { };
+
+  pyprof2calltree = callPackage ../development/python-modules/pyprof2calltree { };
+
+  pyproj = callPackage ../development/python-modules/pyproj { };
+
+  pyproject-api = callPackage ../development/python-modules/pyproject-api { };
+
+  pyproject-hooks = callPackage ../development/python-modules/pyproject-hooks { };
+
+  pyproject-metadata = callPackage ../development/python-modules/pyproject-metadata { };
+
+  pyproject-parser = callPackage ../development/python-modules/pyproject-parser { };
+
+  pyprosegur = callPackage ../development/python-modules/pyprosegur { };
+
+  pyprusalink = callPackage ../development/python-modules/pyprusalink { };
+
+  pypsrp = callPackage ../development/python-modules/pypsrp { };
+
+  pyptlib = callPackage ../development/python-modules/pyptlib { };
+
+  pypubsub = callPackage ../development/python-modules/pypubsub { };
+
+  pypugjs = callPackage ../development/python-modules/pypugjs { };
+
+  pypykatz = callPackage ../development/python-modules/pypykatz { };
+
+  pypytools = callPackage ../development/python-modules/pypytools { };
+
+  pyqldb = callPackage ../development/python-modules/pyqldb { };
+
+  pyqrcode = callPackage ../development/python-modules/pyqrcode { };
+
+  pyqt-builder = callPackage ../development/python-modules/pyqt-builder { };
+
+  pyqt3d = pkgs.libsForQt5.callPackage ../development/python-modules/pyqt3d {
+    inherit (self)
+      buildPythonPackage
+      pyqt5
+      pyqt-builder
+      python
+      pythonOlder
+      setuptools
+      sip
+      ;
+  };
+
+  pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { inherit (pkgs) mesa; };
+
+  pyqt5-multimedia = self.pyqt5.override { withMultimedia = true; };
+
+  pyqt5-sip = callPackage ../development/python-modules/pyqt/sip.nix { };
+
+  pyqt5-stubs = callPackage ../development/python-modules/pyqt5-stubs { };
+
+  # `pyqt5-webkit` should not be used by python libraries in
+  # pkgs/development/python-modules/*. Putting this attribute in
+  # `propagatedBuildInputs` may cause collisions.
+  pyqt5-webkit = self.pyqt5.override { withWebKit = true; };
+
+  pyqt6 = callPackage ../development/python-modules/pyqt/6.x.nix { };
+
+  pyqt6-charts = callPackage ../development/python-modules/pyqt6-charts { };
+
+  pyqt6-sip = callPackage ../development/python-modules/pyqt/pyqt6-sip.nix { };
+
+  pyqt6-webengine = callPackage ../development/python-modules/pyqt6-webengine { };
+
+  pyqtchart = pkgs.libsForQt5.callPackage ../development/python-modules/pyqtchart {
+    inherit (self)
+      buildPythonPackage
+      pyqt5
+      pyqt-builder
+      python
+      pythonOlder
+      setuptools
+      sip
+      ;
+  };
+
+  pyqtdarktheme = callPackage ../development/python-modules/pyqtdarktheme { };
+
+  pyqtdatavisualization =
+    pkgs.libsForQt5.callPackage ../development/python-modules/pyqtdatavisualization
+      {
+        inherit (self)
+          buildPythonPackage
+          pyqt5
+          pyqt-builder
+          python
+          pythonOlder
+          setuptools
+          sip
+          ;
+      };
+
+  pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
+
+  pyqtwebengine = callPackage ../development/python-modules/pyqtwebengine { };
+
+  pyquaternion = callPackage ../development/python-modules/pyquaternion { };
+
+  pyquery = callPackage ../development/python-modules/pyquery { };
+
+  pyquerylist = callPackage ../development/python-modules/pyquerylist { };
+
+  pyquil = callPackage ../development/python-modules/pyquil { };
+
+  pyqvrpro = callPackage ../development/python-modules/pyqvrpro { };
+
+  pyqwikswitch = callPackage ../development/python-modules/pyqwikswitch { };
+
+  pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
+
+  pyrad = callPackage ../development/python-modules/pyrad { };
+
+  pyradiomics = callPackage ../development/python-modules/pyradiomics { };
+
+  pyradios = callPackage ../development/python-modules/pyradios { };
+
+  pyrail = callPackage ../development/python-modules/pyrail { };
+
+  pyrainbird = callPackage ../development/python-modules/pyrainbird { };
+
+  pyramid = callPackage ../development/python-modules/pyramid { };
+
+  pyramid-beaker = callPackage ../development/python-modules/pyramid-beaker { };
+
+  pyramid-chameleon = callPackage ../development/python-modules/pyramid-chameleon { };
+
+  pyramid-exclog = callPackage ../development/python-modules/pyramid-exclog { };
+
+  pyramid-jinja2 = callPackage ../development/python-modules/pyramid-jinja2 { };
+
+  pyramid-mako = callPackage ../development/python-modules/pyramid-mako { };
+
+  pyramid-multiauth = callPackage ../development/python-modules/pyramid-multiauth { };
+
+  pyrate-limiter = callPackage ../development/python-modules/pyrate-limiter { };
+
+  pyrdfa3 = callPackage ../development/python-modules/pyrdfa3 { };
+
+  pyre-extensions = callPackage ../development/python-modules/pyre-extensions { };
+
+  pyreaderwriterlock = callPackage ../development/python-modules/pyreaderwriterlock { };
+
+  pyreadstat = callPackage ../development/python-modules/pyreadstat { };
+
+  pyrealsense2 = toPythonModule (
+    pkgs.librealsense.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
+
+  pyrealsense2WithCuda = toPythonModule (
+    pkgs.librealsenseWithCuda.override {
+      cudaSupport = true;
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
+
+  pyrealsense2WithoutCuda = toPythonModule (
+    pkgs.librealsenseWithoutCuda.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
+
+  pyrect = callPackage ../development/python-modules/pyrect { };
+
+  pyregion = callPackage ../development/python-modules/pyregion { };
+
+  pyrender = callPackage ../development/python-modules/pyrender { };
+
+  pyrevolve = callPackage ../development/python-modules/pyrevolve { };
+
+  pyrfc3339 = callPackage ../development/python-modules/pyrfc3339 { };
+
+  pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };
+
+  pyric = callPackage ../development/python-modules/pyric { };
+
+  pyring-buffer = callPackage ../development/python-modules/pyring-buffer { };
+
+  pyrisco = callPackage ../development/python-modules/pyrisco { };
+
+  pyrituals = callPackage ../development/python-modules/pyrituals { };
+
+  pyrmvtransport = callPackage ../development/python-modules/pyrmvtransport { };
+
+  pyro-api = callPackage ../development/python-modules/pyro-api { };
+
+  pyro-ppl = callPackage ../development/python-modules/pyro-ppl { };
+
+  pyro4 = callPackage ../development/python-modules/pyro4 { };
+
+  pyro5 = callPackage ../development/python-modules/pyro5 { };
+
+  pyrogram = callPackage ../development/python-modules/pyrogram { };
+
+  pyroma = callPackage ../development/python-modules/pyroma { };
+
+  pyroute2 = callPackage ../development/python-modules/pyroute2 { };
+
+  pyrr = callPackage ../development/python-modules/pyrr { };
+
+  pyrsistent = callPackage ../development/python-modules/pyrsistent { };
+
+  pyrss2gen = callPackage ../development/python-modules/pyrss2gen { };
+
+  pyrtlsdr = callPackage ../development/python-modules/pyrtlsdr { };
+
+  pyrympro = callPackage ../development/python-modules/pyrympro { };
+
+  pysabnzbd = callPackage ../development/python-modules/pysabnzbd { };
+
+  pysaj = callPackage ../development/python-modules/pysaj { };
+
+  pysam = callPackage ../development/python-modules/pysam { };
+
+  pysaml2 = callPackage ../development/python-modules/pysaml2 { inherit (pkgs) xmlsec; };
+
+  pysatochip = callPackage ../development/python-modules/pysatochip { };
+
+  pysbd = callPackage ../development/python-modules/pysbd { };
+
+  pysc2 = callPackage ../development/python-modules/pysc2 { };
+
+  pyscaffold = callPackage ../development/python-modules/pyscaffold { };
+
+  pyscaffoldext-cookiecutter =
+    callPackage ../development/python-modules/pyscaffoldext-cookiecutter
+      { };
+
+  pyscaffoldext-custom-extension =
+    callPackage ../development/python-modules/pyscaffoldext-custom-extension
+      { };
+
+  pyscaffoldext-django = callPackage ../development/python-modules/pyscaffoldext-django { };
+
+  pyscaffoldext-dsproject = callPackage ../development/python-modules/pyscaffoldext-dsproject { };
+
+  pyscaffoldext-markdown = callPackage ../development/python-modules/pyscaffoldext-markdown { };
+
+  pyscaffoldext-travis = callPackage ../development/python-modules/pyscaffoldext-travis { };
+
+  pyscard = callPackage ../development/python-modules/pyscard {
+    inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
+  };
+
+  pyscf = callPackage ../development/python-modules/pyscf { };
+
+  pyschedule = callPackage ../development/python-modules/pyschedule { };
+
+  pyschemes = callPackage ../development/python-modules/pyschemes { };
+
+  pyschlage = callPackage ../development/python-modules/pyschlage { };
+
+  pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };
+
+  pyscreeze = callPackage ../development/python-modules/pyscreeze { };
+
+  pyscrypt = callPackage ../development/python-modules/pyscrypt { };
+
+  pyscss = callPackage ../development/python-modules/pyscss { };
+
+  pysdcp = callPackage ../development/python-modules/pysdcp { };
+
+  pysdl2 = callPackage ../development/python-modules/pysdl2 { };
+
+  pysearpc = toPythonModule (pkgs.libsearpc.override { python3 = self.python; });
+
+  pysecuritas = callPackage ../development/python-modules/pysecuritas { };
+
+  pysendfile = callPackage ../development/python-modules/pysendfile { };
+
+  pysensibo = callPackage ../development/python-modules/pysensibo { };
+
+  pysensors = callPackage ../development/python-modules/pysensors { };
+
+  pysequoia = callPackage ../development/python-modules/pysequoia { };
+
+  pyserial = callPackage ../development/python-modules/pyserial { };
+
+  pyserial-asyncio = callPackage ../development/python-modules/pyserial-asyncio { };
+
+  pyserial-asyncio-fast = callPackage ../development/python-modules/pyserial-asyncio-fast { };
+
+  pyseries = callPackage ../development/python-modules/pyseries { };
+
+  pyseventeentrack = callPackage ../development/python-modules/pyseventeentrack { };
+
+  pysftp = callPackage ../development/python-modules/pysftp { };
+
+  pyshark = callPackage ../development/python-modules/pyshark { };
+
+  pyshp = callPackage ../development/python-modules/pyshp { };
+
+  pysiaalarm = callPackage ../development/python-modules/pysiaalarm { };
+
+  pyside2 = toPythonModule (
+    callPackage ../development/python-modules/pyside2 { inherit (pkgs) cmake ninja qt5; }
+  );
+
+  pyside2-tools = toPythonModule (
+    callPackage ../development/python-modules/pyside2-tools { inherit (pkgs) cmake qt5; }
+  );
+
+  pyside6 = toPythonModule (
+    callPackage ../development/python-modules/pyside6 { inherit (pkgs) cmake ninja; }
+  );
+
+  pyside6-qtads = callPackage ../development/python-modules/pyside6-qtads { };
+
+  pysigma = callPackage ../development/python-modules/pysigma { };
+
+  pysigma-backend-elasticsearch =
+    callPackage ../development/python-modules/pysigma-backend-elasticsearch
+      { };
+
+  pysigma-backend-insightidr =
+    callPackage ../development/python-modules/pysigma-backend-insightidr
+      { };
+
+  pysigma-backend-loki = callPackage ../development/python-modules/pysigma-backend-loki { };
+
+  pysigma-backend-opensearch =
+    callPackage ../development/python-modules/pysigma-backend-opensearch
+      { };
+
+  pysigma-backend-qradar = callPackage ../development/python-modules/pysigma-backend-qradar { };
+
+  pysigma-backend-splunk = callPackage ../development/python-modules/pysigma-backend-splunk { };
+
+  pysigma-backend-sqlite = callPackage ../development/python-modules/pysigma-backend-sqlite { };
+
+  pysigma-pipeline-crowdstrike =
+    callPackage ../development/python-modules/pysigma-pipeline-crowdstrike
+      { };
+
+  pysigma-pipeline-sysmon = callPackage ../development/python-modules/pysigma-pipeline-sysmon { };
+
+  pysigma-pipeline-windows = callPackage ../development/python-modules/pysigma-pipeline-windows { };
+
+  pysignalclirestapi = callPackage ../development/python-modules/pysignalclirestapi { };
+
+  pysigset = callPackage ../development/python-modules/pysigset { };
+
+  pysilero-vad = callPackage ../development/python-modules/pysilero-vad { };
+
+  pysim = callPackage ../development/python-modules/pysim { };
+
+  pysimplesoap = callPackage ../development/python-modules/pysimplesoap { };
+
+  pysingleton = callPackage ../development/python-modules/pysingleton { };
+
+  pyskyqhub = callPackage ../development/python-modules/pyskyqhub { };
+
+  pyskyqremote = callPackage ../development/python-modules/pyskyqremote { };
+
+  pyslim = callPackage ../development/python-modules/pyslim { };
+
+  pyslurm = callPackage ../development/python-modules/pyslurm { inherit (pkgs) slurm; };
+
+  pysma = callPackage ../development/python-modules/pysma { };
+
+  pysmappee = callPackage ../development/python-modules/pysmappee { };
+
+  pysmart = callPackage ../development/python-modules/pysmart { };
+
+  pysmartapp = callPackage ../development/python-modules/pysmartapp { };
+
+  pysmartdl = callPackage ../development/python-modules/pysmartdl { };
+
+  pysmartthings = callPackage ../development/python-modules/pysmartthings { };
+
+  pysmb = callPackage ../development/python-modules/pysmb { };
+
+  pysmbc = callPackage ../development/python-modules/pysmbc { };
+
+  pysmf = callPackage ../development/python-modules/pysmf { };
+
+  pysmhi = callPackage ../development/python-modules/pysmhi { };
+
+  pysmi = callPackage ../development/python-modules/pysmi { };
+
+  pysml = callPackage ../development/python-modules/pysml { };
+
+  pysmlight = callPackage ../development/python-modules/pysmlight { };
+
+  pysmt = callPackage ../development/python-modules/pysmt { };
+
+  pysnmp = callPackage ../development/python-modules/pysnmp { };
+
+  pysnmp-pyasn1 = callPackage ../development/python-modules/pysnmp-pyasn1 { };
+
+  pysnmp-pysmi = callPackage ../development/python-modules/pysnmp-pysmi { };
+
+  pysnmpcrypto = callPackage ../development/python-modules/pysnmpcrypto { };
+
+  pysnmplib = callPackage ../development/python-modules/pysnmplib { };
+
+  pysnooper = callPackage ../development/python-modules/pysnooper { };
+
+  pysnooz = callPackage ../development/python-modules/pysnooz { };
+
+  pysnow = callPackage ../development/python-modules/pysnow { };
+
+  pysocks = callPackage ../development/python-modules/pysocks { };
+
+  pysol-cards = callPackage ../development/python-modules/pysol-cards { };
+
+  pysolcast = callPackage ../development/python-modules/pysolcast { };
+
+  pysolr = callPackage ../development/python-modules/pysolr { };
+
+  pysoma = callPackage ../development/python-modules/pysoma { };
+
+  pysonos = callPackage ../development/python-modules/pysonos { };
+
+  pysoundfile = self.soundfile; # Alias added 23-06-2019
+
+  pyspark = callPackage ../development/python-modules/pyspark { };
+
+  pyspcwebgw = callPackage ../development/python-modules/pyspcwebgw { };
+
+  pyspeex-noise = callPackage ../development/python-modules/pyspeex-noise { };
+
+  pyspellchecker = callPackage ../development/python-modules/pyspellchecker { };
+
+  pyspf = callPackage ../development/python-modules/pyspf { };
+
+  pyspice = callPackage ../development/python-modules/pyspice { };
+
+  pyspiflash = callPackage ../development/python-modules/pyspiflash { };
+
+  pyspinel = callPackage ../development/python-modules/pyspinel { };
+
+  pyspnego = callPackage ../development/python-modules/pyspnego { };
+
+  pysptk = callPackage ../development/python-modules/pysptk { };
+
+  pyspx = callPackage ../development/python-modules/pyspx { };
+
+  pysqlcipher3 = callPackage ../development/python-modules/pysqlcipher3 { inherit (pkgs) sqlcipher; };
+
+  pysqlitecipher = callPackage ../development/python-modules/pysqlitecipher { };
+
+  pysqueezebox = callPackage ../development/python-modules/pysqueezebox { };
+
+  pysrim = callPackage ../development/python-modules/pysrim { };
+
+  pysrt = callPackage ../development/python-modules/pysrt { };
+
+  pyssim = callPackage ../development/python-modules/pyssim { };
+
+  pystac = callPackage ../development/python-modules/pystac { };
+
+  pystac-client = callPackage ../development/python-modules/pystac-client { };
+
+  pystache = callPackage ../development/python-modules/pystache { };
+
+  pystardict = callPackage ../development/python-modules/pystardict { };
+
+  pystatgrab = callPackage ../development/python-modules/pystatgrab { };
+
+  pystemd = callPackage ../development/python-modules/pystemd { inherit (pkgs) systemd; };
+
+  pystemmer = callPackage ../development/python-modules/pystemmer { };
+
+  pystray = callPackage ../development/python-modules/pystray { };
+
+  pysubs2 = callPackage ../development/python-modules/pysubs2 { };
+
+  pysuezv2 = callPackage ../development/python-modules/pysuezv2 { };
+
+  pysvg-py3 = callPackage ../development/python-modules/pysvg-py3 { };
+
+  pysvn = callPackage ../development/python-modules/pysvn {
+    inherit (pkgs)
+      bash
+      subversion
+      apr
+      aprutil
+      ;
+  };
+
+  pyswitchbee = callPackage ../development/python-modules/pyswitchbee { };
+
+  pyswitchbot = callPackage ../development/python-modules/pyswitchbot { };
+
+  pysychonaut = callPackage ../development/python-modules/pysychonaut { };
+
+  pysyncobj = callPackage ../development/python-modules/pysyncobj { };
+
+  pysyncthru = callPackage ../development/python-modules/pysyncthru { };
+
+  pytabix = callPackage ../development/python-modules/pytabix { };
+
+  pytablewriter = callPackage ../development/python-modules/pytablewriter { };
+
+  pytaglib = callPackage ../development/python-modules/pytaglib { };
+
+  pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
+
+  pytap2 = callPackage ../development/python-modules/pytap2 { };
+
+  pytapo = callPackage ../development/python-modules/pytapo { };
+
+  pytask = callPackage ../development/python-modules/pytask { };
+
+  pytautulli = callPackage ../development/python-modules/pytautulli { };
+
+  pyte = callPackage ../development/python-modules/pyte { };
+
+  pytedee-async = callPackage ../development/python-modules/pytedee-async { };
+
+  pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
+
+  pytenable = callPackage ../development/python-modules/pytenable { };
+
+  pytensor = callPackage ../development/python-modules/pytensor { };
+
+  pytesseract = callPackage ../development/python-modules/pytesseract { };
+
+  pytest = callPackage ../development/python-modules/pytest { };
+
+  pytest-aio = callPackage ../development/python-modules/pytest-aio { };
+
+  pytest-aiohttp = callPackage ../development/python-modules/pytest-aiohttp { };
+
+  pytest-annotate = callPackage ../development/python-modules/pytest-annotate { };
+
+  pytest-ansible = callPackage ../development/python-modules/pytest-ansible { };
+
+  pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
+
+  pytest-astropy = callPackage ../development/python-modules/pytest-astropy { };
+
+  pytest-astropy-header = callPackage ../development/python-modules/pytest-astropy-header { };
+
+  pytest-asyncio = callPackage ../development/python-modules/pytest-asyncio { };
+
+  pytest-asyncio_0_21 = pytest-asyncio.overridePythonAttrs (old: rec {
+    version = "0.21.2";
+    src = pkgs.fetchFromGitHub {
+      owner = "pytest-dev";
+      repo = "pytest-asyncio";
+      rev = "refs/tags/v${version}";
+      hash = "sha256-AVVvdo/CDF9IU6l779sLc7wKz5h3kzMttdDNTPLYxtQ=";
+    };
+  });
+
+  pytest-base-url = callPackage ../development/python-modules/pytest-base-url { };
+
+  pytest-bdd = callPackage ../development/python-modules/pytest-bdd { };
+
+  pytest-benchmark = callPackage ../development/python-modules/pytest-benchmark { };
+
+  pytest-black = callPackage ../development/python-modules/pytest-black { };
+
+  pytest-cache = self.pytestcache; # added 2021-01-04
+
+  pytest-cases = callPackage ../development/python-modules/pytest-cases { };
+
+  pytest-catchlog = callPackage ../development/python-modules/pytest-catchlog { };
+
+  pytest-celery = callPackage ../development/python-modules/pytest-celery { };
+
+  pytest-check = callPackage ../development/python-modules/pytest-check { };
+
+  pytest-cid = callPackage ../development/python-modules/pytest-cid { };
+
+  pytest-click = callPackage ../development/python-modules/pytest-click { };
+
+  pytest-codspeed = callPackage ../development/python-modules/pytest-codspeed { };
+
+  pytest-console-scripts = callPackage ../development/python-modules/pytest-console-scripts { };
+
+  pytest-cov = callPackage ../development/python-modules/pytest-cov { };
+
+  pytest-cov-stub = callPackage ../development/python-modules/pytest-cov-stub { };
+
+  pytest-cram = callPackage ../development/python-modules/pytest-cram { };
+
+  pytest-datadir = callPackage ../development/python-modules/pytest-datadir { };
+
+  pytest-datafiles = callPackage ../development/python-modules/pytest-datafiles { };
+
+  pytest-dependency = callPackage ../development/python-modules/pytest-dependency { };
+
+  pytest-describe = callPackage ../development/python-modules/pytest-describe { };
+
+  pytest-django = callPackage ../development/python-modules/pytest-django { };
+
+  pytest-docker-tools = callPackage ../development/python-modules/pytest-docker-tools { };
+
+  pytest-doctestplus = callPackage ../development/python-modules/pytest-doctestplus { };
+
+  pytest-dotenv = callPackage ../development/python-modules/pytest-dotenv { };
+
+  pytest-emoji = callPackage ../development/python-modules/pytest-emoji { };
+
+  pytest-env = callPackage ../development/python-modules/pytest-env { };
+
+  pytest-error-for-skips = callPackage ../development/python-modules/pytest-error-for-skips { };
+
+  pytest-examples = callPackage ../development/python-modules/pytest-examples { };
+
+  pytest-expect = callPackage ../development/python-modules/pytest-expect { };
+
+  pytest-factoryboy = callPackage ../development/python-modules/pytest-factoryboy { };
+
+  pytest-filter-subpackage = callPackage ../development/python-modules/pytest-filter-subpackage { };
+
+  pytest-fixture-config = callPackage ../development/python-modules/pytest-fixture-config { };
+
+  pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };
+
+  pytest-flakes = callPackage ../development/python-modules/pytest-flakes { };
+
+  pytest-flask = callPackage ../development/python-modules/pytest-flask { };
+
+  pytest-forked = callPackage ../development/python-modules/pytest-forked { };
+
+  pytest-freezegun = callPackage ../development/python-modules/pytest-freezegun { };
+
+  pytest-freezer = callPackage ../development/python-modules/pytest-freezer { };
+
+  pytest-golden = callPackage ../development/python-modules/pytest-golden { };
+
+  pytest-grpc = callPackage ../development/python-modules/pytest-grpc { };
+
+  pytest-harvest = callPackage ../development/python-modules/pytest-harvest { };
+
+  pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
+
+  pytest-html = callPackage ../development/python-modules/pytest-html { };
+
+  pytest-httpbin = callPackage ../development/python-modules/pytest-httpbin { };
+
+  pytest-httpserver = callPackage ../development/python-modules/pytest-httpserver { };
+
+  pytest-httpx = callPackage ../development/python-modules/pytest-httpx { };
+
+  pytest-image-diff = callPackage ../development/python-modules/pytest-image-diff { };
+
+  pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
+
+  pytest-isort = callPackage ../development/python-modules/pytest-isort { };
+
+  pytest-json-report = callPackage ../development/python-modules/pytest-json-report { };
+
+  pytest-jupyter = callPackage ../development/python-modules/pytest-jupyter { };
+
+  pytest-lazy-fixture = callPackage ../development/python-modules/pytest-lazy-fixture { };
+
+  pytest-lazy-fixtures = callPackage ../development/python-modules/pytest-lazy-fixtures { };
+
+  pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };
+
+  pytest-logdog = callPackage ../development/python-modules/pytest-logdog { };
+
+  pytest-lsp = callPackage ../development/python-modules/pytest-lsp { };
+
+  pytest-markdown-docs = callPackage ../development/python-modules/pytest-markdown-docs { };
+
+  pytest-md-report = callPackage ../development/python-modules/pytest-md-report { };
+
+  pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
+
+  pytest-mock = callPackage ../development/python-modules/pytest-mock { };
+
+  pytest-mockito = callPackage ../development/python-modules/pytest-mockito { };
+
+  pytest-mockservers = callPackage ../development/python-modules/pytest-mockservers { };
+
+  pytest-mpi = callPackage ../development/python-modules/pytest-mpi { };
+
+  pytest-mpl = callPackage ../development/python-modules/pytest-mpl { };
+
+  pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
+
+  pytest-mypy-plugins = callPackage ../development/python-modules/pytest-mypy-plugins { };
+
+  pytest-notebook = callPackage ../development/python-modules/pytest-notebook { };
+
+  pytest-order = callPackage ../development/python-modules/pytest-order { };
+
+  pytest-parallel = callPackage ../development/python-modules/pytest-parallel { };
+
+  pytest-param-files = callPackage ../development/python-modules/pytest-param-files { };
+
+  pytest-playwright = callPackage ../development/python-modules/pytest-playwright { };
+
+  pytest-plt = callPackage ../development/python-modules/pytest-plt { };
+
+  pytest-pook = callPackage ../development/python-modules/pytest-pook { };
+
+  pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };
+
+  pytest-pudb = callPackage ../development/python-modules/pytest-pudb { };
+
+  pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
+
+  pytest-pytestrail = callPackage ../development/python-modules/pytest-pytestrail { };
+
+  pytest-qt = callPackage ../development/python-modules/pytest-qt { };
+
+  pytest-quickcheck = callPackage ../development/python-modules/pytest-quickcheck { };
+
+  pytest-raises = callPackage ../development/python-modules/pytest-raises { };
+
+  pytest-raisesregexp = callPackage ../development/python-modules/pytest-raisesregexp { };
+
+  pytest-raisin = callPackage ../development/python-modules/pytest-raisin { };
+
+  pytest-random-order = callPackage ../development/python-modules/pytest-random-order { };
+
+  pytest-randomly = callPackage ../development/python-modules/pytest-randomly { };
+
+  pytest-recording = callPackage ../development/python-modules/pytest-recording { };
+
+  pytest-regressions = callPackage ../development/python-modules/pytest-regressions { };
+
+  pytest-relaxed = callPackage ../development/python-modules/pytest-relaxed { };
+
+  pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
+
+  pytest-repeat = callPackage ../development/python-modules/pytest-repeat { };
+
+  pytest-rerunfailures = callPackage ../development/python-modules/pytest-rerunfailures { };
+
+  pytest-resource-path = callPackage ../development/python-modules/pytest-resource-path { };
+
+  pytest-responses = callPackage ../development/python-modules/pytest-responses { };
+
+  pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
+
+  pytest-ruff = callPackage ../development/python-modules/pytest-ruff { };
+
+  pytest-selenium = callPackage ../development/python-modules/pytest-selenium { };
+
+  pytest-server-fixtures = callPackage ../development/python-modules/pytest-server-fixtures { };
+
+  pytest-services = callPackage ../development/python-modules/pytest-services { };
+
+  pytest-shutil = callPackage ../development/python-modules/pytest-shutil { };
+
+  pytest-smtpd = callPackage ../development/python-modules/pytest-smtpd { };
+
+  pytest-snapshot = callPackage ../development/python-modules/pytest-snapshot { };
+
+  pytest-socket = callPackage ../development/python-modules/pytest-socket { };
+
+  pytest-spec = callPackage ../development/python-modules/pytest-spec { };
+
+  pytest-subprocess = callPackage ../development/python-modules/pytest-subprocess { };
+
+  pytest-subtesthack = callPackage ../development/python-modules/pytest-subtesthack { };
+
+  pytest-subtests = callPackage ../development/python-modules/pytest-subtests { };
+
+  pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
+
+  pytest-tap = callPackage ../development/python-modules/pytest-tap { };
+
+  pytest-test-utils = callPackage ../development/python-modules/pytest-test-utils { };
+
+  pytest-testinfra = callPackage ../development/python-modules/pytest-testinfra { };
+
+  pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
+
+  pytest-textual-snapshot = callPackage ../development/python-modules/pytest-textual-snapshot { };
+
+  pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
+
+  pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
+
+  pytest-tornasync = callPackage ../development/python-modules/pytest-tornasync { };
+
+  pytest-trio = callPackage ../development/python-modules/pytest-trio { };
+
+  pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };
+
+  pytest-unordered = callPackage ../development/python-modules/pytest-unordered { };
+
+  pytest-variables = callPackage ../development/python-modules/pytest-variables { };
+
+  pytest-vcr = callPackage ../development/python-modules/pytest-vcr { };
+
+  pytest-virtualenv = callPackage ../development/python-modules/pytest-virtualenv { };
+
+  pytest-voluptuous = callPackage ../development/python-modules/pytest-voluptuous { };
+
+  pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
+
+  pytest-watch = callPackage ../development/python-modules/pytest-watch { };
+
+  pytest-xdist = callPackage ../development/python-modules/pytest-xdist { };
+
+  pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
+
+  pytest-xvfb = callPackage ../development/python-modules/pytest-xvfb { };
+
+  pytest7CheckHook = pytestCheckHook.override { pytest = pytest_7; };
+
+  pytest_7 = callPackage ../development/python-modules/pytest/7.nix { };
+
+  pytestcache = callPackage ../development/python-modules/pytestcache { };
+
+  python-aodhclient = callPackage ../development/python-modules/python-aodhclient { };
+
+  python-apt = callPackage ../development/python-modules/python-apt { };
+
+  python-arango = callPackage ../development/python-modules/python-arango { };
+
+  python-awair = callPackage ../development/python-modules/python-awair { };
+
+  python-axolotl = callPackage ../development/python-modules/python-axolotl { };
+
+  python-axolotl-curve25519 = callPackage ../development/python-modules/python-axolotl-curve25519 { };
+
+  python-barbicanclient = callPackage ../development/python-modules/python-barbicanclient { };
+
+  python-barcode = callPackage ../development/python-modules/python-barcode { };
+
+  python-baseconv = callPackage ../development/python-modules/python-baseconv { };
+
+  python-benedict = callPackage ../development/python-modules/python-benedict { };
+
+  python-bidi = callPackage ../development/python-modules/python-bidi { };
+
+  python-binance = callPackage ../development/python-modules/python-binance { };
+
+  python-bitcoinlib = callPackage ../development/python-modules/python-bitcoinlib { };
+
+  python-box = callPackage ../development/python-modules/python-box { };
+
+  python-bring-api = callPackage ../development/python-modules/python-bring-api { };
+
+  python-bsblan = callPackage ../development/python-modules/python-bsblan { };
+
+  python-bugzilla = callPackage ../development/python-modules/python-bugzilla { };
+
+  python-calamine = callPackage ../development/python-modules/python-calamine { };
+
+  python-can = callPackage ../development/python-modules/python-can { };
+
+  python-cinderclient = callPackage ../development/python-modules/python-cinderclient { };
+
+  python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
+
+  python-constraint = callPackage ../development/python-modules/python-constraint { };
+
+  python-creole = callPackage ../development/python-modules/python-creole { };
+
+  python-crfsuite = callPackage ../development/python-modules/python-crfsuite { };
+
+  python-crontab = callPackage ../development/python-modules/python-crontab { };
+
+  python-csxcad = callPackage ../development/python-modules/python-csxcad { };
+
+  python-ctags3 = callPackage ../development/python-modules/python-ctags3 { };
+
+  python-daemon = callPackage ../development/python-modules/python-daemon { };
+
+  python-datemath = callPackage ../development/python-modules/python-datemath { };
+
+  python-dateutil = callPackage ../development/python-modules/python-dateutil { };
+
+  python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };
+
+  python-debian = callPackage ../development/python-modules/python-debian { };
+
+  python-decouple = callPackage ../development/python-modules/python-decouple { };
+
+  python-designateclient = callPackage ../development/python-modules/python-designateclient { };
+
+  python-didl-lite = callPackage ../development/python-modules/python-didl-lite { };
+
+  python-digitalocean = callPackage ../development/python-modules/python-digitalocean { };
+
+  python-djvulibre = callPackage ../development/python-modules/python-djvulibre { };
+
+  python-docs-theme = callPackage ../development/python-modules/python-docs-theme { };
+
+  python-docx = callPackage ../development/python-modules/python-docx { };
+
+  python-doi = callPackage ../development/python-modules/python-doi { };
+
+  python-dotenv = callPackage ../development/python-modules/python-dotenv { };
+
+  python-ecobee-api = callPackage ../development/python-modules/python-ecobee-api { };
+
+  python-editor = callPackage ../development/python-modules/python-editor { };
+
+  python-engineio = callPackage ../development/python-modules/python-engineio { };
+
+  python-engineio-v3 = callPackage ../development/python-modules/python-engineio-v3 { };
+
+  python-escpos = callPackage ../development/python-modules/python-escpos { };
+
+  python-etcd = callPackage ../development/python-modules/python-etcd { };
+
+  python-ev3dev2 = callPackage ../development/python-modules/python-ev3dev2 { };
+
+  python-family-hub-local = callPackage ../development/python-modules/python-family-hub-local { };
+
+  python-fedora = callPackage ../development/python-modules/python-fedora { };
+
+  python-ffmpeg = callPackage ../development/python-modules/python-ffmpeg { };
+
+  python-flirt = callPackage ../development/python-modules/python-flirt { };
+
+  python-fontconfig = callPackage ../development/python-modules/python-fontconfig { };
+
+  python-frontmatter = callPackage ../development/python-modules/python-frontmatter { };
+
+  python-fsutil = callPackage ../development/python-modules/python-fsutil { };
+
+  python-fullykiosk = callPackage ../development/python-modules/python-fullykiosk { };
+
+  python-fx = callPackage ../development/python-modules/python-fx { };
+
+  python-gammu = callPackage ../development/python-modules/python-gammu { };
+
+  python-gitlab = callPackage ../development/python-modules/python-gitlab { };
+
+  python-glanceclient = callPackage ../development/python-modules/python-glanceclient { };
+
+  python-gnupg = callPackage ../development/python-modules/python-gnupg { };
+
+  python-google-drive-api = callPackage ../development/python-modules/python-google-drive-api { };
+
+  python-google-nest = callPackage ../development/python-modules/python-google-nest { };
+
+  python-gvm = callPackage ../development/python-modules/python-gvm { };
+
+  python-hcl2 = callPackage ../development/python-modules/python-hcl2 { };
+
+  python-heatclient = callPackage ../development/python-modules/python-heatclient { };
+
+  python-hglib = callPackage ../development/python-modules/python-hglib { };
+
+  python-hl7 = callPackage ../development/python-modules/python-hl7 { };
+
+  python-homeassistant-analytics =
+    callPackage ../development/python-modules/python-homeassistant-analytics
+      { };
+
+  python-homewizard-energy = callPackage ../development/python-modules/python-homewizard-energy { };
+
+  python-hosts = callPackage ../development/python-modules/python-hosts { };
+
+  python-hpilo = callPackage ../development/python-modules/python-hpilo { };
+
+  python-http-client = callPackage ../development/python-modules/python-http-client { };
+
+  python-i18n = callPackage ../development/python-modules/python-i18n { };
+
+  python-idzip = callPackage ../development/python-modules/python-idzip { };
+
+  python-ipmi = callPackage ../development/python-modules/python-ipmi { };
+
+  python-ipware = callPackage ../development/python-modules/python-ipware { };
+
+  python-ironicclient = callPackage ../development/python-modules/python-ironicclient { };
+
+  python-izone = callPackage ../development/python-modules/python-izone { };
+
+  python-jenkins = callPackage ../development/python-modules/python-jenkins { };
+
+  python-jose = callPackage ../development/python-modules/python-jose { };
+
+  python-json-logger = callPackage ../development/python-modules/python-json-logger { };
+
+  python-jsonrpc-server = callPackage ../development/python-modules/python-jsonrpc-server { };
+
+  python-juicenet = callPackage ../development/python-modules/python-juicenet { };
+
+  python-kadmin-rs = callPackage ../development/python-modules/python-kadmin-rs { };
+
+  python-kasa = callPackage ../development/python-modules/python-kasa { };
+
+  python-keycloak = callPackage ../development/python-modules/python-keycloak { };
+
+  python-keystoneclient = callPackage ../development/python-modules/python-keystoneclient { };
+
+  python-ldap = callPackage ../development/python-modules/python-ldap {
+    inherit (pkgs) openldap cyrus_sasl;
+  };
+
+  python-ldap-test = callPackage ../development/python-modules/python-ldap-test { };
+
+  python-libnmap = callPackage ../development/python-modules/python-libnmap { };
+
+  python-linkplay = callPackage ../development/python-modules/python-linkplay { };
+
+  python-linux-procfs = callPackage ../development/python-modules/python-linux-procfs { };
+
+  python-logging-loki = callPackage ../development/python-modules/python-logging-loki { };
+
+  python-logstash = callPackage ../development/python-modules/python-logstash { };
+
+  python-lorem = callPackage ../development/python-modules/python-lorem { };
+
+  python-louvain = callPackage ../development/python-modules/python-louvain { };
+
+  python-lsp-black = callPackage ../development/python-modules/python-lsp-black { };
+
+  python-lsp-jsonrpc = callPackage ../development/python-modules/python-lsp-jsonrpc { };
+
+  python-lsp-ruff = callPackage ../development/python-modules/python-lsp-ruff { };
+
+  python-lsp-server = callPackage ../development/python-modules/python-lsp-server { };
+
+  python-ly = callPackage ../development/python-modules/python-ly { };
+
+  python-lzf = callPackage ../development/python-modules/python-lzf { };
+
+  python-lzo = callPackage ../development/python-modules/python-lzo { inherit (pkgs) lzo; };
+
+  python-magic = callPackage ../development/python-modules/python-magic { };
+
+  python-magnumclient = callPackage ../development/python-modules/python-magnumclient { };
+
+  python-manilaclient = callPackage ../development/python-modules/python-manilaclient { };
+
+  python-mapnik = callPackage ../development/python-modules/python-mapnik rec {
+    inherit (pkgs)
+      pkg-config
+      cairo
+      icu
+      libjpeg
+      libpng
+      libtiff
+      libwebp
+      proj
+      zlib
+      ;
+    boost = pkgs.boost.override {
+      enablePython = true;
+      inherit python;
+    };
+    harfbuzz = pkgs.harfbuzz.override { withIcu = true; };
+    mapnik = pkgs.mapnik.override { inherit boost harfbuzz; };
+  };
+
+  python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
+
+  python-matter-server = callPackage ../development/python-modules/python-matter-server { };
+
+  python-mbedtls = callPackage ../development/python-modules/python-mbedtls { };
+
+  python-memcached = callPackage ../development/python-modules/python-memcached {
+    inherit (pkgs) memcached;
+  };
+
+  python-miio = callPackage ../development/python-modules/python-miio { };
+
+  python-mimeparse = callPackage ../development/python-modules/python-mimeparse { };
+
+  python-mistralclient = callPackage ../development/python-modules/python-mistralclient { };
+
+  python-mnist = callPackage ../development/python-modules/python-mnist { };
+
+  python-motionmount = callPackage ../development/python-modules/python-motionmount { };
+
+  python-mpv-jsonipc = callPackage ../development/python-modules/python-mpv-jsonipc { };
+
+  python-multipart = callPackage ../development/python-modules/python-multipart { };
+
+  python-musicpd = callPackage ../development/python-modules/python-musicpd { };
+
+  python-mystrom = callPackage ../development/python-modules/python-mystrom { };
+
+  python-ndn = callPackage ../development/python-modules/python-ndn { };
+
+  python-nest = callPackage ../development/python-modules/python-nest { };
+
+  python-neutronclient = callPackage ../development/python-modules/python-neutronclient { };
+
+  python-nmap = callPackage ../development/python-modules/python-nmap { };
+
+  python-nomad = callPackage ../development/python-modules/python-nomad { };
+
+  python-novaclient = callPackage ../development/python-modules/python-novaclient { };
+
+  python-nvd3 = callPackage ../development/python-modules/python-nvd3 { };
+
+  python-oauth2 = callPackage ../development/python-modules/python-oauth2 { };
+
+  python-octaviaclient = callPackage ../development/python-modules/python-octaviaclient { };
+
+  python-olm = callPackage ../development/python-modules/python-olm { };
+
+  python-on-whales = callPackage ../development/python-modules/python-on-whales { };
+
+  python-opendata-transport = callPackage ../development/python-modules/python-opendata-transport { };
+
+  python-openems = callPackage ../development/python-modules/python-openems { };
+
+  python-opensky = callPackage ../development/python-modules/python-opensky { };
+
+  python-openstackclient = callPackage ../development/python-modules/python-openstackclient { };
+
+  python-openzwave = callPackage ../development/python-modules/python-openzwave { };
+
+  python-osc = callPackage ../development/python-modules/python-osc { };
+
+  python-otbr-api = callPackage ../development/python-modules/python-otbr-api { };
+
+  python-overseerr = callPackage ../development/python-modules/python-overseerr { };
+
+  python-owasp-zap-v2-4 = callPackage ../development/python-modules/python-owasp-zap-v2-4 { };
+
+  python-packer = callPackage ../development/python-modules/python-packer { };
+
+  python-pae = callPackage ../development/python-modules/python-pae { };
+
+  python-pam = callPackage ../development/python-modules/python-pam { inherit (pkgs) pam; };
+
+  python-periphery = callPackage ../development/python-modules/python-periphery { };
+
+  python-picnic-api2 = callPackage ../development/python-modules/python-picnic-api2 { };
+
+  python-pidfile = callPackage ../development/python-modules/python-pidfile { };
+
+  python-pipedrive = callPackage ../development/python-modules/python-pipedrive { };
+
+  python-pkcs11 = callPackage ../development/python-modules/python-pkcs11 { };
+
+  python-poppler = callPackage ../development/python-modules/python-poppler { };
+
+  python-pptx = callPackage ../development/python-modules/python-pptx { };
+
+  python-prctl = callPackage ../development/python-modules/python-prctl { };
+
+  python-ptrace = callPackage ../development/python-modules/python-ptrace { };
+
+  python-qt = toPythonModule (pkgs.python-qt.override { python3 = self.python; });
+
+  python-rabbitair = callPackage ../development/python-modules/python-rabbitair { };
+
+  python-rapidjson = callPackage ../development/python-modules/python-rapidjson { };
+
+  python-redis-lock = callPackage ../development/python-modules/python-redis-lock { };
+
+  python-registry = callPackage ../development/python-modules/python-registry { };
+
+  python-roborock = callPackage ../development/python-modules/python-roborock { };
+
+  python-rtmidi = callPackage ../development/python-modules/python-rtmidi {
+    inherit (pkgs.darwin.apple_sdk.frameworks)
+      CoreAudio
+      CoreMIDI
+      CoreServices
+      Foundation
+      ;
+  };
+
+  python-sat = callPackage ../development/python-modules/python-sat { };
+
+  python-secp256k1-cardano = callPackage ../development/python-modules/python-secp256k1-cardano { };
+
+  python-simple-hipchat = callPackage ../development/python-modules/python-simple-hipchat { };
+
+  python-slugify = callPackage ../development/python-modules/python-slugify { };
+
+  python-smarttub = callPackage ../development/python-modules/python-smarttub { };
+
+  python-snap7 = callPackage ../development/python-modules/python-snap7 { inherit (pkgs) snap7; };
+
+  python-snappy = callPackage ../development/python-modules/python-snappy { inherit (pkgs) snappy; };
+
+  python-snoo = callPackage ../development/python-modules/python-snoo { };
+
+  python-socketio = callPackage ../development/python-modules/python-socketio { };
+
+  python-socketio-v4 = callPackage ../development/python-modules/python-socketio-v4 { };
+
+  python-socks = callPackage ../development/python-modules/python-socks { };
+
+  python-songpal = callPackage ../development/python-modules/python-songpal { };
+
+  python-sql = callPackage ../development/python-modules/python-sql { };
+
+  python-status = callPackage ../development/python-modules/python-status { };
+
+  python-stdnum = callPackage ../development/python-modules/python-stdnum { };
+
+  python-string-utils = callPackage ../development/python-modules/python-string-utils { };
+
+  python-swiftclient = callPackage ../development/python-modules/python-swiftclient { };
+
+  python-tado = callPackage ../development/python-modules/python-tado { };
+
+  python-tds = callPackage ../development/python-modules/python-tds { };
+
+  python-technove = callPackage ../development/python-modules/python-technove { };
+
+  python-telegram = callPackage ../development/python-modules/python-telegram { };
+
+  python-telegram-bot = callPackage ../development/python-modules/python-telegram-bot { };
+
+  python-toolbox = callPackage ../development/python-modules/python-toolbox { };
+
+  python-troveclient = callPackage ../development/python-modules/python-troveclient { };
+
+  python-trovo = callPackage ../development/python-modules/python-trovo { };
+
+  python-twitch-client = callPackage ../development/python-modules/python-twitch-client { };
+
+  python-twitter = callPackage ../development/python-modules/python-twitter { };
+
+  python-u2flib-host = callPackage ../development/python-modules/python-u2flib-host { };
+
+  python-u2flib-server = callPackage ../development/python-modules/python-u2flib-server { };
+
+  python-uinput = callPackage ../development/python-modules/python-uinput { };
+
+  python-ulid = callPackage ../development/python-modules/python-ulid { };
+
+  python-unshare = callPackage ../development/python-modules/python-unshare { };
+
+  python-utils = callPackage ../development/python-modules/python-utils { };
+
+  python-vagrant = callPackage ../development/python-modules/python-vagrant { };
+
+  python-velbus = callPackage ../development/python-modules/python-velbus { };
+
+  python-vipaccess = callPackage ../development/python-modules/python-vipaccess { };
+
+  python-vlc = callPackage ../development/python-modules/python-vlc { };
+
+  python-watcherclient = callPackage ../development/python-modules/python-watcherclient { };
+
+  python-whois = callPackage ../development/python-modules/python-whois { };
+
+  python-wifi = callPackage ../development/python-modules/python-wifi { };
+
+  python-wink = callPackage ../development/python-modules/python-wink { };
+
+  python-xapp = callPackage ../development/python-modules/python-xapp {
+    inherit (pkgs.buildPackages) meson;
+    inherit (pkgs)
+      gtk3
+      gobject-introspection
+      polkit
+      xapp
+      ;
+  };
+
+  python-xmp-toolkit = callPackage ../development/python-modules/python-xmp-toolkit { };
+
+  python-xz = callPackage ../development/python-modules/python-xz { };
+
+  python-yakh = callPackage ../development/python-modules/python-yakh { };
+
+  python-yate = callPackage ../development/python-modules/python-yate { };
+
+  python-youtube = callPackage ../development/python-modules/python-youtube { };
+
+  python-zaqarclient = callPackage ../development/python-modules/python-zaqarclient { };
+
+  python-zbar = callPackage ../development/python-modules/python-zbar { };
+
+  python-zunclient = callPackage ../development/python-modules/python-zunclient { };
+
+  python3-application = callPackage ../development/python-modules/python3-application { };
+
+  python3-eventlib = callPackage ../development/python-modules/python3-eventlib { };
+
+  python3-gnutls = callPackage ../development/python-modules/python3-gnutls { };
+
+  python3-openid = callPackage ../development/python-modules/python3-openid { };
+
+  python3-saml = callPackage ../development/python-modules/python3-saml { };
+
+  pythondialog = callPackage ../development/python-modules/pythondialog { };
+
+  pythonefl = callPackage ../development/python-modules/python-efl { };
+
+  pythonegardia = callPackage ../development/python-modules/pythonegardia { };
+
+  pythonfinder = callPackage ../development/python-modules/pythonfinder { };
+
+  pythonix = callPackage ../development/python-modules/pythonix {
+    nix = pkgs.nixVersions.nix_2_3;
+    meson = pkgs.meson.override { python3 = self.python; };
+  };
+
+  pythonnet = callPackage ../development/python-modules/pythonnet { };
+
+  pythonocc-core = toPythonModule (
+    callPackage ../development/python-modules/pythonocc-core {
+      inherit (pkgs) fontconfig rapidjson;
+      inherit (pkgs.xorg)
+        libX11
+        libXi
+        libXmu
+        libXext
+        ;
+      inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+    }
+  );
+
+  pythonqwt = callPackage ../development/python-modules/pythonqwt { };
+
+  pythran = callPackage ../development/python-modules/pythran { inherit (pkgs.llvmPackages) openmp; };
+
+  pytibber = callPackage ../development/python-modules/pytibber { };
+
+  pytikz-allefeld = callPackage ../development/python-modules/pytikz-allefeld { };
+
+  pytile = callPackage ../development/python-modules/pytile { };
+
+  pytimeparse = callPackage ../development/python-modules/pytimeparse { };
+
+  pytimeparse2 = callPackage ../development/python-modules/pytimeparse2 { };
+
+  pytlv = callPackage ../development/python-modules/pytlv { };
+
+  pytm = callPackage ../development/python-modules/pytm { };
+
+  pytmx = callPackage ../development/python-modules/pytmx { };
+
+  pytomlpp = callPackage ../development/python-modules/pytomlpp { };
+
+  pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };
+
+  pytoolconfig = callPackage ../development/python-modules/pytoolconfig { };
+
+  pytools = callPackage ../development/python-modules/pytools { };
+
+  pytorch-bench = callPackage ../development/python-modules/pytorch-bench { };
+
+  pytorch-lightning = callPackage ../development/python-modules/pytorch-lightning { };
+
+  pytorch-metric-learning = callPackage ../development/python-modules/pytorch-metric-learning { };
+
+  pytorch-msssim = callPackage ../development/python-modules/pytorch-msssim { };
+
+  pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
+
+  pytorch3d = callPackage ../development/python-modules/pytorch3d { };
+
+  pytouchline-extended = callPackage ../development/python-modules/pytouchline-extended { };
+
+  pytouchlinesl = callPackage ../development/python-modules/pytouchlinesl { };
+
+  pytraccar = callPackage ../development/python-modules/pytraccar { };
+
+  pytradfri = callPackage ../development/python-modules/pytradfri { };
+
+  pytrafikverket = callPackage ../development/python-modules/pytrafikverket { };
+
+  pytransportnsw = callPackage ../development/python-modules/pytransportnsw { };
+
+  pytransportnswv2 = callPackage ../development/python-modules/pytransportnswv2 { };
+
+  pytricia = callPackage ../development/python-modules/pytricia { };
+
+  pytrydan = callPackage ../development/python-modules/pytrydan { };
+
+  pyttsx3 = callPackage ../development/python-modules/pyttsx3 { };
+
+  pytube = callPackage ../development/python-modules/pytube { };
+
+  pytubefix = callPackage ../development/python-modules/pytubefix { };
+
+  pytun = callPackage ../development/python-modules/pytun { };
+
+  pyturbojpeg = callPackage ../development/python-modules/pyturbojpeg { };
+
+  pytweening = callPackage ../development/python-modules/pytweening { };
+
+  pytz = callPackage ../development/python-modules/pytz { };
+
+  pytz-deprecation-shim = callPackage ../development/python-modules/pytz-deprecation-shim { };
+
+  pyu2f = callPackage ../development/python-modules/pyu2f { };
+
+  pyuca = callPackage ../development/python-modules/pyuca { };
+
+  pyudev = callPackage ../development/python-modules/pyudev { inherit (pkgs) udev; };
+
+  pyunbound = callPackage ../development/python-modules/pyunbound { };
+
+  pyunifi = callPackage ../development/python-modules/pyunifi { };
+
+  pyunormalize = callPackage ../development/python-modules/pyunormalize { };
+
+  pyunpack = callPackage ../development/python-modules/pyunpack { };
+
+  pyupdate = callPackage ../development/python-modules/pyupdate { };
+
+  pyupgrade = callPackage ../development/python-modules/pyupgrade { };
+
+  pyuptimerobot = callPackage ../development/python-modules/pyuptimerobot { };
+
+  pyusb = callPackage ../development/python-modules/pyusb { inherit (pkgs) libusb1; };
+
+  pyuseragents = callPackage ../development/python-modules/pyuseragents { };
+
+  pyutil = callPackage ../development/python-modules/pyutil { };
+
+  pyuv = callPackage ../development/python-modules/pyuv { };
+
+  pyvcd = callPackage ../development/python-modules/pyvcd { };
+
+  pyvera = callPackage ../development/python-modules/pyvera { };
+
+  pyverilog = callPackage ../development/python-modules/pyverilog { };
+
+  pyversasense = callPackage ../development/python-modules/pyversasense { };
+
+  pyvesync = callPackage ../development/python-modules/pyvesync { };
+
+  pyvex = callPackage ../development/python-modules/pyvex { };
+
+  pyvicare = callPackage ../development/python-modules/pyvicare { };
+
+  pyvips = callPackage ../development/python-modules/pyvips { inherit (pkgs) vips glib; };
+
+  pyvirtualdisplay = callPackage ../development/python-modules/pyvirtualdisplay { };
+
+  pyvis = callPackage ../development/python-modules/pyvis { };
+
+  pyvisa = callPackage ../development/python-modules/pyvisa { };
+
+  pyvisa-py = callPackage ../development/python-modules/pyvisa-py { };
+
+  pyvisa-sim = callPackage ../development/python-modules/pyvisa-sim { };
+
+  pyvista = callPackage ../development/python-modules/pyvista { };
+
+  pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
+
+  pyvizio = callPackage ../development/python-modules/pyvizio { };
+
+  pyvlx = callPackage ../development/python-modules/pyvlx { };
+
+  pyvmomi = callPackage ../development/python-modules/pyvmomi { };
+
+  pyvo = callPackage ../development/python-modules/pyvo { };
+
+  pyvolumio = callPackage ../development/python-modules/pyvolumio { };
+
+  pyvoro = callPackage ../development/python-modules/pyvoro { };
+
+  pyvows = callPackage ../development/python-modules/pyvows { };
+
+  pywal = callPackage ../development/python-modules/pywal { };
+
+  pywatchman = callPackage ../development/python-modules/pywatchman { };
+
+  pywaterkotte = callPackage ../development/python-modules/pywaterkotte { };
+
+  pywavefront = callPackage ../development/python-modules/pywavefront { };
+
+  pywavelets = callPackage ../development/python-modules/pywavelets { };
+
+  pywayland = callPackage ../development/python-modules/pywayland { };
+
+  pywaze = callPackage ../development/python-modules/pywaze { };
+
+  pywbem = callPackage ../development/python-modules/pywbem { inherit (pkgs) libxml2; };
+
+  pyweatherflowrest = callPackage ../development/python-modules/pyweatherflowrest { };
+
+  pyweatherflowudp = callPackage ../development/python-modules/pyweatherflowudp { };
+
+  pywebcopy = callPackage ../development/python-modules/pywebcopy { };
+
+  pywebpush = callPackage ../development/python-modules/pywebpush { };
+
+  pywebview = callPackage ../development/python-modules/pywebview { };
+
+  pywemo = callPackage ../development/python-modules/pywemo { };
+
+  pywerview = callPackage ../development/python-modules/pywerview { };
+
+  pywfa = callPackage ../development/python-modules/pywfa { };
+
+  pywikibot = callPackage ../development/python-modules/pywikibot { };
+
+  pywilight = callPackage ../development/python-modules/pywilight { };
+
+  pywinbox = callPackage ../development/python-modules/pywinbox { };
+
+  pywinctl = callPackage ../development/python-modules/pywinctl { };
+
+  pywinrm = callPackage ../development/python-modules/pywinrm { };
+
+  pywizlight = callPackage ../development/python-modules/pywizlight { };
+
+  pywlroots = callPackage ../development/python-modules/pywlroots { wlroots = pkgs.wlroots_0_17; };
+
+  pyworld = callPackage ../development/python-modules/pyworld { };
+
+  pyws66i = callPackage ../development/python-modules/pyws66i { };
+
+  pyx = callPackage ../development/python-modules/pyx { };
+
+  pyxattr = callPackage ../development/python-modules/pyxattr { };
+
+  pyxbe = callPackage ../development/python-modules/pyxbe { };
+
+  pyxdg = callPackage ../development/python-modules/pyxdg { };
+
+  pyxeoma = callPackage ../development/python-modules/pyxeoma { };
+
+  pyxiaomigateway = callPackage ../development/python-modules/pyxiaomigateway { };
+
+  pyxl3 = callPackage ../development/python-modules/pyxl3 { };
+
+  pyxlsb = callPackage ../development/python-modules/pyxlsb { };
+
+  pyxnat = callPackage ../development/python-modules/pyxnat { };
+
+  pyyaml = callPackage ../development/python-modules/pyyaml { };
+
+  pyyaml-env-tag = callPackage ../development/python-modules/pyyaml-env-tag { };
+
+  pyyaml-include = callPackage ../development/python-modules/pyyaml-include { };
+
+  pyyardian = callPackage ../development/python-modules/pyyardian { };
+
+  pyytlounge = callPackage ../development/python-modules/pyytlounge { };
+
+  pyzabbix = callPackage ../development/python-modules/pyzabbix { };
+
+  pyzbar = callPackage ../development/python-modules/pyzbar { };
+
+  pyzerproc = callPackage ../development/python-modules/pyzerproc { };
+
+  pyzipper = callPackage ../development/python-modules/pyzipper { };
+
+  pyzmq = callPackage ../development/python-modules/pyzmq { };
+
+  pyzstd = callPackage ../development/python-modules/pyzstd { zstd-c = pkgs.zstd; };
+
+  pyzx = callPackage ../development/python-modules/pyzx { };
+
+  qasync = callPackage ../development/python-modules/qasync { };
+
+  qbittorrent-api = callPackage ../development/python-modules/qbittorrent-api { };
+
+  qbusmqttapi = callPackage ../development/python-modules/qbusmqttapi { };
+
+  qcelemental = callPackage ../development/python-modules/qcelemental { };
+
+  qcengine = callPackage ../development/python-modules/qcengine { };
+
+  qcodes = callPackage ../development/python-modules/qcodes { };
+
+  qcodes-contrib-drivers = callPackage ../development/python-modules/qcodes-contrib-drivers { };
+
+  qcs-api-client = callPackage ../development/python-modules/qcs-api-client { };
+
+  qcs-api-client-common = callPackage ../development/python-modules/qcs-api-client-common { };
+
+  qcs-sdk-python = callPackage ../development/python-modules/qcs-sdk-python { };
+
+  qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
+
+  qdldl = callPackage ../development/python-modules/qdldl { };
+
+  qdrant-client = callPackage ../development/python-modules/qdrant-client { };
+
+  qemu = callPackage ../development/python-modules/qemu { qemu = pkgs.qemu; };
+
+  qgrid = callPackage ../development/python-modules/qgrid { };
+
+  qiling = callPackage ../development/python-modules/qiling { };
+
+  qimage2ndarray = callPackage ../development/python-modules/qimage2ndarray { };
+
+  qingping-ble = callPackage ../development/python-modules/qingping-ble { };
+
+  qiskit = callPackage ../development/python-modules/qiskit { };
+
+  qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
+
+  qiskit-finance = callPackage ../development/python-modules/qiskit-finance { };
+
+  qiskit-ibmq-provider = callPackage ../development/python-modules/qiskit-ibmq-provider { };
+
+  qiskit-ignis = callPackage ../development/python-modules/qiskit-ignis { };
+
+  qiskit-machine-learning = callPackage ../development/python-modules/qiskit-machine-learning { };
+
+  qiskit-nature = callPackage ../development/python-modules/qiskit-nature { };
+
+  qiskit-optimization = callPackage ../development/python-modules/qiskit-optimization { };
+
+  qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
+
+  qnap-qsw = callPackage ../development/python-modules/qnap-qsw { };
+
+  qnapstats = callPackage ../development/python-modules/qnapstats { };
+
+  qpageview = callPackage ../development/python-modules/qpageview { };
+
+  qpsolvers = callPackage ../development/python-modules/qpsolvers { };
+
+  qrcode = callPackage ../development/python-modules/qrcode { };
+
+  qrcode-terminal = callPackage ../development/python-modules/qrcode-terminal { };
+
+  qreactor = callPackage ../development/python-modules/qreactor { };
+
+  qscintilla = self.qscintilla-qt5;
+
+  qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {
+    pythonPackages = self;
+  };
+
+  qstylizer = callPackage ../development/python-modules/qstylizer { };
+
+  qt-material = callPackage ../development/python-modules/qt-material { };
+
+  qt5reactor = callPackage ../development/python-modules/qt5reactor { };
+
+  qt6 = pkgs.qt6.override { python3 = self.python; };
+
+  qtawesome = callPackage ../development/python-modules/qtawesome { };
+
+  qtconsole = callPackage ../development/python-modules/qtconsole { };
+
+  qtile = callPackage ../development/python-modules/qtile { wlroots = pkgs.wlroots_0_17; };
+
+  qtile-bonsai = callPackage ../development/python-modules/qtile-bonsai { };
+
+  qtile-extras = callPackage ../development/python-modules/qtile-extras { };
+
+  qtpy = callPackage ../development/python-modules/qtpy { };
+
+  quadprog = callPackage ../development/python-modules/quadprog { };
+
+  qualysclient = callPackage ../development/python-modules/qualysclient { };
+
+  quandl = callPackage ../development/python-modules/quandl { };
+
+  quantile-forest = callPackage ../development/python-modules/quantile-forest { };
+
+  quantile-python = callPackage ../development/python-modules/quantile-python { };
+
+  quantiphy = callPackage ../development/python-modules/quantiphy { };
+
+  quantiphy-eval = callPackage ../development/python-modules/quantiphy-eval { };
+
+  quantities = callPackage ../development/python-modules/quantities { };
+
+  quantulum3 = callPackage ../development/python-modules/quantulum3 { };
+
+  quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
+
+  quart = callPackage ../development/python-modules/quart { };
+
+  quart-cors = callPackage ../development/python-modules/quart-cors { };
+
+  quart-schema = callPackage ../development/python-modules/quart-schema { };
+
+  quaternion = callPackage ../development/python-modules/quaternion { };
+
+  qudida = callPackage ../development/python-modules/qudida { };
+
+  querystring-parser = callPackage ../development/python-modules/querystring-parser { };
+
+  questionary = callPackage ../development/python-modules/questionary { };
+
+  questo = callPackage ../development/python-modules/questo { };
+
+  queuelib = callPackage ../development/python-modules/queuelib { };
+
+  quil = callPackage ../development/python-modules/quil { };
+
+  quixote = callPackage ../development/python-modules/quixote { };
+
+  qutip = callPackage ../development/python-modules/qutip { };
+
+  r2pipe = callPackage ../development/python-modules/r2pipe { };
+
+  rachiopy = callPackage ../development/python-modules/rachiopy { };
+
+  radian = callPackage ../development/python-modules/radian { };
+
+  radicale-infcloud = callPackage ../development/python-modules/radicale-infcloud {
+    radicale = pkgs.radicale.override { python3 = python; };
+  };
+
+  radio-beam = callPackage ../development/python-modules/radio-beam { };
+
+  radios = callPackage ../development/python-modules/radios { };
+
+  radiotherm = callPackage ../development/python-modules/radiotherm { };
+
+  radish-bdd = callPackage ../development/python-modules/radish-bdd { };
+
+  radon = callPackage ../development/python-modules/radon { };
+
+  railroad-diagrams = callPackage ../development/python-modules/railroad-diagrams { };
+
+  rainbowstream = callPackage ../development/python-modules/rainbowstream { };
+
+  raincloudy = callPackage ../development/python-modules/raincloudy { };
+
+  ramlfications = callPackage ../development/python-modules/ramlfications { };
+
+  random-user-agent = callPackage ../development/python-modules/random-user-agent { };
+
+  random2 = callPackage ../development/python-modules/random2 { };
+
+  randomfiletree = callPackage ../development/python-modules/randomfiletree { };
+
+  range-typed-integers = callPackage ../development/python-modules/range-typed-integers { };
+
+  rangehttpserver = callPackage ../development/python-modules/rangehttpserver { };
+
+  rangeparser = callPackage ../development/python-modules/rangeparser { };
+
+  rank-bm25 = callPackage ../development/python-modules/rank-bm25 { };
+
+  rapidfuzz = callPackage ../development/python-modules/rapidfuzz { };
+
+  rapidfuzz-capi = callPackage ../development/python-modules/rapidfuzz-capi { };
+
+  rapidgzip = callPackage ../development/python-modules/rapidgzip { inherit (pkgs) nasm; };
+
+  rapidocr-onnxruntime = callPackage ../development/python-modules/rapidocr-onnxruntime { };
+
+  rapt-ble = callPackage ../development/python-modules/rapt-ble { };
+
+  rarfile = callPackage ../development/python-modules/rarfile { inherit (pkgs) libarchive; };
+
+  rasterio = callPackage ../development/python-modules/rasterio { };
+
+  ratarmount = callPackage ../development/python-modules/ratarmount { };
+
+  ratarmountcore = callPackage ../development/python-modules/ratarmountcore { inherit (pkgs) zstd; };
+
+  ratelim = callPackage ../development/python-modules/ratelim { };
+
+  ratelimit = callPackage ../development/python-modules/ratelimit { };
+
+  raven = callPackage ../development/python-modules/raven { };
+
+  rawkit = callPackage ../development/python-modules/rawkit { };
+
+  rawpy = callPackage ../development/python-modules/rawpy { };
+
+  ray = callPackage ../development/python-modules/ray { };
+
+  raylib-python-cffi = callPackage ../development/python-modules/raylib-python-cffi { };
+
+  razdel = callPackage ../development/python-modules/razdel { };
+
+  rbtools = callPackage ../development/python-modules/rbtools { };
+
+  rchitect = callPackage ../development/python-modules/rchitect { };
+
+  rclone-python = callPackage ../development/python-modules/rclone-python { };
+
+  rcssmin = callPackage ../development/python-modules/rcssmin { };
+
+  rdflib = callPackage ../development/python-modules/rdflib { };
+
+  rdkit = callPackage ../development/python-modules/rdkit {
+    boost = pkgs.boost.override {
+      enablePython = true;
+      inherit python;
+    };
+  };
+
+  re-assert = callPackage ../development/python-modules/re-assert { };
+
+  reactivex = callPackage ../development/python-modules/reactivex { };
+
+  readabilipy = callPackage ../development/python-modules/readabilipy { };
+
+  readability-lxml = callPackage ../development/python-modules/readability-lxml { };
+
+  readchar = callPackage ../development/python-modules/readchar { };
+
+  readlike = callPackage ../development/python-modules/readlike { };
+
+  readmdict = callPackage ../development/python-modules/readmdict { };
+
+  readme = callPackage ../development/python-modules/readme { };
+
+  readme-renderer = callPackage ../development/python-modules/readme-renderer { };
+
+  readthedocs-sphinx-ext = callPackage ../development/python-modules/readthedocs-sphinx-ext { };
+
+  rebulk = callPackage ../development/python-modules/rebulk { };
+
+  recipe-scrapers = callPackage ../development/python-modules/recipe-scrapers { };
+
+  recline = callPackage ../development/python-modules/recline { };
+
+  recoll = toPythonModule (pkgs.recoll.override { python3Packages = self; });
+
+  recommonmark = callPackage ../development/python-modules/recommonmark { };
+
+  reconplogger = callPackage ../development/python-modules/reconplogger { };
+
+  recordlinkage = callPackage ../development/python-modules/recordlinkage { };
+
+  rectangle-packer = callPackage ../development/python-modules/rectangle-packer { };
+
+  rectpack = callPackage ../development/python-modules/rectpack { };
+
+  recurring-ical-events = callPackage ../development/python-modules/recurring-ical-events { };
+
+  recursive-pth-loader = toPythonModule (
+    callPackage ../development/python-modules/recursive-pth-loader { }
+  );
+
+  red-black-tree-mod = callPackage ../development/python-modules/red-black-tree-mod { };
+
+  redbaron = callPackage ../development/python-modules/redbaron { };
+
+  redis = callPackage ../development/python-modules/redis { };
+
+  redis-om = callPackage ../development/python-modules/redis-om { };
+
+  redshift-connector = callPackage ../development/python-modules/redshift-connector { };
+
+  reedsolo = callPackage ../development/python-modules/reedsolo { };
+
+  referencing = callPackage ../development/python-modules/referencing { };
+
+  refery = callPackage ../development/python-modules/refery { };
+
+  reflex = callPackage ../development/python-modules/reflex { };
+
+  reflex-chakra = callPackage ../development/python-modules/reflex-chakra { };
+
+  reflex-hosting-cli = callPackage ../development/python-modules/reflex-hosting-cli { };
+
+  reflink = callPackage ../development/python-modules/reflink { };
+
+  refoss-ha = callPackage ../development/python-modules/refoss-ha { };
+
+  regenmaschine = callPackage ../development/python-modules/regenmaschine { };
+
+  regex = callPackage ../development/python-modules/regex { };
+
+  regional = callPackage ../development/python-modules/regional { };
+
+  regress = callPackage ../development/python-modules/regress { };
+
+  reikna = callPackage ../development/python-modules/reikna { };
+
+  related = callPackage ../development/python-modules/related { };
+
+  relatorio = callPackage ../development/python-modules/relatorio { };
+
+  releases = callPackage ../development/python-modules/releases { };
+
+  remarshal = callPackage ../development/python-modules/remarshal { };
+
+  remctl = callPackage ../development/python-modules/remctl { remctl-c = pkgs.remctl; };
+
+  remi = callPackage ../development/python-modules/remi { };
+
+  remote-pdb = callPackage ../development/python-modules/remote-pdb { };
+
+  remotezip = callPackage ../development/python-modules/remotezip { };
+
+  renault-api = callPackage ../development/python-modules/renault-api { };
+
+  rencode = callPackage ../development/python-modules/rencode { };
+
+  reno = callPackage ../development/python-modules/reno { };
+
+  renson-endura-delta = callPackage ../development/python-modules/renson-endura-delta { };
+
+  reolink = callPackage ../development/python-modules/reolink { };
+
+  reolink-aio = callPackage ../development/python-modules/reolink-aio { };
+
+  reorder-python-imports = callPackage ../development/python-modules/reorder-python-imports { };
+
+  reparser = callPackage ../development/python-modules/reparser { };
+
+  repath = callPackage ../development/python-modules/repath { };
+
+  repeated-test = callPackage ../development/python-modules/repeated-test { };
+
+  repl-python-wakatime = callPackage ../development/python-modules/repl-python-wakatime { };
+
+  replicate = callPackage ../development/python-modules/replicate { };
+
+  reportlab = callPackage ../development/python-modules/reportlab { };
+
+  reportlab-qrcode = callPackage ../development/python-modules/reportlab-qrcode { };
+
+  repoze-lru = callPackage ../development/python-modules/repoze-lru { };
+
+  repoze-sphinx-autointerface =
+    callPackage ../development/python-modules/repoze-sphinx-autointerface
+      { };
+
+  repoze-who = callPackage ../development/python-modules/repoze-who { };
+
+  reprint = callPackage ../development/python-modules/reprint { };
+
+  reproject = callPackage ../development/python-modules/reproject { };
+
+  reprshed = callPackage ../development/python-modules/reprshed { };
+
+  reptor = callPackage ../development/python-modules/reptor { };
+
+  reqif = callPackage ../development/python-modules/reqif { };
+
+  requests = callPackage ../development/python-modules/requests { };
+
+  requests-aws4auth = callPackage ../development/python-modules/requests-aws4auth { };
+
+  requests-cache = callPackage ../development/python-modules/requests-cache { };
+
+  requests-credssp = callPackage ../development/python-modules/requests-credssp { };
+
+  requests-download = callPackage ../development/python-modules/requests-download { };
+
+  requests-file = callPackage ../development/python-modules/requests-file { };
+
+  requests-futures = callPackage ../development/python-modules/requests-futures { };
+
+  requests-gssapi = callPackage ../development/python-modules/requests-gssapi { };
+
+  requests-hawk = callPackage ../development/python-modules/requests-hawk { };
+
+  requests-http-signature = callPackage ../development/python-modules/requests-http-signature { };
+
+  requests-kerberos = callPackage ../development/python-modules/requests-kerberos { };
+
+  requests-mock = callPackage ../development/python-modules/requests-mock { };
+
+  requests-ntlm = callPackage ../development/python-modules/requests-ntlm { };
+
+  requests-oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
+
+  requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };
+
+  requests-ratelimiter = callPackage ../development/python-modules/requests-ratelimiter { };
+
+  requests-toolbelt = callPackage ../development/python-modules/requests-toolbelt { };
+
+  requests-unixsocket = callPackage ../development/python-modules/requests-unixsocket { };
+
+  requests-unixsocket2 = callPackage ../development/python-modules/requests-unixsocket2 { };
+
+  requests-wsgi-adapter = callPackage ../development/python-modules/requests-wsgi-adapter { };
+
+  requestsexceptions = callPackage ../development/python-modules/requestsexceptions { };
+
+  requirements-detector = callPackage ../development/python-modules/requirements-detector { };
+
+  requirements-parser = callPackage ../development/python-modules/requirements-parser { };
+
+  reretry = callPackage ../development/python-modules/reretry { };
+
+  rerun-sdk = callPackage ../development/python-modules/rerun-sdk { };
+
+  resampy = callPackage ../development/python-modules/resampy { };
+
+  resend = callPackage ../development/python-modules/resend { };
+
+  resize-right = callPackage ../development/python-modules/resize-right { };
+
+  resolvelib = callPackage ../development/python-modules/resolvelib { };
+
+  responses = callPackage ../development/python-modules/responses { };
+
+  respx = callPackage ../development/python-modules/respx { };
+
+  restfly = callPackage ../development/python-modules/restfly { };
+
+  restrictedpython = callPackage ../development/python-modules/restrictedpython { };
+
+  restructuredtext-lint = callPackage ../development/python-modules/restructuredtext-lint { };
+
+  restview = callPackage ../development/python-modules/restview { };
+
+  result = callPackage ../development/python-modules/result { };
+
+  rethinkdb = callPackage ../development/python-modules/rethinkdb { };
+
+  retinaface = callPackage ../development/python-modules/retinaface { };
+
+  retry = callPackage ../development/python-modules/retry { };
+
+  retry-decorator = callPackage ../development/python-modules/retry-decorator { };
+
+  retry2 = callPackage ../development/python-modules/retry2 { };
+
+  retrying = callPackage ../development/python-modules/retrying { };
+
+  returns = callPackage ../development/python-modules/returns { };
+
+  reuse = callPackage ../development/python-modules/reuse { };
+
+  reverse-geocode = callPackage ../development/python-modules/reverse-geocode { };
+
+  rfc3161-client = callPackage ../development/python-modules/rfc3161-client { };
+
+  rfc3339 = callPackage ../development/python-modules/rfc3339 { };
+
+  rfc3339-validator = callPackage ../development/python-modules/rfc3339-validator { };
+
+  rfc3986 = callPackage ../development/python-modules/rfc3986 { };
+
+  rfc3986-validator = callPackage ../development/python-modules/rfc3986-validator { };
+
+  rfc3987 = callPackage ../development/python-modules/rfc3987 { };
+
+  rfc6555 = callPackage ../development/python-modules/rfc6555 { };
+
+  rfc7464 = callPackage ../development/python-modules/rfc7464 { };
+
+  rfc8785 = callPackage ../development/python-modules/rfc8785 { };
+
+  rfcat = callPackage ../development/python-modules/rfcat { };
+
+  rflink = callPackage ../development/python-modules/rflink { };
+
+  rich = callPackage ../development/python-modules/rich { };
+
+  rich-argparse = callPackage ../development/python-modules/rich-argparse { };
+
+  rich-argparse-plus = callPackage ../development/python-modules/rich-argparse-plus { };
+
+  rich-click = callPackage ../development/python-modules/rich-click { };
+
+  rich-pixels = callPackage ../development/python-modules/rich-pixels { };
+
+  rich-rst = callPackage ../development/python-modules/rich-rst { };
+
+  rich-theme-manager = callPackage ../development/python-modules/rich-theme-manager { };
+
+  rich-toolkit = callPackage ../development/python-modules/rich-toolkit { };
+
+  riden = callPackage ../development/python-modules/riden { };
+
+  rigour = callPackage ../development/python-modules/rigour { };
+
+  ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
+
+  rio-tiler = callPackage ../development/python-modules/rio-tiler { };
+
+  rioxarray = callPackage ../development/python-modules/rioxarray { };
+
+  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
+
+  ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
+
+  riprova = callPackage ../development/python-modules/riprova { };
+
+  ripser = callPackage ../development/python-modules/ripser { };
+
+  riscof = callPackage ../development/python-modules/riscof { };
+
+  riscv-config = callPackage ../development/python-modules/riscv-config { };
+
+  riscv-isac = callPackage ../development/python-modules/riscv-isac { };
+
+  ritassist = callPackage ../development/python-modules/ritassist { };
+
+  rivet = toPythonModule (pkgs.rivet.override { python3 = python; });
+
+  rjpl = callPackage ../development/python-modules/rjpl { };
+
+  rjsmin = callPackage ../development/python-modules/rjsmin { };
+
+  rki-covid-parser = callPackage ../development/python-modules/rki-covid-parser { };
+
+  rkm-codes = callPackage ../development/python-modules/rkm-codes { };
+
+  rlax = callPackage ../development/python-modules/rlax { };
+
+  rlcard = callPackage ../development/python-modules/rlcard { };
+
+  rlp = callPackage ../development/python-modules/rlp { };
+
+  rmcl = callPackage ../development/python-modules/rmcl { };
+
+  rmrl = callPackage ../development/python-modules/rmrl { };
+
+  rmscene = callPackage ../development/python-modules/rmscene { };
+
+  rmsd = callPackage ../development/python-modules/rmsd { };
+
+  rnc2rng = callPackage ../development/python-modules/rnc2rng { };
+
+  rnginline = callPackage ../development/python-modules/rnginline { };
+
+  rns = callPackage ../development/python-modules/rns { };
+
+  roadlib = callPackage ../development/python-modules/roadlib { };
+
+  roadrecon = callPackage ../development/python-modules/roadrecon { };
+
+  roadtools = callPackage ../development/python-modules/roadtools { };
+
+  roadtx = callPackage ../development/python-modules/roadtx { };
+
+  robomachine = callPackage ../development/python-modules/robomachine { };
+
+  robot-detection = callPackage ../development/python-modules/robot-detection { };
+
+  robotframework = callPackage ../development/python-modules/robotframework { };
+
+  robotframework-databaselibrary =
+    callPackage ../development/python-modules/robotframework-databaselibrary
+      { };
+
+  robotframework-excellib = callPackage ../development/python-modules/robotframework-excellib { };
+
+  robotframework-pythonlibcore =
+    callPackage ../development/python-modules/robotframework-pythonlibcore
+      { };
+
+  robotframework-requests = callPackage ../development/python-modules/robotframework-requests { };
+
+  robotframework-selenium2library =
+    callPackage ../development/python-modules/robotframework-selenium2library
+      { };
+
+  robotframework-seleniumlibrary =
+    callPackage ../development/python-modules/robotframework-seleniumlibrary
+      { };
+
+  robotframework-sshlibrary = callPackage ../development/python-modules/robotframework-sshlibrary { };
+
+  robotframework-tools = callPackage ../development/python-modules/robotframework-tools { };
+
+  robotstatuschecker = callPackage ../development/python-modules/robotstatuschecker { };
+
+  robotsuite = callPackage ../development/python-modules/robotsuite { };
+
+  rocket-errbot = callPackage ../development/python-modules/rocket-errbot { };
+
+  rocketchat-api = callPackage ../development/python-modules/rocketchat-api { };
+
+  roku = callPackage ../development/python-modules/roku { };
+
+  rokuecp = callPackage ../development/python-modules/rokuecp { };
+
+  rollbar = callPackage ../development/python-modules/rollbar { };
+
+  roma = callPackage ../development/python-modules/roma { };
+
+  roman = callPackage ../development/python-modules/roman { };
+
+  roman-numerals-py = callPackage ../development/python-modules/roman-numerals-py { };
+
+  romy = callPackage ../development/python-modules/romy { };
+
+  roombapy = callPackage ../development/python-modules/roombapy { };
+
+  roonapi = callPackage ../development/python-modules/roonapi { };
+
+  rope = callPackage ../development/python-modules/rope { };
+
+  ropgadget = callPackage ../development/python-modules/ropgadget { };
+
+  ropper = callPackage ../development/python-modules/ropper { };
+
+  rotary-embedding-torch = callPackage ../development/python-modules/rotary-embedding-torch { };
+
+  rouge-score = callPackage ../development/python-modules/rouge-score { };
+
+  routeros-api = callPackage ../development/python-modules/routeros-api { };
+
+  routes = callPackage ../development/python-modules/routes { };
+
+  rova = callPackage ../development/python-modules/rova { };
+
+  rowan = callPackage ../development/python-modules/rowan { };
+
+  rpcq = callPackage ../development/python-modules/rpcq { };
+
+  rpdb = callPackage ../development/python-modules/rpdb { };
+
+  rpds-py = callPackage ../development/python-modules/rpds-py { };
+
+  rpi-bad-power = callPackage ../development/python-modules/rpi-bad-power { };
+
+  rpi-gpio = callPackage ../development/python-modules/rpi-gpio { };
+
+  rplcd = callPackage ../development/python-modules/rplcd { };
+
+  rply = callPackage ../development/python-modules/rply { };
+
+  rpm = toPythonModule (pkgs.rpm.override { python3 = self.python; });
+
+  rpmfile = callPackage ../development/python-modules/rpmfile { };
+
+  rpmfluff = callPackage ../development/python-modules/rpmfluff { };
+
+  rpy2 = callPackage ../development/python-modules/rpy2 { };
+
+  rpyc = callPackage ../development/python-modules/rpyc { };
+
+  rq = callPackage ../development/python-modules/rq { };
+
+  rsa = callPackage ../development/python-modules/rsa { };
+
+  rsskey = callPackage ../development/python-modules/rsskey { };
+
+  rst2ansi = callPackage ../development/python-modules/rst2ansi { };
+
+  rst2pdf = callPackage ../development/python-modules/rst2pdf { };
+
+  rstcheck = callPackage ../development/python-modules/rstcheck { };
+
+  rstcheck-core = callPackage ../development/python-modules/rstcheck-core { };
+
+  rstr = callPackage ../development/python-modules/rstr { };
+
+  rtb-data = callPackage ../development/python-modules/rtb-data { };
+
+  rtfde = callPackage ../development/python-modules/rtfde { };
+
+  rtfunicode = callPackage ../development/python-modules/rtfunicode { };
+
+  rtmidi-python = callPackage ../development/python-modules/rtmidi-python {
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreAudio CoreMIDI CoreServices;
+  };
+
+  rtmixer = callPackage ../development/python-modules/rtmixer { };
+
+  rtoml = callPackage ../development/python-modules/rtoml { };
+
+  rtp = callPackage ../development/python-modules/rtp { };
+
+  rtree = callPackage ../development/python-modules/rtree { inherit (pkgs) libspatialindex; };
+
+  rtslib-fb = callPackage ../development/python-modules/rtslib-fb { };
+
+  rtsp-to-webrtc = callPackage ../development/python-modules/rtsp-to-webrtc { };
+
+  ruamel-base = callPackage ../development/python-modules/ruamel-base { };
+
+  ruamel-yaml = callPackage ../development/python-modules/ruamel-yaml { };
+
+  ruamel-yaml-clib = callPackage ../development/python-modules/ruamel-yaml-clib { };
+
+  ruamel-yaml-string = callPackage ../development/python-modules/ruamel-yaml-string { };
+
+  rubicon-objc = callPackage ../development/python-modules/rubicon-objc { };
+
+  rubymarshal = callPackage ../development/python-modules/rubymarshal { };
+
+  ruff = callPackage ../development/python-modules/ruff { inherit (pkgs) ruff; };
+
+  ruff-api = callPackage ../development/python-modules/ruff-api { };
+
+  ruffus = callPackage ../development/python-modules/ruffus { };
+
+  rules = callPackage ../development/python-modules/rules { };
+
+  rumps = callPackage ../development/python-modules/rumps { };
+
+  runs = callPackage ../development/python-modules/runs { };
+
+  runstats = callPackage ../development/python-modules/runstats { };
+
+  rustworkx = callPackage ../development/python-modules/rustworkx { };
+
+  ruuvitag-ble = callPackage ../development/python-modules/ruuvitag-ble { };
+
+  ruyaml = callPackage ../development/python-modules/ruyaml { };
+
+  rx = callPackage ../development/python-modules/rx { };
+
+  rxv = callPackage ../development/python-modules/rxv { };
+
+  ryd-client = callPackage ../development/python-modules/ryd-client { };
+
+  rzpipe = callPackage ../development/python-modules/rzpipe { };
+
+  s2clientprotocol = callPackage ../development/python-modules/s2clientprotocol { };
+
+  s3-credentials = callPackage ../development/python-modules/s3-credentials { };
+
+  s3fs = callPackage ../development/python-modules/s3fs { };
+
+  s3transfer = callPackage ../development/python-modules/s3transfer { };
+
+  sabctools = callPackage ../development/python-modules/sabctools { };
+
+  sabyenc = callPackage ../development/python-modules/sabyenc { };
+
+  sabyenc3 = callPackage ../development/python-modules/sabyenc3 { };
+
+  sacn = callPackage ../development/python-modules/sacn { };
+
+  sacrebleu = callPackage ../development/python-modules/sacrebleu { };
+
+  sacremoses = callPackage ../development/python-modules/sacremoses { };
+
+  safe-pysha3 = callPackage ../development/python-modules/safe-pysha3 { };
+
+  safehttpx = callPackage ../development/python-modules/safehttpx { };
+
+  safeio = callPackage ../development/python-modules/safeio { };
+
+  safetensors = callPackage ../development/python-modules/safetensors { };
+
+  safety = callPackage ../development/python-modules/safety { };
+
+  safety-schemas = callPackage ../development/python-modules/safety-schemas { };
+
+  sagemaker = callPackage ../development/python-modules/sagemaker { };
+
+  sagemaker-core = callPackage ../development/python-modules/sagemaker-core { };
+
+  sagemaker-mlflow = callPackage ../development/python-modules/sagemaker-mlflow { };
+
+  salib = callPackage ../development/python-modules/salib { };
+
+  salmon-mail = callPackage ../development/python-modules/salmon-mail { };
+
+  samarium = callPackage ../development/python-modules/samarium { };
+
+  samplerate = callPackage ../development/python-modules/samplerate { inherit (pkgs) libsamplerate; };
+
+  samsungctl = callPackage ../development/python-modules/samsungctl { };
+
+  samsungtvws = callPackage ../development/python-modules/samsungtvws { };
+
+  sane = callPackage ../development/python-modules/sane { inherit (pkgs) sane-backends; };
+
+  saneyaml = callPackage ../development/python-modules/saneyaml { };
+
+  sanic = callPackage ../development/python-modules/sanic {
+    # Don't pass any `sanic` to avoid dependency loops.  `sanic-testing`
+    # has special logic to disable tests when this is the case.
+    sanic-testing = self.sanic-testing.override { sanic = null; };
+  };
+
+  sanic-auth = callPackage ../development/python-modules/sanic-auth { };
+
+  sanic-routing = callPackage ../development/python-modules/sanic-routing { };
+
+  sanic-testing = callPackage ../development/python-modules/sanic-testing { };
+
+  sanix = callPackage ../development/python-modules/sanix { };
+
+  sansio-multipart = callPackage ../development/python-modules/sansio-multipart { };
+
+  sarge = callPackage ../development/python-modules/sarge { };
+
+  sarif-om = callPackage ../development/python-modules/sarif-om { };
+
+  sarif-tools = callPackage ../development/python-modules/sarif-tools { };
+
+  sasmodels = callPackage ../development/python-modules/sasmodels { };
+
+  sbom2dot = callPackage ../development/python-modules/sbom2dot { };
+
+  sbom4files = callPackage ../development/python-modules/sbom4files { };
+
+  scalene = callPackage ../development/python-modules/scalene { };
+
+  scales = callPackage ../development/python-modules/scales { };
+
+  scancode-toolkit = callPackage ../development/python-modules/scancode-toolkit { };
+
+  scapy = callPackage ../development/python-modules/scapy {
+    inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
+  };
+
+  schedule = callPackage ../development/python-modules/schedule { };
+
+  schema = callPackage ../development/python-modules/schema { };
+
+  schema-salad = callPackage ../development/python-modules/schema-salad { };
+
+  schemainspect = callPackage ../development/python-modules/schemainspect { };
+
+  schemdraw = callPackage ../development/python-modules/schemdraw { };
+
+  schiene = callPackage ../development/python-modules/schiene { };
+
+  scholarly = callPackage ../development/python-modules/scholarly { };
+
+  schwifty = callPackage ../development/python-modules/schwifty { };
+
+  scienceplots = callPackage ../development/python-modules/scienceplots { };
+
+  sciform = callPackage ../development/python-modules/sciform { };
+
+  scikit-base = callPackage ../development/python-modules/scikit-base { };
+
+  scikit-bio = callPackage ../development/python-modules/scikit-bio { };
+
+  scikit-build = callPackage ../development/python-modules/scikit-build { };
+
+  scikit-build-core = callPackage ../development/python-modules/scikit-build-core { };
+
+  scikit-fmm = callPackage ../development/python-modules/scikit-fmm { };
+
+  scikit-fuzzy = callPackage ../development/python-modules/scikit-fuzzy { };
+
+  scikit-hep-testdata = callPackage ../development/python-modules/scikit-hep-testdata { };
+
+  scikit-image = callPackage ../development/python-modules/scikit-image { };
+
+  scikit-learn = callPackage ../development/python-modules/scikit-learn {
+    inherit (pkgs) gfortran glibcLocales;
+  };
+
+  scikit-learn-extra = callPackage ../development/python-modules/scikit-learn-extra { };
+
+  scikit-misc = callPackage ../development/python-modules/scikit-misc { };
+
+  scikit-posthocs = callPackage ../development/python-modules/scikit-posthocs { };
+
+  scikit-rf = callPackage ../development/python-modules/scikit-rf { };
+
+  scikit-survival = callPackage ../development/python-modules/scikit-survival { };
+
+  scikit-tda = callPackage ../development/python-modules/scikit-tda { };
+
+  scikits-odes = callPackage ../development/python-modules/scikits-odes { };
+
+  scikits-odes-core = callPackage ../development/python-modules/scikits-odes-core { };
+
+  scikits-odes-daepack = callPackage ../development/python-modules/scikits-odes-daepack { };
+
+  scikits-odes-sundials = callPackage ../development/python-modules/scikits-odes-sundials { };
+
+  scim2-client = callPackage ../development/python-modules/scim2-client { };
+
+  scim2-filter-parser = callPackage ../development/python-modules/scim2-filter-parser { };
+
+  scim2-models = callPackage ../development/python-modules/scim2-models { };
+
+  scim2-server = callPackage ../development/python-modules/scim2-server { };
+
+  scim2-tester = callPackage ../development/python-modules/scim2-tester { };
+
+  scipy = callPackage ../development/python-modules/scipy { };
+
+  scmrepo = callPackage ../development/python-modules/scmrepo { };
+
+  scooby = callPackage ../development/python-modules/scooby { };
+
+  scour = callPackage ../development/python-modules/scour { };
+
+  scp = callPackage ../development/python-modules/scp { };
+
+  scramp = callPackage ../development/python-modules/scramp { };
+
+  scrap-engine = callPackage ../development/python-modules/scrap-engine { };
+
+  scrapy = callPackage ../development/python-modules/scrapy { };
+
+  scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };
+
+  scrapy-fake-useragent = callPackage ../development/python-modules/scrapy-fake-useragent { };
+
+  scrapy-splash = callPackage ../development/python-modules/scrapy-splash { };
+
+  screed = callPackage ../development/python-modules/screed { };
+
+  screeninfo = callPackage ../development/python-modules/screeninfo { };
+
+  screenlogicpy = callPackage ../development/python-modules/screenlogicpy { };
+
+  scripttest = callPackage ../development/python-modules/scripttest { };
+
+  scrypt = callPackage ../development/python-modules/scrypt { };
+
+  scs = callPackage ../development/python-modules/scs {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate;
+  };
+
+  sdds = callPackage ../development/python-modules/sdds { };
+
+  sdjson = callPackage ../development/python-modules/sdjson { };
+
+  sdkmanager = callPackage ../development/python-modules/sdkmanager { };
+
+  sdnotify = callPackage ../development/python-modules/sdnotify { };
+
+  seaborn = callPackage ../development/python-modules/seaborn { };
+
+  seabreeze = callPackage ../development/python-modules/seabreeze { };
+
+  seaserv = toPythonModule (pkgs.seafile-server.override { python3 = self.python; });
+
+  seasonal = callPackage ../development/python-modules/seasonal { };
+
+  seatconnect = callPackage ../development/python-modules/seatconnect { };
+
+  seccomp = callPackage ../development/python-modules/seccomp { };
+
+  secp256k1 = callPackage ../development/python-modules/secp256k1 { inherit (pkgs) secp256k1; };
+
+  secretstorage = callPackage ../development/python-modules/secretstorage { };
+
+  sectools = callPackage ../development/python-modules/sectools { };
+
+  sectxt = callPackage ../development/python-modules/sectxt { };
+
+  secure = callPackage ../development/python-modules/secure { };
+
+  securesystemslib = callPackage ../development/python-modules/securesystemslib { };
+
+  securetar = callPackage ../development/python-modules/securetar { };
+
+  securityreporter = callPackage ../development/python-modules/securityreporter { };
+
+  seedir = callPackage ../development/python-modules/seedir { };
+
+  seekpath = callPackage ../development/python-modules/seekpath { };
+
+  segments = callPackage ../development/python-modules/segments { };
+
+  segno = callPackage ../development/python-modules/segno { };
+
+  segyio = callPackage ../development/python-modules/segyio { inherit (pkgs) cmake ninja; };
+
+  selenium = callPackage ../development/python-modules/selenium { };
+
+  selenium-wire = callPackage ../development/python-modules/selenium-wire { };
+
+  semantic-version = callPackage ../development/python-modules/semantic-version { };
+
+  semaphore-bot = callPackage ../development/python-modules/semaphore-bot { };
+
+  semchunk = callPackage ../development/python-modules/semchunk { };
+
+  semgrep = callPackage ../development/python-modules/semgrep {
+    semgrep-core = callPackage ../development/python-modules/semgrep/semgrep-core.nix { };
+  };
+
+  semver = callPackage ../development/python-modules/semver { };
+
+  send2trash = callPackage ../development/python-modules/send2trash { };
+
+  sendgrid = callPackage ../development/python-modules/sendgrid { };
+
+  senf = callPackage ../development/python-modules/senf { };
+
+  sensai-utils = callPackage ../development/python-modules/sensai-utils { };
+
+  sense-energy = callPackage ../development/python-modules/sense-energy { };
+
+  sensirion-ble = callPackage ../development/python-modules/sensirion-ble { };
+
+  sensor-state-data = callPackage ../development/python-modules/sensor-state-data { };
+
+  sensorpro-ble = callPackage ../development/python-modules/sensorpro-ble { };
+
+  sensorpush-api = callPackage ../development/python-modules/sensorpush-api { };
+
+  sensorpush-ble = callPackage ../development/python-modules/sensorpush-ble { };
+
+  sensorpush-ha = callPackage ../development/python-modules/sensorpush-ha { };
+
+  sensoterra = callPackage ../development/python-modules/sensoterra { };
+
+  sentence-splitter = callPackage ../development/python-modules/sentence-splitter { };
+
+  sentence-transformers = callPackage ../development/python-modules/sentence-transformers { };
+
+  sentencepiece = callPackage ../development/python-modules/sentencepiece {
+    inherit (pkgs) sentencepiece;
+  };
+
+  sentinel = callPackage ../development/python-modules/sentinel { };
+
+  sentinels = callPackage ../development/python-modules/sentinels { };
+
+  sentry-sdk = sentry-sdk_1;
+
+  sentry-sdk_1 = callPackage ../development/python-modules/sentry-sdk/1.nix { };
+
+  sentry-sdk_2 = callPackage ../development/python-modules/sentry-sdk/default.nix { };
+
+  sepaxml = callPackage ../development/python-modules/sepaxml { };
+
+  seqdiag = callPackage ../development/python-modules/seqdiag { };
+
+  seqeval = callPackage ../development/python-modules/seqeval { };
+
+  serialio = callPackage ../development/python-modules/serialio { };
+
+  serializable = callPackage ../development/python-modules/serializable { };
+
+  serpent = callPackage ../development/python-modules/serpent { };
+
+  serpy = callPackage ../development/python-modules/serpy { };
+
+  servefile = callPackage ../development/python-modules/servefile { };
+
+  serverfiles = callPackage ../development/python-modules/serverfiles { };
+
+  serverlessrepo = callPackage ../development/python-modules/serverlessrepo { };
+
+  service-identity = callPackage ../development/python-modules/service-identity { };
+
+  setproctitle = callPackage ../development/python-modules/setproctitle { };
+
+  setupmeta = callPackage ../development/python-modules/setupmeta { };
+
+  setuptools-changelog-shortener =
+    callPackage ../development/python-modules/setuptools-changelog-shortener
+      { };
+
+  setuptools-declarative-requirements =
+    callPackage ../development/python-modules/setuptools-declarative-requirements
+      { };
+
+  setuptools-dso = callPackage ../development/python-modules/setuptools-dso { };
+
+  setuptools-generate = callPackage ../development/python-modules/setuptools-generate { };
+
+  setuptools-gettext = callPackage ../development/python-modules/setuptools-gettext { };
+
+  setuptools-git = callPackage ../development/python-modules/setuptools-git { };
+
+  setuptools-git-versioning = callPackage ../development/python-modules/setuptools-git-versioning { };
+
+  setuptools-lint = callPackage ../development/python-modules/setuptools-lint { };
+
+  setuptools-odoo = callPackage ../development/python-modules/setuptools-odoo { };
+
+  setuptools-rust = callPackage ../development/python-modules/setuptools-rust { };
+
+  setuptools-scm = callPackage ../development/python-modules/setuptools-scm { };
+
+  setuptools-scm-git-archive =
+    callPackage ../development/python-modules/setuptools-scm-git-archive
+      { };
+
+  setuptools-trial = callPackage ../development/python-modules/setuptools-trial { };
+
+  sev-snp-measure = callPackage ../development/python-modules/sev-snp-measure { };
+
+  seventeentrack = callPackage ../development/python-modules/seventeentrack { };
+
+  sexpdata = callPackage ../development/python-modules/sexpdata { };
+
+  sfepy = callPackage ../development/python-modules/sfepy { };
+
+  sfrbox-api = callPackage ../development/python-modules/sfrbox-api { };
+
+  sgmllib3k = callPackage ../development/python-modules/sgmllib3k { };
+
+  sgp4 = callPackage ../development/python-modules/sgp4 { };
+
+  sh = callPackage ../development/python-modules/sh { };
+
+  shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
+
+  shap = callPackage ../development/python-modules/shap { };
+
+  shapely = callPackage ../development/python-modules/shapely { };
+
+  shaperglot = callPackage ../development/python-modules/shaperglot { };
+
+  sharedmem = callPackage ../development/python-modules/sharedmem { };
+
+  sharkiq = callPackage ../development/python-modules/sharkiq { };
+
+  sharp-aquos-rc = callPackage ../development/python-modules/sharp-aquos-rc { };
+
+  shazamio = callPackage ../development/python-modules/shazamio { };
+
+  shellescape = callPackage ../development/python-modules/shellescape { };
+
+  shellingham = callPackage ../development/python-modules/shellingham { };
+
+  shiboken2 = toPythonModule (
+    callPackage ../development/python-modules/shiboken2 { inherit (pkgs) cmake llvmPackages_15 qt5; }
+  );
+
+  shiboken6 = toPythonModule (
+    callPackage ../development/python-modules/shiboken6 { inherit (pkgs) cmake llvmPackages; }
+  );
+
+  shimmy = callPackage ../development/python-modules/shimmy { };
+
+  shiny = callPackage ../development/python-modules/shiny { };
+
+  shippai = callPackage ../development/python-modules/shippai { };
+
+  shippinglabel = callPackage ../development/python-modules/shippinglabel { };
+
+  shiv = callPackage ../development/python-modules/shiv { };
+
+  shlib = callPackage ../development/python-modules/shlib { };
+
+  shodan = callPackage ../development/python-modules/shodan { };
+
+  shortuuid = callPackage ../development/python-modules/shortuuid { };
+
+  should-dsl = callPackage ../development/python-modules/should-dsl { };
+
+  show-in-file-manager = callPackage ../development/python-modules/show-in-file-manager { };
+
+  showit = callPackage ../development/python-modules/showit { };
+
+  shtab = callPackage ../development/python-modules/shtab { };
+
+  shutilwhich = callPackage ../development/python-modules/shutilwhich { };
+
+  sievelib = callPackage ../development/python-modules/sievelib { };
+
+  signalslot = callPackage ../development/python-modules/signalslot { };
+
+  signedjson = callPackage ../development/python-modules/signedjson { };
+
+  signify = callPackage ../development/python-modules/signify { };
+
+  signxml = callPackage ../development/python-modules/signxml { };
+
+  sigparse = callPackage ../development/python-modules/sigparse { };
+
+  sigrok = callPackage ../development/python-modules/sigrok { };
+
+  sigstore = callPackage ../development/python-modules/sigstore { };
+
+  sigstore-protobuf-specs = callPackage ../development/python-modules/sigstore-protobuf-specs { };
+
+  sigstore-rekor-types = callPackage ../development/python-modules/sigstore-rekor-types { };
+
+  sigtools = callPackage ../development/python-modules/sigtools { };
+
+  simanneal = callPackage ../development/python-modules/simanneal { };
+
+  simber = callPackage ../development/python-modules/simber { };
+
+  simpful = callPackage ../development/python-modules/simpful { };
+
+  simple-dftd3 = callPackage ../development/libraries/science/chemistry/simple-dftd3/python.nix {
+    inherit (pkgs) simple-dftd3;
+  };
+
+  simple-di = callPackage ../development/python-modules/simple-di { };
+
+  simple-parsing = callPackage ../development/python-modules/simple-parsing { };
+
+  simple-rest-client = callPackage ../development/python-modules/simple-rest-client { };
+
+  simple-rlp = callPackage ../development/python-modules/simple-rlp { };
+
+  simple-salesforce = callPackage ../development/python-modules/simple-salesforce { };
+
+  simple-term-menu = callPackage ../development/python-modules/simple-term-menu { };
+
+  simple-websocket = callPackage ../development/python-modules/simple-websocket { };
+
+  simple-websocket-server = callPackage ../development/python-modules/simple-websocket-server { };
+
+  simpleaudio = callPackage ../development/python-modules/simpleaudio { };
+
+  simplebayes = callPackage ../development/python-modules/simplebayes { };
+
+  simpleeval = callPackage ../development/python-modules/simpleeval { };
+
+  simplefin4py = callPackage ../development/python-modules/simplefin4py { };
+
+  simplefix = callPackage ../development/python-modules/simplefix { };
+
+  simplegeneric = callPackage ../development/python-modules/simplegeneric { };
+
+  simplehound = callPackage ../development/python-modules/simplehound { };
+
+  simpleitk = callPackage ../development/python-modules/simpleitk { inherit (pkgs) itk simpleitk; };
+
+  simplejson = callPackage ../development/python-modules/simplejson { };
+
+  simplekml = callPackage ../development/python-modules/simplekml { };
+
+  simplekv = callPackage ../development/python-modules/simplekv { };
+
+  simplemma = callPackage ../development/python-modules/simplemma { };
+
+  simplenote = callPackage ../development/python-modules/simplenote { };
+
+  simplepush = callPackage ../development/python-modules/simplepush { };
+
+  simplesat = callPackage ../development/python-modules/simplesat { };
+
+  simplesqlite = callPackage ../development/python-modules/simplesqlite { };
+
+  simplisafe-python = callPackage ../development/python-modules/simplisafe-python { };
+
+  simpy = callPackage ../development/python-modules/simpy { };
+
+  simsimd = callPackage ../development/python-modules/simsimd { };
+
+  single-source = callPackage ../development/python-modules/single-source { };
+
+  single-version = callPackage ../development/python-modules/single-version { };
+
+  siobrultech-protocols = callPackage ../development/python-modules/siobrultech-protocols { };
+
+  siosocks = callPackage ../development/python-modules/siosocks { };
+
+  sip = callPackage ../development/python-modules/sip { };
+
+  sip4 = callPackage ../development/python-modules/sip/4.x.nix { };
+
+  siphash24 = callPackage ../development/python-modules/siphash24 { };
+
+  siphashc = callPackage ../development/python-modules/siphashc { };
+
+  sipyco = callPackage ../development/python-modules/sipyco { };
+
+  sirius = toPythonModule (
+    pkgs.sirius.override {
+      enablePython = true;
+      pythonPackages = self;
+    }
+  );
+
+  sismic = callPackage ../development/python-modules/sismic { };
+
+  sisyphus-control = callPackage ../development/python-modules/sisyphus-control { };
+
+  siuba = callPackage ../development/python-modules/siuba { };
+
+  six = callPackage ../development/python-modules/six { };
+
+  sjcl = callPackage ../development/python-modules/sjcl { };
+
+  skein = callPackage ../development/python-modules/skein { };
+
+  skia-pathops = callPackage ../development/python-modules/skia-pathops {
+    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices OpenGL;
+  };
+
+  skidl = callPackage ../development/python-modules/skidl { };
+
+  skl2onnx = callPackage ../development/python-modules/skl2onnx { };
+
+  sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
+
+  skodaconnect = callPackage ../development/python-modules/skodaconnect { };
+
+  skops = callPackage ../development/python-modules/skops { };
+
+  skorch = callPackage ../development/python-modules/skorch { };
+
+  skrl = callPackage ../development/python-modules/skrl { };
+
+  skybellpy = callPackage ../development/python-modules/skybellpy { };
+
+  skyboxremote = callPackage ../development/python-modules/skyboxremote { };
+
+  skyfield = callPackage ../development/python-modules/skyfield { };
+
+  skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
+
+  skytemple-eventserver = callPackage ../development/python-modules/skytemple-eventserver { };
+
+  skytemple-files = callPackage ../development/python-modules/skytemple-files { };
+
+  skytemple-icons = callPackage ../development/python-modules/skytemple-icons { };
+
+  skytemple-rust = callPackage ../development/python-modules/skytemple-rust {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Foundation;
+  };
+
+  skytemple-ssb-debugger = callPackage ../development/python-modules/skytemple-ssb-debugger { };
+
+  skytemple-ssb-emulator = callPackage ../development/python-modules/skytemple-ssb-emulator { };
+
+  slack-bolt = callPackage ../development/python-modules/slack-bolt { };
+
+  slack-sdk = callPackage ../development/python-modules/slack-sdk { };
+
+  slapd = callPackage ../development/python-modules/slapd { };
+
+  sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };
+
+  sleekxmppfs = callPackage ../development/python-modules/sleekxmppfs { };
+
+  sleepyq = callPackage ../development/python-modules/sleepyq { };
+
+  slepc4py = toPythonModule (
+    pkgs.slepc.override {
+      pythonSupport = true;
+      python3 = self.python;
+      python3Packages = self;
+      petsc = petsc4py;
+    }
+  );
+
+  sleqp = toPythonModule (
+    pkgs.sleqp.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  slicedimage = callPackage ../development/python-modules/slicedimage { };
+
+  slicer = callPackage ../development/python-modules/slicer { };
+
+  slicerator = callPackage ../development/python-modules/slicerator { };
+
+  slimit = callPackage ../development/python-modules/slimit { };
+
+  slip10 = callPackage ../development/python-modules/slip10 { };
+
+  slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };
+
+  slixmpp = callPackage ../development/python-modules/slixmpp { inherit (pkgs) gnupg; };
+
+  slob = callPackage ../development/python-modules/slob { };
+
+  slovnet = callPackage ../development/python-modules/slovnet { };
+
+  slowapi = callPackage ../development/python-modules/slowapi { };
+
+  slpp = callPackage ../development/python-modules/slpp { };
+
+  slugid = callPackage ../development/python-modules/slugid { };
+
+  sly = callPackage ../development/python-modules/sly { };
+
+  smart-meter-texas = callPackage ../development/python-modules/smart-meter-texas { };
+
+  smart-open = callPackage ../development/python-modules/smart-open { };
+
+  smarthab = callPackage ../development/python-modules/smarthab { };
+
+  smartypants = callPackage ../development/python-modules/smartypants { };
+
+  smbprotocol = callPackage ../development/python-modules/smbprotocol { };
+
+  smbus-cffi = callPackage ../development/python-modules/smbus-cffi { };
+
+  smbus2 = callPackage ../development/python-modules/smbus2 { };
+
+  smdebug-rulesconfig = callPackage ../development/python-modules/smdebug-rulesconfig { };
+
+  smhi-pkg = callPackage ../development/python-modules/smhi-pkg { };
+
+  smmap = callPackage ../development/python-modules/smmap { };
+
+  smoke-zephyr = callPackage ../development/python-modules/smoke-zephyr { };
+
+  smolagents = callPackage ../development/python-modules/smolagents { };
+
+  smpp-pdu = callPackage ../development/python-modules/smpp-pdu { };
+
+  smpplib = callPackage ../development/python-modules/smpplib { };
+
+  smtpdfix = callPackage ../development/python-modules/smtpdfix { };
+
+  snack = toPythonModule (pkgs.newt.override { inherit (self) python; });
+
+  snakebite = callPackage ../development/python-modules/snakebite { };
+
+  snakemake = toPythonModule (pkgs.snakemake.override { python3Packages = self; });
+
+  snakemake-executor-plugin-cluster-generic =
+    callPackage ../development/python-modules/snakemake-executor-plugin-cluster-generic
+      { };
+
+  snakemake-interface-common =
+    callPackage ../development/python-modules/snakemake-interface-common
+      { };
+
+  snakemake-interface-executor-plugins =
+    callPackage ../development/python-modules/snakemake-interface-executor-plugins
+      { };
+
+  snakemake-interface-report-plugins =
+    callPackage ../development/python-modules/snakemake-interface-report-plugins
+      { };
+
+  snakemake-interface-storage-plugins =
+    callPackage ../development/python-modules/snakemake-interface-storage-plugins
+      { };
+
+  snakemake-storage-plugin-fs =
+    callPackage ../development/python-modules/snakemake-storage-plugin-fs
+      { };
+
+  snakemake-storage-plugin-s3 =
+    callPackage ../development/python-modules/snakemake-storage-plugin-s3
+      { };
+
+  snakemake-storage-plugin-xrootd =
+    callPackage ../development/python-modules/snakemake-storage-plugin-xrootd
+      { };
+
+  snakeviz = callPackage ../development/python-modules/snakeviz { };
+
+  snap-helpers = callPackage ../development/python-modules/snap-helpers { };
+
+  snapcast = callPackage ../development/python-modules/snapcast { };
+
+  snapshottest = callPackage ../development/python-modules/snapshottest { };
+
+  snaptime = callPackage ../development/python-modules/snaptime { };
+
+  sniffio = callPackage ../development/python-modules/sniffio { };
+
+  snitun = callPackage ../development/python-modules/snitun { };
+
+  snorkel = callPackage ../development/python-modules/snorkel { };
+
+  snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
+
+  snowflake-connector-python =
+    callPackage ../development/python-modules/snowflake-connector-python
+      { };
+
+  snowflake-sqlalchemy = callPackage ../development/python-modules/snowflake-sqlalchemy { };
+
+  snowplow-tracker = callPackage ../development/python-modules/snowplow-tracker { };
+
+  snscrape = callPackage ../development/python-modules/snscrape { };
+
+  snuggs = callPackage ../development/python-modules/snuggs { };
+
+  soapysdr = toPythonModule (
+    pkgs.soapysdr.override {
+      inherit (self) python;
+      usePython = true;
+    }
+  );
+
+  soapysdr-with-plugins = toPythonModule (
+    pkgs.soapysdr-with-plugins.override {
+      inherit (self) python;
+      usePython = true;
+    }
+  );
+
+  social-auth-app-django = callPackage ../development/python-modules/social-auth-app-django { };
+
+  social-auth-core = callPackage ../development/python-modules/social-auth-core { };
+
+  socialscan = callPackage ../development/python-modules/socialscan { };
+
+  socid-extractor = callPackage ../development/python-modules/socid-extractor { };
+
+  socketio-client = callPackage ../development/python-modules/socketio-client { };
+
+  sockio = callPackage ../development/python-modules/sockio { };
+
+  sockjs = callPackage ../development/python-modules/sockjs { };
+
+  sockjs-tornado = callPackage ../development/python-modules/sockjs-tornado { };
+
+  socksio = callPackage ../development/python-modules/socksio { };
+
+  socksipy-branch = callPackage ../development/python-modules/socksipy-branch { };
+
+  soco = callPackage ../development/python-modules/soco { };
+
+  softlayer = callPackage ../development/python-modules/softlayer { };
+
+  solarlog-cli = callPackage ../development/python-modules/solarlog-cli { };
+
+  solax = callPackage ../development/python-modules/solax { };
+
+  solc-select = callPackage ../development/python-modules/solc-select { };
+
+  solidpython2 = callPackage ../development/python-modules/solidpython2 { };
+
+  solo-python = disabledIf (!pythonAtLeast "3.6") (
+    callPackage ../development/python-modules/solo-python { }
+  );
+
+  somajo = callPackage ../development/python-modules/somajo { };
+
+  somfy-mylink-synergy = callPackage ../development/python-modules/somfy-mylink-synergy { };
+
+  somweb = callPackage ../development/python-modules/somweb { };
+
+  sonos-websocket = callPackage ../development/python-modules/sonos-websocket { };
+
+  sopel = callPackage ../development/python-modules/sopel { };
+
+  sorl-thumbnail = callPackage ../development/python-modules/sorl-thumbnail { };
+
+  sortedcollections = callPackage ../development/python-modules/sortedcollections { };
+
+  sortedcontainers = callPackage ../development/python-modules/sortedcontainers { };
+
+  sotabenchapi = callPackage ../development/python-modules/sotabenchapi { };
+
+  soundcard = callPackage ../development/python-modules/soundcard { };
+
+  soundcloud-v2 = callPackage ../development/python-modules/soundcloud-v2 { };
+
+  sounddevice = callPackage ../development/python-modules/sounddevice { };
+
+  soundfile = callPackage ../development/python-modules/soundfile { };
+
+  soupsieve = callPackage ../development/python-modules/soupsieve { };
+
+  sourmash = callPackage ../development/python-modules/sourmash { };
+
+  soxr = callPackage ../development/python-modules/soxr { libsoxr = pkgs.soxr; };
+
+  spacy = callPackage ../development/python-modules/spacy {
+    # fix error: ‘_PyCFrame’ has no member named ‘use_tracing’
+    # see: https://aur.archlinux.org/packages/python-spacy
+    cython_0 = cython_0.overridePythonAttrs (old: rec {
+      version = "0.29.37";
+      src = pkgs.fetchPypi {
+        pname = "Cython";
+        inherit version;
+        hash = "sha256-+BPUpt2Ure5dT/JmGR0dlb9tQWSk+sxTVCLAIbJQTPs=";
+      };
+    });
+  };
+
+  spacy-alignments = callPackage ../development/python-modules/spacy-alignments { };
+
+  spacy-curated-transformers =
+    callPackage ../development/python-modules/spacy-curated-transformers
+      { };
+
+  spacy-legacy = callPackage ../development/python-modules/spacy/legacy.nix { };
+
+  spacy-loggers = callPackage ../development/python-modules/spacy-loggers { };
+
+  spacy-lookups-data = callPackage ../development/python-modules/spacy/lookups-data.nix { };
+
+  spacy-models = callPackage ../development/python-modules/spacy/models.nix { inherit (pkgs) jq; };
+
+  spacy-pkuseg = callPackage ../development/python-modules/spacy-pkuseg { };
+
+  spacy-transformers = callPackage ../development/python-modules/spacy-transformers { };
+
+  spake2 = callPackage ../development/python-modules/spake2 { };
+
+  spark-parser = callPackage ../development/python-modules/spark-parser { };
+
+  sparklines = callPackage ../development/python-modules/sparklines { };
+
+  sparqlwrapper = callPackage ../development/python-modules/sparqlwrapper { };
+
+  sparse = callPackage ../development/python-modules/sparse { };
+
+  sparsezoo = callPackage ../development/python-modules/sparsezoo { };
+
+  spatial-image = callPackage ../development/python-modules/spatial-image { };
+
+  spatialmath-python = callPackage ../development/python-modules/spatialmath-python { };
+
+  spdx = callPackage ../development/python-modules/spdx { };
+
+  spdx-lookup = callPackage ../development/python-modules/spdx-lookup { };
+
+  spdx-tools = callPackage ../development/python-modules/spdx-tools { };
+
+  speaklater = callPackage ../development/python-modules/speaklater { };
+
+  speaklater3 = callPackage ../development/python-modules/speaklater3 { };
+
+  spectra = callPackage ../development/python-modules/spectra { };
+
+  spectral-cube = callPackage ../development/python-modules/spectral-cube { };
+
+  speechbrain = callPackage ../development/python-modules/speechbrain { };
+
+  speechrecognition = callPackage ../development/python-modules/speechrecognition { };
+
+  speedtest-cli = callPackage ../development/python-modules/speedtest-cli { };
+
+  speg = callPackage ../development/python-modules/speg { };
+
+  spglib = callPackage ../development/python-modules/spglib { };
+
+  sphfile = callPackage ../development/python-modules/sphfile { };
+
+  sphinx = callPackage ../development/python-modules/sphinx { };
+
+  sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
+
+  sphinx-autoapi = callPackage ../development/python-modules/sphinx-autoapi { };
+
+  sphinx-autobuild = callPackage ../development/python-modules/sphinx-autobuild { };
+
+  sphinx-autodoc-typehints = callPackage ../development/python-modules/sphinx-autodoc-typehints { };
+
+  sphinx-autodoc2 = callPackage ../development/python-modules/sphinx-autodoc2 { };
+
+  sphinx-automodapi = callPackage ../development/python-modules/sphinx-automodapi {
+    graphviz = pkgs.graphviz;
+  };
+
+  sphinx-basic-ng = callPackage ../development/python-modules/sphinx-basic-ng { };
+
+  sphinx-better-theme = callPackage ../development/python-modules/sphinx-better-theme { };
+
+  sphinx-book-theme = callPackage ../development/python-modules/sphinx-book-theme { };
+
+  sphinx-click = callPackage ../development/python-modules/sphinx-click { };
+
+  sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
+
+  sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };
+
+  sphinx-copybutton = callPackage ../development/python-modules/sphinx-copybutton { };
+
+  sphinx-design = callPackage ../development/python-modules/sphinx-design { };
+
+  sphinx-external-toc = callPackage ../development/python-modules/sphinx-external-toc { };
+
+  sphinx-favicon = callPackage ../development/python-modules/sphinx-favicon { };
+
+  sphinx-fortran = callPackage ../development/python-modules/sphinx-fortran { };
+
+  sphinx-hoverxref = callPackage ../development/python-modules/sphinx-hoverxref { };
+
+  sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
+
+  sphinx-intl = callPackage ../development/python-modules/sphinx-intl { };
+
+  sphinx-issues = callPackage ../development/python-modules/sphinx-issues { };
+
+  sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
+
+  sphinx-jupyterbook-latex = callPackage ../development/python-modules/sphinx-jupyterbook-latex { };
+
+  sphinx-lv2-theme = callPackage ../development/python-modules/sphinx-lv2-theme { };
+
+  sphinx-markdown-builder = callPackage ../development/python-modules/sphinx-markdown-builder { };
+
+  sphinx-markdown-parser = callPackage ../development/python-modules/sphinx-markdown-parser { };
+
+  sphinx-markdown-tables = callPackage ../development/python-modules/sphinx-markdown-tables { };
+
+  sphinx-material = callPackage ../development/python-modules/sphinx-material { };
+
+  sphinx-mdinclude = callPackage ../development/python-modules/sphinx-mdinclude { };
+
+  sphinx-multitoc-numbering = callPackage ../development/python-modules/sphinx-multitoc-numbering { };
+
+  sphinx-multiversion = callPackage ../development/python-modules/sphinx-multiversion { };
+
+  sphinx-notfound-page = callPackage ../development/python-modules/sphinx-notfound-page { };
+
+  sphinx-prompt = callPackage ../development/python-modules/sphinx-prompt { };
+
+  sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
+
+  sphinx-rtd-dark-mode = callPackage ../development/python-modules/sphinx-rtd-dark-mode { };
+
+  sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };
+
+  sphinx-serve = callPackage ../development/python-modules/sphinx-serve { };
+
+  sphinx-sitemap = callPackage ../development/python-modules/sphinx-sitemap { };
+
+  sphinx-tabs = callPackage ../development/python-modules/sphinx-tabs { };
+
+  sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
+
+  sphinx-thebe = callPackage ../development/python-modules/sphinx-thebe { };
+
+  sphinx-togglebutton = callPackage ../development/python-modules/sphinx-togglebutton { };
+
+  sphinx-version-warning = callPackage ../development/python-modules/sphinx-version-warning { };
+
+  sphinx-versions = callPackage ../development/python-modules/sphinx-versions { };
+
+  sphinxawesome-theme = callPackage ../development/python-modules/sphinxawesome-theme { };
+
+  sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };
+
+  sphinxcontrib-apidoc = callPackage ../development/python-modules/sphinxcontrib-apidoc { };
+
+  sphinxcontrib-applehelp = callPackage ../development/python-modules/sphinxcontrib-applehelp { };
+
+  sphinxcontrib-asyncio = callPackage ../development/python-modules/sphinxcontrib-asyncio { };
+
+  sphinxcontrib-bayesnet = callPackage ../development/python-modules/sphinxcontrib-bayesnet { };
+
+  sphinxcontrib-bibtex = callPackage ../development/python-modules/sphinxcontrib-bibtex { };
+
+  sphinxcontrib-blockdiag = callPackage ../development/python-modules/sphinxcontrib-blockdiag { };
+
+  sphinxcontrib-confluencebuilder =
+    callPackage ../development/python-modules/sphinxcontrib-confluencebuilder
+      { };
+
+  sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp { };
+
+  sphinxcontrib-ditaa = callPackage ../development/python-modules/sphinxcontrib-ditaa { };
+
+  sphinxcontrib-excel-table = callPackage ../development/python-modules/sphinxcontrib-excel-table { };
+
+  sphinxcontrib-fulltoc = callPackage ../development/python-modules/sphinxcontrib-fulltoc { };
+
+  sphinxcontrib-htmlhelp = callPackage ../development/python-modules/sphinxcontrib-htmlhelp { };
+
+  sphinxcontrib-httpdomain = callPackage ../development/python-modules/sphinxcontrib-httpdomain { };
+
+  sphinxcontrib-images = callPackage ../development/python-modules/sphinxcontrib-images { };
+
+  sphinxcontrib-jinjadomain = callPackage ../development/python-modules/sphinxcontrib-jinjadomain { };
+
+  sphinxcontrib-jquery = callPackage ../development/python-modules/sphinxcontrib-jquery { };
+
+  sphinxcontrib-jsmath = callPackage ../development/python-modules/sphinxcontrib-jsmath { };
+
+  sphinxcontrib-katex = callPackage ../development/python-modules/sphinxcontrib-katex { };
+
+  sphinxcontrib-log-cabinet = callPackage ../development/python-modules/sphinxcontrib-log-cabinet { };
+
+  sphinxcontrib-moderncmakedomain =
+    callPackage ../development/python-modules/sphinxcontrib-moderncmakedomain
+      { };
+
+  sphinxcontrib-mscgen = callPackage ../development/python-modules/sphinxcontrib-mscgen {
+    inherit (pkgs) mscgen;
+  };
+
+  sphinxcontrib-newsfeed = callPackage ../development/python-modules/sphinxcontrib-newsfeed { };
+
+  sphinxcontrib-nwdiag = callPackage ../development/python-modules/sphinxcontrib-nwdiag { };
+
+  sphinxcontrib-openapi = callPackage ../development/python-modules/sphinxcontrib-openapi { };
+
+  sphinxcontrib-plantuml = callPackage ../development/python-modules/sphinxcontrib-plantuml {
+    inherit (pkgs) plantuml;
+  };
+
+  sphinxcontrib-programoutput =
+    callPackage ../development/python-modules/sphinxcontrib-programoutput
+      { };
+
+  sphinxcontrib-qthelp = callPackage ../development/python-modules/sphinxcontrib-qthelp { };
+
+  sphinxcontrib-seqdiag = callPackage ../development/python-modules/sphinxcontrib-seqdiag { };
+
+  sphinxcontrib-serializinghtml =
+    callPackage ../development/python-modules/sphinxcontrib-serializinghtml
+      { };
+
+  sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
+
+  sphinxcontrib-svg2pdfconverter =
+    callPackage ../development/python-modules/sphinxcontrib-svg2pdfconverter
+      { };
+
+  sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz { };
+
+  sphinxcontrib-wavedrom = callPackage ../development/python-modules/sphinxcontrib-wavedrom { };
+
+  sphinxcontrib-websupport = callPackage ../development/python-modules/sphinxcontrib-websupport { };
+
+  sphinxcontrib-youtube = callPackage ../development/python-modules/sphinxcontrib-youtube { };
+
+  sphinxemoji = callPackage ../development/python-modules/sphinxemoji { };
+
+  sphinxext-opengraph = callPackage ../development/python-modules/sphinxext-opengraph { };
+
+  sphinxext-rediraffe = callPackage ../development/python-modules/sphinxext-rediraffe { };
+
+  spiderpy = callPackage ../development/python-modules/spiderpy { };
+
+  spidev = callPackage ../development/python-modules/spidev { };
+
+  spinners = callPackage ../development/python-modules/spinners { };
+
+  splinter = callPackage ../development/python-modules/splinter { };
+
+  splunk-sdk = callPackage ../development/python-modules/splunk-sdk { };
+
+  spotifyaio = callPackage ../development/python-modules/spotifyaio { };
+
+  spotipy = callPackage ../development/python-modules/spotipy { };
+
+  spsdk = callPackage ../development/python-modules/spsdk { };
+
+  spur = callPackage ../development/python-modules/spur { };
+
+  spyder = callPackage ../development/python-modules/spyder { };
+
+  spyder-kernels = callPackage ../development/python-modules/spyder-kernels { };
+
+  spylls = callPackage ../development/python-modules/spylls { };
+
+  spyse-python = callPackage ../development/python-modules/spyse-python { };
+
+  spython = callPackage ../development/python-modules/spython { };
+
+  sqids = callPackage ../development/python-modules/sqids { };
+
+  sqlalchemy = callPackage ../development/python-modules/sqlalchemy { };
+
+  sqlalchemy-citext = callPackage ../development/python-modules/sqlalchemy-citext { };
+
+  sqlalchemy-continuum = callPackage ../development/python-modules/sqlalchemy-continuum { };
+
+  sqlalchemy-file = callPackage ../development/python-modules/sqlalchemy-file { };
+
+  sqlalchemy-i18n = callPackage ../development/python-modules/sqlalchemy-i18n { };
+
+  sqlalchemy-json = callPackage ../development/python-modules/sqlalchemy-json { };
+
+  sqlalchemy-jsonfield = callPackage ../development/python-modules/sqlalchemy-jsonfield { };
+
+  sqlalchemy-mixins = callPackage ../development/python-modules/sqlalchemy-mixins { };
+
+  sqlalchemy-utils = callPackage ../development/python-modules/sqlalchemy-utils { };
+
+  sqlalchemy-views = callPackage ../development/python-modules/sqlalchemy-views { };
+
+  sqlalchemy_1_4 = callPackage ../development/python-modules/sqlalchemy/1_4.nix { };
+
+  sqlbag = callPackage ../development/python-modules/sqlbag { };
+
+  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 { };
+
+  sqlcipher3-binary = callPackage ../development/python-modules/sqlcipher3-binary { };
+
+  sqlcipher3-wheels = callPackage ../development/python-modules/sqlcipher3-wheels { };
+
+  sqlfmt = callPackage ../development/python-modules/sqlfmt { };
+
+  sqlglot = callPackage ../development/python-modules/sqlglot { };
+
+  sqlite-anyio = callPackage ../development/python-modules/sqlite-anyio { };
+
+  sqlite-fts4 = callPackage ../development/python-modules/sqlite-fts4 { };
+
+  sqlite-migrate = callPackage ../development/python-modules/sqlite-migrate { };
+
+  sqlite-utils = callPackage ../development/python-modules/sqlite-utils { };
+
+  sqlitedict = callPackage ../development/python-modules/sqlitedict { };
+
+  sqliteschema = callPackage ../development/python-modules/sqliteschema { };
+
+  sqlmap = callPackage ../development/python-modules/sqlmap { };
+
+  sqlmodel = callPackage ../development/python-modules/sqlmodel { };
+
+  sqlobject = callPackage ../development/python-modules/sqlobject { };
+
+  sqlparse = callPackage ../development/python-modules/sqlparse { };
+
+  sqltrie = callPackage ../development/python-modules/sqltrie { };
+
+  squarify = callPackage ../development/python-modules/squarify { };
+
+  sre-yield = callPackage ../development/python-modules/sre-yield { };
+
+  srp = callPackage ../development/python-modules/srp { };
+
+  srpenergy = callPackage ../development/python-modules/srpenergy { };
+
+  srptools = callPackage ../development/python-modules/srptools { };
+
+  srsly = callPackage ../development/python-modules/srsly { };
+
+  srt = callPackage ../development/python-modules/srt { };
+
+  srvlookup = callPackage ../development/python-modules/srvlookup { };
+
+  ssdeep = callPackage ../development/python-modules/ssdeep { inherit (pkgs) ssdeep; };
+
+  ssdp = callPackage ../development/python-modules/ssdp { };
+
+  ssdpy = callPackage ../development/python-modules/ssdpy { };
+
+  sse-starlette = callPackage ../development/python-modules/sse-starlette { };
+
+  sseclient = callPackage ../development/python-modules/sseclient { };
+
+  sseclient-py = callPackage ../development/python-modules/sseclient-py { };
+
+  ssg = callPackage ../development/python-modules/ssg { };
+
+  ssh-python = callPackage ../development/python-modules/ssh-python { };
+
+  ssh2-python = callPackage ../development/python-modules/ssh2-python { };
+
+  sshfs = callPackage ../development/python-modules/sshfs { };
+
+  sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
+
+  sshtunnel = callPackage ../development/python-modules/sshtunnel { };
+
+  sslib = callPackage ../development/python-modules/sslib { };
+
+  ssort = callPackage ../development/python-modules/ssort { };
+
+  stable-baselines3 = callPackage ../development/python-modules/stable-baselines3 { };
+
+  stack-data = callPackage ../development/python-modules/stack-data { };
+
+  stamina = callPackage ../development/python-modules/stamina { };
+
+  standard-aifc =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-aifc { } else null;
+
+  standard-chunk =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-chunk { } else null;
+
+  standard-imghdr =
+    if pythonAtLeast "3.13" then
+      callPackage ../development/python-modules/standard-imghdr { }
+    else
+      null;
+
+  standard-pipes =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-pipes { } else null;
+
+  standard-sunau =
+    if pythonAtLeast "3.13" then callPackage ../development/python-modules/standard-sunau { } else null;
+
+  standard-telnetlib =
+    if pythonAtLeast "3.13" then
+      callPackage ../development/python-modules/standard-telnetlib { }
+    else
+      null;
+
+  standardwebhooks = callPackage ../development/python-modules/standardwebhooks { };
+
+  stanio = callPackage ../development/python-modules/stanio { };
+
+  stanza = callPackage ../development/python-modules/stanza { };
+
+  starkbank-ecdsa = callPackage ../development/python-modules/starkbank-ecdsa { };
+
+  starlette = callPackage ../development/python-modules/starlette { };
+
+  starlette-admin = callPackage ../development/python-modules/starlette-admin { };
+
+  starlette-context = callPackage ../development/python-modules/starlette-context { };
+
+  starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };
+
+  starline = callPackage ../development/python-modules/starline { };
+
+  stashy = callPackage ../development/python-modules/stashy { };
+
+  static3 = callPackage ../development/python-modules/static3 { };
+
+  staticjinja = callPackage ../development/python-modules/staticjinja { };
+
+  staticmap = callPackage ../development/python-modules/staticmap { };
+
+  statistics = callPackage ../development/python-modules/statistics { };
+
+  statmake = callPackage ../development/python-modules/statmake { };
+
+  statsd = callPackage ../development/python-modules/statsd { };
+
+  statsmodels = callPackage ../development/python-modules/statsmodels { };
+
+  std-uritemplate = callPackage ../development/python-modules/std-uritemplate { };
+
+  std2 = callPackage ../development/python-modules/std2 { };
+
+  stdiomask = callPackage ../development/python-modules/stdiomask { };
+
+  stdlib-list = callPackage ../development/python-modules/stdlib-list { };
+
+  stdlibs = callPackage ../development/python-modules/stdlibs { };
+
+  steamodd = callPackage ../development/python-modules/steamodd { };
+
+  steamship = callPackage ../development/python-modules/steamship { };
+
+  stem = callPackage ../development/python-modules/stem { };
+
+  stemming = callPackage ../development/python-modules/stemming { };
+
+  stestr = callPackage ../development/python-modules/stestr { };
+
+  stevedore = callPackage ../development/python-modules/stevedore { };
+
+  stickytape = callPackage ../development/python-modules/stickytape { };
+
+  stim = callPackage ../development/python-modules/stim { };
+
+  stix2 = callPackage ../development/python-modules/stix2 { };
+
+  stix2-patterns = callPackage ../development/python-modules/stix2-patterns { };
+
+  stix2-validator = callPackage ../development/python-modules/stix2-validator { };
+
+  stm32loader = callPackage ../development/python-modules/stm32loader { };
+
+  stone = callPackage ../development/python-modules/stone { };
+
+  stookalert = callPackage ../development/python-modules/stookalert { };
+
+  stookwijzer = callPackage ../development/python-modules/stookwijzer { };
+
+  stop-words = callPackage ../development/python-modules/stop-words { };
+
+  stopit = callPackage ../development/python-modules/stopit { };
+
+  stp = toPythonModule (pkgs.stp.override { python3 = self.python; });
+
+  stransi = callPackage ../development/python-modules/stransi { };
+
+  strategies = callPackage ../development/python-modules/strategies { };
+
+  stravalib = callPackage ../development/python-modules/stravalib { };
+
+  stravaweblib = callPackage ../development/python-modules/stravaweblib { };
+
+  strawberry-django = callPackage ../development/python-modules/strawberry-django { };
+
+  strawberry-graphql = callPackage ../development/python-modules/strawberry-graphql { };
+
+  strct = callPackage ../development/python-modules/strct { };
+
+  streamcontroller-plugin-tools =
+    callPackage ../development/python-modules/streamcontroller-plugin-tools
+      { };
+
+  streamdeck = callPackage ../development/python-modules/streamdeck { };
+
+  streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };
+
+  streamlabswater = callPackage ../development/python-modules/streamlabswater { };
+
+  streamlit = callPackage ../development/python-modules/streamlit { };
+
+  streamz = callPackage ../development/python-modules/streamz { };
+
+  strenum = callPackage ../development/python-modules/strenum { };
+
+  strict-rfc3339 = callPackage ../development/python-modules/strict-rfc3339 { };
+
+  strictyaml = callPackage ../development/python-modules/strictyaml { };
+
+  stringbrewer = callPackage ../development/python-modules/stringbrewer { };
+
+  stringcase = callPackage ../development/python-modules/stringcase { };
+
+  stringly = callPackage ../development/python-modules/stringly { };
+
+  stringparser = callPackage ../development/python-modules/stringparser { };
+
+  stringzilla = callPackage ../development/python-modules/stringzilla { };
+
+  strip-ansi = callPackage ../development/python-modules/strip-ansi { };
+
+  stripe = callPackage ../development/python-modules/stripe { };
+
+  striprtf = callPackage ../development/python-modules/striprtf { };
+
+  strpdatetime = callPackage ../development/python-modules/strpdatetime { };
+
+  structlog = callPackage ../development/python-modules/structlog { };
+
+  stubserver = callPackage ../development/python-modules/stubserver { };
+
+  stumpy = callPackage ../development/python-modules/stumpy { };
+
+  stupidartnet = callPackage ../development/python-modules/stupidartnet { };
+
+  stups-cli-support = callPackage ../development/python-modules/stups-cli-support { };
+
+  stups-fullstop = callPackage ../development/python-modules/stups-fullstop { };
+
+  stups-pierone = callPackage ../development/python-modules/stups-pierone { };
+
+  stups-tokens = callPackage ../development/python-modules/stups-tokens { };
+
+  stups-zign = callPackage ../development/python-modules/stups-zign { };
+
+  stytra = callPackage ../development/python-modules/stytra { };
+
+  subarulink = callPackage ../development/python-modules/subarulink { };
+
+  subliminal = callPackage ../development/python-modules/subliminal { };
+
+  submitit = callPackage ../development/python-modules/submitit { };
+
+  subprocess-tee = callPackage ../development/python-modules/subprocess-tee { };
+
+  subunit = callPackage ../development/python-modules/subunit {
+    inherit (pkgs) subunit cppunit check;
+  };
+
+  subunit2sql = callPackage ../development/python-modules/subunit2sql { };
+
+  subzerod = callPackage ../development/python-modules/subzerod { };
+
+  succulent = callPackage ../development/python-modules/succulent { };
+
+  sudachidict-core = callPackage ../development/python-modules/sudachidict { };
+
+  sudachidict-full = callPackage ../development/python-modules/sudachidict {
+    sudachidict = pkgs.sudachidict.override { dict-type = "full"; };
+  };
+
+  sudachidict-small = callPackage ../development/python-modules/sudachidict {
+    sudachidict = pkgs.sudachidict.override { dict-type = "small"; };
+  };
+
+  sudachipy = callPackage ../development/python-modules/sudachipy { };
+
+  suds = callPackage ../development/python-modules/suds { };
+
+  suds-community = callPackage ../development/python-modules/suds-community { };
+
+  summarytools = callPackage ../development/python-modules/summarytools { };
+
+  sumo = callPackage ../development/python-modules/sumo { };
+
+  sumtypes = callPackage ../development/python-modules/sumtypes { };
+
+  sunpy = callPackage ../development/python-modules/sunpy { };
+
+  sunwatcher = callPackage ../development/python-modules/sunwatcher { };
+
+  sunweg = callPackage ../development/python-modules/sunweg { };
+
+  superqt = callPackage ../development/python-modules/superqt { };
+
+  supervise-api = callPackage ../development/python-modules/supervise-api { };
+
+  supervisor = callPackage ../development/python-modules/supervisor { };
+
+  sure = callPackage ../development/python-modules/sure { };
+
+  surepy = callPackage ../development/python-modules/surepy { };
+
+  surt = callPackage ../development/python-modules/surt { };
+
+  survey = callPackage ../development/python-modules/survey { };
+
+  sv-ttk = callPackage ../development/python-modules/sv-ttk { };
+
+  svg-path = callPackage ../development/python-modules/svg-path { };
+
+  svg-py = callPackage ../development/python-modules/svg-py { };
+
+  svg2tikz = callPackage ../development/python-modules/svg2tikz { };
+
+  svgelements = callPackage ../development/python-modules/svgelements { };
+
+  svglib = callPackage ../development/python-modules/svglib { };
+
+  svgutils = callPackage ../development/python-modules/svgutils { };
+
+  svgwrite = callPackage ../development/python-modules/svgwrite { };
+
+  swagger-spec-validator = callPackage ../development/python-modules/swagger-spec-validator { };
+
+  swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
+
+  swift = callPackage ../development/python-modules/swift { };
+
+  swifter = callPackage ../development/python-modules/swifter { };
+
+  swisshydrodata = callPackage ../development/python-modules/swisshydrodata { };
+
+  switchbot-api = callPackage ../development/python-modules/switchbot-api { };
+
+  swspotify = callPackage ../development/python-modules/swspotify { };
+
+  sybil = callPackage ../development/python-modules/sybil { };
+
+  symbolic = callPackage ../development/python-modules/symbolic { };
+
+  symengine = callPackage ../development/python-modules/symengine { inherit (pkgs) symengine; };
+
+  symfc = callPackage ../development/python-modules/symfc { };
+
+  sympy = callPackage ../development/python-modules/sympy { };
+
+  symspellpy = callPackage ../development/python-modules/symspellpy { };
+
+  syncedlyrics = callPackage ../development/python-modules/syncedlyrics { };
+
+  syncer = callPackage ../development/python-modules/syncer { };
+
+  syndication-domination = toPythonModule (
+    pkgs.syndication-domination.override {
+      enablePython = true;
+      python3Packages = self;
+    }
+  );
+
+  synergy = callPackage ../development/python-modules/synergy { };
+
+  syrupy = callPackage ../development/python-modules/syrupy { };
+
+  syslog-rfc5424-formatter = callPackage ../development/python-modules/syslog-rfc5424-formatter { };
+
+  sysrsync = callPackage ../development/python-modules/sysrsync { };
+
+  systembridge = callPackage ../development/python-modules/systembridge { };
+
+  systembridgeconnector = callPackage ../development/python-modules/systembridgeconnector { };
+
+  systembridgemodels = callPackage ../development/python-modules/systembridgemodels { };
+
+  systemd = callPackage ../development/python-modules/systemd { inherit (pkgs) systemd; };
+
+  systemdunitparser = callPackage ../development/python-modules/systemdunitparser { };
+
+  sysv-ipc = callPackage ../development/python-modules/sysv-ipc { };
+
+  tabcmd = callPackage ../development/python-modules/tabcmd { };
+
+  tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
+
+  tableauserverclient = callPackage ../development/python-modules/tableauserverclient { };
+
+  tabledata = callPackage ../development/python-modules/tabledata { };
+
+  tables = callPackage ../development/python-modules/tables { };
+
+  tablib = callPackage ../development/python-modules/tablib { };
+
+  tabula-py = callPackage ../development/python-modules/tabula-py { };
+
+  tabulate = callPackage ../development/python-modules/tabulate { };
+
+  tabview = callPackage ../development/python-modules/tabview { };
+
+  taco = toPythonModule (
+    pkgs.taco.override {
+      inherit (self) python;
+      enablePython = true;
+    }
+  );
+
+  tadasets = callPackage ../development/python-modules/tadasets { };
+
+  tag-expressions = callPackage ../development/python-modules/tag-expressions { };
+
+  tago = callPackage ../development/python-modules/tago { };
+
+  tagoio-sdk = callPackage ../development/python-modules/tagoio-sdk { };
+
+  tahoma-api = callPackage ../development/python-modules/tahoma-api { };
+
+  tailer = callPackage ../development/python-modules/tailer { };
+
+  tailscale = callPackage ../development/python-modules/tailscale { };
+
+  takethetime = callPackage ../development/python-modules/takethetime { };
+
+  tank-utility = callPackage ../development/python-modules/tank-utility { };
+
+  tappy = callPackage ../development/python-modules/tappy { };
+
+  tasklib = callPackage ../development/python-modules/tasklib { };
+
+  taskw = callPackage ../development/python-modules/taskw { };
+
+  taskw-ng = callPackage ../development/python-modules/taskw-ng { };
+
+  tatsu = callPackage ../development/python-modules/tatsu { };
+
+  tatsu-lts = callPackage ../development/python-modules/tatsu-lts { };
+
+  taxi = callPackage ../development/python-modules/taxi { };
+
+  taxii2-client = callPackage ../development/python-modules/taxii2-client { };
+
+  tbats = callPackage ../development/python-modules/tbats { };
+
+  tblib = callPackage ../development/python-modules/tblib { };
+
+  tblite = callPackage ../development/libraries/science/chemistry/tblite/python.nix {
+    inherit (pkgs) tblite meson simple-dftd3;
+  };
+
+  tbm-utils = callPackage ../development/python-modules/tbm-utils { };
+
+  tcolorpy = callPackage ../development/python-modules/tcolorpy { };
+
+  tcxfile = callPackage ../development/python-modules/tcxfile { };
+
+  tcxparser = callPackage ../development/python-modules/tcxparser { };
+
+  tcxreader = callPackage ../development/python-modules/tcxreader { };
+
+  tdir = callPackage ../development/python-modules/tdir { };
+
+  teamcity-messages = callPackage ../development/python-modules/teamcity-messages { };
+
+  telegram-text = callPackage ../development/python-modules/telegram-text { };
+
+  telegraph = callPackage ../development/python-modules/telegraph { };
+
+  telepath = callPackage ../development/python-modules/telepath { };
+
+  telethon = callPackage ../development/python-modules/telethon { inherit (pkgs) openssl; };
+
+  telethon-session-sqlalchemy =
+    callPackage ../development/python-modules/telethon-session-sqlalchemy
+      { };
+
+  teletype = callPackage ../development/python-modules/teletype { };
+
+  telfhash = callPackage ../development/python-modules/telfhash { };
+
+  tellduslive = callPackage ../development/python-modules/tellduslive { };
+
+  temescal = callPackage ../development/python-modules/temescal { };
+
+  temperusb = callPackage ../development/python-modules/temperusb { };
+
+  tempest = callPackage ../development/python-modules/tempest { };
+
+  templateflow = callPackage ../development/python-modules/templateflow { };
+
+  tempman = callPackage ../development/python-modules/tempman { };
+
+  tempora = callPackage ../development/python-modules/tempora { };
+
+  tenacity = callPackage ../development/python-modules/tenacity { };
+
+  tenant-schemas-celery = callPackage ../development/python-modules/tenant-schemas-celery { };
+
+  tencentcloud-sdk-python = callPackage ../development/python-modules/tencentcloud-sdk-python { };
+
+  tendo = callPackage ../development/python-modules/tendo { };
+
+  tensorboard = callPackage ../development/python-modules/tensorboard { };
+
+  tensorboard-data-server = callPackage ../development/python-modules/tensorboard-data-server { };
+
+  tensorboard-plugin-profile =
+    callPackage ../development/python-modules/tensorboard-plugin-profile
+      { };
+
+  tensorboard-plugin-wit = callPackage ../development/python-modules/tensorboard-plugin-wit { };
+
+  tensorboardx = callPackage ../development/python-modules/tensorboardx { };
+
+  tensordict = callPackage ../development/python-modules/tensordict { };
+
+  tensorflow = self.tensorflow-bin;
+
+  tensorflow-bin = callPackage ../development/python-modules/tensorflow/bin.nix {
+    inherit (pkgs.config) cudaSupport;
+    # https://www.tensorflow.org/install/source#gpu
+    cudaPackages = pkgs.cudaPackages_12;
+  };
+
+  tensorflow-build =
+    let
+      compat = rec {
+        protobufTF = pkgs.protobuf_21.override { abseil-cpp = pkgs.abseil-cpp_202301; };
+        # https://www.tensorflow.org/install/source#gpu
+        cudaPackagesTF = pkgs.cudaPackages_11;
+        grpcTF =
+          (pkgs.grpc.overrideAttrs (oldAttrs: rec {
+            # nvcc fails on recent grpc versions, so we use the latest patch level
+            #  of the grpc version bundled by upstream tensorflow to allow CUDA
+            #  support
+            version = "1.27.3";
+            src = pkgs.fetchFromGitHub {
+              owner = "grpc";
+              repo = "grpc";
+              rev = "v${version}";
+              hash = "sha256-PpiOT4ZJe1uMp5j+ReQulC9jpT0xoR2sAl6vRYKA0AA=";
+              fetchSubmodules = true;
+            };
+            patches = [ ];
+            postPatch = ''
+              sed -i "s/-std=c++11/-std=c++17/" CMakeLists.txt
+              echo "set(CMAKE_CXX_STANDARD 17)" >> CMakeLists.txt
+            '';
+          })).override
+            { protobuf = protobufTF; };
+        protobuf-pythonTF = self.protobuf4.override { protobuf = protobufTF; };
+        grpcioTF = self.grpcio.override { protobuf = protobufTF; };
+        tensorboardTF = self.tensorboard.override {
+          grpcio = grpcioTF;
+          protobuf = protobuf-pythonTF;
+        };
+      };
+    in
+    callPackage ../development/python-modules/tensorflow {
+      inherit (pkgs.config) cudaSupport;
+      inherit (pkgs.darwin.apple_sdk.frameworks) Foundation Security;
+      flatbuffers-core = pkgs.flatbuffers;
+      flatbuffers-python = self.flatbuffers;
+      cudaPackages = compat.cudaPackagesTF;
+      protobuf-core = compat.protobufTF;
+      protobuf-python = compat.protobuf-pythonTF;
+      grpc = compat.grpcTF;
+      grpcio = compat.grpcioTF;
+      tensorboard = compat.tensorboardTF;
+      abseil-cpp = pkgs.abseil-cpp_202301;
+
+      # Tensorflow 2.13 doesn't support gcc13:
+      # https://github.com/tensorflow/tensorflow/issues/61289
+      #
+      # We use the nixpkgs' default libstdc++ to stay compatible with other
+      # python modules
+      stdenv = pkgs.stdenvAdapters.useLibsFrom stdenv pkgs.gcc12Stdenv;
+    };
+
+  tensorflow-datasets = callPackage ../development/python-modules/tensorflow-datasets { };
+
+  tensorflow-estimator-bin =
+    callPackage ../development/python-modules/tensorflow-estimator/bin.nix
+      { };
+
+  tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
+
+  tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
+
+  tensorflowWithCuda = self.tensorflow.override { cudaSupport = true; };
+
+  tensorflowWithoutCuda = self.tensorflow.override { cudaSupport = false; };
+
+  tensorly = callPackage ../development/python-modules/tensorly { };
+
+  tensorrt = callPackage ../development/python-modules/tensorrt {
+    cudaPackages = pkgs.cudaPackages_11;
+  };
+
+  tensorstore = callPackage ../development/python-modules/tensorstore { };
+
+  term-image = callPackage ../development/python-modules/term-image { };
+
+  termcolor = callPackage ../development/python-modules/termcolor { };
+
+  termgraph = callPackage ../development/python-modules/termgraph { };
+
+  terminado = callPackage ../development/python-modules/terminado { };
+
+  terminaltables = callPackage ../development/python-modules/terminaltables { };
+
+  terminaltables3 = callPackage ../development/python-modules/terminaltables3 { };
+
+  terminaltexteffects = callPackage ../development/python-modules/terminaltexteffects { };
+
+  termplotlib = callPackage ../development/python-modules/termplotlib { };
+
+  termstyle = callPackage ../development/python-modules/termstyle { };
+
+  tern = callPackage ../development/python-modules/tern { };
+
+  tesla-fleet-api = callPackage ../development/python-modules/tesla-fleet-api { };
+
+  tesla-powerwall = callPackage ../development/python-modules/tesla-powerwall { };
+
+  tesla-wall-connector = callPackage ../development/python-modules/tesla-wall-connector { };
+
+  teslajsonpy = callPackage ../development/python-modules/teslajsonpy { };
+
+  teslemetry-stream = callPackage ../development/python-modules/teslemetry-stream { };
+
+  tess = callPackage ../development/python-modules/tess { };
+
+  tesserocr = callPackage ../development/python-modules/tesserocr { };
+
+  test-results-parser = callPackage ../development/python-modules/test-results-parser { };
+
+  test-tube = callPackage ../development/python-modules/test-tube { };
+
+  testbook = callPackage ../development/python-modules/testbook { };
+
+  testcontainers = callPackage ../development/python-modules/testcontainers { };
+
+  testfixtures = callPackage ../development/python-modules/testfixtures { };
+
+  testing-common-database = callPackage ../development/python-modules/testing-common-database { };
+
+  testing-postgresql = callPackage ../development/python-modules/testing-postgresql { };
+
+  testpath = callPackage ../development/python-modules/testpath { };
+
+  testrail-api = callPackage ../development/python-modules/testrail-api { };
+
+  testrepository = callPackage ../development/python-modules/testrepository { };
+
+  testresources = callPackage ../development/python-modules/testresources { };
+
+  testscenarios = callPackage ../development/python-modules/testscenarios { };
+
+  testtools = callPackage ../development/python-modules/testtools { };
+
+  texsoup = callPackage ../development/python-modules/texsoup { };
+
+  text-unidecode = callPackage ../development/python-modules/text-unidecode { };
+
+  text2digits = callPackage ../development/python-modules/text2digits { };
+
+  textacy = callPackage ../development/python-modules/textacy { };
+
+  textblob = callPackage ../development/python-modules/textblob { };
+
+  textdistance = callPackage ../development/python-modules/textdistance { };
+
+  textfsm = callPackage ../development/python-modules/textfsm { };
+
+  textile = callPackage ../development/python-modules/textile { };
+
+  textnets = callPackage ../development/python-modules/textnets {
+    en_core_web_sm = spacy-models.en_core_web_sm;
+  };
+
+  textparser = callPackage ../development/python-modules/textparser { };
+
+  textstat = callPackage ../development/python-modules/textstat { };
+
+  texttable = callPackage ../development/python-modules/texttable { };
+
+  textual = callPackage ../development/python-modules/textual { };
+
+  textual-autocomplete = callPackage ../development/python-modules/textual-autocomplete { };
+
+  textual-dev = callPackage ../development/python-modules/textual-dev { };
+
+  textual-fastdatatable = callPackage ../development/python-modules/textual-fastdatatable { };
+
+  textual-serve = callPackage ../development/python-modules/textual-serve { };
+
+  textual-slider = callPackage ../development/python-modules/textual-slider { };
+
+  textual-textarea = callPackage ../development/python-modules/textual-textarea { };
+
+  textual-universal-directorytree =
+    callPackage ../development/python-modules/textual-universal-directorytree
+      { };
+
+  textualeffects = callPackage ../development/python-modules/textualeffects { };
+
+  textwrap3 = callPackage ../development/python-modules/textwrap3 { };
+
+  textx = callPackage ../development/python-modules/textx { };
+
+  tf-keras = callPackage ../development/python-modules/tf-keras { };
+
+  tf2onnx = callPackage ../development/python-modules/tf2onnx { };
+
+  tflearn = callPackage ../development/python-modules/tflearn { };
+
+  tftpy = callPackage ../development/python-modules/tftpy { };
+
+  tgcrypto = callPackage ../development/python-modules/tgcrypto { };
+
+  thefuzz = callPackage ../development/python-modules/thefuzz { };
+
+  thelogrus = callPackage ../development/python-modules/thelogrus { };
+
+  thermobeacon-ble = callPackage ../development/python-modules/thermobeacon-ble { };
+
+  thermopro-ble = callPackage ../development/python-modules/thermopro-ble { };
+
+  thespian = callPackage ../development/python-modules/thespian { };
+
+  thinc = callPackage ../development/python-modules/thinc {
+    inherit (pkgs.darwin.apple_sdk.frameworks)
+      Accelerate
+      CoreFoundation
+      CoreGraphics
+      CoreVideo
+      ;
+  };
+
+  thinqconnect = callPackage ../development/python-modules/thinqconnect { };
+
+  thorlabspm100 = callPackage ../development/python-modules/thorlabspm100 { };
+
+  threadloop = callPackage ../development/python-modules/threadloop { };
+
+  threadpool = callPackage ../development/python-modules/threadpool { };
+
+  threadpoolctl = callPackage ../development/python-modules/threadpoolctl { };
+
+  threat9-test-bed = callPackage ../development/python-modules/threat9-test-bed { };
+
+  three-merge = callPackage ../development/python-modules/three-merge { };
+
+  thrift = callPackage ../development/python-modules/thrift { };
+
+  thriftpy2 = callPackage ../development/python-modules/thriftpy2 { };
+
+  throttler = callPackage ../development/python-modules/throttler { };
+
+  thttp = callPackage ../development/python-modules/thttp { };
+
+  tianshou = callPackage ../development/python-modules/tianshou { };
+
+  tidalapi = callPackage ../development/python-modules/tidalapi { };
+
+  tidyexc = callPackage ../development/python-modules/tidyexc { };
+
+  tidylib = callPackage ../development/python-modules/pytidylib { };
+
+  tifffile = callPackage ../development/python-modules/tifffile { };
+
+  tika = callPackage ../development/python-modules/tika { };
+
+  tika-client = callPackage ../development/python-modules/tika-client { };
+
+  tiktoken = callPackage ../development/python-modules/tiktoken { };
+
+  tikzplotlib = callPackage ../development/python-modules/tikzplotlib { };
+
+  tiledb = callPackage ../development/python-modules/tiledb { inherit (pkgs) tiledb; };
+
+  tilequant = callPackage ../development/python-modules/tilequant { };
+
+  tiler = callPackage ../development/python-modules/tiler { };
+
+  tilestache = callPackage ../development/python-modules/tilestache { };
+
+  tilt-ble = callPackage ../development/python-modules/tilt-ble { };
+
+  time-machine = callPackage ../development/python-modules/time-machine { };
+
+  timeago = callPackage ../development/python-modules/timeago { };
+
+  timecop = callPackage ../development/python-modules/timecop { };
+
+  timelib = callPackage ../development/python-modules/timelib { };
+
+  timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };
+
+  timeslot = callPackage ../development/python-modules/timeslot { };
+
+  timetagger = callPackage ../development/python-modules/timetagger { };
+
+  timezonefinder = callPackage ../development/python-modules/timezonefinder { };
+
+  timing-asgi = callPackage ../development/python-modules/timing-asgi { };
+
+  timm = callPackage ../development/python-modules/timm { };
+
+  timy = callPackage ../development/python-modules/timy { };
+
+  tiny-cuda-nn = toPythonModule (
+    pkgs.tiny-cuda-nn.override {
+      cudaPackages = self.torch.cudaPackages;
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
+  tiny-proxy = callPackage ../development/python-modules/tiny-proxy { };
+
+  tinycss = callPackage ../development/python-modules/tinycss { };
+
+  tinycss2 = callPackage ../development/python-modules/tinycss2 { };
+
+  tinydb = callPackage ../development/python-modules/tinydb { };
+
+  tinygrad = callPackage ../development/python-modules/tinygrad { };
+
+  tinyhtml5 = callPackage ../development/python-modules/tinyhtml5 { };
+
+  tinyobjloader-py = callPackage ../development/python-modules/tinyobjloader-py { };
+
+  tinyrecord = callPackage ../development/python-modules/tinyrecord { };
+
+  tinysegmenter = callPackage ../development/python-modules/tinysegmenter { };
+
+  tinytag = callPackage ../development/python-modules/tinytag { };
+
+  tinytuya = callPackage ../development/python-modules/tinytuya { };
+
+  tiptapy = callPackage ../development/python-modules/tiptapy { };
+
+  titlecase = callPackage ../development/python-modules/titlecase { };
+
+  tivars = callPackage ../development/python-modules/tivars { };
+
+  tkinter = callPackage ../development/python-modules/tkinter {
+    py = python.override (lib.optionalAttrs (!python.isPyPy) { x11Support = true; });
+  };
+
+  tld = callPackage ../development/python-modules/tld { };
+
+  tldextract = callPackage ../development/python-modules/tldextract { };
+
+  tlds = callPackage ../development/python-modules/tlds { };
+
+  tls-client = callPackage ../development/python-modules/tls-client { };
+
+  tls-parser = callPackage ../development/python-modules/tls-parser { };
+
+  tlsh = callPackage ../development/python-modules/tlsh { };
+
+  tlslite-ng = callPackage ../development/python-modules/tlslite-ng { };
+
+  tlv8 = callPackage ../development/python-modules/tlv8 { };
+
+  tmb = callPackage ../development/python-modules/tmb { };
+
+  todoist = callPackage ../development/python-modules/todoist { };
+
+  todoist-api-python = callPackage ../development/python-modules/todoist-api-python { };
+
+  toggl-cli = callPackage ../development/python-modules/toggl-cli { };
+
+  token-bucket = callPackage ../development/python-modules/token-bucket { };
+
+  tokenize-rt = callPackage ../development/python-modules/tokenize-rt { };
+
+  tokenizers = callPackage ../development/python-modules/tokenizers { };
+
+  tokenlib = callPackage ../development/python-modules/tokenlib { };
+
+  tokentrim = callPackage ../development/python-modules/tokentrim { };
+
+  tololib = callPackage ../development/python-modules/tololib { };
+
+  toml = callPackage ../development/python-modules/toml { };
+
+  toml-adapt = callPackage ../development/python-modules/toml-adapt { };
+
+  tomli = callPackage ../development/python-modules/tomli { };
+
+  tomli-w = callPackage ../development/python-modules/tomli-w { };
+
+  tomlkit = callPackage ../development/python-modules/tomlkit { };
+
+  toolz = callPackage ../development/python-modules/toolz { };
+
+  toonapi = callPackage ../development/python-modules/toonapi { };
+
+  toposort = callPackage ../development/python-modules/toposort { };
+
+  toptica-lasersdk = callPackage ../development/python-modules/toptica-lasersdk { };
+
+  torch = callPackage ../development/python-modules/torch { };
+
+  torch-audiomentations = callPackage ../development/python-modules/torch-audiomentations { };
+
+  torch-bin = callPackage ../development/python-modules/torch/bin.nix { triton = self.triton-bin; };
+
+  torch-geometric = callPackage ../development/python-modules/torch-geometric { };
+
+  # Required to test triton
+  torch-no-triton = self.torch.override { tritonSupport = false; };
+
+  torch-pitch-shift = callPackage ../development/python-modules/torch-pitch-shift { };
+
+  torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
+
+  torchWithCuda = self.torch.override {
+    triton = self.triton-cuda;
+    cudaSupport = true;
+    rocmSupport = false;
+  };
+
+  torchWithRocm = self.torch.override {
+    triton = self.triton-no-cuda;
+    rocmSupport = true;
+    cudaSupport = false;
+  };
+
+  torchWithVulkan = self.torch.override { vulkanSupport = true; };
+
+  torchWithoutCuda = self.torch.override { cudaSupport = false; };
+
+  torchWithoutRocm = self.torch.override { rocmSupport = false; };
+
+  torchaudio = callPackage ../development/python-modules/torchaudio { };
+
+  torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix {
+    cudaPackages = pkgs.cudaPackages_12;
+  };
+
+  torchbench = callPackage ../development/python-modules/torchbench { };
+
+  torchcrepe = callPackage ../development/python-modules/torchcrepe { };
+
+  torchdiffeq = callPackage ../development/python-modules/torchdiffeq { };
+
+  torcheval = callPackage ../development/python-modules/torcheval { };
+
+  torchinfo = callPackage ../development/python-modules/torchinfo { };
+
+  torchio = callPackage ../development/python-modules/torchio { };
+
+  torchlibrosa = callPackage ../development/python-modules/torchlibrosa { };
+
+  torchmetrics = callPackage ../development/python-modules/torchmetrics { };
+
+  torchprofile = callPackage ../development/python-modules/torchprofile { };
+
+  torchrl = callPackage ../development/python-modules/torchrl { };
+
+  torchsde = callPackage ../development/python-modules/torchsde { };
+
+  torchsnapshot = callPackage ../development/python-modules/torchsnapshot { };
+
+  torchsummary = callPackage ../development/python-modules/torchsummary { };
+
+  torchtnt = callPackage ../development/python-modules/torchtnt { };
+
+  torchtnt-nightly = callPackage ../development/python-modules/torchtnt-nightly { };
+
+  torchvision = callPackage ../development/python-modules/torchvision { };
+
+  torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix {
+    cudaPackages = pkgs.cudaPackages_12;
+  };
+
+  tornado = callPackage ../development/python-modules/tornado { };
+
+  torpy = callPackage ../development/python-modules/torpy { };
+
+  torrent-parser = callPackage ../development/python-modules/torrent-parser { };
+
+  torrequest = callPackage ../development/python-modules/torrequest { };
+
+  total-connect-client = callPackage ../development/python-modules/total-connect-client { };
+
+  towncrier = callPackage ../development/python-modules/towncrier { inherit (pkgs) git; };
+
+  tox = callPackage ../development/python-modules/tox { };
+
+  tplink-omada-client = callPackage ../development/python-modules/tplink-omada-client { };
+
+  tpm2-pytss = callPackage ../development/python-modules/tpm2-pytss { };
+
+  tqdm = callPackage ../development/python-modules/tqdm { };
+
+  tqdm-multiprocess = callPackage ../development/python-modules/tqdm-multiprocess { };
+
+  traceback2 = callPackage ../development/python-modules/traceback2 { };
+
+  tracerite = callPackage ../development/python-modules/tracerite { };
+
+  tracing = callPackage ../development/python-modules/tracing { };
+
+  trackpy = callPackage ../development/python-modules/trackpy { };
+
+  trafilatura = callPackage ../development/python-modules/trafilatura { };
+
+  trailrunner = callPackage ../development/python-modules/trailrunner { };
+
+  trainer = callPackage ../development/python-modules/trainer { };
+
+  traitlets = callPackage ../development/python-modules/traitlets { };
+
+  traits = callPackage ../development/python-modules/traits { };
+
+  traitsui = callPackage ../development/python-modules/traitsui { };
+
+  traittypes = callPackage ../development/python-modules/traittypes { };
+
+  trakit = callPackage ../development/python-modules/trakit { };
+
+  trampoline = callPackage ../development/python-modules/trampoline { };
+
+  transaction = callPackage ../development/python-modules/transaction { };
+
+  transformers = callPackage ../development/python-modules/transformers { };
+
+  transforms3d = callPackage ../development/python-modules/transforms3d { };
+
+  transitions = callPackage ../development/python-modules/transitions { };
+
+  translate-toolkit = callPackage ../development/python-modules/translate-toolkit { };
+
+  translatehtml = callPackage ../development/python-modules/translatehtml { };
+
+  translatepy = callPackage ../development/python-modules/translatepy { };
+
+  translation-finder = callPackage ../development/python-modules/translation-finder { };
+
+  translationstring = callPackage ../development/python-modules/translationstring { };
+
+  translitcodec = callPackage ../development/python-modules/translitcodec { };
+
+  transmission-rpc = callPackage ../development/python-modules/transmission-rpc { };
+
+  trectools = callPackage ../development/python-modules/trectools { };
+
+  tree-sitter = callPackage ../development/python-modules/tree-sitter { };
+
+  tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
+
+  tree-sitter-javascript = callPackage ../development/python-modules/tree-sitter-javascript { };
+
+  tree-sitter-json = callPackage ../development/python-modules/tree-sitter-json { };
+
+  tree-sitter-languages = callPackage ../development/python-modules/tree-sitter-languages { };
+
+  tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
+
+  tree-sitter-python = callPackage ../development/python-modules/tree-sitter-python { };
+
+  tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };
+
+  tree-sitter_0_21 = callPackage ../development/python-modules/tree-sitter/0_21.nix { };
+
+  treelib = callPackage ../development/python-modules/treelib { };
+
+  treelog = callPackage ../development/python-modules/treelog { };
+
+  treeo = callPackage ../development/python-modules/treeo { };
+
+  treescope = callPackage ../development/python-modules/treescope { };
+
+  treex = callPackage ../development/python-modules/treex { };
+
+  treq = callPackage ../development/python-modules/treq { };
+
+  trezor = callPackage ../development/python-modules/trezor { };
+
+  trezor-agent = callPackage ../development/python-modules/trezor-agent {
+    pinentry = pkgs.pinentry-curses;
+  };
+
+  trie = callPackage ../development/python-modules/trie { };
+
+  trimesh = callPackage ../development/python-modules/trimesh { };
+
+  trino-python-client = callPackage ../development/python-modules/trino-python-client { };
+
+  trio = callPackage ../development/python-modules/trio { };
+
+  trio-asyncio = callPackage ../development/python-modules/trio-asyncio { };
+
+  trio-websocket = callPackage ../development/python-modules/trio-websocket { };
+
+  triton = callPackage ../development/python-modules/triton { llvm = pkgs.triton-llvm; };
+
+  triton-bin = callPackage ../development/python-modules/triton/bin.nix { };
+
+  triton-cuda = self.triton.override { cudaSupport = true; };
+
+  triton-no-cuda = self.triton.override { cudaSupport = false; };
+
+  tritonclient = callPackage ../development/python-modules/tritonclient { };
+
+  trlib = toPythonModule (
+    pkgs.trlib.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  troposphere = callPackage ../development/python-modules/troposphere { };
+
+  trove-classifiers = callPackage ../development/python-modules/trove-classifiers { };
+
+  trubar = callPackage ../development/python-modules/trubar { };
+
+  trueskill = callPackage ../development/python-modules/trueskill { };
+
+  truncnorm = callPackage ../development/python-modules/truncnorm { };
+
+  trustme = callPackage ../development/python-modules/trustme { };
+
+  truststore = callPackage ../development/python-modules/truststore { };
+
+  trx-python = callPackage ../development/python-modules/trx-python { };
+
+  trytond = callPackage ../development/python-modules/trytond { };
+
+  ts1-signatures = callPackage ../development/python-modules/ts1-signatures { };
+
+  tsfresh = callPackage ../development/python-modules/tsfresh { };
+
+  tsid = toPythonModule (
+    pkgs.tsid.override {
+      pythonSupport = true;
+      python3Packages = self;
+    }
+  );
+
+  tskit = callPackage ../development/python-modules/tskit { };
+
+  ttach = callPackage ../development/python-modules/ttach { };
+
+  ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };
+
+  ttls = callPackage ../development/python-modules/ttls { };
+
+  ttn-client = callPackage ../development/python-modules/ttn-client { };
+
+  ttp = callPackage ../development/python-modules/ttp { };
+
+  ttp-templates = callPackage ../development/python-modules/ttp-templates { };
+
+  ttstokenizer = callPackage ../development/python-modules/ttstokenizer { };
+
+  tubes = callPackage ../development/python-modules/tubes { };
+
+  tubeup = callPackage ../development/python-modules/tubeup { };
+
+  tuf = callPackage ../development/python-modules/tuf { };
+
+  tunigo = callPackage ../development/python-modules/tunigo { };
+
+  turnt = callPackage ../development/python-modules/turnt { };
+
+  turrishw = callPackage ../development/python-modules/turrishw { };
+
+  tuya-device-sharing-sdk = callPackage ../development/python-modules/tuya-device-sharing-sdk { };
+
+  tuya-iot-py-sdk = callPackage ../development/python-modules/tuya-iot-py-sdk { };
+
+  tuyaha = callPackage ../development/python-modules/tuyaha { };
+
+  tvdb-api = callPackage ../development/python-modules/tvdb-api { };
+
+  tweedledum = callPackage ../development/python-modules/tweedledum { };
+
+  tweepy = callPackage ../development/python-modules/tweepy { };
+
+  twentemilieu = callPackage ../development/python-modules/twentemilieu { };
+
+  twiggy = callPackage ../development/python-modules/twiggy { };
+
+  twilio = callPackage ../development/python-modules/twilio { };
+
+  twill = callPackage ../development/python-modules/twill { };
+
+  twine = callPackage ../development/python-modules/twine { };
+
+  twinkly-client = callPackage ../development/python-modules/twinkly-client { };
+
+  twisted = callPackage ../development/python-modules/twisted { };
+
+  twitch-python = callPackage ../development/python-modules/twitch-python { };
+
+  twitchapi = callPackage ../development/python-modules/twitchapi { };
+
+  twitter = callPackage ../development/python-modules/twitter { };
+
+  twitterapi = callPackage ../development/python-modules/twitterapi { };
+
+  twofish = callPackage ../development/python-modules/twofish { };
+
+  txaio = callPackage ../development/python-modules/txaio { };
+
+  txamqp = callPackage ../development/python-modules/txamqp { };
+
+  txdbus = callPackage ../development/python-modules/txdbus { };
+
+  txgithub = callPackage ../development/python-modules/txgithub { };
+
+  txi2p-tahoe = callPackage ../development/python-modules/txi2p-tahoe { };
+
+  txredisapi = callPackage ../development/python-modules/txredisapi { };
+
+  txrequests = callPackage ../development/python-modules/txrequests { };
+
+  txtai = callPackage ../development/python-modules/txtai { };
+
+  txtorcon = callPackage ../development/python-modules/txtorcon { };
+
+  txzmq = callPackage ../development/python-modules/txzmq { };
+
+  type-infer = callPackage ../development/python-modules/type-infer { };
+
+  typechecks = callPackage ../development/python-modules/typechecks { };
+
+  typecode = callPackage ../development/python-modules/typecode { };
+
+  typecode-libmagic = callPackage ../development/python-modules/typecode/libmagic.nix {
+    inherit (pkgs) file zlib;
+  };
+
+  typed-ast = callPackage ../development/python-modules/typed-ast { };
+
+  typed-settings = callPackage ../development/python-modules/typed-settings { };
+
+  typeguard = callPackage ../development/python-modules/typeguard { };
+
+  typepy = callPackage ../development/python-modules/typepy { };
+
+  typer = callPackage ../development/python-modules/typer { };
+
+  typer-shell = callPackage ../development/python-modules/typer-shell { };
+
+  types-aiobotocore = callPackage ../development/python-modules/types-aiobotocore { };
+
   types-appdirs = callPackage ../development/python-modules/types-appdirs { };
 
   types-awscrt = callPackage ../development/python-modules/types-awscrt { };
@@ -18286,9 +18326,9 @@ self: super: with self; {
 
   types-redis = callPackage ../development/python-modules/types-redis { };
 
-  types-retry = callPackage ../development/python-modules/types-retry { };
-
   types-requests = callPackage ../development/python-modules/types-requests { };
+
+  types-retry = callPackage ../development/python-modules/types-retry { };
 
   types-s3transfer = callPackage ../development/python-modules/types-s3transfer { };
 
@@ -18334,17 +18374,17 @@ self: super: with self; {
 
   tzlocal = callPackage ../development/python-modules/tzlocal { };
 
-  rustworkx = callPackage ../development/python-modules/rustworkx { };
-
-  uamqp = callPackage ../development/python-modules/uamqp {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CFNetwork CoreFoundation Security;
-  };
+  u-msgpack-python = callPackage ../development/python-modules/u-msgpack-python { };
 
   ua-parser = callPackage ../development/python-modules/ua-parser { };
 
   ua-parser-builtins = callPackage ../development/python-modules/ua-parser-builtins { };
 
   ua-parser-rs = callPackage ../development/python-modules/ua-parser-rs { };
+
+  uamqp = callPackage ../development/python-modules/uamqp {
+    inherit (pkgs.darwin.apple_sdk.frameworks) CFNetwork CoreFoundation Security;
+  };
 
   uarray = callPackage ../development/python-modules/uarray { };
 
@@ -18359,6 +18399,8 @@ self: super: with self; {
   ucsmsdk = callPackage ../development/python-modules/ucsmsdk { };
 
   udatetime = callPackage ../development/python-modules/udatetime { };
+
+  ueagle = callPackage ../development/python-modules/ueagle { };
 
   ueberzug = callPackage ../development/python-modules/ueberzug {
     inherit (pkgs.xorg) libX11 libXext;
@@ -18379,8 +18421,6 @@ self: super: with self; {
   ufonormalizer = callPackage ../development/python-modules/ufonormalizer { };
 
   ufoprocessor = callPackage ../development/python-modules/ufoprocessor { };
-
-  ueagle = callPackage ../development/python-modules/ueagle { };
 
   uharfbuzz = callPackage ../development/python-modules/uharfbuzz {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
@@ -18410,8 +18450,6 @@ self: super: with self; {
 
   umodbus = callPackage ../development/python-modules/umodbus { };
 
-  u-msgpack-python = callPackage ../development/python-modules/u-msgpack-python { };
-
   unasync = callPackage ../development/python-modules/unasync { };
 
   unblob-native = callPackage ../development/python-modules/unblob-native { };
@@ -18426,15 +18464,15 @@ self: super: with self; {
 
   unearth = callPackage ../development/python-modules/unearth { };
 
+  unicode-rbnf = callPackage ../development/python-modules/unicode-rbnf { };
+
+  unicode-slugify = callPackage ../development/python-modules/unicode-slugify { };
+
   unicodecsv = callPackage ../development/python-modules/unicodecsv { };
 
   unicodedata2 = callPackage ../development/python-modules/unicodedata2 { };
 
   unicodeit = callPackage ../development/python-modules/unicodeit { };
-
-  unicode-rbnf = callPackage ../development/python-modules/unicode-rbnf { };
-
-  unicode-slugify = callPackage ../development/python-modules/unicode-slugify { };
 
   unicorn = callPackage ../development/python-modules/unicorn { inherit (pkgs) unicorn; };
 
@@ -18442,9 +18480,9 @@ self: super: with self; {
     inherit (pkgs) unicorn-angr;
   };
 
-  unicurses = callPackage ../development/python-modules/unicurses { };
-
   unicrypto = callPackage ../development/python-modules/unicrypto { };
+
+  unicurses = callPackage ../development/python-modules/unicurses { };
 
   unidata-blocks = callPackage ../development/python-modules/unidata-blocks { };
 
@@ -18462,9 +18500,9 @@ self: super: with self; {
 
   unifi-discovery = callPackage ../development/python-modules/unifi-discovery { };
 
-  unify = callPackage ../development/python-modules/unify { };
-
   unifiled = callPackage ../development/python-modules/unifiled { };
+
+  unify = callPackage ../development/python-modules/unify { };
 
   unique-log-filter = callPackage ../development/python-modules/unique-log-filter { };
 
@@ -18526,9 +18564,9 @@ self: super: with self; {
 
   uranium = callPackage ../development/python-modules/uranium { };
 
-  uritemplate = callPackage ../development/python-modules/uritemplate { };
-
   uri-template = callPackage ../development/python-modules/uri-template { };
+
+  uritemplate = callPackage ../development/python-modules/uritemplate { };
 
   uritools = callPackage ../development/python-modules/uritools { };
 
@@ -18550,11 +18588,13 @@ self: super: with self; {
 
   urwid = callPackage ../development/python-modules/urwid { };
 
+  urwid-readline = callPackage ../development/python-modules/urwid-readline { };
+
   urwidgets = callPackage ../development/python-modules/urwidgets { };
 
   urwidtrees = callPackage ../development/python-modules/urwidtrees { };
 
-  urwid-readline = callPackage ../development/python-modules/urwid-readline { };
+  us = callPackage ../development/python-modules/us { };
 
   usb-devices = callPackage ../development/python-modules/usb-devices { };
 
@@ -18565,8 +18605,6 @@ self: super: with self; {
   usbrelay-py = callPackage ../os-specific/linux/usbrelay/python.nix { };
 
   usbtmc = callPackage ../development/python-modules/usbtmc { };
-
-  us = callPackage ../development/python-modules/us { };
 
   user-agents = callPackage ../development/python-modules/user-agents { };
 
@@ -18594,9 +18632,9 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices CoreServices;
   };
 
-  uxsim = callPackage ../development/python-modules/uxsim { };
-
   uwsgi-chunked = callPackage ../development/python-modules/uwsgi-chunked { };
+
+  uxsim = callPackage ../development/python-modules/uxsim { };
 
   vaa = callPackage ../development/python-modules/vaa { };
 
@@ -18640,17 +18678,17 @@ self: super: with self; {
 
   vector = callPackage ../development/python-modules/vector { };
 
-  vehicle = callPackage ../development/python-modules/vehicle { };
-
   vega = callPackage ../development/python-modules/vega { };
 
   vega-datasets = callPackage ../development/python-modules/vega-datasets { };
 
+  vehicle = callPackage ../development/python-modules/vehicle { };
+
+  velbus-aio = callPackage ../development/python-modules/velbus-aio { };
+
   venstarcolortouch = callPackage ../development/python-modules/venstarcolortouch { };
 
   venusian = callPackage ../development/python-modules/venusian { };
-
-  velbus-aio = callPackage ../development/python-modules/velbus-aio { };
 
   verboselogs = callPackage ../development/python-modules/verboselogs { };
 
@@ -18714,11 +18752,11 @@ self: super: with self; {
 
   vispy = callPackage ../development/python-modules/vispy { };
 
+  viv-utils = callPackage ../development/python-modules/viv-utils { };
+
   vivisect = callPackage ../development/python-modules/vivisect {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
-
-  viv-utils = callPackage ../development/python-modules/viv-utils { };
 
   vllm = callPackage ../development/python-modules/vllm { };
 
@@ -18819,6 +18857,8 @@ self: super: with self; {
 
   wandb = callPackage ../development/python-modules/wandb { };
 
+  waqiasync = callPackage ../development/python-modules/waqiasync { };
+
   warble = callPackage ../development/python-modules/warble { };
 
   warcio = callPackage ../development/python-modules/warcio { };
@@ -18831,19 +18871,11 @@ self: super: with self; {
 
   warrant-lite = callPackage ../development/python-modules/warrant-lite { };
 
-  waqiasync = callPackage ../development/python-modules/waqiasync { };
-
   wasabi = callPackage ../development/python-modules/wasabi { };
 
-  wasserstein = callPackage ../development/python-modules/wasserstein { };
-
   wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
-  inherit (self.wasmerPackages)
-    wasmer
-    wasmer-compiler-cranelift
-    wasmer-compiler-llvm
-    wasmer-compiler-singlepass
-    ;
+
+  wasserstein = callPackage ../development/python-modules/wasserstein { };
 
   wat = callPackage ../development/python-modules/wat { };
 
@@ -18887,6 +18919,10 @@ self: super: with self; {
 
   weaviate-client = callPackage ../development/python-modules/weaviate-client { };
 
+  web = callPackage ../development/python-modules/web { };
+
+  web-cache = callPackage ../development/python-modules/web-cache { };
+
   web3 = callPackage ../development/python-modules/web3 { };
 
   webargs = callPackage ../development/python-modules/webargs { };
@@ -18894,10 +18930,6 @@ self: super: with self; {
   webassets = callPackage ../development/python-modules/webassets { };
 
   webauthn = callPackage ../development/python-modules/webauthn { };
-
-  web = callPackage ../development/python-modules/web { };
-
-  web-cache = callPackage ../development/python-modules/web-cache { };
 
   webcolors = callPackage ../development/python-modules/webcolors { };
 
@@ -18915,11 +18947,11 @@ self: super: with self; {
 
   webexteamssdk = callPackage ../development/python-modules/webexteamssdk { };
 
-  webmin-xmlrpc = callPackage ../development/python-modules/webmin-xmlrpc { };
-
   weblate-language-data = callPackage ../development/python-modules/weblate-language-data { };
 
   weblate-schemas = callPackage ../development/python-modules/weblate-schemas { };
+
+  webmin-xmlrpc = callPackage ../development/python-modules/webmin-xmlrpc { };
 
   webob = callPackage ../development/python-modules/webob { };
 
@@ -19011,9 +19043,9 @@ self: super: with self; {
 
   wikipedia = callPackage ../development/python-modules/wikipedia { };
 
-  wikipedia2vec = callPackage ../development/python-modules/wikipedia2vec { };
-
   wikipedia-api = callPackage ../development/python-modules/wikipedia-api { };
+
+  wikipedia2vec = callPackage ../development/python-modules/wikipedia2vec { };
 
   wikitextparser = callPackage ../development/python-modules/wikitextparser { };
 
@@ -19081,6 +19113,8 @@ self: super: with self; {
 
   wsproto = callPackage ../development/python-modules/wsproto { };
 
+  wtf-peewee = callPackage ../development/python-modules/wtf-peewee { };
+
   wtforms = callPackage ../development/python-modules/wtforms { };
 
   wtforms-bootstrap5 = callPackage ../development/python-modules/wtforms-bootstrap5 { };
@@ -19088,8 +19122,6 @@ self: super: with self; {
   wtforms-sqlalchemy = callPackage ../development/python-modules/wtforms-sqlalchemy { };
 
   wunsen = callPackage ../development/python-modules/wunsen { };
-
-  wtf-peewee = callPackage ../development/python-modules/wtf-peewee { };
 
   wurlitzer = callPackage ../development/python-modules/wurlitzer { };
 
@@ -19133,6 +19165,8 @@ self: super: with self; {
 
   xdot = callPackage ../development/python-modules/xdot { inherit (pkgs) graphviz; };
 
+  xdxf2html = callPackage ../development/python-modules/xdxf2html { };
+
   xen = toPythonModule (pkgs.xen.override { python3Packages = self; });
 
   xformers = callPackage ../development/python-modules/xformers { };
@@ -19165,6 +19199,8 @@ self: super: with self; {
 
   xmind = callPackage ../development/python-modules/xmind { };
 
+  xml-marshaller = callPackage ../development/python-modules/xml-marshaller { };
+
   xml2rfc = callPackage ../development/python-modules/xml2rfc { };
 
   xmldiff = callPackage ../development/python-modules/xmldiff { };
@@ -19184,8 +19220,6 @@ self: super: with self; {
   };
 
   xmltodict = callPackage ../development/python-modules/xmltodict { };
-
-  xml-marshaller = callPackage ../development/python-modules/xml-marshaller { };
 
   xmod = callPackage ../development/python-modules/xmod { };
 
@@ -19207,13 +19241,13 @@ self: super: with self; {
 
   xsdata = callPackage ../development/python-modules/xsdata { };
 
+  xstatic = callPackage ../development/python-modules/xstatic { };
+
   xstatic-asciinema-player = callPackage ../development/python-modules/xstatic-asciinema-player { };
 
   xstatic-bootbox = callPackage ../development/python-modules/xstatic-bootbox { };
 
   xstatic-bootstrap = callPackage ../development/python-modules/xstatic-bootstrap { };
-
-  xstatic = callPackage ../development/python-modules/xstatic { };
 
   xstatic-font-awesome = callPackage ../development/python-modules/xstatic-font-awesome { };
 
@@ -19233,13 +19267,13 @@ self: super: with self; {
 
   xxhash = callPackage ../development/python-modules/xxhash { };
 
-  xdxf2html = callPackage ../development/python-modules/xdxf2html { };
-
   xyzservices = callPackage ../development/python-modules/xyzservices { };
 
   y-py = callPackage ../development/python-modules/y-py { };
 
   yabadaba = callPackage ../development/python-modules/yabadaba { };
+
+  yacs = callPackage ../development/python-modules/yacs { };
 
   yalesmartalarmclient = callPackage ../development/python-modules/yalesmartalarmclient { };
 
@@ -19285,8 +19319,6 @@ self: super: with self; {
 
   yattag = callPackage ../development/python-modules/yattag { };
 
-  yacs = callPackage ../development/python-modules/yacs { };
-
   ydata-profiling = callPackage ../development/python-modules/ydata-profiling { };
 
   ydiff = callPackage ../development/python-modules/ydiff { };
@@ -19313,27 +19345,27 @@ self: super: with self; {
 
   youtube-dl-light = callPackage ../tools/misc/youtube-dl { ffmpegSupport = false; };
 
-  youtubeaio = callPackage ../development/python-modules/youtubeaio { };
-
-  yoyo-migrations = callPackage ../development/python-modules/yoyo-migrations { };
-
-  yt-dlp = toPythonModule (pkgs.yt-dlp.override { python3Packages = self; });
-
-  yt-dlp-light = toPythonModule (pkgs.yt-dlp-light.override { python3Packages = self; });
-
-  yt-dlp-dearrow = callPackage ../development/python-modules/yt-dlp-dearrow { };
-
   youtube-search = callPackage ../development/python-modules/youtube-search { };
 
   youtube-search-python = callPackage ../development/python-modules/youtube-search-python { };
 
   youtube-transcript-api = callPackage ../development/python-modules/youtube-transcript-api { };
 
+  youtubeaio = callPackage ../development/python-modules/youtubeaio { };
+
   yowsup = callPackage ../development/python-modules/yowsup { };
+
+  yoyo-migrations = callPackage ../development/python-modules/yoyo-migrations { };
 
   ypy-websocket = callPackage ../development/python-modules/ypy-websocket { };
 
   yq = callPackage ../development/python-modules/yq { inherit (pkgs) jq; };
+
+  yt-dlp = toPythonModule (pkgs.yt-dlp.override { python3Packages = self; });
+
+  yt-dlp-dearrow = callPackage ../development/python-modules/yt-dlp-dearrow { };
+
+  yt-dlp-light = toPythonModule (pkgs.yt-dlp-light.override { python3Packages = self; });
 
   yte = callPackage ../development/python-modules/yte { };
 
@@ -19343,14 +19375,14 @@ self: super: with self; {
 
   yubico-client = callPackage ../development/python-modules/yubico-client { };
 
-  z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };
-
   z3-solver =
     (toPythonModule (
       (pkgs.z3.override { inherit python; }).overrideAttrs (_: {
         pname = "z3-solver";
       })
     )).python;
+
+  z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };
 
   zabbix-utils = callPackage ../development/python-modules/zabbix-utils { };
 
@@ -19498,9 +19530,9 @@ self: super: with self; {
 
   zulip-emoji-mapping = callPackage ../development/python-modules/zulip-emoji-mapping { };
 
-  zwave-me-ws = callPackage ../development/python-modules/zwave-me-ws { };
-
   zwave-js-server-python = callPackage ../development/python-modules/zwave-js-server-python { };
+
+  zwave-me-ws = callPackage ../development/python-modules/zwave-me-ws { };
 
   zxcvbn = callPackage ../development/python-modules/zxcvbn { };
 


### PR DESCRIPTION
[keep-sorted](https://github.com/google/keep-sorted) is a language-agnostic formatter that sorts lines between two markers in a larger file.

This is a first step to use keep-sorted to enforce sorting in nixpkgs, adding a CI job and sorting python-packages.nix (as it had a quite uniform structure already). The nixfmt format comes in handy here, as the way blocks are formatted make it really easy for keep-sorted.

As the workflow has pull_request_target trigger, it won't run on this PR, I've tested it on my fork: https://github.com/katexochen/nixpkgs/actions/runs/13934128359/job/38998162445?pr=1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
