### PR TITLE
synapse-http-antispam: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/default.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/default.nix
@@ -7,4 +7,5 @@
   matrix-synapse-pam = callPackage ./pam.nix { };
   matrix-synapse-s3-storage-provider = callPackage ./s3-storage-provider.nix { };
   matrix-synapse-shared-secret-auth = callPackage ./shared-secret-auth.nix { };
+  synapse-http-antispam = callPackage ./synapse-http-antispam.nix { };
 }

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/synapse-http-antispam.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/synapse-http-antispam.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  matrix-synapse-unwrapped,
+  nix-update-script,
+  twisted,
+}:
+
+buildPythonPackage rec {
+  pname = "synapse-http-antispam";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "maunium";
+    repo = "synapse-http-antispam";
+    tag = "v${version}";
+    hash = "sha256-wWm23+3o+/nx3xGkyShJm28mDPTbOhPbKgW3WfuB0Ng=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "synapse_http_antispam" ];
+
+  buildInputs = [ matrix-synapse-unwrapped ];
+  dependencies = [ twisted ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Synapse module that forwards spam checking to an HTTP server";
+    homepage = "https://github.com/maunium/synapse-http-antispam";
+    changelog = "https://github.com/maunium/synapse-http-antispam/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sumnerevans ];
+  };
+}


### PR DESCRIPTION
I don't know if this is the correct place to put Synapse plugins anymore. Maybe it should be in by-name/sy/synapse-http-antispam?

https://github.com/maunium/synapse-http-antispam/releases/tag/v0.3.0

Signed-off-by: Sumner Evans <me@sumnerevans.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I'm using this on my homeserver with meowlnir.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
