### PR TITLE
workflows/build-nixos-manual: run on aarch64-linux too and upload the result

### DIFF
--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -41,3 +41,10 @@ jobs:
           export NIX_PATH=nixpkgs=$(pwd)
           nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux -o result-x86_64-linux
           nix-build --option restrict-eval true nixos/release.nix -A manual.aarch64-linux -o result-aarch64-linux
+
+      - name: Upload NixOS manual
+        uses: actions/upload-artifact@3850ca5b6c832f17a0f754f6293181ebbf4e161d # v3.2.5
+        with:
+          name: nixos-manual-result
+          path: result-**
+          if-no-files-found: error

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -34,7 +34,10 @@ jobs:
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
           name: nixpkgs-ci
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Building NixOS manual
-        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux
+        run: |
+          export NIX_PATH=nixpkgs=$(pwd)
+          nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux -o result-x86_64-linux
+          nix-build --option restrict-eval true nixos/release.nix -A manual.aarch64-linux -o result-aarch64-linux


### PR DESCRIPTION
Since we distribute for `aarch64-linux` platform too, it makes sense the CI to test both platforms for NixOS module (manual) related changes.

Additionally upload the result dir, so if anyone wants to check it without building locally, they totally can.

Tested in https://github.com/JohnRTitor/nixpkgs/actions/runs/13999244787