### PR TITLE
workflows/manual-nixos-v2: use a matrix to build on different systems

### DIFF
--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -19,7 +19,15 @@ permissions: {}
 jobs:
   nixos:
     name: nixos-manual-build
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - x86_64-linux
+          - aarch64-linux
+    runs-on: >-
+      ${{ (matrix.system == 'x86_64-linux' && 'ubuntu-24.04')
+      || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm') }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -36,22 +44,13 @@ jobs:
           name: nixpkgs-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Building NixOS manual
-        run: |
-          export NIX_PATH=nixpkgs=$(pwd)
-          nix-build --option restrict-eval true nixos/release.nix -A manual.x86_64-linux -o result-x86_64-linux
-          nix-build --option restrict-eval true nixos/release.nix -A manual.aarch64-linux -o result-aarch64-linux
+      - name: Build NixOS manual
+        id: build-manual
+        run: NIX_PATH=nixpkgs=$(pwd) nix-build --option restrict-eval true nixos/release.nix -A manual.${{ matrix.system }}
 
-      - name: Upload NixOS manual for x86_64
+      - name: Upload NixOS manual
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: nixos-manual-x86_64-linux
-          path: result-x86_64-linux
-          if-no-files-found: error
-
-      - name: Upload NixOS manual for aarch64
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: nixos-manual-aarch64-linux
-          path: result-aarch64-linux
+          name: nixos-manual-${{ matrix.system }}
+          path: result/
           if-no-files-found: error


### PR DESCRIPTION
So apparently we have to build the manual on hostPlatform.

Tested:
On https://github.com/JohnRTitor/nixpkgs/actions/runs/14019104683

