### PR TITLE
netpbm: Unbreak on macOS and unblock NixOS tests on macOS

### DIFF
--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -1,19 +1,20 @@
-{ lib
-, stdenv
-, fetchsvn
-, pkg-config
-, libjpeg
-, libpng
-, jbigkit
-, flex
-, zlib
-, perl
-, libxml2
-, makeWrapper
-, libtiff
-, enableX11 ? false
-, libX11
-, buildPackages
+{
+  lib,
+  stdenv,
+  fetchsvn,
+  pkg-config,
+  libjpeg,
+  libpng,
+  jbigkit,
+  flex,
+  zlib,
+  perl,
+  libxml2,
+  makeWrapper,
+  libtiff,
+  enableX11 ? false,
+  libX11,
+  buildPackages,
 }:
 
 stdenv.mkDerivation {
@@ -22,7 +23,11 @@ stdenv.mkDerivation {
   pname = "netpbm";
   version = "11.9.2";
 
-  outputs = [ "bin" "out" "dev" ];
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+  ];
 
   src = fetchsvn {
     url = "https://svn.code.sf.net/p/netpbm/code/advanced";
@@ -46,7 +51,6 @@ stdenv.mkDerivation {
     jbigkit
   ] ++ lib.optional enableX11 libX11;
 
-
   strictDeps = true;
 
   enableParallelBuilding = true;
@@ -60,40 +64,43 @@ stdenv.mkDerivation {
       --replace '/sharedlink' '/lib'
   '';
 
-  configurePhase = ''
-    runHook preConfigure
+  configurePhase =
+    ''
+      runHook preConfigure
 
-    cp config.mk.in config.mk
+      cp config.mk.in config.mk
 
-    # Disable building static library
-    echo "STATICLIB_TOO = N" >> config.mk
+      # Disable building static library
+      echo "STATICLIB_TOO = N" >> config.mk
 
-    # Enable cross-compilation
-    echo 'AR = ${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar' >> config.mk
-    echo 'CC = ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc' >> config.mk
-    echo 'CC_FOR_BUILD = ${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc' >> config.mk
-    echo 'LD_FOR_BUILD = $(CC_FOR_BUILD)' >> config.mk
-    echo 'PKG_CONFIG = ${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config' >> config.mk
-    echo 'RANLIB = ${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib' >> config.mk
+      # Enable cross-compilation
+      echo 'AR = ${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar' >> config.mk
+      echo 'CC = ${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc' >> config.mk
+      echo 'CC_FOR_BUILD = ${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc' >> config.mk
+      echo 'LD_FOR_BUILD = $(CC_FOR_BUILD)' >> config.mk
+      echo 'PKG_CONFIG = ${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config' >> config.mk
+      echo 'RANLIB = ${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib' >> config.mk
 
-    # Use libraries from Nixpkgs
-    echo "TIFFLIB = libtiff.so" >> config.mk
-    echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
-    echo "TIFFLIB_NEEDS_Z = N" >> config.mk
-    echo "JPEGLIB = libjpeg.so" >> config.mk
-    echo "JBIGLIB = libjbig.a" >> config.mk
-    # Insecure
-    echo "JASPERLIB = NONE" >> config.mk
+      # Use libraries from Nixpkgs
+      echo "TIFFLIB = libtiff.so" >> config.mk
+      echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
+      echo "TIFFLIB_NEEDS_Z = N" >> config.mk
+      echo "JPEGLIB = libjpeg.so" >> config.mk
+      echo "JBIGLIB = libjbig.a" >> config.mk
+      # Insecure
+      echo "JASPERLIB = NONE" >> config.mk
 
-    # Fix path to rgb.txt
-    echo "RGB_DB_PATH = $out/share/netpbm/misc/rgb.txt" >> config.mk
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
-    echo "NETPBMLIBTYPE = dylib" >> config.mk
-    echo "NETPBMLIBSUFFIX = dylib" >> config.mk
-  '' + ''
-    runHook postConfigure
-  '';
+      # Fix path to rgb.txt
+      echo "RGB_DB_PATH = $out/share/netpbm/misc/rgb.txt" >> config.mk
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      echo "LDSHLIB=-dynamiclib -install_name $out/lib/libnetpbm.\$(MAJ).dylib" >> config.mk
+      echo "NETPBMLIBTYPE = dylib" >> config.mk
+      echo "NETPBMLIBSUFFIX = dylib" >> config.mk
+    ''
+    + ''
+      runHook postConfigure
+    '';
 
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -6,6 +6,7 @@
   libjpeg,
   libpng,
   jbigkit,
+  enableJBigKit ? !stdenv.isDarwin,
   flex,
   zlib,
   perl,
@@ -41,15 +42,17 @@ stdenv.mkDerivation {
     makeWrapper
   ];
 
-  buildInputs = [
-    zlib
-    perl
-    libpng
-    libjpeg
-    libxml2
-    libtiff
-    jbigkit
-  ] ++ lib.optional enableX11 libX11;
+  buildInputs =
+    [
+      zlib
+      perl
+      libpng
+      libjpeg
+      libxml2
+      libtiff
+    ]
+    ++ lib.optional enableJBigKit jbigkit
+    ++ lib.optional enableX11 libX11;
 
   strictDeps = true;
 
@@ -86,7 +89,11 @@ stdenv.mkDerivation {
       echo "TIFFLIB_NEEDS_JPEG = N" >> config.mk
       echo "TIFFLIB_NEEDS_Z = N" >> config.mk
       echo "JPEGLIB = libjpeg.so" >> config.mk
+    ''
+    + lib.optionalString enableJBigKit ''
       echo "JBIGLIB = libjbig.a" >> config.mk
+    ''
+    + ''
       # Insecure
       echo "JASPERLIB = NONE" >> config.mk
 


### PR DESCRIPTION
- Reformatted libpbm with nixfmt-rfc-style
- unbroke the package on darwin

This breakage blocks running nixos integration tests on macOS.
Broken since https://github.com/NixOS/nixpkgs/commit/ab24b9495e8cf0fb6c079beea95d82eaba63e7e9 (cc @drupol)

cc @zupo, this way we won't need https://github.com/NixOS/nixpkgs/pull/391555 anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
