### PR TITLE
cudaPackages.tensorrt: 10.8.0.43 -> 10.9.0.34

### DIFF
--- a/pkgs/development/cuda-modules/tensorrt/releases.nix
+++ b/pkgs/development/cuda-modules/tensorrt/releases.nix
@@ -127,6 +127,22 @@
         filename = "TensorRT-10.8.0.43.Linux.x86_64-gnu.cuda-12.8.tar.gz";
         hash = "sha256-V31tivU4FTQUuYZ8ZmtPZYUvwusefA6jogbl+vvH1J4=";
       }
+      {
+        version = "10.9.0.34";
+        minCudaVersion = "11.0";
+        maxCudaVersion = "11.8";
+        cudnnVersion = "8.9";
+        filename = "TensorRT-10.9.0.34.Linux.x86_64-gnu.cuda-11.8.tar.gz";
+        hash = "sha256-nQtdgeOIxRA8RsL3ZvQHeBxA4dbJvyWEoFvmSxPaBLA=";
+      }
+      {
+        version = "10.9.0.34";
+        minCudaVersion = "12.0";
+        maxCudaVersion = "12.8";
+        cudnnVersion = "9.7";
+        filename = "TensorRT-10.9.0.34.Linux.x86_64-gnu.cuda-12.8.tar.gz";
+        hash = "sha256-M74OYeO/F3u7yrtIkr8BPwyKxx0r5z8oA4SKOCyxQnI=";
+      }
     ];
   };
 }

--- a/pkgs/development/python-modules/tensorrt/default.nix
+++ b/pkgs/development/python-modules/tensorrt/default.nix
@@ -10,10 +10,22 @@
 
 let
   pyVersion = "${lib.versions.major python.version}${lib.versions.minor python.version}";
+  buildVersion = lib.optionalString (cudaPackages ? tensorrt) cudaPackages.tensorrt.version;
+  wheelVersion = lib.optionalString (cudaPackages ? tensorrt) (
+    if
+      (builtins.elem buildVersion [
+        "8.6.1.6"
+        "10.3.0.26"
+      ])
+    then
+      builtins.concatStringsSep "." (lib.take 3 (builtins.splitVersion buildVersion))
+    else
+      buildVersion
+  );
 in
 buildPythonPackage rec {
   pname = "tensorrt";
-  version = lib.optionalString (cudaPackages ? tensorrt) cudaPackages.tensorrt.version;
+  version = wheelVersion;
 
   src = cudaPackages.tensorrt.src;
 
@@ -30,7 +42,7 @@ buildPythonPackage rec {
   preUnpack = ''
     mkdir -p dist
     tar --strip-components=2 -xf "$src" --directory=dist \
-      "TensorRT-${version}/python/tensorrt-${version}-cp${pyVersion}-none-linux_x86_64.whl"
+      "TensorRT-${buildVersion}/python/tensorrt-${wheelVersion}-cp${pyVersion}-none-linux_x86_64.whl"
   '';
 
   sourceRoot = ".";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates tensorrt to 10.9 ([release notes](https://docs.nvidia.com/deeplearning/tensorrt/latest/getting-started/release-notes.html#tensorrt-10-9-0)). Not sure which cudnn to set for the CUDA 12 version as the [support matrix](https://docs.nvidia.com/deeplearning/tensorrt/latest/getting-started/support-matrix.html) only lists 8.9, so I used the same one as 10.8.

Also fixes python module builds for some older versions where the version is missing the build number.

cc @prusnak 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
