### PR TITLE
nc4nix: allow Darwin builds

### DIFF
--- a/pkgs/by-name/nc/nc4nix/package.nix
+++ b/pkgs/by-name/nc/nc4nix/package.nix
@@ -26,6 +26,6 @@ buildGoModule {
     homepage = "https://github.com/helsinki-systems/nc4nix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
`nc4nix` builds and runs on Darwin, so add it to the platforms list.


## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Tests

Demonstration of a run:

```
~/dev/nixpkgs/pkgs/servers/nextcloud/packages on nc4nix-allow-darwin|✚1 logan@scandium 0 [12:52:14] 0s
$ ./generate.sh
this derivation will be built:
  /nix/store/i3cbf6npdx52g3x8mdhg3s5g1jrnidb5-nc4nix-0-unstable-2024-09-28.drv
these 72 paths will be fetched (196.36 MiB download, 1385.75 MiB unpacked):
  /nix/store/8vpszm9fnh00d6s8m5hi67xrpxnxdd5c-apple-sdk-11.3
  /nix/store/hmffg6n6ylbl4c30pqc9i71mwqzrd0iv-bash-5.2p37
  /nix/store/lilfrlzz6wch60mzq661nkgfc96anjld-bash-interactive-5.2p37
  /nix/store/5988q68ifr0plfhb5xm2vakhkhjvj6jd-bzip2-1.0.8
  /nix/store/9l7x0z8y92lxmnqgc2vlnmn9r1hd2f9z-bzip2-1.0.8-bin
<snip>
+ APPS=app_api,bookmarks,calendar,collectives,contacts,cookbook,cospend,deck,end_to_end_encryption,files_automatedtagging,files_markdown,files_mindmap,files_retention,files_texteditor,forms,gpoddersync,groupfolders,impersonate,integration_deepl,integration_openai,integration_paperless,mail,maps,memories,music,news,notes,onlyoffice,phonetrack,polls,previewgenerator,qownnotesapi,quota_warning,registration,richdocuments,sociallogin,spreed,tasks,twofactor_nextcloud_notification,twofactor_totp,twofactor_webauthn,unroundedcorners,unsplash,user_oidc,user_saml,whiteboard
+ nc4nix -apps app_api,bookmarks,calendar,collectives,contacts,cookbook,cospend,deck,end_to_end_encryption,files_automatedtagging,files_markdown,files_mindmap,files_retention,files_texteditor,forms,gpoddersync,groupfolders,impersonate,integration_deepl,integration_openai,integration_paperless,mail,maps,memories,music,news,notes,onlyoffice,phonetrack,polls,previewgenerator,qownnotesapi,quota_warning,registration,richdocuments,sociallogin,spreed,tasks,twofactor_nextcloud_notification,twofactor_totp,twofactor_webauthn,unroundedcorners,unsplash,user_oidc,user_saml,whiteboard
2025/03/20 12:52:47 Starting to process apps for version 29.0.14
2025/03/20 12:52:47 Querying API at https://apps.nextcloud.com//api/v1/platform/29.0.14/apps.json
2025/03/20 12:53:00 Loading 29.json
2025/03/20 12:53:00 Loaded 29.json
2025/03/20 12:53:00 Found app maps (1.4.0) at https://github.com/nextcloud/maps/releases/download/v1.4.0/maps-1.4.0.tar.gz
2025/03/20 12:53:00 Found app files_mindmap (0.0.33) at https://github.com/ACTom/files_mindmap/releases/download/v0.0.33/files_mindmap-0.0.33.tar.gz
2025/03/20 12:53:00 Skipping app files_archive () because it only has a compatible prerelease
<snip>

~/dev/nixpkgs/pkgs/servers/nextcloud/packages on nc4nix-allow-darwin|✚4 logan@scandium 0 [12:53:28] 69s
$ git status                           
On branch nc4nix-allow-darwin
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   ../../../by-name/nc/nc4nix/package.nix
	modified:   29.json
	modified:   30.json
	modified:   31.json

no changes added to commit (use "git add" and/or "git commit -a")

$ uname -a
Darwin scandium 23.4.0 Darwin Kernel Version 23.4.0: Wed Feb 21 21:44:43 PST 2024; root:xnu-10063.101.15~2/RELEASE_ARM64_T6000 arm64 arm Darwin
```