### PR TITLE
python312Packages.openai: 1.66.3 -> 1.68.2

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -19,10 +19,16 @@
   tqdm,
   typing-extensions,
 
+  # optional-dependencies (datalib)
   numpy,
   pandas,
   pandas-stubs,
+
+  # optional-dependencies (realtime)
   websockets,
+
+  # optional-dependencies (voice-helpers)
+  sounddevice,
 
   # check deps
   pytestCheckHook,
@@ -32,11 +38,15 @@
   pytest-asyncio,
   pytest-mock,
   respx,
+
+  # optional-dependencies toggle
+  withRealtime ? true,
+  withVoiceHelpers ? true,
 }:
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "1.66.3";
+  version = "1.68.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -45,24 +55,31 @@ buildPythonPackage rec {
     owner = "openai";
     repo = "openai-python";
     tag = "v${version}";
-    hash = "sha256-T9ZW/93ovzJgLEjLgzp/4bPezONxqlYNFpe6U8a7q/A=";
+    hash = "sha256-TA+gr6cFGFlbAUqfgSbLFsoKdSZktPwk6DUfeq99PsM=";
   };
+
+  postPatch = ''substituteInPlace pyproject.toml --replace-fail "hatchling==1.26.3" "hatchling"'';
 
   build-system = [
     hatchling
     hatch-fancy-pypi-readme
   ];
 
-  dependencies = [
-    anyio
-    distro
-    httpx
-    jiter
-    pydantic
-    sniffio
-    tqdm
-    typing-extensions
-  ] ++ optional-dependencies.realtime;
+  dependencies =
+    [
+      anyio
+      distro
+      httpx
+      jiter
+      numpy
+      pydantic
+      sniffio
+      sounddevice
+      tqdm
+      typing-extensions
+    ]
+    ++ lib.optionals withRealtime optional-dependencies.realtime
+    ++ lib.optionals withVoiceHelpers optional-dependencies.voice-helpers;
 
   optional-dependencies = {
     datalib = [
@@ -72,6 +89,10 @@ buildPythonPackage rec {
     ];
     realtime = [
       websockets
+    ];
+    voice-helpers = [
+      numpy
+      sounddevice
     ];
   };
 


### PR DESCRIPTION
Update to latest version. Remove very specific version requirement on `hatchling`, and add new dependencies.

Diff: https://github.com/openai/openai-python/compare/refs/tags/v1.66.3...v1.68.2
Changelog: https://github.com/openai/openai-python/blob/v1.68.2/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
