### PR TITLE
umu-launcher{-unwrapped}: 1.2.5 -> 1.2.6; add update script

### DIFF
--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -14,18 +14,18 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "umu-launcher-unwrapped";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = fetchFromGitHub {
     owner = "Open-Wine-Components";
     repo = "umu-launcher";
     tag = version;
-    hash = "sha256-bZ6Ywc524NrapkFrwFiWbqmVe1j0hunEH9YKrYQ8R2E=";
+    hash = "sha256-DkfB78XhK9CXgN/OpJZTjwHB7IcLC4h2HM/1JW42ZO0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-nU4xZn9NPd7NgexiaNYLdo4BCbH98duZ07XYeUiceP0=";
+    hash = "sha256-JhNErFDJsM20BhgIgJSUBeNzAst8f+s1NzpLfl2m2es=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   hatch,
   lib,
+  nix-update-script,
   python3Packages,
   rustPlatform,
   scdoc,
@@ -82,6 +83,8 @@ python3Packages.buildPythonPackage rec {
     # Fails with AssertionError: SystemExit not raised
     "test_parse_args_noopts"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Unified launcher for Windows games on Linux using the Steam Linux Runtime and Tools";


### PR DESCRIPTION
- Added `passthru.updateScript`
- Bumped version to 1.2.6
- See [Changelog](https://github.com/Open-Wine-Components/umu-launcher/releases/tag/1.2.6)

The update script can be used by the maintainers/scripts/update.nix script:

```sh
# Attempt to update a specific package:
nix-shell ./maintainers/scripts/update.nix --argstr package umu-launcher-unwrapped

# Or all packaged you maintain:
nix-shell ./maintainers/scripts/update.nix --argstr maintainer MattSturgeon
```

This should bump `version` to the latest released tag, and update the `src` and `cargoDeps` hashes. See [Automatic package updates](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#automatic-package-updates) in the `./pkgs` readme.

cc maintainers: @diniamo @LovingMelody

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
