### PR TITLE
treewide: fix and improve some `src`s

### DIFF
--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "0.44";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/devilspie2/devilspie2-${version}.tar.xz";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.xz";
     sha256 = "Cp8erdKyKjGBY+QYAGXUlSIboaQ60gIepoZs0RgEJkA=";
   };
 

--- a/pkgs/applications/misc/devilspie2/default.nix
+++ b/pkgs/applications/misc/devilspie2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://savannah/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "Cp8erdKyKjGBY+QYAGXUlSIboaQ60gIepoZs0RgEJkA=";
+    hash = "sha256-Cp8erdKyKjGBY+QYAGXUlSIboaQ60gIepoZs0RgEJkA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/radio/klog/default.nix
+++ b/pkgs/applications/radio/klog/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "1.3.2";
 
   src = fetchurl {
-    url = "https://download.savannah.nongnu.org/releases/klog/${pname}-${version}.tar.gz";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1d5x7rq0mgfrqws3q1y4z8wh2qa3gvsmd0ssf2yqgkyq3fhdrb5c";
   };
 

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -221,7 +221,13 @@
 
   # GNU Savannah
   savannah = [
-    # Mirrors from https://download-mirror.savannah.gnu.org/releases/00_MIRRORS.html
+    # Try the official HTTP(S) dispatchers first.
+    # These generate redirects to mirrors appropriate for the user.
+    "https://download.savannah.gnu.org/releases/"
+    "https://download.savannah.nongnu.org/releases/"
+
+    # If the above fail, try some individual mirrors.
+    # These are taken from https://download-mirror.savannah.gnu.org/releases/00_MIRRORS.html
     "https://mirror.easyname.at/nongnu/"
     "https://savannah.c3sl.ufpr.br/"
     "https://mirror.csclub.uwaterloo.ca/nongnu/"

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -215,8 +215,8 @@
 
   # SAMBA
   samba = [
-    "https://www.samba.org/ftp/"
-    "http://www.samba.org/ftp/"
+    "https://download.samba.org/pub/"
+    "http://download.samba.org/pub/"
   ];
 
   # GNU Savannah

--- a/pkgs/by-name/cu/cuyo/package.nix
+++ b/pkgs/by-name/cu/cuyo/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "2.1.0";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/cuyo/cuyo-2.1.0.tar.gz";
+    url = "mirror://savannah/cuyo/cuyo-2.1.0.tar.gz";
     sha256 = "17yqv924x7yvwix7yz9jdhgyar8lzdhqvmpvv0any8rdkajhj23c";
   };
 

--- a/pkgs/by-name/fa/fastjar/package.nix
+++ b/pkgs/by-name/fa/fastjar/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchzip {
     pname = "fastjar-source";
     inherit (finalAttrs) version;
-    url = "https://download.savannah.gnu.org/releases/fastjar/fastjar-${finalAttrs.version}.tar.gz";
+    url = "mirror://savannah/fastjar/fastjar-${finalAttrs.version}.tar.gz";
     hash = "sha256-8VyKNQaPLrXAy/UEm2QkBx56SSSoLdU/7w4IwrxbsQc=";
   };
 

--- a/pkgs/by-name/gu/guile-reader/package.nix
+++ b/pkgs/by-name/gu/guile-reader/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "0.6.3";
 
   src = fetchurl {
-    url = "http://download.savannah.nongnu.org/releases/${pname}/${pname}-${version}.tar.gz";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
     hash = "sha256-OMK0ROrbuMDKt42QpE7D6/9CvUEMW4SpEBjO5+tk0rs=";
   };
 

--- a/pkgs/by-name/m1/m17n_db/package.nix
+++ b/pkgs/by-name/m1/m17n_db/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "1.8.9";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/m17n/m17n-db-${version}.tar.gz";
+    url = "mirror://savannah/m17n/${pname}-${version}.tar.gz";
     sha256 = "sha256-SBJUo4CqnGbX9Ow6o3Kn4dL+R/w53252BEvUQBfEJKQ=";
   };
 

--- a/pkgs/by-name/m1/m17n_db/package.nix
+++ b/pkgs/by-name/m1/m17n_db/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://savannah/m17n/${pname}-${version}.tar.gz";
-    sha256 = "sha256-SBJUo4CqnGbX9Ow6o3Kn4dL+R/w53252BEvUQBfEJKQ=";
+    hash = "sha256-SBJUo4CqnGbX9Ow6o3Kn4dL+R/w53252BEvUQBfEJKQ=";
   };
 
   nativeBuildInputs = [ gettext ];

--- a/pkgs/by-name/mi/mi2ly/package.nix
+++ b/pkgs/by-name/mi/mi2ly/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://savannah/${pname}/${pname}.${version}.tar.bz2";
-    sha256 = "sha256-lFbqH+syFaQDMbXfb+OUcWnyKnjfVz9yl7DbTTn7JKw=";
+    hash = "sha256-lFbqH+syFaQDMbXfb+OUcWnyKnjfVz9yl7DbTTn7JKw=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/mi/mi2ly/package.nix
+++ b/pkgs/by-name/mi/mi2ly/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "0.12";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/mi2ly/mi2ly.${version}.tar.bz2";
+    url = "mirror://savannah/${pname}/${pname}.${version}.tar.bz2";
     sha256 = "sha256-lFbqH+syFaQDMbXfb+OUcWnyKnjfVz9yl7DbTTn7JKw=";
   };
 

--- a/pkgs/by-name/nm/nmh/package.nix
+++ b/pkgs/by-name/nm/nmh/package.nix
@@ -60,8 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "New MH Mail Handling System";
     homepage = "https://nmh.nongnu.org/";
-    downloadPage = "http://download.savannah.nongnu.org/releases/nmh/";
-    changelog = "http://savannah.nongnu.org/news/?group=nmh";
+    downloadPage = "https://download.savannah.nongnu.org/releases/nmh/";
+    changelog = "https://savannah.nongnu.org/news/?group=nmh";
     license = [ lib.licenses.bsd3 ];
     longDescription = ''
       This is the nmh mail user agent (reader/sender), a command-line based

--- a/pkgs/by-name/sk/skribilo/package.nix
+++ b/pkgs/by-name/sk/skribilo/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
 
   src = fetchurl {
-    url = "http://download.savannah.nongnu.org/releases/skribilo/skribilo-${finalAttrs.version}.tar.gz";
+    url = "mirror://savannah/skribilo/skribilo-${finalAttrs.version}.tar.gz";
     hash = "sha256-jP9I7hds7f1QMmSaNJpGlSvqUOwGcg+CnBzMopIS9Q4=";
   };
 

--- a/pkgs/by-name/st/storeBackup/package.nix
+++ b/pkgs/by-name/st/storeBackup/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ];
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/storebackup/storeBackup-${version}.tar.bz2";
+    url = "mirror://savannah/storebackup/storeBackup-${version}.tar.bz2";
     hash = "sha256-Ki1DT2zypFFiiMVd9Y8eSX7T+yr8moWMoALmAexjqWU=";
   };
 

--- a/pkgs/by-name/xl/xlog/package.nix
+++ b/pkgs/by-name/xl/xlog/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "2.0.25";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/xlog/${pname}-${version}.tar.gz";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
     sha256 = "sha256-NYC3LgoLXnJQURcZTc2xHOzOleotrWtOETMBgadf2qU=";
   };
 

--- a/pkgs/by-name/xl/xlog/package.nix
+++ b/pkgs/by-name/xl/xlog/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-NYC3LgoLXnJQURcZTc2xHOzOleotrWtOETMBgadf2qU=";
+    hash = "sha256-NYC3LgoLXnJQURcZTc2xHOzOleotrWtOETMBgadf2qU=";
   };
 
   # glib-2.62 deprecations

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -21,7 +21,12 @@ lib.fix (
     version = "1.3.7";
 
     src = fetchurl {
-      url = "https://www.aleksey.com/xmlsec/download/xmlsec1-${version}.tar.gz";
+      urls = [
+        "https://www.aleksey.com/xmlsec/download/xmlsec1-${version}.tar.gz"
+
+        # for when the ${version} gets older than the last two
+        "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-${version}.tar.gz"
+      ];
       sha256 = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
     };
 

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -27,7 +27,7 @@ lib.fix (
         # for when the ${version} gets older than the last two
         "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-${version}.tar.gz"
       ];
-      sha256 = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
+      hash = "sha256-2C6TtpuKogWmFrYpF6JpMiv2Oj6q+zd1AU5hdSsgE+o=";
     };
 
     patches = [

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -192,7 +192,7 @@ buildPythonPackage rec {
       doCheck = true;
       freetype = freetype.overrideAttrs (_: {
         src = fetchurl {
-          url = "https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz";
+          url = "mirror://savannah/freetype/freetype-old/freetype-2.6.1.tar.gz";
           sha256 = "sha256-Cjx9+9ptoej84pIy6OltmHq6u79x68jHVlnkEyw2cBQ=";
         };
         patches = [ ];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -193,7 +193,7 @@ buildPythonPackage rec {
       freetype = freetype.overrideAttrs (_: {
         src = fetchurl {
           url = "mirror://savannah/freetype/freetype-old/freetype-2.6.1.tar.gz";
-          sha256 = "sha256-Cjx9+9ptoej84pIy6OltmHq6u79x68jHVlnkEyw2cBQ=";
+          hash = "sha256-Cjx9+9ptoej84pIy6OltmHq6u79x68jHVlnkEyw2cBQ=";
         };
         patches = [ ];
       });

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   version = "1.8.4";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/m17n/m17n-lib-${version}.tar.gz";
+    url = "mirror://savannah/m17n/${pname}-${version}.tar.gz";
     hash = "sha256-xqJYLG5PKowueihE+lx+s2Oq0lOLBS8gPHEGSd1CHMg=";
   };
 

--- a/pkgs/tools/inputmethods/m17n-lib/otf.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/otf.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "0.9.16";
 
   src = fetchurl {
-    url = "https://download.savannah.gnu.org/releases/m17n/${pname}-${version}.tar.gz";
+    url = "mirror://savannah/m17n/${pname}-${version}.tar.gz";
     sha256 = "0sq6g3xaxw388akws6qrllp3kp2sxgk2dv4j79k6mm52rnihrnv8";
   };
 


### PR DESCRIPTION
This fixes some source-related build failures I noticed while building nixpkgs without using cache.nixos.org, and then adds some related improvements on top, to make these particular issues less likely in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
- With
  - [X] `sandbox = true`
- [X] This should be a noop, since no hashes change.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
