### PR TITLE
nixosTests.limine.bios: init

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -39,6 +39,14 @@
 
   This partition layout is unsuitable for UEFI.
 
+  #### `legacy+boot`
+
+  The image is partitioned using MBR and:
+  - creates a FAT32 BOOT partition from 1MiB to specified `bootSize` parameter (256MiB by default), set it bootable ;
+  - creates a primary ext4 partition starting after the boot partition and extending to the full disk image
+
+  This partition layout is unsuitable for UEFI.
+
   #### `legacy+gpt`
 
   This partition table type uses GPT and:
@@ -106,7 +114,7 @@
   additionalSpace ? "512M",
 
   # size of the boot partition, is only used if partitionTableType is
-  # either "efi" or "hybrid"
+  # either "efi", "hybrid", or "legacy+boot"
   # This will be undersized slightly, as this is actually the offset of
   # the end of the partition. Generally it will be 1MiB smaller.
   bootSize ? "256M",
@@ -197,6 +205,7 @@
 assert (
   lib.assertOneOf "partitionTableType" partitionTableType [
     "legacy"
+    "legacy+boot"
     "legacy+gpt"
     "efi"
     "efixbootldr"
@@ -260,6 +269,7 @@ let
     {
       # switch-case
       legacy = "1";
+      "legacy+boot" = "2";
       "legacy+gpt" = "2";
       efi = "2";
       efixbootldr = "3";
@@ -274,6 +284,14 @@ let
         parted --script $diskImage -- \
           mklabel msdos \
           mkpart primary ext4 1MiB 100% \
+          print
+      '';
+      "legacy+boot" = ''
+        parted --script $diskImage -- \
+          mklabel msdos \
+          mkpart primary fat32 1MiB $bootSizeMiB \
+          set 1 boot on \
+          mkpart primary ext4 $bootSizeMiB 100% \
           print
       '';
       "legacy+gpt" = ''
@@ -540,6 +558,12 @@ let
                 # Add the 1MiB aligned reserved space (includes MBR)
                 reservedSpace=$(( mebibyte ))
               ''
+            else if partitionTableType == "legacy+boot" then
+              ''
+                # The explanation from the above "efi" case applies here too,
+                # but gptSpace is not needed without a GPT.
+                reservedSpace=$(( bootSize ))
+              ''
             else
               ''
                 reservedSpace=0
@@ -693,6 +717,11 @@ let
           mount /dev/vda2 /mnt/boot
 
           ${lib.optionalString touchEFIVars "mount -t efivarfs efivarfs /sys/firmware/efi/efivars"}
+        ''}
+        ${lib.optionalString (partitionTableType == "legacy+boot") ''
+          mkdir -p /mnt/boot
+          mkfs.vfat -n BOOT /dev/vda1
+          mount /dev/vda1 /mnt/boot
         ''}
 
         # Install a configuration.nix

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1159,6 +1159,9 @@ in
       `useBootLoader` useless. You might want to disable one of those options.
     '';
 
+    # Install Limine on the bootloader device
+    boot.loader.limine.biosDevice = cfg.bootLoaderDevice;
+
     # In UEFI boot, we use a EFI-only partition table layout, thus GRUB will fail when trying to install
     # legacy and UEFI. In order to avoid this, we have to put "nodev" to force UEFI-only installs.
     # Otherwise, we set the proper bootloader device for this.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -65,12 +65,12 @@ let
     {
       useEFIBoot,
       useDefaultFilesystems,
-      useBootPartition,
+      useBIOSBoot,
     }:
     if useDefaultFilesystems then
       if useEFIBoot then
         "efi"
-      else if useBootPartition then
+      else if useBIOSBoot then
         "legacy+boot"
       else
         "legacy"
@@ -350,7 +350,7 @@ let
     onlyNixStore = false;
     label = rootFilesystemLabel;
     partitionTableType = selectPartitionTableLayout {
-      inherit (cfg) useBootPartition useDefaultFilesystems useEFIBoot;
+      inherit (cfg) useBIOSBoot useDefaultFilesystems useEFIBoot;
     };
     installBootLoader = cfg.installBootLoader;
     touchEFIVars = cfg.useEFIBoot;
@@ -448,13 +448,13 @@ in
       default =
         if cfg.useEFIBoot then
           "/dev/disk/by-label/${espFilesystemLabel}"
-        else if cfg.useBootPartition then
+        else if cfg.useBIOSBoot then
           "/dev/disk/by-label/BOOT"
         else
           null;
       defaultText = literalExpression ''
         if cfg.useEFIBoot then "/dev/disk/by-label/${espFilesystemLabel}"
-        else if cfg.useBootPartition then "/dev/disk/by-label/BOOT"
+        else if cfg.useBIOSBoot then "/dev/disk/by-label/BOOT"
         else null'';
       example = "/dev/disk/by-label/esp";
       description = ''
@@ -952,11 +952,11 @@ in
       '';
     };
 
-    virtualisation.useBootPartition = mkEnableOption null // {
+    virtualisation.useBIOSBoot = mkEnableOption null // {
       description = ''
         If enabled for legacy MBR VMs, the VM image will have a separate boot
         partition mounted at /boot.
-        useBootPartition is ignored if useEFIBoot == true.
+        useBIOSBoot is ignored if useEFIBoot == true.
       '';
     };
 

--- a/nixos/tests/limine/bios.nix
+++ b/nixos/tests/limine/bios.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+{
+  name = "bios";
+  meta.maintainers = with lib.maintainers; [
+    lzcunt
+    phip1611
+    programmerlexi
+  ];
+  meta.platforms = [
+    "i686-linux"
+    "x86_64-linux"
+  ];
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useBootPartition = true;
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = false;
+      boot.loader.timeout = 0;
+    };
+
+  testScript = ''
+    machine.start()
+    with subtest('Machine boots correctly'):
+      machine.wait_for_unit('multi-user.target')
+  '';
+}

--- a/nixos/tests/limine/bios.nix
+++ b/nixos/tests/limine/bios.nix
@@ -14,7 +14,7 @@
     { ... }:
     {
       virtualisation.useBootLoader = true;
-      virtualisation.useBootPartition = true;
+      virtualisation.useBIOSBoot = true;
       boot.loader.limine.enable = true;
       boot.loader.limine.efiSupport = false;
       boot.loader.timeout = 0;

--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -3,6 +3,7 @@
   ...
 }:
 {
+  bios = runTest ./bios.nix;
   checksum = runTest ./checksum.nix;
   secureBoot = runTest ./secure-boot.nix;
   specialisations = runTest ./specialisations.nix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds a NixOS test for Limine on BIOS systems. This requires some infrastructure to build VMs with a separate FAT32 boot partition, required because Limine can't read ext4 partitions. This is useful because none of the Limine package and module maintainers have a proper setup to test BIOS systems - e.g. my and @programmerlexi's systems have broken CSM implementations - and we'd like to easily verify that there's no regressions for BIOS systems without waiting for a NixOS user on BIOS to test it and report any issues, this should reduce the number of review cycles needed for PRs to the Limine package or module.

This is my first nontrivial PR, please nitpick every bit of these patches. I enjoy fixing nitpicky stuff and I want this to be as tidy as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
