### PR TITLE
globalplatform: init at 2.4.0-unstable-2025-03-23

### DIFF
--- a/pkgs/by-name/gl/globalplatform/package.nix
+++ b/pkgs/by-name/gl/globalplatform/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pcsclite,
+  PCSC,
+  pkg-config,
+  cmake,
+  zlib,
+  pandoc,
+  doxygen,
+  graphviz,
+  openssl,
+  cmocka,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "globalplatform";
+  version = "2.4.0-unstable-2025-03-23";
+
+  src = fetchFromGitHub {
+    owner = "kaoh";
+    repo = "globalplatform";
+    rev = "0f970751c5d9e8a7030f897ca2d1b86d0eeba4c2";
+    sha256 = "sha256-H/muc/gY5glXPWKj75fHi6+1DAP91YGAUefdQkX9nfk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    pandoc
+    doxygen
+    graphviz
+  ];
+
+  buildInputs =
+    [
+      zlib
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      pcsclite
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      PCSC
+    ];
+
+  cmakeFlags = [
+    "-DTESTING=ON"
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    cmocka
+  ];
+
+  preCheck = ''
+    cp "$src/gpshell/helloworld.cap" globalplatform/src
+    cp "$src/globalplatform/src/rsa_pub_key_test.pem" globalplatform/src
+  '';
+
+  # libglobalplatform.so uses dlopen() to load specified connection plugins at runtime.
+  # Currently, libgppcscconnectionplugin.so is the only plugin included.
+  # The user has to specify custom plugin locations by setting LD_LIBRARY_PATH.
+
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf $out/lib/libglobalplatform.so --add-rpath "$out/lib"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -add_rpath "$out/lib" "$out/lib/libglobalplatform.dylib"
+    '';
+
+  meta = {
+    description = "C library + command-line for Open- / GlobalPlatform smart cards";
+    mainProgram = "gpshell";
+    homepage = "https://github.com/kaoh/globalplatform";
+    # Clarify license for GPShell
+    # https://github.com/kaoh/globalplatform/issues/81
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ stargate01 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3375,6 +3375,10 @@ with pkgs;
 
   gitqlient = libsForQt5.callPackage ../applications/version-management/gitqlient { };
 
+  globalplatform = callPackage ../by-name/gl/globalplatform/package.nix {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
+  };
+
   glogg = libsForQt5.callPackage ../tools/text/glogg { };
 
   gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {


### PR DESCRIPTION
This PR adds the libraries and tools of https://github.com/kaoh/globalplatform , most notably the `gpshell` smartcard management tool. It provides a similar functionality to the already packaged `global-platform-pro` software, but uses scripted batch processing instead of an interactive CLI.

I wanted to package the upstream 2.4.0 tagged release directly, but since then some very useful PRs were accepted, without which the software does not even compile properly on NixOS. I have also taken care to enable and run all provided automatic tests.

I have added support for Darwin on a best-effort basis, but I do not have a system to test with. Upstream claims to support it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
