### PR TITLE
nixos/caddy: Make virtualHosts' logFormat optional

### DIFF
--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -30,9 +30,11 @@ let
         ${optionalString (
           hostOpts.useACMEHost != null
         ) "tls ${sslCertDir}/cert.pem ${sslCertDir}/key.pem"}
-        log {
-          ${hostOpts.logFormat}
-        }
+        ${optionalString (hostOpts.logFormat != null) ''
+          log {
+            ${hostOpts.logFormat}
+          }
+        ''}
 
         ${hostOpts.extraConfig}
       }

--- a/nixos/modules/services/web-servers/caddy/vhost-options.nix
+++ b/nixos/modules/services/web-servers/caddy/vhost-options.nix
@@ -56,7 +56,7 @@ in
     };
 
     logFormat = mkOption {
-      type = types.lines;
+      type = types.nullOr types.lines;
       default = ''
         output file ${cfg.logDir}/access-${lib.replaceStrings [ "/" " " ] [ "_" "_" ] config.hostName}.log
       '';


### PR DESCRIPTION
Allow `services.caddy.virtualHosts.<name>.logFormat` to be null, and in that case, do not add a `log {}` block to the Caddy configuration. This makes it possible to have multiple loggers declared in the global configuration, and instruct Caddy to use a logger by name.

The Caddy NixOS module currently emits a `log {}` block for every virtual host, and has no way of setting the logger name (`log <name>`), interfering with more complex configurations. To preserve existing behaviour, I opted to make `virtualHosts.<name>.logFormat` nullable, rather than adding special meaning to it being an empty string.

I have done basic manual testing, to verify that setting `.logFormat` to an empty string still emits an empty `log { }` block, but setting it to `null` results in no `log` statement in the virtualhost parts.

> [!NOTE]
> I am contributing this as-is. If changes are required, someone else will have to take it further. I already worked around the problem, and I do not have the resources - nor the desire, really - to further update this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
