### PR TITLE
bitbox-bridge: add systemd service and udev rule for linux distributions

### DIFF
--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -34,6 +34,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libudev-zero
   ];
 
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/lib/systemd/user
+    substitute bitbox-bridge/release/linux/bitbox-bridge.service $out/lib/systemd/user/bitbox-bridge.service \
+      --replace-fail /opt/bitbox-bridge/bin/bitbox-bridge $out/bin/bitbox-bridge
+    install -Dm644 bitbox-bridge/release/linux/hid-digitalbitbox.rules $out/lib/udev/rules.d/50-hid-digitalbitbox.rules
+  '';
+
   meta = {
     description = "A bridge service that connects web wallets like Rabby to BitBox02";
     homepage = "https://github.com/BitBoxSwiss/bitbox-bridge";


### PR DESCRIPTION
## Things done

- Add udev rule to enable computer <> device communication. 
- Add a systemd service.

In the next PR(not this one), I plan to create nixos module to introduce `programs.bitbox-bridge.enable` and `services.bitbox-bridge.enable` with few options. These changes in this PR I suspect is needed for all linux distributions other than `NixOS` that allows users to install `bitbox-bridge` via `nix` or `home-manager`.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).