### PR TITLE
libselinux: fix build on 32-bit LFS platforms

### DIFF
--- a/pkgs/by-name/li/libselinux/fix-build-32bit-lfs.patch
+++ b/pkgs/by-name/li/libselinux/fix-build-32bit-lfs.patch
@@ -1,0 +1,72 @@
+From 86211534862622124d26e8570034efc1f5d78823 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Sat, 22 Feb 2025 23:09:30 +0100
+Subject: [PATCH] Inject matchpathcon_filespec_add64() if
+ !defined(__INO_T_MATCHES_INO64_T) instead of using __BITS_PER_LONG < 64 as
+ proxy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The __INO_T_MATCHES_INO64_T is defined
+if ino_t would be the same size as ino64_t
+if -D_FILE_OFFSET_BITS=64 were not defined.
+
+This is /exactly/ what
+  /* ABI backwards-compatible shim for non-LFS 32-bit systems */
+  #if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
+is trying to get at, but currently fails because x32/RV32 are "LFS"
+with 32-bit longs and 64-bit time_ts natively.
+
+Thus, the
+  static_assert(sizeof(unsigned long) == sizeof(__ino_t), "inode size mismatch");
+assertion fails (__ino_t is the "kernel ino_t" type,
+which generally corresponds to the kernel's ulong, which is u64 on x32).
+
+glibc headers allow us to check the condition we care about directly.
+
+Fixes: commit 9395cc0322 ("Always build for LFS mode on 32-bit archs.")
+Closes: #463
+Closes: Debian#1098481
+Signed-off-by: наб <nabijaczleweli@nabijaczleweli.xyz>
+Cc: Alba Mendez <me@alba.sh>
+---
+ libselinux/include/selinux/selinux.h | 2 +-
+ libselinux/src/matchpathcon.c        | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git libselinux/include/selinux/selinux.h libselinux/include/selinux/selinux.h
+index f3cf5a209..f64896b7a 100644
+--- libselinux/include/selinux/selinux.h
++++ libselinux/include/selinux/selinux.h
+@@ -537,7 +537,7 @@ extern int matchpathcon_index(const char *path,
+    with the same inode (e.g. due to multiple hard links).  If so, then
+    use the latter of the two specifications based on their order in the 
+    file contexts configuration.  Return the used specification index. */
+-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
++#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && !defined(__INO_T_MATCHES_INO64_T)
+ #define matchpathcon_filespec_add matchpathcon_filespec_add64
+ #endif
+ extern int matchpathcon_filespec_add(ino_t ino, int specind, const char *file);
+diff --git libselinux/src/matchpathcon.c libselinux/src/matchpathcon.c
+index 51f0e4ff9..ab7c3090a 100644
+--- libselinux/src/matchpathcon.c
++++ libselinux/src/matchpathcon.c
+@@ -261,7 +261,7 @@ int matchpathcon_filespec_add(ino_t ino, int specind, const char *file)
+ 	return -1;
+ }
+ 
+-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
++#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && !defined(__INO_T_MATCHES_INO64_T)
+ /* alias defined in the public header but we undefine it here */
+ #undef matchpathcon_filespec_add
+ 
+@@ -282,7 +282,7 @@ int matchpathcon_filespec_add(unsigned long ino, int specind,
+ }
+ #else
+ 
+-static_assert(sizeof(unsigned long) == sizeof(ino_t), "inode size mismatch");
++static_assert(sizeof(uint64_t) == sizeof(ino_t), "inode size mismatch");
+ 
+ #endif
+ 

--- a/pkgs/by-name/li/libselinux/package.nix
+++ b/pkgs/by-name/li/libselinux/package.nix
@@ -56,6 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://git.yoctoproject.org/meta-selinux/plain/recipes-security/selinux/libselinux/0003-libselinux-restore-drop-the-obsolete-LSF-transitiona.patch?id=62b9c816a5000dc01b28e78213bde26b58cbca9d";
       hash = "sha256-RiEUibLVzfiRU6N/J187Cs1iPAih87gCZrlyRVI2abU=";
     })
+
+    # PR: https://github.com/SELinuxProject/selinux/pull/464
+    # Fix build on 32-bit LFS platforms
+    ./fix-build-32bit-lfs.patch
   ];
 
   nativeBuildInputs =


### PR DESCRIPTION
Compilation of libselinux on modern 32-bit platforms has been broken since v3.8. For example:

~~~
nix-build --arg crossSystem '{ config="riscv32-unknown-linux-gnu"; }' -A libselinux
~~~

A debian maintainer and me prepared a fix in https://github.com/SELinuxProject/selinux/pull/464 (see discussion and first commit), and I'd like to get this patch here while it's reviewed and released upstream (hopefully in some months). The [patch](https://github.com/SELinuxProject/selinux/commit/86211534862622124d26e8570034efc1f5d78823) is small and I've tested it doesn't break the build on x64 (a 64-bit platform) and x86 (a 32-bit non-LFS platform).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
- N/A Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - N/A (Package updates) Added a release notes entry if the change is major or breaking
  - N/A (Module updates) Added a release notes entry if the change is significant
  - N/A (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
