### PR TITLE
nixos/systemd-user: enable systemd-tmpfiles-clean.timer

### DIFF
--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -12,6 +12,9 @@ with lib;
 let
   cfg = config.systemd.user;
 
+  hasTmpfiles =
+    cfg.tmpfiles.rules != [ ] || any (cfg': cfg'.rules != [ ]) (attrValues cfg.tmpfiles.users);
+
   systemd = config.systemd.package;
 
   inherit (systemdUtils.lib)
@@ -210,11 +213,15 @@ in
       // mapAttrs' (n: v: nameValuePair "${n}.target" (targetToUnit v)) cfg.targets
       // mapAttrs' (n: v: nameValuePair "${n}.timer" (timerToUnit v)) cfg.timers;
 
+    systemd.user.timers = {
+      # enable systemd user tmpfiles
+      systemd-tmpfiles-clean.wantedBy = optional hasTmpfiles "timers.target";
+    }
     # Generate timer units for all services that have a ‘startAt’ value.
-    systemd.user.timers = mapAttrs (name: service: {
+    // (mapAttrs (name: service: {
       wantedBy = [ "timers.target" ];
       timerConfig.OnCalendar = service.startAt;
-    }) (filterAttrs (name: service: service.startAt != [ ]) cfg.services);
+    }) (filterAttrs (name: service: service.startAt != [ ]) cfg.services));
 
     # Provide the systemd-user PAM service, required to run systemd
     # user instances.
@@ -233,9 +240,7 @@ in
     systemd.services.systemd-user-sessions.restartIfChanged = false; # Restart kills all active sessions.
 
     # enable systemd user tmpfiles
-    systemd.user.services.systemd-tmpfiles-setup.wantedBy = optional (
-      cfg.tmpfiles.rules != [ ] || any (cfg': cfg'.rules != [ ]) (attrValues cfg.tmpfiles.users)
-    ) "basic.target";
+    systemd.user.services.systemd-tmpfiles-setup.wantedBy = optional hasTmpfiles "basic.target";
 
     # /run/current-system/sw/etc/xdg is in systemd's $XDG_CONFIG_DIRS so we can
     # write the tmpfiles.d rules for everyone there

--- a/nixos/tests/systemd-user-tmpfiles-rules.nix
+++ b/nixos/tests/systemd-user-tmpfiles-rules.nix
@@ -21,6 +21,15 @@
         users.alice.rules = [
           "d %h/only_alice"
         ];
+        users.bob.rules = [
+          "D %h/cleaned_up - - - 0"
+        ];
+      };
+
+      # run every 10 seconds
+      systemd.user.timers.systemd-tmpfiles-clean.timerConfig = {
+        OnStartupSec = "10s";
+        OnUnitActiveSec = "10s";
       };
     };
 
@@ -36,5 +45,9 @@
       machine.wait_until_succeeds("systemctl --user --machine=bob@ is-active systemd-tmpfiles-setup.service")
       machine.succeed("[ -d ~bob/user_tmpfiles_created ]")
       machine.succeed("[ ! -e ~bob/only_alice ]")
+
+      machine.succeed("systemctl --user --machine=bob@ is-active systemd-tmpfiles-clean.timer")
+      machine.succeed("runuser -u bob -- touch ~bob/cleaned_up/file")
+      machine.wait_until_fails("[ -e ~bob/cleaned_up/file ]")
     '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Set systemd.user.timers.systemd-tmpfiles-clean.wantedBy when any user tmpfiles rules are set so NixOS knows to enable the unit. Previously (https://github.com/NixOS/nixpkgs/pull/207468) the systemd user unit `systemd-tmpfiles-clean.timer` was not enabled.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
