### PR TITLE
lixPackages.lix_2_92: init

### DIFF
--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -1,13 +1,34 @@
 {
+  binutils,
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   cmake,
   openssl,
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+let
+  # HACK: work around https://github.com/NixOS/nixpkgs/issues/177129
+  # Though this is an issue between Clang and GCC,
+  # so it may not get fixed anytime soon...
+  empty-libgcc_eh = clangStdenv.mkDerivation {
+    pname = "empty-libgcc_eh";
+    version = "0";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p "$out"/lib
+      "${binutils}"/bin/ar r "$out"/lib/libgcc_eh.a
+    '';
+  };
+in
+
+# NOTE: This must be `clang` because `gcc` is known to miscompile or ICE while
+# compiling `capnproto` coroutines.
+#
+# See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102051
+# See: https://gerrit.lix.systems/c/lix/+/1874
+clangStdenv.mkDerivation rec {
   pname = "capnproto";
   version = "1.1.0";
 
@@ -23,7 +44,26 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     openssl
     zlib
+  ] ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.targetPlatform.isStatic) empty-libgcc_eh;
+
+  # FIXME: separate the binaries from the stuff that user systems actually use
+  # This runs into a terrible UX issue in Lix and I just don't want to debug it
+  # right now for the couple MB of closure size:
+  # https://git.lix.systems/lix-project/lix/issues/551
+  # outputs = [ "bin" "dev" "out" ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    # Take optimization flags from CXXFLAGS rather than cmake injecting them
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
   ];
+
+  env = {
+    # Required to build the coroutine library
+    CXXFLAGS = "-std=c++20";
+  };
+
+  separateDebugInfo = true;
 
   meta = with lib; {
     homepage = "https://capnproto.org/";
@@ -35,6 +75,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ ];
+    maintainers = lib.teams.lix.members;
   };
 }

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchFromGitHub,
   suffix ? "",
   version,
   src,
@@ -8,6 +7,7 @@
   patches ? [ ],
   maintainers ? lib.teams.lix.members,
 }@args:
+
 {
   stdenv,
   meson,
@@ -67,6 +67,7 @@
   stateDir,
   storeDir,
 }:
+
 let
   isLegacyParser = lib.versionOlder version "2.91";
 in

--- a/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
+++ b/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
@@ -1,0 +1,57 @@
+# NOTE: Eventually this should probably be renamed `common-lix-eval-jobs.nix`.
+{
+  lib,
+  suffix ? "",
+  version,
+  src,
+  patches ? [ ],
+  maintainers ? lib.teams.lix.members,
+}@args:
+
+{
+  stdenv,
+  lib,
+  lix,
+  boost,
+  nlohmann_json,
+  meson,
+  pkg-config,
+  ninja,
+  cmake,
+  clang-tools,
+}:
+
+stdenv.mkDerivation {
+  # TODO: Should this be called `lix-eval-jobs`?
+  pname = "nix-eval-jobs";
+  version = "${version}${suffix}";
+  inherit src patches;
+  buildInputs = [
+    nlohmann_json
+    lix
+    boost
+  ];
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    # nlohmann_json can be only discovered via cmake files
+    cmake
+  ] ++ (lib.optional stdenv.cc.isClang [ clang-tools ]);
+
+  # point 'nix edit' and ofborg at the file that defines the attribute,
+  # not this common file.
+  pos = builtins.unsafeGetAttrPos "version" args;
+  meta = {
+    description = "Hydra's builtin `hydra-eval-jobs` as a standalone tool";
+    homepage =
+      # Starting with 2.93, `nix-eval-jobs` lives in the `lix` repository.
+      if lib.versionAtLeast version "2.93" then
+        "https://git.lix.systems/lix-project/lix/src/branch/main/subprojects/nix-eval-jobs"
+      else
+        "https://git.lix.systems/lix-project/nix-eval-jobs";
+    license = lib.licenses.gpl3;
+    inherit maintainers;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -3,58 +3,78 @@
   aws-sdk-cpp,
   boehmgc,
   callPackage,
+  fetchgit,
   fetchFromGitHub,
   rustPlatform,
   Security,
+  newScope,
 
   storeDir ? "/nix/store",
   stateDir ? "/nix/var",
   confDir ? "/etc",
 }:
 let
-  boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
-
-  boehmgc-nix = boehmgc-nix_2_3.overrideAttrs (drv: {
-    patches = (drv.patches or [ ]) ++ [
-      # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
-      ../nix/patches/boehmgc-coroutine-sp-fallback.patch
-    ];
-  });
-
-  aws-sdk-cpp-nix =
-    (aws-sdk-cpp.override {
-      apis = [
-        "s3"
-        "transfer"
-      ];
-      customMemoryManagement = false;
-    }).overrideAttrs
-      {
-        # only a stripped down version is build which takes a lot less resources to build
-        requiredSystemFeatures = [ ];
-      };
-
-  # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
-  needsBoehmgcPatches = version: lib.versionOlder version "2.91";
-
-  common =
-    args:
-    callPackage (import ./common.nix ({ inherit lib fetchFromGitHub; } // args)) {
+  makeLixScope =
+    {
+      lix,
+      nix-eval-jobs,
+    }:
+    lib.makeScope newScope (self: {
       inherit
         Security
         storeDir
         stateDir
         confDir
         ;
-      boehmgc = if needsBoehmgcPatches args.version then boehmgc-nix else boehmgc-nix_2_3;
-      aws-sdk-cpp = aws-sdk-cpp-nix;
-    };
+
+      boehmgc =
+        # TODO: Why is this called `boehmgc-nix_2_3`?
+        let
+          boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
+        in
+        # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
+        if lib.versionOlder lix.version "2.91" then
+          boehmgc-nix_2_3.overrideAttrs (drv: {
+            patches = (drv.patches or [ ]) ++ [
+              # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
+              ../nix/patches/boehmgc-coroutine-sp-fallback.patch
+            ];
+          })
+        else
+          boehmgc-nix_2_3;
+
+      aws-sdk-cpp =
+        (aws-sdk-cpp.override {
+          apis = [
+            "s3"
+            "transfer"
+          ];
+          customMemoryManagement = false;
+        }).overrideAttrs
+          {
+            # only a stripped down version is build which takes a lot less resources to build
+            requiredSystemFeatures = [ ];
+          };
+
+      # NOTE: The `common-*.nix` helpers contain a top-level function which
+      # takes the Lix source to build and version information. We use the
+      # outer `callPackage` for that.
+      #
+      # That *returns* another function which takes the actual build
+      # dependencies, and that uses the new scope's `self.callPackage` so
+      # that `nix-eval-jobs` can be built against the correct `lix` version.
+      lix = self.callPackage (callPackage ./common-lix.nix lix) { };
+
+      # TODO: Should this be named `lix-eval-jobs`?
+      nix-eval-jobs = self.callPackage (callPackage ./common-nix-eval-jobs.nix nix-eval-jobs) { };
+    });
+
 in
 lib.makeExtensible (self: {
-  buildLix = common;
+  makeLixScope = makeLixScope;
 
-  lix_2_90 = (
-    common rec {
+  lix_2_90 = self.makeLixScope {
+    lix = rec {
       version = "2.90.0";
 
       src = fetchFromGitHub {
@@ -71,11 +91,21 @@ lib.makeExtensible (self: {
         sourceRoot = "${src.name or src}/lix-doc";
         hash = "sha256-VPcrf78gfLlkTRrcbLkPgLOk0o6lsOJBm6HYLvavpNU=";
       };
-    }
-  );
+    };
 
-  lix_2_91 = (
-    common rec {
+    nix-eval-jobs = {
+      version = "2.90.0";
+      src = fetchgit {
+        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
+        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.90
+        rev = "9c23772cf25e0d891bef70b7bcb7df36239672a5";
+        hash = "sha256-oT273pDmYzzI7ACAFUOcsxtT6y34V5KF7VBSqTza7j8=";
+      };
+    };
+  };
+
+  lix_2_91 = self.makeLixScope {
+    lix = rec {
       version = "2.91.1";
 
       src = fetchFromGitHub {
@@ -92,8 +122,18 @@ lib.makeExtensible (self: {
         sourceRoot = "${src.name or src}/lix-doc";
         hash = "sha256-U820gvcbQIBaFr2OWPidfFIDXycDFGgXX1NpWDDqENs=";
       };
-    }
-  );
+    };
+
+    nix-eval-jobs = {
+      version = "2.91.0";
+      src = fetchgit {
+        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
+        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.91
+        rev = "1f98b0c016a6285f29ad278fa5cd82b8f470d66a";
+        hash = "sha256-ZJKOC/iLuO8qjPi9/ql69Vgh3NIu0tU6CSI0vbiCrKA=";
+      };
+    };
+  };
 
   latest = self.lix_2_91;
   stable = self.lix_2_91;

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -5,9 +5,12 @@
   callPackage,
   fetchgit,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   Security,
   newScope,
+  editline,
+  ncurses,
 
   storeDir ? "/nix/store",
   stateDir ? "/nix/var",
@@ -56,6 +59,30 @@ let
             requiredSystemFeatures = [ ];
           };
 
+      editline = editline.overrideAttrs (prev: {
+        patches = (prev.patches or [ ]) ++ [
+          # Recognize `Alt-Left` and `Alt-Right` for navigating by words in more
+          # terminals/shells/platforms.
+          #
+          # See: https://github.com/troglobit/editline/pull/70
+          (fetchpatch {
+            url = "https://github.com/troglobit/editline/commit/fb4d7268de024ed31ad2417f533cc0cbc2cd9b29.diff";
+            hash = "sha256-5zMsmpU5zFoffRUwFhI/vP57pEhGotcMPgn9AfI1SNg=";
+          })
+        ];
+
+        configureFlags = (prev.configureFlags or [ ]) ++ [
+          # Enable SIGSTOP (Ctrl-Z) behavior.
+          (lib.enableFeature true "sigstop")
+          # Enable ANSI arrow keys.
+          (lib.enableFeature true "arrow-keys")
+          # Use termcap library to query terminal size.
+          (lib.enableFeature true "termcap")
+        ];
+
+        propagatedBuildInputs = (prev.propagatedBuildInputs or [ ]) ++ [ ncurses ];
+      });
+
       # NOTE: The `common-*.nix` helpers contain a top-level function which
       # takes the Lix source to build and version information. We use the
       # outer `callPackage` for that.
@@ -84,11 +111,13 @@ lib.makeExtensible (self: {
         hash = "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=";
       };
 
+      docSourceRoot = "lix-doc";
+
       docCargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-doc-${version}";
         inherit src;
         allowGitDependencies = false;
-        sourceRoot = "${src.name or src}/lix-doc";
+        sourceRoot = "${src.name or src}/${docSourceRoot}";
         hash = "sha256-VPcrf78gfLlkTRrcbLkPgLOk0o6lsOJBm6HYLvavpNU=";
       };
     };
@@ -115,11 +144,13 @@ lib.makeExtensible (self: {
         hash = "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=";
       };
 
+      docSourceRoot = "lix-doc";
+
       docCargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-doc-${version}";
         inherit src;
         allowGitDependencies = false;
-        sourceRoot = "${src.name or src}/lix-doc";
+        sourceRoot = "${src.name or src}/${docSourceRoot}";
         hash = "sha256-U820gvcbQIBaFr2OWPidfFIDXycDFGgXX1NpWDDqENs=";
       };
     };
@@ -135,6 +166,37 @@ lib.makeExtensible (self: {
     };
   };
 
-  latest = self.lix_2_91;
-  stable = self.lix_2_91;
+  lix_2_92 = self.makeLixScope {
+    lix = rec {
+      version = "2.92.0";
+
+      src = fetchFromGitHub {
+        owner = "lix-project";
+        repo = "lix";
+        rev = version;
+        hash = "sha256-CCKIAE84dzkrnlxJCKFyffAxP3yfsOAbdvydUGqq24g=";
+      };
+
+      docSourceRoot = "lix/lix-doc";
+
+      docCargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-doc-${version}";
+        inherit src;
+        allowGitDependencies = false;
+        hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
+      };
+    };
+
+    nix-eval-jobs = rec {
+      version = "2.92.0";
+      src = fetchgit {
+        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
+        rev = version;
+        hash = "sha256-tPr61X9v/OMVt7VXOs1RRStciwN8gDGxEKx+h0/Fg48=";
+      };
+    };
+  };
+
+  latest = self.lix_2_92;
+  stable = self.lix_2_92;
 })

--- a/pkgs/tools/package-management/lix/doc/default.nix
+++ b/pkgs/tools/package-management/lix/doc/default.nix
@@ -1,16 +1,35 @@
 {
+  lib,
   src,
   rustPlatform,
   version,
   cargoDeps,
+  docSourceRoot,
 }:
 
-rustPlatform.buildRustPackage {
-  pname = "lix-doc";
-  sourceRoot = "${src.name or src}/lix-doc";
-  inherit
-    version
-    src
-    cargoDeps
-    ;
-}
+rustPlatform.buildRustPackage (
+  {
+    pname = "lix-doc";
+    inherit
+      version
+      src
+      cargoDeps
+      ;
+  }
+  // (
+    # Lix 2.92 and above has a Cargo workspace described in `Cargo.toml`. This
+    # means that even though the `lix-doc` crate is in `docSourceRoot`, the
+    # `Cargo.lock` is in the top-level source directory.
+    #
+    # In earlier versions, the `Cargo.lock` is in `docSourceRoot` directly, so
+    # we use that as the `sourceRoot`.
+    if lib.versionAtLeast version "2.92" then
+      {
+        buildAndTestSubdir = docSourceRoot;
+      }
+    else
+      {
+        sourceRoot = "${src.name or src}/${docSourceRoot}";
+      }
+  )
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17497,13 +17497,16 @@ with pkgs;
 
   nixStatic = pkgsStatic.nix;
 
-  lixVersions = recurseIntoAttrs (callPackage ../tools/package-management/lix {
+  lixPackages = recurseIntoAttrs (callPackage ../tools/package-management/lix {
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";
     inherit (darwin.apple_sdk.frameworks) Security;
   });
 
-  lix = lixVersions.stable;
+  # Alias for compatibility, can be removed in 25.05.
+  lixVersions = pkgs.lixPackages;
+
+  lix = lixVersions.stable.lix;
 
   lixStatic = pkgsStatic.lix;
 


### PR DESCRIPTION
This packages Lix 2.92. Needs #391402, also needs the `capnproto` changes split out, also the `editline` changes probably. And it probably breaks the builds of the other Lix versions. But it's close :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
