### PR TITLE
capnproto: build shared libs, debuginfo, etc.

### DIFF
--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -1,13 +1,34 @@
 {
+  binutils,
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   cmake,
   openssl,
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+let
+  # HACK: work around https://github.com/NixOS/nixpkgs/issues/177129
+  # Though this is an issue between Clang and GCC,
+  # so it may not get fixed anytime soon...
+  empty-libgcc_eh = clangStdenv.mkDerivation {
+    pname = "empty-libgcc_eh";
+    version = "0";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p "$out"/lib
+      "${binutils}"/bin/ar r "$out"/lib/libgcc_eh.a
+    '';
+  };
+in
+
+# NOTE: This must be `clang` because `gcc` is known to miscompile or ICE while
+# compiling `capnproto` coroutines.
+#
+# See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102051
+# See: https://gerrit.lix.systems/c/lix/+/1874
+clangStdenv.mkDerivation rec {
   pname = "capnproto";
   version = "1.1.0";
 
@@ -23,7 +44,26 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     openssl
     zlib
+  ] ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.targetPlatform.isStatic) empty-libgcc_eh;
+
+  # FIXME: separate the binaries from the stuff that user systems actually use
+  # This runs into a terrible UX issue in Lix and I just don't want to debug it
+  # right now for the couple MB of closure size:
+  # https://git.lix.systems/lix-project/lix/issues/551
+  # outputs = [ "bin" "dev" "out" ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    # Take optimization flags from CXXFLAGS rather than cmake injecting them
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
   ];
+
+  env = {
+    # Required to build the coroutine library
+    CXXFLAGS = "-std=c++20";
+  };
+
+  separateDebugInfo = true;
 
   meta = with lib; {
     homepage = "https://capnproto.org/";
@@ -35,6 +75,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ ];
+    maintainers = lib.teams.lix.members;
   };
 }


### PR DESCRIPTION
This makes several improvements to the `capnproto` derivation:
- Build shared libs
- Build debuginfo
  See: https://git.lix.systems/lix-project/lix/issues/550
- Set the correct cmake build type
- Set the correct cxxflags to build the coroutine library
- Always build with clang
- Work around a broken static build
  See: https://github.com/avdv/scalals/commit/a2de0eff59cb4c9be6f8a33b2957e31727f87b89

See: https://git.lix.systems/lix-project/lix/issues/527

This upstreams the fixes from https://gerrit.lix.systems/c/lix/+/2074


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
