### PR TITLE
time-decode: 7.0.2 -> 9.0.0, python313Packages.juliandate: init at 1.0.5

### DIFF
--- a/pkgs/by-name/ti/time-decode/package.nix
+++ b/pkgs/by-name/ti/time-decode/package.nix
@@ -6,38 +6,37 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "time-decode";
-  version = "7.0.2";
+  version = "9.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "digitalsleuth";
     repo = "time_decode";
     tag = "v${version}";
-    hash = "sha256-K60xIQ6TWPYlsR6YjIquey5Ioaw4oAId59CPlQNK4yk=";
+    hash = "sha256-kydH5WN2PELq6YnoSBFRsyVnxL+0r09WxXuqFANXuNs=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    setuptools
-  ];
+  nativeBuildInputs = with python3.pkgs; [ setuptools ];
 
   propagatedBuildInputs = with python3.pkgs; [
     colorama
-    python-dateutil
+    juliandate
     pyqt6
+    python-dateutil
+    pytz
+    tzdata
   ];
 
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "time_decode"
-  ];
+  pythonImportsCheck = [ "time_decode" ];
 
   meta = with lib; {
     description = "Timestamp and date decoder";
     homepage = "https://github.com/digitalsleuth/time_decode";
     changelog = "https://github.com/digitalsleuth/time_decode/releases/tag/v${version}";
-    license = with licenses; [ mit ];
+    license = licenses.mit;
     maintainers = with maintainers; [ fab ];
     mainProgram = "time-decode";
   };

--- a/pkgs/development/python-modules/juliandate/default.nix
+++ b/pkgs/development/python-modules/juliandate/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "juliandate";
+  version = "1.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "seanredmond";
+    repo = "juliandate";
+    tag = "v${version}";
+    hash = "sha256-pOWyrPBFqKmG9oKbXY/L14LblIcc8KfZSqZAEQP29V8=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "juliandate" ];
+
+  meta = {
+    description = "Conversions between Julian Dates and Julian/Gregorian calendar dates";
+    homepage = "https://github.com/seanredmond/juliandate";
+    changelog = "https://github.com/seanredmond/juliandate/blob/v${src.tag}/HISTORY.MD";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6966,6 +6966,8 @@ self: super: with self; {
 
   jug = callPackage ../development/python-modules/jug { };
 
+  juliandate = callPackage ../development/python-modules/juliandate { };
+
   julius = callPackage ../development/python-modules/julius { };
 
   junitparser = callPackage ../development/python-modules/junitparser { };


### PR DESCRIPTION
Diff: https://github.com/digitalsleuth/time_decode/compare/refs/tags/v7.0.2...v9.0.0

Changelog: https://github.com/digitalsleuth/time_decode/releases/tag/v9.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
