### PR TITLE
libserialport: enable on windows

### DIFF
--- a/pkgs/by-name/li/libserialport/package.nix
+++ b/pkgs/by-name/li/libserialport/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Cross-platform shared library for serial port access";
     homepage = "https://sigrok.org/";
     license = lib.licenses.gpl3Plus;
-    platforms = with lib; platforms.linux ++ platforms.darwin;
+    platforms = with lib; platforms.linux ++ platforms.darwin ++ platforms.windows;
     maintainers = [ lib.maintainers.bjornfor ];
   };
 })

--- a/pkgs/by-name/li/libserialport/package.nix
+++ b/pkgs/by-name/li/libserialport/package.nix
@@ -7,13 +7,13 @@
   darwin,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libserialport";
   version = "0.1.2";
 
   src = fetchurl {
-    url = "https://sigrok.org/download/source/libserialport/${pname}-${version}.tar.gz";
-    sha256 = "sha256-XeuStcpywDR7B7eGhINQ3sotz9l1zmE7jg4dlHpLTKk=";
+    url = "https://sigrok.org/download/source/libserialport/libserialport-${finalAttrs.version}.tar.gz";
+    hash = "sha256-XeuStcpywDR7B7eGhINQ3sotz9l1zmE7jg4dlHpLTKk=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -21,11 +21,11 @@ stdenv.mkDerivation rec {
     lib.optional stdenv.hostPlatform.isLinux udev
     ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.IOKit;
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform shared library for serial port access";
     homepage = "https://sigrok.org/";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = [ maintainers.bjornfor ];
+    license = lib.licenses.gpl3Plus;
+    platforms = with lib; platforms.linux ++ platforms.darwin;
+    maintainers = [ lib.maintainers.bjornfor ];
   };
-}
+})


### PR DESCRIPTION
## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] pkgsCross.mingw32.libserialport
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
