### PR TITLE
Revert "ecryptfs: add test to release-combined.nix"

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -85,7 +85,6 @@ rec {
         (onFullSupported "nixos.tests.containers-imperative")
         (onFullSupported "nixos.tests.containers-ip")
         (onSystems [ "x86_64-linux" ] "nixos.tests.docker")
-        (onFullSupported "nixos.tests.ecryptfs")
         (onFullSupported "nixos.tests.env")
 
         # Way too many manual retries required on Hydra.


### PR DESCRIPTION
This reverts commit de80d0544caecb797df40fa108710c801f38bf27. Well, not a pure revert, but logically yes.
It's been so many years, and this version is almost 9 years old, and now it won't even build anymore.  Anyway, it shouldn't be a blocker.
https://hydra.nixos.org/build/292468814/nixlog/4/tail


_The normal checklist doesn't apply really._
<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
