### PR TITLE
haskellPackages.postgres-websockets: adopt & unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2479,6 +2479,17 @@ self: super: {
   # unbreak with tasty-quickcheck 0.11, can be dropped for Stackage LTS >= 23.9
   text-builder = doDistribute self.text-builder_0_6_7_3;
 
+  postgres-websockets = lib.pipe super.postgres-websockets [
+    (addTestToolDepends [ pkgs.postgresql pkgs.postgresqlTestHook ])
+    (dontCheckIf pkgs.postgresqlTestHook.meta.broken)
+    (overrideCabal {
+      preCheck = ''
+        export postgresqlEnableTCP=1
+        export PGDATABASE=postgres_ws_test
+      '';
+    })
+  ];
+
   postgrest = lib.pipe
     (super.postgrest.overrideScope (self: super: {
       # 2025-01-19: Upstream is stuck at hasql < 1.7

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4496,7 +4496,6 @@ broken-packages:
   - postgresql-typed-lifted # failure in job https://hydra.nixos.org/build/233215141 at 2023-09-02
   - postgres-tmp # failure in job https://hydra.nixos.org/build/233258685 at 2023-09-02
   - postgrest-ws # failure in job https://hydra.nixos.org/build/233247807 at 2023-09-02
-  - postgres-websockets # failure in job https://hydra.nixos.org/build/233199923 at 2023-09-02
   - postie # failure in job https://hydra.nixos.org/build/233259075 at 2023-09-02
   - postmark-streams # failure in job https://hydra.nixos.org/build/233233210 at 2023-09-02
   - postmaster # failure in job https://hydra.nixos.org/build/233258599 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -677,6 +677,7 @@ package-maintainers:
     - warp-systemd
     - amazonka
   wolfgangwalther:
+    - postgres-websockets
     - postgrest
 
 unsupported-platforms:


### PR DESCRIPTION
Asked for some bumps and a new release in https://github.com/diogob/postgres-websockets/pull/101.

In the meantime, this makes it build again - and even run the tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
