### PR TITLE
nixos/networking: allow users to override FQDN

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -578,21 +578,22 @@ in
     };
 
     networking.fqdn = mkOption {
-      readOnly = true;
       type = types.str;
       default =
         if (cfg.hostName != "" && cfg.domain != null) then
           "${cfg.hostName}.${cfg.domain}"
         else
           throw ''
-            The FQDN is required but cannot be determined. Please make sure that
-            both networking.hostName and networking.domain are set properly.
+            The FQDN is required but cannot be determined from `networking.hostName`
+            and `networking.domain`. Please ensure these options are set properly or
+            set `networking.fqdn` directly.
           '';
       defaultText = literalExpression ''"''${networking.hostName}.''${networking.domain}"'';
       description = ''
-        The fully qualified domain name (FQDN) of this host. It is the result
-        of combining `networking.hostName` and `networking.domain.` Using this
-        option will result in an evaluation error if the hostname is empty or
+        The fully qualified domain name (FQDN) of this host. By default, it is
+        the result of combining `networking.hostName` and `networking.domain.`
+
+        Using this option will result in an evaluation error if the hostname is empty or
         no domain is specified.
 
         Modules that accept a mere `networking.hostName` but prefer a fully qualified


### PR DESCRIPTION
This may be useful for users where `${cfg.hostname}.${cfg.domain}` isn't actually the fully quantified domain name of the server.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
