### PR TITLE
raysession: 0.14.3 -> 0.14.4; fix ray_jackpatch

### DIFF
--- a/pkgs/applications/audio/raysession/default.nix
+++ b/pkgs/applications/audio/raysession/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonApplication rec {
   pname = "raysession";
-  version = "0.14.3";
+  version = "0.14.4";
 
   src = fetchurl {
     url = "https://github.com/Houston4444/RaySession/releases/download/v${version}/RaySession-${version}-source.tar.gz";
-    sha256 = "sha256-3+g1zdjGkxNEpyuKuxzhr2p9gkEFjYAso4fPedbjmlY=";
+    sha256 = "sha256-cr9kqZdqY6Wq+RkzwYxNrb/PLFREKUgWeVNILVUkc7A=";
   };
 
   postPatch = ''

--- a/pkgs/applications/audio/raysession/default.nix
+++ b/pkgs/applications/audio/raysession/default.nix
@@ -24,6 +24,7 @@ buildPythonApplication rec {
     substituteInPlace Makefile --replace '$(DESTDIR)/' '$(DESTDIR)$(PREFIX)/'
     # Do not wrap an importable module with a shell script.
     chmod -x src/daemon/desktops_memory.py
+    chmod -x src/clients/jackpatch/main_loop.py
   '';
 
   format = "other";


### PR DESCRIPTION
Two problems were fixed:
- https://github.com/NixOS/nixpkgs/issues/381323
 `ray-jackpatch.py` loads `main_loop.py`, but that was being replaced with a
    wrapper, which couldn't be loaded correctly by python. Removing the
    executable bit of `main_loop.py` avoids it getting wrapped.
- Session file creation was broken due to the session file not being writable. This was fixed upstream, so I updated the version from 0.14.3 to 0.14.4 to include the fix.

Complete Changelog for [0.14.4](https://github.com/Houston4444/RaySession/releases/tag/v0.14.4):
```
Bug fix release.

Bug Fixes:

    Support pyliblo3 as well as pyliblo (Done by AdamWill)
    ray_control open_session_off fixed (very important for some scripts)
    execute chmod +w on session files after their copy from template (needed for NixOs)
    save_via_windows script is now POSIX compliant (Done by Dennis Braun)

Improvments:

    add --osc-port argument to sooperloooper_nsm executable (Done by Jean-Emmanuel)
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
