### PR TITLE
alsa-ucm-conf: 1.2.15.1 → 1.2.15.3-unstable-2026-01-29; validate in alsa-lib

### DIFF
--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -2,8 +2,10 @@
   lib,
   stdenv,
   fetchurl,
+  fetchFromGitHub,
   alsa-topology-conf,
   alsa-ucm-conf,
+  python3,
   testers,
   directoryListingUpdater,
 }:
@@ -15,6 +17,13 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-lib-${finalAttrs.version}.tar.bz2";
     hash = "sha256-f5g8qJykIIcsoW6Kn4+X+2PbbBxuJYW5Fzegi7A/Vmw=";
+  };
+
+  alsa-tests = fetchFromGitHub {
+    owner = "alsa-project";
+    repo = "alsa-tests";
+    rev = "53d34b67078540273899e15544e01c6d996f5240";
+    hash = "sha256-eclBmTsPtUJ0kuVf5pCn20zgDz87Ne/V6g9KHTQxu1E=";
   };
 
   patches = [
@@ -30,6 +39,21 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     ln -s ${alsa-ucm-conf}/share/alsa/{ucm,ucm2} $out/share/alsa
     ln -s ${alsa-topology-conf}/share/alsa/topology $out/share/alsa
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ python3 ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # validate UCM configuration
+    pushd ${finalAttrs.alsa-tests}/python/ucm-validator2
+    LD_LIBRARY_PATH="$out/lib" \
+      python3 ucm.py configs --ucmdir="$out/share/alsa/ucm2"
+    popd
+
+    runHook postInstallCheck
   '';
 
   outputs = [

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   stdenvNoCC,
+  alsa-utils-nhlt ? null,
   coreutils,
   kmod ? null,
   alsa-lib,
@@ -25,8 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   executablePkgs = {
-    # circular dependency
-    # alsa-utils = [ "nhlt-dmic-info" ];
+    alsa-utils-nhlt = [ "nhlt-dmic-info" ];
 
     coreutils = [
       "mkdir"

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -20,6 +20,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   dontBuild = true;
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall
@@ -38,6 +39,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r ucm ucm2 $out/share/alsa
 
     runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    if grep -E -r '\<exec\>\s+"-?/s?bin/' "$out"; then
+      echo found at least one unattended exec directive >&2
+      exit 1
+    fi
+
+    runHook postInstallCheck
   '';
 
   passthru = {

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -5,6 +5,7 @@
   stdenvNoCC,
   coreutils,
   kmod,
+  alsa-lib,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -39,8 +40,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=branch" ];
+  passthru = {
+    tests = { inherit alsa-lib; };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
   };
 
   meta = {

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -1,6 +1,6 @@
 {
-  directoryListingUpdater,
-  fetchurl,
+  nix-update-script,
+  fetchFromGitHub,
   lib,
   stdenvNoCC,
   coreutils,
@@ -9,11 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alsa-ucm-conf";
-  version = "1.2.15.1";
+  version = "1.2.15.3-unstable-2026-01-29";
 
-  src = fetchurl {
-    url = "mirror://alsa/lib/alsa-ucm-conf-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-JGxdWdIXtvf0ehH9EPG3ZtJavLDZyZavMHm7nJrFobA=";
+  src = fetchFromGitHub {
+    owner = "alsa-project";
+    repo = "alsa-ucm-conf";
+    rev = "4b0668f670409e13f98ffa6ee434bac886212762";
+    hash = "sha256-CbgYe2/CTFBcjEdiJx+eVFIOmLwQRiPH47HdYbSvn3M=";
   };
 
   dontBuild = true;
@@ -37,8 +39,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = directoryListingUpdater {
-    url = "https://www.alsa-project.org/files/pub/lib/";
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
   };
 
   meta = {

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -4,11 +4,13 @@
   lib,
   stdenvNoCC,
   coreutils,
-  kmod,
+  kmod ? null,
   alsa-lib,
-}:
+}@attrs:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "alsa-ucm-conf";
   version = "1.2.15.3-unstable-2026-01-29";
 
@@ -22,21 +24,54 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   doInstallCheck = true;
 
+  executablePkgs = {
+    # circular dependency
+    # alsa-utils = [ "nhlt-dmic-info" ];
+
+    coreutils = [
+      "mkdir"
+      "rm"
+    ];
+
+    kmod = [ "modprobe" ];
+  };
+
+  postPatch = ''
+    # substitute executable paths in exec directives with absolute store paths
+    find . -type f -name \*.conf -print0 | xargs -0 -r -- sed -E -i \
+    ${
+      lib.concatStringsSep " \\\n" (
+        lib.mapAttrsToList (
+          name: exes:
+          let
+            pkg = attrs.${name};
+          in
+          "  -e "
+          +
+            lib.escapeShellArg
+              # matches exec directives with opening quote and executable names,
+              # optionally prefixed with ‘-’ and ‘/bin/’ or ‘/sbin/’, capturing
+              # the directive with opening quote and optional ‘-’ (\1), the path
+              # prefix (\2) and the executable name (\3)
+              ''s:(\<exec\>\s+"-?)(/s?bin/)?\<(${lib.concatStringsSep "|" exes})\>:\1${
+                if pkg != null && lib.meta.availableOn stdenvNoCC.hostPlatform pkg then
+                  lib.getBin pkg + "/bin/\\3"
+                else
+                  # fall back to ‘false’ for unavailable packages
+                  lib.getExe' coreutils "false"
+              }:''
+
+        ) finalAttrs.executablePkgs
+      )
+    } \
+      --
+  '';
+
   installPhase = ''
     runHook preInstall
 
-    substituteInPlace ucm2/lib/card-init.conf \
-      --replace-fail "/bin/rm" "${coreutils}/bin/rm" \
-      --replace-fail "/bin/mkdir" "${coreutils}/bin/mkdir"
-  ''
-  + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
-    substituteInPlace ucm2/common/ctl/led.conf \
-      --replace-fail '/sbin/modprobe' '${kmod}/bin/modprobe'
-  ''
-  + ''
-
-    mkdir -p $out/share/alsa
-    cp -r ucm ucm2 $out/share/alsa
+    mkdir -p "$out/share/alsa"
+    cp -r ucm ucm2 "$out/share/alsa"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Switch `alsa-ucm-conf` to rolling release.

Updates to the UCM configuration files are released in tandem with the ALSA library every half year or so.

The UCM configuration files however receive frequent updates with new profiles for additional hardware and I believe that users would benefit from making these available in nixpkgs independently of the ALSA lib release cycle.

The configuration files are validated automatically by upstream after review and so I don’t expect this to break very often.
Just to make sure, I added validation of the UCM configuration to `alsa-lib`, as part of `installCheckPhase`.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
