### PR TITLE
postgresql: always build with JIT enabled

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -20,7 +20,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions = ps: [ ps.anonymizer ];
             settings.shared_preload_libraries = [ "anon" ];
           };

--- a/nixos/tests/postgresql/citus.nix
+++ b/nixos/tests/postgresql/citus.nix
@@ -35,7 +35,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions =
               ps: with ps; [
                 citus

--- a/nixos/tests/postgresql/pgjwt.nix
+++ b/nixos/tests/postgresql/pgjwt.nix
@@ -24,7 +24,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions =
               ps: with ps; [
                 pgjwt

--- a/nixos/tests/postgresql/pgvecto-rs.nix
+++ b/nixos/tests/postgresql/pgvecto-rs.nix
@@ -38,7 +38,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions =
               ps: with ps; [
                 pgvecto-rs

--- a/nixos/tests/postgresql/postgresql-jit.nix
+++ b/nixos/tests/postgresql/postgresql-jit.nix
@@ -51,5 +51,4 @@ let
 in
 genTests {
   inherit makeTestFor;
-  filter = n: _: lib.hasSuffix "_jit" n;
 }

--- a/nixos/tests/postgresql/postgresql-tls-client-cert.nix
+++ b/nixos/tests/postgresql/postgresql-tls-client-cert.nix
@@ -51,7 +51,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             enableTCPIP = true;
             ensureUsers = [
               {

--- a/nixos/tests/postgresql/postgresql-wal-receiver.nix
+++ b/nixos/tests/postgresql/postgresql-wal-receiver.nix
@@ -32,7 +32,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             settings = {
               max_replication_slots = 10;
               max_wal_senders = 10;

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -15,41 +15,33 @@ let
       postgresql-clauses = makeEnsureTestFor package;
     };
 
-  test-sql =
-    enablePLv8Test:
-    pkgs.writeText "postgresql-test" (
-      ''
-        CREATE EXTENSION pgcrypto; -- just to check if lib loading works
-        CREATE TABLE sth (
-          id int
-        );
-        INSERT INTO sth (id) VALUES (1);
-        INSERT INTO sth (id) VALUES (1);
-        INSERT INTO sth (id) VALUES (1);
-        INSERT INTO sth (id) VALUES (1);
-        INSERT INTO sth (id) VALUES (1);
-        CREATE TABLE xmltest ( doc xml );
-        INSERT INTO xmltest (doc) VALUES ('<test>ok</test>'); -- check if libxml2 enabled
-      ''
-      + lib.optionalString enablePLv8Test ''
-        -- check if hardening gets relaxed
-        CREATE EXTENSION plv8;
-        -- try to trigger the V8 JIT, which requires MemoryDenyWriteExecute
-        DO $$
-          let xs = [];
-          for (let i = 0, n = 400000; i < n; i++) {
-              xs.push(Math.round(Math.random() * n))
-          }
-          console.log(xs.reduce((acc, x) => acc + x, 0));
-        $$ LANGUAGE plv8;
-      ''
+  test-sql = pkgs.writeText "postgresql-test" (''
+    CREATE EXTENSION pgcrypto; -- just to check if lib loading works
+    CREATE TABLE sth (
+      id int
     );
+    INSERT INTO sth (id) VALUES (1);
+    INSERT INTO sth (id) VALUES (1);
+    INSERT INTO sth (id) VALUES (1);
+    INSERT INTO sth (id) VALUES (1);
+    INSERT INTO sth (id) VALUES (1);
+    CREATE TABLE xmltest ( doc xml );
+    INSERT INTO xmltest (doc) VALUES ('<test>ok</test>'); -- check if libxml2 enabled
+
+    -- check if hardening gets relaxed
+    CREATE EXTENSION plv8;
+    -- try to trigger the V8 JIT, which requires MemoryDenyWriteExecute
+    DO $$
+      let xs = [];
+      for (let i = 0, n = 400000; i < n; i++) {
+          xs.push(Math.round(Math.random() * n))
+      }
+      console.log(xs.reduce((acc, x) => acc + x, 0));
+    $$ LANGUAGE plv8;
+  '');
 
   makeTestForWithBackupAll =
     package: backupAll:
-    let
-      enablePLv8Check = !package.pkgs.plv8.meta.broken;
-    in
     makeTest {
       name = "postgresql${lib.optionalString backupAll "-backup-all"}-${package.name}";
       meta = with lib.maintainers; {
@@ -63,11 +55,9 @@ let
             inherit package;
             enable = true;
             enableJIT = lib.hasInfix "-jit-" package.name;
-            # plv8 doesn't support postgresql with JIT, so we only run the test
-            # for the non-jit variant.
             # TODO(@Ma27) split this off into its own VM test and move a few other
             # extension tests to use postgresqlTestExtension.
-            extensions = lib.mkIf enablePLv8Check (ps: with ps; [ plv8 ]);
+            extensions = ps: with ps; [ plv8 ];
           };
 
           services.postgresqlBackup = {
@@ -94,7 +84,7 @@ let
 
           with subtest("Postgresql is available just after unit start"):
               machine.succeed(
-                  "cat ${test-sql enablePLv8Check} | sudo -u postgres psql"
+                  "cat ${test-sql} | sudo -u postgres psql"
               )
 
           with subtest("Postgresql survives restart (bug #1735)"):
@@ -184,7 +174,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             ensureUsers = [
               {
                 name = "all-clauses";

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -54,7 +54,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             # TODO(@Ma27) split this off into its own VM test and move a few other
             # extension tests to use postgresqlTestExtension.
             extensions = ps: with ps; [ plv8 ];

--- a/nixos/tests/postgresql/timescaledb.nix
+++ b/nixos/tests/postgresql/timescaledb.nix
@@ -54,7 +54,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions =
               ps: with ps; [
                 timescaledb

--- a/nixos/tests/postgresql/tsja.nix
+++ b/nixos/tests/postgresql/tsja.nix
@@ -21,7 +21,6 @@ let
           services.postgresql = {
             inherit package;
             enable = true;
-            enableJIT = lib.hasInfix "-jit-" package.name;
             extensions =
               ps: with ps; [
                 tsja

--- a/nixos/tests/postgresql/wal2json.nix
+++ b/nixos/tests/postgresql/wal2json.nix
@@ -17,7 +17,6 @@ let
         services.postgresql = {
           inherit package;
           enable = true;
-          enableJIT = lib.hasInfix "-jit-" package.name;
           extensions = with package.pkgs; [ wal2json ];
           settings = {
             wal_level = "logical";

--- a/pkgs/by-name/ko/kore/package.nix
+++ b/pkgs/by-name/ko/kore/package.nix
@@ -2,15 +2,15 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   openssl,
   curl,
-  postgresql_16,
+  libpq,
   yajl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "kore";
-  # TODO: Check on next update whether postgresql 17 is supported.
   version = "4.2.3";
 
   src = fetchFromGitHub {
@@ -20,15 +20,26 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-p0M2P02xwww5EnT28VnEtj5b+/jkPW3YkJMuK79vp4k=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/jorisvink/kore/commit/978cb0ab79c9c939c35996f34f7d835f9c671831.patch";
+      hash = "sha256-uHTWiliM4m2i9/6GQQfnAo31XBXd/2+fzysPeNo2dQ0=";
+    })
+    (fetchpatch {
+      url = "https://github.com/jorisvink/kore/commit/6122affe22bf676eed0f544e421c53699aa7a2e2.patch";
+      hash = "sha256-xaiUOjBJPEgEwwuseXe6VbOTkOCKdQ5tuwDdL7DojHM=";
+    })
+  ];
+
   buildInputs = [
     openssl
     curl
-    postgresql_16
+    libpq
     yajl
   ];
 
   nativeBuildInputs = [
-    postgresql_16.pg_config
+    libpq.pg_config
   ];
 
   makeFlags = [

--- a/pkgs/by-name/ko/kore/package.nix
+++ b/pkgs/by-name/ko/kore/package.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     yajl
   ];
 
+  nativeBuildInputs = [
+    postgresql_16.pg_config
+  ];
+
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "ACME=1"

--- a/pkgs/by-name/pg/pg_checksums/package.nix
+++ b/pkgs/by-name/pg/pg_checksums/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   libxslt,
   docbook_xsl,
   postgresql,
 }:
 
-stdenv.mkDerivation rec {
+clangStdenv.mkDerivation rec {
   pname = "pg_checksums";
   version = "1.2";
 

--- a/pkgs/by-name/pg/pgcopydb/package.nix
+++ b/pkgs/by-name/pg/pgcopydb/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   libkrb5,
   openssl,
@@ -13,7 +13,7 @@
   zlib,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "pgcopydb";
   version = "0.15";
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       sqlite
       zlib
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
+    ++ lib.optionals clangStdenv.hostPlatform.isLinux [
       pam
     ];
 

--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
     libpq.pg_config
     uvloop
     postgresql
+    postgresql.pg_config
     pytest-xdist
     pytestCheckHook
     distro

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -22,12 +22,10 @@ let
       version: path:
       let
         attrName = if jitSupport then "${version}_jit" else version;
+        postgresql = import path { inherit self; };
+        attrValue = if jitSupport then postgresql.withJIT else postgresql.withoutJIT;
       in
-      self.lib.nameValuePair attrName (
-        import path {
-          inherit jitSupport self;
-        }
-      )
+      self.lib.nameValuePair attrName attrValue
     ) versions;
 
   libpq = self.callPackage ./libpq.nix { };
@@ -35,7 +33,8 @@ let
 in
 {
   # variations without and with JIT
-  postgresqlVersions = mkAttributes false // mkAttributes true;
+  postgresqlVersions = mkAttributes false;
+  postgresqlJitVersions = mkAttributes true;
 
   inherit libpq;
 }

--- a/pkgs/servers/sql/postgresql/ext/plv8/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  jitSupport,
   lib,
   nodejs_20,
   perl,
@@ -140,6 +139,5 @@ postgresqlBuildExtension (finalAttrs: {
       "aarch64-linux"
     ];
     license = lib.licenses.postgresql;
-    broken = jitSupport;
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/plv8/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/plv8/package.nix
@@ -134,10 +134,8 @@ postgresqlBuildExtension (finalAttrs: {
     homepage = "https://plv8.github.io/";
     changelog = "https://github.com/plv8/plv8/blob/r${finalAttrs.version}/Changes";
     maintainers = [ ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -288,6 +288,15 @@ let
           # those paths. This avoids a lot of circular dependency problems with different outputs,
           # and allows splitting them cleanly.
           CFLAGS = "-fdata-sections -ffunction-sections -flto";
+
+          # This flag was introduced upstream in:
+          # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
+          # It causes errors when linking against libpq.a in pkgsStatic:
+          #   undefined reference to `pg_encoding_to_char'
+          # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
+          # to have initdb load a libpq.so from a different major version and how to avoid that.
+          # This doesn't apply to us with Nix.
+          NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
         }
         // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
         // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -457,7 +457,10 @@ let
           # the tests works fine most of the time. But once the tests (or any package using
           # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
           # will be stuck around, and any future builds with the tests enabled *will* fail.
-          !(stdenv'.hostPlatform.isDarwin);
+          !(stdenv'.hostPlatform.isDarwin)
+        &&
+          # Regression tests currently fail in pkgsMusl because of a difference in EXPLAIN output.
+          !(stdenv'.hostPlatform.isMusl);
       installCheckTarget = "check-world";
 
       passthru =

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -66,7 +66,11 @@ let
       icu,
 
       # JIT
-      jitSupport, # not default on purpose, this is set via "_jit or not" attributes
+      jitSupport ?
+        stdenv.hostPlatform.canExecute stdenv.buildPlatform
+        # Building with JIT in pkgsStatic fails like this:
+        #   fatal error: 'stdio.h' file not found
+        && !stdenv.hostPlatform.isStatic,
       llvmPackages,
       nukeReferences,
       overrideCC,
@@ -135,10 +139,8 @@ let
 
       dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
 
-      pname = "postgresql";
-
       stdenv' =
-        if jitSupport && !stdenv.cc.isClang then
+        if !stdenv.cc.isClang then
           overrideCC llvmPackages.stdenv (
             llvmPackages.stdenv.cc.override {
               # LLVM bintools are not used by default, but are needed to make -flto work below.
@@ -150,7 +152,7 @@ let
     in
     stdenv'.mkDerivation (finalAttrs: {
       inherit version;
-      pname = pname + lib.optionalString jitSupport "-jit";
+      pname = "postgresql";
 
       src = fetchFromGitHub {
         owner = "postgres";
@@ -162,8 +164,6 @@ let
 
       __structuredAttrs = true;
 
-      hardeningEnable = lib.optionals (!stdenv'.cc.isClang) [ "pie" ];
-
       outputs =
         [
           "out"
@@ -172,51 +172,67 @@ let
           "lib"
           "man"
         ]
+        ++ lib.optionals jitSupport [ "jit" ]
         ++ lib.optionals perlSupport [ "plperl" ]
         ++ lib.optionals pythonSupport [ "plpython3" ]
         ++ lib.optionals tclSupport [ "pltcl" ];
-      outputChecks = {
-        out = {
-          disallowedReferences = [
-            "dev"
-            "doc"
-            "man"
-          ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-          ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
 
-        lib = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-            "man"
-          ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-          ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
+      outputChecks =
+        {
+          out = {
+            disallowedReferences = [
+              "dev"
+              "doc"
+              "man"
+            ] ++ lib.optionals jitSupport [ "jit" ];
+            disallowedRequisites = [
+              stdenv'.cc
+              llvmPackages.llvm.out
+            ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+          };
 
-        doc = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "man"
-          ];
-        };
+          lib = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "doc"
+              "man"
+            ] ++ lib.optionals jitSupport [ "jit" ];
+            disallowedRequisites = [
+              stdenv'.cc
+              llvmPackages.llvm.out
+            ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+          };
 
-        man = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-          ];
+          doc = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "man"
+            ] ++ lib.optionals jitSupport [ "jit" ];
+          };
+
+          man = {
+            disallowedReferences = [
+              "out"
+              "dev"
+              "doc"
+            ] ++ lib.optionals jitSupport [ "jit" ];
+          };
+        }
+        // lib.optionalAttrs jitSupport {
+          jit = {
+            disallowedReferences = [
+              "dev"
+              "doc"
+              "man"
+            ];
+            disallowedRequisites = [
+              stdenv'.cc
+              llvmPackages.llvm.out
+            ] ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+          };
         };
-      };
 
       strictDeps = true;
 
@@ -271,9 +287,7 @@ let
           # flags will remove unused sections from all shared libraries and binaries - including
           # those paths. This avoids a lot of circular dependency problems with different outputs,
           # and allows splitting them cleanly.
-          CFLAGS =
-            "-fdata-sections -ffunction-sections"
-            + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
+          CFLAGS = "-fdata-sections -ffunction-sections -flto";
         }
         // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
         // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
@@ -364,11 +378,25 @@ let
 
       installTargets = [ "install-world" ];
 
-      postPatch = ''
-        substituteInPlace "src/Makefile.global.in" --subst-var out
-        substituteInPlace "src/common/config_info.c" --subst-var dev
-        cat ${./pg_config.env.mk} >> src/common/Makefile
-      '';
+      postPatch =
+        ''
+          substituteInPlace "src/Makefile.global.in" --subst-var out
+          substituteInPlace "src/common/config_info.c" --subst-var dev
+          cat ${./pg_config.env.mk} >> src/common/Makefile
+        ''
+        # This check was introduced upstream to prevent calls to "exit" inside libpq.
+        # However, this doesn't work reliably with static linking, see this and following:
+        # https://postgr.es/m/flat/20210703001639.GB2374652%40rfd.leadboat.com#52584ca4bd3cb9dac376f3158c419f97
+        # Thus, disable the check entirely, as it would currently fail with this:
+        # > libpq.so.5.17:                  U atexit
+        # > libpq.so.5.17:                  U pthread_exit
+        # > libpq must not be calling any function which invokes exit
+        # Don't mind the fact that this checks libpq.**so** in pkgsStatic - that's correct, since PostgreSQL
+        # still needs a shared library internally.
+        + lib.optionalString (atLeast "15" && stdenv'.hostPlatform.isStatic) ''
+          substituteInPlace src/interfaces/libpq/Makefile \
+            --replace-fail "echo 'libpq must not be calling any function which invokes exit'; exit 1;" "echo;"
+        '';
 
       postInstall =
         ''
@@ -415,6 +443,9 @@ let
 
           # Stop lib depending on the -dev output of llvm
           remove-references-to -t ${llvmPackages.llvm.dev} "$out/lib/llvmjit${dlSuffix}"
+
+          moveToOutput "lib/bitcode" "$jit"
+          moveToOutput "lib/llvmjit*" "$jit"
         ''
         + lib.optionalString stdenv'.hostPlatform.isDarwin ''
           # The darwin specific Makefile for PGXS contains a reference to the postgres
@@ -466,17 +497,14 @@ let
       passthru =
         let
           this = self.callPackage generic args;
-          jitToggle = this.override {
-            jitSupport = !jitSupport;
-          };
         in
         {
           inherit dlSuffix;
 
           psqlSchema = lib.versions.major version;
 
-          withJIT = if jitSupport then this else jitToggle;
-          withoutJIT = if jitSupport then jitToggle else this;
+          withJIT = this.withPackages (_: [ this.jit ]);
+          withoutJIT = this;
 
           pkgs =
             let
@@ -586,18 +614,38 @@ let
         inherit installedExtensions;
         inherit (postgresql)
           pg_config
+          pkgs
           psqlSchema
           version
           ;
 
         withJIT = postgresqlWithPackages {
-          inherit buildEnv lib makeBinaryWrapper;
-          postgresql = postgresql.withJIT;
-        } f;
+          inherit
+            buildEnv
+            lib
+            makeBinaryWrapper
+            postgresql
+            ;
+        } (_: installedExtensions ++ [ postgresql.jit ]);
         withoutJIT = postgresqlWithPackages {
-          inherit buildEnv lib makeBinaryWrapper;
-          postgresql = postgresql.withoutJIT;
-        } f;
+          inherit
+            buildEnv
+            lib
+            makeBinaryWrapper
+            postgresql
+            ;
+        } (_: lib.remove postgresql.jit installedExtensions);
+
+        withPackages =
+          f':
+          postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
+              ;
+          } (ps: installedExtensions ++ f' ps);
       };
     };
 

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -91,6 +91,15 @@ stdenv.mkDerivation (finalAttrs: {
     "-fdata-sections -ffunction-sections"
     + (if stdenv.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
 
+  # This flag was introduced upstream in:
+  # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
+  # It causes errors when linking against libpq.a in pkgsStatic:
+  #   undefined reference to `pg_encoding_to_char'
+  # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
+  # to have initdb load a libpq.so from a different major version and how to avoid that.
+  # This doesn't apply to us with Nix.
+  env.NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
+
   configureFlags =
     [
       "--enable-debug"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12455,6 +12455,7 @@ with pkgs;
 
   inherit (import ../servers/sql/postgresql pkgs)
     postgresqlVersions
+    postgresqlJitVersions
     libpq
     ;
 
@@ -12464,7 +12465,9 @@ with pkgs;
     postgresql_15
     postgresql_16
     postgresql_17
+    ;
 
+  inherit (postgresqlJitVersions)
     postgresql_13_jit
     postgresql_14_jit
     postgresql_15_jit


### PR DESCRIPTION
Inspired by #385859.

This changes the build to always enable JIT - but to only enable it at run-time, when required. This keeps the runtime closure small without JIT, but allows enabling it without a rebuild. We can do this, because JIT is actually built as a shared module, which is loaded at run-time. We put it into a `-jit` output and only link it into the environment when requested.

Under the hood, this uses `withPackages` and adds the "JIT package" - thus, to be able to use `withPackages` on top of that, we also need to be able to apply `withPackages` repeatedly.

This cuts down the number of NixOS tests in half, because we don't need to run it for every version with and without JIT anymore. There really is no point in running everything with `llvmjit.so` in place, when the queries are not making use of it anyway.

Also, we only need to build each extension once and not twice, further reducing the number of rebuilds required for PRs touching `postgresql`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
