### PR TITLE
treewide: replace pythonImportCheck(s) with pythonImportsCheck

### DIFF
--- a/pkgs/development/python-modules/curated-transformers/default.nix
+++ b/pkgs/development/python-modules/curated-transformers/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   # Unit tests are hard to use, since most tests rely on downloading
   # models from Hugging Face Hub.
-  pythonImportCheck = [ "curated_transformers" ];
+  pythonImportsCheck = [ "curated_transformers" ];
 
   meta = with lib; {
     description = "PyTorch library of curated Transformer models and their composable components";

--- a/pkgs/development/python-modules/mergecal/default.nix
+++ b/pkgs/development/python-modules/mergecal/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pythonImportChecks = [ "mergecal" ];
+  pythonImportsCheck = [ "mergecal" ];
 
   meta = {
     homepage = "https://mergecal.readthedocs.io/en/latest/";

--- a/pkgs/development/python-modules/spacy-curated-transformers/default.nix
+++ b/pkgs/development/python-modules/spacy-curated-transformers/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   # Unit tests are hard to use, since most tests rely on downloading
   # models from Hugging Face Hub.
-  pythonImportCheck = [ "spacy_curated_transformers" ];
+  pythonImportsCheck = [ "spacy_curated_transformers" ];
 
   meta = with lib; {
     description = "spaCy entry points for Curated Transformers";


### PR DESCRIPTION
fixing typos. resurgence of #340809

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 12 packages built:</summary>
  <ul>
    <li>open-web-calendar</li>
    <li>open-web-calendar.dist</li>
    <li>python312Packages.curated-transformers</li>
    <li>python312Packages.curated-transformers.dist</li>
    <li>python312Packages.mergecal</li>
    <li>python312Packages.mergecal.dist</li>
    <li>python312Packages.spacy-curated-transformers</li>
    <li>python312Packages.spacy-curated-transformers.dist</li>
    <li>python313Packages.curated-transformers</li>
    <li>python313Packages.curated-transformers.dist</li>
    <li>python313Packages.mergecal</li>
    <li>python313Packages.mergecal.dist</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
