### PR TITLE
jbigkit: fix darwin build, mark unbroken

### DIFF
--- a/pkgs/by-name/jb/jbigkit/package.nix
+++ b/pkgs/by-name/jb/jbigkit/package.nix
@@ -14,37 +14,40 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3nEGtr+vSV1oZcfdesbKE4G9EuDYFAXqgefyFnJj2TI=";
   };
 
-  patches = [
-    # Archlinux patch: build shared object
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-shared_lib.patch";
-      hash = "sha256-+efeeKg3FJ/TjSOj58kD+DwnaCm3zhGzKLfUes/d5rg=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-ldflags.patch";
-      hash = "sha256-ik3NifyuhDHnIMTrNLAKInPgu2F5u6Gvk9daqrn8ZhY=";
-    })
-    # Archlinux patch: update coverity
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-coverity.patch";
-      hash = "sha256-APm9A2f4sMufuY3cnL9HOcSCa9ov3pyzgQTTKLd49/E=";
-    })
-    # Archlinux patch: fix build warnings
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-build_warnings.patch";
-      hash = "sha256-lDEJ1bvZ+zR7K4CiTq+aXJ8PGjILE3W13kznLLlGOOg=";
-    })
-    # Archlinux patch: this helps users to reduce denial-of-service risks, as in CVE-2017-9937
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/0013-new-jbig.c-limit-s-maxmem-maximum-decoded-image-size.patch";
-      hash = "sha256-Yq5qCTF7KZTrm4oeWbpctb+QLt3shJUGEReZvd0ey9k=";
-    })
-    # Archlinux patch: fix heap overflow
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/0015-jbg_newlen-check-for-end-of-file-within-MARKER_NEWLE.patch";
-      hash = "sha256-F3qA/btR9D9NfzrNY76X4Z6vG6NrisI36SjCDjS+F5s=";
-    })
-  ];
+  patches =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      # Archlinux patch: build shared object
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-shared_lib.patch";
+        hash = "sha256-+efeeKg3FJ/TjSOj58kD+DwnaCm3zhGzKLfUes/d5rg=";
+      })
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-ldflags.patch";
+        hash = "sha256-ik3NifyuhDHnIMTrNLAKInPgu2F5u6Gvk9daqrn8ZhY=";
+      })
+    ]
+    ++ [
+      # Archlinux patch: update coverity
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-coverity.patch";
+        hash = "sha256-APm9A2f4sMufuY3cnL9HOcSCa9ov3pyzgQTTKLd49/E=";
+      })
+      # Archlinux patch: fix build warnings
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-build_warnings.patch";
+        hash = "sha256-lDEJ1bvZ+zR7K4CiTq+aXJ8PGjILE3W13kznLLlGOOg=";
+      })
+      # Archlinux patch: this helps users to reduce denial-of-service risks, as in CVE-2017-9937
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/0013-new-jbig.c-limit-s-maxmem-maximum-decoded-image-size.patch";
+        hash = "sha256-Yq5qCTF7KZTrm4oeWbpctb+QLt3shJUGEReZvd0ey9k=";
+      })
+      # Archlinux patch: fix heap overflow
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/0015-jbg_newlen-check-for-end-of-file-within-MARKER_NEWLE.patch";
+        hash = "sha256-F3qA/btR9D9NfzrNY76X4Z6vG6NrisI36SjCDjS+F5s=";
+      })
+    ];
 
   makeFlags = [
     "AR=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
@@ -61,26 +64,32 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    ''
+      runHook preInstall
 
-    install -vDm 644 libjbig/*.h -t "$out/include/"
-    install -vDm 755 pbmtools/{jbgtopbm{,85},pbmtojbg{,85}} -t "$out/bin/"
-    install -vDm 644 pbmtools/*.1* -t "$out/share/man/man1/"
-
-    install -vDm 755 libjbig/*.so.* -t "$out/lib/"
-    for lib in libjbig.so libjbig85.so; do
-      ln -sv "$lib.${finalAttrs.version}" "$out/lib/$lib"
-      ln -sv "$out/lib/$lib.${finalAttrs.version}" "$out/lib/$lib.0"
-    done
-
-    runHook postInstall
-  '';
+      mkdir -p $out/{bin,include,lib,share/man/man1}
+      install -vDm 644 libjbig/*.h -t "$out/include/"
+      install -vDm 755 pbmtools/{jbgtopbm{,85},pbmtojbg{,85}} -t "$out/bin/"
+      install -vDm 644 pbmtools/*.1* -t "$out/share/man/man1/"
+    ''
+    + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      install -vDm 755 libjbig/*.so.* -t "$out/lib/"
+      for lib in libjbig.so libjbig85.so; do
+        ln -sv "$lib.${finalAttrs.version}" "$out/lib/$lib"
+        ln -sv "$out/lib/$lib.${finalAttrs.version}" "$out/lib/$lib.0"
+      done
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+      install -vDm 644 libjbig/libjbig*.a $out/lib
+    ''
+    + ''
+      runHook postInstall
+    '';
 
   doCheck = true;
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Software implementation of the JBIG1 data compression standard";
     homepage = "http://www.cl.cam.ac.uk/~mgk25/jbigkit/";
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
In https://github.com/amarshall/nixpkgs/commit/ab24b9495e8cf0fb6c079beea95d82eaba63e7e9, shared object building was
adjusted to use `-soname`, which does not work on Darwin, so condition
out those patches and the `install`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I only use this library by proxy through a deep dependency, so do not know how to best perform any program-specific testing. Tested mostly by successfully building `diffoscope`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
