### PR TITLE
tinygo: 0.35.0 -> 0.37.0

### DIFF
--- a/pkgs/development/compilers/tinygo/0001-GNUmakefile.patch
+++ b/pkgs/development/compilers/tinygo/0001-GNUmakefile.patch
@@ -1,7 +1,7 @@
 diff --git a/GNUmakefile b/GNUmakefile
 --- a/GNUmakefile
 +++ b/GNUmakefile
-@@ -14,11 +14,6 @@ LLVM_VERSIONS = 18 17 16 15
+@@ -14,11 +14,6 @@ LLVM_VERSIONS = 19 18 17 16 15
  errifempty = $(if $(1),$(1),$(error $(2)))
  detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
  toolSearchPathsVersion = $(1)-$(2)
@@ -13,26 +13,27 @@ diff --git a/GNUmakefile b/GNUmakefile
  # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
  findLLVMTool = $(call detect,$(1),$(abspath llvm-build/bin/$(1)) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
  CLANG ?= $(call findLLVMTool,clang)
-@@ -848,9 +843,8 @@ endif
+@@ -939,10 +934,9 @@ endif
  wasmtest:
  	$(GO) test ./tests/wasm
  
 -build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
 +build/release:
  	@mkdir -p build/release/tinygo/bin
+ 	@mkdir -p build/release/tinygo/lib/bdwgc
 -	@mkdir -p build/release/tinygo/lib/clang/include
  	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
  	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
  	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-@@ -871,7 +865,6 @@ build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN
- ifneq ($(USE_SYSTEM_BINARYEN),1)
+@@ -964,7 +958,6 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
  	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
  endif
+ 	@cp -rp lib/bdwgc/*                  build/release/tinygo/lib/bdwgc
 -	@cp -p $(abspath $(CLANG_SRC))/lib/Headers/*.h build/release/tinygo/lib/clang/include
  	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
  	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
  	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
-@@ -927,8 +920,7 @@ endif
+@@ -1026,8 +1019,7 @@ endif
  	@cp -rp lib/wasi-libc/libc-top-half/musl/include                build/release/tinygo/lib/wasi-libc/libc-top-half/musl
  	@cp -rp lib/wasi-libc/sysroot                                   build/release/tinygo/lib/wasi-libc/sysroot
  	@cp -rp lib/wasi-cli/wit                                        build/release/tinygo/lib/wasi-cli/wit
@@ -43,5 +44,5 @@ diff --git a/GNUmakefile b/GNUmakefile
  	@cp -rp targets                      build/release/tinygo/targets
  
 -- 
-2.37.2
+2.48.1
 

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -34,13 +34,13 @@ in
 
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.35.0";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    hash = "sha256-oy6797o3lMMRJ+bPHY59Bv7mX25aEwBn4OslAohfY2g=";
+    hash = "sha256-I/9JXjt6aF/80Mh3iRgUYXv4l+m3XIpmKsIBviOuWCo=";
     fetchSubmodules = true;
     # The public hydra server on `hydra.nixos.org` is configured with
     # `max_output_size` of 3GB. The purpose of this `postFetch` step
@@ -51,7 +51,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-aY1gX++Dc5/G6VFXnP7sBdekk2IKHlenOC0erlB/Quw=";
+  vendorHash = "sha256-juADakh+s8oEY9UXUwxknvVeL1TgB/zRi8Xtzt/4qPA=";
 
   patches = [
     ./0001-GNUmakefile.patch

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6676,9 +6676,7 @@ with pkgs;
 
   tinycc = darwin.apple_sdk_11_0.callPackage ../development/compilers/tinycc { };
 
-  tinygo = callPackage ../development/compilers/tinygo {
-    llvmPackages = llvmPackages_18;
-  };
+  tinygo = callPackage ../development/compilers/tinygo { };
 
   urweb = callPackage ../development/compilers/urweb {
     icu = icu67;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Update tinygo to 0.37.0: https://github.com/tinygo-org/tinygo/releases/tag/v0.37.0

@rvolosatovs has previously created PR https://github.com/NixOS/nixpkgs/pull/389791 to upgrade to 0.36.0. Since then the 0.37.0 was quickly released, so I made that jump. This required unsetting the llvm version pin (as mentioned by @muscaln) and redoing the GNUMake patch. Fair warning, I just reapplied the same patch again without understanding what it does exactly. (PS this is my first contribution, feel free to yell at me if I forgot something :+1: )


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
