### PR TITLE
sops: remove hardcoded golang version

### DIFF
--- a/pkgs/by-name/so/sops/bash_autocomplete
+++ b/pkgs/by-name/so/sops/bash_autocomplete
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
-# based on https://github.com/urfave/cli/blob/v2.3.0/autocomplete/bash_autocomplete
+# based on https://github.com/urfave/cli/blob/v3.0.0-beta1.01/autocomplete/bash_autocomplete
 
-_cli_bash_autocomplete() {
-    if [[ "${COMP_WORDS[0]}" != "source" ]]; then
-        local cur opts
-        COMPREPLY=()
-        cur="${COMP_WORDS[COMP_CWORD]}"
-        if [[ "$cur" == "-"* ]]; then
-            opts=$("${COMP_WORDS[@]:0:$COMP_CWORD}" "${cur}" --generate-bash-completion)
-        else
-            opts=$("${COMP_WORDS[@]:0:$COMP_CWORD}" --generate-bash-completion)
-        fi
-        IFS=$'\n' read -d '' -ra COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
-        return 0
-    fi
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+__sops_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
 }
 
-complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete sops
+__sops_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      __sops_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F __sops_bash_autocomplete sops

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -1,12 +1,15 @@
 {
   lib,
+  go_1_22,
   buildGo122Module,
   fetchFromGitHub,
   installShellFiles,
   versionCheckHook,
   nix-update-script,
 }:
-
+let
+  go = go_1_22;
+in
 buildGo122Module rec {
   pname = "sops";
   version = "3.9.4";
@@ -20,9 +23,11 @@ buildGo122Module rec {
 
   vendorHash = "sha256-wxmSj3QaFChGE+/2my7Oe2mhprwi404izUxteecyggY=";
 
+  # sops Makefile runs "go mod tidy" on fly to update go.mod
+  # it needs internet access so we need to modify it manually instead
   postPatch = ''
     substituteInPlace go.mod \
-      --replace-fail "go 1.22" "go 1.22.7"
+      --replace-fail "go 1.22" "go ${go.version}"
   '';
 
   subPackages = [ "cmd/sops" ];

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -41,8 +41,9 @@ buildGo122Module rec {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    installShellCompletion --cmd sops --bash ${./bash_autocomplete}
-    installShellCompletion --cmd sops --zsh ${./zsh_autocomplete}
+    installShellCompletion --cmd sops \
+      --bash ${./bash_autocomplete} \
+      --zsh ${./zsh_autocomplete}
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/so/sops/zsh_autocomplete
+++ b/pkgs/by-name/so/sops/zsh_autocomplete
@@ -1,25 +1,30 @@
 #compdef sops
+compdef _sops sops
 
-## based on https://github.com/urfave/cli/blob/v2.3.0/autocomplete/zsh_autocomplete
+## based on https://github.com/urfave/cli/blob/v3.0.0-beta1.01/autocomplete/zsh_autocomplete
 
-_cli_zsh_autocomplete() {
+_sops() {
+	local -a opts # Declare a local array
+	local current
+	current=${words[-1]} # -1 means "the last element"
+	if [[ "$current" == "-"* ]]; then
+		# Current word starts with a hyphen, so complete flags/options
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} ${current} --generate-bash-completion)}")
+	else
+		# Current word does not start with a hyphen, so complete subcommands
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+	fi
 
-  local -a opts
-  local cur
-  cur=${words[-1]}
-  if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
-  else
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
-  fi
-
-  if [[ "${opts[1]}" != "" ]]; then
-    _describe 'values' opts
-  else
-    _files
-  fi
-
-  return
+	if [[ "${opts[1]}" != "" ]]; then
+		_describe 'values' opts
+	else
+		_files
+	fi
 }
 
-compdef _cli_zsh_autocomplete sops
+# Don't run the completion function when being source-ed or eval-ed.
+# See https://github.com/urfave/cli/issues/1874 for discussion.
+if [ "$funcstack[1]" = "_sops" ]; then
+	_sops
+fi
+


### PR DESCRIPTION
Hey,

I needed to build sops from main branch to get access for unreleased features like supporting keys made with age-plugin-se. (see my other PR to add it into nixpkgs here: #382902)

We had a lengthy discussion on how to build sops from main branch in NixOS discourse:
https://discourse.nixos.org/t/how-to-override-and-build-certain-package-from-master-main-branch/61877

**Main goal with this:**
It would be neat if users wouldn't need to overwrite this in downstream changes:
```nix
postPatch = ''
    substituteInPlace go.mod \
      --replace-fail "go 1.22" "go 1.22.7"
  '';
```

[Here's example of what I needed to do to build sops from main in my own repo](https://github.com/midworkhq/midwork/blob/335e2b83dfced50c23d589ab8adfe384a5146fb3/devenv.nix#L29-L44).

I'm not sure if these changes are enough but I assume that after this I could just override `go_1_22` and then changes to postPatch would not be needed anymore on my own changes.

Thanks in advance 💯 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
