### PR TITLE
nixos/limine: Fix reading generations for primary profile and specialisations

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -29,10 +29,12 @@ def config(*path: List[str]) -> Optional[Any]:
 
 
 def get_system_path(profile: str = 'system', gen: Optional[str] = None, spec: Optional[str] = None) -> str:
+    basename = f'{profile}-{gen}-link' if gen is not None else profile
+    profiles_dir = '/nix/var/nix/profiles'
     if profile == 'system':
-        result = os.path.join('/nix', 'var', 'nix', 'profiles', 'system')
+        result = os.path.join(profiles_dir, basename)
     else:
-        result = os.path.join('/nix', 'var', 'nix', 'profiles', 'system-profiles', profile + f'-{gen}-link' if gen is not None else '')
+        result = os.path.join(profiles_dir, 'system-profiles', basename)
 
     if spec is not None:
         result = os.path.join(result, 'specialisation', spec)
@@ -169,8 +171,8 @@ def generate_config_entry(profile: str, gen: str) -> str:
     boot_spec = bootjson_to_bootspec(boot_json)
 
     entry = config_entry(2, boot_spec, f'Generation {gen}', time)
-    for spec in boot_spec.specialisations:
-        entry += config_entry(2, boot_spec, f'Generation {gen}, Specialisation {spec}', str(time))
+    for spec, spec_boot_spec in boot_spec.specialisations.items():
+        entry += config_entry(2, spec_boot_spec, f'Generation {gen}, Specialisation {spec}', str(time))
     return entry
 
 


### PR DESCRIPTION
Previously, all generations for the primary system profile read their data from the currently active one rather than their own path, and specialisations in general all used their parent bootspec rather than their own. This fixes both issues.

This commit still uses the parent path's build date for specialisations, but this is more minor issue and the times shouldn't be meaningfully different in most cases anyways.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* Read system generations from `system-{gen}-link` rather than `system`
* Read boot-spec for specialisations from the specialisation entry of the parent boot-spec

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
