### PR TITLE
[Backport release-24.11] buildNpmPackage: support finalAttrs through lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -7,6 +7,11 @@
   cctools,
 }@topLevelArgs:
 
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs:
 {
   name ? "${args.pname}-${args.version}",
   src ? null,
@@ -77,9 +82,7 @@ let
     inherit nodejs;
   };
 in
-stdenv.mkDerivation (
-  args
-  // {
+{
     inherit npmDeps npmBuildScript;
 
     nativeBuildInputs =
@@ -103,5 +106,5 @@ stdenv.mkDerivation (
     meta = (args.meta or { }) // {
       platforms = args.meta.platforms or nodejs.meta.platforms;
     };
-  }
-)
+  };
+}

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -12,99 +12,99 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? "${args.pname}-${args.version}",
-  src ? null,
-  srcs ? null,
-  sourceRoot ? null,
-  prePatch ? "",
-  patches ? [ ],
-  postPatch ? "",
-  patchFlags ? [ ],
-  nativeBuildInputs ? [ ],
-  buildInputs ? [ ],
-  # The output hash of the dependencies for this project.
-  # Can be calculated in advance with prefetch-npm-deps.
-  npmDepsHash ? "",
-  # Whether to force the usage of Git dependencies that have install scripts, but not a lockfile.
-  # Use with care.
-  forceGitDeps ? false,
-  # Whether to force allow an empty dependency cache.
-  # This can be enabled if there are truly no remote dependencies, but generally an empty cache indicates something is wrong.
-  forceEmptyCache ? false,
-  # Whether to make the cache writable prior to installing dependencies.
-  # Don't set this unless npm tries to write to the cache directory, as it can slow down the build.
-  makeCacheWritable ? false,
-  # The script to run to build the project.
-  npmBuildScript ? "build",
-  # Flags to pass to all npm commands.
-  npmFlags ? [ ],
-  # Flags to pass to `npm ci`.
-  npmInstallFlags ? [ ],
-  # Flags to pass to `npm rebuild`.
-  npmRebuildFlags ? [ ],
-  # Flags to pass to `npm run ${npmBuildScript}`.
-  npmBuildFlags ? [ ],
-  # Flags to pass to `npm pack`.
-  npmPackFlags ? [ ],
-  # Flags to pass to `npm prune`.
-  npmPruneFlags ? npmInstallFlags,
-  # Value for npm `--workspace` flag and directory in which the files to be installed are found.
-  npmWorkspace ? null,
-  nodejs ? topLevelArgs.nodejs,
-  npmDeps ? fetchNpmDeps {
-    inherit
-      forceGitDeps
-      forceEmptyCache
-      src
-      srcs
-      sourceRoot
-      prePatch
-      patches
-      postPatch
-      patchFlags
-      ;
-    name = "${name}-npm-deps";
-    hash = npmDepsHash;
-  },
-  # Custom npmConfigHook
-  npmConfigHook ? null,
-  # Custom npmBuildHook
-  npmBuildHook ? null,
-  # Custom npmInstallHook
-  npmInstallHook ? null,
-  ...
-}@args:
+    {
+      name ? "${args.pname}-${args.version}",
+      src ? null,
+      srcs ? null,
+      sourceRoot ? null,
+      prePatch ? "",
+      patches ? [ ],
+      postPatch ? "",
+      patchFlags ? [ ],
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+      # The output hash of the dependencies for this project.
+      # Can be calculated in advance with prefetch-npm-deps.
+      npmDepsHash ? "",
+      # Whether to force the usage of Git dependencies that have install scripts, but not a lockfile.
+      # Use with care.
+      forceGitDeps ? false,
+      # Whether to force allow an empty dependency cache.
+      # This can be enabled if there are truly no remote dependencies, but generally an empty cache indicates something is wrong.
+      forceEmptyCache ? false,
+      # Whether to make the cache writable prior to installing dependencies.
+      # Don't set this unless npm tries to write to the cache directory, as it can slow down the build.
+      makeCacheWritable ? false,
+      # The script to run to build the project.
+      npmBuildScript ? "build",
+      # Flags to pass to all npm commands.
+      npmFlags ? [ ],
+      # Flags to pass to `npm ci`.
+      npmInstallFlags ? [ ],
+      # Flags to pass to `npm rebuild`.
+      npmRebuildFlags ? [ ],
+      # Flags to pass to `npm run ${npmBuildScript}`.
+      npmBuildFlags ? [ ],
+      # Flags to pass to `npm pack`.
+      npmPackFlags ? [ ],
+      # Flags to pass to `npm prune`.
+      npmPruneFlags ? npmInstallFlags,
+      # Value for npm `--workspace` flag and directory in which the files to be installed are found.
+      npmWorkspace ? null,
+      nodejs ? topLevelArgs.nodejs,
+      npmDeps ? fetchNpmDeps {
+        inherit
+          forceGitDeps
+          forceEmptyCache
+          src
+          srcs
+          sourceRoot
+          prePatch
+          patches
+          postPatch
+          patchFlags
+          ;
+        name = "${name}-npm-deps";
+        hash = npmDepsHash;
+      },
+      # Custom npmConfigHook
+      npmConfigHook ? null,
+      # Custom npmBuildHook
+      npmBuildHook ? null,
+      # Custom npmInstallHook
+      npmInstallHook ? null,
+      ...
+    }@args:
 
-let
-  # .override {} negates splicing, so we need to use buildPackages explicitly
-  npmHooks = buildPackages.npmHooks.override {
-    inherit nodejs;
-  };
-in
-{
-    inherit npmDeps npmBuildScript;
+    let
+      # .override {} negates splicing, so we need to use buildPackages explicitly
+      npmHooks = buildPackages.npmHooks.override {
+        inherit nodejs;
+      };
+    in
+    {
+      inherit npmDeps npmBuildScript;
 
-    nativeBuildInputs =
-      nativeBuildInputs
-      ++ [
-        nodejs
-        # Prefer passed hooks
-        (if npmConfigHook != null then npmConfigHook else npmHooks.npmConfigHook)
-        (if npmBuildHook != null then npmBuildHook else npmHooks.npmBuildHook)
-        (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
-        nodejs.python
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
-    buildInputs = buildInputs ++ [ nodejs ];
+      nativeBuildInputs =
+        nativeBuildInputs
+        ++ [
+          nodejs
+          # Prefer passed hooks
+          (if npmConfigHook != null then npmConfigHook else npmHooks.npmConfigHook)
+          (if npmBuildHook != null then npmBuildHook else npmHooks.npmBuildHook)
+          (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
+          nodejs.python
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
+      buildInputs = buildInputs ++ [ nodejs ];
 
-    strictDeps = true;
+      strictDeps = true;
 
-    # Stripping takes way too long with the amount of files required by a typical Node.js project.
-    dontStrip = args.dontStrip or true;
+      # Stripping takes way too long with the amount of files required by a typical Node.js project.
+      dontStrip = args.dontStrip or true;
 
-    meta = (args.meta or { }) // {
-      platforms = args.meta.platforms or nodejs.meta.platforms;
+      meta = (args.meta or { }) // {
+        platforms = args.meta.platforms or nodejs.meta.platforms;
+      };
     };
-  };
 }

--- a/pkgs/by-name/fi/filen-cli/package.nix
+++ b/pkgs/by-name/fi/filen-cli/package.nix
@@ -1,0 +1,59 @@
+{
+  stdenv,
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "filen-cli";
+  version = "0.0.29";
+
+  src = fetchFromGitHub {
+    owner = "FilenCloudDienste";
+    repo = "filen-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ftbRv75x6o1HgElY4oLBBe5SRuLtxdrjpjZznSCyroI=";
+  };
+
+  npmDepsHash = "sha256-a+sq0vFsk4c7bl0Nn2KfBFxyq3ZF2HPvt8d1vxegnHg=";
+
+  postPatch = ''
+    # The filen-cli repository does not contain the correct version string;
+    # it is replaced during publishing in the same way:
+    # https://github.com/FilenCloudDienste/filen-cli/blob/c7d5eb2a2cd6d514321992815f16475f6909af36/.github/workflows/build-and-publish.yml#L24
+    substituteInPlace package.json \
+      --replace-fail '"version": "0.0.0"' '"version": "${finalAttrs.version}"'
+  '';
+
+  # A special random 256-bit string called CRYPTO_BASE_KEY has to be injected
+  # during build. It can be randomly generated using the generateKey.mjs
+  # script, however, generating a key here will invalidate the session on every
+  # rebuild, and hence we need to provide a constant key. The key below is
+  # extracted from the official filen-cli releases. Example:
+  # $ strings filen-cli-v0.0.29-linux-x64 | grep checkInjectedBuildInfo -A 6
+  # That also makes the session data compatible with the official distribution.
+  env.FILEN_CLI_CRYPTO_BASE_KEY = "f47fb2011c90d8aad21f7415d19989cea2c1ac8bc674daf36af48de8697a83e0";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/filen";
+  versionCheckProgramArg = [ "--version" ];
+
+  # Writes $HOME/Library/Application Support on darwin
+  doInstallCheck = !stdenv.hostPlatform.isDarwin;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
+  };
+
+  meta = {
+    description = "CLI tool for interacting with the Filen cloud";
+    homepage = "https://github.com/FilenCloudDienste/filen-cli";
+    changelog = "https://github.com/FilenCloudDienste/filen-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ eilvelia ];
+    mainProgram = "filen";
+  };
+})


### PR DESCRIPTION
A most diligent backport to release-24.11 has been undertaken by human hands, prompted by a most considerate remark in #390099.

Before it is ushered into the fold, let us ensure that it is indeed a fitting addition to this release. Even those not bestowed with the power to commit may, upon discerning any unseemly aspects, offer their observations in earnest.

The most recent commit has been most judiciously cherry-picked, serving as a fine exemplar for consideration.