### PR TITLE
jdk: replace jdk23 with jdk24

### DIFF
--- a/pkgs/by-name/bi/bisq2/package.nix
+++ b/pkgs/by-name/bi/bisq2/package.nix
@@ -7,7 +7,7 @@
   makeDesktopItem,
   copyDesktopItems,
   imagemagick,
-  jdk23,
+  jdk24,
   dpkg,
   writeShellScript,
   bash,
@@ -20,7 +20,7 @@
 let
   version = "2.1.6";
 
-  jdk = jdk23.override { enableJavaFX = true; };
+  jdk = jdk24.override { enableJavaFX = true; };
 
   bisq-launcher =
     args:

--- a/pkgs/by-name/cr/cratedb/package.nix
+++ b/pkgs/by-name/cr/cratedb/package.nix
@@ -4,13 +4,13 @@
   maven,
   fetchFromGitHub,
   replaceVars,
-  openjdk23,
+  openjdk24,
   libarchive,
   makeWrapper,
 }:
 let
   # Wants at least Java 22
-  jdk = openjdk23;
+  jdk = openjdk24;
   version = "5.9.6";
 in
 maven.buildMavenPackage {

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fuse3,
   glib,
-  jdk23,
+  jdk24,
   lib,
   libayatana-appindicator,
   makeShellWrapper,
@@ -13,7 +13,7 @@
 }:
 
 let
-  jdk = jdk23.override { enableJavaFX = true; };
+  jdk = jdk24.override { enableJavaFX = true; };
 in
 maven.buildMavenPackage rec {
   pname = "cryptomator";

--- a/pkgs/by-name/je/jextract/package.nix
+++ b/pkgs/by-name/je/jextract/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   gradle,
-  jdk23,
+  jdk24,
   llvmPackages,
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   gradleFlags = [
     "-Pllvm_home=${lib.getLib llvmPackages.libclang}"
-    "-Pjdk22_home=${jdk23}"
+    "-Pjdk22_home=${jdk24}"
   ];
 
   doCheck = true;
@@ -47,13 +47,13 @@ stdenv.mkDerivation {
     description = "Tool which mechanically generates Java bindings from a native library headers";
     mainProgram = "jextract";
     homepage = "https://github.com/openjdk/jextract";
-    platforms = jdk23.meta.platforms;
+    platforms = jdk24.meta.platforms;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
       jlesquembre
       sharzy
     ];
-    # Not yet updated for JDK 23
+    # Not yet updated for JDK 24
     broken = true;
   };
 }

--- a/pkgs/by-name/ko/komga/package.nix
+++ b/pkgs/by-name/ko/komga/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchurl,
   makeWrapper,
-  jdk23_headless,
+  jdk24_headless,
   nixosTests,
 }:
 
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   buildCommand = ''
-    makeWrapper ${jdk23_headless}/bin/java $out/bin/komga --add-flags "-jar $src"
+    makeWrapper ${jdk24_headless}/bin/java $out/bin/komga --add-flags "-jar $src"
   '';
 
   passthru.tests = {
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Free and open source comics/mangas server";
     homepage = "https://komga.org/";
     license = lib.licenses.mit;
-    platforms = jdk23_headless.meta.platforms;
+    platforms = jdk24_headless.meta.platforms;
     maintainers = with lib.maintainers; [
       tebriel
       govanify

--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -4,12 +4,12 @@
   buildPackages,
   fetchzip,
   makeWrapper,
-  openjdk23,
+  openjdk24,
   wrapGAppsHook3,
   jvmFlags ? [ ],
 }:
 let
-  jdk = openjdk23.override {
+  jdk = openjdk24.override {
     enableJavaFX = true;
   };
 in

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -35,12 +35,12 @@
 
   jdk17_headless,
   jdk21_headless,
-  jdk23_headless,
+  jdk24_headless,
   jdk-bootstrap ?
     {
       "17" = jdk17_headless;
       "21" = jdk21_headless;
-      "23" = jdk23_headless;
+      "24" = jdk24_headless;
     }
     .${featureVersion},
 }:

--- a/pkgs/by-name/re/recaf-launcher/package.nix
+++ b/pkgs/by-name/re/recaf-launcher/package.nix
@@ -19,7 +19,7 @@ buildFHSEnv {
     p: with p; [
       jar
 
-      openjdk23
+      openjdk24
       xorg.libX11
       at-spi2-atk
       cairo

--- a/pkgs/development/compilers/openjdk/23/source.json
+++ b/pkgs/development/compilers/openjdk/23/source.json
@@ -1,6 +1,0 @@
-{
-  "hash": "sha256-zlL2DV6iOfV3hgq/Ci95gTwVrhcvz5MWsg4/+O2ntE8=",
-  "owner": "openjdk",
-  "repo": "jdk23u",
-  "rev": "refs/tags/jdk-23.0.2+7"
-}

--- a/pkgs/development/compilers/openjdk/24/patches/fix-java-home-jdk24.patch
+++ b/pkgs/development/compilers/openjdk/24/patches/fix-java-home-jdk24.patch
@@ -1,0 +1,14 @@
+--- a/src/hotspot/os/linux/os_linux.cpp	2017-07-04 23:09:02.533972226 -0400
++++ b/src/hotspot/os/linux/os_linux.cpp	2017-07-04 23:07:52.118338845 -0400
+@@ -2758,8 +2758,5 @@
+   assert(ret, "cannot locate libjvm");
+   char *rp = nullptr;
+   if (ret && dli_fname[0] != '\0') {
+-    rp = os::realpath(dli_fname, buf, buflen);
+-  }
+-  if (rp == nullptr) {
+-    return;
++    snprintf(buf, buflen, "%s", dli_fname);
+   }
+
+   if (Arguments::sun_java_launcher_is_altjvm()) {

--- a/pkgs/development/compilers/openjdk/24/patches/read-truststore-from-env-jdk24.patch
+++ b/pkgs/development/compilers/openjdk/24/patches/read-truststore-from-env-jdk24.patch
@@ -1,0 +1,30 @@
+--- a/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java	2017-06-26 21:48:25.000000000 -0400
++++ b/src/java.base/share/classes/sun/security/ssl/TrustStoreManager.java	2017-07-05 20:45:57.491295030 -0400
+@@ -68,6 +68,7 @@
+      *
+      * The preference of the default trusted KeyStore is:
+      *    javax.net.ssl.trustStore
++     *    system environment variable JAVAX_NET_SSL_TRUSTSTORE
+      *    jssecacerts
+      *    cacerts
+      */
+@@ -125,7 +126,8 @@
+         static TrustStoreDescriptor createInstance() {
+             // Get the system properties for trust store.
+             String storePropName = System.getProperty(
+-                    "javax.net.ssl.trustStore", jsseDefaultStore);
++                    "javax.net.ssl.trustStore",
++                    System.getenv("JAVAX_NET_SSL_TRUSTSTORE"));
+             String storePropType = System.getProperty(
+                     "javax.net.ssl.trustStoreType",
+                     KeyStore.getDefaultType());
+@@ -137,6 +139,9 @@
+             String temporaryName = "";
+             File temporaryFile = null;
+             long temporaryTime = 0L;
++            if (storePropName == null) {
++                storePropName = jsseDefaultStore;
++            }
+             if (!"NONE".equals(storePropName)) {
+                 String[] fileNames =
+                         new String[] {storePropName, defaultStore};

--- a/pkgs/development/compilers/openjdk/24/source.json
+++ b/pkgs/development/compilers/openjdk/24/source.json
@@ -1,0 +1,6 @@
+{
+  "hash": "sha256-ogWq6oLyZzzvxGTqEEoPMXdtfbobUyXcC5bXXxBxfuo=",
+  "owner": "openjdk",
+  "repo": "jdk24u",
+  "rev": "refs/tags/jdk-24+36"
+}

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 17, 21, 23)
+feature_versions = (8, 11, 17, 21, 24)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot",)

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -19,6 +19,6 @@ in
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 
-  jdk-23 = common { sourcePerArch = sources.jdk.openjdk23; };
-  jre-23 = common { sourcePerArch = sources.jre.openjdk23; };
+  jdk-24 = common { sourcePerArch = sources.jdk.openjdk24; };
+  jre-24 = common { sourcePerArch = sources.jre.openjdk24; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -24,6 +24,6 @@ in
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 
-  jdk-23 = common { sourcePerArch = sources.jdk.openjdk23; };
-  jre-23 = common { sourcePerArch = sources.jre.openjdk23; };
+  jdk-24 = common { sourcePerArch = sources.jdk.openjdk24; };
+  jre-24 = common { sourcePerArch = sources.jre.openjdk24; };
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -38,20 +38,20 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "b55c5c881a2fed17ec5a59feaa33d9263703b399d1bfae3a5eaed3f140aa4570",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "4a673456aa6e726b86108a095a21868b7ebcdde050a92b3073d50105ff92f07f",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_aarch64_alpine-linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "2c05c6dfea23a83fdbfaf5b03cc3cfd8d998c8069e930e0e585a39d4a99f3d99",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "a642608f0da78344ee6812fb1490b8bc1d7ad5a18064c70994d6f330568c51cb",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_x64_alpine-linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {
@@ -102,20 +102,20 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "248a2ffb3abcb0cee7841ce648af7af415c96ee88cba4f8bf676c0115d38de5e",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "0bc8181c7e85d55bba652503db62e60846439f279271d583b740ac70f9f5ae87",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_aarch64_alpine-linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "4513750bd10cc6c38f0c19d335dac7dcc112bba64e52010f81ba29e7a71e2a76",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "0f738719d0483d6fe7f08a1371d1c696d68dcfe39f073b4241673f35ffc8d655",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_x64_alpine-linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {
@@ -234,32 +234,26 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "fb43ae1202402842559cb6223886ec1663b90ffbec48479abbcb92c92c9012eb",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "18071047526ab4b53131f9bb323e8703485ae37fcb2f2c5ef0f1b7bab66d1b94",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_aarch64_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jdk",
           "powerpc64le": {
-            "build": "7",
-            "sha256": "548fd82af4eb0802fe20b0b61a4664a69c7f03cd963540908f30dbf73636dafe",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_ppc64le_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "riscv64": {
-            "build": "7",
-            "sha256": "1e102e1e6653f8810ef6c275b0d38ea7036abd4a8709f0f916b339f65e76bb56",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_riscv64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "3a5641ab862a2bbae56886d4ec47f735052780bfe124df7aea2ca40e0f973b5a",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_ppc64le_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "870ac8c05c6fe563e7a3878a47d0234b83c050e83651d2c47e8b822ec74512dd",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "c340dee97b6aa215d248bc196dcac5b56e7be9b5c5d45e691344d40d5d0b171d",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_x64_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {
@@ -400,32 +394,26 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "b2a8a287ebd2d2a1d5d32eb6b79768cf2b5e02f1b4d6d4791297feb8636b9e2f",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "782a46008490272affe0b797155c2ae8e759e10c8ba4540f1f7285ef3d2902de",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_aarch64_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jre",
           "powerpc64le": {
-            "build": "7",
-            "sha256": "a21355923fdcdcc49fcf6359f2763f49f001bd4caeb970f7313f18aeaa61b588",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_ppc64le_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "riscv64": {
-            "build": "7",
-            "sha256": "c2c8f8add6af6518cfc565ec0a7410e031301b91f2d8bd594303d7f04680da4e",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_riscv64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "e7c90ab80d5e9419f794aee63c8f1bf3ed29e656d4e8e967a45d3069bd643c07",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_ppc64le_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "1a16c654e67a72dadfa632969a457404ad1cc30c6375857fdcb393e0592ce3ba",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "e8d8f5707d765a6bfca3de61320e0bb2618191c77947bc467ac5021e6193f351",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_x64_linux_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {
@@ -514,20 +502,20 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "749993e751f085c7ae713140066a90800075e4aeedfac50a5ed0c5457131c5a0",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "8e343d2aaa1d00fdee351d392a4a3f537d81fa4a36f5fdf05e2e2c26d5c50af9",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_aarch64_mac_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "97fca2e90668351f248f149d4e96e16875094eba6716a8dd1dcf163be9e19085",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "07a99d4a81c4d5e0c4936bf4b9f901565213781c67e865f304a8d8eb75e880d8",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_x64_mac_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {
@@ -590,20 +578,20 @@
             "version": "21.0.6"
           }
         },
-        "openjdk23": {
+        "openjdk24": {
           "aarch64": {
-            "build": "7",
-            "sha256": "56b86d4f5745ba44894310c3417755e4b4aaa62d4a17a5cb4dab6200c14c56fe",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "fa9783caf9298b7e927b4589435257cf9a2cf12e1eb915992911b988f3d310bc",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_aarch64_mac_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "7",
-            "sha256": "2c5b81ce3234d6bef0ec352734aa2de19c0950020c55a1cbfc21ae5fda7690b8",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
+            "build": "36",
+            "sha256": "10b2a32a5544c03a4bf36f12efc3a770bb789be20ff3c9edf85102c5879479de",
+            "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_x64_mac_hotspot_24_36.tar.gz",
+            "version": "24.0.0"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/zulu/24.nix
+++ b/pkgs/development/compilers/zulu/24.nix
@@ -10,43 +10,43 @@ callPackage ./common.nix (
     # Note that the latest build may differ by platform
     dists = {
       x86_64-linux = {
-        zuluVersion = "23.28.85";
-        jdkVersion = "23.0.0";
+        zuluVersion = "24.28.83";
+        jdkVersion = "24+36";
         hash =
           if enableJavaFX then
-            "sha256-HEQ0lxHsoyHG+ZWIlWsbkqMf/rauARafzWoiElRwekA="
+            "sha256-0EQ0lxHsoyHG+ZWIlWsbkqMf/rauARafzWoiElRwekA="
           else
-            "sha256-a1YPqBMaWkoruNFoSckLyx00LCOZNsowlSn2L3XCDJA=";
+            "sha256-01YPqBMaWkoruNFoSckLyx00LCOZNsowlSn2L3XCDJA=";
       };
 
       aarch64-linux = {
-        zuluVersion = "23.28.85";
-        jdkVersion = "23.0.0";
+        zuluVersion = "24.28.83";
+        jdkVersion = "24+36";
         hash =
           if enableJavaFX then
             throw "JavaFX is not available for aarch64-linux"
           else
-            "sha256-/i+ch7BMAwMQ1C4e3shp9BHuQ67vVXfmIK1YKs7L24M=";
+            "sha256-0i+ch7BMAwMQ1C4e3shp9BHuQ67vVXfmIK1YKs7L24M=";
       };
 
       x86_64-darwin = {
-        zuluVersion = "23.28.85";
-        jdkVersion = "23.0.0";
+        zuluVersion = "24.28.83";
+        jdkVersion = "24+36";
         hash =
           if enableJavaFX then
-            "sha256-1/YmLWA/men8jMjnhkZVMf2irf6Tc/5x7UECxqKJcL4="
+            "sha256-00YmLWA/men8jMjnhkZVMf2irf6Tc/5x7UECxqKJcL4="
           else
-            "sha256-rEr8M3KF9Z95gV8sHqi5lQD2RJjtssZx8Q8goy6danw=";
+            "sha256-0Er8M3KF9Z95gV8sHqi5lQD2RJjtssZx8Q8goy6danw=";
       };
 
       aarch64-darwin = {
-        zuluVersion = "23.28.85";
-        jdkVersion = "23.0.0";
+        zuluVersion = "24.28.83";
+        jdkVersion = "24+36";
         hash =
           if enableJavaFX then
-            "sha256-TumPJoHmvklMlcpF4PFY/Arcdc5fkX5z0xeIuNFxluQ="
+            "sha256-0umPJoHmvklMlcpF4PFY/Arcdc5fkX5z0xeIuNFxluQ="
           else
-            "sha256-gFvfJL0RQgIOATLTMdfa+fStUCrdHYC3rxy0j5eNVDc=";
+            "sha256-0FvfJL0RQgIOATLTMdfa+fStUCrdHYC3rxy0j5eNVDc=";
       };
     };
   }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4961,7 +4961,7 @@ with pkgs;
 
   sparrow-unwrapped = callPackage ../applications/blockchains/sparrow {
     openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix {};
-    openjdk = jdk23.override { enableJavaFX = true; };
+    openjdk = jdk24.override { enableJavaFX = true; };
   };
 
   sparrow = callPackage ../applications/blockchains/sparrow/fhsenv.nix { };
@@ -5524,8 +5524,8 @@ with pkgs;
 
   ### DEVELOPMENT / COMPILERS
 
-  temurin-bin-23 = javaPackages.compiler.temurin-bin.jdk-23;
-  temurin-jre-bin-23 = javaPackages.compiler.temurin-bin.jre-23;
+  temurin-bin-24 = javaPackages.compiler.temurin-bin.jdk-24;
+  temurin-jre-bin-24 = javaPackages.compiler.temurin-bin.jre-24;
 
   temurin-bin-21 = javaPackages.compiler.temurin-bin.jdk-21;
   temurin-jre-bin-21 = javaPackages.compiler.temurin-bin.jre-21;
@@ -6198,7 +6198,7 @@ with pkgs;
 
   openjfx17 = openjfx;
   openjfx21 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "21"; };
-  openjfx23 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "23"; };
+  openjfx24 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "24"; };
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;
   openjdk8 = javaPackages.compiler.openjdk8;
@@ -6225,10 +6225,10 @@ with pkgs;
   jdk21 = openjdk21;
   jdk21_headless = openjdk21_headless;
 
-  openjdk23 = javaPackages.compiler.openjdk23;
-  openjdk23_headless = javaPackages.compiler.openjdk23.headless;
-  jdk23 = openjdk23;
-  jdk23_headless = openjdk23_headless;
+  openjdk24 = javaPackages.compiler.openjdk24;
+  openjdk24_headless = javaPackages.compiler.openjdk24.headless;
+  jdk24 = openjdk24;
+  jdk24_headless = openjdk24_headless;
 
   /* default JDK */
   jdk = jdk21;
@@ -6782,7 +6782,7 @@ with pkgs;
   zulu11 = callPackage ../development/compilers/zulu/11.nix { };
   zulu17 = callPackage ../development/compilers/zulu/17.nix { };
   zulu21 = callPackage ../development/compilers/zulu/21.nix { };
-  zulu23 = callPackage ../development/compilers/zulu/23.nix { };
+  zulu24 = callPackage ../development/compilers/zulu/24.nix { };
   zulu = zulu21;
 
   ### DEVELOPMENT / INTERPRETERS
@@ -13851,7 +13851,7 @@ with pkgs;
   jabref = callPackage ../applications/office/jabref {
     jdk = jdk21.override {
       enableJavaFX = true;
-      openjfx_jdk = openjfx23;
+      openjfx_jdk = openjfx24;
     };
   };
 
@@ -18091,7 +18091,7 @@ with pkgs;
   };
 
   weasis = callPackage ../by-name/we/weasis/package.nix {
-    jre = jdk23;
+    jre = jdk24;
   };
 
   sieveshell = with python3.pkgs; toPythonApplication managesieve;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -3,7 +3,7 @@
 with pkgs;
 
 {
-  inherit (pkgs) openjfx17 openjfx21 openjfx23;
+  inherit (pkgs) openjfx17 openjfx21 openjfx24;
 
   compiler =
     let
@@ -38,7 +38,7 @@ with pkgs;
       openjdk11 = mkOpenjdk "11" ../development/compilers/zulu/11.nix;
       openjdk17 = mkOpenjdk "17" ../development/compilers/zulu/17.nix;
       openjdk21 = mkOpenjdk "21" ../development/compilers/zulu/21.nix;
-      openjdk23 = mkOpenjdk "23" ../development/compilers/zulu/23.nix;
+      openjdk24 = mkOpenjdk "24" ../development/compilers/zulu/24.nix;
 
       # Legacy aliases
       openjdk8-bootstrap = temurin-bin.jdk-8;


### PR DESCRIPTION
Replace the previous non-LTS JDK with the latest one.

Unfinished (hence draft): missing some hash updates and openjdk is failing with:

```
ERROR: noBrokenSymlinks: the symlink /nix/store/b011ynydmx6650kwp9xgjx78kdpr1fyh-openjdk-24+36/share/man points to a missing target: /nix/store/b011ynydmx6650kwp9xgjx78kdpr1fyh-openjdk-24+36/lib/openjdk/man
ERROR: noBrokenSymlinks: found 1 dangling symlinks and 0 reflexive symlinks
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
