### PR TITLE
[24.11] libblake3: 1.5.5 -> 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20468,6 +20468,11 @@
     githubId = 91412114;
     keys = [ { fingerprint = "C1DA A551 B422 7A6F 3FD9  6B3A 467B 7D12 9EA7 3AC9"; } ];
   };
+  silvanshade = {
+    github = "silvanshade";
+    githubId = 11022302;
+    name = "silvanshade";
+  };
   Silver-Golden = {
     name = "Brendan Golden";
     email = "github+nixpkgs@brendan.ie";

--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -3,23 +3,30 @@
   stdenv,
   cmake,
   fetchFromGitHub,
+  tbb_2022_0,
+  useTBB ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libblake3";
-  version = "1.5.5";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "BLAKE3-team";
     repo = "BLAKE3";
     tag = finalAttrs.version;
-    hash = "sha256-2M8OQNmtWwfDcbZYspaxpGz2clpfILru//4+P6dClNw=";
+    hash = "sha256-08D5hnU3I0VJ+RM/TNk2LxsEAvOLuO52+08zlKssXbc=";
   };
 
   sourceRoot = finalAttrs.src.name + "/c";
 
-  nativeBuildInputs = [
-    cmake
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optionals useTBB [ tbb_2022_0 ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BLAKE3_USE_TBB" useTBB)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
 
   meta = {

--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
       asl20
       cc0
     ];
-    maintainers = with lib.maintainers; [ fgaz ];
+    maintainers = with lib.maintainers; [
+      fgaz
+      silvanshade
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tbb";
+  version = "2022.0.0";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneTBB";
+    tag = "v${version}";
+    hash = "sha256-XOlC1+rf65oEGKDba9N561NuFo1YJhn3Q1CTGtvkn7A=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  patches = [
+    # Fix musl build from https://github.com/oneapi-src/oneTBB/pull/899
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
+      hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
+    })
+  ];
+
+  # Fix build with modern gcc
+  # In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [ "-Wno-error=array-bounds" "-Wno-error=stringop-overflow" ] ++
+    # error: variable 'val' set but not used
+    lib.optionals stdenv.cc.isClang [ "-Wno-error=unused-but-set-variable" ] ++
+    # Workaround for gcc-12 ICE when using -O3
+    # https://gcc.gnu.org/PR108854
+    lib.optionals (stdenv.cc.isGNU && stdenv.hostPlatform.isx86_32) [ "-O2" ];
+
+  # Fix undefined reference errors with version script under LLVM.
+  NIX_LDFLAGS = lib.optionalString (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17") "--undefined-version";
+
+  # Disable failing test on musl
+  # test/conformance/conformance_resumable_tasks.cpp:37:24: error: ‘suspend’ is not a member of ‘tbb::v1::task’; did you mean ‘tbb::detail::r1::suspend’?
+  postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
+    substituteInPlace test/CMakeLists.txt \
+      --replace-fail 'tbb_add_test(SUBDIR conformance NAME conformance_resumable_tasks DEPENDENCIES TBB::tbb)' ""
+  '';
+
+  meta = with lib; {
+    description = "Intel Thread Building Blocks C++ Library";
+    homepage = "http://threadingbuildingblocks.org/";
+    license = licenses.asl20;
+    longDescription = ''
+      Intel Threading Building Blocks offers a rich and complete approach to
+      expressing parallelism in a C++ program. It is a library that helps you
+      take advantage of multi-core processor performance without having to be a
+      threading expert. Intel TBB is not just a threads-replacement library. It
+      represents a higher-level, task-based parallelism that abstracts platform
+      details and threading mechanisms for scalability and performance.
+    '';
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice tmarkus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7100,6 +7100,7 @@ with pkgs;
   tbb_2020_3 = callPackage ../development/libraries/tbb/2020_3.nix { };
   tbb_2021_5 = callPackage ../development/libraries/tbb/2021_5.nix { } ;
   tbb_2021_11 = callPackage ../development/libraries/tbb { };
+  tbb_2022_0 = callPackage ../development/libraries/tbb/2022_0.nix { };
   # many packages still fail with latest version
   tbb = tbb_2020_3;
 


### PR DESCRIPTION
This PR is a backport of `libblake3` version `1.7.0` to release `24.11` from https://github.com/NixOS/nixpkgs/pull/390458

This PR depends on another backport PR for `tbb_2022_0`: https://github.com/NixOS/nixpkgs/pull/391413

The backport is needed for https://github.com/NixOS/nix/pull/12676

@Ericson2314 