### PR TITLE
mmh: unstable-2020-08-21 -> unstable-2023-09-24, unbreak on GCC 14

### DIFF
--- a/pkgs/by-name/mm/mmh/package.nix
+++ b/pkgs/by-name/mm/mmh/package.nix
@@ -7,21 +7,21 @@
   flex,
 }:
 let
-  rev = "b17ea39dc17e5514f33b3f5c34ede92bd16e208c";
+  rev = "7e93dee44df1a7e8f551a2e408a600b2e90a0974";
 in
 stdenv.mkDerivation {
   pname = "mmh";
-  version = "unstable-2020-08-21";
+  version = "unstable-2023-09-24";
 
   src = fetchurl {
     url = "http://git.marmaro.de/?p=mmh;a=snapshot;h=${rev};sf=tgz";
     name = "mmh-${rev}.tgz";
-    sha256 = "1bqfxafw4l2y46pnsxgy4ji1xlyifzw01k1ykbsjj9p61q3nv6l6";
+    hash = "sha256-t2Qnwtkli+/MDk6uaikS2SIP9LucK64os8kGcn2ytRU=";
   };
 
   postPatch = ''
     substituteInPlace sbr/Makefile.in \
-      --replace "ar " "${stdenv.cc.targetPrefix}ar "
+      --replace-fail "ar " "${stdenv.cc.targetPrefix}ar "
   '';
 
   buildInputs = [ ncurses ];
@@ -30,12 +30,18 @@ stdenv.mkDerivation {
     flex
   ];
 
-  meta = with lib; {
+  # mhl.c:1031:58: error: pointer type mismatch in conditional expression []
+  #  1031 |                 putstr((c1->c_flags & RTRIM) ? rtrim(cp) : cp);
+  NIX_CFLAGS_COMPILE = [ " -Wno-error=incompatible-pointer-types" ];
+
+  enableParallelBuilding = true;
+
+  meta = {
     description = "Set of electronic mail handling programs";
     homepage = "http://marmaro.de/prog/mmh";
-    license = licenses.bsd3;
-    platforms = platforms.unix;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
-    maintainers = with maintainers; [ kaction ];
+    maintainers = with lib.maintainers; [ kaction ];
   };
 }


### PR DESCRIPTION
Update to the latest git commit. Silence `incompatible-pointer-types` error to fix building on the new GCC 14.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
