### PR TITLE
nixos/config/sysctl: enable common TOCTOU vulnerability mitigations

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -87,6 +87,28 @@ in
       # the value below is used by default on several other distros.
       "fs.inotify.max_user_instances" = lib.mkDefault 524288;
       "fs.inotify.max_user_watches" = lib.mkDefault 524288;
+
+      # Mitigate some TOCTOU vulnerabilites
+      # cf. https://www.kernel.org/doc/Documentation/admin-guide/sysctl/fs.rst
+      #
+      # Don’t allow O_CREAT open on FIFOs not owned by the user in world‐ or
+      # group‐writable sticky directories (e.g. /tmp), unless owned by the
+      # directory owner
+      "fs.protected_fifos" = lib.mkDefault 2;
+
+      # Don’t allow users to create hardlinks unless they own the source
+      # file or have read/write access to it
+      "fs.protected_hardlinks" = lib.mkDefault 1;
+
+      # Don’t allow O_CREAT open on regular files not owned by user in world‐
+      # or group‐writable sticky directories (e.g. /tmp), unless owned by the
+      # directory owner
+      "fs.protected_regular" = lib.mkDefault 2;
+
+      # Don’t follow symlinks in sticky world‐writable directories (e.g. /tmp),
+      # unless the user ID of the follower matches the symlink, or the
+      # directory owner matches the symlink
+      "fs.protected_symlinks" = lib.mkDefault 1;
     };
   };
 }


### PR DESCRIPTION
This enables mitigations for some common time‐of‐check‐time‐of‐use (TOCTOU) race vulnerabilities by default, mostly related to use of `/tmp`.

cf. <https://www.kernel.org/doc/Documentation/admin-guide/sysctl/fs.rst>

These could instead be moved to the hardened profile, they should however be safe to enable on all systems.

I have been running all my systems with these enabled for years without running into any problems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
