### PR TITLE
treewide: fix some more `sourceRoot`s

### DIFF
--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -45,7 +45,7 @@ let
   };
 in
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   inherit pname version;
 
   # Use `fetchFromGitHub` instead of `fetchCrate` because the latter does not
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage {
 
   # Upstream doesn't include the lockfile so we need to add it back
   postUnpack = ''
-    cp ${cargoLock} source/Cargo.lock
+    cp ${cargoLock} ${finalAttrs.src.name}/Cargo.lock
   '';
 
   useFetchCargoVendor = true;
@@ -103,4 +103,4 @@ rustPlatform.buildRustPackage {
     # The profiler runtime is (currently) disabled on non-Linux platforms
     broken = !(stdenv.hostPlatform.isLinux && !stdenv.targetPlatform.isRedox);
   };
-}
+})

--- a/pkgs/by-name/fi/firmware-updater/package.nix
+++ b/pkgs/by-name/fi/firmware-updater/package.nix
@@ -5,13 +5,13 @@
   fetchFromGitHub,
 }:
 
-flutter.buildFlutterApplication {
+flutter.buildFlutterApplication rec {
   pname = "firmware-updater";
   version = "0-unstable-2024-20-11";
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
 
-  sourceRoot = "./source/apps/firmware_updater";
+  sourceRoot = "${src.name}/apps/firmware_updater";
 
   gitHashes = {
     fwupd = "sha256-l/+HrrJk1mE2Mrau+NmoQ7bu9qhHU6wX68+m++9Hjd4=";

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     hash = "sha256-Ir+/ZZJHm6E+044wczU3UvL+Py9Wprgw2QKJaYyDrKU=";
   };
 
-  sourceRoot = "source/src/runtime";
+  sourceRoot = "${src.name}/src/runtime";
 
   vendorHash = null;
 

--- a/pkgs/by-name/ni/nitrokey-start-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-start-firmware/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   postPatch = ''
     patchShebangs configure

--- a/pkgs/by-name/ni/nitrokey-storage-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-storage-firmware/package.nix
@@ -50,7 +50,7 @@ in
 stdenv.mkDerivation {
   inherit pname version src;
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/ni/nitrokey-trng-rs232-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-trng-rs232-firmware/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ pkgsCross.avr.stdenv.cc ];
 
-  sourceRoot = "source/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
 
   makeFlags = [ "all" ];
 

--- a/pkgs/by-name/ps/ps3netsrv/package.nix
+++ b/pkgs/by-name/ps/ps3netsrv/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-ynFuCD+tp8E/DDdB/HU9BCmwKcmQy6NBx26MKnP4W0o=";
   };
 
-  sourceRoot = "./source/${pname}";
+  sourceRoot = "${src.name}/${pname}";
 
   buildInputs = [
     meson

--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     patchShebangs ../vpp-api/
   '';
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   enableParallelBuilding = true;
   env.NIX_CFLAGS_COMPILE = "-Wno-error -Wno-array-bounds -Wno-maybe-uninitialized";

--- a/pkgs/by-name/xa/xar/package.nix
+++ b/pkgs/by-name/xa/xar/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # We do not use or modify files outside of the xar subdirectory.
   patchFlags = [ "-p2" ];
-  sourceRoot = "source/xar";
+  sourceRoot = "${finalAttrs.src.name}/xar";
 
   outputs = [
     "out"

--- a/pkgs/development/coq-modules/Vpl/default.nix
+++ b/pkgs/development/coq-modules/Vpl/default.nix
@@ -14,7 +14,7 @@ mkCoqDerivation {
 
   release."0.5".sha256 = "sha256-mSD/xSweeK9WMxWDdX/vzN96iXo74RkufjuNvtzsP9o=";
 
-  sourceRoot = "source/coq";
+  setSourceRoot = "sourceRoot=$(echo */coq)";
 
   meta = {
     description = "Coq interface to VPL abstract domain of convex polyhedra";

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -216,8 +216,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   postUnpack = ''
-    patchShebangs source/doc/*.py
-    patchShebangs source/doc/input-filter-h.sh
+    patchShebangs ${finalAttrs.src.name}/doc/*.py
+    patchShebangs ${finalAttrs.src.name}/doc/input-filter-h.sh
   '';
 
   postInstall = ''

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -67,7 +67,7 @@ let
         pname = "indi-3rdparty-${pname}";
         inherit src version;
 
-        sourceRoot = "source/${pname}";
+        sourceRoot = "${src.name}/${pname}";
 
         cmakeFlags =
           [

--- a/pkgs/development/python-modules/biliass/default.nix
+++ b/pkgs/development/python-modules/biliass/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-IrzFjjMNuD5UgdccHxIxZoeZpM1PGtVQRTWHOocnmAU=";
   };
 
-  sourceRoot = "source/packages/biliass";
+  sourceRoot = "${src.name}/packages/biliass";
   cargoRoot = "rust";
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -177,7 +177,7 @@ buildPythonPackage rec {
 
     requiredSystemFeatures = [ "big-parallel" ];
 
-    sourceRoot = "source/py-polars";
+    sourceRoot = "${src.name}/py-polars";
     postPatch = ''
       for f in * ; do
         [[ "$f" == "tests" ]] || \

--- a/pkgs/development/tools/analysis/rr/zen_workaround.nix
+++ b/pkgs/development/tools/analysis/rr/zen_workaround.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   pname = "rr-zen_workaround";
 
   inherit (rr) src version;
-  sourceRoot = "source/third-party/zen-pmu-workaround";
+  sourceRoot = "${rr.src.name}/third-party/zen-pmu-workaround";
 
   hardeningDisable = [ "pic" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   # See https://github.com/baduhai/Koi/blob/master/development/Nix%20OS/dev.nix
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
@@ -21,7 +21,7 @@ let
   baseAttrs = finalAttrs: {
     releaseName = "ICU";
 
-    sourceRoot = "source/icu/icu4c/source";
+    sourceRoot = "${finalAttrs.src.name}/icu/icu4c/source";
 
     patches = [
       # Skip MessageFormatTest test, which is known to crash sometimes and should be suppressed if it does.

--- a/pkgs/os-specific/darwin/apple-source-releases/locale/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/locale/package.nix
@@ -6,7 +6,7 @@
   stdenvNoCC,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "locale";
   version = "118";
 
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-KzaAlqXqfJW2s31qmA0D7qteaZY57Va2o86aZrwyR74=";
   };
 
-  sourceRoot = "source/usr-share-locale.tproj";
+  sourceRoot = "${finalAttrs.src.name}/usr-share-locale.tproj";
 
   postPatch = ''
     # bmake expects `Makefile` not `BSDmakefile`.
@@ -60,4 +60,4 @@ stdenvNoCC.mkDerivation {
     ];
     maintainers = lib.teams.darwin.members;
   };
-}
+})

--- a/pkgs/tools/networking/curl-impersonate/chrome/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/chrome/default.nix
@@ -95,13 +95,13 @@ stdenv.mkDerivation rec {
 
   postUnpack =
     lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (name: dep: "ln -sT ${dep.outPath} source/${name}") (
+      lib.mapAttrsToList (name: dep: "ln -sT ${dep.outPath} ${src.name}/${name}") (
         lib.filterAttrs (n: v: v ? outPath) passthru.deps
       )
     )
     + ''
 
-      curltar=$(realpath -s source/curl-*.tar.gz)
+      curltar=$(realpath -s ${src.name}/curl-*.tar.gz)
 
       pushd "$(mktemp -d)"
 

--- a/pkgs/tools/networking/curl-impersonate/firefox/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/firefox/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
   dontUseNinjaCheck = true;
 
   postUnpack = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (name: dep: "ln -sT ${dep.outPath} source/${name}") (
+    lib.mapAttrsToList (name: dep: "ln -sT ${dep.outPath} ${src.name}/${name}") (
       lib.filterAttrs (n: v: v ? outPath) passthru.deps
     )
   );


### PR DESCRIPTION
Continuation of #248528 with more things that were since discovered to be broken with non-default values of `config.fetchedSourceNameDefault` of #49862.

I.e. this replaces more references to `fetchzip`'s "source" in `sourceRoot` package attribute with `src.name` and similar.

Should be a noop (up to some tiny changes causing micro-rebuilds).