### PR TITLE
tsx: init at 4.19.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21415,6 +21415,12 @@
     github = "sdaqo";
     githubId = 63876564;
   };
+  sdedovic = {
+    name = "Stevan Dedovic";
+    email = "stevan@dedovic.com";
+    github = "sdedovic";
+    githubId = 599915;
+  };
   sdht0 = {
     email = "nixpkgs@sdht.in";
     github = "sdht0";

--- a/pkgs/by-name/ts/tsx/package.nix
+++ b/pkgs/by-name/ts/tsx/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pnpm_9,
+  nodejs_22,
+  versionCheckHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "tsx";
+  version = "4.19.3";
+
+  src = fetchFromGitHub {
+    owner = "privatenumber";
+    repo = "tsx";
+    tag = "v${version}";
+    hash = "sha256-wdv2oqJNc6U0Fyv4jT+0LUcYaDfodHk1vQZGMdyFF/E=";
+  };
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-57KDZ9cHb7uqnypC0auIltmYMmIhs4PWyf0HTRWEFiU=";
+  };
+
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm_9.configHook
+  ];
+
+  buildInputs = [
+    nodejs_22
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+
+    # by default pnpm builds the docs workspace and this was just
+    #  the easiest way I found to stop that, as pnpmWorkspaces and
+    #  other flags did not work
+    rm pnpm-workspace.yaml
+
+    # because tsx uses semantic-release, the package.json has a placeholder
+    #  version number. this patches it to match the version of the nix package,
+    #  which in turn is the release version in github.
+    substituteInPlace package.json --replace-fail "0.0.0-semantic-release" "${version}"
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run build
+
+    # remove devDependencies that are only required to build
+    #  and package the typescript code
+    pnpm prune --prod
+
+    # Clean up broken symlinks left behind by `pnpm prune`
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/tsx}
+    cp -r {dist,node_modules} $out/lib/tsx
+    chmod +x $out/lib/tsx/dist/cli.mjs
+    ln -s $out/lib/tsx/dist/cli.mjs $out/bin/tsx
+
+    runHook postInstall
+  '';
+
+  # 8 / 85 tests are failing, I do not know why, while regular usage shows no issues.
+  doCheck = false;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "TypeScript Execute (tsx): The easiest way to run TypeScript in Node.js";
+    homepage = "https://tsx.is";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sdedovic ];
+    mainProgram = "tsx";
+  };
+}


### PR DESCRIPTION
Homepage: [https://tsx.is](https://tsx.is)
Description: TSX is an environment to natively execute typescript code with Node.js. It is more actively developed than ts-node.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
