### PR TITLE
graphviz: drop libXaw and libXpm dependencies, fix vimdot, format

### DIFF
--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -12,6 +12,7 @@
 , libjpeg
 , libpng
 , libtool
+, makeWrapper
 , pango
 , bash
 , bison
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    makeWrapper
     pkg-config
     python3
     bison
@@ -81,9 +83,11 @@ stdenv.mkDerivation rec {
 
   postFixup = optionalString withXorg ''
     substituteInPlace $out/bin/vimdot \
-      --replace '"/usr/bin/vi"' '"$(command -v vi)"' \
-      --replace '"/usr/bin/vim"' '"$(command -v vim)"' \
-      --replace /usr/bin/vimdot $out/bin/vimdot \
+      --replace-warn '"/usr/bin/vi"' '"$(command -v vi)"' \
+      --replace-warn '"/usr/bin/vim"' '"$(command -v vim)"' \
+      --replace-warn /usr/bin/vimdot $out/bin/vimdot
+
+    wrapProgram $out/bin/vimdot --prefix PATH : "$out/bin"
   '';
 
   passthru.tests = {

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     gts
     pango
     bash
-  ] ++ optionals withXorg (with xorg; [ libXrender libXaw libXpm ])
+  ] ++ optionals withXorg (with xorg; [ libXrender ])
   ++ optionals stdenv.hostPlatform.isDarwin [ ApplicationServices Foundation ];
 
   hardeningDisable = [ "fortify" ];

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -1,31 +1,32 @@
-{ lib
-, stdenv
-, fetchFromGitLab
-, autoreconfHook
-, pkg-config
-, cairo
-, expat
-, flex
-, fontconfig
-, gd
-, gts
-, libjpeg
-, libpng
-, libtool
-, makeWrapper
-, pango
-, bash
-, bison
-, xorg
-, ApplicationServices
-, Foundation
-, python3
-, withXorg ? true
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  autoreconfHook,
+  pkg-config,
+  cairo,
+  expat,
+  flex,
+  fontconfig,
+  gd,
+  gts,
+  libjpeg,
+  libpng,
+  libtool,
+  makeWrapper,
+  pango,
+  bash,
+  bison,
+  xorg,
+  ApplicationServices,
+  Foundation,
+  python3,
+  withXorg ? true,
 
-# for passthru.tests
-, exiv2
-, fltk
-, graphicsmagick
+  # for passthru.tests
+  exiv2,
+  fltk,
+  graphicsmagick,
 }:
 
 let
@@ -51,17 +52,22 @@ stdenv.mkDerivation rec {
     flex
   ];
 
-  buildInputs = [
-    libpng
-    libjpeg
-    expat
-    fontconfig
-    gd
-    gts
-    pango
-    bash
-  ] ++ optionals withXorg (with xorg; [ libXrender ])
-  ++ optionals stdenv.hostPlatform.isDarwin [ ApplicationServices Foundation ];
+  buildInputs =
+    [
+      libpng
+      libjpeg
+      expat
+      fontconfig
+      gd
+      gts
+      pango
+      bash
+    ]
+    ++ optionals withXorg (with xorg; [ libXrender ])
+    ++ optionals stdenv.hostPlatform.isDarwin [
+      ApplicationServices
+      Foundation
+    ];
 
   hardeningDisable = [ "fortify" ];
 
@@ -72,8 +78,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  CPPFLAGS = optionalString (withXorg && stdenv.hostPlatform.isDarwin)
-    "-I${cairo.dev}/include/cairo";
+  CPPFLAGS = optionalString (withXorg && stdenv.hostPlatform.isDarwin) "-I${cairo.dev}/include/cairo";
 
   doCheck = false; # fails with "Graphviz test suite requires ksh93" which is not in nixpkgs
 
@@ -96,12 +101,12 @@ stdenv.mkDerivation rec {
       pydot
       pygraphviz
       xdot
-    ;
+      ;
     inherit
       exiv2
       fltk
       graphicsmagick
-    ;
+      ;
   };
 
   meta = with lib; {
@@ -109,6 +114,9 @@ stdenv.mkDerivation rec {
     description = "Graph visualization tools";
     license = licenses.epl10;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ bjornfor raskin ];
+    maintainers = with maintainers; [
+      bjornfor
+      raskin
+    ];
   };
 }


### PR DESCRIPTION
### graphviz: drop libXaw and libXpm dependencies

The test build intended for debian [1] uses these dependencies as build time dependencies only.
The arch package [2] does not use these dependencies at all.
libXaw was added 11 years ago in 08131bd5d5f627f03625cf28ca8afbd7eb83e7fa.

On arch, xterm links in libXaw and is used for vimdot support.
However, the xterm nix package also explicitly links libXaw [3], and vimdot generally works.
The build succeeds, and with vimdot working (through xwayland), this seems fully non-breaking.

This change will drop libXaw from being a mass rebuild.
While libXaw seems somewhat maintained, recent releases [4] are not even signed anymore,
thus probably should not be a core component of nix packages.

[1] https://gitlab.com/graphviz/graphviz/-/blob/2649f2366435525085cc79fb1e95ec23c84eb047/debian/control#L6
[2] https://archlinux.org/packages/extra/x86_64/graphviz/
[3] https://github.com/NixOS/nixpkgs/blob/a84ebe20c6bc2ecbcfb000a50776219f48d134cc/pkgs/by-name/xt/xterm/package.nix#L40
[4] https://gitlab.freedesktop.org/xorg/lib/libxaw/-/tags#

### graphviz: provide $PATH to vimdot

vimdot expects dot to be in $PATH [1].
This meant previoiusly vimdot would only work if graphviz was in the $PATH,
breaking vimdot in certain scenarios (e.g. executing `result/bin/vimdot`).
Wrapping vimdot to put the graphviz output bin into PATH fixes this issue.

[1] https://gitlab.com/graphviz/graphviz/-/blob/2649f2366435525085cc79fb1e95ec23c84eb047/plugin/xlib/vimdot.sh#L45

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
