### PR TITLE
python3.pkgs.strip-ansi: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/strip-ansi/default.nix
+++ b/pkgs/development/python-modules/strip-ansi/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchpatch,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "strip-ansi";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-XWDyOcyKN/3VK0PD5m6JPUW6BCMRXbWeyg0u74Owdyk=";
+  };
+
+  patches = [
+    # Replace `poetry` with `poetry-core`. Unreleased.
+    # See: https://github.com/NixOS/nixpkgs/issues/103325
+    (fetchpatch {
+      url = "https://github.com/gwennlbh/python-strip-ansi/commit/0ea9b418d5b21bd3d3b1b3b91fad7e66f25acb97.diff";
+      hash = "sha256-Pzlc7fx4kEmM8pezu+8K7z5oV44uq/rzeByqKxHVKx0=";
+    })
+  ];
+
+  build-system = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "strip_ansi"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Strip ANSI escape sequences from a string";
+    homepage = "https://pypi.org/project/strip-ansi";
+    # License is in the repository but not in PyPI metadata.
+    # See: https://github.com/gwennlbh/python-strip-ansi/blob/master/LICENSE
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers._9999years ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16100,6 +16100,8 @@ self: super: with self; {
 
   stringzilla = callPackage ../development/python-modules/stringzilla { };
 
+  strip-ansi = callPackage ../development/python-modules/strip-ansi { };
+
   stripe = callPackage ../development/python-modules/stripe { };
 
   striprtf = callPackage ../development/python-modules/striprtf { };


### PR DESCRIPTION
https://pypi.org/project/strip-ansi/
77k monthly downloads: https://pypistats.org/packages/strip-ansi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
