### PR TITLE
python3Packages.motmetrics: unbreak, 1.4.0-unstable-20240130 -> 1.4.0-unstable-2025-01-14

### DIFF
--- a/pkgs/development/python-modules/motmetrics/default.nix
+++ b/pkgs/development/python-modules/motmetrics/default.nix
@@ -25,14 +25,14 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "cheind";
     repo = "py-motmetrics";
-    # latest release is not compatible with pandas 2.0
+    # Latest release is not compatible with pandas 2.0
     rev = "c199b3e853d589af4b6a7d88f5bcc8b8802fc434";
     hash = "sha256-DJ82nioW3jdIVo1B623BE8bBhVa1oMzYIkhhit4Z4dg=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     pandas
     scipy
@@ -44,11 +44,14 @@ buildPythonPackage {
     pytest-benchmark
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [ "motmetrics" ];
 
   meta = with lib; {
-    description = "Bar_chart: Benchmark multiple object trackers (MOT) in Python";
+    description = "Benchmark multiple object trackers (MOT) in Python";
     homepage = "https://github.com/cheind/py-motmetrics";
+    changelog = "https://github.com/cheind/py-motmetrics/releases/tag/${version}";
     license = licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/motmetrics/default.nix
+++ b/pkgs/development/python-modules/motmetrics/default.nix
@@ -19,15 +19,15 @@
 
 buildPythonPackage {
   pname = "motmetrics";
-  version = "1.4.0-unstable-20240130";
+  version = "1.4.0-unstable-2025-01-14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cheind";
     repo = "py-motmetrics";
     # latest release is not compatible with pandas 2.0
-    rev = "7210fcce0be1b76c96a62f6fe4ddbc90d944eacb";
-    hash = "sha256-7LKLHXWgW4QpivAgzvWl6qEG0auVvpiZ6bfDViCKsFY=";
+    rev = "c199b3e853d589af4b6a7d88f5bcc8b8802fc434";
+    hash = "sha256-DJ82nioW3jdIVo1B623BE8bBhVa1oMzYIkhhit4Z4dg=";
   };
 
   nativeBuildInputs = [ setuptools ];


### PR DESCRIPTION
Updated to fix tests build as NumPy 2.0 removed `np.asfarray` in favor of `np.asarray`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
