### PR TITLE
postfix: re-add no-warnings patch

### DIFF
--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -98,6 +98,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./postfix-script-shell.patch
     ./post-install-script.patch
+    ./postfix-3.0-no-warnings.patch
     ./relative-symlinks.patch
 
     # glibc 2.34 compat

--- a/pkgs/by-name/po/postfix/postfix-3.0-no-warnings.patch
+++ b/pkgs/by-name/po/postfix/postfix-3.0-no-warnings.patch
@@ -1,0 +1,86 @@
+diff -ru3 postfix-3.0.3/conf/postfix-script postfix-3.0.3-new/conf/postfix-script
+--- postfix-3.0.3/conf/postfix-script	2014-06-27 18:05:15.000000000 +0400
++++ postfix-3.0.3-new/conf/postfix-script	2016-01-09 17:51:38.545733631 +0300
+@@ -84,24 +84,6 @@
+ 	exit 1
+ }
+ 
+-# If this is a secondary instance, don't touch shared files.
+-
+-instances=`test ! -f $def_config_directory/main.cf ||
+-    $command_directory/postconf -qc $def_config_directory \
+-    -h multi_instance_directories | sed 'y/,/ /'` || {
+-	$FATAL cannot execute $command_directory/postconf!
+-	exit 1
+-}
+-
+-check_shared_files=1
+-for name in $instances
+-do
+-    case "$name" in
+-    "$def_config_directory") ;;
+-    "$config_directory") check_shared_files=; break;;
+-    esac
+-done
+-
+ #
+ # Parse JCL
+ #
+@@ -262,22 +244,6 @@
+ 	    -prune \( -perm -020 -o -perm -002 \) \
+ 	    -exec $WARN group or other writable: {} \;
+ 
+-	# Check Postfix root-owned directory tree owner/permissions.
+-
+-	todo="$config_directory/."
+-	test -n "$check_shared_files" && {
+-		todo="$daemon_directory/. $meta_directory/. $todo"
+-		test "$shlib_directory" = "no" || 
+-		    todo="$shlib_directory/. $todo"
+-	}
+-	todo=`echo "$todo" | tr ' ' '\12' | sort -u`
+-
+-	find $todo ! -user root \
+-	    -exec $WARN not owned by root: {} \;
+-
+-	find $todo \( -perm -020 -o -perm -002 \) \
+-	    -exec $WARN group or other writable: {} \;
+-
+ 	# Check Postfix mail_owner-owned directory tree owner/permissions.
+ 
+ 	find $data_directory/. ! -user $mail_owner \
+@@ -302,18 +268,11 @@
+ 	# Check Postfix setgid_group-owned directory and file group/permissions.
+ 
+ 	todo="$queue_directory/public $queue_directory/maildrop"
+-	test -n "$check_shared_files" && 
+-	   todo="$command_directory/postqueue $command_directory/postdrop $todo"
+ 
+ 	find $todo \
+ 	    -prune ! -group $setgid_group \
+ 	    -exec $WARN not owned by group $setgid_group: {} \;
+ 
+-	test -n "$check_shared_files" &&
+-	find $command_directory/postqueue $command_directory/postdrop \
+-	    -prune ! -perm -02111 \
+-	    -exec $WARN not set-gid or not owner+group+world executable: {} \;
+-
+ 	# Check non-Postfix root-owned directory tree owner/content.
+ 
+ 	for dir in bin etc lib sbin usr
+@@ -334,15 +293,6 @@
+ 
+ 	find corrupt -type f -exec $WARN damaged message: {} \;
+ 
+-	# Check for non-Postfix MTA remnants.
+-
+-	test -n "$check_shared_files" -a -f /usr/sbin/sendmail -a \
+-		-f /usr/lib/sendmail && {
+-	    cmp -s /usr/sbin/sendmail /usr/lib/sendmail || {
+-		$WARN /usr/lib/sendmail and /usr/sbin/sendmail differ
+-		$WARN Replace one by a symbolic link to the other
+-	    }
+-	}
+ 	exit 0
+ 	;;
+ 


### PR DESCRIPTION
This patch was removed in #383517, but is still needed for nixos-mailserver tests to pass
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
