### PR TITLE
apriltag: init at v3.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18682,6 +18682,12 @@
     githubId = 88469;
     name = "Jaime Breva";
   };
+  phodina = {
+    email = "phodina@protonmail.com";
+    github = "phodina";
+    githubId = 2997905;
+    name = "Petr Hodina";
+  };
   photex = {
     email = "photex@gmail.com";
     github = "photex";

--- a/pkgs/by-name/ap/apriltag/package.nix
+++ b/pkgs/by-name/ap/apriltag/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  python3Packages,
+  nix-update-script,
+}:
+
+let
+  opencv4WithGtk = python3Packages.opencv4.override {
+    enableGtk2 = true; # For GTK2 support
+    enableGtk3 = true; # For GTK3 support
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "apriltags";
+  version = "3.4.3";
+
+  src = fetchFromGitHub {
+    owner = "AprilRobotics";
+    repo = "AprilTags";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1XbsyyadUvBZSpIc9KPGiTcp+3G7YqHepWoORob01Ss=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [ opencv4WithGtk ];
+
+  cmakeFlags = [ (lib.cmakeBool "BUILD_EXAMPLES" true) ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Visual fiducial system popular for robotics research";
+    homepage = "https://april.eecs.umich.edu/software/apriltag";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Add new package for Computer Vision - `apriltag`.

https://april.eecs.umich.edu/software/apriltag
https://github.com/AprilRobotics/apriltag


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Other PRs:
- https://github.com/NixOS/nixpkgs/pull/392321
