### PR TITLE
pdf4qt: 4.0.0.0 -> 5.0.0.0

### DIFF
--- a/pkgs/by-name/bl/blend2d/package.nix
+++ b/pkgs/by-name/bl/blend2d/package.nix
@@ -8,16 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "blend2d";
-  # Note: this is an outdated version for pdf4qt, but vcpkg also uses it
-  # See 'Commit Hashes' in https://blend2d.com/download.html for newest
-  # If the newest version is needed, we can rename this package.
-  version = "0.10";
+  version = "0.12";
 
   src = fetchFromGitHub {
     owner = "blend2d";
     repo = "blend2d";
-    rev = "452d549751188b04367b5af46c040cb737f5f76c";
-    hash = "sha256-LDhnXsp/V1A3YqVyjBVaL7/V6Nhts/1E9hRhl2P293o=";
+    rev = "717cbf4bc0f2ca164cf2f0c48f0497779241b6c5";
+    hash = "sha256-L3wDsjy0cocncZqKLy8in2yirrFJoqU3tFBfeBxlhs0=";
   };
 
   outputs = [

--- a/pkgs/by-name/pd/pdf4qt/find_lcms2_path.patch
+++ b/pkgs/by-name/pd/pdf4qt/find_lcms2_path.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 98752ec..aa029b3 100644
+index 298cdca..8894db3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -55,7 +55,15 @@ endif()
  qt_standard_project_setup()
  
  find_package(OpenSSL REQUIRED)
--find_package(lcms REQUIRED)
+-find_package(lcms2 REQUIRED)
 +SET(LCMS2_NAMES ${LCMS2_NAMES} lcms2 liblcms2 liblcms2_static)
 +FIND_LIBRARY(LCMS2_LIBRARY NAMES ${LCMS2_NAMES} )
 +FIND_PATH(LCMS2_INCLUDE_DIR lcms2.h)
@@ -14,7 +14,7 @@ index 98752ec..aa029b3 100644
 +set_target_properties(lcms2::lcms2 PROPERTIES
 +    IMPORTED_LOCATION ${LCMS2_LIBRARY}
 +    INTERFACE_INCLUDE_DIRECTORIES ${LCMS2_INCLUDE_DIR}
-+    INTERFACE_COMPILE_DEFINITIONS "HAVE_LCMS2=1;CMS_NO_REGISTER_KEYWORD=1")
++    INTERFACE_COMPILE_DEFINITIONS "HAVE_LCMS2=1;CMS_NO_REGISTER_KEYWORD=1") 
 +set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP lcms2::lcms2)
  find_package(ZLIB REQUIRED)
  find_package(Freetype REQUIRED)

--- a/pkgs/by-name/pd/pdf4qt/package.nix
+++ b/pkgs/by-name/pd/pdf4qt/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdf4qt";
-  version = "1.4.0.0";
+  version = "1.5.0.0";
 
   src = fetchFromGitHub {
     owner = "JakubMelka";
     repo = "PDF4QT";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-NlIy/C4uHRG5wwXPuqCShe113qhhsQ5jp50zrOLLA2c=";
+    hash = "sha256-ELdmnOEKFGCtuf240R/0M6r8aPwRQiXurAxrqcCZvOI=";
   };
 
   patches = [


### PR DESCRIPTION
Updated, including dependency that previously needed exception (removed this).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).