### PR TITLE
xz-after-bootstrap: init at & 5.6.4 add to release blockers

### DIFF
--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -99,6 +99,7 @@ rec {
       mariadb
       nginx
       nodejs
+      xz-after-bootstrap
       openssh
       opensshTest
       php

--- a/pkgs/tools/compression/xz/xz-after-bootstrap.nix
+++ b/pkgs/tools/compression/xz/xz-after-bootstrap.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  automake,
+  autoconf,
+  perl,
+  libtool,
+  gettext,
+  perl538Packages,
+  xz,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xz";
+  version = xz.version;
+
+  src = fetchFromGitHub {
+    owner = "tukaani-project";
+    repo = "xz";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Xp1uLtQIoOG/qVLpq5D/KFmTOJ0+mNkNclyuJsvlUbE=";
+  };
+
+  strictDeps = true;
+
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+    "man"
+    "doc"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  nativeBuildInputs = [
+    gettext
+    libtool
+    automake
+    autoconf
+    perl
+    perl538Packages.Po4a
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  postPhases = [ "compareArtifacts" ];
+
+  compareArtifacts = ''
+    diff $out/lib/liblzma.so ${xz.out}/lib/liblzma.so
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/tukaani-project/xz/releases/tag/v${finalAttrs.version}";
+    description = "General-purpose data compression software, successor of LZMA";
+    homepage = "https://tukaani.org/xz/";
+    longDescription = ''
+      XZ Utils is free general-purpose data compression software with high
+      compression ratio.  XZ Utils were written for POSIX-like systems,
+      but also work on some not-so-POSIX systems.  XZ Utils are the
+      successor to LZMA Utils.
+
+      The core of the XZ Utils compression code is based on LZMA SDK, but
+      it has been modified quite a lot to be suitable for XZ Utils.  The
+      primary compression algorithm is currently LZMA2, which is used
+      inside the .xz container format.  With typical files, XZ Utils
+      create 30 % smaller output than gzip and 15 % smaller output than
+      bzip2.
+
+      Note that this is the version built after the bootstrap of nixpkgs.
+    '';
+    license = with licenses; [
+      gpl2Plus
+      lgpl21Plus
+    ];
+    maintainers = with maintainers; [ julienmalka ];
+    platforms = platforms.all;
+    pkgConfigModules = [ "liblzma" ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4106,6 +4106,7 @@ with pkgs;
   liquidctl = with python3Packages; toPythonApplication liquidctl;
 
   xz = callPackage ../tools/compression/xz { };
+  xz-after-bootstrap = callPackage ../tools/compression/xz/xz-after-bootstrap.nix { };
 
   madlang = haskell.lib.compose.justStaticExecutables haskellPackages.madlang;
 


### PR DESCRIPTION
Oppening this PR as a draft because it is more of a proof of concept design to trigger community feedback that patch destined to be merged as is. At the very least the `comparePhase` should be generalized to check all outputs.

This PR showcase a protection option that helps build trust into tarballs used to build software in our `stdenv`. In particular, with this kind of protection we avoid software supply chain attacks built on malicious maintainer provided tarballs such as the `xz` backdoor.

The idea here is to rebuild xz after the bootstrap from trusted sources. Given that xz is reproducible, if it doesn't produce the same results as the xz built during the bootstrap, something is wrong.

I discuss this proposition and alternatives at great length [in this blog post.](https://luj.fr/blog/how-nixos-could-have-detected-xz.html)