### PR TITLE
miktex: init at 25.2

### DIFF
--- a/pkgs/by-name/mi/miktex/find-exectables-in-path.patch
+++ b/pkgs/by-name/mi/miktex/find-exectables-in-path.patch
@@ -1,0 +1,20 @@
+diff --git a/Libraries/MiKTeX/Core/Session/filetypes.cpp b/Libraries/MiKTeX/Core/Session/filetypes.cpp
+index 82e55382f..84ac206e9 100644
+--- a/Libraries/MiKTeX/Core/Session/filetypes.cpp
++++ b/Libraries/MiKTeX/Core/Session/filetypes.cpp
+@@ -198,6 +198,15 @@ void SessionImpl::RegisterFileType(FileType fileType)
+       searchPath.push_back(myPrefixBinCanon.ToString());
+     }
+ #endif
++    if (Utils::GetEnvironmentString("PATH", str))
++    {
++      PathName binDir(str);
++      binDir.Canonicalize();
++      if (std::find(searchPath.begin(), searchPath.end(), binDir.ToString()) == searchPath.end())
++      {
++        searchPath.push_back(binDir.ToString());
++      }
++    }
+     break;
+   }
+   case FileType::OTF:

--- a/pkgs/by-name/mi/miktex/package.nix
+++ b/pkgs/by-name/mi/miktex/package.nix
@@ -1,0 +1,247 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  runCommand,
+  writeText,
+  biber,
+
+  # nativeBuildInputs
+  bison,
+  cmake,
+  curl,
+  flex,
+  fop,
+  libxslt,
+  pkg-config,
+  writableTmpDirAsHomeHook,
+
+  # buildInputs
+  apr,
+  aprutil,
+  boost,
+  bzip2,
+  cairo,
+  expat,
+  fontconfig,
+  freetype,
+  fribidi,
+  gd,
+  gmp,
+  graphite2,
+  harfbuzzFull,
+  hunspell,
+  libjpeg,
+  log4cxx,
+  xz,
+  mpfr,
+  mpfi,
+  libmspack,
+  libressl,
+  pixman,
+  libpng,
+  popt,
+  uriparser,
+  zziplib,
+  qt6Packages,
+}:
+let
+  # This is needed for some bootstrap packages.
+  webArchivePrefix = "https://web.archive.org/web/20250323131915if_";
+  miktexRemoteRepository = "https://ctan.org/tex-archive/systems/win32/miktex/tm/packages";
+  miktexLocalRepository =
+    runCommand "miktex-local-repository"
+      {
+        src1 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-zzdb1-2.9.tar.lzma";
+          hash = "sha256-XYhbKlxhVSOlCcm0IOs2ddFgAt/CWXJoY6IuLSw74y4=";
+        };
+        src2 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-zzdb3-2.9.tar.lzma";
+          hash = "sha256-5vLuGwjddqtJ5F/DtVKuRVRqgGNbkGFxRF41cXwseIs=";
+        };
+        src3 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-config-2.9.tar.lzma";
+          hash = "sha256-fkh5KL+BU+gl8Sih8xBLi1DOx2vMuSflXlSTchjlGWQ=";
+        };
+        src4 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-dvips.tar.lzma";
+          hash = "sha256-eJQdLhYetNlXAyyiGD/JRDA3fv0BbALwXtNfRxkLM7o=";
+        };
+        src5 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-fontconfig.tar.lzma";
+          hash = "sha256-dxH/0iIL3SnjCSXLGAcNTb5cGJb5AQmV/JbH5CcPHdk=";
+        };
+        src6 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/miktex-misc.tar.lzma";
+          hash = "sha256-ysNREvnKWseqqN59cwNzlV21UmccbjSGFyno8lv2H+M=";
+        };
+        src7 = fetchurl {
+          url = "${webArchivePrefix}/${miktexRemoteRepository}/tetex.tar.lzma";
+          hash = "sha256-DE1o66r2SFxxxuYeCRuFn6L1uBn26IFnje9b/qeVl6Q=";
+        };
+      }
+      ''
+        mkdir $out
+        cp $src1 $out/miktex-zzdb1-2.9.tar.lzma
+        cp $src2 $out/miktex-zzdb3-2.9.tar.lzma
+        cp $src3 $out/miktex-config-2.9.tar.lzma
+        cp $src4 $out/miktex-dvips.tar.lzma
+        cp $src5 $out/miktex-fontconfig.tar.lzma
+        cp $src6 $out/miktex-misc.tar.lzma
+        cp $src7 $out/tetex.tar.lzma
+      '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "miktex";
+  version = "25.2";
+
+  src = fetchFromGitHub {
+    owner = "miktex";
+    repo = "miktex";
+    tag = finalAttrs.version;
+    hash = "sha256-egN9+BRO/EAcbrn/jZac4Lb79H5N/LEjReMPGHVM/yM=";
+  };
+
+  patches = [
+    ./startup-config-support-nix-store.patch
+    # Miktex will search exectables in "GetMyPrefix(true)/bin".
+    # The path evalutate to "/usr/bin" in FHS style linux distrubution,
+    # compared to "/nix/store/.../bin" in NixOS.
+    # As a result, miktex will fail to find e.g. 'pkexec','ksudo','gksu'
+    # under /run/wrappers/bin in NixOS.
+    # We fix this by adding the PATH environment variable to exectables' search path.
+    ./find-exectables-in-path.patch
+  ];
+
+  postPatch =
+    ''
+      # dont symlink fontconfig to /etc/fonts/conf.d
+      substituteInPlace Programs/MiKTeX/miktex/topics/fontmaps/commands/FontMapManager.cpp \
+        --replace-fail 'this->ctx->session->IsAdminMode()' 'false'
+
+      substituteInPlace \
+        Libraries/MiKTeX/App/app.cpp \
+        Programs/Editors/TeXworks/miktex/miktex-texworks.cpp \
+        Programs/MiKTeX/Console/Qt/main.cpp \
+        Programs/MiKTeX/PackageManager/mpm/mpm.cpp \
+        Programs/MiKTeX/Yap/MFC/StdAfx.h \
+        Programs/MiKTeX/initexmf/initexmf.cpp \
+        Programs/MiKTeX/miktex/miktex.cpp \
+        --replace-fail "log4cxx/rollingfileappender.h" "log4cxx/rolling/rollingfileappender.h"
+
+      substitute cmake/modules/FindPOPPLER_QT5.cmake \
+        cmake/modules/FindPOPPLER_QT6.cmake \
+        --replace-fail "QT5" "QT6" \
+        --replace-fail "qt5" "qt6"
+
+      substituteInPlace Programs/TeXAndFriends/omega/otps/source/outocp.c \
+        --replace-fail 'fprintf(stderr, s);' 'fprintf(stderr, "%s", s);'
+    ''
+    # This patch fixes mismatch char types (signed int and unsigned int) on aarch64-linux platform.
+    # Should not be applied to other platforms otherwise the build will fail.
+    + lib.optionalString (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) ''
+      sed -i 's/--using-namespace=MiKTeX::TeXAndFriends/& --chars-are-unsigned/g' \
+        Programs/TeXAndFriends/Knuth/web/CMakeLists.txt
+    '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    curl
+    flex
+    fop
+    libxslt
+    pkg-config
+    writableTmpDirAsHomeHook
+    qt6Packages.wrapQtAppsHook
+    qt6Packages.qttools
+    qt6Packages.qt5compat
+  ];
+
+  buildInputs = [
+    apr
+    aprutil
+    boost
+    bzip2
+    cairo
+    expat
+    fontconfig
+    freetype
+    fribidi
+    gd
+    gmp
+    graphite2
+    harfbuzzFull
+    hunspell
+    libjpeg
+    log4cxx
+    xz
+    mpfr
+    mpfi
+    libmspack
+    libressl
+    pixman
+    libpng
+    popt
+    uriparser
+    zziplib
+    qt6Packages.poppler
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_BOOTSTRAPPING" true)
+    (lib.cmakeBool "USE_SYSTEM_POPPLER" true)
+    (lib.cmakeBool "USE_SYSTEM_POPPLER_QT" true)
+    (lib.cmakeBool "MIKTEX_SELF_CONTAINED" false)
+    # Miktex infers install prefix by stripping CMAKE_INSTALL_BINDIR from the called program.
+    # It should not be set to absolute path in default cmakeFlags, otherwise an infinite loop will happen.
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBEXECDIR" "libexec")
+    (lib.cmakeFeature "MIKTEX_SYSTEM_LINK_TARGET_DIR" "${placeholder "out"}/bin")
+    (lib.cmakeFeature "MIKTEX_USER_LINK_TARGET_DIR" "${placeholder "out"}/bin")
+  ];
+
+  env = {
+    LANG = "C.UTF-8";
+    MIKTEX_REPOSITORY = "file://${miktexLocalRepository}/";
+  };
+
+  enableParallelBuilding = false;
+
+  enableParallelChecking = false;
+
+  doCheck = true;
+
+  # Todo: figure out the exact binary to be Qt wrapped.
+  dontWrapQtApps = true;
+
+  postFixup =
+    ''
+      wrapQtApp $out/bin/miktex-console
+      wrapQtApp $out/bin/miktex-texworks
+      $out/bin/miktexsetup finish --verbose
+    ''
+    # Biber binary is missing on ctan.org for aarch64-linux platform.
+    + lib.optionalString (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) ''
+      ln -sf ${biber}/bin/biber $out/bin/biber
+    '';
+
+  meta = {
+    description = "A modern TeX distribution";
+    homepage = "https://miktex.org";
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
+      lppl13c
+      gpl2Plus
+      gpl3Plus
+      publicDomain
+    ];
+    maintainers = with lib.maintainers; [
+      qbisi
+    ];
+  };
+})

--- a/pkgs/by-name/mi/miktex/startup-config-support-nix-store.patch
+++ b/pkgs/by-name/mi/miktex/startup-config-support-nix-store.patch
@@ -1,0 +1,40 @@
+diff --git a/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp b/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp
+index 1728e7af9..727c36d8c 100644
+--- a/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp
++++ b/Libraries/MiKTeX/Core/Session/unx/unxStartupConfig.cpp
+@@ -90,6 +90,10 @@ InternalStartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, Ver
+   {
+     pos = n - 2;
+   }
++  else if (n > 3 && splittedPrefix[1] == "nix" && splittedPrefix[2] == "store")
++  {
++    pos = 1;
++  }
+   if (pos < n)
+   {
+     PathName destdir;
+@@ -98,10 +102,10 @@ InternalStartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, Ver
+       destdir /= splittedPrefix[i];
+     }
+     MIKTEX_ASSERT(MIKTEX_SYSTEM_VAR_LIB_DIR[0] == '/');
+-    ret.commonConfigRoot = destdir / (MIKTEX_SYSTEM_VAR_LIB_DIR + 1) / MIKTEX_PREFIX "texmf";
++    ret.commonConfigRoot = destdir / (MIKTEX_SYSTEM_VAR_LIB_DIR + 1) / MIKTEX_PREFIX "texmf" / "config";
+     MIKTEX_ASSERT(MIKTEX_SYSTEM_VAR_CACHE_DIR[0] == '/');
+     ret.commonDataRoot = destdir / (MIKTEX_SYSTEM_VAR_CACHE_DIR + 1) / MIKTEX_PREFIX "texmf";
+-    ret.commonInstallRoot = destdir / "usr" / "local" / MIKTEX_INSTALL_DIR;
++    ret.commonInstallRoot = destdir / (MIKTEX_SYSTEM_VAR_LIB_DIR + 1) / MIKTEX_PREFIX "texmf" / "install";
+   }
+ #endif
+   if (ret.commonConfigRoot.Empty())
+@@ -124,9 +128,9 @@ InternalStartupConfig SessionImpl::DefaultConfig(MiKTeXConfiguration config, Ver
+ 
+   PathName myLoc = GetMyLocation(true);
+ #if defined(MIKTEX_MACOS_BUNDLE)
+-  ret.isSharedSetup = Utils::IsParentDirectoryOf(PathName("/usr"), myLoc) || Utils::IsParentDirectoryOf(PathName("/Applications"), myLoc) ? TriState::True : TriState::False;
++  ret.isSharedSetup = Utils::IsParentDirectoryOf(PathName("/nix/store"), myLoc) || Utils::IsParentDirectoryOf(PathName("/usr"), myLoc) || Utils::IsParentDirectoryOf(PathName("/Applications"), myLoc) ? TriState::True : TriState::False;
+ #else
+-  ret.isSharedSetup = Utils::IsParentDirectoryOf(PathName("/usr"), myLoc) || Utils::IsParentDirectoryOf(PathName("/opt"), myLoc) ? TriState::True : TriState::False;
++  ret.isSharedSetup = Utils::IsParentDirectoryOf(PathName("/nix/store"), myLoc) || Utils::IsParentDirectoryOf(PathName("/usr"), myLoc) || Utils::IsParentDirectoryOf(PathName("/opt"), myLoc) ? TriState::True : TriState::False;
+ #endif
+ 
+   return ret;


### PR DESCRIPTION
# Intro
MiKTeX is a modern TeX distribution for Windows, Linux and macOS.

MiKTeX's integrated package manager installs missing components from the Internet, if required. This allows you to keep your TeX installation as minimal as possible ([“Just enough TeX”](https://miktex.org/kb/just-enough-tex)).

Statefull Location used by original miktex:
- texmf directory:
  UserConfig: $HOME/.miktex/texmfs/config
  UserData: $HOME/.miktex/texmfs/data
  UserInstall: $HOME/.miktex/texmfs/install
  CommonConfig: /var/lib/miktex-texmf
  CommonData: /var/cache/miktex-texmf
  CommonInstall: /usr/local/share/miktex-texmf
- links to miktex exec:
  MIKTEX_SYSTEM_LINK_TARGET_DIR: "/usr/local/bin"
  MIKTEX_USER_LINK_TARGET_DIR: "~/bin"

Modification in nixpkgs#miktex
- texmf directory:
  UserConfig: $HOME/.miktex/texmfs/config
  UserData: $HOME/.miktex/texmfs/data
  UserInstall: $HOME/.miktex/texmfs/install
  CommonConfig: /var/lib/miktex-texmf/config
  CommonData: /var/cache/miktex-texmf
  CommonInstall: /var/lib/miktex-texmf/install
- links to miktex exec:
  MIKTEX_SYSTEM_LINK_TARGET_DIR: $out/bin
  MIKTEX_USER_LINK_TARGET_DIR: $out/bin

# Usage(**IMPORTANT**): 
Before startup  run `miktexsetup finish` to generate texmf directory.
you may also want to 
 1) run `miktex packages update` to check for updates.
 2) enable automatic package installation: `initexmf --set-config-value '[MPM]AutoInstall=1'`

more information can be found in https://miktex.org/download.
It is recmmend to use miktex in private user mode.

# Limitation
miktex mainly focus on x86-64 platform, some packages are missing on aarch64 platform e.g. biber.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
