### PR TITLE
python3Packages.aiohttp-swagger: fix tests

### DIFF
--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   setuptools,
   aiohttp,
   jinja2,
@@ -23,6 +24,17 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-M43sNpbXWXFRTd549cZhvhO35nBB6OH+ki36BzSk87Q=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cr0hn/aiohttp-swagger/pull/108/commits/a4be5331c8a50d46ea64c4c69e00292300245f3b.patch";
+      hash = "sha256-lPrXzctXl6aNr+SIUpqAFhq49hMeoqTFfckvh5awgPQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/cr0hn/aiohttp-swagger/pull/108/commits/968f40b23e5bf5cc3e19053c764806574026d3e7.patch";
+      hash = "sha256-tkZ2PbRuciFzV6bx/1HYn9ZWbP/4bEmBHL0ObPz4fMQ=";
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/aiohttp-swagger/default.nix
+++ b/pkgs/development/python-modules/aiohttp-swagger/default.nix
@@ -7,6 +7,8 @@
   aiohttp,
   jinja2,
   markupsafe,
+  pytest-aiohttp,
+  pytestCheckHook,
   pythonOlder,
   pyyaml,
 }:
@@ -45,6 +47,11 @@ buildPythonPackage rec {
     jinja2
     markupsafe
     pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-aiohttp
   ];
 
   pythonRelaxDeps = [


### PR DESCRIPTION
During attempt to build `apache-airflow 2.10.5` I faced failed tests on `aiohttp-swagger` package build due to unset `asyncio_default_fixture_loop_scope` option which is now deprecated
https://github.com/pytest-dev/pytest-asyncio/issues/924
This PR sets it with environmental variable.

This is also included in https://github.com/NixOS/nixpkgs/pull/396544.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
