### PR TITLE
kanidm: don't log provisioned passwords via instrumentation

### DIFF
--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -306,6 +306,10 @@ import ./make-test-python.nix (
             provision.succeed('${specialisations}/credentialProvision/bin/switch-to-configuration test')
             provision_login("${provisionIdmAdminPassword}")
 
+            # Make sure neither password is logged
+            provision.fail("journalctl --since -10m --unit kanidm.service --grep '${provisionAdminPassword}'")
+            provision.fail("journalctl --since -10m --unit kanidm.service --grep '${provisionIdmAdminPassword}'")
+
             # Test provisioned admin pw
             out = provision.succeed("KANIDM_PASSWORD=${provisionAdminPassword} kanidm login -D admin")
             assert_contains(out, "Login Success for admin")

--- a/pkgs/by-name/ka/kanidm/patches/1_3/recover-account.patch
+++ b/pkgs/by-name/ka/kanidm/patches/1_3/recover-account.patch
@@ -19,7 +19,8 @@ index 40c18777f..40d553b40 100644
  
      #[instrument(
          level = "info",
-         skip(self, eventid),
+-        skip(self, eventid),
++        skip(self, password, eventid),
          fields(uuid = ?eventid)
      )]
      pub(crate) async fn handle_admin_recover_account(

--- a/pkgs/by-name/ka/kanidm/patches/1_4/recover-account.patch
+++ b/pkgs/by-name/ka/kanidm/patches/1_4/recover-account.patch
@@ -19,7 +19,8 @@ index 420e72c6c..5c4353116 100644
  
      #[instrument(
          level = "info",
-         skip(self, eventid),
+-        skip(self, eventid),
++        skip(self, password, eventid),
          fields(uuid = ?eventid)
      )]
      pub(crate) async fn handle_admin_recover_account(

--- a/pkgs/by-name/ka/kanidm/patches/1_5/recover-account.patch
+++ b/pkgs/by-name/ka/kanidm/patches/1_5/recover-account.patch
@@ -19,7 +19,8 @@ index 420e72c6c..5c4353116 100644
  
      #[instrument(
          level = "info",
-         skip(self, eventid),
+-        skip(self, eventid),
++        skip(self, password, eventid),
          fields(uuid = ?eventid)
      )]
      pub(crate) async fn handle_admin_recover_account(


### PR DESCRIPTION
The current provisioning patchset for kanidm logs the provisioned password through the function instrumentation
into the system log. This updates the patches for all versions to prevent this from happening.
This also make sure to test this behavior in the related nixos test.

Fixes: CVE-2025-30205
Thanks to @qenya for reporting this


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
