### PR TITLE
photoprism: 240711-2197af848 -> 250321-57590c48b

### DIFF
--- a/pkgs/by-name/ph/photoprism/backend.nix
+++ b/pkgs/by-name/ph/photoprism/backend.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     substituteInPlace internal/commands/passwd.go --replace '/bin/stty' "${coreutils}/bin/stty"
   '';
 
-  vendorHash = "sha256-eKMcSqAJ+11+50A/3vOC1UJ/Z517J4wdrmkyfRkpBGE=";
+  vendorHash = "sha256-eHdnTpcVBSvGR9ZiK6A32jfjik8VClDTkv92bD8EIgA=";
 
   subPackages = [ "cmd/photoprism" ];
 

--- a/pkgs/by-name/ph/photoprism/backend.nix
+++ b/pkgs/by-name/ph/photoprism/backend.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     substituteInPlace internal/commands/passwd.go --replace '/bin/stty' "${coreutils}/bin/stty"
   '';
 
-  vendorHash = "sha256-6xE1j/Vh9ltE6TpBkvjK4rzLyXv8OJzy84vf9Iqw3yU=";
+  vendorHash = "sha256-eKMcSqAJ+11+50A/3vOC1UJ/Z517J4wdrmkyfRkpBGE=";
 
   subPackages = [ "cmd/photoprism" ];
 

--- a/pkgs/by-name/ph/photoprism/frontend.nix
+++ b/pkgs/by-name/ph/photoprism/frontend.nix
@@ -13,7 +13,7 @@ buildNpmPackage {
     cd frontend
   '';
 
-  npmDepsHash = "sha256-1bo/mJ6cmidd3oduLFMNOBHUB18yvYPyEocoUE/ziyo=";
+  npmDepsHash = "sha256-3cytU/QaPSsGu/984AEh3YsdV4H5cjf/br3NSc5Zd1M=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ph/photoprism/frontend.nix
+++ b/pkgs/by-name/ph/photoprism/frontend.nix
@@ -13,7 +13,7 @@ buildNpmPackage {
     cd frontend
   '';
 
-  npmDepsHash = "sha256-y2Mj0sJP2urTDrsVPReVFi7G9fLjuKz76vDPLvkaMFA=";
+  npmDepsHash = "sha256-1bo/mJ6cmidd3oduLFMNOBHUB18yvYPyEocoUE/ziyo=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -17,14 +17,14 @@
 }:
 
 let
-  version = "250228-43447fa38";
+  version = "250321-57590c48b";
   pname = "photoprism";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-7WN3XRASKdRZODXkHiKUcYITUtIS1o6b0xoqfL3i5xs=";
+    hash = "sha256-tJA1Q8kcX4UYDCV+rmHyd5gfEU8WkoaqNfx1/0Iy3l8=";
   };
 
   libtensorflow = callPackage ./libtensorflow.nix { };

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -17,14 +17,14 @@
 }:
 
 let
-  version = "240711-2197af848";
+  version = "250228-43447fa38";
   pname = "photoprism";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    hash = "sha256-ihDv5c5RUjDbFcAHJjzp/8qCwKfA+rlFXPziaYarzs8=";
+    hash = "sha256-7WN3XRASKdRZODXkHiKUcYITUtIS1o6b0xoqfL3i5xs=";
   };
 
   libtensorflow = callPackage ./libtensorflow.nix { };


### PR DESCRIPTION
Update to the most recent version.
https://github.com/photoprism/photoprism/releases/tag/250321-57590c48b
https://github.com/photoprism/photoprism/releases/tag/240915-e1280b2fb https://github.com/photoprism/photoprism/releases/tag/250223-b79d21907 https://github.com/photoprism/photoprism/releases/tag/250224-834c16bc7 https://github.com/photoprism/photoprism/releases/tag/250228-43447fa38

https://github.com/photoprism/photoprism/releases/tag/250321-57590c48b


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
