### PR TITLE
gotestsum: 1.12.0-unstable-2024-09-17 -> 1.12.1

### DIFF
--- a/pkgs/by-name/go/gotestsum/package.nix
+++ b/pkgs/by-name/go/gotestsum/package.nix
@@ -3,41 +3,36 @@
   fetchFromGitHub,
   buildGoModule,
 }:
-let
-  version = "1.12.0";
-in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "gotestsum";
-
-  # move back to stable releases when build is successful
-  version = "${version}-unstable-2024-09-17";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "gotestyourself";
     repo = "gotestsum";
-    rev = "2f61a73f997821b2e5a1823496e8362630e213f9";
-    hash = "sha256-5zgchATcpoM4g5Mxex9wYanzrR0Pie9GYqx48toORkM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nIdGon14bAaSxUmJNlpLztQVbA8SJ76+Ve46gbM0awk=";
   };
 
-  vendorHash = "sha256-DR4AyEhgD71hFFEAnPfSxaWYFFV7FlPugZBHUjDynEE=";
+  vendorHash = "sha256-x48jjd6cIX/M8U+5QwrKalt1iLgeQKeJItLJsxXrPgY=";
 
   doCheck = false;
 
   ldflags = [
     "-s"
     "-w"
-    "-X gotest.tools/gotestsum/cmd.version=${version}"
+    "-X gotest.tools/gotestsum/cmd.version=${finalAttrs.version}"
   ];
 
   subPackages = [ "." ];
 
   meta = {
     homepage = "https://github.com/gotestyourself/gotestsum";
-    changelog = "https://github.com/gotestyourself/gotestsum/releases/tag/v${version}";
+    changelog = "https://github.com/gotestyourself/gotestsum/releases/tag/v${finalAttrs.version}";
     description = "Human friendly `go test` runner";
     mainProgram = "gotestsum";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ isabelroses ];
   };
-}
+})


### PR DESCRIPTION
supersedes https://github.com/NixOS/nixpkgs/pull/349366 which had issues with darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
