### PR TITLE
lix: package `nix-eval-jobs`

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchFromGitHub,
   suffix ? "",
   version,
   src,
@@ -8,6 +7,7 @@
   patches ? [ ],
   maintainers ? lib.teams.lix.members,
 }@args:
+
 {
   stdenv,
   meson,
@@ -67,6 +67,7 @@
   stateDir,
   storeDir,
 }:
+
 let
   isLegacyParser = lib.versionOlder version "2.91";
 in

--- a/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
+++ b/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  suffix ? "",
+  version,
+  src,
+  patches ? [ ],
+  maintainers ? lib.teams.lix.members,
+}@args:
+
+{
+  stdenv,
+  lib,
+  lix,
+  boost,
+  nlohmann_json,
+  meson,
+  pkg-config,
+  ninja,
+  cmake,
+  clang-tools,
+}:
+
+stdenv.mkDerivation {
+  pname = "nix-eval-jobs";
+  version = "${version}${suffix}";
+  inherit src patches;
+  buildInputs = [
+    nlohmann_json
+    lix
+    boost
+  ];
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    # nlohmann_json can be only discovered via cmake files
+    cmake
+  ] ++ (lib.optional stdenv.cc.isClang [ clang-tools ]);
+
+  # point 'nix edit' and ofborg at the file that defines the attribute,
+  # not this common file.
+  pos = builtins.unsafeGetAttrPos "version" args;
+  meta = {
+    description = "Hydra's builtin `hydra-eval-jobs` as a standalone tool";
+    mainProgram = "nix-eval-jobs";
+    homepage =
+      # Starting with 2.93, `nix-eval-jobs` lives in the `lix` repository.
+      if lib.versionAtLeast version "2.93" then
+        "https://git.lix.systems/lix-project/lix/src/branch/main/subprojects/nix-eval-jobs"
+      else
+        "https://git.lix.systems/lix-project/nix-eval-jobs";
+    license = lib.licenses.gpl3;
+    inherit maintainers;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -3,58 +3,80 @@
   aws-sdk-cpp,
   boehmgc,
   callPackage,
+  fetchgit,
   fetchFromGitHub,
   rustPlatform,
   Security,
+  newScope,
 
   storeDir ? "/nix/store",
   stateDir ? "/nix/var",
   confDir ? "/etc",
 }:
 let
-  boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
+  makeLixScope =
+    {
+      lix-args,
+      nix-eval-jobs-args,
+    }:
+    lib.makeScope newScope (
+      self:
+      lib.recurseIntoAttrs {
+        inherit
+          Security
+          storeDir
+          stateDir
+          confDir
+          ;
 
-  boehmgc-nix = boehmgc-nix_2_3.overrideAttrs (drv: {
-    patches = (drv.patches or [ ]) ++ [
-      # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
-      ../nix/patches/boehmgc-coroutine-sp-fallback.patch
-    ];
-  });
+        boehmgc =
+          # TODO: Why is this called `boehmgc-nix_2_3`?
+          let
+            boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
+          in
+          # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
+          if lib.versionOlder lix-args.version "2.91" then
+            boehmgc-nix_2_3.overrideAttrs (drv: {
+              patches = (drv.patches or [ ]) ++ [
+                # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
+                ../nix/patches/boehmgc-coroutine-sp-fallback.patch
+              ];
+            })
+          else
+            boehmgc-nix_2_3;
 
-  aws-sdk-cpp-nix =
-    (aws-sdk-cpp.override {
-      apis = [
-        "s3"
-        "transfer"
-      ];
-      customMemoryManagement = false;
-    }).overrideAttrs
-      {
-        # only a stripped down version is build which takes a lot less resources to build
-        requiredSystemFeatures = [ ];
-      };
+        aws-sdk-cpp =
+          (aws-sdk-cpp.override {
+            apis = [
+              "s3"
+              "transfer"
+            ];
+            customMemoryManagement = false;
+          }).overrideAttrs
+            {
+              # only a stripped down version is build which takes a lot less resources to build
+              requiredSystemFeatures = [ ];
+            };
 
-  # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
-  needsBoehmgcPatches = version: lib.versionOlder version "2.91";
+        # NOTE: The `common-*.nix` helpers contain a top-level function which
+        # takes the Lix source to build and version information. We use the
+        # outer `callPackage` for that.
+        #
+        # That *returns* another function which takes the actual build
+        # dependencies, and that uses the new scope's `self.callPackage` so
+        # that `nix-eval-jobs` can be built against the correct `lix` version.
+        lix = self.callPackage (callPackage ./common-lix.nix lix-args) { };
 
-  common =
-    args:
-    callPackage (import ./common.nix ({ inherit lib fetchFromGitHub; } // args)) {
-      inherit
-        Security
-        storeDir
-        stateDir
-        confDir
-        ;
-      boehmgc = if needsBoehmgcPatches args.version then boehmgc-nix else boehmgc-nix_2_3;
-      aws-sdk-cpp = aws-sdk-cpp-nix;
-    };
+        nix-eval-jobs = self.callPackage (callPackage ./common-nix-eval-jobs.nix nix-eval-jobs-args) { };
+      }
+    );
+
 in
 lib.makeExtensible (self: {
-  buildLix = common;
+  inherit makeLixScope;
 
-  lix_2_90 = (
-    common rec {
+  lix_2_90 = self.makeLixScope {
+    lix-args = rec {
       version = "2.90.0";
 
       src = fetchFromGitHub {
@@ -71,11 +93,21 @@ lib.makeExtensible (self: {
         sourceRoot = "${src.name or src}/lix-doc";
         hash = "sha256-VPcrf78gfLlkTRrcbLkPgLOk0o6lsOJBm6HYLvavpNU=";
       };
-    }
-  );
+    };
 
-  lix_2_91 = (
-    common rec {
+    nix-eval-jobs-args = {
+      version = "2.90.0";
+      src = fetchgit {
+        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
+        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.90
+        rev = "9c23772cf25e0d891bef70b7bcb7df36239672a5";
+        hash = "sha256-oT273pDmYzzI7ACAFUOcsxtT6y34V5KF7VBSqTza7j8=";
+      };
+    };
+  };
+
+  lix_2_91 = self.makeLixScope {
+    lix-args = rec {
       version = "2.91.1";
 
       src = fetchFromGitHub {
@@ -92,9 +124,37 @@ lib.makeExtensible (self: {
         sourceRoot = "${src.name or src}/lix-doc";
         hash = "sha256-U820gvcbQIBaFr2OWPidfFIDXycDFGgXX1NpWDDqENs=";
       };
-    }
-  );
+    };
+
+    nix-eval-jobs-args = {
+      version = "2.91.0";
+      src = fetchgit {
+        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
+        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.91
+        rev = "1f98b0c016a6285f29ad278fa5cd82b8f470d66a";
+        hash = "sha256-ZJKOC/iLuO8qjPi9/ql69Vgh3NIu0tU6CSI0vbiCrKA=";
+      };
+    };
+  };
 
   latest = self.lix_2_91;
   stable = self.lix_2_91;
+
+  # Previously, `nix-eval-jobs` was not packaged here, so we export an
+  # attribute with the previously-expected structure for compatibility. This
+  # is also available (for now) as `pkgs.lixVersions`.
+  renamedDeprecatedLixVersions =
+    let
+      mkAlias =
+        version:
+        lib.warnOnInstantiate "'lixVersions.${version}' has been renamed to 'lixPackageSets.${version}.lix'"
+          self.${version}.lix;
+    in
+    lib.dontRecurseIntoAttrs {
+      lix_2_90 = mkAlias "lix_2_90";
+      lix_2_91 = mkAlias "lix_2_91";
+      # NOTE: Do not add new versions of Lix here.
+      stable = mkAlias "stable";
+      latest = mkAlias "latest";
+    };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -910,6 +910,8 @@ mapAliases {
 
   linuxstopmotion = stopmotion; # Added 2024-11-01
 
+  lixVersions = lixPackageSets.renamedDeprecatedLixVersions; # Added 2025-03-20, warning in ../tools/package-management/lix/default.nix
+
   llvmPackages_git = (callPackages ../development/compilers/llvm { }).git;
 
   lld_9 = throw "lld_9 has been removed from nixpkgs"; # Added 2024-04-08

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17497,13 +17497,13 @@ with pkgs;
 
   nixStatic = pkgsStatic.nix;
 
-  lixVersions = recurseIntoAttrs (callPackage ../tools/package-management/lix {
+  lixPackageSets = recurseIntoAttrs (callPackage ../tools/package-management/lix {
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";
     inherit (darwin.apple_sdk.frameworks) Security;
   });
 
-  lix = lixVersions.stable;
+  lix = lixPackageSets.stable.lix;
 
   lixStatic = pkgsStatic.lix;
 


### PR DESCRIPTION
This adds packaging for the Lix fork of `nix-eval-jobs`.

`lixVersions.lix_2_91` has been renamed to `lixPackageSets.lix_2_91.lix`.

The elements of `lixPackageSets` are proper scopes instead of single packages. This makes it easy to build `nix-eval-jobs` against the correct version of Lix.

TODO:
- [x] Should the attribute be called `nix-eval-jobs` or `lix-eval-jobs`?
- [x] Should the overridden dependencies be part of the scope as well, or should I keep those hidden like they were previously?

```
$ nix repl --file .
nix-repl> lixPackageSets.lix_2_91
{
  Security = «derivation /nix/store/ivj0dwr2g18gf3bci9xva6g8qfan59ya-Security-11.0.drv»;
  aws-sdk-cpp = «derivation /nix/store/cds59fiybckyg0d4ls5a4l5afp2y1q1c-aws-sdk-cpp-1.11.448.drv»;
  boehmgc = «derivation /nix/store/r6i08v2sj1gkxf1nwq79sm6qfc96qlbs-boehm-gc-8.2.8.drv»;
  callPackage = «lambda callPackageWith @ /Users/wiggles/nixpkgs/lixos-module/lib/customisation.nix:240:15»;
  confDir = "/etc";
  lix = «derivation /nix/store/1mmy5wyr8fmprc52f9xkgrvn3qm7wfs3-lix-2.91.1.drv»;
  newScope = «lambda newScope @ /Users/wiggles/nixpkgs/lixos-module/lib/customisation.nix:609:20»;
  nix-eval-jobs = «derivation /nix/store/ka5lm9g1ylbzznzrdfkyadgkjxvhvjvv-nix-eval-jobs-2.91.0.drv»;
  overrideScope = «lambda overrideScope @ /Users/wiggles/nixpkgs/lixos-module/lib/customisation.nix:611:25»;
  packages = «lambda @ /Users/wiggles/nixpkgs/lixos-module/pkgs/tools/package-management/lix/default.nix:22:29»;
  stateDir = "/nix/var";
  storeDir = "/nix/store";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
