### PR TITLE
muon: 0.2.0 -> 0.4.0

### DIFF
--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "muon" + lib.optionalString embedSamurai "-embedded-samurai";
-  version = "0.2.0";
+  version = "0.4.0";
 
   src = fetchFromSourcehut {
     name = "muon-src";
     owner = "~lattis";
     repo = "muon";
     rev = finalAttrs.version;
-    hash = "sha256-ZHWyUV/BqM3ihauXDqDVkZURDDbBiRcEzptyGQmw94I=";
+    hash = "sha256-xTdyqK8t741raMhjjJBMbWnAorLMMdZ02TeMXK7O+Yw=";
   };
 
   outputs = [ "out" ] ++ lib.optionals buildDocs [ "man" ];
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     [
       pkgconf
-      samurai
     ]
+    ++ lib.optionals (!embedSamurai) [ samurai ]
     ++ lib.optionals buildDocs [
       (python3.withPackages (ps: [ ps.pyyaml ]))
       scdoc
@@ -43,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     libarchive
     libpkgconf
-    samurai
     zlib
   ];
 
@@ -54,20 +53,25 @@ stdenv.mkDerivation (finalAttrs: {
       # URLs manually extracted from subprojects directory
       meson-docs-wrap = fetchurl {
         name = "meson-docs-wrap";
-        url = "https://mochiro.moe/wrap/meson-docs-1.0.1-19-gdd8d4ee22.tar.gz";
-        hash = "sha256-jHSPdLFR5jUeds4e+hLZ6JOblor5iuCV5cIwoc4K9gI=";
+        url = "https://github.com/muon-build/meson-docs/archive/5bc0b250984722389419dccb529124aed7615583.tar.gz";
+        hash = "sha256-5MmmiZfadCuUJ2jy5Rxubwf4twX0jcpr+TPj5ssdSbM=";
       };
 
-      samurai-wrap = fetchurl {
-        name = "samurai-wrap";
-        url = "https://mochiro.moe/wrap/samurai-1.2-32-g81cef5d.tar.gz";
-        hash = "sha256-aPMAtScqweGljvOLaTuR6B0A0GQQQrVbRviXY4dpCoc=";
+      meson-tests-wrap = fetchurl {
+        name = "meson-tests-wrap";
+        url = "https://github.com/muon-build/meson-tests/archive/591b5a053f9aa15245ccbd1d334cf3f8031b1035.tar.gz";
+        hash = "sha256-6GXfcheZyB/S/xl/j7pj5EAWtsmx4N0fVhLPMJ2wC/w=";
       };
     in
     ''
-      pushd $sourceRoot/subprojects
-      ${lib.optionalString buildDocs "tar xvf ${meson-docs-wrap}"}
-      ${lib.optionalString embedSamurai "tar xvf ${samurai-wrap}"}
+      mkdir -p $sourceRoot/subprojects/meson-docs
+      pushd $sourceRoot/subprojects/meson-docs
+      ${lib.optionalString buildDocs "tar xvf ${meson-docs-wrap} --strip-components=1"}
+      popd
+
+      mkdir -p $sourceRoot/subprojects/meson-tests
+      pushd $sourceRoot/subprojects/meson-tests
+      tar xvf ${meson-tests-wrap} --strip-components=1
       popd
     '';
 
@@ -99,13 +103,15 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       runHook preBuild
 
-      ./bootstrap.sh stage-1
+      ${
+        lib.optionalString (!embedSamurai) "CFLAGS=\"$CFLAGS -DBOOTSTRAP_NO_SAMU\""
+      } ./bootstrap.sh stage-1
 
-      ./stage-1/muon setup ${cmdlineForMuon} stage-2
-      samu ${cmdlineForSamu} -C stage-2
+      ./stage-1/muon-bootstrap setup ${cmdlineForMuon} stage-2
+      ${lib.optionalString embedSamurai "./stage-1/muon-bootstrap"} samu ${cmdlineForSamu} -C stage-2
 
-      stage-2/muon setup -Dprefix=$out ${cmdlineForMuon} stage-3
-      samu ${cmdlineForSamu} -C stage-3
+      ./stage-2/muon setup -Dprefix=$out ${cmdlineForMuon} stage-3
+      ${lib.optionalString embedSamurai "./stage-2/muon"} samu ${cmdlineForSamu} -C stage-3
 
       runHook postBuild
     '';


### PR DESCRIPTION
Somewhat unsure about the need to add ninja to nativeBuildInputs but otherwise there is an error like so for muon (but not muonStandalone). Hoping this can be removed again in the future.

```
 /build/muon-src/tests/project/meson.build:396:23: error cannot return the full_path() of an external program with multiple elements (have: ['/build/muon-src/stage-1/muon-bootstrap', 'samu'])
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
