### PR TITLE
nixos/h2o: wait for open ports in tests, use runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -502,7 +502,7 @@ in {
   guacamole-server = handleTest ./guacamole-server.nix {};
   guix = handleTest ./guix {};
   gvisor = handleTest ./gvisor.nix {};
-  h2o = discoverTests (import ./web-servers/h2o { inherit handleTestOn; });
+  h2o = import ./web-servers/h2o { inherit recurseIntoAttrs runTest; };
   hadoop = import ./hadoop { inherit handleTestOn; package=pkgs.hadoop; };
   hadoop_3_3 = import ./hadoop { inherit handleTestOn; package=pkgs.hadoop_3_3; };
   hadoop2 = import ./hadoop { inherit handleTestOn; package=pkgs.hadoop2; };

--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -1,144 +1,142 @@
-import ../../make-test-python.nix (
-  { lib, pkgs, ... }:
+{ hostPkgs, lib, ... }:
 
-  # Tests basics such as TLS, creating a mime-type & serving Unicode characters.
+# Tests basics such as TLS, creating a mime-type & serving Unicode characters.
 
-  let
-    domain = {
-      HTTP = "h2o.local";
-      TLS = "acme.test";
-    };
+let
+  domain = {
+    HTTP = "h2o.local";
+    TLS = "acme.test";
+  };
 
-    port = {
-      HTTP = 8080;
-      TLS = 8443;
-    };
+  port = {
+    HTTP = 8080;
+    TLS = 8443;
+  };
 
-    sawatdi_chao_lok = "สวัสดีชาวโลก";
+  sawatdi_chao_lok = "สวัสดีชาวโลก";
 
-    hello_world_txt = pkgs.writeTextFile {
-      name = "/hello_world.txt";
-      text = sawatdi_chao_lok;
-    };
+  hello_world_txt = hostPkgs.writeTextFile {
+    name = "/hello_world.txt";
+    text = sawatdi_chao_lok;
+  };
 
-    hello_world_rst = pkgs.writeTextFile {
-      name = "/hello_world.rst";
-      text = # rst
-        ''
-          ====================
-          Thaiger Sprint 2025‼
-          ====================
+  hello_world_rst = hostPkgs.writeTextFile {
+    name = "/hello_world.rst";
+    text = # rst
+      ''
+        ====================
+        Thaiger Sprint 2025‼
+        ====================
 
-          ${sawatdi_chao_lok}
-        '';
-    };
-  in
-  {
-    name = "h2o-basic";
+        ${sawatdi_chao_lok}
+      '';
+  };
+in
+{
+  name = "h2o-basic";
 
-    meta = {
-      maintainers = with lib.maintainers; [ toastal ];
-    };
+  meta = {
+    maintainers = with lib.maintainers; [ toastal ];
+  };
 
-    nodes = {
-      server =
-        { pkgs, ... }:
-        {
-          services.h2o = {
-            enable = true;
-            defaultHTTPListenPort = port.HTTP;
-            defaultTLSListenPort = port.TLS;
-            hosts = {
-              "${domain.HTTP}" = {
-                settings = {
-                  paths = {
-                    "/hello_world.txt" = {
-                      "file.file" = "${hello_world_txt}";
-                    };
-                  };
-                };
-              };
-              "${domain.TLS}" = {
-                tls = {
-                  policy = "force";
-                  identity = [
-                    {
-                      key-file = ../../common/acme/server/acme.test.key.pem;
-                      certificate-file = ../../common/acme/server/acme.test.cert.pem;
-                    }
-                  ];
-                  extraSettings = {
-                    minimum-version = "TLSv1.3";
-                  };
-                };
-                settings = {
-                  paths = {
-                    "/hello_world.rst" = {
-                      "file.file" = "${hello_world_rst}";
-                    };
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        services.h2o = {
+          enable = true;
+          defaultHTTPListenPort = port.HTTP;
+          defaultTLSListenPort = port.TLS;
+          hosts = {
+            "${domain.HTTP}" = {
+              settings = {
+                paths = {
+                  "/hello_world.txt" = {
+                    "file.file" = "${hello_world_txt}";
                   };
                 };
               };
             };
-            settings = {
-              compress = "ON";
-              compress-minimum-size = 32;
-              "file.mime.addtypes" = {
-                "text/x-rst" = {
-                  extensions = [ ".rst" ];
-                  is_compressible = "YES";
+            "${domain.TLS}" = {
+              tls = {
+                policy = "force";
+                identity = [
+                  {
+                    key-file = ../../common/acme/server/acme.test.key.pem;
+                    certificate-file = ../../common/acme/server/acme.test.cert.pem;
+                  }
+                ];
+                extraSettings = {
+                  minimum-version = "TLSv1.3";
                 };
               };
-              ssl-offload = "kernel";
+              settings = {
+                paths = {
+                  "/hello_world.rst" = {
+                    "file.file" = "${hello_world_rst}";
+                  };
+                };
+              };
             };
           };
-
-          security.pki.certificates = [
-            (builtins.readFile ../../common/acme/server/ca.cert.pem)
-          ];
-
-          networking = {
-            firewall.allowedTCPPorts = with port; [
-              HTTP
-              TLS
-            ];
-            extraHosts = ''
-              127.0.0.1 ${domain.HTTP}
-              127.0.0.1 ${domain.TLS}
-            '';
+          settings = {
+            compress = "ON";
+            compress-minimum-size = 32;
+            "file.mime.addtypes" = {
+              "text/x-rst" = {
+                extensions = [ ".rst" ];
+                is_compressible = "YES";
+              };
+            };
+            ssl-offload = "kernel";
           };
         };
-    };
 
-    testScript =
-      let
-        portStrHTTP = builtins.toString port.HTTP;
-        portStrTLS = builtins.toString port.TLS;
-      in
-      # python
-      ''
-        server.wait_for_unit("h2o.service")
-        server.wait_for_open_port(${portStrHTTP})
-        server.wait_for_open_port(${portStrTLS})
+        security.pki.certificates = [
+          (builtins.readFile ../../common/acme/server/ca.cert.pem)
+        ];
 
-        http_hello_world_body = server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
-        assert "${sawatdi_chao_lok}" in http_hello_world_body
+        networking = {
+          firewall.allowedTCPPorts = with port; [
+            HTTP
+            TLS
+          ];
+          extraHosts = ''
+            127.0.0.1 ${domain.HTTP}
+            127.0.0.1 ${domain.TLS}
+          '';
+        };
+      };
+  };
 
-        tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
-        assert "http/2 200" in tls_hello_world_head
-        assert "server: h2o" in tls_hello_world_head
-        assert "content-type: text/x-rst" in tls_hello_world_head
+  testScript =
+    let
+      portStrHTTP = builtins.toString port.HTTP;
+      portStrTLS = builtins.toString port.TLS;
+    in
+    # python
+    ''
+      server.wait_for_unit("h2o.service")
+      server.wait_for_open_port(${portStrHTTP})
+      server.wait_for_open_port(${portStrTLS})
 
-        tls_hello_world_body = server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
-        assert "${sawatdi_chao_lok}" in tls_hello_world_body
+      http_hello_world_body = server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
+      assert "${sawatdi_chao_lok}" in http_hello_world_body
 
-        tls_hello_world_head_redirected = server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'").lower()
-        assert "redirected" in tls_hello_world_head_redirected
+      tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
+      assert "http/2 200" in tls_hello_world_head
+      assert "server: h2o" in tls_hello_world_head
+      assert "content-type: text/x-rst" in tls_hello_world_head
 
-        server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
+      tls_hello_world_body = server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
+      assert "${sawatdi_chao_lok}" in tls_hello_world_body
 
-        tls_hello_world_body_redirected = server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
-        assert "${sawatdi_chao_lok}" in tls_hello_world_body_redirected
-      '';
-  }
-)
+      tls_hello_world_head_redirected = server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'").lower()
+      assert "redirected" in tls_hello_world_head_redirected
+
+      server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
+
+      tls_hello_world_body_redirected = server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
+      assert "${sawatdi_chao_lok}" in tls_hello_world_body_redirected
+    '';
+}

--- a/nixos/tests/web-servers/h2o/basic.nix
+++ b/nixos/tests/web-servers/h2o/basic.nix
@@ -110,27 +110,34 @@ import ../../make-test-python.nix (
         };
     };
 
-    testScript = # python
+    testScript =
+      let
+        portStrHTTP = builtins.toString port.HTTP;
+        portStrTLS = builtins.toString port.TLS;
+      in
+      # python
       ''
         server.wait_for_unit("h2o.service")
+        server.wait_for_open_port(${portStrHTTP})
+        server.wait_for_open_port(${portStrTLS})
 
-        http_hello_world_body = server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${builtins.toString port.HTTP}/hello_world.txt'")
+        http_hello_world_body = server.succeed("curl --fail-with-body 'http://${domain.HTTP}:${portStrHTTP}/hello_world.txt'")
         assert "${sawatdi_chao_lok}" in http_hello_world_body
 
-        tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${builtins.toString port.TLS}/hello_world.rst'").lower()
+        tls_hello_world_head = server.succeed("curl -v --head --compressed --http2 --tlsv1.3 --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'").lower()
         assert "http/2 200" in tls_hello_world_head
         assert "server: h2o" in tls_hello_world_head
         assert "content-type: text/x-rst" in tls_hello_world_head
 
-        tls_hello_world_body = server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${builtins.toString port.TLS}/hello_world.rst'")
+        tls_hello_world_body = server.succeed("curl -v --http2 --tlsv1.3 --compressed --fail-with-body 'https://${domain.TLS}:${portStrTLS}/hello_world.rst'")
         assert "${sawatdi_chao_lok}" in tls_hello_world_body
 
         tls_hello_world_head_redirected = server.succeed("curl -v --head --fail-with-body 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'").lower()
         assert "redirected" in tls_hello_world_head_redirected
 
-        server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'")
+        server.fail("curl --location --max-redirs 0 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
 
-        tls_hello_world_body_redirected = server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${builtins.toString port.HTTP}/hello_world.rst'")
+        tls_hello_world_body_redirected = server.succeed("curl -v --location --fail-with-body 'http://${domain.TLS}:${portStrHTTP}/hello_world.rst'")
         assert "${sawatdi_chao_lok}" in tls_hello_world_body_redirected
       '';
   }

--- a/nixos/tests/web-servers/h2o/default.nix
+++ b/nixos/tests/web-servers/h2o/default.nix
@@ -1,17 +1,7 @@
-{
-  system ? builtins.currentSystem,
-  handleTestOn,
-}:
+{ recurseIntoAttrs, runTest }:
 
-let
-  supportedSystems = [
-    "x86_64-linux"
-    "i686-linux"
-    "aarch64-linux"
-  ];
-in
-{
-  basic = handleTestOn supportedSystems ./basic.nix { inherit system; };
-  mruby = handleTestOn supportedSystems ./mruby.nix { inherit system; };
-  tls-recommendations = handleTestOn supportedSystems ./tls-recommendations.nix { inherit system; };
+recurseIntoAttrs {
+  basic = runTest ./basic.nix;
+  mruby = runTest ./mruby.nix;
+  tls-recommendations = runTest ./tls-recommendations.nix;
 }

--- a/nixos/tests/web-servers/h2o/mruby.nix
+++ b/nixos/tests/web-servers/h2o/mruby.nix
@@ -1,69 +1,67 @@
-import ../../make-test-python.nix (
-  { lib, pkgs, ... }:
+{ lib, ... }:
 
-  let
-    domain = "h2o.local";
+let
+  domain = "h2o.local";
 
-    port = 8080;
+  port = 8080;
 
-    sawatdi_chao_lok = "สวัสดีชาวโลก";
-  in
-  {
-    name = "h2o-mruby";
+  sawatdi_chao_lok = "สวัสดีชาวโลก";
+in
+{
+  name = "h2o-mruby";
 
-    meta = {
-      maintainers = with lib.maintainers; [ toastal ];
-    };
+  meta = {
+    maintainers = with lib.maintainers; [ toastal ];
+  };
 
-    nodes = {
-      server =
-        { pkgs, ... }:
-        {
-          services.h2o = {
-            enable = true;
-            package = pkgs.h2o.override { withMruby = true; };
-            settings = {
-              listen = port;
-              hosts = {
-                "${domain}" = {
-                  paths = {
-                    "/hello_world" = {
-                      "mruby.handler" = # ruby
-                        ''
-                          Proc.new do |env|
-                            [200, {'content-type' => 'text/plain'}, ["${sawatdi_chao_lok}"]]
-                          end
-                        '';
-                    };
-                    "/file_handler" = {
-                      "mruby.handler-file" = ./file_handler.rb;
-                    };
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        services.h2o = {
+          enable = true;
+          package = pkgs.h2o.override { withMruby = true; };
+          settings = {
+            listen = port;
+            hosts = {
+              "${domain}" = {
+                paths = {
+                  "/hello_world" = {
+                    "mruby.handler" = # ruby
+                      ''
+                        Proc.new do |env|
+                          [200, {'content-type' => 'text/plain'}, ["${sawatdi_chao_lok}"]]
+                        end
+                      '';
+                  };
+                  "/file_handler" = {
+                    "mruby.handler-file" = ./file_handler.rb;
                   };
                 };
               };
             };
           };
-
-          networking.extraHosts = ''
-            127.0.0.1 ${domain}
-          '';
         };
-    };
 
-    testScript =
-      let
-        portStr = builtins.toString port;
-      in
-      # python
-      ''
-        server.wait_for_unit("h2o.service")
-        server.wait_for_open_port(${portStr})
+        networking.extraHosts = ''
+          127.0.0.1 ${domain}
+        '';
+      };
+  };
 
-        hello_world = server.succeed("curl --fail-with-body http://${domain}:${portStr}/hello_world")
-        assert "${sawatdi_chao_lok}" in hello_world
+  testScript =
+    let
+      portStr = builtins.toString port;
+    in
+    # python
+    ''
+      server.wait_for_unit("h2o.service")
+      server.wait_for_open_port(${portStr})
 
-        file_handler = server.succeed("curl --fail-with-body http://${domain}:${portStr}/file_handler")
-        assert "FILE_HANDLER" in file_handler
-      '';
-  }
-)
+      hello_world = server.succeed("curl --fail-with-body http://${domain}:${portStr}/hello_world")
+      assert "${sawatdi_chao_lok}" in hello_world
+
+      file_handler = server.succeed("curl --fail-with-body http://${domain}:${portStr}/file_handler")
+      assert "FILE_HANDLER" in file_handler
+    '';
+}

--- a/nixos/tests/web-servers/h2o/mruby.nix
+++ b/nixos/tests/web-servers/h2o/mruby.nix
@@ -50,14 +50,19 @@ import ../../make-test-python.nix (
         };
     };
 
-    testScript = # python
+    testScript =
+      let
+        portStr = builtins.toString port;
+      in
+      # python
       ''
         server.wait_for_unit("h2o.service")
+        server.wait_for_open_port(${portStr})
 
-        hello_world = server.succeed("curl --fail-with-body http://${domain}:${builtins.toString port}/hello_world")
+        hello_world = server.succeed("curl --fail-with-body http://${domain}:${portStr}/hello_world")
         assert "${sawatdi_chao_lok}" in hello_world
 
-        file_handler = server.succeed("curl --fail-with-body http://${domain}:${builtins.toString port}/file_handler")
+        file_handler = server.succeed("curl --fail-with-body http://${domain}:${portStr}/file_handler")
         assert "FILE_HANDLER" in file_handler
       '';
   }

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -1,118 +1,116 @@
-import ../../make-test-python.nix (
-  { lib, pkgs, ... }:
+{ hostPkgs, lib, ... }:
 
-  let
-    domain = "acme.test";
-    port = 8443;
+let
+  domain = "acme.test";
+  port = 8443;
 
-    hello_txt =
-      name:
-      pkgs.writeTextFile {
-        name = "/hello_${name}.txt";
-        text = "Hello, ${name}!";
-      };
+  hello_txt =
+    name:
+    hostPkgs.writeTextFile {
+      name = "/hello_${name}.txt";
+      text = "Hello, ${name}!";
+    };
 
-    mkH2OServer =
-      recommendations:
-      { pkgs, lib, ... }:
-      {
-        services.h2o = {
-          enable = true;
-          package = pkgs.h2o.override (
-            lib.optionalAttrs
-              (builtins.elem recommendations [
-                "intermediate"
-                "old"
-              ])
-              {
-                openssl = pkgs.openssl_legacy;
-              }
-          );
-          defaultTLSRecommendations = "modern"; # prove overridden
-          hosts = {
-            "${domain}" = {
-              tls = {
-                inherit port recommendations;
-                policy = "force";
-                identity = [
-                  {
-                    key-file = ../../common/acme/server/acme.test.key.pem;
-                    certificate-file = ../../common/acme/server/acme.test.cert.pem;
-                  }
-                ];
-              };
-              settings = {
-                paths."/"."file.file" = "${hello_txt recommendations}";
-              };
+  mkH2OServer =
+    recommendations:
+    { pkgs, lib, ... }:
+    {
+      services.h2o = {
+        enable = true;
+        package = pkgs.h2o.override (
+          lib.optionalAttrs
+            (builtins.elem recommendations [
+              "intermediate"
+              "old"
+            ])
+            {
+              openssl = pkgs.openssl_legacy;
+            }
+        );
+        defaultTLSRecommendations = "modern"; # prove overridden
+        hosts = {
+          "${domain}" = {
+            tls = {
+              inherit port recommendations;
+              policy = "force";
+              identity = [
+                {
+                  key-file = ../../common/acme/server/acme.test.key.pem;
+                  certificate-file = ../../common/acme/server/acme.test.cert.pem;
+                }
+              ];
+            };
+            settings = {
+              paths."/"."file.file" = "${hello_txt recommendations}";
             };
           };
-          settings = {
-            ssl-offload = "kernel";
-          };
         };
-
-        security.pki.certificates = [
-          (builtins.readFile ../../common/acme/server/ca.cert.pem)
-        ];
-
-        networking = {
-          firewall.allowedTCPPorts = [ port ];
-          extraHosts = "127.0.0.1 ${domain}";
+        settings = {
+          ssl-offload = "kernel";
         };
       };
-  in
-  {
-    name = "h2o-tls-recommendations";
 
-    meta = {
-      maintainers = with lib.maintainers; [ toastal ];
+      security.pki.certificates = [
+        (builtins.readFile ../../common/acme/server/ca.cert.pem)
+      ];
+
+      networking = {
+        firewall.allowedTCPPorts = [ port ];
+        extraHosts = "127.0.0.1 ${domain}";
+      };
     };
+in
+{
+  name = "h2o-tls-recommendations";
 
-    nodes = {
-      server_modern = mkH2OServer "modern";
-      server_intermediate = mkH2OServer "intermediate";
-      server_old = mkH2OServer "old";
-    };
+  meta = {
+    maintainers = with lib.maintainers; [ toastal ];
+  };
 
-    testScript =
-      let
-        portStr = builtins.toString port;
-      in
-      # python
-      ''
-        curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:${portStr}/'"
-        curl_head = "curl -v --head 'https://${domain}:${portStr}/'"
-        curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:${portStr}/'"
-        curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:${portStr}/'"
-        curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:${portStr}/'"
+  nodes = {
+    server_modern = mkH2OServer "modern";
+    server_intermediate = mkH2OServer "intermediate";
+    server_old = mkH2OServer "old";
+  };
 
-        server_modern.wait_for_unit("h2o.service")
-        server_modern.wait_for_open_port(${portStr})
-        modern_response = server_modern.succeed(curl_basic)
-        assert "Hello, modern!" in modern_response
-        modern_head = server_modern.succeed(curl_head)
-        assert "strict-transport-security" in modern_head
-        server_modern.fail(curl_max_tls1_2)
+  testScript =
+    let
+      portStr = builtins.toString port;
+    in
+    # python
+    ''
+      curl_basic = "curl -v --tlsv1.3 --http2 'https://${domain}:${portStr}/'"
+      curl_head = "curl -v --head 'https://${domain}:${portStr}/'"
+      curl_max_tls1_2 ="curl -v --tlsv1.0 --tls-max 1.2 'https://${domain}:${portStr}/'"
+      curl_max_tls1_2_intermediate_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' 'https://${domain}:${portStr}/'"
+      curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:${portStr}/'"
 
-        server_intermediate.wait_for_unit("h2o.service")
-        server_intermediate.wait_for_open_port(${portStr})
-        intermediate_response = server_intermediate.succeed(curl_basic)
-        assert "Hello, intermediate!" in intermediate_response
-        intermediate_head = server_modern.succeed(curl_head)
-        assert "strict-transport-security" in intermediate_head
-        server_intermediate.succeed(curl_max_tls1_2)
-        server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher)
-        server_intermediate.fail(curl_max_tls1_2_old_cipher)
+      server_modern.wait_for_unit("h2o.service")
+      server_modern.wait_for_open_port(${portStr})
+      modern_response = server_modern.succeed(curl_basic)
+      assert "Hello, modern!" in modern_response
+      modern_head = server_modern.succeed(curl_head)
+      assert "strict-transport-security" in modern_head
+      server_modern.fail(curl_max_tls1_2)
 
-        server_old.wait_for_unit("h2o.service")
-        server_old.wait_for_open_port(${portStr})
-        old_response = server_old.succeed(curl_basic)
-        assert "Hello, old!" in old_response
-        old_head = server_modern.succeed(curl_head)
-        assert "strict-transport-security" in old_head
-        server_old.succeed(curl_max_tls1_2)
-        server_old.succeed(curl_max_tls1_2_intermediate_cipher)
-        server_old.succeed(curl_max_tls1_2_old_cipher)
-      '';
-  }
-)
+      server_intermediate.wait_for_unit("h2o.service")
+      server_intermediate.wait_for_open_port(${portStr})
+      intermediate_response = server_intermediate.succeed(curl_basic)
+      assert "Hello, intermediate!" in intermediate_response
+      intermediate_head = server_modern.succeed(curl_head)
+      assert "strict-transport-security" in intermediate_head
+      server_intermediate.succeed(curl_max_tls1_2)
+      server_intermediate.succeed(curl_max_tls1_2_intermediate_cipher)
+      server_intermediate.fail(curl_max_tls1_2_old_cipher)
+
+      server_old.wait_for_unit("h2o.service")
+      server_old.wait_for_open_port(${portStr})
+      old_response = server_old.succeed(curl_basic)
+      assert "Hello, old!" in old_response
+      old_head = server_modern.succeed(curl_head)
+      assert "strict-transport-security" in old_head
+      server_old.succeed(curl_max_tls1_2)
+      server_old.succeed(curl_max_tls1_2_intermediate_cipher)
+      server_old.succeed(curl_max_tls1_2_old_cipher)
+    '';
+}

--- a/nixos/tests/web-servers/h2o/tls-recommendations.nix
+++ b/nixos/tests/web-servers/h2o/tls-recommendations.nix
@@ -87,6 +87,7 @@ import ../../make-test-python.nix (
         curl_max_tls1_2_old_cipher ="curl -v --tlsv1.0 --tls-max 1.2 --ciphers 'ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256' 'https://${domain}:${portStr}/'"
 
         server_modern.wait_for_unit("h2o.service")
+        server_modern.wait_for_open_port(${portStr})
         modern_response = server_modern.succeed(curl_basic)
         assert "Hello, modern!" in modern_response
         modern_head = server_modern.succeed(curl_head)
@@ -94,6 +95,7 @@ import ../../make-test-python.nix (
         server_modern.fail(curl_max_tls1_2)
 
         server_intermediate.wait_for_unit("h2o.service")
+        server_intermediate.wait_for_open_port(${portStr})
         intermediate_response = server_intermediate.succeed(curl_basic)
         assert "Hello, intermediate!" in intermediate_response
         intermediate_head = server_modern.succeed(curl_head)
@@ -103,6 +105,7 @@ import ../../make-test-python.nix (
         server_intermediate.fail(curl_max_tls1_2_old_cipher)
 
         server_old.wait_for_unit("h2o.service")
+        server_old.wait_for_open_port(${portStr})
         old_response = server_old.succeed(curl_basic)
         assert "Hello, old!" in old_response
         old_head = server_modern.succeed(curl_head)


### PR DESCRIPTION
Hydra can sometimes timeout here. It’s a better practice anyhow.

Definitely go by commit since moving to `runTest` is a heavy diff (mostly white space so recommend reviewing without white space).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
