### PR TITLE
cc-wrapper: keep machine cflags if the same target is passed

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -28,8 +28,6 @@ done
 
 if $targetPassed && [[ "$targetValue" != "@defaultTarget@" ]]; then
     echo "Warning: supplying the --target $targetValue != @defaultTarget@ argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead." >&2
-fi
-
-if ! $targetPassed && [[ $0 != *cpp ]]; then
+elif [[ $0 != *cpp ]]; then
     extraBefore+=(-target @defaultTarget@ @machineFlags@)
 fi

--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -1,4 +1,4 @@
-needsTarget=true
+targetPassed=false
 targetValue=""
 
 declare -i n=0
@@ -14,22 +14,22 @@ while (("$n" < "$nParams")); do
             echo "Error: -target requires an argument" >&2
             exit 1
         fi
-        needsTarget=false
+        targetPassed=true
         targetValue=$v
         # skip parsing the value of -target
         n+=1
         ;;
     --target=*)
-        needsTarget=false
+        targetPassed=true
         targetValue="${p#*=}"
         ;;
     esac
 done
 
-if ! $needsTarget && [[ "$targetValue" != "@defaultTarget@" ]]; then
+if $targetPassed && [[ "$targetValue" != "@defaultTarget@" ]]; then
     echo "Warning: supplying the --target $targetValue != @defaultTarget@ argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead." >&2
 fi
 
-if $needsTarget && [[ $0 != *cpp ]]; then
+if ! $targetPassed && [[ $0 != *cpp ]]; then
     extraBefore+=(-target @defaultTarget@ @machineFlags@)
 fi


### PR DESCRIPTION
Since #291901 / #317273, compiler-rt doesn't honor machine cflags. This can yield unusable LLVM stdenvs, for example this one even fails to build:

~~~bash
nix-build \
  --arg crossSystem '{ config = "riscv32-unknown-linux-gnu"; gcc.arch = "rv32ima"; useLLVM = true; }' \
  -A stdenv
~~~

This is because compiler-rt always passes `--target`, causing machine flags to be dropped.

Reading comments from @alyssais, @emilazy and #379593, I think there is general agreement that it's okay for things like compiler-rt to expect a multi-target compiler and pass `--target`. #379593 dropped the warning when a `--target` matching the wrapper's is passed. I believe the most natural behavior is for the machine flags to be kept in that case, too, so that

```
$CC ...
$CC --target=$TARGET ...
```

produce the same binaries. WDYT?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - N/A (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - N/A (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
