### PR TITLE
nixos/test-driver: add backdoor based on systemd-ssh-proxy & AF_VSOCK

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -63,6 +63,35 @@ using:
 Once the connection is established, you can enter commands in the socat terminal
 where socat is running.
 
+## SSH Access for test machines {#sec-nixos-test-ssh-access}
+
+An SSH-based backdoor to log into machines can be enabled with
+
+```nix
+{
+  name = "…";
+  nodes.machines = { /* … */ };
+  sshBackdoor.enable = true;
+}
+```
+
+This creates a [vsock socket](https://man7.org/linux/man-pages/man7/vsock.7.html)
+for each VM to log in with SSH. This configures root login with an empty password.
+
+When the VMs get started interactively with the test-driver, it's possible to
+connect to `machine` with
+
+```
+$ ssh vsock/3 -o User=root
+```
+
+The socket numbers correspond to the node number of the test VM, but start
+at three instead of one because that's the lowest possible
+vsock number.
+
+On non-NixOS systems you'll probably need to enable
+the SSH config from {manpage}`systemd-ssh-proxy(1)` yourself.
+
 ## Port forwarding to NixOS test VMs {#sec-nixos-test-port-forwarding}
 
 If your test has only a single VM, you may use e.g.

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1817,6 +1817,9 @@
   "sec-test-options-reference": [
     "index.html#sec-test-options-reference"
   ],
+  "test-opt-sshBackdoor.enable": [
+    "index.html#test-opt-sshBackdoor.enable"
+  ],
   "test-opt-defaults": [
     "index.html#test-opt-defaults"
   ],
@@ -1903,6 +1906,9 @@
   ],
   "sec-nixos-test-shell-access": [
     "index.html#sec-nixos-test-shell-access"
+  ],
+  "sec-nixos-test-ssh-access": [
+    "index.html#sec-nixos-test-ssh-access"
   ],
   "sec-nixos-test-port-forwarding": [
     "index.html#sec-nixos-test-port-forwarding"

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -109,6 +109,11 @@ def main() -> None:
         help="the test script to run",
         type=Path,
     )
+    arg_parser.add_argument(
+        "--dump-vsocks",
+        help="indicates that the interactive SSH backdoor is active and dumps information about it on start",
+        action="store_true",
+    )
 
     args = arg_parser.parse_args()
 
@@ -136,6 +141,8 @@ def main() -> None:
         if args.interactive:
             history_dir = os.getcwd()
             history_path = os.path.join(history_dir, ".nixos-test-history")
+            if args.dump_vsocks:
+                driver.dump_machine_ssh()
             ptpython.ipython.embed(
                 user_ns=driver.test_symbols(),
                 history_filename=history_path,

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 from unittest import TestCase
 
+from colorama import Style
+
 from test_driver.errors import MachineError, RequestedAssertionFailed
 from test_driver.logger import AbstractLogger
 from test_driver.machine import Machine, NixStartScript, retry
@@ -175,6 +177,19 @@ class Driver:
             + ", ".join(list(general_symbols.keys()))
         )
         return {**general_symbols, **machine_symbols, **vlan_symbols}
+
+    def dump_machine_ssh(self) -> None:
+        print("SSH backdoor enabled, the machines can be accessed like this:")
+        print(
+            f"{Style.BRIGHT}Note:{Style.RESET_ALL} this requires {Style.BRIGHT}systemd-ssh-proxy(1){Style.RESET_ALL} to be enabled (default on NixOS 25.05 and newer)."
+        )
+        names = [machine.name for machine in self.machines]
+        longest_name = len(max(names, key=len))
+        for num, name in enumerate(names, start=3):
+            spaces = " " * (longest_name - len(name) + 2)
+            print(
+                f"    {name}:{spaces}{Style.BRIGHT}ssh -o User=root vsock/{num}{Style.RESET_ALL}"
+            )
 
     def test_script(self) -> None:
         """Run the test script"""

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -75,6 +75,7 @@ pkgs.lib.throwIf (args ? specialArgs)
           ),
         extraPythonPackages ? (_: [ ]),
         interactive ? { },
+        sshBackdoor ? { },
       }@t:
       let
         testConfig =

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -13,6 +13,7 @@ let
     mapAttrs
     mkDefault
     mkIf
+    mkMerge
     mkOption
     mkForce
     optional
@@ -77,6 +78,14 @@ in
 {
 
   options = {
+    sshBackdoor = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether to turn on the vsock-based SSH backdoor for all VMs.";
+      };
+    };
+
     node.type = mkOption {
       type = types.raw;
       default = baseOS.type;
@@ -172,10 +181,15 @@ in
 
     passthru.nodes = config.nodesCompat;
 
-    defaults = mkIf config.node.pkgsReadOnly {
-      nixpkgs.pkgs = config.node.pkgs;
-      imports = [ ../../modules/misc/nixpkgs/read-only.nix ];
-    };
+    defaults = mkMerge [
+      (mkIf config.node.pkgsReadOnly {
+        nixpkgs.pkgs = config.node.pkgs;
+        imports = [ ../../modules/misc/nixpkgs/read-only.nix ];
+      })
+      (mkIf config.sshBackdoor.enable {
+        testing.sshBackdoor.enable = true;
+      })
+    ];
 
   };
 }

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -82,7 +82,7 @@ in
       enable = mkOption {
         default = false;
         type = types.bool;
-        description = "Whether to turn on the vsock-based SSH backdoor for all VMs.";
+        description = "Whether to turn on the VSOCK-based access to all VMs. This provides an unauthenticated access intended for debugging.";
       };
     };
 

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -181,6 +181,10 @@ in
 
     passthru.nodes = config.nodesCompat;
 
+    extraDriverArgs = mkIf config.sshBackdoor.enable [
+      "--dump-vsocks"
+    ];
+
     defaults = mkMerge [
       (mkIf config.node.pkgsReadOnly {
         nixpkgs.pkgs = config.node.pkgs;


### PR DESCRIPTION
__Note:__ Only the last commit is relevant right now.
Depends on #390996 & #372979.

----

With this it's possible to trivially SSH into running machines from the
test-driver. This is especially useful when running VM tests
interactively on a remote system.

This is based on `systemd-ssh-proxy(1)`, so there's no need to configure
any additional networking on the host-side.

Suggested-by: Ryan Lahfa <masterancpp@gmail.com>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
