### PR TITLE
msieve: unbreak on GCC 14

### DIFF
--- a/pkgs/by-name/ms/msieve/package.nix
+++ b/pkgs/by-name/ms/msieve/package.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-6ErVn4pYPMG5VFjOQURLsHNpN0pGdp55+rjY8988onU=";
   };
 
+  patches = [ ./savefile_t-pointer-type.patch ];
+
   buildInputs = [
     zlib
     gmp
@@ -30,6 +32,8 @@ stdenv.mkDerivation rec {
     "CC=${stdenv.cc.targetPrefix}cc"
     "all"
   ];
+
+  enableParallelBuilding = true;
 
   installPhase = ''
     mkdir -p $out/bin/

--- a/pkgs/by-name/ms/msieve/savefile_t-pointer-type.patch
+++ b/pkgs/by-name/ms/msieve/savefile_t-pointer-type.patch
@@ -1,0 +1,31 @@
+Index: include/msieve.h
+===================================================================
+--- a/include/msieve.h
++++ b/include/msieve.h
+@@ -100,9 +100,9 @@
+ 	HANDLE file_handle;
+ 	uint32 read_size;
+ 	uint32 eof;
+ #else
+-	gzFile *fp;
++	gzFile fp;
+ 	char isCompressed;
+ 	char is_a_FILE;
+ #endif
+ 	char *name;
+
+Index: common/savefile.c
+===================================================================
+--- a/common/savefile.c
++++ b/common/savefile.c
+@@ -151,9 +151,9 @@
+ 			   so we will fopen a FILE to append plainly */
+ 			fclose(fp);
+ 		}
+ 		if (s->is_a_FILE) {
+-			s->fp = (gzFile *)fopen(s->name, "a");
++			s->fp = (gzFile)fopen(s->name, "a");
+ 		} else {
+ 			s->fp = gzopen(s->name, "a");
+ 			s->isCompressed = 1;
+ 		}


### PR DESCRIPTION
Patch `gzFile *fp` to `gzFile fp` in order to fix pointer compatibility enforced since GCC 14.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
