### PR TITLE
immich-go: 0.22.1 -> 0.25.0

### DIFF
--- a/pkgs/by-name/im/immich-go/package.nix
+++ b/pkgs/by-name/im/immich-go/package.nix
@@ -5,16 +5,17 @@
   nix-update-script,
   testers,
   immich-go,
+  writableTmpDirAsHomeHook,
 }:
 buildGoModule rec {
   pname = "immich-go";
-  version = "0.22.1";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "simulot";
     repo = "immich-go";
-    rev = "${version}";
-    hash = "sha256-6bLjHKkEghbY+UQFrgbfeHwOjtks1HjXbDXEr7DuJbU=";
+    tag = "v${version}";
+    hash = "sha256-C7QfuCJNraOan6N67k7k30hKwJUDzRCNvWpJM3N328s=";
 
     # Inspired by: https://github.com/NixOS/nixpkgs/blob/f2d7a289c5a5ece8521dd082b81ac7e4a57c2c5c/pkgs/applications/graphics/pdfcpu/default.nix#L20-L32
     # The intention here is to write the information into files in the `src`'s
@@ -31,27 +32,31 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-jED1K2zHv60zxMY4P7Z739uzf7PtlsnvZyStOSLKi4M=";
+  vendorHash = "sha256-J8vqii0X6GGmOCJ6L9lILz9NQEPa7Idg/ULrdRqBS9U=";
 
   # options used by upstream:
-  # https://github.com/simulot/immich-go/blob/0.13.2/.goreleaser.yaml
+  # https://github.com/simulot/immich-go/blob/v0.25.0/.goreleaser.yaml
   ldflags = [
     "-s"
     "-w"
     "-extldflags=-static"
-    "-X main.version=${version}"
+    "-X github.com/simulot/immich-go/app.Version=${version}"
   ];
 
   preBuild = ''
-    ldflags+=" -X main.commit=$(cat COMMIT)"
-    ldflags+=" -X main.date=$(cat SOURCE_DATE)"
+    ldflags+=" -X github.com/simulot/immich-go/Commit=$(cat COMMIT)"
+    ldflags+=" -X github.com/simulot/immich-go/Date=$(cat SOURCE_DATE)"
   '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
   passthru = {
     updateScript = nix-update-script { };
     tests.versionTest = testers.testVersion {
       package = immich-go;
-      command = "immich-go -version";
+      command = "immich-go --version";
       version = version;
     };
   };
@@ -66,6 +71,6 @@ buildGoModule rec {
     mainProgram = "immich-go";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ kai-tub ];
-    changelog = "https://github.com/simulot/immich-go/releases/tag/${version}";
+    changelog = "https://github.com/simulot/immich-go/releases/tag/${src.tag}";
   };
 }


### PR DESCRIPTION
Diff: https://github.com/simulot/immich-go/compare/0.22.1...v0.25.0

Changelog: https://github.com/simulot/immich-go/releases/tag/v0.25.0



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Fixes #391527 and should fix the update bot.