### PR TITLE
Revert "expat: 2.6.4 -> 2.7.0"

### DIFF
--- a/pkgs/by-name/ex/expat/package.nix
+++ b/pkgs/by-name/ex/expat/package.nix
@@ -18,7 +18,7 @@
 # files.
 
 let
-  version = "2.7.0";
+  version = "2.6.4";
   tag = "R_${lib.replaceStrings [ "." ] [ "_" ] version}";
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     url =
       with finalAttrs;
       "https://github.com/libexpat/libexpat/releases/download/${tag}/${pname}-${version}.tar.xz";
-    hash = "sha256-Jd8T3SgZ6F+yehzgQxdytwR9cq+BrnjcJrTG4IBfSNE=";
+    hash = "sha256-ppVina4EcFWzfVCg/0d20dRdCkyELPTM7hWEQfVf9+4=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#390052

Failures with the perl XML-Parser package as tracked by https://github.com/cpan-authors/XML-Parser/issues/104. Looks like upstream won't have a fix soon so let's unblock staging.