### PR TITLE
erlang_28: 28.0-rc1 -> 28.0-rc2, erlang: stop building web docs

### DIFF
--- a/pkgs/development/interpreters/erlang/28.nix
+++ b/pkgs/development/interpreters/erlang/28.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "28.0-rc1";
-  sha256 = "sha256-fjje31F5YW5rzetb2r4fkESwKt9N+WOH3yrqETUjJzg=";
+  version = "28.0-rc2";
+  sha256 = "sha256-ENarmypS1rs6gG7e0/WOC9p/jabwrjbj/u1rFeWDHck=";
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -12,7 +12,6 @@
   openssl,
   perl,
   runtimeShell,
-  autoconf,
   openjdk11 ? null, # javacSupport
   unixODBC ? null, # odbcSupport
   libGL ? null,
@@ -121,7 +120,6 @@ stdenv.mkDerivation (
     LANG = "C.UTF-8";
 
     nativeBuildInputs = [
-      autoconf
       makeWrapper
       perl
       gnum4
@@ -160,10 +158,6 @@ stdenv.mkDerivation (
         substituteInPlace lib/os_mon/src/disksup.erl \
           --replace-fail '"sh ' '"${runtimeShell} '
       '';
-
-    preConfigure = ''
-      ./otp_build autoconf
-    '';
 
     configureFlags =
       [ "--with-ssl=${lib.getOutput "out" opensslPackage}" ]

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -19,11 +19,9 @@
   libGLU ? null,
   wxGTK ? null,
   xorg ? null,
-  ex_doc ? null,
   parallelBuild ? false,
   systemd,
   wxSupport ? true,
-  ex_docSupport ? false,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd, # systemd support in epmd
   # updateScript deps
   writeScript,
@@ -76,14 +74,6 @@
   installPhase ? "",
   preInstall ? "",
   postInstall ? "",
-  installTargets ?
-    if ((lib.versionOlder version "27.0") || ex_docSupport) then
-      [
-        "install"
-        "install-docs"
-      ]
-    else
-      [ "install" ],
   checkPhase ? "",
   preCheck ? "",
   postCheck ? "",
@@ -104,7 +94,6 @@ assert
 
 assert odbcSupport -> unixODBC != null;
 assert javacSupport -> openjdk11 != null;
-assert ex_docSupport -> ex_doc != null;
 
 let
   inherit (lib)
@@ -140,11 +129,9 @@ stdenv.mkDerivation (
       libxml2
     ];
 
-    env = lib.optionalAttrs ((lib.versionAtLeast "28.0-rc1" version) && ex_docSupport) {
-      # erlang-28.0-rc> warning: jinterface.html redirects to ../lib/jinterface/doc/html/index.html, which does not exist
-      # erlang-28.0-rc>
-      # erlang-28.0-rc> warning: odbc.html redirects to ../lib/odbc/doc/html/index.html, which does not exist
-      EX_DOC_WARNINGS_AS_ERRORS = "false";
+    env = {
+      # only build shell/IDE docs and man pages
+      DOC_TARGETS = "chunks man";
     };
 
     buildInputs =
@@ -174,24 +161,9 @@ stdenv.mkDerivation (
           --replace-fail '"sh ' '"${runtimeShell} '
       '';
 
-    # For OTP 27+ we need ex_doc to build the documentation
-    # When ex_docSupport is enabled, grab the raw ex_doc executable from the ex_doc
-    # derivation. Next, patch the first line to use the escript that will be
-    # built during the build phase of this derivation. Finally, building the
-    # documentation requires the erlang-logo.png asset.
-    preConfigure =
-      ''
-        ./otp_build autoconf
-      ''
-      + optionalString ex_docSupport ''
-        mkdir -p $out/bin
-        cp ${ex_doc}/bin/.ex_doc-wrapped $out/bin/ex_doc
-        sed -i "1 s:^.*$:#!$out/bin/escript:" $out/bin/ex_doc
-        export EX_DOC=$out/bin/ex_doc
-
-        mkdir -p $out/lib/erlang/system/doc/assets
-        cp $src/system/doc/assets/erlang-logo.png $out/lib/erlang/system/doc/assets
-      '';
+    preConfigure = ''
+      ./otp_build autoconf
+    '';
 
     configureFlags =
       [ "--with-ssl=${lib.getOutput "out" opensslPackage}" ]
@@ -211,6 +183,10 @@ stdenv.mkDerivation (
 
     # install-docs will generate and install manpages and html docs
     # (PDFs are generated only when fop is available).
+    installTargets = [
+      "install"
+      "install-docs"
+    ];
 
     postInstall = ''
       ln -s $out/lib/erlang/lib/erl_interface*/bin/erl_call $out/bin/erl_call
@@ -295,7 +271,6 @@ stdenv.mkDerivation (
   // optionalAttrs (preCheck != "") { inherit preCheck; }
   // optionalAttrs (postCheck != "") { inherit postCheck; }
   // optionalAttrs (installPhase != "") { inherit installPhase; }
-  // optionalAttrs (installTargets != [ ]) { inherit installTargets; }
   // optionalAttrs (preInstall != "") { inherit preInstall; }
   // optionalAttrs (fixupPhase != "") { inherit fixupPhase; }
   // optionalAttrs (preFixup != "") { inherit preFixup; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6904,12 +6904,6 @@ with pkgs;
     wxSupport = false;
     systemdSupport = false;
   };
-  beam_nodocs = callPackage ./beam-packages.nix {
-    beam = beam_nodocs;
-    wxSupport = false;
-    systemdSupport = false;
-    ex_docSupport = false;
-  };
 
   inherit (beam.interpreters)
     erlang erlang_28 erlang_27 erlang_26 erlang_25

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -3,7 +3,6 @@
   beam,
   callPackage,
   wxGTK32,
-  buildPackages,
   stdenv,
   wxSupport ? true,
   systemd,
@@ -38,21 +37,18 @@ in
     erlang_27 = self.beamLib.callErlang ../development/interpreters/erlang/27.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
-      autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
 
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
-      autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
 
     erlang_25 = self.beamLib.callErlang ../development/interpreters/erlang/25.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
-      autoconf = buildPackages.autoconf269;
       inherit wxSupport systemdSupport;
     };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,12 +1,10 @@
 {
   lib,
   beam,
-  beam_nodocs,
   callPackage,
   wxGTK32,
   buildPackages,
   stdenv,
-  ex_docSupport ? true,
   wxSupport ? true,
   systemd,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
@@ -34,17 +32,14 @@ in
     erlang_28 = self.beamLib.callErlang ../development/interpreters/erlang/28.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
-      # ex_doc failing to build with erlang 28
-      inherit (beam_nodocs.packages.erlang_27) ex_doc;
-      inherit ex_docSupport wxSupport systemdSupport;
+      inherit wxSupport systemdSupport;
     };
 
     erlang_27 = self.beamLib.callErlang ../development/interpreters/erlang/27.nix {
       wxGTK = wxGTK32;
       parallelBuild = true;
       autoconf = buildPackages.autoconf269;
-      inherit (beam_nodocs.packages.erlang_27) ex_doc;
-      inherit ex_docSupport wxSupport systemdSupport;
+      inherit wxSupport systemdSupport;
     };
 
     erlang_26 = self.beamLib.callErlang ../development/interpreters/erlang/26.nix {


### PR DESCRIPTION
https://github.com/erlang/otp/releases/tag/OTP-28.0-rc2

I also removed the building of web docs, as it requires us to build erlang twice for ex_doc and is likely unnecessary. Using the docs targets as recommended in https://github.com/erlang/otp/issues/9618


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
