### PR TITLE
corretto{11,17,21}: {11.0.25.9.1,17.0.13.11.1,21.0.5.11.1} -> {11.0.2…

### DIFF
--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -26,12 +26,12 @@ let
       # Corretto, too.
       "--disable-warnings-as-errors"
     ];
-    version = "11.0.25.9.1";
+    version = "11.0.26.4.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-11";
       rev = version;
-      hash = "sha256-ewGGj4BHmwoPdULeT3PSI0Fo9T3cFbTO7cZXhzuKISY=";
+      hash = "sha256-buJlSvmyOVeMwaP9oDcHhG+Sabr1exf0nRUt4O7MaIY=";
     };
   };
 in

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -21,12 +21,12 @@ let
       ;
     jdk = jdk17;
     gradle = gradle_7;
-    version = "17.0.13.11.1";
+    version = "17.0.14.7.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-17";
       rev = version;
-      hash = "sha256-2jMre5aI02uDFjSgToTyVNriyb4EuZ01lKsNi822o5Q=";
+      hash = "sha256-ohQrguEJ8QvTaNjyQxKFujGhXNxCQTGkLILurzD7cy0=";
     };
   };
 in

--- a/pkgs/development/compilers/corretto/21.nix
+++ b/pkgs/development/compilers/corretto/21.nix
@@ -21,12 +21,12 @@ let
       ;
     jdk = jdk21;
     gradle = gradle_7;
-    version = "21.0.5.11.1";
+    version = "21.0.6.7.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-21";
       rev = version;
-      hash = "sha256-Df2Pq2aPrTxD4FeqG12apE/USfQULmMGsDsgXrmCINc=";
+      hash = "sha256-kF7Quf8bU5scfunmwfEYLkje/jEJOx7CFnBIUWCovzI=";
     };
   };
 in

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -18,12 +18,13 @@
 # builds. However, Corretto uses `gradle` as build tool (which in turn will
 # invoke `make`). The configure/build phases are adapted as needed.
 
-let
-  pname = "corretto";
-in
 # The version scheme is different between OpenJDK & Corretto.
 # See https://github.com/corretto/corretto-17/blob/release-17.0.8.8.1/build.gradle#L40
 # "major.minor.security.build.revision"
+let
+  majorVersion = builtins.head (lib.strings.splitString "." version); # same as "featureVersion" for OpenJDK
+  pname = "corretto${majorVersion}";
+in
 jdk.overrideAttrs (
   finalAttrs: oldAttrs: {
     inherit pname version src;


### PR DESCRIPTION
…6.4.1,17.0.14.7.1,21.0.6.7.1}

I explored whether it's possible to decouple the corretto build from the jdk build (currently, `jdk.overrideAtrs` is used). I looked into the [code](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/development/compilers/openjdk/generic.nix) for the jdk compilation in more detail and figured it would be way to much work (and probably a lot of copy-and-paste) to do that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
