### PR TITLE
xlink: init at 0-unstable-2025-14-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18682,6 +18682,12 @@
     githubId = 88469;
     name = "Jaime Breva";
   };
+  phodina = {
+    email = "phodina@protonmail.com";
+    github = "phodina";
+    githubId = 2997905;
+    name = "Petr Hodina";
+  };
   photex = {
     email = "photex@gmail.com";
     github = "photex";

--- a/pkgs/by-name/xl/xlink/001-remove-hunter.patch
+++ b/pkgs/by-name/xl/xlink/001-remove-hunter.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b6be6e8..057a056 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,12 +4,12 @@
+ 
+ cmake_minimum_required(VERSION 3.2)
+ 
+-include("cmake/HunterGate.cmake")
+-HunterGate(
+-    URL "https://github.com/cpp-pm/hunter/archive/9d9242b60d5236269f894efd3ddd60a9ca83dd7f.tar.gz"
+-    SHA1 "16cc954aa723bccd16ea45fc91a858d0c5246376"
+-    LOCAL # Local config for dependencies
+-)
++# include("cmake/HunterGate.cmake")
++# HunterGate(
++#     URL "https://github.com/cpp-pm/hunter/archive/9d9242b60d5236269f894efd3ddd60a9ca83dd7f.tar.gz"
++#     SHA1 "16cc954aa723bccd16ea45fc91a858d0c5246376"
++#     LOCAL # Local config for dependencies
++# )
+ 
+ ### Constants
+ set(TARGET_NAME "XLink")

--- a/pkgs/by-name/xl/xlink/package.nix
+++ b/pkgs/by-name/xl/xlink/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libusb1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlink";
+  version = "0-unstable-2025-14-03";
+
+  src = fetchFromGitHub {
+    owner = "luxonis";
+    repo = "XLink";
+    rev = "fe8b5450f545a2ebf26dbc093e98c0265d7f4029";
+    hash = "sha256-OTqJfTDudiNrdsDBe1Pg0T1dJcfneGXO/+AIbXpVfxk=";
+  };
+
+  outputs = [
+    "out"
+    "share"
+  ];
+
+  # Remove CMake Hunter package manager - needs network connection
+  patches = [
+    ./001-remove-hunter.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libusb1
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "XLINK_ENABLE_LIBUSB" true)
+    (lib.cmakeBool "XLINK_BUILD_EXAMPLES" true)
+    (lib.cmakeBool "XLINK_BUILD_TESTS" true)
+    (lib.cmakeBool "XLINK_LIBUSB_SYSTEM" true)
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+  ];
+
+  postInstall = ''
+    mkdir -p $out/include
+    mkdir -p $share/examples
+    mkdir -p $share/tests
+
+    cp -r $src/include/* $out/include/
+
+    examples=(
+      "boot_firmware"
+      "list_devices"
+      "boot_bootloader"
+      "search_devices"
+      "Makefile"
+      "device_connect_reset"
+    )
+
+    tests=(
+      "multiple_open_stream"
+      "multithreading_search_test"
+    )
+
+    find $buildDir
+    for file in "''${examples[@]}"; do
+      cp examples/$file $share/examples/$file
+    done
+    for file in "''${tests[@]}"; do
+      cp tests/$file $share/tests/$file
+    done
+  '';
+
+  meta = {
+    description = "XLink library for communication with Myriad VPUs";
+    homepage = "https://github.com/luxonis/XLink";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Library to access Intel MyriadX devices (e.g. Luxonis OAK cameras, Intel compute sticks ...)

https://github.com/luxonis/XLink

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).