### PR TITLE
nixos/geoclue2: add options for static source

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -578,6 +578,8 @@
 
 - GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
+- [`services.geoclue2`](#opt-services.geoclue2.enable) now has an `enableStatic` option, which allows the NixOS configuration to specify a fixed location for GeoClue to use.
+
 - [`services.mongodb`](#opt-services.mongodb.enable) is now compatible with the `mongodb-ce` binary package. To make use of it, set [`services.mongodb.package`](#opt-services.mongodb.package) to `pkgs.mongodb-ce`.
 
 - [`services.jupyter`](#opt-services.jupyter.enable) is now compatible with `Jupyter Notebook 7`. See [the migration guide](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html) for details.

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -136,6 +136,48 @@ in
         '';
       };
 
+      enableStatic = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to enable the static source. This source defines a fixed
+          location using the `staticLatitude`, `staticLongitude`,
+          `staticAltitude`, and `staticAccuracy` options.
+
+          Setting `enableStatic` to true will disable all other sources, to
+          prevent conflicts. Use `lib.mkForce true` when enabling other sources
+          if for some reason you want to override this.
+        '';
+      };
+
+      staticLatitude = lib.mkOption {
+        type = lib.types.numbers.between (-90) 90;
+        description = ''
+          Latitude to use for the static source. Defaults to `location.latitude`.
+        '';
+      };
+
+      staticLongitude = lib.mkOption {
+        type = lib.types.numbers.between (-180) 180;
+        description = ''
+          Longitude to use for the static source. Defaults to `location.longitude`.
+        '';
+      };
+
+      staticAltitude = lib.mkOption {
+        type = lib.types.number;
+        description = ''
+          Altitude in meters to use for the static source.
+        '';
+      };
+
+      staticAccuracy = lib.mkOption {
+        type = lib.types.numbers.positive;
+        description = ''
+          Accuracy radius in meters to use for the static source.
+        '';
+      };
+
       geoProviderUrl = lib.mkOption {
         type = lib.types.str;
         default = "https://location.services.mozilla.com/v1/geolocate?key=geoclue";
@@ -224,6 +266,16 @@ in
       groups.geoclue = { };
     };
 
+    services.geoclue2 = {
+      enable3G = lib.mkIf cfg.enableStatic false;
+      enableCDMA = lib.mkIf cfg.enableStatic false;
+      enableModemGPS = lib.mkIf cfg.enableStatic false;
+      enableNmea = lib.mkIf cfg.enableStatic false;
+      enableWifi = lib.mkIf cfg.enableStatic false;
+      staticLatitude = lib.mkDefault config.location.latitude;
+      staticLongitude = lib.mkDefault config.location.longitude;
+    };
+
     systemd.services.geoclue = {
       wants = lib.optionals cfg.enableWifi [ "network-online.target" ];
       after = lib.optionals cfg.enableWifi [ "network-online.target" ];
@@ -284,16 +336,33 @@ in
         modem-gps = {
           enable = cfg.enableModemGPS;
         };
-        wifi = {
-          enable = cfg.enableWifi;
-          url = cfg.geoProviderUrl;
-          submit-data = lib.boolToString cfg.submitData;
-          submission-url = cfg.submissionUrl;
-          submission-nick = cfg.submissionNick;
+        wifi =
+          {
+            enable = cfg.enableWifi;
+          }
+          // lib.optionalAttrs cfg.enableWifi {
+            url = cfg.geoProviderUrl;
+            submit-data = lib.boolToString cfg.submitData;
+            submission-url = cfg.submissionUrl;
+            submission-nick = cfg.submissionNick;
+          };
+        static-source = {
+          enable = cfg.enableStatic;
         };
       }
       // lib.mapAttrs' appConfigToINICompatible cfg.appConfig
     );
+
+    environment.etc.geolocation = lib.mkIf cfg.enableStatic {
+      mode = "0440";
+      group = "geoclue";
+      text = ''
+        ${toString cfg.staticLatitude}
+        ${toString cfg.staticLongitude}
+        ${toString cfg.staticAltitude}
+        ${toString cfg.staticAccuracy}
+      '';
+    };
   };
 
   meta = with lib; {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -455,6 +455,7 @@ in {
   garage = handleTest ./garage {};
   gatus = runTest ./gatus.nix;
   gemstash = handleTest ./gemstash.nix {};
+  geoclue2 = runTest ./geoclue2.nix;
   geoserver = runTest ./geoserver.nix;
   gerrit = handleTest ./gerrit.nix {};
   geth = handleTest ./geth.nix {};

--- a/nixos/tests/geoclue2.nix
+++ b/nixos/tests/geoclue2.nix
@@ -1,0 +1,36 @@
+{ config, lib, ... }:
+{
+  name = "geoclue2";
+  meta = {
+    maintainers = with lib.maintainers; [ rhendric ];
+  };
+
+  nodes.machine = {
+    imports = [ common/user-account.nix ];
+
+    location = {
+      latitude = 12.345;
+      longitude = -67.890;
+    };
+
+    services.geoclue2 = {
+      enable = true;
+      enableDemoAgent = true;
+      enableStatic = true;
+      staticAltitude = 123.45;
+      staticAccuracy = 1000;
+    };
+  };
+
+  testScript =
+    let
+      inherit (config.node) pkgs;
+    in
+    ''
+      whereAmI = machine.succeed('machinectl shell alice@.host ${pkgs.geoclue2}/libexec/geoclue-2.0/demos/where-am-i -t 5')
+      assert ("Latitude:    12.345000°" in whereAmI), f"Incorrect latitude in:\n{whereAmI}"
+      assert ("Longitude:   -67.890000°" in whereAmI), f"Incorrect longitude in:\n{whereAmI}"
+      assert ("Altitude:    123.450000 meters" in whereAmI), f"Incorrect altitude in:\n{whereAmI}"
+      assert ("Accuracy:    1000.000000 meters" in whereAmI), f"Incorrect accuracy in:\n{whereAmI}"
+    '';
+}

--- a/pkgs/by-name/ge/geoclue2/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/ge/geoclue2/add-option-for-installation-sysconfdir.patch
@@ -2,14 +2,6 @@ diff --git a/data/meson.build b/data/meson.build
 index b22ff55..01c5910 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -1,6 +1,6 @@
- if get_option('enable-backend')
-     conf = configuration_data()
--    conf.set('sysconfdir', sysconfdir)
-+    conf.set('sysconfdir', sysconfdir_install)
- 
-     if get_option('demo-agent')
-         conf.set('demo_agent', 'geoclue-demo-agent;')
 @@ -14,7 +14,7 @@ if get_option('enable-backend')
          conf.set('default_wifi_enable', 'false')
      endif
@@ -19,15 +11,6 @@ index b22ff55..01c5910 100644
      configure_file(output: 'geoclue.conf',
                     input: 'geoclue.conf.in',
                     configuration: conf,
-@@ -23,7 +23,7 @@ if get_option('enable-backend')
-     conf = configuration_data()
-     conf.set('libexecdir', libexecdir)
-     conf.set('dbus_srv_user', get_option('dbus-srv-user'))
--    conf.set('sysconfdir', sysconfdir)
-+    conf.set('sysconfdir', sysconfdir_install)
- 
-     confd_dir = join_paths(conf_dir, 'conf.d')
-     install_emptydir(confd_dir)
 diff --git a/demo/meson.build b/demo/meson.build
 index 1427fbe..2623f16 100644
 --- a/demo/meson.build

--- a/pkgs/by-name/ge/geoclue2/package.nix
+++ b/pkgs/by-name/ge/geoclue2/package.nix
@@ -24,6 +24,7 @@
   vala,
   withDemoAgent ? false,
   nix-update-script,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -107,7 +108,12 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs demo/install-file.py
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) geoclue2;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin && withDemoAgent;


### PR DESCRIPTION
As an alternative to discovering location via hardware or geolocation web services or the like, GeoClue supports a ‘static source’ that will read location data from a file in `/etc`. This PR adds support for configuring that source to the `geoclue2` module, and fixes the `geoclue2` package so that it reads from the correct location.

Spiritually connected to #64309, which created the `location.latitude` and `location.longitude` properties. I was somewhat torn on whether to add `altitude` and `accuracy` alongside them, or to keep those specific to the `geoclue2` module as I ultimately did. @infinisil, maybe you have an opinion?

Also, it might make sense to enable the static source if `location.provider == "manual"`, but if that's a good idea it should probably be gated by a `stateVersion` check to ensure that nobody's GeoClue setup stops working unexpectedly, since `location.provider = "manual"` is the default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
