### PR TITLE
yandex-disk: fix missing libstdc++.so.6

### DIFF
--- a/pkgs/by-name/ya/yandex-disk/package.nix
+++ b/pkgs/by-name/ya/yandex-disk/package.nix
@@ -14,7 +14,7 @@ let
     if stdenv.hostPlatform.is64bit then
       {
         arch = "x86_64";
-        gcclib = "${lib.getLib stdenv.cc.cc}/lib64";
+        gcclib = "${lib.getLib stdenv.cc.cc}/lib";
         sha256 = "sha256-HH/pLZmDr6m/B3e6MHafDGnNWR83oR2y1ijVMR/LOF0=";
         webarchive = "20220519080155";
       }
@@ -39,6 +39,10 @@ stdenv.mkDerivation rec {
     sha256 = p.sha256;
   };
 
+  buildInputs = [
+    zlib
+    stdenv.cc.cc
+  ];
   builder = writeText "builder.sh" ''
     mkdir -pv $out/bin
     mkdir -pv $out/share


### PR DESCRIPTION
The yandex-disk binary fails to find libstdc++.so.6 due to incorrect library path resolution. The issue was gcclib was set to ${lib.getLib stdenv.cc.cc}/lib64, but libstdc++.so.6 is in /lib, not /lib64. 
I fixed this and added stdenv.cc.cc to buildInputs to ensure the library is available at runtime.

Closes #391549
Maintainers: @sergei-mironov @jagajaga