### PR TITLE
doc: add section on inkscape plugins

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -14,6 +14,7 @@ fish.section.md
 fuse.section.md
 geant4.section.md
 ibus.section.md
+inkscape.section.md
 kakoune.section.md
 krita.section.md
 linux.section.md

--- a/doc/packages/inkscape.section.md
+++ b/doc/packages/inkscape.section.md
@@ -1,0 +1,29 @@
+# Inkscape {#sec-inkscape}
+
+[Inkscape](https://inkscape.org) is a powerful vector graphics editor.
+
+## Plugins {#inkscape-plugins}
+Inkscape plugins are collected in the [`inkscape-extensions`](https://search.nixos.org/packages?channel=unstable&type=packages&query=cudaPackages) package set.
+To enable them, use an override on `inkscape-with-extensions`:
+
+```nix
+inkscape-with-extensions.override {
+  inkscapeExtensions = with inkscape-extensions; [
+    inkstitch
+  ];
+}
+```
+
+Similarly, this works in the shell:
+
+```bash
+$ nix-shell -p 'inkscape-with-extensions.override { inkscapeExtensions = with inkscape-extensions; [inkstitch]; }'
+[nix-shell:~]$ # Ink/Stitch is now available via the extension menu
+[nix-shell:~]$ inkscape
+```
+
+All available extension can be enabled by passing `inkscapeExtensions = null;`.
+
+::: {.note}
+Loading the Inkscape extensions stand-alone (without using `override`) does not affect Inkscape at all.
+:::

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -17,6 +17,9 @@
   "ex-testEqualArrayOrMap-test-function-add-cowbell": [
     "index.html#ex-testEqualArrayOrMap-test-function-add-cowbell"
   ],
+  "inkscape-plugins": [
+    "index.html#inkscape-plugins"
+  ],
   "neovim": [
     "index.html#neovim"
   ],
@@ -61,6 +64,9 @@
   ],
   "sec-build-helper-extendMkDerivation": [
     "index.html#sec-build-helper-extendMkDerivation"
+  ],
+  "sec-inkscape": [
+    "index.html#sec-inkscape"
   ],
   "sec-language-cosmic": [
     "index.html#sec-language-cosmic"


### PR DESCRIPTION
This expands the documentation by a section on Inkscape and its plugins.

It answers the questions I had when using them, so I hope it's good enough for everyday usage.

This is my first commit on documentation, and the redirects didn't work properly for me by just launching `nix-shell` and then `devmode`.
I've compared it to existing entries in `redirects.json` and the documentation, and recon it should work though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
