### PR TITLE
pythonPackages.wxpython: drop SDL dependency

### DIFF
--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -29,7 +29,6 @@
   libglvnd,
   libgbm,
   pango,
-  SDL,
   webkitgtk_4_0,
   wxGTK,
   xorgproto,
@@ -71,7 +70,6 @@ buildPythonPackage rec {
     attrdict
     pkg-config
     setuptools
-    SDL
     sip
     which
     wxGTK
@@ -80,7 +78,6 @@ buildPythonPackage rec {
   buildInputs =
     [
       wxGTK
-      SDL
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       gst_all_1.gst-plugins-base
@@ -108,7 +105,6 @@ buildPythonPackage rec {
 
     export DOXYGEN=${doxygen}/bin/doxygen
     export PATH="${wxGTK}/bin:$PATH"
-    export SDL_CONFIG="${lib.getExe' (lib.getDev SDL) "sdl-config"}"
     export WAF=$PWD/bin/waf
 
     ${python.pythonOnBuildForHost.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py


### PR DESCRIPTION
this dependency was unused:

```
$ nix why-depends .#python313Packages.wxpython .#SDL --precise --all
these 5 paths will be fetched (4.96 MiB download, 21.60 MiB unpacked):
  /nix/store/vhz0cn55wadyknv3bz4in7drm0mmpny3-SDL_compat-1.2.68
  /nix/store/jfia42fgcpz2gmb5l1mqps5qaaan3lcn-libadwaita-1.6.4
  /nix/store/555981fqc4rkjdfapzsw092bqyrbi5s3-sdl2-compat-2.32.52
  /nix/store/kq5gmdxv139qk1j50grxlqvrsrlx9aq5-sdl3-3.2.6-lib
  /nix/store/d9vlzcqg021zzyw6vwc7dfin8lbm86a1-zenity-4.0.5
'git+file:///home/grimmauld/nixpkgs#python313Packages.wxpython' does not depend on 'git+file:///home/grimmauld/nixpkgs#SDL'
```

```
$ nix why-depends .#python313Packages.wxpython .#SDL --derivation --all
/nix/store/79x3l16rh508qmbprz7xslqvd568gd8z-python3.13-wxpython-4.2.2.drv
└───/nix/store/s0kxrg633g9j5yvqiw1d2dgw76hg5r53-SDL_compat-1.2.68.drv
```

This is output from `staging-next` branch. Current master still has a dependency via ffmpeg/libvisual which has been dropped on staging. But no direct dependency on SDL either.

Pinging @mweinelt as maintainer of wxpython

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
