### PR TITLE
nabi: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/na/nabi/package.nix
+++ b/pkgs/by-name/na/nabi/package.nix
@@ -1,34 +1,51 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   gtk2,
   libhangul,
+  autoconf,
+  automake,
 }:
 
 stdenv.mkDerivation rec {
   pname = "nabi";
-  version = "1.0.0";
+  version = "1.0.1";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/nabi/nabi-${version}.tar.gz";
-    sha256 = "0craa24pw7b70sh253arv9bg9sy4q3mhsjwfss3bnv5nf0xwnncw";
+  src = fetchFromGitHub {
+    owner = "libhangul";
+    repo = "nabi";
+    tag = "nabi-${version}";
+    hash = "sha256-C6K8sXVCGf45VZtGSCB5emFzZPV21kG9JxAwBHRiFsY=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+    automake
+  ];
+
   buildInputs = [
     gtk2
     libhangul
   ];
 
-  meta = with lib; {
+  postPatch = ''
+    patchShebangs ./autogen.sh
+  '';
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = {
     description = "Easy Hangul XIM";
     mainProgram = "nabi";
-    homepage = "https://github.com/choehwanjin/nabi";
+    homepage = "https://github.com/libhangul/nabi";
     changelog = "https://github.com/libhangul/nabi/blob/nabi-${version}/NEWS";
-    license = licenses.gpl2Plus;
-    maintainers = [ maintainers.ianwookim ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ianwookim ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
- update to 1.0.1
- switch `src` to `fetchFromGitHub` as there are no sources for 1.0.1
in "Google Code Archive"
- add `autoconf` and `automake` to run provided `autogen.sh`

---

Fixes build failure of `nabi` (fails since `2025-01-14`, GCC update to 14 #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.nabi.x86_64-linux
https://hydra.nixos.org/build/293040079
Error log:
```
handler.c: In function 'nabi_handler_forward_event':
handler.c:142:14: error: implicit declaration of function 'nabi_ic_lookup_keysym' []
  142 |     keysym = nabi_ic_lookup_keysym(ic, kevent);
      |              ^~~~~~~~~~~~~~~~~~~~~
```
Upstream issue: https://github.com/libhangul/nabi/issues/4
Upstream commit fixing it (included in `1.0.1`): https://github.com/libhangul/nabi/commit/11f55b4de0db41faff21f35f22b4ff17a52ef741
Tracking GCC 14 issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
