### PR TITLE
hplip: fix plugin fetch

### DIFF
--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -43,12 +43,8 @@ let
   };
 
   plugin = fetchurl {
-    url = "https://developers.hp.com/sites/default/files/${pname}-${version}-plugin.run";
+    url = "https://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${pname}-${version}-plugin.run";
     hash = "sha256-Hzxr3SVmGoouGBU2VdbwbwKMHZwwjWnI7P13Z6LQxao=";
-    curlOptsList = [
-      "--user-agent"
-      "Mozilla/5.0 (X11; Linux x86_64; rv:136.0)"
-    ];
   };
 
   hplipState = replaceVars ./hplip.state {

--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -45,6 +45,10 @@ let
   plugin = fetchurl {
     url = "https://developers.hp.com/sites/default/files/${pname}-${version}-plugin.run";
     hash = "sha256-Hzxr3SVmGoouGBU2VdbwbwKMHZwwjWnI7P13Z6LQxao=";
+    curlOptsList = [
+      "--user-agent"
+      "Mozilla/5.0 (X11; Linux x86_64; rv:136.0)"
+    ];
   };
 
   hplipState = replaceVars ./hplip.state {
@@ -238,6 +242,7 @@ python311Packages.buildPythonApplication {
   # Running `hp-diagnose_plugin -g` can be used to diagnose
   # issues with plugins.
   #
+  plugin = if withPlugin then plugin else null;
   postInstall =
     ''
       for resolution in 16x16 32x32 64x64 128x128 256x256; do
@@ -247,7 +252,7 @@ python311Packages.buildPythonApplication {
       done
     ''
     + lib.optionalString withPlugin ''
-      sh ${plugin} --noexec --keep
+      sh $plugin --noexec --keep
       cd plugin_tmp
 
       cp plugin.spec $out/share/hplip/


### PR DESCRIPTION
HP now returns 403 for unrecognized user-agents:

```
building '/nix/store/r9airhak8ic5pqpmbl7v9ixv1sif43rn-hplip-3.24.4-plugin.run.drv'...
error: builder for '/nix/store/r9airhak8ic5pqpmbl7v9ixv1sif43rn-hplip-3.24.4-plugin.run.drv' failed with exit code 1;
       last 19 log lines:
       >
       > trying https://developers.hp.com/sites/default/files/hplip-3.24.4-plugin.run
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 1 seconds. 3 retries
       > Warning: left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
       > Warning: left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retries
       > Warning: left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > error: cannot download hplip-3.24.4-plugin.run from any mirror
       For full logs, run 'nix log /nix/store/r9airhak8ic5pqpmbl7v9ixv1sif43rn-hplip-3.24.4-plugin.run.drv'.
```

This change sets fetch user-agent to Firefox prefix (bare 'Mozilla/5.0' wasn't enough).

Also adds plugin source as a second source instead of a closed-over binding so it's possible to read and override it from outside (e.g. point at internal mirror or vendor the file).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
