### PR TITLE
luaPackages.fzf-lua: fix flaky test

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -159,6 +159,15 @@ in
   });
 
   fzf-lua = prev.fzf-lua.overrideAttrs {
+    patches = [
+      # https://github.com/ibhagwan/fzf-lua/pull/1914
+      (fetchpatch {
+        name = "fix-flaky-test.patch"; # Not a fix for Darwin
+        url = "https://github.com/midchildan/fzf-lua/commit/97328ccb7674ec3031b33c1fee616c93f4d1cd08.patch";
+        hash = "sha256-4mCub9k1LeSvJUL94uaFW/pbYSZTFQQrFpvEwIFlRAs=";
+      })
+    ];
+
     # FIXME: Darwin flaky tests
     # address already in use on second test run
     # Previewer transient failure


### PR DESCRIPTION
Fix a flaky test in fzf-lua that's causing build failures.

https://hydra.nixos.org/build/292958691

I submitted a fix upstream in https://github.com/ibhagwan/fzf-lua/pull/1914, but marked it as draft because it's yet to be seen if this will actually resolve the issue on Hydra.

I was able to fix the same error on my own GitHub Actions workflow though.

- [Failing commit](https://github.com/midchildan/dotfiles/commit/3f82a4e82bbfd9d1471ba40863d19ed24cb949ee)
- ~[Fixed commit](https://github.com/midchildan/dotfiles/commit/dcf915a4af10b18d7c8972cfb97e86f833fdb1b0)~ This just coincidentally passed because the overlay didn't properly apply to `vimPlugins.fzf-lua` due to multiple mistakes. [Another fix](https://github.com/midchildan/dotfiles/commit/87bcb7bb7373274016fc18a16957adc7e1c36ad3) did pass though, but this could be by coincidence too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
