### PR TITLE
emacs: set `FD_SETSIZE` and `DARWIN_UNLIMITED_SELECT` on darwin

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -460,10 +460,13 @@ mkDerivation (finalAttrs: {
       NATIVE_FULL_AOT = "1";
       LIBRARY_PATH = lib.concatStringsSep ":" libGccJitLibraryPaths;
     }
-    // lib.optionalAttrs (variant == "macport") {
-      # Fixes intermittent segfaults when compiled with LLVM >= 7.0.
-      # See https://github.com/NixOS/nixpkgs/issues/127902
-      NIX_CFLAGS_COMPILE = "-include ${./macport_noescape_noop.h}";
+    // {
+      NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
+        # Fixes intermittent segfaults when compiled with LLVM >= 7.0.
+        # See https://github.com/NixOS/nixpkgs/issues/127902
+        (lib.optionalString (variant == "macport") "-include ${./macport_noescape_noop.h}")
+        (lib.optionalString stdenv.hostPlatform.isDarwin "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT")
+      ];
     };
 
   enableParallelBuilding = true;


### PR DESCRIPTION

This fixes the issue with macOS and `too many open files`. Before this patch on macOS this would `(shell-command-to-string "ulimit -n")` return 1024 and only a few hundred process would complete:

```
;; Taken from https://en.liujiacai.net/2022/09/03/emacs-maxopenfiles/
(shell-command-to-string "ulimit -n")
;; 10000

(dotimes (i 2000)
 (make-process
  :name (format "Sleep-%s" i)
  :buffer nil
  :command '("sleep" "60000")
  :connection-type 'pipe))
```

with this patch I get `9472` returned for `(shell-command-to-string "ulimit -n")` I started 4000 which was more than enough for my testing.

Prior work:

https://github.com/d12frosted/homebrew-emacs-plus/commit/4b34ed7402a4f3e1f212b2c6fa0851f4b59e247c

Context:

https://en.liujiacai.net/2022/09/03/emacs-maxopenfiles/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
