### PR TITLE
fish: fix aarch64-linux test failures

### DIFF
--- a/pkgs/by-name/fi/fish/1d78c8bd4295262a3118f478e6b3a7c7536fa282.patch
+++ b/pkgs/by-name/fi/fish/1d78c8bd4295262a3118f478e6b3a7c7536fa282.patch
@@ -1,0 +1,74 @@
+From 1d78c8bd4295262a3118f478e6b3a7c7536fa282 Mon Sep 17 00:00:00 2001
+From: Johannes Altmanninger <aclopte@gmail.com>
+Date: Wed, 19 Mar 2025 09:39:04 +0100
+Subject: [PATCH] Fix concurrent setlocale() in string escape tests
+
+In our C++ implementation, these tests were run serially.  As pointed out in
+https://github.com/fish-shell/fish-shell/issues/11254#issuecomment-2735623229
+we run them in parallel now, which means that one test could be changing
+the global locale used by another.
+
+In theory this could be fine because all tests are setting setting the
+global locale to the same thing but the existence of a lock suggests that
+setlocale() is not guaranteed to be atomic, so it's possible that another
+thread uses a temporarily-invalid locale.
+
+Fixes #11254
+---
+ src/tests/string_escape.rs | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/src/tests/string_escape.rs b/src/tests/string_escape.rs
+index ba8ee7534ebf..4428d679cd35 100644
+--- a/src/tests/string_escape.rs
++++ b/src/tests/string_escape.rs
+@@ -1,3 +1,5 @@
++use std::sync::MutexGuard;
++
+ use crate::common::{
+     escape_string, str2wcstring, unescape_string, wcs2string, EscapeFlags, EscapeStringStyle,
+     UnescapeStringStyle, ENCODE_DIRECT_BASE, ENCODE_DIRECT_END,
+@@ -10,21 +12,21 @@ use rand::{Rng, RngCore};
+ 
+ /// wcs2string is locale-dependent, so ensure we have a multibyte locale
+ /// before using it in a test.
+-fn setlocale() {
+-    let _guard = LOCALE_LOCK.lock().unwrap();
++fn setlocale() -> MutexGuard<'static, ()> {
++    let guard = LOCALE_LOCK.lock().unwrap();
+ 
+     #[rustfmt::skip]
+     const UTF8_LOCALES: &[&str] = &[
+         "C.UTF-8", "en_US.UTF-8", "en_GB.UTF-8", "de_DE.UTF-8", "C.utf8", "UTF-8",
+     ];
+     if crate::libc::MB_CUR_MAX() > 1 {
+-        return;
++        return guard;
+     }
+     for locale in UTF8_LOCALES {
+         let locale = std::ffi::CString::new(locale.to_owned()).unwrap();
+         unsafe { libc::setlocale(libc::LC_CTYPE, locale.as_ptr()) };
+         if crate::libc::MB_CUR_MAX() > 1 {
+-            return;
++            return guard;
+         }
+     }
+     panic!("No UTF-8 locale found");
+@@ -100,7 +102,7 @@ fn test_escape_var() {
+ }
+ 
+ fn escape_test(escape_style: EscapeStringStyle, unescape_style: UnescapeStringStyle) {
+-    setlocale();
++    let _locale_guard = setlocale();
+     let seed: u128 = 92348567983274852905629743984572;
+     let mut rng = get_seeded_rng(seed);
+ 
+@@ -174,7 +176,7 @@ fn str2hex(input: &[u8]) -> String {
+ /// string comes back through double conversion.
+ #[test]
+ fn test_convert() {
+-    setlocale();
++    let _locale_guard = setlocale();
+     let seed = get_rng_seed();
+     let mut rng = get_seeded_rng(seed);
+     let mut origin = Vec::new();

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -188,6 +188,10 @@ stdenv.mkDerivation (finalAttrs: {
     # * <https://github.com/LnL7/nix-darwin/issues/122>
     # * <https://github.com/fish-shell/fish-shell/issues/7142>
     ./nix-darwin-path.patch
+
+    # remove 4.0.2
+    # https://github.com/fish-shell/fish-shell/issues/11254
+    ./1d78c8bd4295262a3118f478e6b3a7c7536fa282.patch
   ];
 
   # Fix FHS paths in tests
@@ -317,16 +321,12 @@ stdenv.mkDerivation (finalAttrs: {
       darwin.system_cmds
     ];
 
+  # we target the top-level make target which runs all the cmake/ctest
+  # tests, including test_cargo-test
   checkTarget = "fish_run_tests";
   preCheck = ''
     export TERMINFO="${ncurses}/share/terminfo"
   '';
-  checkFlags = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    # thread 'tests::string_escape::test_escape_random_url' panicked at src/tests/string_escape.rs:122:9:
-    # assertion `left == right` failed: Escaped and then unescaped string ... but got back a different string ...
-    # https://github.com/fish-shell/fish-shell/issues/11254
-    "--skip=tests::string_escape::test_escape_random_url"
-  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Apply upstream fix.

Previously #389895
Closes #390901
Fixed #389377
Upstream https://github.com/fish-shell/fish-shell/issues/11254


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
