### PR TITLE
webkitgtk_6_0: 2.46.6 → 2.48.0

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -37,6 +37,7 @@
   libxslt,
   harfbuzz,
   hyphen,
+  icu,
   libsysprof-capture,
   libpthreadstubs,
   nettle,
@@ -79,7 +80,7 @@
 # https://webkitgtk.org/2024/10/04/webkitgtk-2.46.html recommends building with clang.
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "webkitgtk";
-  version = "2.46.6";
+  version = "2.48.0";
   name = "${finalAttrs.pname}-${finalAttrs.version}+abi=${
     if lib.versionAtLeast gtk3.version "4.0" then
       "6.0"
@@ -99,7 +100,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/webkitgtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-8rMd5pMiC6m6t2zm3f5bC/qyUVyysKcPPFTUBQdmwys=";
+    hash = "sha256-lJBKVc8S1EpONs6tr/8C1G2nPXa+m0dp80y/3w7r+I4=";
   };
 
   patches = lib.optionals clangStdenv.hostPlatform.isLinux [
@@ -135,6 +136,7 @@ clangStdenv.mkDerivation (finalAttrs: {
       at-spi2-core
       cairo # required even when using skia
       enchant2
+      flite
       libavif
       libepoxy
       libjxl
@@ -143,6 +145,7 @@ clangStdenv.mkDerivation (finalAttrs: {
       gst-plugins-base
       harfbuzz
       hyphen
+      icu
       libGL
       libGLU
       libgbm
@@ -186,7 +189,7 @@ clangStdenv.mkDerivation (finalAttrs: {
       geoclue2
     ]
     ++ lib.optionals enableExperimental [
-      flite
+      # For ENABLE_WEB_RTC
       openssl
     ]
     ++ lib.optionals withLibsecret [


### PR DESCRIPTION
https://github.com/WebKit/WebKit/compare/webkitgtk-2.46.6...webkitgtk-2.48.0
https://webkitgtk.org/2024/10/29/webkitgtk2.47.1-released.html
https://webkitgtk.org/2024/11/26/webkitgtk2.47.2-released.html
https://webkitgtk.org/2025/01/21/webkitgtk2.47.3-released.html
https://webkitgtk.org/2025/02/05/webkitgtk2.47.4-released.html
https://webkitgtk.org/2025/02/25/webkitgtk2.47.90-released.html
https://webkitgtk.org/2025/03/14/webkitgtk2.48.0-released.html
https://webkitgtk.org/security/WSA-2025-0002.html

CVE-2024-44192, CVE-2024-54467, CVE-2025-24201


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Skimmed `git diff webkitgtk-2.46.6..webkitgtk-2.48.0 -- '*cmake*' '*CMake*'`
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
