### PR TITLE
Reapply "build(deps): bump cachix/install-nix-action from 30 to 31"

### DIFF
--- a/.github/workflows/check-maintainers-sorted.yml
+++ b/.github/workflows/check-maintainers-sorted.yml
@@ -20,7 +20,7 @@ jobs:
             lib
             maintainers
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 

--- a/.github/workflows/check-nix-format.yml
+++ b/.github/workflows/check-nix-format.yml
@@ -44,7 +44,7 @@ jobs:
           rev=$(jq -r .rev ci/pinned-nixpkgs.json)
           echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
           nix_path: nixpkgs=${{ env.url }}

--- a/.github/workflows/check-nixf-tidy.yml
+++ b/.github/workflows/check-nixf-tidy.yml
@@ -34,7 +34,7 @@ jobs:
           rev=$(jq -r .rev ci/pinned-nixpkgs.json)
           echo "url=https://github.com/NixOS/nixpkgs/archive/$rev.tar.gz" >> "$GITHUB_ENV"
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
           nix_path: nixpkgs=${{ env.url }}

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
 
       - name: Build shell
         run: nix-build shell.nix

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -45,7 +45,7 @@ jobs:
     needs: get-merge-commit
     if: github.repository_owner == 'NixOS' && needs.get-merge-commit.outputs.mergedSha
     steps:
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
 
       # Important: Because we use pull_request_target, this checks out the base branch of the PR, not the PR head.
       # This is intentional, because we need to request the review of owners as declared in the base branch.

--- a/.github/workflows/editorconfig-v2.yml
+++ b/.github/workflows/editorconfig-v2.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           # nixpkgs commit is pinned so that it doesn't break
           # editorconfig-checker 2.4.0

--- a/.github/workflows/eval-lib-tests.yml
+++ b/.github/workflows/eval-lib-tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -43,7 +43,7 @@ jobs:
           echo "targetSha=$targetSha" >> "$GITHUB_OUTPUT"
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 
@@ -71,7 +71,7 @@ jobs:
           path: nixpkgs
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 
@@ -108,7 +108,7 @@ jobs:
           path: nixpkgs
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 
@@ -149,7 +149,7 @@ jobs:
           path: nixpkgs
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 
@@ -254,7 +254,7 @@ jobs:
           path: comparison
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+        uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
 
       # Important: This workflow job runs with extra permissions,
       # so we need to make sure to not run untrusted code from PRs

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
 

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
         if: ${{ env.CHANGED_FILES && env.CHANGED_FILES != '' }}
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
         with:
           extra_nix_config: sandbox = true
           nix_path: nixpkgs=channel:nixpkgs-unstable

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -43,7 +43,7 @@ jobs:
           git worktree add "$target" "$(git rev-parse HEAD^1)"
           echo "target=$target" >> "$GITHUB_ENV"
 
-      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
 
       - name: Fetching the pinned tool
         # Update the pinned version using ci/nixpkgs-vet/update-pinned-tool.sh

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -71,7 +71,15 @@ let
     getLabels
     ;
 
-  getAttrs = dir: builtins.fromJSON (builtins.readFile "${dir}/outpaths.json");
+  getAttrs =
+    dir:
+    let
+      raw = builtins.readFile "${dir}/outpaths.json";
+      # The file contains Nix paths; we need to ignore them for evaluation purposes,
+      # else there will be a "is not allowed to refer to a store path" error.
+      data = builtins.unsafeDiscardStringContext raw;
+    in
+    builtins.fromJSON data;
   beforeAttrs = getAttrs beforeResultDir;
   afterAttrs = getAttrs afterResultDir;
 


### PR DESCRIPTION
This was reverted in #390695, more discussion over there.

I was not able to reproduce the problem locally, but easily in my own fork by re-applying the commit:
https://github.com/wolfgangwalther/nixpkgs/actions/runs/13953151439/job/39057945183

I then applied the fix as suggested by @Mic92 in https://github.com/NixOS/nixpkgs/pull/390695#issuecomment-2729959688. This fixed it.

I also double-checked, the other uses of `builtins.fromJSON` (as well as `builtins.readFile`) in the ci-code are not going to deal with store paths, this is the only case.

Thus, it should be safe to re-apply this again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested in my fork
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
