### PR TITLE
nixos/config/sysctl: set options from nested set, as they become available

### DIFF
--- a/nixos/doc/manual/configuration/config-file.section.md
+++ b/nixos/doc/manual/configuration/config-file.section.md
@@ -127,7 +127,7 @@ Integers
 
     ```nix
     {
-      boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 60;
+      boot.kernel.sysctl.net.ipv4.tcp_keepalive_time = 60;
     }
     ```
 

--- a/nixos/doc/manual/configuration/ipv6-config.section.md
+++ b/nixos/doc/manual/configuration/ipv6-config.section.md
@@ -16,7 +16,7 @@ You can disable IPv6 on a single interface using a normal sysctl (in
 this example, we use interface `eth0`):
 
 ```nix
-{ boot.kernel.sysctl."net.ipv6.conf.eth0.disable_ipv6" = true; }
+{ boot.kernel.sysctl.net.ipv6.conf.eth0.disable_ipv6 = true; }
 ```
 
 As with IPv4 networking interfaces are automatically configured via

--- a/nixos/doc/manual/configuration/linux-kernel.chapter.md
+++ b/nixos/doc/manual/configuration/linux-kernel.chapter.md
@@ -92,7 +92,7 @@ Kernel runtime parameters can be set through
 [](#opt-boot.kernel.sysctl), e.g.
 
 ```nix
-{ boot.kernel.sysctl."net.ipv4.tcp_keepalive_time" = 120; }
+{ boot.kernel.sysctl.net.ipv4.tcp_keepalive_time = 120; }
 ```
 
 sets the kernel's TCP keepalive time to 120 seconds. To see the

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -201,6 +201,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `hyphen` now supports over 40 language variants through `hyphenDicts` and now allows to enable all supported languages through `hyphenDicts.all`.
 
+- [`boot.kernel.sysctl`](#opt-boot.kernel.sysctl) now accepts a nested attribute set and applies the options as they become available in `/proc/sys`.
+
 - [services.resolved](#opt-services.resolved.enable) module was converted to RFC42-style settings. The moved options have also been renamed to match the upstream names. Aliases mean current configs will continue to function, but users should move to the new options as convenient.
 
 - Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.

--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -1,92 +1,661 @@
-{ config, lib, ... }:
-let
+{
+  lib,
+  config,
+  utils,
+  pkgs,
+  ...
+}:
 
-  sysctlOption = lib.mkOptionType {
-    name = "sysctl option value";
-    check =
-      val:
-      let
-        checkType = x: lib.isBool x || lib.isString x || lib.isInt x || x == null;
-      in
-      checkType val || (val._type or "" == "override" && checkType val.content);
-    merge = loc: defs: lib.mergeOneOption loc defs;
+let
+  inherit (lib)
+    all
+    any
+    concatLines
+    concatStringsSep
+    escapeShellArg
+    filter
+    flatten
+    floatToString
+    foldl'
+    head
+    isDerivation
+    isFloat
+    isList
+    length
+    listToAttrs
+    match
+    mkOption
+    nameValuePair
+    removePrefix
+    splitString
+    tail
+    throwIf
+    types
+    ;
+
+  inherit (lib.options)
+    showDefs
+    showOption
+    ;
+
+  inherit (lib.strings)
+    escapeC
+    isConvertibleWithToString
+    ;
+
+  inherit (lib.types)
+    optionDescriptionPhrase
+    ;
+
+  inherit (lib.path.subpath) join;
+
+  inherit (utils) escapeSystemdPath;
+
+  cfg = config.boot.kernel.sysctl;
+
+  mapAttrsToListRecursive' = lib.mapAttrsToListRecursiveCond (_: v: !isDerivation v);
+
+  mergeEqualValueStrOption =
+    loc: defs:
+    if length defs == 1 then
+      (head defs).value
+    else
+      (foldl' (
+        first: def:
+        # merge definitions if they produce the same value string
+        throwIf (mkValueString first.value != mkValueString def.value)
+          "The option \"${showOption loc}\" has conflicting definition values:${
+            showDefs [
+              first
+              def
+            ]
+          }"
+          first
+      ) (head defs) (tail defs)).value;
+
+  sysctlAttrs = with types; nullOr (either sysctlValue (attrsOf sysctlAttrs));
+  sysctlValue = lib.mkOptionType {
+    name = "sysctl value";
+    description = "sysctl option value";
+    descriptionClass = "noun";
+    check = v: isConvertibleWithToString v;
+    merge = mergeEqualValueStrOption;
   };
 
+  sysctlBool = with types; either bool (ints.between 0 1);
+  sysctlTuple =
+    len: elemType:
+    with types;
+    addCheck (listOf elemType) (val: length val == len)
+    // {
+      description = "${toString len}-tuple (list) of ${
+        optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
+      }";
+      merge = mergeEqualValueStrOption;
+    };
+
+  sysctlMax = types.ints.unsigned // {
+    merge =
+      loc: defs:
+      lib.foldl (a: b: if b.value == null then null else lib.max a b.value) 0 (lib.filterOverrides defs);
+  };
+
+  mkPath = p: "/proc/sys" + removePrefix "." (join (flatten (map (splitString ".") p)));
+  hasGlob = p: any (n: match ''(.*[^\\])?[*?[].*'' n != null) p;
+
+  mkValueString =
+    v:
+    # true will be converted to "1" by toString, saving one branch
+    if v == false then
+      "0"
+    else if isFloat v then
+      floatToString v # warn about loss of precision
+    else if isList v then
+      toString (map mkValueString v)
+    else
+      toString v;
+
+  # escape whitespace and linebreaks, as well as the escape character itself,
+  # to ensure that field boundaries are always preserved
+  escapeTmpfiles = escapeC [
+    "\t"
+    "\n"
+    "\r"
+    " "
+    "\\"
+  ];
+
+  tmpfiles = pkgs.runCommand "nixos-sysctl-tmpfiles.d" { } (
+    ''
+      mkdir "$out"
+    ''
+    + concatLines (
+      filter (v: v != null) (
+        mapAttrsToListRecursive' (
+          p: v:
+          let
+            path = mkPath p;
+          in
+          if v != null then
+            ''
+              printf 'w %s - - - - %s\n' \
+                ${escapeShellArg (escapeTmpfiles path)} \
+                ${escapeShellArg (escapeTmpfiles (mkValueString v))} \
+                >"$out"/${escapeShellArg (escapeSystemdPath path)}.conf
+            ''
+          else
+            null
+        ) cfg
+      )
+    )
+  );
+
+  commonConf = {
+    forwarding = mkOption {
+      type = with types; nullOr (either bool (ints.between 0 1));
+      default = null;
+      description = "Enable packet forwarding between interfaces.";
+    };
+  };
+
+  ipv4Conf = commonConf // {
+    accept_arp = mkOption {
+      type = with types; nullOr (either bool (ints.between 0 1));
+      default = null;
+      description = "Accept ARP on interface.";
+    };
+  };
+
+  ipv6Conf = commonConf // {
+    acceprt_ra = mkOption {
+      type = with types; nullOr (either bool (ints.between 0 1));
+      default = null;
+      description = "Accept router advertisements on interface.";
+    };
+  };
 in
-
 {
-
   options = {
+    boot.kernel.sysctl = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf sysctlAttrs // {
+          description = "nested attribute set of null or sysctl option values";
+        };
 
-    boot.kernel.sysctl = lib.mkOption {
-      type =
-        let
-          highestValueType = lib.types.ints.unsigned // {
-            merge = loc: defs: lib.foldl (a: b: if b.value == null then null else lib.max a b.value) 0 defs;
-          };
-        in
-        lib.types.submodule {
-          freeformType = lib.types.attrsOf sysctlOption;
-          options = {
-            "net.core.rmem_max" = lib.mkOption {
-              type = lib.types.nullOr highestValueType;
+        options = {
+          fs = {
+            nr_open = mkOption {
+              type = types.nullOr sysctlMax;
               default = null;
-              description = "The maximum receive socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+              description = ''
+                Maximum number of open file handles per process.
+
+                In case of conflicting definitions, the highest value will be
+                used.
+              '';
+            };
+          };
+
+          kernel = {
+            dmesg_restrict = mkOption {
+              type = with types; nullOr sysctlBool;
+              default = null;
+              description = ''
+                Restrict access access to kernel log for unprivileged users.
+              '';
             };
 
-            "net.core.wmem_max" = lib.mkOption {
-              type = lib.types.nullOr highestValueType;
+            nmi_watchdog = mkOption {
+              type = with types; nullOr sysctlBool;
               default = null;
-              description = "The maximum send socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+              description = ''
+                Enable the NMI watchdog (hard lock‐up detector) on x86 systems.
+              '';
+            };
+
+            panic = mkOption {
+              type = with types; nullOr int;
+              default = null;
+              description = ''
+                Kernel behaviour on panic:
+
+                - if zero, the kernel will loop forever;
+                - if negative, the kernel will reboot immediately;
+                - if positive, the kernel will reboot after the corresponding
+                  number of seconds.
+              '';
+            };
+
+            sysrq = mkOption {
+              type = with types; nullOr (either bool ints.unsigned);
+              default = null;
+              description = ''
+                Magic system request (SysRq) function configuration:
+
+                - 0: disable SysRq completely,
+                - 1: enable all SysRq functions,
+                - >1: bit mask of allowed SysRq functions.
+
+                cf. <https://docs.kernel.org/admin-guide/sysrq.html>
+              '';
+            };
+          };
+
+          net = {
+            core = {
+              bpf_jit_enable = mkOption {
+                type = with types; nullOr (either bool (ints.between 0 2));
+                default = null;
+                description = ''
+                  Enable the BPF just‐in‐time (JIT) compiler.
+
+                  - 0 or false: disable the JIT,
+                  - 1 or true: enable the JIT,
+                  - 2: enable the JIT and emit traces.
+                '';
+              };
+
+              bpf_jit_harden = mkOption {
+                type = with types; nullOr (ints.between 0 2);
+                default = null;
+                description = ''
+                  Harden the BPF just‐in‐time (JIT) compiler.
+
+                  - 0: disable JIT hardening,
+                  - 1: enable JIT hardening for unprivileged users only,
+                  - 2: enable JIT hardening for all users.
+                '';
+              };
+
+              default_qdisc = mkOption {
+                type = with types; nullOr (strMatching "[a-z_]+");
+                default = null;
+                description = ''
+                  Default queuing discipline for network devices.
+                '';
+              };
+
+              rmem_default = mkOption {
+                type = with types; nullOr sysctlMax;
+                default = null;
+                description = ''
+                  Default socket receive buffer size in bytes.
+
+                  In case of conflicting values, the highest will be used.
+                '';
+              };
+
+              rmem_max = mkOption {
+                default = null;
+                description = ''
+                  Maximum socket receive buffer size in bytes.
+
+                  In case of conflicting values, the highest will be used.
+                '';
+              };
+
+              wmem_default = mkOption {
+                type = with types; nullOr sysctlMax;
+                default = null;
+                description = ''
+                  Default socket send buffer size in bytes.
+
+                  In case of conflicting values, the highest will be used.
+                '';
+              };
+
+              wmem_max = mkOption {
+                type = with types; nullOr sysctlMax;
+                default = null;
+                description = ''
+                  Maximum socket send buffer size in bytes.
+
+                  In case of conflicting values, the highest will be used.
+                '';
+              };
+
+              optmem_max = mkOption {
+                type = with types; nullOr sysctlMax;
+                default = null;
+                description = ''
+                  Maximum socket ancillary buffer size in bytes.
+
+                  In case of conflicting values, the highest will be used.
+                '';
+              };
+            };
+
+            ipv4 = {
+              conf = mkOption {
+                type =
+                  with types;
+                  submodule {
+                    freeformType = attrsOf (submodule {
+                      freeformType = sysctlValue;
+                      options = ipv4Conf;
+                    });
+
+                    options = {
+                      default = mkOption {
+                        type =
+                          with types;
+                          submodule {
+                            freeformType = attrsOf sysctlValue;
+                            options = ipv4Conf;
+                          };
+
+                        default = { };
+                        description = ''
+                          Network interface IPv4 settings defaults.
+                        '';
+                      };
+
+                      all = mkOption {
+                        type =
+                          with types;
+                          submodule {
+                            freeformType = attrsOf sysctlValue;
+                            options = ipv4Conf;
+                          };
+
+                        default = { };
+                        description = ''
+                          Network interface IPv6 settings overrides.
+                        '';
+                      };
+                    };
+                  };
+
+                default = { };
+                description = ''
+                  Network interface settings.
+                '';
+              };
+
+              ip_forward = mkOption {
+                type = with types; nullOr sysctlBool;
+                default = null;
+                description = ''
+                  Enable packet forwarding between interfaces.
+                '';
+              };
+
+              tcp_congestion_control = mkOption {
+                type = with types; nullOr (strMatching "[a-z_]+");
+                default = null;
+                description = ''
+                  TCP congestion control algorithm for new connections.
+                '';
+              };
+
+              tcp_ecn = mkOption {
+                type = with types; nullOr (ints.between 0 2);
+                default = null;
+                description = ''
+                  Explicit Congestion Notification for TCP connections:
+
+                  - 0: disable ECN,
+                  - 1: enable ECN when requested by incoming connections,
+                    and also request ECN on outgoing connections.
+                  - 2: enable ECN when requested by incoming connections,
+                    but do not request ECN on outgoing connections.
+                '';
+              };
+
+              tcp_rmem = mkOption {
+                type = with types; nullOr (sysctlTuple 3 sysctlMax);
+                default = null;
+                description = ''
+                  Minimum, default, and maximum TCP socket receive buffer sizes
+                  in bytes, provided as a list of three integers.
+                '';
+              };
+
+              tcp_syncookies = mkOption {
+                type = with types; nullOr sysctlBool;
+                default = null;
+                description = ''
+                  Enable TCP SYN cookies.
+                '';
+              };
+
+              tcp_fastopen = mkOption {
+                type = with types; nullOr ints.unsigned;
+                default = null;
+                description = ''
+                  TCP Fast Open settings to send and accept data in the opening
+                  SYN packet. The value is a bitmap of flags.
+                '';
+              };
+
+              tcp_wmem = mkOption {
+                type = with types; nullOr (sysctlTuple 3 sysctlMax);
+                default = null;
+                description = ''
+                  Minimum, default, and maximum TCP socket send buffer sizes
+                  in bytes, provided as a list of three integers.
+                '';
+              };
+            };
+
+            ipv6 = {
+              conf = mkOption {
+                type =
+                  with types;
+                  submodule {
+                    freeformType =
+                      with types;
+                      attrsOf (submodule {
+                        freeformType = attrsOf sysctlValue;
+                        options = ipv6Conf;
+                      });
+
+                    options = {
+                      default = mkOption {
+                        type =
+                          with types;
+                          submodule {
+                            freeformType = attrsOf sysctlValue;
+                            options = ipv6Conf;
+                          };
+
+                        default = { };
+                        description = ''
+                          Network interface IPv6 settings defaults.
+                        '';
+                      };
+
+                      all = mkOption {
+                        type =
+                          with types;
+                          submodule {
+                            freeformType = attrsOf sysctlValue;
+                            options = ipv6Conf;
+                          };
+
+                        default = { };
+                        description = ''
+                          Network interface IPv6 settings overrides.
+                        '';
+                      };
+                    };
+                  };
+
+                default = { };
+                description = ''
+                  Network interface settings.
+                '';
+              };
+            };
+          };
+
+          vm = {
+            dirty_expire_centisecs = mkOption {
+              type = with types; nullOr ints.unsigned;
+              default = null;
+              description = ''
+                Minimum age in centiseconds after which dirty page cache data
+                becomes eligible for flushing by the kernel flusher thread.
+              '';
+            };
+
+            dirty_background_ratio = mkOption {
+              type = with types; nullOr (ints.between 0 100);
+              default = null;
+              description = ''
+                Percentage of available memory at which the background kernel
+                flusher thread will start writing out dirty page cache data to
+                disk.
+              '';
+            };
+
+            dirty_ratio = mkOption {
+              type = with types; nullOr (ints.between 0 100);
+              default = null;
+              description = ''
+                Percentage of available memory at which processes generating
+                disk writes will start writing out data to disk synchronously.
+              '';
+            };
+
+            swappiness = mkOption {
+              type = with types; nullOr (ints.between 0 200);
+              default = null;
+              description = ''
+                Relative I/O cost of swapping versus filesystem paging:
+              '';
             };
           };
         };
-      default = { };
-      example = lib.literalExpression ''
-        { "net.ipv4.tcp_syncookies" = false; "vm.swappiness" = 60; }
-      '';
+      };
+
       description = ''
-        Runtime parameters of the Linux kernel, as set by
-        {manpage}`sysctl(8)`.  Note that sysctl
-        parameters names must be enclosed in quotes
-        (e.g. `"vm.swappiness"` instead of
-        `vm.swappiness`).  The value of each
-        parameter may be a string, integer, boolean, or null
-        (signifying the option will not appear at all).
+        sysctl options to be set as soon as they become available in the
+        /proc/sys filesystem.
+
+        Attribute names represent path components and cannot be `.` or `..` nor
+        contain any slash character (`/`).
+
+        Names may contain shell‐style glob patterns (`*`, `?` and `[…]`)
+        matching a single path component, these should however be used with
+        caution, as they may produce non‐deterministic results if attribute
+        paths overlap.
+
+        Values will be converted to strings, with list elements concatenated
+        with spaces and booleans converted to numeric values (`0` or `1`).
+        `null` values are ignored, allowing removal of values defined in other
+        modules, as are empty attribute sets.
+
+        List values defined in different modules will _not_ be concatenated.
+
+        This option may only be used for sysctl options which can be set
+        idempotently, as the configured values might be written more than once.
       '';
 
-    };
+      default = { };
 
+      example = lib.literalExpression ''
+        {
+          net.ipv4.tcp_syncookies = false;
+          vm.swappiness = 60;
+        }
+      '';
+    };
   };
 
   config = {
+    systemd = {
+      paths = {
+        "nixos-sysctl@" = {
+          description = "/%I sysctl watcher";
+          pathConfig.PathExistsGlob = "/%I";
+          unitConfig.DefaultDependencies = false;
+        };
+      }
+      // listToAttrs (
+        filter (v: v != null) (
+          mapAttrsToListRecursive' (
+            p: v:
+            if v != null then
+              nameValuePair "nixos-sysctl@${escapeSystemdPath (mkPath p)}" {
+                overrideStrategy = "asDropin";
+                wantedBy = [ "sysinit.target" ];
+                before = [ "sysinit.target" ];
+              }
+            else
+              null
+          ) cfg
+        )
+      );
 
-    environment.etc."sysctl.d/60-nixos.conf".text = lib.concatStrings (
-      lib.mapAttrsToList (
-        n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
-      ) config.boot.kernel.sysctl
-    );
+      services."nixos-sysctl@" = {
+        description = "/%I sysctl setter";
+        unitConfig = {
+          DefaultDependencies = false;
+          AssertPathIsMountPoint = "/proc";
+          AssertPathExistsGlob = "/%I";
+        };
 
-    systemd.services.systemd-sysctl = {
-      wantedBy = [ "multi-user.target" ];
-      restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+
+          # while we could be tempted to use simple shell script to set the
+          # sysfs attributes specified by the path or glob pattern, it is
+          # almost impossible to properly escape a glob pattern so that it
+          # can be used safely in a shell script
+          ExecStart = "${lib.getExe' config.systemd.package "systemd-tmpfiles"} --prefix=/proc/sys --create ${tmpfiles}/%i.conf";
+
+          # hardening may be overkill for such a simple and short‐lived
+          # service, the following settings would however be suitable to deny
+          # access to anything but /proc
+          #InaccessiblePaths = [ "/sys" ];
+          #ProtectProc = "noaccess";
+          #ProtectSystem = "strict";
+          #PrivateDevices = true;
+          #SystemCallErrorNumber = "EPERM";
+          #SystemCallFilter = [
+          #  "@basic-io"
+          #  "@file-system"
+          #];
+        };
+      };
     };
 
-    # NixOS wide defaults
+    warnings = flatten (
+      mapAttrsToListRecursive' (
+        p: _:
+        # we might want to check if there actually is an overlap between a glob
+        # pattern and another path, before warning about it
+        lib.optional (hasGlob p)
+          "Attribute path \"${concatStringsSep "." p}\" contains glob patterns. Please ensure that these do not overlap with other sysctl options."
+        ++ lib.optional (
+          match ''.+\..+'' (head p) != null
+        ) "Attribute \"${head p}\" uses the old option format. Please remove the quotes around it."
+      ) cfg
+    );
+
+    assertions = mapAttrsToListRecursive' (p: _: {
+      assertion = all (n: match ''(\.\.?|.*/.*)'' n == null) p;
+      message = "Attribute path \"${concatStringsSep "." p}\" has invalid components.";
+    }) cfg;
+
     boot.kernel.sysctl = {
       # Hide kernel pointers (e.g. in /proc/modules) for unprivileged
       # users as these make it easier to exploit kernel vulnerabilities.
-      "kernel.kptr_restrict" = lib.mkDefault 1;
+      kernel.kptr_restrict = lib.mkDefault 1;
 
       # Improve compatibility with applications that allocate
       # a lot of memory, like modern games
-      "vm.max_map_count" = lib.mkDefault 1048576;
+      vm.max_map_count = lib.mkDefault 1048576;
 
       # The default max inotify watches is 8192.
       # Nowadays most apps require a good number of inotify watches,
       # the value below is used by default on several other distros.
-      "fs.inotify.max_user_instances" = lib.mkDefault 524288;
-      "fs.inotify.max_user_watches" = lib.mkDefault 524288;
+      fs.inotify.max_user_instances = lib.mkDefault 524288;
+      fs.inotify.max_user_watches = lib.mkDefault 524288;
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ mvs ];
 }

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -101,36 +101,36 @@ in
     ];
 
     # Hide kptrs even for processes with CAP_SYSLOG
-    boot.kernel.sysctl."kernel.kptr_restrict" = mkOverride 500 2;
+    boot.kernel.sysctl.kernel.kptr_restrict = mkOverride 500 2;
 
     # Disable bpf() JIT (to eliminate spray attacks)
-    boot.kernel.sysctl."net.core.bpf_jit_enable" = mkDefault false;
+    boot.kernel.sysctl.net.core.bpf_jit_enable = mkDefault false;
 
     # Disable ftrace debugging
-    boot.kernel.sysctl."kernel.ftrace_enabled" = mkDefault false;
+    boot.kernel.sysctl.kernel.ftrace_enabled = mkDefault false;
 
     # Enable strict reverse path filtering (that is, do not attempt to route
     # packets that "obviously" do not belong to the iface's network; dropped
     # packets are logged as martians).
-    boot.kernel.sysctl."net.ipv4.conf.all.log_martians" = mkDefault true;
-    boot.kernel.sysctl."net.ipv4.conf.all.rp_filter" = mkDefault "1";
-    boot.kernel.sysctl."net.ipv4.conf.default.log_martians" = mkDefault true;
-    boot.kernel.sysctl."net.ipv4.conf.default.rp_filter" = mkDefault "1";
+    boot.kernel.sysctl.net.ipv4.conf.all.log_martians = mkDefault true;
+    boot.kernel.sysctl.net.ipv4.conf.all.rp_filter = mkDefault 1;
+    boot.kernel.sysctl.net.ipv4.conf.default.log_martians = mkDefault true;
+    boot.kernel.sysctl.net.ipv4.conf.default.rp_filter = mkDefault 1;
 
     # Ignore broadcast ICMP (mitigate SMURF)
-    boot.kernel.sysctl."net.ipv4.icmp_echo_ignore_broadcasts" = mkDefault true;
+    boot.kernel.sysctl.net.ipv4.icmp_echo_ignore_broadcasts = mkDefault true;
 
     # Ignore incoming ICMP redirects (note: default is needed to ensure that the
     # setting is applied to interfaces added after the sysctls are set)
-    boot.kernel.sysctl."net.ipv4.conf.all.accept_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv4.conf.all.secure_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv4.conf.default.accept_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv4.conf.default.secure_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv6.conf.all.accept_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv6.conf.default.accept_redirects" = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.all.accept_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.all.secure_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.default.accept_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.default.secure_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv6.conf.all.accept_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv6.conf.default.accept_redirects = mkDefault false;
 
     # Ignore outgoing ICMP redirects (this is ipv4 only)
-    boot.kernel.sysctl."net.ipv4.conf.all.send_redirects" = mkDefault false;
-    boot.kernel.sysctl."net.ipv4.conf.default.send_redirects" = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.all.send_redirects = mkDefault false;
+    boot.kernel.sysctl.net.ipv4.conf.default.send_redirects = mkDefault false;
   };
 }

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -99,7 +99,7 @@ with lib;
     # fairly often, preventing processes such as nix-worker or
     # download-using-manifests.pl from forking even if there is
     # plenty of free memory.
-    boot.kernel.sysctl."vm.overcommit_memory" = "1";
+    boot.kernel.sysctl.vm.overcommit_memory = 1;
 
     # To speed up installation a little bit, include the complete
     # stdenvNoCC in the Nix store on the CD.

--- a/nixos/modules/security/misc.nix
+++ b/nixos/modules/security/misc.nix
@@ -111,7 +111,7 @@
       # Setting the number of allowed user namespaces to 0 effectively disables
       # the feature at runtime.  Note that root may raise the limit again
       # at any time.
-      boot.kernel.sysctl."user.max_user_namespaces" = 0;
+      boot.kernel.sysctl.user.max_user_namespaces = 0;
 
       assertions = [
         {
@@ -122,14 +122,14 @@
     })
 
     (lib.mkIf config.security.unprivilegedUsernsClone {
-      boot.kernel.sysctl."kernel.unprivileged_userns_clone" = lib.mkDefault true;
+      boot.kernel.sysctl.kernel.unprivileged_userns_clone = lib.mkDefault true;
     })
 
     (lib.mkIf config.security.protectKernelImage {
       # Disable hibernation (allows replacing the running kernel)
       boot.kernelParams = [ "nohibernate" ];
       # Prevent replacing the running kernel image w/o reboot
-      boot.kernel.sysctl."kernel.kexec_load_disabled" = lib.mkDefault true;
+      boot.kernel.sysctl.kernel.kexec_load_disabled = lib.mkDefault true;
     })
 
     (lib.mkIf (!config.security.allowSimultaneousMultithreading) {

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -316,9 +316,9 @@ in
       services.kubernetes.kubelet.seedDockerImages = [ infraContainer ];
 
       boot.kernel.sysctl = {
-        "net.bridge.bridge-nf-call-iptables" = 1;
-        "net.ipv4.ip_forward" = 1;
-        "net.bridge.bridge-nf-call-ip6tables" = 1;
+        net.bridge.bridge-nf-call-iptables = 1;
+        net.ipv4.ip_forward = true;
+        net.bridge.bridge-nf-call-ip6tables = 1;
       };
 
       systemd.services.kubelet = {

--- a/nixos/modules/services/databases/aerospike.nix
+++ b/nixos/modules/services/databases/aerospike.nix
@@ -110,8 +110,8 @@ in
     users.groups.aerospike.gid = config.ids.gids.aerospike;
 
     boot.kernel.sysctl = {
-      "net.core.rmem_max" = lib.mkDefault 15728640;
-      "net.core.wmem_max" = lib.mkDefault 5242880;
+      net.core.rmem_max = lib.mkDefault 15728640;
+      net.core.wmem_max = lib.mkDefault 5242880;
     };
 
     systemd.services.aerospike = rec {

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -463,7 +463,7 @@ in
     );
 
     boot.kernel.sysctl = lib.mkIf cfg.vmOverCommit {
-      "vm.overcommit_memory" = "1";
+      vm.overcommit_memory = "1";
     };
 
     networking.firewall.allowedTCPPorts = lib.concatMap (

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -336,8 +336,8 @@ in
     environment.variables.IPFS_PATH = fakeKuboRepo;
 
     # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-    boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 7500000;
-    boot.kernel.sysctl."net.core.wmem_max" = lib.mkDefault 7500000;
+    boot.kernel.sysctl.net.core.rmem_max = lib.mkDefault 7500000;
+    boot.kernel.sysctl.net.core.wmem_max = lib.mkDefault 7500000;
 
     programs.fuse = lib.mkIf (cfg.autoMount && cfg.settings.Mounts.FuseAllowOther) {
       userAllowOther = true;

--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -95,14 +95,22 @@ in
   config = lib.mkIf config.services.babeld.enable {
 
     boot.kernel.sysctl = {
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.all.accept_redirects" = 0;
-      "net.ipv4.conf.all.forwarding" = 1;
-      "net.ipv4.conf.all.rp_filter" = 0;
-    }
-    // lib.mapAttrs' (
-      ifname: _: lib.nameValuePair "net.ipv4.conf.${ifname}.rp_filter" (lib.mkDefault 0)
-    ) config.services.babeld.interfaces;
+      net.ipv6.conf = {
+        all.forwarding = true;
+        all.accept_redirects = false;
+      };
+
+      net.ipv4.conf = {
+        all.forwarding = true;
+        all.rp_filter = false;
+      }
+      // lib.mapAttrs' (
+        ifname: _:
+        lib.nameValuePair ifname {
+          rp_filter = lib.mkDefault false;
+        }
+      ) config.services.babeld.interfaces;
+    };
 
     systemd.services.babeld = {
       description = "Babel routing daemon";

--- a/nixos/modules/services/networking/easytier.nix
+++ b/nixos/modules/services/networking/easytier.nix
@@ -281,8 +281,8 @@ in
     ) activeInsts;
 
     boot.kernel.sysctl = mkIf cfg.allowSystemForward {
-      "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
-      "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
+      net.ipv4.conf.all.forwarding = mkOverride 97 true;
+      net.ipv6.conf.all.forwarding = mkOverride 97 true;
     };
   };
 

--- a/nixos/modules/services/networking/firewall-firewalld.nix
+++ b/nixos/modules/services/networking/firewall-firewalld.nix
@@ -15,7 +15,7 @@ in
       }
     ];
 
-    boot.kernel.sysctl."net.ipv4.conf.all.rp_filter" =
+    boot.kernel.sysctl.net.ipv4.conf.all.rp_filter =
       if cfg.checkReversePath == false then
         0
       else if cfg.checkReversePath == "loose" then

--- a/nixos/modules/services/networking/hans.nix
+++ b/nixos/modules/services/networking/hans.nix
@@ -105,7 +105,7 @@ in
 
   config = lib.mkIf (cfg.server.enable || cfg.clients != { }) {
     boot.kernel.sysctl = lib.optionalAttrs cfg.server.respondToSystemPings {
-      "net.ipv4.icmp_echo_ignore_all" = 1;
+      net.ipv4.icmp_echo_ignore_all = 1;
     };
 
     boot.kernelModules = [ "tun" ];

--- a/nixos/modules/services/networking/jitsi-videobridge.nix
+++ b/nixos/modules/services/networking/jitsi-videobridge.nix
@@ -313,8 +313,8 @@ in
 
     # (from videobridge2 .deb)
     # this sets the max, so that we can bump the JVB UDP single port buffer size.
-    boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 10485760;
-    boot.kernel.sysctl."net.core.netdev_max_backlog" = lib.mkDefault 100000;
+    boot.kernel.sysctl.net.core.rmem_max = lib.mkDefault 10485760;
+    boot.kernel.sysctl.net.core.netdev_max_backlog = lib.mkDefault 100000;
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
       jvbConfig.videobridge.ice.tcp.port

--- a/nixos/modules/services/networking/nat.nix
+++ b/nixos/modules/services/networking/nat.nix
@@ -197,18 +197,18 @@ in
     boot = {
       kernelModules = [ "nf_nat_ftp" ];
       kernel.sysctl = {
-        "net.ipv4.conf.all.forwarding" = mkOverride 99 true;
-        "net.ipv4.conf.default.forwarding" = mkOverride 99 true;
+        net.ipv4.conf.all.forwarding = mkOverride 99 true;
+        net.ipv4.conf.default.forwarding = mkOverride 99 true;
       }
       // optionalAttrs cfg.enableIPv6 {
         # Do not prevent IPv6 autoconfiguration.
         # See <http://strugglers.net/~andy/blog/2011/09/04/linux-ipv6-router-advertisements-and-forwarding/>.
-        "net.ipv6.conf.all.accept_ra" = mkOverride 99 2;
-        "net.ipv6.conf.default.accept_ra" = mkOverride 99 2;
+        net.ipv6.conf.all.accept_ra = mkOverride 99 2;
+        net.ipv6.conf.default.accept_ra = mkOverride 99 2;
 
         # Forward IPv6 packets.
-        "net.ipv6.conf.all.forwarding" = mkOverride 99 true;
-        "net.ipv6.conf.default.forwarding" = mkOverride 99 true;
+        net.ipv6.conf.all.forwarding = mkOverride 99 true;
+        net.ipv6.conf.default.forwarding = mkOverride 99 true;
       };
     };
 

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -517,8 +517,8 @@ in
 
       # Required for the routing ("Exit node") feature(s) to work
       boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {
-        "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
-        "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
+        net.ipv4.conf.all.forwarding = mkOverride 97 true;
+        net.ipv6.conf.all.forwarding = mkOverride 97 true;
       };
 
       networking.firewall = {

--- a/nixos/modules/services/networking/sslh.nix
+++ b/nixos/modules/services/networking/sslh.nix
@@ -224,8 +224,8 @@ in
     # the only difference is using iptables mark 0x2 instead of 0x1 to avoid conflicts with nixos/nat module
     (mkIf (cfg.enable && cfg.settings.transparent) {
       # Set route_localnet = 1 on all interfaces so that ssl can use "localhost" as destination
-      boot.kernel.sysctl."net.ipv4.conf.default.route_localnet" = 1;
-      boot.kernel.sysctl."net.ipv4.conf.all.route_localnet" = 1;
+      boot.kernel.sysctl.net.ipv4.conf.default.route_localnet = 1;
+      boot.kernel.sysctl.net.ipv4.conf.all.route_localnet = 1;
 
       systemd.services.sslh =
         let

--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -250,8 +250,8 @@ in
     };
 
     boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {
-      "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
-      "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
+      net.ipv4.conf.all.forwarding = mkOverride 97 true;
+      net.ipv6.conf.all.forwarding = mkOverride 97 true;
     };
 
     networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ cfg.port ];

--- a/nixos/modules/services/networking/wg-access-server.nix
+++ b/nixos/modules/services/networking/wg-access-server.nix
@@ -100,8 +100,8 @@ in
         ];
 
     boot.kernel.sysctl = {
-      "net.ipv4.conf.all.forwarding" = "1";
-      "net.ipv6.conf.all.forwarding" = "1";
+      net.ipv4.conf.all.forwarding = true;
+      net.ipv6.conf.all.forwarding = true;
     };
 
     systemd.services.wg-access-server = {

--- a/nixos/modules/services/networking/yggdrasil.md
+++ b/nixos/modules/services/networking/yggdrasil.md
@@ -63,7 +63,7 @@ in
     };
   };
 
-  boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = 1;
+  boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
   # Forward traffic under the prefix.
 
   networking.interfaces.${eth0}.ipv6.addresses = [
@@ -102,7 +102,7 @@ let
   # Again, taken from the output of "yggdrasilctl getself".
 in
 {
-  boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = 1;
+  boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
   # Enable IPv6 forwarding.
 
   networking = {

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -566,28 +566,28 @@ in
       # https://trac.transmissionbt.com/browser/trunk/libtransmission/tr-udp.c?rev=11956.
       # at least up to the values hardcoded here:
       (mkIf cfg.settings.utp-enabled {
-        "net.core.rmem_max" = mkDefault 4194304; # 4MB
-        "net.core.wmem_max" = mkDefault 1048576; # 1MB
+        net.core.rmem_max = mkDefault 4194304; # 4MB
+        net.core.wmem_max = mkDefault 1048576; # 1MB
       })
       (mkIf cfg.performanceNetParameters {
         # Increase the number of available source (local) TCP and UDP ports to 49151.
         # Usual default is 32768 60999, ie. 28231 ports.
         # Find out your current usage with: ss -s
-        "net.ipv4.ip_local_port_range" = mkDefault "16384 65535";
+        net.ipv4.ip_local_port_range = mkDefault "16384 65535";
         # Timeout faster generic TCP states.
         # Usual default is 600.
         # Find out your current usage with: watch -n 1 netstat -nptuo
-        "net.netfilter.nf_conntrack_generic_timeout" = mkDefault 60;
+        net.netfilter.nf_conntrack_generic_timeout = mkDefault 60;
         # Timeout faster established but inactive connections.
         # Usual default is 432000.
-        "net.netfilter.nf_conntrack_tcp_timeout_established" = mkDefault 600;
+        net.netfilter.nf_conntrack_tcp_timeout_established = mkDefault 600;
         # Clear immediately TCP states after timeout.
         # Usual default is 120.
-        "net.netfilter.nf_conntrack_tcp_timeout_time_wait" = mkDefault 1;
+        net.netfilter.nf_conntrack_tcp_timeout_time_wait = mkDefault 1;
         # Increase the number of trackable connections.
         # Usual default is 262144.
         # Find out your current usage with: conntrack -C
-        "net.netfilter.nf_conntrack_max" = mkDefault 1048576;
+        net.netfilter.nf_conntrack_max = mkDefault 1048576;
       })
     ];
 

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -448,8 +448,8 @@ in
     '';
 
     # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-    boot.kernel.sysctl."net.core.rmem_max" = mkDefault 2500000;
-    boot.kernel.sysctl."net.core.wmem_max" = mkDefault 2500000;
+    boot.kernel.sysctl.net.core.rmem_max = mkDefault 2500000;
+    boot.kernel.sysctl.net.core.wmem_max = mkDefault 2500000;
 
     systemd.packages = [ cfg.package ];
     systemd.services.caddy = {

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -431,7 +431,7 @@ in
         "nomodeset"
       ];
 
-      boot.kernel.sysctl."kernel.printk" = mkDefault config.boot.consoleLogLevel;
+      boot.kernel.sysctl.kernel.printk = mkDefault config.boot.consoleLogLevel;
 
       boot.kernelModules = [
         "loop"

--- a/nixos/modules/system/boot/shutdown.nix
+++ b/nixos/modules/system/boot/shutdown.nix
@@ -28,6 +28,6 @@
     };
   };
 
-  boot.kernel.sysctl."kernel.poweroff_cmd" = "${config.systemd.package}/sbin/poweroff";
+  boot.kernel.sysctl.kernel.poweroff_cmd = "${config.systemd.package}/sbin/poweroff";
 
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -834,7 +834,7 @@ in
 
     # Increase numeric PID range (set directly instead of copying a one-line file from systemd)
     # https://github.com/systemd/systemd/pull/12226
-    boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
+    boot.kernel.sysctl.kernel.pid_max = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
 
     services.logrotate.settings = {
       "/var/log/btmp" = mapAttrs (_: mkDefault) {

--- a/nixos/modules/system/boot/systemd/coredump.nix
+++ b/nixos/modules/system/boot/systemd/coredump.nix
@@ -79,7 +79,7 @@ in
     })
 
     (mkIf (!cfg.enable) {
-      boot.kernel.sysctl."kernel.core_pattern" = mkDefault "core";
+      boot.kernel.sysctl.kernel.core_pattern = mkDefault "core";
     })
 
   ];

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -576,7 +576,7 @@ in
         Additionally it is recommended to only use lower-case characters.
         If (e.g. for legacy reasons) a FQDN is required as the Linux kernel
         network node hostname (uname --nodename) the option
-        boot.kernel.sysctl."kernel.hostname" can be used as a workaround (but
+        boot.kernel.sysctl.kernel.hostname can be used as a workaround (but
         the 64 character limit still applies).
 
         WARNING: Do not use underscores (_) or you may run into unexpected issues.
@@ -1735,29 +1735,56 @@ in
       optionalString hasBonds "options bonding max_bonds=0";
 
     boot.kernel.sysctl = {
-      "net.ipv4.conf.all.forwarding" = mkDefault (any (i: i.proxyARP) interfaces);
-      "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
-      "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+      net.ipv4.conf = {
+        all.forwarding = mkDefault (any (i: i.proxyARP) interfaces);
+      }
+      // listToAttrs (
+        forEach interfaces (
+          i:
+          nameValuePair i.name {
+            proxy_arp = i.proxyARP;
+          }
+        )
+      );
+
       # allow all users to do ICMP echo requests (ping)
-      "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
-      # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
-      "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
-    }
-    // listToAttrs (
-      forEach interfaces (
-        i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
-      )
-    )
-    // listToAttrs (
-      forEach interfaces (
-        i:
-        let
-          opt = i.tempAddress;
-          val = tempaddrValues.${opt}.sysctl;
-        in
-        nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
-      )
-    );
+      net.ipv4.ping_group_range = mkDefault [
+        0
+        2147483647
+      ];
+
+      net.ipv6.conf = {
+        all.disable_ipv6 = mkDefault (!cfg.enableIPv6);
+        default.disable_ipv6 = mkDefault (!cfg.enableIPv6);
+
+        # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
+        default.use_tempaddr = tempaddrValues.${cfg.tempAddresses}.sysctl;
+      }
+      // listToAttrs (
+        forEach interfaces (
+          i:
+          let
+            opt = i.tempAddress;
+            val = tempaddrValues.${opt}.sysctl;
+          in
+          nameValuePair i.name {
+            use_tempaddr = val;
+          }
+        )
+      );
+    };
+
+    systemd.services.domainname = lib.mkIf (cfg.domain != null) {
+      wantedBy = [ "sysinit.target" ];
+      before = [
+        "sysinit.target"
+        "shutdown.target"
+      ];
+      conflicts = [ "shutdown.target" ];
+      unitConfig.DefaultDependencies = false;
+      serviceConfig.ExecStart = ''${pkgs.nettools}/bin/domainname "${cfg.domain}"'';
+      serviceConfig.Type = "oneshot";
+    };
 
     environment.etc.hostid = mkIf (cfg.hostId != null) { source = hostidFile; };
     boot.initrd.systemd.contents."/etc/hostid" = mkIf (cfg.hostId != null) { source = hostidFile; };

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -191,11 +191,11 @@ in
     };
 
     boot.kernel.sysctl = {
-      "kernel.hung_task_timeout_secs" = 600;
+      kernel.hung_task_timeout_secs = 600;
       # Panic on out-of-memory conditions rather than letting the
       # OOM killer randomly get rid of processes, since this leads
       # to failures that are hard to diagnose.
-      "vm.panic_on_oom" = lib.mkDefault 2;
+      vm.panic_on_oom = lib.mkDefault 2;
     };
 
     boot.kernelParams = [

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -243,8 +243,8 @@ in
         "xt_nat"
       ];
       boot.kernel.sysctl = {
-        "net.ipv4.conf.all.forwarding" = mkOverride 98 true;
-        "net.ipv4.conf.default.forwarding" = mkOverride 98 true;
+        net.ipv4.conf.all.forwarding = mkOverride 98 true;
+        net.ipv4.conf.default.forwarding = mkOverride 98 true;
       };
       environment.systemPackages = [ cfg.package ];
       users.groups.docker.gid = config.ids.gids.docker;

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -310,16 +310,16 @@ in
 
     # https://github.com/lxc/incus/blob/f145309929f849b9951658ad2ba3b8f10cbe69d1/doc/reference/server_settings.md
     boot.kernel.sysctl = {
-      "fs.aio-max-nr" = lib.mkDefault 524288;
-      "fs.inotify.max_queued_events" = lib.mkDefault 1048576;
-      "fs.inotify.max_user_instances" = lib.mkOverride 1050 1048576; # override in case conflict nixos/modules/services/x11/xserver.nix
-      "fs.inotify.max_user_watches" = lib.mkOverride 1050 1048576; # override in case conflict nixos/modules/services/x11/xserver.nix
-      "kernel.dmesg_restrict" = lib.mkDefault 1;
-      "kernel.keys.maxbytes" = lib.mkDefault 2000000;
-      "kernel.keys.maxkeys" = lib.mkDefault 2000;
-      "net.core.bpf_jit_limit" = lib.mkDefault 1000000000;
-      "net.ipv4.neigh.default.gc_thresh3" = lib.mkDefault 8192;
-      "net.ipv6.neigh.default.gc_thresh3" = lib.mkDefault 8192;
+      fs.aio-max-nr = lib.mkDefault 524288;
+      fs.inotify.max_queued_events = lib.mkDefault 1048576;
+      fs.inotify.max_user_instances = lib.mkOverride 1050 1048576; # override in case conflict nixos/modules/services/x11/xserver.nix
+      fs.inotify.max_user_watches = lib.mkOverride 1050 1048576; # override in case conflict nixos/modules/services/x11/xserver.nix
+      kernel.dmesg_restrict = lib.mkDefault 1;
+      kernel.keys.maxbytes = lib.mkDefault 2000000;
+      kernel.keys.maxkeys = lib.mkDefault 2000;
+      net.core.bpf_jit_limit = lib.mkDefault 1000000000;
+      net.ipv4.neigh.default.gc_thresh3 = lib.mkDefault 8192;
+      net.ipv6.neigh.default.gc_thresh3 = lib.mkDefault 8192;
       # vm.max_map_count is set higher in nixos/modules/config/sysctl.nix
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1539,6 +1539,7 @@ in
   syncthing-many-devices = runTest ./syncthing/many-devices.nix;
   syncthing-no-settings = runTest ./syncthing/no-settings.nix;
   syncthing-relay = runTest ./syncthing/relay.nix;
+  sysctl = runTest ./sysctl.nix;
   sysfs = runTest ./sysfs.nix;
   sysinit-reactivation = runTest ./sysinit-reactivation.nix;
   systemd = runTest ./systemd.nix;

--- a/nixos/tests/clatd.nix
+++ b/nixos/tests/clatd.nix
@@ -83,8 +83,8 @@
     # be a second source NAT44 to map all clients behind one IPv4 address.
     router = {
       boot.kernel.sysctl = {
-        "net.ipv4.conf.all.forwarding" = 1;
-        "net.ipv6.conf.all.forwarding" = 1;
+        net.ipv4.conf.all.forwarding = true;
+        net.ipv6.conf.all.forwarding = true;
       };
 
       virtualisation.vlans = [

--- a/nixos/tests/connman.nix
+++ b/nixos/tests/connman.nix
@@ -13,7 +13,7 @@
 
       virtualisation.vlans = [ 1 ];
 
-      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+      boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
 
       networking = {
         useDHCP = false;

--- a/nixos/tests/corerad.nix
+++ b/nixos/tests/corerad.nix
@@ -4,7 +4,7 @@
     router = {
       # This machine simulates a router with IPv6 forwarding and a static IPv6 address.
       boot.kernel.sysctl = {
-        "net.ipv6.conf.all.forwarding" = true;
+        net.ipv6.conf.all.forwarding = true;
       };
       networking.interfaces.eth1 = {
         ipv6.addresses = [
@@ -45,7 +45,7 @@
         # Use IPv6 SLAAC from router advertisements, and install rdisc6 so we can
         # trigger one immediately.
         boot.kernel.sysctl = {
-          "net.ipv6.conf.all.autoconf" = true;
+          net.ipv6.conf.all.autoconf = true;
         };
         environment.systemPackages = with pkgs; [
           ndisc6

--- a/nixos/tests/firezone/firezone.nix
+++ b/nixos/tests/firezone/firezone.nix
@@ -283,10 +283,10 @@ in
           '';
         };
 
-        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
-        # boot.kernel.sysctl."net.ipv4.conf.all.src_valid_mark" = "1";
-        boot.kernel.sysctl."net.ipv6.conf.default.forwarding" = "1";
-        boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = "1";
+        boot.kernel.sysctl.net.ipv4.ip_forward = true;
+        # boot.kernel.sysctl.net.ipv4.conf.all.src_valid_mark = true;
+        boot.kernel.sysctl.net.ipv6.conf.default.forwarding = true;
+        boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
 
         security.pki.certificateFiles = [ certs.ca.cert ];
         networking.extraHosts = ''

--- a/nixos/tests/frr.nix
+++ b/nixos/tests/frr.nix
@@ -56,7 +56,7 @@ in
           1
           2
         ];
-        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+        boot.kernel.sysctl.net.ipv4.ip_forward = true;
         networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
         services.frr = {
           ospfd.enable = true;
@@ -75,7 +75,7 @@ in
           3
           2
         ];
-        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+        boot.kernel.sysctl.net.ipv4.ip_forward = true;
         networking.firewall.extraCommands = "iptables -A nixos-fw -i eth2 -p ospfigp -j ACCEPT";
         services.frr = {
           ospfd.enable = true;

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -111,7 +111,7 @@ in
                   # Arbitrary sysctl setting changed from nixos default
                   # used for verifying `distrobuilder.generator` properly allows
                   # for containers to modify sysctl
-                  boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+                  boot.kernel.sysctl.net.ipv4.ip_forward = true;
                 };
 
                 testScript = # python

--- a/nixos/tests/iodine.nix
+++ b/nixos/tests/iodine.nix
@@ -15,8 +15,8 @@ in
           trustedInterfaces = [ "dns0" ];
         };
         boot.kernel.sysctl = {
-          "net.ipv4.ip_forward" = 1;
-          "net.ipv6.ip_forward" = 1;
+          net.ipv4.ip_forward = true;
+          net.ipv6.ip_forward = true;
         };
 
         services.iodine.server = {

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -51,8 +51,8 @@ in
 
       # Enable packet routing
       boot.kernel.sysctl = {
-        "net.ipv6.conf.all.forwarding" = 1;
-        "net.ipv4.conf.all.forwarding" = 1;
+        net.ipv6.conf.all.forwarding = true;
+        net.ipv4.conf.all.forwarding = true;
       };
 
       networking.useDHCP = false;
@@ -171,8 +171,8 @@ in
 
       # Enable packet routing
       boot.kernel.sysctl = {
-        "net.ipv6.conf.all.forwarding" = 1;
-        "net.ipv4.conf.all.forwarding" = 1;
+        net.ipv6.conf.all.forwarding = true;
+        net.ipv4.conf.all.forwarding = true;
       };
 
       networking.useDHCP = false;

--- a/nixos/tests/libreswan-nat.nix
+++ b/nixos/tests/libreswan-nat.nix
@@ -112,10 +112,10 @@ in
 
       boot.kernel.sysctl = {
         # enable forwarding packets
-        "net.ipv6.conf.all.forwarding" = 1;
-        "net.ipv4.conf.all.forwarding" = 1;
+        net.ipv6.conf.all.forwarding = true;
+        net.ipv4.conf.all.forwarding = true;
         # enable NDP proxy for VPN clients
-        "net.ipv6.conf.all.proxy_ndp" = 1;
+        net.ipv6.conf.all.proxy_ndp = true;
       };
 
       services.libreswan.configSetup = "listen-tcp=yes";

--- a/nixos/tests/libreswan.nix
+++ b/nixos/tests/libreswan.nix
@@ -109,7 +109,7 @@ in
         }
       ];
       environment.systemPackages = [ pkgs.tcpdump ];
-      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+      boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
     };
 
   testScript = ''

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -63,7 +63,7 @@ in
         enable = true;
         wheelNeedsPassword = false;
       };
-      boot.kernel.sysctl."vm.swappiness" = 1;
+      boot.kernel.sysctl.vm.swappiness = 1;
       boot.kernelParams = [ "vsyscall=emulate" ];
       system.extraDependencies = [ foo ];
     };

--- a/nixos/tests/ndppd.nix
+++ b/nixos/tests/ndppd.nix
@@ -32,8 +32,8 @@
       { pkgs, ... }:
       {
         boot.kernel.sysctl = {
-          "net.ipv6.conf.all.forwarding" = "1";
-          "net.ipv6.conf.default.forwarding" = "1";
+          net.ipv6.conf.all.forwarding = true;
+          net.ipv6.conf.default.forwarding = true;
         };
         environment.systemPackages = [ pkgs.tcpdump ];
         networking.useDHCP = false;

--- a/nixos/tests/networking/networkd-and-scripted.nix
+++ b/nixos/tests/networking/networkd-and-scripted.nix
@@ -1136,7 +1136,7 @@ let
       name = "Privacy";
       nodes.router = {
         virtualisation.interfaces.enp1s0.vlan = 1;
-        boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+        boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
         networking = {
           useNetworkd = networkd;
           useDHCP = false;

--- a/nixos/tests/networking/router-eap.nix
+++ b/nixos/tests/networking/router-eap.nix
@@ -77,7 +77,7 @@ in
     2
     3
   ];
-  boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+  boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
   networking = {
     useDHCP = false;
     useNetworkd = true;

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -12,7 +12,7 @@ in
     2
     3
   ];
-  boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+  boot.kernel.sysctl.net.ipv6.conf.all.forwarding = true;
   networking = {
     useDHCP = false;
     useNetworkd = networkd;

--- a/nixos/tests/shadowsocks/common.nix
+++ b/nixos/tests/shadowsocks/common.nix
@@ -14,7 +14,7 @@ import ../make-test-python.nix (
 
     nodes = {
       server = {
-        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+        boot.kernel.sysctl.net.ipv4.ip_forward = "1";
         networking.useDHCP = false;
         networking.interfaces.eth1.ipv4.addresses = [
           {

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -165,7 +165,7 @@ in
       { pkgs, ... }:
       {
         boot.kernel.sysctl = {
-          "net.ipv4.conf.all.forwarding" = 1;
+          net.ipv4.conf.all.forwarding = true;
         };
 
         networking = {

--- a/nixos/tests/swapspace.nix
+++ b/nixos/tests/swapspace.nix
@@ -30,7 +30,7 @@ import ./make-test-python.nix (
           device = "/root/swapfile";
         }
       ];
-      boot.kernel.sysctl."vm.swappiness" = 60;
+      boot.kernel.sysctl.vm.swappiness = 60;
     };
 
     testScript = ''

--- a/nixos/tests/sysctl.nix
+++ b/nixos/tests/sysctl.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+{
+  name = "sysctl";
+  meta.maintainers = with lib.maintainers; [ mvs ];
+  nodes.machine = {
+    boot.kernel.sysctl = {
+      net.core = {
+        bpf_jit_enable = 1;
+        bpf_jit_harden = 2;
+      };
+
+      net.ipv4.conf."eth[0-9]*".log_martians = true;
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      inherit (nodes.machine.boot.kernel) sysctl;
+    in
+    ''
+      from shlex import quote
+      def check(filename, contents):
+        machine.succeed('grep -F -q {} {}'.format(quote(contents), quote(filename)))
+
+      check('/proc/sys/net/core/bpf_jit_enable', '${toString sysctl.net.core.bpf_jit_enable}')
+      check('/proc/sys/net/core/bpf_jit_harden', '${toString sysctl.net.core.bpf_jit_harden}')
+      check('/proc/sys/net/ipv4/conf/eth0/log_martians', '1')
+    '';
+}

--- a/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
+++ b/nixos/tests/systemd-networkd-ipv6-prefix-delegation.nix
@@ -191,7 +191,7 @@ import ./make-test-python.nix (
 
         boot.kernel.sysctl = {
           # we want to forward packets from the ISP to the client and back.
-          "net.ipv6.conf.all.forwarding" = 1;
+          net.ipv6.conf.all.forwarding = 1;
         };
 
         networking = {

--- a/nixos/tests/tayga.nix
+++ b/nixos/tests/tayga.nix
@@ -77,8 +77,8 @@
     # second source NAT44 to map all clients behind one IPv4 address.
     router_systemd = {
       boot.kernel.sysctl = {
-        "net.ipv4.ip_forward" = 1;
-        "net.ipv6.conf.all.forwarding" = 1;
+        net.ipv4.ip_forward = true;
+        net.ipv6.conf.all.forwarding = true;
       };
 
       virtualisation.vlans = [
@@ -151,8 +151,8 @@
 
     router_nixos = {
       boot.kernel.sysctl = {
-        "net.ipv4.ip_forward" = 1;
-        "net.ipv6.conf.all.forwarding" = 1;
+        net.ipv4.ip_forward = true;
+        net.ipv6.conf.all.forwarding = true;
       };
 
       virtualisation.vlans = [

--- a/nixos/tests/wireguard/make-peer.nix
+++ b/nixos/tests/wireguard/make-peer.nix
@@ -7,9 +7,9 @@
   imports = [
     {
       boot.kernel.sysctl = {
-        "net.ipv6.conf.all.forwarding" = "1";
-        "net.ipv6.conf.default.forwarding" = "1";
-        "net.ipv4.ip_forward" = "1";
+        net.ipv6.conf.all.forwarding = true;
+        net.ipv6.conf.default.forwarding = true;
+        net.ipv4.ip_forward = true;
       };
 
       networking.useDHCP = false;

--- a/nixos/tests/yggdrasil.nix
+++ b/nixos/tests/yggdrasil.nix
@@ -100,7 +100,7 @@ in
           };
         };
 
-        boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = 1;
+        boot.kernel.sysctl.net.ipv6.conf.all.forwarding = 1;
 
         networking = {
           bridges.br0.interfaces = [ ];


### PR DESCRIPTION
This is an almost complete re‐write of the `config/sysctl` module with three significant changes:

- Instead of setting the sysctl options once during system start‐up, they are set when the corresponding file in `/proc/sys` becomes available for the first time, through systemd path units. This allows setting of options that might only become available at a later time.
- The `boot.kernel.sysctl` option now is a nested attribute set, which means that paths no longer require quoting. The old style is still supported for compatibility, but the module warns about its use.
- Attribute names may contain glob patterns (`*`, `?` and `[…]`) to set multiple sysctls at once, these should however be used with caution as their use can lead to non‐deterministic behaviour when option paths overlap.

In addition I added a bit of documentation for a number of common sysctls.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
