### PR TITLE
python3Packages.chevron: 0.13.1 -> 0.14.0-unstable-2021-03-21

### DIFF
--- a/pkgs/development/python-modules/chevron/default.nix
+++ b/pkgs/development/python-modules/chevron/default.nix
@@ -1,32 +1,37 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitHub,
+  lib,
   python,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "chevron";
   version = "0.14.0-unstable-2021-03-21";
-  format = "setuptools";
+  pyproject = true;
 
   # No tests available in the PyPI tarball
   src = fetchFromGitHub {
     owner = "noahmorrison";
     repo = "chevron";
     rev = "5e1c12827b7fc3db30cb3b24cae9a7ee3092822b";
-    sha256 = "sha256-44cxkliJJ+IozmhS4ekbb+pCa7tcUuX9tRNYTK0mC+w=";
+    hash = "sha256-44cxkliJJ+IozmhS4ekbb+pCa7tcUuX9tRNYTK0mC+w=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   checkPhase = ''
     ${python.interpreter} test_spec.py
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/noahmorrison/chevron";
     description = "Python implementation of the mustache templating language";
     mainProgram = "chevron";
-    license = licenses.mit;
-    maintainers = with maintainers; [ dhkl ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dhkl ];
   };
 }

--- a/pkgs/development/python-modules/chevron/default.nix
+++ b/pkgs/development/python-modules/chevron/default.nix
@@ -7,15 +7,15 @@
 
 buildPythonPackage {
   pname = "chevron";
-  version = "0.13.1";
+  version = "0.14.0-unstable-2021-03-21";
   format = "setuptools";
 
   # No tests available in the PyPI tarball
   src = fetchFromGitHub {
     owner = "noahmorrison";
     repo = "chevron";
-    rev = "0.13.1";
-    sha256 = "0l1ik8dvi6bgyb3ym0w4ii9dh25nzy0x4yawf4zbcyvvcb6af470";
+    rev = "5e1c12827b7fc3db30cb3b24cae9a7ee3092822b";
+    sha256 = "sha256-44cxkliJJ+IozmhS4ekbb+pCa7tcUuX9tRNYTK0mC+w=";
   };
 
   checkPhase = ''


### PR DESCRIPTION
v0.13.1 is from 2018, but there have been a few changes until 2021. This had been released on pypi as 0.14.0, but never been tagged on GitHub.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
