### PR TITLE
gnat14: add aarch64-linux support

### DIFF
--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, autoPatchelfHook, fetchzip, xz, ncurses5, ncurses, readline, gmp, mpfr
-, expat, libipt, zlib, dejagnu, sourceHighlight, python3, elfutils, guile, glibc
+, expat, libipt, zlib, zstd, dejagnu, sourceHighlight, python3, elfutils, guile, glibc
 , majorVersion
 }:
 
@@ -69,6 +69,11 @@ stdenv.mkDerivation(finalAttrs:
         hash = "sha256-pH3IuOpCM9sY/ppTYcxBmgpsUiMrisIjmAa/rmmZXb4=";
         upstreamTriplet = "x86_64-pc-linux-gnu";
       };
+      aarch64-linux = {
+        inherit url;
+        hash = "sha256-SVW/0yyj6ZH1GAjvD+unII+zSLGd3KGFt1bjjQ3SEFU=";
+        upstreamTriplet = "aarch64-linux-gnu";
+      };
     }.${stdenv.hostPlatform.system} or throwUnsupportedSystem;
   };
   inherit (versionMap.${majorVersion}) gccVersion alireRevision upstreamTriplet;
@@ -101,6 +106,8 @@ in {
 
   buildInputs = [
     expat
+  ] ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    zstd
   ] ++ lib.optionals (lib.versionAtLeast majorVersion "13") [
     ncurses
   ] ++ lib.optionals (lib.versionOlder majorVersion "13") [
@@ -187,7 +194,7 @@ in {
     homepage = "https://www.gnu.org/software/gnat";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ethindp ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })


### PR DESCRIPTION
…enables gnat14 to build.


<!--
Since version 14 the repository from which we get the binaries for this bootstrap gnat compiler also provides linux-aarch64 packges. This new derivation makes use of that. It adds a new dependency that is needed in the build process. This addition to the derivation enables also the gnat14 package to build without further modification.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
