### PR TITLE
ibus-table-chinese: Fix missing share/ibus-table

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -66,6 +66,11 @@ stdenv.mkDerivation {
     export HOME=$(mktemp -d)/ibus-table-chinese
   '';
 
+  # Fix missing share/ibus-table, see https://github.com/NixOS/nixpkgs/issues/392191
+  postInstall = ''
+    cp -r /build/source/share/ibus-table $out/share
+  '';
+
   postFixup = ''
     rm -rf $HOME
   '';

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -8,6 +8,7 @@
   ibus-table,
   python3,
   cmake,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -62,22 +63,15 @@ stdenv.mkDerivation {
   # FileExistsError: [Errno 17] File exists: '/build/tmp.BfVAUM4llr/ibus-table-chinese/.local/share/ibus-table'
   enableParallelBuilding = false;
 
-  preBuild = ''
-    export HOME=$(mktemp -d)/ibus-table-chinese
-  '';
-
   # Fix missing share/ibus-table, see https://github.com/NixOS/nixpkgs/issues/392191
   postInstall = ''
     cp -r /build/source/share/ibus-table $out/share
   '';
 
-  postFixup = ''
-    rm -rf $HOME
-  '';
-
   nativeBuildInputs = [
     cmake
     pkg-config
+    writableTmpDirAsHomeHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/392191.

Add `postInstall` to copy `share/ibus-table`.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
