### PR TITLE
mealie: 2.7.1 -> 2.8.0; python3Packages.ingredient-parser-nlp: init at 2.0.0

### DIFF
--- a/nixos/modules/services/web-apps/mealie.nix
+++ b/nixos/modules/services/web-apps/mealie.nix
@@ -65,7 +65,7 @@ in
         API_PORT = toString cfg.port;
         BASE_URL = "http://localhost:${toString cfg.port}";
         DATA_DIR = "/var/lib/mealie";
-        CRF_MODEL_PATH = "/var/lib/mealie/model.crfmodel";
+        NLTK_DATA = pkgs.nltk-data.averaged_perceptron_tagger_eng;
       } // (builtins.mapAttrs (_: val: toString val) cfg.settings);
 
       serviceConfig = {

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -1,46 +1,28 @@
 {
   lib,
-  stdenv,
   callPackage,
   fetchFromGitHub,
   makeWrapper,
   nixosTests,
   python3Packages,
+  nltk-data,
   writeShellScript,
   nix-update-script,
 }:
 
 let
-  version = "2.7.1";
+  version = "2.8.0";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-nN8AuSzxHjIDKc8rGN+O2/vlzkH/A5LAr4aoAlOTLlk=";
+    hash = "sha256-0LUT7OdYoOZTdR/UXJO2eL2Afo2Y7GjBPIrjWUt205E=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };
 
   pythonpkgs = python3Packages;
   python = pythonpkgs.python;
-
-  crfpp = stdenv.mkDerivation {
-    pname = "mealie-crfpp";
-    version = "unstable-2024-02-12";
-    src = fetchFromGitHub {
-      owner = "mealie-recipes";
-      repo = "crfpp";
-      rev = "c56dd9f29469c8a9f34456b8c0d6ae0476110516";
-      hash = "sha256-XNps3ZApU8m07bfPEnvip1w+3hLajdn9+L5+IpEaP0c=";
-    };
-
-    # Can remove once the `register` keyword is removed from source files
-    # Configure overwrites CXXFLAGS so patch it in the Makefile
-    postConfigure = lib.optionalString stdenv.cc.isClang ''
-      substituteInPlace Makefile \
-        --replace-fail "CXXFLAGS = " "CXXFLAGS = -std=c++14 "
-    '';
-  };
 in
 
 pythonpkgs.buildPythonApplication rec {
@@ -69,6 +51,7 @@ pythonpkgs.buildPythonApplication rec {
     gunicorn
     html2text
     httpx
+    ingredient-parser-nlp
     itsdangerous
     jinja2
     lxml
@@ -106,7 +89,6 @@ pythonpkgs.buildPythonApplication rec {
         ${lib.getExe pythonpkgs.gunicorn} "$@" -k uvicorn.workers.UvicornWorker mealie.app:app;
       '';
       init_db = writeShellScript "init-mealie-db" ''
-        ${python.interpreter} $OUT/${python.sitePackages}/mealie/scripts/install_model.py
         ${python.interpreter} $OUT/${python.sitePackages}/mealie/db/init_db.py
       '';
     in
@@ -116,9 +98,7 @@ pythonpkgs.buildPythonApplication rec {
 
       makeWrapper ${start_script} $out/bin/mealie \
         --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
-        --set LD_LIBRARY_PATH "${crfpp}/lib" \
-        --set STATIC_FILES "${frontend}" \
-        --set PATH "${lib.makeBinPath [ crfpp ]}"
+        --set STATIC_FILES "${frontend}"
 
       makeWrapper ${init_db} $out/libexec/init_db \
         --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
@@ -126,6 +106,11 @@ pythonpkgs.buildPythonApplication rec {
     '';
 
   nativeCheckInputs = with pythonpkgs; [ pytestCheckHook ];
+
+  # Needed for tests
+  preCheck = ''
+    export NLTK_DATA=${nltk-data.averaged_perceptron_tagger_eng}
+  '';
 
   disabledTestPaths = [
     # KeyError: 'alembic_version'

--- a/pkgs/development/python-modules/ingredient-parser-nlp/default.nix
+++ b/pkgs/development/python-modules/ingredient-parser-nlp/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  setuptools,
+
+  nltk,
+  python-crfsuite,
+  pint,
+  floret,
+
+  pytestCheckHook,
+  nltk-data,
+}:
+buildPythonPackage rec {
+  pname = "ingredient-parser-nlp";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "strangetom";
+    repo = "ingredient-parser";
+    tag = version;
+    hash = "sha256-i14RKBcvU56pDNGxNVBvvpQ65FCbitMIfvN5eLLJCWU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    nltk
+    python-crfsuite
+    pint
+    floret
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "ingredient_parser"
+  ];
+
+  # Needed for tests
+  preCheck = ''
+    export NLTK_DATA=${nltk-data.averaged_perceptron_tagger_eng}
+  '';
+
+  meta = {
+    description = "Parse structured information from recipe ingredient sentences";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/strangetom/ingredient-parser/";
+    changelog = "https://github.com/strangetom/ingredient-parser/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ antonmosich ];
+  };
+}

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -67,6 +67,11 @@ lib.makeScope newScope (self: {
     location = "taggers";
     hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
   };
+  averaged_perceptron_tagger_eng = makeNltkDataPackage {
+    pname = "averaged_perceptron_tagger_eng";
+    location = "taggers";
+    hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
+  };
   snowball_data = makeNltkDataPackage {
     pname = "snowball_data";
     location = "stemmers";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6630,6 +6630,8 @@ self: super: with self; {
 
   inform = callPackage ../development/python-modules/inform { };
 
+  ingredient-parser-nlp = callPackage ../development/python-modules/ingredient-parser-nlp { };
+
   iniconfig = callPackage ../development/python-modules/iniconfig { };
 
   inifile = callPackage ../development/python-modules/inifile { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Mealie has a new dependency in its latest update: ingredient-parser-nlp, which is added to nixpkgs in this PR as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
