### PR TITLE
dive: 0.12.0 -> 0.13.0

### DIFF
--- a/pkgs/by-name/di/dive/package.nix
+++ b/pkgs/by-name/di/dive/package.nix
@@ -3,25 +3,23 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
   pkg-config,
   btrfs-progs,
   gpgme,
   lvm2,
 }:
-
 buildGoModule rec {
   pname = "dive";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "wagoodman";
     repo = "dive";
     rev = "v${version}";
-    hash = "sha256-CuVRFybsn7PVPgz3fz5ghpjOEOsTYTv6uUAgRgFewFw=";
+    hash = "sha256-kVFXidcvSlYi+aD+3yEPYy1Esm0bl02ioX1DmO0L1Hs=";
   };
 
-  vendorHash = "sha256-uzzawa/Doo6j/Fh9dJMzGKbpp24UTLAo9VGmuQ80IZE=";
+  vendorHash = "sha256-9lNtKpfGDVE3U0ZX0QcaCJrqCxoubvWqR26IvSKkImM=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -29,26 +27,6 @@ buildGoModule rec {
     btrfs-progs
     gpgme
     lvm2
-  ];
-
-  patches = [
-    # fix scrolling
-    # See https://github.com/wagoodman/dive/pull/447
-    (fetchpatch {
-      name = "fix-scrolling.patch";
-      url = "https://github.com/wagoodman/dive/pull/473/commits/a885fa6e68b3763d52de20603ee1b9cd8949276f.patch";
-      hash = "sha256-6gTWfyvK19xDqc7Ah33ewgz/WQRcQHLYwerrwUtRpJc=";
-    })
-    (fetchpatch {
-      name = "add-scrolling-layers.patch";
-      url = "https://github.com/wagoodman/dive/pull/473/commits/840653158e235bdd59b4c4621cf282ce6499c714.patch";
-      hash = "sha256-dYqg5JpWKOzy3hVjIVCHA2vmKCtCgc8W+oHEzuGpyxc=";
-    })
-    (fetchpatch {
-      name = "fix-render-update.patch";
-      url = "https://github.com/wagoodman/dive/pull/473/commits/36177a9154eebe9e3ae9461a9e6f6b368f7974e1.patch";
-      hash = "sha256-rSeEYxUaYlEZGv+NWYK+nATBYS4P2swqjC3HimHyqNI=";
-    })
   ];
 
   ldflags = [


### PR DESCRIPTION
- Also removes unneccessary patches that have been merged upstream
- Tested the build result using: 
  ```console
  $ nix-build -A dive
  ...
  Running phase: installPhase
  Running phase: fixupPhase
  shrinking RPATHs of ELF executables and libraries in /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0
  shrinking /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0/bin/dive
  checking for references to /build/ in /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0...
  patching script interpreter paths in /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0
  stripping (with command strip and flags -S -p) in  /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0/bin
  /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0
  
  $ # image.tar obtained from https://github.com/wagoodman/dive/issues/507 (a broken repro for dive 0.12.0)
  $ /nix/store/r1kk9r9m5rzwvbdxjc30493k0cbfcglc-dive-0.13.0/bin/dive --source docker-archive /tmp/image.tar 
  Image Source: docker-archive:///tmp/image.tar
  Extracting image from docker-archive... (this can take a while for large images)
  Analyzing image...
  Building cache...
  ## Confirmed dive runs normally (it's a fullscreen terminal application)
  ```

Dive had started to seem like it was a dead project, but the owner came back and worked with a fork maintainer to upstream the work from the leading fork. That work resulted in wagoodman/dive#570 - with 0.13.0 released today. Thank you @wagoodman! 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
