### PR TITLE
flang,flang-rt: init for LLVM 21+

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -44,7 +44,7 @@ while (( "$n" < "$nParams" )); do
 
     case "$p" in
         -[cSEM] | -MM) dontLink=1 ;;
-        -cc1) cc1=1 ;;
+        -cc1 | -fc1) cc1=1 ;;
         -nostdinc) cInclude=0 cxxInclude=0 ;;
         -nostdinc++) cxxInclude=0 ;;
         -nostdlib) cxxLibrary=0 ;;

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -212,6 +212,8 @@ let
     passthru = {
       inherit libllvm;
       isClang = true;
+      langC = true;
+      langCC = true;
       hardeningUnsupportedFlagsByTargetPlatform = targetPlatform:
         [ "fortify3" ]
         ++ lib.optional (

--- a/pkgs/development/compilers/llvm/common/flang-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang-rt/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  src ? null,
+  monorepoSrc ? null,
+  runCommand,
+  cmake,
+  libclang,
+  libllvm,
+  mlir,
+  ninja,
+  python3,
+  flang-unwrapped,
+  version,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flang-rt";
+  inherit version;
+
+  src =
+    if monorepoSrc != null then
+      runCommand "${finalAttrs.pname}-src-${version}"
+        {
+          inherit (monorepoSrc) passthru;
+        }
+        (''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+
+          mkdir -p "$out/llvm"
+          cp -r ${monorepoSrc}/llvm/cmake "$out/llvm"
+          cp -r ${monorepoSrc}/llvm/utils "$out/llvm"
+          cp -r ${monorepoSrc}/third-party "$out"
+
+          cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+          cp -r ${monorepoSrc}/flang "$out"
+          cp -r ${monorepoSrc}/runtimes "$out"
+        '')
+    else
+      src;
+
+  sourceRoot = "${finalAttrs.src.name}/runtimes";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    flang-unwrapped
+    cmake
+    ninja
+    python3
+  ];
+  buildInputs = [
+    libclang
+    libllvm
+    mlir
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "LLVM_DEFAULT_TARGET_TRIPLE" stdenv.hostPlatform.config)
+    (lib.cmakeFeature "CMAKE_Fortran_COMPILER" "${flang-unwrapped}/bin/flang")
+    (lib.cmakeBool "CMAKE_Fortran_COMPILER_WORKS" true)
+    (lib.cmakeBool "CMAKE_Fortran_COMPILER_SUPPORTS_F90" true)
+    (lib.cmakeFeature "CLANG_DIR" "${libclang.dev}/lib/cmake/clang")
+    (lib.cmakeFeature "MLIR_DIR" "${mlir.dev}/lib/cmake/mlir")
+    (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
+    (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "flang-rt")
+  ];
+
+  meta = llvm_meta // {
+    homepage = "https://flang.llvm.org";
+    description = "LLVM Fortran Runtime";
+  };
+})

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  src ? null,
+  monorepoSrc ? null,
+  runCommand,
+  cmake,
+  libclang,
+  libllvm,
+  libxml2,
+  python3,
+  lit,
+  mlir,
+  ninja,
+  version,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flang";
+  inherit version;
+
+  src =
+
+    if monorepoSrc != null then
+      runCommand "${finalAttrs.pname}-src-${finalAttrs.version}"
+        {
+          inherit (monorepoSrc) passthru;
+        }
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/flang-rt "$out"
+          cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+        ''
+    else
+      src;
+
+  sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pname}";
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+  buildInputs = [
+    libclang
+    libllvm
+    libxml2
+    mlir
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CLANG_DIR" "${libclang.dev}/lib/cmake/clang")
+    (lib.cmakeFeature "MLIR_DIR" "${mlir.dev}/lib/cmake/mlir")
+    (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
+    (lib.cmakeBool "MLIR_LINK_MLIR_DYLIB" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${lit}/bin/lit")
+    (lib.cmakeFeature "LLVM_LIT_ARGS" "-v")
+    # Tests depend on test libs from MLIR which are only available in a
+    # build tree.
+    (lib.cmakeBool "FLANG_INCLUDE_TESTS" false)
+  ];
+
+  passthru = {
+    # Used by cc-wrapper to determine whether or not the default setup hook is enabled.
+    langC = false;
+    langCC = false;
+    langFortran = true;
+    isClang = true;
+
+    hardeningUnsupportedFlags = [
+      "zerocallusedregs"
+      "stackprotector"
+    ];
+  };
+
+  meta = llvm_meta // {
+    homepage = "https://flang.llvm.org";
+    description = "LLVM Fortran Compiler";
+  };
+})

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -1,17 +1,22 @@
-{ lib
-, stdenv
-, llvm_meta
-, release_version
-, buildLlvmTools
-, monorepoSrc
-, runCommand
-, cmake
-, ninja
-, libxml2
-, libllvm
-, version
-, doCheck ? (!stdenv.hostPlatform.isx86_32 /* TODO: why */) && (!stdenv.hostPlatform.isMusl)
-, devExtraCmakeFlags ? []
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  release_version,
+  buildLlvmTools,
+  monorepoSrc,
+  runCommand,
+  cmake,
+  ninja,
+  libxml2,
+  libllvm,
+  version,
+  doCheck ?
+    (
+      !stdenv.hostPlatform.isx86_32 # TODO: why
+    )
+    && (!stdenv.hostPlatform.isMusl),
+  devExtraCmakeFlags ? [ ],
 }:
 
 stdenv.mkDerivation rec {
@@ -19,16 +24,20 @@ stdenv.mkDerivation rec {
   inherit version doCheck;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "${pname}-src-${version}" { inherit (monorepoSrc) passthru; } (''
-    mkdir -p "$out"
-  '' + lib.optionalString (lib.versionAtLeast release_version "14") ''
-    cp -r ${monorepoSrc}/cmake "$out"
-  '' + ''
-    cp -r ${monorepoSrc}/mlir "$out"
-    cp -r ${monorepoSrc}/third-party "$out/third-party"
+  src = runCommand "${pname}-src-${version}" { inherit (monorepoSrc) passthru; } (
+    ''
+      mkdir -p "$out"
+    ''
+    + lib.optionalString (lib.versionAtLeast release_version "14") ''
+      cp -r ${monorepoSrc}/cmake "$out"
+    ''
+    + ''
+      cp -r ${monorepoSrc}/mlir "$out"
+      cp -r ${monorepoSrc}/third-party "$out/third-party"
 
-    mkdir -p "$out/llvm"
-  '');
+      mkdir -p "$out/llvm"
+    ''
+  );
 
   sourceRoot = "${src.name}/mlir";
 
@@ -46,30 +55,36 @@ stdenv.mkDerivation rec {
     libxml2
   ];
 
-  cmakeFlags = [
-    "-DLLVM_BUILD_TOOLS=ON"
-    # Install headers as well
-    "-DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF"
-    "-DMLIR_TOOLS_INSTALL_DIR=${placeholder "out"}/bin/"
-    "-DLLVM_ENABLE_IDE=OFF"
-    "-DMLIR_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/mlir"
-    "-DMLIR_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake/mlir"
-    "-DLLVM_BUILD_TESTS=${if doCheck then "ON" else "OFF"}"
-    "-DLLVM_ENABLE_FFI=ON"
-    "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_ENABLE_DUMP=ON"
-    "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/llvm-tblgen"
-    "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/mlir-tblgen"
-    (lib.cmakeBool "LLVM_BUILD_LLVM_DYLIB" (!stdenv.hostPlatform.isStatic))
-  ] ++ lib.optionals stdenv.hostPlatform.isStatic [
-    # Disables building of shared libs, -fPIC is still injected by cc-wrapper
-    "-DLLVM_ENABLE_PIC=OFF"
-    "-DLLVM_BUILD_STATIC=ON"
-    "-DLLVM_LINK_LLVM_DYLIB=OFF"
-  ] ++ devExtraCmakeFlags;
+  cmakeFlags =
+    [
+      "-DLLVM_BUILD_TOOLS=ON"
+      # Install headers as well
+      "-DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF"
+      "-DMLIR_TOOLS_INSTALL_DIR=${placeholder "out"}/bin/"
+      "-DLLVM_ENABLE_IDE=OFF"
+      "-DMLIR_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/mlir"
+      "-DMLIR_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake/mlir"
+      "-DLLVM_BUILD_TESTS=${if doCheck then "ON" else "OFF"}"
+      "-DLLVM_ENABLE_FFI=ON"
+      "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
+      "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+      "-DLLVM_ENABLE_DUMP=ON"
+      "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/llvm-tblgen"
+      "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/mlir-tblgen"
+      (lib.cmakeBool "LLVM_BUILD_LLVM_DYLIB" (!stdenv.hostPlatform.isStatic))
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isStatic [
+      # Disables building of shared libs, -fPIC is still injected by cc-wrapper
+      "-DLLVM_ENABLE_PIC=OFF"
+      "-DLLVM_BUILD_STATIC=ON"
+      "-DLLVM_LINK_LLVM_DYLIB=OFF"
+    ]
+    ++ devExtraCmakeFlags;
 
-  outputs = [ "out" "dev" ];
+  outputs = [
+    "out"
+    "dev"
+  ];
 
   meta = llvm_meta // {
     # Very broken since the dependencies aren't propagating at all with tblgen through the CMake.

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -45,6 +45,13 @@ stdenv.mkDerivation rec {
     ./gnu-install-dirs.patch
   ];
 
+  # Don't clobber the MLIR_TABLEGEN_EXE that we pass in, and instead let the
+  # installed MLIRConfig.cmake refer to the mlir-tblgen we pass in cmakeFlags.
+  postPatch = ''
+    substituteInPlace cmake/modules/CMakeLists.txt \
+      --replace-fail 'set(MLIR_CONFIG_TABLEGEN_EXE mlir-tblgen)' ""
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja


### PR DESCRIPTION
Adds `flang` and `flang-rt` for LLVM 21+. While `flang{,-new}` is available in older versions of LLVM, this is the first release that splits out the `flang-rt` runtime build, which IMO makes it slot nicely into the nixpkgs cross build logic.

- This PR targets staging because of the cc-wrapper changes (really, just the `-fc1` bit), but happy to split this out if it's easier to land separately
- I use overrideCC to force clang for the flang build since g++ was reliably OOMing my machine. There's a cmake flag for helping this now [`FLANG_PARALLEL_COMPILE_JOBS`](https://github.com/llvm/llvm-project/blob/6b00ae6359b6442b827d0961357a09ec8dce72a4/flang/CMakeLists.txt#L470), but then it seems a bit funky - maybe use `$NIX_BUILD_CORES / 2`?
- I haven't tried openmp at all
- Depends on PR #390756 for fixing MLIR
- I haven't added myself as a maintainer, but happy to do so!

What I've tested:
- `x86_64-linux` native
- `aarch64-linux` native
- `x86_64-linux` cross to `riscv64-linux`
- `aarch64-linux` cross to `riscv64-linux`

Closes issue #361133

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
