### PR TITLE
node-env.nix: remove references to python2

### DIFF
--- a/pkgs/development/compilers/elm/packages/node/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node/node-composition.nix
@@ -13,7 +13,6 @@ let
     inherit (pkgs)
       stdenv
       lib
-      python2
       runCommand
       writeTextFile
       writeShellScript

--- a/pkgs/development/node-packages/composition.nix
+++ b/pkgs/development/node-packages/composition.nix
@@ -13,7 +13,6 @@ let
     inherit (pkgs)
       stdenv
       lib
-      python2
       runCommand
       writeTextFile
       writeShellScript

--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -1,9 +1,9 @@
 # This file originates from node2nix
 
-{lib, stdenv, nodejs, python2, pkgs, libtool, runCommand, writeTextFile, writeShellScript}:
+{lib, stdenv, nodejs, pkgs, libtool, runCommand, writeTextFile, writeShellScript, ...}:
 
 let
-  python = if nodejs ? python then nodejs.python else python2;
+  inherit (nodejs) python;
 
   # Create a tar wrapper that filters all the 'Ignoring unknown extended header keyword' noise
   tarWrapper = runCommand "tarWrapper" {} ''

--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -1,6 +1,6 @@
 # This file originates from node2nix
 
-{lib, stdenv, nodejs, pkgs, libtool, runCommand, writeTextFile, writeShellScript, ...}:
+{lib, stdenv, nodejs, pkgs, libtool, runCommand, writeTextFile, writeShellScript}:
 
 let
   inherit (nodejs) python;

--- a/pkgs/misc/base16-builder/node-packages.nix
+++ b/pkgs/misc/base16-builder/node-packages.nix
@@ -6,7 +6,7 @@
 
 let
   nodeEnv = import ../../development/node-packages/node-env.nix {
-    inherit (pkgs) stdenv lib python2 runCommand writeTextFile writeShellScript;
+    inherit (pkgs) stdenv lib runCommand writeTextFile writeShellScript;
     inherit pkgs nodejs;
     libtool = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };

--- a/pkgs/servers/mx-puppet-discord/node-composition.nix
+++ b/pkgs/servers/mx-puppet-discord/node-composition.nix
@@ -13,7 +13,6 @@ let
     inherit (pkgs)
       stdenv
       lib
-      python2
       runCommand
       writeTextFile
       writeShellScript

--- a/pkgs/servers/web-apps/ethercalc/node-packages.nix
+++ b/pkgs/servers/web-apps/ethercalc/node-packages.nix
@@ -13,7 +13,6 @@ let
     inherit (pkgs)
       stdenv
       lib
-      python2
       runCommand
       writeTextFile
       writeShellScript

--- a/pkgs/tools/security/onlykey/onlykey.nix
+++ b/pkgs/tools/security/onlykey/onlykey.nix
@@ -13,7 +13,6 @@ let
     inherit (pkgs)
       stdenv
       lib
-      python2
       runCommand
       writeTextFile
       writeShellScript


### PR DESCRIPTION
## Things done

Methodology: search for mentions of python2 in `node-*.nix` files containing the string "node2nix".
Update dependent packages accordingly.

The first commit swaps out `python2` for ellipsis, and the last commit removes them. 
Every commit in between removes a usage of `python2` for a package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
