### PR TITLE
vulkan-cts: 1.3.10.0 -> 1.4.1.3

### DIFF
--- a/pkgs/by-name/vu/vulkan-cts/package.nix
+++ b/pkgs/by-name/vu/vulkan-cts/package.nix
@@ -107,6 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     # For vulkan-validation-layers
     "-DGLSLANG_INSTALL_DIR=${glslang}"
     "-DSPIRV_HEADERS_INSTALL_DIR=${spirv-headers}"
+    "-DSELECTED_BUILD_TARGETS=deqp-vk"
   ];
 
   postInstall = ''
@@ -114,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     ! test -e $out
 
     mkdir -p $out/bin $out/archive-dir
-    cp -a external/vulkancts/modules/vulkan/deqp-vk external/vulkancts/modules/vulkan/deqp-vksc $out/bin/
+    cp -a external/vulkancts/modules/vulkan/deqp-vk $out/bin/
     cp -a external/vulkancts/modules/vulkan/vulkan $out/archive-dir/
     cp -a external/vulkancts/modules/vulkan/vk-default $out/
 

--- a/pkgs/by-name/vu/vulkan-cts/package.nix
+++ b/pkgs/by-name/vu/vulkan-cts/package.nix
@@ -45,13 +45,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vulkan-cts";
-  version = "1.3.10.0";
+  version = "1.4.1.3";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "VK-GL-CTS";
     rev = "vulkan-cts-${finalAttrs.version}";
-    hash = "sha256-owa4Z/gu9+plPxeSfduS3gUk9WTOHSDoXLTBju6tTGc=";
+    hash = "sha256-44UGGeuKMCP4fLsZnIPdWDjozd87su9TUbFBnftVrNY=";
   };
 
   prePatch = ''

--- a/pkgs/by-name/vu/vulkan-cts/sources.nix
+++ b/pkgs/by-name/vu/vulkan-cts/sources.nix
@@ -4,15 +4,15 @@ rec {
   amber = fetchFromGitHub {
     owner = "google";
     repo = "amber";
-    rev = "67fea651b886460d7b72295e680528c059bbbe40";
-    hash = "sha256-oDN7UdyfNMG4r36nnRJmYdbd0wyd1titGQQNa9e/3tU=";
+    rev = "1ec5e96db7e0343d045a52c590e30eba154f74a8";
+    hash = "sha256-4LoV7PfkwLrg+7GyuB1poC/9zE/3jy8nhs+uPe2U3lA=";
   };
 
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "c5b76b78c9dec95251e9c1840a671e19bf61abe3";
-    hash = "sha256-N7vGPqQieWnr+mbrmdbvzz7n9q3bbRKLxkYt6OiaJvU=";
+    rev = "3a2834e7702651043ca9f35d022739e740563516";
+    hash = "sha256-hHmqvdgBS23bLGCzlKJtlElw79/WvxEbPSwpbQFHQYY=";
   };
 
   jsoncpp = fetchFromGitHub {
@@ -25,40 +25,54 @@ rec {
   nvidia-video-samples = fetchFromGitHub {
     owner = "Igalia";
     repo = "vk_video_samples";
-    rev = "6821adf11eb4f84a2168264b954c170d03237699";
-    hash = "sha256-prshOzxUHLYi64Pbyytsp+XvmtIIyhx/3n5IVimYH64=";
+    rev = "45fe88b456c683120138f052ea81f0a958ff3ec4";
+    hash = "sha256-U5IoiRKXsdletVlnHVz8rgMEwDOZFAuld5Bzs0rvcR4=";
   };
 
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "2a9b6f951c7d6b04b6c21fe1bf3f475b68b84801";
-    hash = "sha256-o1yRTvP7a+XVwendTKBJKNnelVGWLD0gH258GGeUDhQ=";
+    rev = "36d5e2ddaa54c70d2f29081510c66f4fc98e5e53";
+    hash = "sha256-8hx8/1vaY4mRnfNaBsghWqpzyzY4hkVkNFbQEFZif9g=";
   };
 
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "44936c4a9d42f1c67e34babb5792adf5bce7f76b";
-    hash = "sha256-kSiP94hMlblFod2mQhlAQDAENGOvBh7v8bCxxaiYWq4=";
+    rev = "3fb52548bc8a68d349d31e21bd4e80e3d953e87c";
+    hash = "sha256-RJ3Q3U4GjqvUXDy8Jd4NWgjhKOxYMMK1Jerj19dAqno=";
+  };
+
+  video_generator = fetchFromGitHub {
+    owner = "Igalia";
+    repo = "video_generator";
+    rev = "426300e12a5cc5d4676807039a1be237a2b68187";
+    hash = "sha256-zdYYpX3hed7i5onY7c60LnM/e6PLa3VdrhXTV9oSlvg=";
   };
 
   vulkan-docs = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Docs";
-    rev = "486e4b289053a7d64784e7ce791711843c60c235";
-    hash = "sha256-LGAHUeWF9X6Li1HcdD14pgnBUquWxA+bQpAL09JmwLQ=";
+    rev = "c7a3955e47d223c6a37fb29e2061c973eec98d0a";
+    hash = "sha256-dTkLzENuEfe0TVvJAgYevJNPyI/lWbjx8Pzz3Lj76PY=";
   };
 
   vulkan-validationlayers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
-    rev = "9a46ae006fa5c92e2d2af7944187f7794210844b";
-    hash = "sha256-qVQy3kKkZRWHjtj2YxJTZqKg1kwnmLa3bgVathisfOc=";
+    rev = "902f3cf8d51e76be0c0deb4be39c6223abebbae2";
+    hash = "sha256-p4DFlyU1jjfVFlEOE21aNHfqaTZ8QbSCFQfpsYS0KR0=";
+  };
+
+  vulkan-video-samples = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-Video-Samples";
+    rev = "0e87744edbb84c9c56c3fc8de9ea5150af5ee4ea";
+    hash = "sha256-CZ1zoX9gI+Ac/jf2IxWk59NXPiW6qcMhj9laoZnQfd8=";
   };
 
   prePatch = ''
-    mkdir -p external/amber external/glslang external/jsoncpp external/nvidia-video-samples external/spirv-headers external/spirv-tools external/vulkan-docs external/vulkan-validationlayers
+    mkdir -p external/amber external/glslang external/jsoncpp external/nvidia-video-samples external/spirv-headers external/spirv-tools external/video_generator external/vulkan-docs external/vulkan-validationlayers external/vulkan-video-samples
 
     cp -r ${amber} external/amber/src
     cp -r ${glslang} external/glslang/src
@@ -66,7 +80,9 @@ rec {
     cp -r ${nvidia-video-samples} external/nvidia-video-samples/src
     cp -r ${spirv-headers} external/spirv-headers/src
     cp -r ${spirv-tools} external/spirv-tools/src
+    cp -r ${video_generator} external/video_generator/src
     cp -r ${vulkan-docs} external/vulkan-docs/src
     cp -r ${vulkan-validationlayers} external/vulkan-validationlayers/src
+    cp -r ${vulkan-video-samples} external/vulkan-video-samples/src
   '';
 }

--- a/pkgs/by-name/vu/vulkan-cts/vk-cts-sources.py
+++ b/pkgs/by-name/vu/vulkan-cts/vk-cts-sources.py
@@ -74,7 +74,7 @@ def main():
                 f.write(f"    hash = \"{hash}\";\n");
                 f.write(f"  }};\n");
 
-        f.write("\n\n  prePatch = ''\n");
+        f.write("\n  prePatch = ''\n");
         f.write("    mkdir -p");
         for pkg in pkgs:
             if isinstance(pkg, fetch_sources.GitRepo):


### PR DESCRIPTION
Vulkan SC (Safety Critical) CTS is separate from the Vulkan CTS. This change splits it out into a separate vulkansc-cts package, and uses the latest Vulkan SC CTS tag, vulkansc-cts-1.0.2.1 with this package.

Then, the Vulkan CTS is upgraded: 1.3.10.0 -> 1.4.1.2.

These changes were prompted by the Vulkan SC executable (deqp-vksc) failing to build with the newer Vulkan CTS version. This build failure is not a bug of the CTS as the vulkan-cts-* tags are for the Vulkan CTS and not the Vulkan SC CTS. In other words, vulkan-cts-* tags support the Vulkan CTS and vulcansc-cts-* tags support the Vulkan SC CTS.

I don't have access to a Vulkan SC setup, so I was only able to test this command (to dump the CTS test names) with the new vulkansc-cts package:
 * `deqp-vksc --deqp-runmode=txt-caselist`

Cc: @Flakebi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
