### PR TITLE
home-assistant-custom-components.lednetwf_ble: init at 0.0.14.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/lednetwf_ble/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/lednetwf_ble/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  bluetooth-sensor-state-data,
+  bleak-retry-connector,
+  bleak,
+  nix-update-script,
+}:
+let
+  version = "0.0.14.2";
+in
+buildHomeAssistantComponent {
+  owner = "8none1";
+  domain = "lednetwf_ble";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "8none1";
+    repo = "lednetwf_ble";
+    tag = "v.${version}";
+    hash = "sha256-FgLUBCIYsmvrU8auraFVJ+hnl/p6KHpEeIWMT4KGJBM=";
+  };
+
+  dependencies = [
+    bluetooth-sensor-state-data
+    bleak-retry-connector
+    bleak
+  ];
+
+  # Currently there are no tests run, so we skip
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Home Assistant custom integration for LEDnetWF devices";
+    homepage = "https://github.com/8none1/lednetwf_ble";
+    changelog = "https://github.com/8none1/lednetwf_ble/releases/tag/v.${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ blenderfreaky ];
+  };
+}


### PR DESCRIPTION
Simple home-assistant Integration for LEDnetWF/Zengge devices. Have been successfully using this package with my lights so far.

The 4-part version is a bit odd, but it's what's used on upstream.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
