### PR TITLE
cassandra_3_0, cassandra_3_11: remove due to EOL

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -93,6 +93,8 @@
   Packages wishing to maintain compatibility with Nixpkgs 24.11 must set `useFetchCargoVendor` to `true` explicitly.
   `rustPlatform.importCargoLock` may also be appropriate in some circumstances.
 
+- `cassandra_3_0` and `cassandra_3_11` have been removed as they have reached end-of-life. Please update to `cassandra_4`. See the [changelog](https://github.com/apache/cassandra/blob/cassandra-4.0.17/NEWS.txt) for more information about the upgrade process.
+
 - NetBox was updated to `>= 4.2.0`. Have a look at the breaking changes
   of the [4.1 release](https://github.com/netbox-community/netbox/releases/tag/v4.1.0)
   and the [4.2 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -24,10 +24,6 @@ let
 
   cfg = config.services.cassandra;
 
-  atLeast3 = versionAtLeast cfg.package.version "3";
-  atLeast3_11 = versionAtLeast cfg.package.version "3.11";
-  atLeast4 = versionAtLeast cfg.package.version "4";
-
   defaultUser = "cassandra";
 
   cassandraConfig = flip recursiveUpdate cfg.extraConfig (
@@ -41,6 +37,7 @@ let
       data_file_directories = [ "${cfg.homeDir}/data" ];
       commitlog_directory = "${cfg.homeDir}/commitlog";
       saved_caches_directory = "${cfg.homeDir}/saved_caches";
+      hints_directory = "${cfg.homeDir}/hints";
     }
     // optionalAttrs (cfg.seedAddresses != [ ]) {
       seed_provider = [
@@ -49,9 +46,6 @@ let
           parameters = [ { seeds = concatStringsSep "," cfg.seedAddresses; } ];
         }
       ];
-    }
-    // optionalAttrs atLeast3 {
-      hints_directory = "${cfg.homeDir}/hints";
     }
   );
 
@@ -97,9 +91,7 @@ let
       # Delete default password file
       sed -i '/-Dcom.sun.management.jmxremote.password.file=\/etc\/cassandra\/jmxremote.password/d' "$out/cassandra-env.sh"
 
-      ${lib.optionalString atLeast4 ''
-        cp $package/conf/jvm*.options $out/
-      ''}
+      cp $package/conf/jvm*.options $out/
     '';
   };
 
@@ -109,17 +101,17 @@ let
 
   fullJvmOptions =
     cfg.jvmOpts
+    ++ [
+      # Historically, we don't use a log dir, whereas the upstream scripts do
+      # expect this. We override those by providing our own -Xlog:gc flag.
+      "-Xlog:gc=warning,heap*=warning,age*=warning,safepoint=warning,promotion*=warning"
+    ]
     ++ optionals (cfg.jmxRoles != [ ]) [
       "-Dcom.sun.management.jmxremote.authenticate=true"
       "-Dcom.sun.management.jmxremote.password.file=${cfg.jmxRolesFile}"
     ]
     ++ optionals cfg.remoteJmx [
       "-Djava.rmi.server.hostname=${cfg.rpcAddress}"
-    ]
-    ++ optionals atLeast4 [
-      # Historically, we don't use a log dir, whereas the upstream scripts do
-      # expect this. We override those by providing our own -Xlog:gc flag.
-      "-Xlog:gc=warning,heap*=warning,age*=warning,safepoint=warning,promotion*=warning"
     ];
 
   commonEnv = {
@@ -169,7 +161,7 @@ in
     };
 
     package = mkPackageOption pkgs "cassandra" {
-      example = "cassandra_3_11";
+      example = "cassandra_4";
     };
 
     jvmOpts = mkOption {
@@ -462,14 +454,11 @@ in
 
     jmxRolesFile = mkOption {
       type = types.nullOr types.path;
-      default = if atLeast3_11 then pkgs.writeText "jmx-roles-file" defaultJmxRolesFile else null;
-      defaultText = literalMD ''generated configuration file if version is at least 3.11, otherwise `null`'';
+      default = pkgs.writeText "jmx-roles-file" defaultJmxRolesFile;
+      defaultText = "generated configuration file";
       example = "/var/lib/cassandra/jmx.password";
       description = ''
         Specify your own jmx roles file.
-
-        Make sure the permissions forbid "others" from reading the file if
-        you're using Cassandra below version 3.11.
       '';
     };
   };
@@ -492,8 +481,7 @@ in
         assertion = cfg.remoteJmx -> cfg.jmxRolesFile != null;
         message = ''
           If you want JMX available remotely you need to set a password using
-          <literal>jmxRoles</literal> or <literal>jmxRolesFile</literal> if
-          using Cassandra older than v3.11.
+          <literal>jmxRoles</literal>.
         '';
       }
     ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -281,8 +281,6 @@ in
   calibre-server = import ./calibre-server.nix { inherit pkgs runTest; };
   canaille = handleTest ./canaille.nix { };
   castopod = handleTest ./castopod.nix { };
-  cassandra_3_0 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_0; };
-  cassandra_3_11 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_3_11; };
   cassandra_4 = handleTest ./cassandra.nix { testPackage = pkgs.cassandra_4; };
   centrifugo = runTest ./centrifugo.nix;
   ceph-multi-node = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./ceph-multi-node.nix { };

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -11,7 +11,7 @@
   which,
   jre,
   nixosTests,
-  # generation is the attribute version suffix such as 3_11 in pkgs.cassandra_3_11
+  # generation is the attribute version suffix such as 4 in pkgs.cassandra_4
   generation,
   version,
   sha256,

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -394,6 +394,8 @@ mapAliases {
   cargo-information = throw "'cargo-information' has been removed due to being merged upstream into 'cargo'"; # Added 2025-03-09
   cargo-inspect = throw "'cargo-inspect' has been removed due to lack of upstream maintenance. Upstream recommends cargo-expand."; # Added 2025-01-26
   cargo-web = throw "'cargo-web' has been removed due to lack of upstream maintenance"; # Added 2025-01-26
+  cassandra_3_0 = throw "'cassandra_3_0' has been removed has it reached end-of-life"; # Added 2025-03-23
+  cassandra_3_11 = throw "'cassandra_3_11' has been removed has it reached end-of-life"; # Added 2025-03-23
   cawbird = throw "cawbird has been abandoned upstream and is broken anyways due to Twitter closing its API";
   centerim = throw "centerim has been removed due to upstream disappearing"; # Added 2025-04-18
   certmgr-selfsigned = certmgr; # Added 2023-11-30

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11800,14 +11800,6 @@ with pkgs;
 
   appdaemon = callPackage ../servers/home-assistant/appdaemon.nix { };
 
-  cassandra_3_0 = callPackage ../servers/nosql/cassandra/3.0.nix {
-    jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-    python = python2;
-  };
-  cassandra_3_11 = callPackage ../servers/nosql/cassandra/3.11.nix {
-    jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-    python = python2;
-  };
   cassandra_4 = callPackage ../servers/nosql/cassandra/4.nix {
     # Effective Cassandra 4.0.2 there is full Java 11 support
     #  -- https://cassandra.apache.org/doc/latest/cassandra/new/java11.html


### PR DESCRIPTION
Cassandra 3.0 and 3.11 are End of Life.
https://cassandra.apache.org/_/blog/Apache-Cassandra-3.0.x-and-3.11.x-End-of-Life-Announcement.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
