### PR TITLE
[Backport release-24.11] buildRustPackage: support fixed-point arguments via lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -18,6 +18,18 @@
   windows,
 }:
 
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
+    "depsExtraArgs"
+    "cargoUpdateHook"
+    "cargoDeps"
+    "cargoLock"
+  ];
+
+  extendDrvArgs =
+    finalAttrs:
 {
   name ? "${args.pname}-${args.version}",
 
@@ -116,15 +128,7 @@ let
   target = stdenv.hostPlatform.rust.rustcTargetSpec;
   targetIsJSON = lib.hasSuffix ".json" target;
 in
-
-stdenv.mkDerivation (
-  (removeAttrs args [
-    "depsExtraArgs"
-    "cargoUpdateHook"
-    "cargoDeps"
-    "cargoLock"
-  ])
-  // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
+  lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
     RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
   }
   // {
@@ -192,5 +196,5 @@ stdenv.mkDerivation (
       # default to Rust's platforms
       platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
     };
-  }
-)
+  };
+}

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -30,171 +30,171 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? "${args.pname}-${args.version}",
+    {
+      name ? "${args.pname}-${args.version}",
 
-  # Name for the vendored dependencies tarball
-  cargoDepsName ? name,
+      # Name for the vendored dependencies tarball
+      cargoDepsName ? name,
 
-  src ? null,
-  srcs ? null,
-  preUnpack ? null,
-  unpackPhase ? null,
-  postUnpack ? null,
-  cargoPatches ? [ ],
-  patches ? [ ],
-  sourceRoot ? null,
-  logLevel ? "",
-  buildInputs ? [ ],
-  nativeBuildInputs ? [ ],
-  cargoUpdateHook ? "",
-  cargoDepsHook ? "",
-  buildType ? "release",
-  meta ? { },
-  useFetchCargoVendor ? false,
-  cargoDeps ? null,
-  cargoLock ? null,
-  cargoVendorDir ? null,
-  checkType ? buildType,
-  buildNoDefaultFeatures ? false,
-  checkNoDefaultFeatures ? buildNoDefaultFeatures,
-  buildFeatures ? [ ],
-  checkFeatures ? buildFeatures,
-  useNextest ? false,
-  auditable ? !cargo-auditable.meta.broken,
+      src ? null,
+      srcs ? null,
+      preUnpack ? null,
+      unpackPhase ? null,
+      postUnpack ? null,
+      cargoPatches ? [ ],
+      patches ? [ ],
+      sourceRoot ? null,
+      logLevel ? "",
+      buildInputs ? [ ],
+      nativeBuildInputs ? [ ],
+      cargoUpdateHook ? "",
+      cargoDepsHook ? "",
+      buildType ? "release",
+      meta ? { },
+      useFetchCargoVendor ? false,
+      cargoDeps ? null,
+      cargoLock ? null,
+      cargoVendorDir ? null,
+      checkType ? buildType,
+      buildNoDefaultFeatures ? false,
+      checkNoDefaultFeatures ? buildNoDefaultFeatures,
+      buildFeatures ? [ ],
+      checkFeatures ? buildFeatures,
+      useNextest ? false,
+      auditable ? !cargo-auditable.meta.broken,
 
-  depsExtraArgs ? { },
+      depsExtraArgs ? { },
 
-  # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
-  # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
-  # case for `rustfmt`/etc from the `rust-sources).
-  # Otherwise, everything from the tarball would've been built/tested.
-  buildAndTestSubdir ? null,
-  ...
-}@args:
+      # Needed to `pushd`/`popd` into a subdir of a tarball if this subdir
+      # contains a Cargo.toml, but isn't part of a workspace (which is e.g. the
+      # case for `rustfmt`/etc from the `rust-sources).
+      # Otherwise, everything from the tarball would've been built/tested.
+      buildAndTestSubdir ? null,
+      ...
+    }@args:
 
-let
+    let
 
-  cargoDeps' =
-    if cargoVendorDir != null then
-      null
-    else if cargoDeps != null then
-      cargoDeps
-    else if cargoLock != null then
-      importCargoLock cargoLock
-    else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
-      throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
-    else if useFetchCargoVendor then
-      fetchCargoVendor (
-        {
-          inherit
-            src
-            srcs
-            sourceRoot
-            preUnpack
-            unpackPhase
-            postUnpack
-            ;
-          name = cargoDepsName;
-          patches = cargoPatches;
-          hash = args.cargoHash;
-        }
-        // depsExtraArgs
-      )
-    else
-      fetchCargoTarball (
-        {
-          inherit
-            src
-            srcs
-            sourceRoot
-            preUnpack
-            unpackPhase
-            postUnpack
-            cargoUpdateHook
-            ;
-          name = cargoDepsName;
-          patches = cargoPatches;
-        }
-        // lib.optionalAttrs (args ? cargoHash) {
-          hash = args.cargoHash;
-        }
-        // lib.optionalAttrs (args ? cargoSha256) {
-          sha256 = lib.warn "cargoSha256 is deprecated. Please use cargoHash with SRI hash instead" args.cargoSha256;
-        }
-        // depsExtraArgs
-      );
+      cargoDeps' =
+        if cargoVendorDir != null then
+          null
+        else if cargoDeps != null then
+          cargoDeps
+        else if cargoLock != null then
+          importCargoLock cargoLock
+        else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
+          throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
+        else if useFetchCargoVendor then
+          fetchCargoVendor (
+            {
+              inherit
+                src
+                srcs
+                sourceRoot
+                preUnpack
+                unpackPhase
+                postUnpack
+                ;
+              name = cargoDepsName;
+              patches = cargoPatches;
+              hash = args.cargoHash;
+            }
+            // depsExtraArgs
+          )
+        else
+          fetchCargoTarball (
+            {
+              inherit
+                src
+                srcs
+                sourceRoot
+                preUnpack
+                unpackPhase
+                postUnpack
+                cargoUpdateHook
+                ;
+              name = cargoDepsName;
+              patches = cargoPatches;
+            }
+            // lib.optionalAttrs (args ? cargoHash) {
+              hash = args.cargoHash;
+            }
+            // lib.optionalAttrs (args ? cargoSha256) {
+              sha256 = lib.warn "cargoSha256 is deprecated. Please use cargoHash with SRI hash instead" args.cargoSha256;
+            }
+            // depsExtraArgs
+          );
 
-  target = stdenv.hostPlatform.rust.rustcTargetSpec;
-  targetIsJSON = lib.hasSuffix ".json" target;
-in
-  lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
-    RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
-  }
-  // {
-    cargoDeps = cargoDeps';
-    inherit buildAndTestSubdir;
+      target = stdenv.hostPlatform.rust.rustcTargetSpec;
+      targetIsJSON = lib.hasSuffix ".json" target;
+    in
+    lib.optionalAttrs (stdenv.hostPlatform.isDarwin && buildType == "debug") {
+      RUSTFLAGS = "-C split-debuginfo=packed " + (args.RUSTFLAGS or "");
+    }
+    // {
+      cargoDeps = cargoDeps';
+      inherit buildAndTestSubdir;
 
-    cargoBuildType = buildType;
+      cargoBuildType = buildType;
 
-    cargoCheckType = checkType;
+      cargoCheckType = checkType;
 
-    cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
+      cargoBuildNoDefaultFeatures = buildNoDefaultFeatures;
 
-    cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
+      cargoCheckNoDefaultFeatures = checkNoDefaultFeatures;
 
-    cargoBuildFeatures = buildFeatures;
+      cargoBuildFeatures = buildFeatures;
 
-    cargoCheckFeatures = checkFeatures;
+      cargoCheckFeatures = checkFeatures;
 
-    patchRegistryDeps = ./patch-registry-deps;
+      patchRegistryDeps = ./patch-registry-deps;
 
-    nativeBuildInputs =
-      nativeBuildInputs
-      ++ lib.optionals auditable [
-        (buildPackages.cargo-auditable-cargo-wrapper.override {
-          inherit cargo cargo-auditable;
-        })
-      ]
-      ++ [
-        cargoBuildHook
-        (if useNextest then cargoNextestHook else cargoCheckHook)
-        cargoInstallHook
-        cargoSetupHook
-        rustc
-      ];
+      nativeBuildInputs =
+        nativeBuildInputs
+        ++ lib.optionals auditable [
+          (buildPackages.cargo-auditable-cargo-wrapper.override {
+            inherit cargo cargo-auditable;
+          })
+        ]
+        ++ [
+          cargoBuildHook
+          (if useNextest then cargoNextestHook else cargoCheckHook)
+          cargoInstallHook
+          cargoSetupHook
+          rustc
+        ];
 
-    buildInputs =
-      buildInputs
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
-      ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
+      buildInputs =
+        buildInputs
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
+        ++ lib.optionals stdenv.hostPlatform.isMinGW [ windows.pthreads ];
 
-    patches = cargoPatches ++ patches;
+      patches = cargoPatches ++ patches;
 
-    PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+      PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
 
-    postUnpack =
-      ''
-        eval "$cargoDepsHook"
+      postUnpack =
+        ''
+          eval "$cargoDepsHook"
 
-        export RUST_LOG=${logLevel}
-      ''
-      + (args.postUnpack or "");
+          export RUST_LOG=${logLevel}
+        ''
+        + (args.postUnpack or "");
 
-    configurePhase =
-      args.configurePhase or ''
-        runHook preConfigure
-        runHook postConfigure
-      '';
+      configurePhase =
+        args.configurePhase or ''
+          runHook preConfigure
+          runHook postConfigure
+        '';
 
-    doCheck = args.doCheck or true;
+      doCheck = args.doCheck or true;
 
-    strictDeps = true;
+      strictDeps = true;
 
-    meta = meta // {
-      badPlatforms = meta.badPlatforms or [ ] ++ rustc.badTargetPlatforms;
-      # default to Rust's platforms
-      platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
+      meta = meta // {
+        badPlatforms = meta.badPlatforms or [ ] ++ rustc.badTargetPlatforms;
+        # default to Rust's platforms
+        platforms = lib.intersectLists meta.platforms or lib.platforms.all rustc.targetPlatforms;
+      };
     };
-  };
 }

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -61,12 +61,6 @@
   ...
 }@args:
 
-assert
-  cargoVendorDir == null && cargoDeps == null && cargoLock == null
-  ->
-    !(args ? cargoSha256 && args.cargoSha256 != null) && !(args ? cargoHash && args.cargoHash != null)
-  -> throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set";
-
 let
 
   cargoDeps' =
@@ -76,6 +70,8 @@ let
       cargoDeps
     else if cargoLock != null then
       importCargoLock cargoLock
+    else if (args.cargoHash or null == null) && (args.cargoSha256 or null == null) then
+      throw "cargoHash, cargoVendorDir, cargoDeps, or cargoLock must be set"
     else if useFetchCargoVendor then
       fetchCargoVendor (
         {


### PR DESCRIPTION
This is the manual backport of PR #382550.

This PR enables future backports of Rust package changes which use `finalAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
