### PR TITLE
nixos/initrd: add extraFirmwarePaths option

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -19,6 +19,7 @@ let
     kernel = config.system.modulesTree;
     firmware = config.hardware.firmware;
     allowMissing = false;
+    inherit (config.boot.initrd) extraFirmwarePaths;
   };
 
 
@@ -481,6 +482,14 @@ in
       type = types.listOf types.str;
       description = ''
         Other initrd files to prepend to the final initrd we are building.
+      '';
+    };
+
+    boot.initrd.extraFirmwarePaths = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = ''
+        Other firmware files (relative to `"''${config.hardware.firmware}/lib/firmware"`) to include in the final initrd we are building.
       '';
     };
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -105,6 +105,7 @@ let
     kernel = config.system.modulesTree;
     firmware = config.hardware.firmware;
     allowMissing = false;
+    inherit (config.boot.initrd) extraFirmwarePaths;
   };
 
   initrdBinEnv = pkgs.buildEnv {

--- a/pkgs/build-support/kernel/modules-closure.nix
+++ b/pkgs/build-support/kernel/modules-closure.nix
@@ -11,6 +11,7 @@
   rootModules,
   kmod,
   allowMissing ? false,
+  extraFirmwarePaths ? [ ],
 }:
 
 stdenvNoCC.mkDerivation {
@@ -25,6 +26,7 @@ stdenvNoCC.mkDerivation {
     firmware
     rootModules
     allowMissing
+    extraFirmwarePaths
     ;
   allowedReferences = [ "out" ];
 }

--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -87,6 +87,15 @@ for module in $(< ~-/closure); do
     done || :
 done
 
+for path in $extraFirmwarePaths; do
+    mkdir -p $(dirname $out/lib/firmware/$path)
+    for name in "$path" "$path.xz" "$path.zst" ""; do
+        if cp -v --parents --no-preserve=mode lib/firmware/$name "$out" 2>/dev/null; then
+            break
+        fi
+    done
+done
+
 if test -e lib/firmware/edid ; then
     echo "lib/firmware/edid found, copying."
     mkdir -p "$out/lib/firmware"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -709,9 +709,9 @@ with pkgs;
 
   compressFirmwareZstd = callPackage ../build-support/kernel/compress-firmware.nix { type = "zstd"; };
 
-  makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:
+  makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false, extraFirmwarePaths ? [ ] }:
     callPackage ../build-support/kernel/modules-closure.nix {
-      inherit kernel firmware rootModules allowMissing;
+      inherit kernel firmware rootModules allowMissing extraFirmwarePaths;
     };
 
   mkBinaryCache = callPackage ../build-support/binary-cache { };


### PR DESCRIPTION
Some platforms don't specify firmware needed by kernel drivers in the driver code itself (i.e. [query-able with modinfo](https://github.com/nixos/nixpkgs/blob/cdc1e34423c71bfe786c6dacaae2a0dcfd3d22cd/pkgs/build-support/kernel/modules-closure.sh#L79)). Platforms that use devicetree often specify firmware in the devicetree itself (to see what boards do this from a linux source tree, run `grep -r 'firmware-name =' arch/*/boot/dts`). Since our existing initrd builder cannot auto-detect all firmware to include in this case outlined above, we should provide a way to specify extra firmware files to include in the initrd.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
