### PR TITLE
mum: init at 0.5.1

### DIFF
--- a/pkgs/by-name/mu/mum/package.nix
+++ b/pkgs/by-name/mu/mum/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  gdk-pixbuf,
+  glib,
+  libnotify,
+  libopus,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+  installShellFiles,
+
+  withNotifications ? true,
+  withOgg ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mum";
+  version = "0.5.1";
+  src = fetchFromGitHub {
+    owner = "mum-rs";
+    repo = "mum";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r2isuwXq79dOQQWB+CsofYCLQYu9VKm7kzoxw103YV4=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ey3nT6vZ5YOZGk08HykK9RxI7li+Sz+sER3HioGSXP0=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    alsa-lib
+    gdk-pixbuf
+    glib
+    libopus
+    openssl
+  ] ++ lib.optional withNotifications libnotify;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional withNotifications "notifications" ++ lib.optional withOgg "ogg";
+
+  postInstall = ''
+    installManPage documentation/*.{1,5}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/mumctl";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Daemon/cli mumble client";
+    homepage = "https://github.com/mum-rs/mum";
+    changelog = "https://github.com/mum-rs/mum/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ lykos153 ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
Add mum, a daemon/cli mumble client 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
