### PR TITLE
Revert "emacs: set `FD_SETSIZE` and `DARWIN_UNLIMITED_SELECT` on darwin"

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -460,13 +460,10 @@ mkDerivation (finalAttrs: {
       NATIVE_FULL_AOT = "1";
       LIBRARY_PATH = lib.concatStringsSep ":" libGccJitLibraryPaths;
     }
-    // {
-      NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-        # Fixes intermittent segfaults when compiled with LLVM >= 7.0.
-        # See https://github.com/NixOS/nixpkgs/issues/127902
-        (lib.optionalString (variant == "macport") "-include ${./macport_noescape_noop.h}")
-        (lib.optionalString stdenv.hostPlatform.isDarwin "-DFD_SETSIZE=10000 -DDARWIN_UNLIMITED_SELECT")
-      ];
+    // lib.optionalAttrs (variant == "macport") {
+      # Fixes intermittent segfaults when compiled with LLVM >= 7.0.
+      # See https://github.com/NixOS/nixpkgs/issues/127902
+      NIX_CFLAGS_COMPILE = "-include ${./macport_noescape_noop.h}";
     };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#391407

This should be handled via proper MacOS apis, not some inline hack.

The changes merged introduce severe performance impacts when using emacs on battery. The FD_SETSIZE is a cheap way to fix the issues that few people have encountered when using Emacs + LSP, which points to the fact that the issue should be solved directly within the Emacs codebase and not NixPkgs.

Another reason to not go the route of FD_SETSIZE

https://threadreaderapp.com/thread/1723398619313603068.html