### PR TITLE
lcevcdec: 3.2.1 -> 3.3.5

### DIFF
--- a/pkgs/by-name/lc/lcevcdec/package.nix
+++ b/pkgs/by-name/lc/lcevcdec/package.nix
@@ -2,7 +2,6 @@
   cmake,
   copyPkgconfigItems,
   fetchFromGitHub,
-  fetchpatch,
   fmt,
   git,
   gitUpdater,
@@ -19,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lcevcdec";
-  version = "3.2.1";
+  version = "3.3.5";
 
   outputs = [
     "out"
@@ -31,16 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "v-novaltd";
     repo = "LCEVCdec";
     tag = finalAttrs.version;
-    hash = "sha256-Nf0YntB1A3AH0MTXlfUHhxYbzZqeB0EH9Fe9Xrqdsts=";
+    hash = "sha256-PcV31lLABv7SGzrD/+rR9j1Z9/uZrp1hFPdW0EZwOqc=";
   };
-
-  patches = [
-    # fix for build with GCC 14
-    (fetchpatch {
-      url = "https://github.com/v-novaltd/LCEVCdec/commit/43ef5a17ec1ced77f834136945b3cbfe2e46b9b4.patch";
-      hash = "sha256-8OgPh6v+nmRIUB6flR93qOjvaL8fUJdqIe48ZA+8Pr0=";
-    })
-  ];
 
   postPatch =
     ''


### PR DESCRIPTION
Upstream finally resolved all build issues on GCC 14, making the patch obsolete.

https://github.com/v-novaltd/LCEVCdec/issues/13
https://github.com/v-novaltd/LCEVCdec/issues/11

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).