### PR TITLE
xpilot-ng, bloodspilot-client, boodspilot-server: fix

### DIFF
--- a/pkgs/games/xpilot/bloodspilot-client.nix
+++ b/pkgs/games/xpilot/bloodspilot-client.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     sha256 = "1qwl95av5an2zl01m7saj6fyy49xpixga7gbn4lwbpgpqs1rbwxj";
   };
 
+  patches = [ ./bloodspilot-sdl-window-fix.patch ];
+
   buildInputs = [
     libX11
     SDL

--- a/pkgs/games/xpilot/bloodspilot-sdl-window-fix.patch
+++ b/pkgs/games/xpilot/bloodspilot-sdl-window-fix.patch
@@ -1,0 +1,95 @@
+--- a/src/client/sdl/scrap.c	2012-09-02 11:25:23.000000000 +0200
++++ b/src/client/sdl/scrap.c	2025-03-23 12:01:51.968751308 +0100
+@@ -71,13 +71,13 @@
+ #if defined(X11_SCRAP)
+ /* * */
+ static Display *SDL_Display;
+-static Window SDL_Window;
++static Window BloodsPilot_SDL_Window;
+ static void (*Lock_Display) (void);
+ static void (*Unlock_Display) (void);
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-static HWND SDL_Window;
++static HWND BloodsPilot_SDL_Window;
+ 
+ #elif defined(QNX_SCRAP)
+ /* * */
+@@ -274,7 +274,7 @@
+ /* * */
+ 		if (info.subsystem == SDL_SYSWM_X11) {
+ 			SDL_Display = info.info.x11.display;
+-			SDL_Window = info.info.x11.window;
++			BloodsPilot_SDL_Window = info.info.x11.window;
+ 			Lock_Display = info.info.x11.lock_func;
+ 			Unlock_Display = info.info.x11.unlock_func;
+ 
+@@ -290,7 +290,7 @@
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-		SDL_Window = info.window;
++		BloodsPilot_SDL_Window = info.window;
+ 		retval = 0;
+ 
+ #elif defined(QNX_SCRAP)
+@@ -310,12 +310,12 @@
+ #if defined(X11_SCRAP)
+ /* * */
+ 	Lock_Display();
+-	retval = (XGetSelectionOwner(SDL_Display, XA_PRIMARY) != SDL_Window);
++	retval = (XGetSelectionOwner(SDL_Display, XA_PRIMARY) != BloodsPilot_SDL_Window);
+ 	Unlock_Display();
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-	retval = (GetClipboardOwner() != SDL_Window);
++	retval = (GetClipboardOwner() != BloodsPilot_SDL_Window);
+ 
+ #elif defined(QNX_SCRAP)
+ /* * */
+@@ -346,14 +346,14 @@
+ 				(unsigned char *) dst, dstlen);
+ 		free(dst);
+ 		if (lost_scrap())
+-			XSetSelectionOwner(SDL_Display, XA_PRIMARY, SDL_Window,
++			XSetSelectionOwner(SDL_Display, XA_PRIMARY, BloodsPilot_SDL_Window,
+ 					   CurrentTime);
+ 		Unlock_Display();
+ 	}
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-	if (OpenClipboard(SDL_Window)) {
++	if (OpenClipboard(BloodsPilot_SDL_Window)) {
+ 		HANDLE hMem;
+ 
+ 		hMem = GlobalAlloc((GMEM_MOVEABLE | GMEM_DDESHARE), dstlen);
+@@ -441,7 +441,7 @@
+ 		Lock_Display();
+ 		owner = XGetSelectionOwner(SDL_Display, XA_PRIMARY);
+ 		Unlock_Display();
+-		if ((owner == None) || (owner == SDL_Window)) {
++		if ((owner == None) || (owner == BloodsPilot_SDL_Window)) {
+ 			owner = DefaultRootWindow(SDL_Display);
+ 			selection1 = XA_CUT_BUFFER0;
+ 		}
+@@ -449,7 +449,7 @@
+ 			int selection_response = 0;
+ 			SDL_Event event;
+ 
+-			owner = SDL_Window;
++			owner = BloodsPilot_SDL_Window;
+ 			Lock_Display();
+ 			selection1 = XInternAtom(SDL_Display, "SDL_SELECTION", False);
+ 			XConvertSelection(SDL_Display, XA_PRIMARY, format,
+@@ -485,7 +485,7 @@
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-	if (IsClipboardFormatAvailable(format) && OpenClipboard(SDL_Window)) {
++	if (IsClipboardFormatAvailable(format) && OpenClipboard(BloodsPilot_SDL_Window)) {
+ 		HANDLE hMem;
+ 		char *src;
+ 

--- a/pkgs/games/xpilot/bloodspilot-server-strcpy-fix.patch
+++ b/pkgs/games/xpilot/bloodspilot-server-strcpy-fix.patch
@@ -1,0 +1,40 @@
+Fortify catches a possible strcpy overcopy, throw more space at it
+
+--- a/src/server/contact.c	2010-05-24 14:51:41.000000000 +0200
++++ b/src/server/contact.c	2025-03-23 12:15:36.426805646 +0100
+@@ -58,11 +58,11 @@
+ 
+ struct queued_player {
+ 	struct queued_player *next;
+-	char real_name[MAX_CHARS];
+-	char nick_name[MAX_CHARS];
+-	char disp_name[MAX_CHARS];
+-	char host_name[MAX_CHARS];
+-	char host_addr[24];
++	char real_name[MAX_CHARS + 32];
++	char nick_name[MAX_CHARS + 32];
++	char disp_name[MAX_CHARS + 32];
++	char host_name[MAX_CHARS + 32];
++	char host_addr[1056];
+ 	int32_t port;
+ 	team_t *team;
+ 	uint32_t version;
+@@ -271,12 +271,12 @@
+ 	uint32_t my_magic;
+ 	uint16_t port;
+ 	char ch;
+-	char real_name[MAX_CHARS];
+-	char disp_name[MAX_CHARS];
+-	char nick_name[MAX_CHARS];
+-	char host_name[MAX_CHARS];
+-	char host_addr[24];
+-	char str[MSG_LEN];
++	char real_name[MAX_CHARS + 32 ];
++	char disp_name[MAX_CHARS + 32 ];
++	char nick_name[MAX_CHARS + 32 ];
++	char host_name[MAX_CHARS + 32 ];
++	char host_addr[1056];
++	char str[MSG_LEN + 32];
+ 
+ 	/*
+ 	 * Someone connected to us, now try and decipher the message :)

--- a/pkgs/games/xpilot/bloodspilot-server.nix
+++ b/pkgs/games/xpilot/bloodspilot-server.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./server-gcc5.patch
+    ./bloodspilot-server-strcpy-fix.patch
   ];
 
   meta = with lib; {

--- a/pkgs/games/xpilot/default.nix
+++ b/pkgs/games/xpilot/default.nix
@@ -4,6 +4,7 @@
   fetchurl,
   libX11,
   libSM,
+  libXext,
   SDL,
   libGLU,
   libGL,
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libX11
     libSM
+    libXext
     SDL
     SDL_ttf
     SDL_image
@@ -33,7 +35,10 @@ stdenv.mkDerivation rec {
     libXxf86misc
   ];
 
-  patches = [ ./xpilot-ng-gcc-14-fix.patch ];
+  patches = [
+    ./xpilot-ng-gcc-14-fix.patch
+    ./xpilot-ng-sdl-window-fix.patch
+  ];
 
   meta = with lib; {
     description = "Multiplayer X11 space combat game";

--- a/pkgs/games/xpilot/xpilot-ng-sdl-window-fix.patch
+++ b/pkgs/games/xpilot/xpilot-ng-sdl-window-fix.patch
@@ -1,0 +1,96 @@
+XPilot-NG uses SDL_Window (now an SDL type name) as a variable name
+
+--- a/src/client/sdl/scrap.c	2025-03-23 11:48:45.045699445 +0100
++++ b.src/client/sdl/scrap.c	2025-03-23 11:48:48.773699690 +0100
+@@ -57,13 +57,13 @@
+ #if defined(X11_SCRAP)
+ /* * */
+ static Display *SDL_Display;
+-static Window SDL_Window;
++static Window XPilot_SDL_Window;
+ static void (*Lock_Display)(void);
+ static void (*Unlock_Display)(void);
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-static HWND SDL_Window;
++static HWND XPilot_SDL_Window;
+ 
+ #elif defined(QNX_SCRAP)
+ /* * */
+@@ -285,7 +285,7 @@
+       if ( info.subsystem == SDL_SYSWM_X11 )
+         {
+           SDL_Display = info.info.x11.display;
+-          SDL_Window = info.info.x11.window;
++          XPilot_SDL_Window = info.info.x11.window;
+           Lock_Display = info.info.x11.lock_func;
+           Unlock_Display = info.info.x11.unlock_func;
+ 
+@@ -302,7 +302,7 @@
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-      SDL_Window = info.window;
++      XPilot_SDL_Window = info.window;
+       retval = 0;
+ 
+ #elif defined(QNX_SCRAP)
+@@ -323,12 +323,12 @@
+ #if defined(X11_SCRAP)
+ /* * */
+   Lock_Display();
+-  retval = ( XGetSelectionOwner(SDL_Display, XA_PRIMARY) != SDL_Window );
++  retval = ( XGetSelectionOwner(SDL_Display, XA_PRIMARY) != XPilot_SDL_Window );
+   Unlock_Display();
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-  retval = ( GetClipboardOwner() != SDL_Window );
++  retval = ( GetClipboardOwner() != XPilot_SDL_Window );
+ 
+ #elif defined(QNX_SCRAP)
+ /* * */
+@@ -360,13 +360,13 @@
+         XA_CUT_BUFFER0, format, 8, PropModeReplace, (unsigned char *)dst, dstlen);
+       free(dst);
+       if ( lost_scrap() )
+-        XSetSelectionOwner(SDL_Display, XA_PRIMARY, SDL_Window, CurrentTime);
++        XSetSelectionOwner(SDL_Display, XA_PRIMARY, XPilot_SDL_Window, CurrentTime);
+       Unlock_Display();
+     }
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-  if ( OpenClipboard(SDL_Window) )
++  if ( OpenClipboard(XPilot_SDL_Window) )
+     {
+       HANDLE hMem;
+ 
+@@ -461,7 +461,7 @@
+     Lock_Display();
+     owner = XGetSelectionOwner(SDL_Display, XA_PRIMARY);
+     Unlock_Display();
+-    if ( (owner == None) || (owner == SDL_Window) )
++    if ( (owner == None) || (owner == XPilot_SDL_Window) )
+       {
+         owner = DefaultRootWindow(SDL_Display);
+         selection1 = XA_CUT_BUFFER0;
+@@ -471,7 +471,7 @@
+         int selection_response = 0;
+         SDL_Event event;
+ 
+-        owner = SDL_Window;
++        owner = XPilot_SDL_Window;
+         Lock_Display();
+         selection1 = XInternAtom(SDL_Display, "SDL_SELECTION", False);
+         XConvertSelection(SDL_Display, XA_PRIMARY, format,
+@@ -511,7 +511,7 @@
+ 
+ #elif defined(WIN_SCRAP)
+ /* * */
+-  if ( IsClipboardFormatAvailable(format) && OpenClipboard(SDL_Window) )
++  if ( IsClipboardFormatAvailable(format) && OpenClipboard(XPilot_SDL_Window) )
+     {
+       HANDLE hMem;
+       char *src;


### PR DESCRIPTION
There were minor issues either building or running with «fortify» at the new default. Fixed.

As these are clear (and small) fixes of old games, and I am the only maintainer, will self-merge after CI.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
