### PR TITLE
kbd: remove dependency on bash

### DIFF
--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -13,10 +13,18 @@
   bzip2,
   xz,
   zstd,
+  bash,
   gitUpdater,
+  # This might be worthwhile to disable if the store lives on a compressed filesystem.
+  withCompression ? true,
+  # Allow disabling the unicode_start/unicode_stop utilities, which
+  # unfortunately pull in bash into the closure.
+  withScripts ? true,
 }:
 
 stdenv.mkDerivation rec {
+  strictDeps = true;
+
   pname = "kbd";
   version = "2.7.1";
 
@@ -39,6 +47,11 @@ stdenv.mkDerivation rec {
       "--enable-libkeymap"
       "--disable-nls"
     ]
+    # Compression support is otherwise autodetected because gzip et
+    # al. are in stdenv.
+    ++ lib.optionals (!withCompression) [
+      "--disable-compress"
+    ]
     ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"
@@ -48,44 +61,75 @@ stdenv.mkDerivation rec {
     ./search-paths.patch
   ];
 
-  postPatch = ''
-    # Renaming keymaps with name clashes, because loadkeys just picks
-    # the first keymap it sees. The clashing names lead to e.g.
-    # "loadkeys no" defaulting to a norwegian dvorak map instead of
-    # the much more common qwerty one.
-    pushd data/keymaps/i386
-    mv qwertz/cz{,-qwertz}.map
-    mv olpc/es{,-olpc}.map
-    mv olpc/pt{,-olpc}.map
-    mv fgGIod/trf{,-fgGIod}.map
-    mv colemak/{en-latin9,colemak}.map
-    popd
+  postPatch =
+    ''
+      # Renaming keymaps with name clashes, because loadkeys just picks
+      # the first keymap it sees. The clashing names lead to e.g.
+      # "loadkeys no" defaulting to a Norwegian Dvorak map instead of
+      # the much more common QWERTY one.
+      pushd data/keymaps/i386
+      mv qwertz/cz{,-qwertz}.map
+      mv olpc/es{,-olpc}.map
+      mv olpc/pt{,-olpc}.map
+      mv fgGIod/trf{,-fgGIod}.map
+      mv colemak/{en-latin9,colemak}.map
+      popd
 
-    # Fix paths to decompressors. Trailing space to avoid replacing `xz` in `".xz"`.
-    substituteInPlace src/libkbdfile/kbdfile.c \
-      --replace-fail 'gzip '  '${gzip}/bin/gzip ' \
-      --replace-fail 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
-      --replace-fail 'xz '    '${xz.bin}/bin/xz ' \
-      --replace-fail 'zstd '  '${zstd.bin}/bin/zstd '
+    ''
+    + lib.optionalString withCompression ''
+      # Fix paths to decompressors. Trailing space to avoid replacing `xz` in `".xz"`.
+      substituteInPlace src/libkbdfile/kbdfile.c \
+        --replace-fail 'gzip '  '${gzip}/bin/gzip ' \
+        --replace-fail 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
+        --replace-fail 'xz '    '${xz.bin}/bin/xz ' \
+        --replace-fail 'zstd '  '${zstd.bin}/bin/zstd '
+    ''
+    + ''
 
-    sed -i '
-      1i prefix:=$(vlock)
-      1i bindir := $(vlock)/bin' \
-      src/vlock/Makefile.in \
-      src/vlock/Makefile.am
-  '';
+      sed -i '
+        1i prefix:=$(vlock)
+        1i bindir := $(vlock)/bin' \
+        src/vlock/Makefile.in \
+        src/vlock/Makefile.am
+    ''
+    + lib.optionalString (!withScripts) ''
+      substituteInPlace src/Makefile.am \
+        --replace-fail 'dist_bin_SCRIPTS = unicode_start unicode_stop' 'dist_bin_SCRIPTS ='
+    '';
 
-  postInstall = ''
+  postInstall = lib.optionalString withScripts ''
     for i in $out/bin/unicode_{start,stop}; do
       substituteInPlace "$i" \
         --replace /usr/bin/tty ${coreutils}/bin/tty
     done
   '';
 
-  buildInputs = [
-    check
-    pam
+  buildInputs =
+    [
+      check
+      pam
+    ]
+    ++ lib.optionals (withScripts) [
+      # We install shell scripts as well. Due to strictDeps we must be
+      # explicit with the buildInputs.
+      bash
+    ]
+    ++ lib.optionals (withCompression) [
+      gzip
+      bzip2
+      xz
+      zstd
+    ];
+
+  # There are two ways how bash is pulled into the closure. One is the
+  # obvious route via scripts. The other path is compression support,
+  # because it actually shells out to gzip, xz, etc.
+  disallowedReferences = lib.optionals (!withScripts && !withCompression) [
+    bash
   ];
+
+  enableParallelBuilding = true;
+
   NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";
   nativeBuildInputs = [
     autoreconfHook
@@ -93,17 +137,21 @@ stdenv.mkDerivation rec {
     flex
   ];
 
-  passthru.tests = {
-    inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
-  };
-  passthru = {
-    gzip = gzip;
-    updateScript = gitUpdater {
-      # No nicer place to find latest release.
-      url = "https://github.com/legionus/kbd.git";
-      rev-prefix = "v";
+  passthru =
+    {
+      updateScript = gitUpdater {
+        # No nicer place to find latest release.
+        url = "https://github.com/legionus/kbd.git";
+        rev-prefix = "v";
+      };
+
+      tests = {
+        inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;
+      };
+    }
+    // lib.optionalAttrs withCompression {
+      inherit gzip;
     };
-  };
 
   meta = with lib; {
     homepage = "https://kbd-project.org/";


### PR DESCRIPTION
This PR makes the parts of `kbd` optional that depend on bash:

- Compression support is now optional. It only saves 2MB (and is not useful, in case you have a compressed /nix/store) and pulls in bash via `popen` calls.
- Installing `unicode_start` and `unicode_stop` are now optional. As far as I can tell, these are not used anyhow?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
