### PR TITLE
azerothcore: init at 4.0.0-unstable-20250322

### DIFF
--- a/pkgs/by-name/az/azerothcore/package.nix
+++ b/pkgs/by-name/az/azerothcore/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  cmake,
+  git,
+  boost,
+  openssl,
+  zlib,
+  readline,
+  bzip2,
+  mysql84,
+
+  modules ? {
+    mod-guildhouse = fetchFromGitHub {
+      owner = "azerothcore";
+      repo = "mod-guildhouse";
+      rev = "23b86dcc78471c50c60b3fc27e07e4cda8a3e200";
+      hash = "sha256-K1N9iYoQFmhK079JVOsD27xzFH1CmWxKk0DfVegZFJM=";
+    };
+    mod-autobalance = fetchFromGitHub {
+      owner = "azerothcore";
+      repo = "mod-autobalance";
+      rev = "2bf60989fc2384d4f92be4e2804aeca0ac6ed077";
+      hash = "sha256-kgkVlu1d9Dz5T3GD/e37QZHkCZKjut+PFkCo+PRkAUE=";
+    };
+    mod-ah-bot = fetchFromGitHub {
+      owner = "azerothcore";
+      repo = "mod-ah-bot";
+      rev = "60d80b8673abb722178d9bd64349d0ff4765de98";
+      hash = "sha256-EkQhR64/pAhYDjsSlwRs/4uN3WfbZNbu2czwht2u8x8=";
+    };
+  },
+  buildTools ? "all",
+  buildApps ? "all",
+  buildScripts ? "static",
+  buildModules ? "static",
+}:
+
+let
+  linkModules = lib.concatMapAttrsStringSep "\n" (
+    name: source: ''ln -s "${source}" "modules/${name}"''
+  );
+in
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "azerothcore";
+  version = "4.0.0-unstable-20250322";
+
+  src = fetchFromGitHub {
+    owner = "azerothcore";
+    repo = "azerothcore-wotlk";
+    rev = "ae76703b755cbb73efc76c768a8859bf140f78e9";
+    hash = "sha256-7Iu0Q3iau73KV1Sw7vo8OBJQjpshTd/dhx6C2SDteN0=";
+    leaveDotGit = true;
+  };
+
+  # Darwin uses ld64 as linker, which does not understand this parameter
+  postPatch = lib.optionalString clangStdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/cmake/compiler/clang/settings.cmake \
+      --replace-fail "--no-undefined" ""
+  '';
+
+  preConfigure = linkModules modules;
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  buildInputs = [
+    boost
+    openssl
+    zlib
+    readline
+    bzip2
+    # Since https://github.com/azerothcore/azerothcore-wotlk/pull/19451, azerothcore
+    # is not compatible with MariaDB and mariadb-connector-c anymore, which libmysqlclient
+    # unfortunately is aliased to on nixpkgs.
+    # However, the MySQL package itself contains the headers and libraries we need.
+    mysql84
+  ];
+
+  cmakeFlags = [
+    "-DTOOLS_BUILD=${buildTools}"
+    "-DAPPS_BUILD=${buildApps}"
+    "-DSCRIPTS=${buildScripts}"
+    "-DMODULES=${buildModules}"
+    # Required to make try_compile pass
+    "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
+  ];
+
+  meta = {
+    description = "Complete Open Source and Modular solution for MMO";
+    homepage = "https://www.azerothcore.org/";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ niklaskorz ];
+    mainProgram = "azerothcore-wotlk";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

WIP until I figured out how to build modules as separate packages through upstream's experimental dynamic library mode

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
