### PR TITLE
chromium,chromedriver: 134.0.6998.88 -> 134.0.6998.117

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "134.0.6998.88",
+    "version": "134.0.6998.117",
     "chromedriver": {
-      "hash_darwin": "sha256-UtXlvBUnMZpCXT/xI7l4nfv3EgJZgugP1/fVg4rKgk4=",
-      "hash_darwin_aarch64": "sha256-yWRVP5LaEEhHfKkV0UmC7cpEuSnU5sgL3C/Aa2Ri3sc="
+      "hash_darwin": "sha256-/o95v3X6mot2yReOEazoCNvfhuDm6xy/O1ksb0blWzU=",
+      "hash_darwin_aarch64": "sha256-9CFDVWt/UPg1mgP1lc7uVrzNV6Eiy8Ze/svoJNmT8Mw="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "7e3d5c978c6d3a6eda25692cfac7f893a2b20dd0",
-        "hash": "sha256-4RRB7uYI3I7c1dSypU2gzF9TCA2MJ7yStKEvm6vfSnE=",
+        "rev": "cbb247b860ca6b9b18dfa791157e274eab8cad6e",
+        "hash": "sha256-StWP7bsmD5Byn9uLZz6mo/OTChUsW1Y0RhxuofsPLbY=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -615,8 +615,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "fb519f2fe5d4409bc0033a4ae00ab9a7095fe566",
-        "hash": "sha256-Y0KtUKn6DxpxVLRM+jPvUPhPzekTAma1HYs27xlJlkw="
+        "rev": "aefbd9403c1b3032ad4cd0281ef312ed262c7125",
+        "hash": "sha256-tP6DnMeOoVqfTSn6bYXMLiCb4wg5f9uB28KzYMAeBUw="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -780,8 +780,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "a57459aad9ec3ed5f78d9ded700d52e31029efd2",
-        "hash": "sha256-IE1X6lfMyoXsN+7ebJ3RWXAgpR98AjituL3faQbNag0="
+        "rev": "4f282ae4acae85cdcc8c167cbc296a86d24c1cf6",
+        "hash": "sha256-wpz9W/ZurpCT/dGIHGpmdkI3dsXbP8TPNeee2w9zBU8="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/03/stable-channel-update-for-desktop_19.html

This update includes 2 security fixes.

CVEs:
CVE-2025-2476

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).