### PR TITLE
nixos/test-driver: use breakpointHook to debug tests with pdb & ssh; add `dump()` function

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -312,3 +312,53 @@ id-prefix: test-opt-
 list-id: test-options-list
 source: @NIXOS_TEST_OPTIONS_JSON@
 ```
+
+## Accessing VMs in the sandbox with SSH {#sec-test-sandbox-breakpoint}
+
+As explained in [](#sec-nixos-test-ssh-access), it's possible to configure an
+SSH backdoor based on AF_VSOCK. This can be used to SSH into a VM of a running build
+in a sandbox.
+
+This can be either done when something in the test fails, e.g.
+
+```nix
+{
+  nodes.machine = {};
+  sshBackdoor.enable = true;
+
+  testScript = ''
+    start_all()
+    debug.enable_failure_hook()
+    machine.succeed("false")
+  '';
+}
+```
+
+For the AF_VSOCK feature to work, `/dev/vhost-vsock` is needed in the sandbox which
+can be done with e.g.
+
+```
+nix-build -A nixosTests.foo --option sandbox-paths /dev/vhost-vsock
+```
+
+This will halt the test execution on a test-failure and print instructions
+on how to enter the sandbox shell of the VM test. Inside, one can log into
+e.g. `machine` with
+
+```
+ssh -F ./ssh_config vsock/3
+```
+
+As explained in [](#sec-nixos-test-ssh-access), the numbers for vsock start at `3`
+instead of `1`. So the first VM in the network (sorted alphabetically) can be
+accessed with `vsock/3`.
+
+Alternatively, it's possible to explicitly set a breakpoint with
+`debug.breakpoint()`. This also has the benefit, that one can step through
+`testScript` with `pdb` like this:
+
+```
+$ sudo /nix/store/eeeee-attach <id>
+bash# telnet 127.0.0.1 4444
+pdb$ …
+```

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -205,6 +205,34 @@ way:
 }
 ```
 
+To print out values from the test script itself, e.g. for debugging or more detailed logs,
+it's recommended to use `dump(…)` instead of `print()` since this prefixes each line of the
+output to make it easier to spot between the other log output.
+
+For instance,
+
+```nix
+{
+  nodes.machine = {};
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    dump(machine.succeed("uname -a"))
+  '';
+};
+```
+
+will result in an output like this:
+
+```
+machine: must succeed: uname -a
+machine: (finished: must succeed: uname -a, in 0.02 seconds)
+(test-script) Linux machine 6.12.19 #1-NixOS SMP PREEMPT_DYNAMIC Thu Mar 13 12:02:20 UTC 2025 x86_64 GNU/Linux
+(finished: run the VM test script, in 14.40 seconds)
+test script finished in 14.49s
+cleanup
+```
+
 ## Failing tests early {#ssec-failing-tests-early}
 
 To fail tests early when certain invariants are no longer met (instead of waiting for the build to time out), the decorator `polling_condition` is provided. For example, if we are testing a program `foo` that should not quit after being started, we might write the following:

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1946,6 +1946,12 @@
   "sec-test-the-test-framework": [
     "index.html#sec-test-the-test-framework"
   ],
+  "sec-nixos-test-ssh-access": [
+    "index.html#sec-nixos-test-ssh-access"
+  ],
+  "sec-test-sandbox-breakpoint": [
+    "index.html#sec-test-sandbox-breakpoint"
+  ],
   "ch-testing-installer": [
     "index.html#ch-testing-installer"
   ],

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -13,6 +13,8 @@
   vde2,
   extraPythonPackages ? (_: [ ]),
   nixosTests,
+  breakpointHook,
+  openssh,
 }:
 python3Packages.buildPythonApplication {
   pname = "nixos-test-driver";
@@ -25,6 +27,11 @@ python3Packages.buildPythonApplication {
     setuptools
   ];
 
+  postPatch = ''
+    substituteInPlace test_driver/driver.py \
+      --replace-fail "@attach@" "${breakpointHook.attach}"
+  '';
+
   dependencies =
     with python3Packages;
     [
@@ -32,6 +39,7 @@ python3Packages.buildPythonApplication {
       junit-xml
       ptpython
       ipython
+      remote-pdb
     ]
     ++ extraPythonPackages python3Packages;
 

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -159,6 +159,7 @@ class Driver:
             polling_condition=self.polling_condition,
             Machine=Machine,  # for typing
             t=AssertionTester(),
+            dump=self.logger.dump,
         )
         machine_symbols = {pythonize_name(m.name): m for m in self.machines}
         # If there's exactly one machine, make it available under the name
@@ -219,10 +220,9 @@ class Driver:
                     if lineno := frame.lineno:
                         self.logger.log_test_error(f"    {code[lineno - 1].strip()}")
 
-                self.logger.log_test_error("")  # blank line for readability
+                self.logger.log_test_error("\n")  # blank line for readability
                 exc_prefix = exc_type.__name__ if exc_type is not None else "Error"
-                for line in f"{exc_prefix}: {exc}".splitlines():
-                    self.logger.log_test_error(line)
+                self.logger.log_test_error(f"{exc_prefix}: {exc}")
 
                 sys.exit(1)
 

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -1,7 +1,7 @@
 # This file contains type hints that can be prepended to Nix test scripts so they can be type
 # checked.
 
-from test_driver.driver import Driver
+from test_driver.driver import Driver, Debug
 from test_driver.vlan import VLan
 from test_driver.machine import Machine
 from test_driver.logger import AbstractLogger
@@ -54,3 +54,4 @@ serial_stdout_on: Callable[[], None]
 polling_condition: PollingConditionProtocol
 t: TestCase
 dump: Callable[[str], None]
+debug: Debug

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -53,3 +53,4 @@ serial_stdout_off: Callable[[], None]
 serial_stdout_on: Callable[[], None]
 polling_condition: PollingConditionProtocol
 t: TestCase
+dump: Callable[[str], None]

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -51,11 +51,20 @@ in
         ++ lib.optionals hostPkgs.stdenv.hostPlatform.isLinux [ "kvm" ]
         ++ lib.optionals hostPkgs.stdenv.hostPlatform.isDarwin [ "apple-virt" ];
 
+      nativeBuildInputs = [
+        hostPkgs.openssh
+        hostPkgs.inetutils
+      ];
+
       buildCommand = ''
         mkdir -p $out
 
         # effectively mute the XMLLogger
         export LOGFILE=/dev/null
+
+        ln -sf \
+          ${hostPkgs.systemd}/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf \
+          ssh_config
 
         ${config.driver}/bin/nixos-test-driver -o $out
       '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

__Note:__ draft, depends on #392030,  #390996 & #372979.

After a discussion with @tfc it was clear that the interactive part (#392030) is less controversial, so this is another PR on top. Only the last two commits are the relevant changes.

----


This uses the `attach.sh` from our `breakpointHook` to allow getting
into the sandbox of the VM test. In there, it's now possible to do two
things:

* debugging the test script interactively with pdb[1] via

    telnet 127.0.0.1 4444

* use the AF_VSOCK part to SSH into a VM.

Also, add a `dump()` function that outputs stuff, but with a log prefix to make it clear where it's coming from.

[1] https://docs.python.org/3/library/pdb.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
