### PR TITLE
Revert "cargo-about: 0.6.6 -> 0.7.1"

### DIFF
--- a/pkgs/by-name/ca/cargo-about/package.nix
+++ b/pkgs/by-name/ca/cargo-about/package.nix
@@ -10,17 +10,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-about";
-  version = "0.7.1";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-about";
     rev = version;
-    sha256 = "sha256-h5+Fp6+yGa1quJENsCv6WE4NC2A+ceIGMXVWyeTPPLQ=";
+    sha256 = "sha256-6jza0IHdX7vyjZt1lknoVhlu7RONF5SnTdn7EDsj2oo=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-JTcRYdBZdXxM7r+XZSbFaAeWrJ5HULM1YE3p3smRW/Q=";
+  cargoHash = "sha256-MXUfldlAu+SezlNi0QbqKJ/ddJiKCrs4bi4ryG68EPU=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#392011

I messed up, as this broke `zed-editor`. I am not in a position right now to fix `zed-editor`, so I propose to revert this patch to unbreak it.

If someone else wants to chime in and fix the `zed-editor` (which would be the preferred way of course), that'd be awesome!