### PR TITLE
python312Packages.smolagents: disable test that requires missing dep `mlx-lm`

### DIFF
--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   accelerate,
   buildPythonPackage,
   docker,
@@ -103,22 +104,27 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "smolagents" ];
 
-  disabledTests = [
-    # Missing dependencies
-    "test_ddgs_with_kwargs"
-    "test_e2b_executor_instantiation"
-    "test_flatten_messages_as_text_for_all_models"
-    "test_from_mcp"
-    "test_import_smolagents_without_extras"
-    "test_vision_web_browser_main"
-    # Tests require network access
-    "test_agent_type_output"
-    "test_can_import_sklearn_if_explicitly_authorized"
-    "test_transformers_message_no_tool"
-    "test_transformers_message_vl_no_tool"
-    "test_transformers_toolcalling_agent"
-    "test_visit_webpage"
-  ];
+  disabledTests =
+    [
+      # Missing dependencies
+      "test_ddgs_with_kwargs"
+      "test_e2b_executor_instantiation"
+      "test_flatten_messages_as_text_for_all_models"
+      "test_from_mcp"
+      "test_import_smolagents_without_extras"
+      "test_vision_web_browser_main"
+      # Tests require network access
+      "test_agent_type_output"
+      "test_can_import_sklearn_if_explicitly_authorized"
+      "test_transformers_message_no_tool"
+      "test_transformers_message_vl_no_tool"
+      "test_transformers_toolcalling_agent"
+      "test_visit_webpage"
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      # Missing dependencies
+      "test_get_mlx"
+    ];
 
   meta = {
     description = "Barebones library for agents";


### PR DESCRIPTION
Get building by disabling test that requires missing python dependency `mlx-lm`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
