### PR TITLE
nixos/dnsmasq: Fix failure on read-only /etc when resolveLocalQueries=false

### DIFF
--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -149,7 +149,7 @@ in
           mkdir -m 755 -p ${stateDir}
           touch ${stateDir}/dnsmasq.leases
           chown -R dnsmasq ${stateDir}
-          touch /etc/dnsmasq-{conf,resolv}.conf
+          ${lib.optionalString cfg.resolveLocalQueries "touch /etc/dnsmasq-{conf,resolv}.conf"}
           dnsmasq --test
         '';
         serviceConfig = {


### PR DESCRIPTION
This fixes an issue where dnsmasq fails to start if /etc is read-only and services.dnsmasq.resolveLocalQueries = false.

Previously, the preStart script unconditionally ran: touch /etc/dnsmasq-{conf,resolv}.conf, these files are only needed when resolveLocalQueries = true. Now, the script only touches them when necessary.

Closes https://github.com/NixOS/nixpkgs/issues/388054
Maintainers: @fpletz @globin