### PR TITLE
openroad: pin Boost 1.86

### DIFF
--- a/pkgs/applications/science/electronics/openroad/default.nix
+++ b/pkgs/applications/science/electronics/openroad/default.nix
@@ -9,7 +9,8 @@
   git,
   python3,
   swig,
-  boost,
+  # pin Boost 1.86 due to use of asio::io_service
+  boost186,
   cbc, # for clp
   cimg,
   clp, # for or-tools
@@ -70,7 +71,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
-    boost
+    boost186
     cbc
     cimg
     clp


### PR DESCRIPTION
Fixes #392198

Sort of reverts #370364

ref. #369118

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).