### PR TITLE
nemo-preview: init at 6.4.0, xreader: enable introspection

### DIFF
--- a/pkgs/by-name/ne/nemo-preview/package.nix
+++ b/pkgs/by-name/ne/nemo-preview/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  pkg-config,
+  ninja,
+  glib,
+  gtk3,
+  cjs,
+  gtksourceview4,
+  gobject-introspection,
+  libmusicbrainz5,
+  webkitgtk_4_1,
+  clutter-gtk,
+  clutter-gst,
+  wrapGAppsHook3,
+  nemo,
+  xreader,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nemo-preview";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    tag = finalAttrs.version;
+    hash = "sha256-39hWA4SNuEeaPA6D5mWMHjJDs4hYK7/ZdPkTyskvm5Y=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/nemo-preview";
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+    meson
+    pkg-config
+    glib
+    ninja
+  ];
+
+  buildInputs = [
+    gtk3
+    cjs
+    gtksourceview4
+    libmusicbrainz5
+    webkitgtk_4_1
+    clutter-gtk
+    clutter-gst
+    nemo
+    xreader
+  ];
+
+  meta = {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-preview";
+    description = "Quick previewer for Nemo, the Cinnamon desktop file manager";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.cinnamon.members;
+  };
+})

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dmathjax-directory=${nodePackages.mathjax}"
+    "-Dintrospection=true"
   ] ++ (map (x: "-D${x}=true") backends);
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the nemo-preview extension to the Nemo file manager. By selecting a file and pressing spacebar, nemo-preview allows the contents of the file to be displayed. 

See https://github.com/linuxmint/nemo-extensions/tree/master/nemo-preview

In order for nemo-preview to work, this also requires GTK introspection to be enabled for xreader. This PR also implements that change

Closes https://github.com/NixOS/nixpkgs/issues/373218

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
