### PR TITLE
gd: clean up; lib/licenses: add GD License

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -654,6 +654,11 @@ lib.mapAttrs mkLicense (
       url = "https://geant4.web.cern.ch/geant4/license/LICENSE.html";
     };
 
+    gd = {
+      spdxId = "GD";
+      fullName = "GD License";
+    };
+
     geogebra = {
       fullName = "GeoGebra Non-Commercial License Agreement";
       url = "https://www.geogebra.org/license";

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/libgd/libgd/releases/download/gd-${finalAttrs.version}/libgd-${finalAttrs.version}.tar.xz";
-    sha256 = "0qas3q9xz3wgw06dm2fj0i189rain6n60z1vyq50d5h7wbn25s1z";
+    hash = "sha256-P+gi7OIHlgYK9jt8YKyxUeWEQgTSidoM4I+P3xMeWmE=";
   };
 
   patches = [
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
       # included in > 2.3.3
       name = "restore-GD_FLIP.patch";
       url = "https://github.com/libgd/libgd/commit/f4bc1f5c26925548662946ed7cfa473c190a104a.diff";
-      sha256 = "XRXR3NOkbEub3Nybaco2duQk0n8vxif5mTl2AUacn9w=";
+      hash = "sha256-XRXR3NOkbEub3Nybaco2duQk0n8vxif5mTl2AUacn9w=";
     })
   ];
 

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -3,8 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
-  autoconf,
-  automake,
+  autoreconfHook,
   pkg-config,
   zlib,
   libpng,
@@ -43,8 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isDarwin "--enable-werror=no";
 
   nativeBuildInputs = [
-    autoconf
-    automake
+    autoreconfHook
     pkg-config
   ];
 

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -15,6 +15,7 @@
   libavif,
   fontconfig,
   freetype,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -69,6 +70,13 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "gd-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://libgd.github.io/";

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -36,8 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  hardeningDisable = [ "format" ];
-
   configureFlags = [
     "--enable-gd-formats"
   ]

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://libgd.github.io/";
     description = "Dynamic image creation library";
-    license = lib.licenses.free; # some custom license
+    license = lib.licenses.gd;
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     zlib
     freetype
+    fontconfig
     libpng
     libjpeg
     libwebp
@@ -60,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     libavif
   ]
   ++ lib.optionals withXorg [
-    fontconfig
     libxpm
   ];
 

--- a/pkgs/by-name/gd/gd/package.nix
+++ b/pkgs/by-name/gd/gd/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = false; # fails 2 tests
+  doCheck = true;
 
   meta = {
     homepage = "https://libgd.github.io/";


### PR DESCRIPTION
Clean up and improvements:

- Build with `fontconfig` irrespective of `withXorg`, as it has no dependency on X,
- provide more precise licence information,
- re‐enable tests,
- provide an update script,
- remove unnecessary `hardeningDisable`,
- use `autoreconfHook` to generate automake / autoconf build files,
- ~use `finalAttrs` pattern~,
- ~remove use of `with lib;`~, and
- convert hashes to SRI form.

Including `fontconfig` irrespective of the `withXorg` argument is necessary to build a number of packages generating documentation with Doxygen like `wayland` in an X‐less environment. If anyone really needs GD without `fontconfig`, they can still set the argument to `null`.

The licence added is specific to the GD graphics library and roughly comparable to a two‐clause BSD licence. It allows distribution, modification and derivation, provided that the authors are credited in user‐accessible supporting documentation.

While neither OSI‐approved nor classified by the FSF, it is included in the SPDX License List.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
