### PR TITLE
eslint: avoid dev dependencies to reduce closure size

### DIFF
--- a/pkgs/by-name/es/eslint/package.nix
+++ b/pkgs/by-name/es/eslint/package.nix
@@ -31,14 +31,10 @@ buildNpmPackage' rec {
   '';
 
   npmDepsHash = "sha256-F3EUANBvniczR7QxNfo1LlksYPxXt16uqJDFzN6u64Y=";
+  npmInstallFlags = [ "--omit=dev" ];
 
   dontNpmBuild = true;
   dontNpmPrune = true;
-
-  postFixup = ''
-    # Remove broken symlink
-    rm $out/lib/node_modules/eslint/node_modules/eslint-config-eslint
-  '';
 
   meta = {
     description = "Find and fix problems in your JavaScript code";


### PR DESCRIPTION
Omitting npm dev dependencies reduces eslint closure size significantly. This is helpful when using eslint in build pipelines. 
What is unclear to me, is there a specific reason to include the npm dev dependencies? Are they needed in some cases?

Following numbers from `nix path-info --size --closure-size --human-readable` on aarch64-darwin:

| size of  |        eslint  | closure     |   remark                                                |
| ------- | ---------- | ---------- | ------------------------------------ |
| before: | 438.3 MiB |   2.7 GiB    | (includes apple-sdk, compiler, etc.) |
| after:    |    10.6 MiB | 202.1 MiB |  (with npmInstallFlags --omit=dev)   |

Similar results on aarch64-linux (from within a docker container):
| size of  | eslint         |   closure   |
| ------- | ---------- | ---------- |
| before: | 546.3 MiB |     2.1 GiB  |
| after:    |  10.6 MiB   | 227.7 MiB |

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (in docker container)
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
