### PR TITLE
ltex-ls-plus: add jvm option

### DIFF
--- a/pkgs/by-name/lt/ltex-ls-plus/package.nix
+++ b/pkgs/by-name/lt/ltex-ls-plus/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   makeBinaryWrapper,
   jre_headless,
+  jvmOptions ? [ ],
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -17,18 +18,22 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    let
+      java_opts = lib.optionalString (jvmOptions != [ ]) ''--set JAVA_OPTS "${toString jvmOptions}"'';
+    in
+    ''
+      runHook preInstall
 
-    mkdir -p $out
-    cp -rfv bin/ lib/ $out
-    rm -fv $out/bin/.lsp-cli.json $out/bin/*.bat
-    for file in $out/bin/{ltex-ls-plus,ltex-cli-plus}; do
-      wrapProgram $file --set JAVA_HOME "${jre_headless}"
-    done
+      mkdir -p $out
+      cp -rfv bin/ lib/ $out
+      rm -fv $out/bin/.lsp-cli.json $out/bin/*.bat
+      for file in $out/bin/{ltex-ls-plus,ltex-cli-plus}; do
+        wrapProgram $file --set JAVA_HOME "${jre_headless}" ${java_opts}
+      done
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
   meta =
     let


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It's nice to be able to configure JVM options used by ltex-ls-plus. According to [this](https://github.com/ltex-plus/ltex-ls-plus/blob/3e6567d271d3a5c26f177839aed279bf706af318/pom.xml#L374-L375) part of the source code, it follows the env var `JAVA_OPTS`. This PR exposes this `JAVA_OPTS` via the package's arguments.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
