### PR TITLE
git-of-theseus: init at 0-unstable-2023-02-13

### DIFF
--- a/pkgs/by-name/gi/git-of-theseus/package.nix
+++ b/pkgs/by-name/gi/git-of-theseus/package.nix
@@ -1,0 +1,42 @@
+{
+  python3,
+  fetchFromGitHub,
+  lib,
+}:
+python3.pkgs.buildPythonApplication {
+  pname = "git-of-theseus";
+  version = "0-unstable-2023-11-25";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "erikbern";
+    repo = "git-of-theseus";
+    rev = "961bda027ffa9fcd8bbe99d5b8809cc0eaa86464";
+    hash = "sha256-FZXLJbximJWrDyuRril6whlOYWppGLns3k8sDNRmOuI=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    gitpython
+    matplotlib
+    numpy
+    progressbar2
+    pygments
+    scipy
+    tqdm
+    wcmatch
+  ];
+
+  pythonImportsCheck = [ "git_of_theseus" ];
+
+  meta = {
+    description = "Analyze how a Git repo grows over time";
+    homepage = "https://github.com/erikbern/git-of-theseus";
+    license = lib.licenses.apsl20;
+    maintainers = with lib.maintainers; [ fzakaria ];
+    mainProgram = "git-of-theseus";
+  };
+}


### PR DESCRIPTION
Very cool tool to make nice graph plots of Git repositories.

Who wants to try this on Nixpkgs ? :P

Here is a sample image I did on the llvm-project (took a few hours)
![image](https://github.com/user-attachments/assets/56f16727-2504-4ede-aa14-f5ab3190ae28)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC author: @erikbern
