### PR TITLE
ocamlPackages.logs: 0.7.0 → 0.8.0

### DIFF
--- a/pkgs/by-name/ac/acgtk/package.nix
+++ b/pkgs/by-name/ac/acgtk/package.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation {
     hash = "sha256-XuPcubt1lvnQio+km6MhmDu41NXNVXKKpzGd/Y1XzLo=";
   };
 
+  # Compatibility with logs 0.8.0
+  postPatch = ''
+    substituteInPlace src/utils/dune \
+      --replace-warn 'logs mtime' 'logs logs.fmt mtime'
+  '';
+
   strictDeps = true;
 
   nativeBuildInputs = with ocamlPackages; [

--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -27,6 +27,11 @@ buildDunePackage rec {
     hash = "sha256-k4iDUJik7UTuztBw7YaFXASd8SqYMR1JgLm3JOyriGA=";
   };
 
+  # Compatibility with logs 0.8.0
+  postPatch = ''
+    substituteInPlace test/unix/dune --replace-warn logs.fmt 'logs.fmt logs.threaded'
+  '';
+
   minimalOCamlVersion = "4.08";
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -11,7 +11,7 @@
   cmdliner,
   fmt,
   fmtSupport ? lib.versionAtLeast ocaml.version "4.08",
-  js_of_ocaml,
+  js_of_ocaml-compiler,
   jsooSupport ? true,
   lwtSupport ? true,
   cmdlinerSupport ? true,
@@ -22,8 +22,8 @@ let
 
   optional_deps = [
     {
-      pkg = js_of_ocaml;
-      enable_flag = "--with-js_of_ocaml";
+      pkg = js_of_ocaml-compiler;
+      enable_flag = "--with-js_of_ocaml-compiler";
       enabled = jsooSupport;
     }
     {
@@ -55,11 +55,11 @@ else
 
   stdenv.mkDerivation rec {
     name = "ocaml${ocaml.version}-${pname}-${version}";
-    version = "0.7.0";
+    version = "0.8.0";
 
     src = fetchurl {
       url = "${webpage}/releases/${pname}-${version}.tbz";
-      sha256 = "1jnmd675wmsmdwyb5mx5b0ac66g4c6gpv5s4mrx2j6pb0wla1x46";
+      hash = "sha256-mmFRQJX6QvMBIzJiO2yNYF1Ce+qQS2oNF3+OwziCNtg=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
