### PR TITLE
petsc: refactor inputs, configureFlags; add tests, petscPackages scope

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -2,16 +2,14 @@
   lib,
   stdenv,
   fetchzip,
-  gfortran,
   replaceVars,
-  python3,
-  python3Packages,
-  blas,
-  lapack,
-  zlib, # propagated by p4est but required by petsc
+  bash,
+  pkg-config,
+  gfortran,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  bash,
+  python3,
+  python3Packages,
 
   # Build options
   petsc-optimized ? true,
@@ -33,14 +31,16 @@
   withP4est ? withFullDeps,
 
   # External libraries
+  blas,
+  lapack,
   hdf5-fortran-mpi,
   metis,
   parmetis,
   scotch,
   scalapack,
   mumps_par,
-  pkg-config,
   p4est,
+  zlib, # propagated by p4est but required by petsc
 }:
 assert withFullDeps -> withCommonDeps;
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -258,12 +258,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   setupHook = ./setup-hook.sh;
 
-  meta = with lib; {
+  meta = {
     description = "Portable Extensible Toolkit for Scientific computation";
     homepage = "https://petsc.org/release/";
-    license = licenses.bsd2;
+    license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       cburstedde
       qbisi
     ];

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -27,10 +27,10 @@
   withHdf5 ? withCommonDeps,
   withMetis ? withCommonDeps,
   withZlib ? withP4est,
-  withScalapack ? withFullDeps,
+  withScalapack ? withCommonDeps && mpiSupport,
   withParmetis ? withFullDeps, # parmetis is unfree
-  withPtscotch ? withFullDeps,
-  withMumps ? withFullDeps,
+  withPtscotch ? withCommonDeps && mpiSupport,
+  withMumps ? withCommonDeps,
   withP4est ? withFullDeps,
 
   # External libraries
@@ -58,7 +58,7 @@ assert withParmetis -> (withMetis && mpiSupport);
 
 assert withPtscotch -> mpiSupport;
 assert withScalapack -> mpiSupport;
-assert withMumps -> withScalapack;
+assert (withMumps && mpiSupport) -> withScalapack;
 
 let
   petscPackages = lib.makeScope newScope (self: {
@@ -167,6 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withPtscotch "--with-ptscotch=1"
     ++ lib.optional withScalapack "--with-scalapack=1"
     ++ lib.optional withMumps "--with-mumps=1"
+    ++ lib.optional (withMumps && !mpiSupport) "--with-mumps-serial=1"
     ++ lib.optional withP4est "--with-p4est=1"
     ++ lib.optional withZlib "--with-zlib=1"
     ++ lib.optional withHdf5 "--with-hdf5=1";

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -118,12 +118,19 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-precision=${petsc-precision}"
       "--with-mpi=${if mpiSupport then "1" else "0"}"
     ]
-    ++ lib.optional pythonSupport "--with-petsc4py=1"
     ++ lib.optionals mpiSupport [
       "--CC=mpicc"
       "--with-cxx=mpicxx"
       "--with-fc=mpif90"
     ]
+    ++ lib.optionals petsc-optimized [
+      "--with-debugging=0"
+      "COPTFLAGS=-O3"
+      "FOPTFLAGS=-O3"
+      "CXXOPTFLAGS=-O3"
+      "CXXFLAGS=-O3"
+    ]
+    ++ lib.optional pythonSupport "--with-petsc4py=1"
     ++ lib.optional withMetis "--with-metis=1"
     ++ lib.optional withParmetis "--with-parmetis=1"
     ++ lib.optional withPtscotch "--with-ptscotch=1"
@@ -131,14 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withMumps "--with-mumps=1"
     ++ lib.optional withP4est "--with-p4est=1"
     ++ lib.optional withZlib "--with-zlib=1"
-    ++ lib.optional withHdf5 "--with-hdf5=1"
-    ++ lib.optionals petsc-optimized [
-      "--with-debugging=0"
-      "COPTFLAGS=-O3"
-      "FOPTFLAGS=-O3"
-      "CXXOPTFLAGS=-O3"
-      "CXXFLAGS=-O3"
-    ];
+    ++ lib.optional withHdf5 "--with-hdf5=1";
 
   hardeningDisable = lib.optionals (!petsc-optimized) [
     "fortify"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -220,12 +220,18 @@ stdenv.mkDerivation (finalAttrs: {
         petsc = finalAttrs.finalPackage;
       }
     );
-    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      fullDeps = petsc.override {
-        withFullDeps = true;
-        withParmetis = false;
+    tests =
+      {
+        serial = petsc.override {
+          mpiSupport = false;
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        fullDeps = petsc.override {
+          withFullDeps = true;
+          withParmetis = false;
+        };
       };
-    };
   };
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -32,6 +32,10 @@
   withPtscotch ? withCommonDeps && mpiSupport,
   withMumps ? withCommonDeps,
   withP4est ? withFullDeps,
+  withHypre ? withCommonDeps && mpiSupport,
+  withFftw ? withCommonDeps,
+  withSuperLu ? withCommonDeps,
+  withSuitesparse ? withCommonDeps,
 
   # External libraries
   blas,
@@ -44,6 +48,10 @@
   mumps,
   p4est,
   zlib, # propagated by p4est but required by petsc
+  hypre,
+  fftw,
+  superlu,
+  suitesparse,
 
   # Used in passthru.tests
   petsc,
@@ -59,6 +67,7 @@ assert withParmetis -> (withMetis && mpiSupport);
 assert withPtscotch -> mpiSupport;
 assert withScalapack -> mpiSupport;
 assert (withMumps && mpiSupport) -> withScalapack;
+assert withHypre -> mpiSupport;
 
 let
   petscPackages = lib.makeScope newScope (self: {
@@ -86,6 +95,10 @@ let
     scalapack = self.callPackage scalapack.override { };
     mumps = self.callPackage mumps.override { };
     p4est = self.callPackage p4est.override { };
+    hypre = self.callPackage hypre.override { };
+    fftw = self.callPackage fftw.override { };
+    superlu = self.callPackage superlu.override { };
+    suitesparse = self.callPackage suitesparse.override { };
   });
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -123,7 +136,11 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withParmetis petscPackages.parmetis
     ++ lib.optional withPtscotch petscPackages.scotch
     ++ lib.optional withScalapack petscPackages.scalapack
-    ++ lib.optional withMumps petscPackages.mumps;
+    ++ lib.optional withMumps petscPackages.mumps
+    ++ lib.optional withHypre petscPackages.hypre
+    ++ lib.optional withSuperLu petscPackages.superlu
+    ++ lib.optional withFftw petscPackages.fftw
+    ++ lib.optional withSuitesparse petscPackages.suitesparse;
 
   propagatedBuildInputs = lib.optional pythonSupport python3Packages.numpy;
 
@@ -170,7 +187,11 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional (withMumps && !mpiSupport) "--with-mumps-serial=1"
     ++ lib.optional withP4est "--with-p4est=1"
     ++ lib.optional withZlib "--with-zlib=1"
-    ++ lib.optional withHdf5 "--with-hdf5=1";
+    ++ lib.optional withHdf5 "--with-hdf5=1"
+    ++ lib.optional withHypre "--with-hypre=1"
+    ++ lib.optional withSuperLu "--with-superlu=1"
+    ++ lib.optional withFftw "--with-fftw=1"
+    ++ lib.optional withSuitesparse "--with-suitesparse=1";
 
   hardeningDisable = lib.optionals (!petsc-optimized) [
     "fortify"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "petsc";
-  version = "3.22.4";
+  version = "3.23.0";
 
   src = fetchzip {
     url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${finalAttrs.version}.tar.gz";
-    hash = "sha256-8WV1ylXytkhiNa7YpWSOIpSvzLCCjdVVe5SiGfhicas=";
+    hash = "sha256-OcI4iyDOR0YTVV+JoOhbfutoW00EmfapNaMnD/JJFsI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -7,6 +7,7 @@
   bash,
   pkg-config,
   gfortran,
+  bison,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
   python3,
@@ -26,7 +27,7 @@
   # External libraries options
   withHdf5 ? withCommonDeps,
   withMetis ? withCommonDeps,
-  withZlib ? withP4est,
+  withZlib ? (withP4est || withPtscotch),
   withScalapack ? withCommonDeps && mpiSupport,
   withParmetis ? withFullDeps, # parmetis is unfree
   withPtscotch ? withCommonDeps && mpiSupport,
@@ -64,7 +65,7 @@ assert withP4est -> (mpiSupport && withZlib);
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
 
-assert withPtscotch -> mpiSupport;
+assert withPtscotch -> (mpiSupport && withZlib);
 assert withScalapack -> mpiSupport;
 assert (withMumps && mpiSupport) -> withScalapack;
 assert withHypre -> mpiSupport;
@@ -117,6 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       python3
       gfortran
       pkg-config
+      bison
     ]
     ++ lib.optional mpiSupport mpi
     ++ lib.optionals pythonSupport [

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -54,12 +54,12 @@ assert withPtscotch -> mpiSupport;
 assert withScalapack -> mpiSupport;
 assert withMumps -> withScalapack;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "petsc";
   version = "3.22.4";
 
   src = fetchzip {
-    url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${version}.tar.gz";
+    url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${finalAttrs.version}.tar.gz";
     hash = "sha256-8WV1ylXytkhiNa7YpWSOIpSvzLCCjdVVe5SiGfhicas=";
   };
 
@@ -213,4 +213,4 @@ stdenv.mkDerivation rec {
       qbisi
     ];
   };
-}
+})

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -24,6 +24,7 @@
   # External libraries options
   withHdf5 ? withCommonDeps,
   withMetis ? withCommonDeps,
+  withZlib ? withP4est,
   withScalapack ? withFullDeps,
   withParmetis ? withFullDeps, # parmetis is unfree
   withPtscotch ? withFullDeps,
@@ -48,7 +49,7 @@
 assert withFullDeps -> withCommonDeps;
 
 # This version of PETSc does not support a non-MPI p4est build
-assert withP4est -> (p4est.mpiSupport && mpiSupport);
+assert withP4est -> (p4est.mpiSupport && mpiSupport && withZlib);
 
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
@@ -86,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
       lapack
     ]
     ++ lib.optional withHdf5 hdf5-fortran-mpi
+    ++ lib.optional withZlib zlib
     ++ lib.optional withP4est p4est
     ++ lib.optional withMetis metis
     ++ lib.optional withParmetis parmetis
@@ -127,10 +129,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withPtscotch "--with-ptscotch=1"
     ++ lib.optional withScalapack "--with-scalapack=1"
     ++ lib.optional withMumps "--with-mumps=1"
-    ++ lib.optionals withP4est [
-      "--with-p4est=1"
-      "--with-zlib=1"
-    ]
+    ++ lib.optional withP4est "--with-p4est=1"
+    ++ lib.optional withZlib "--with-zlib=1"
     ++ lib.optional withHdf5 "--with-hdf5=1"
     ++ lib.optionals petsc-optimized [
       "--with-debugging=0"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -16,6 +16,7 @@
   petsc-scalar-type ? "real",
   petsc-precision ? "double",
   mpiSupport ? true,
+  fortranSupport ? true,
   pythonSupport ? false, # petsc python binding
   withExamples ? false,
   withFullDeps ? false, # full External libraries support
@@ -130,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
       "CXXOPTFLAGS=-O3"
       "CXXFLAGS=-O3"
     ]
+    ++ lib.optional (!fortranSupport) "--with-fortran-bindings=0"
     ++ lib.optional pythonSupport "--with-petsc4py=1"
     ++ lib.optional withMetis "--with-metis=1"
     ++ lib.optional withParmetis "--with-parmetis=1"
@@ -179,7 +181,11 @@ stdenv.mkDerivation (finalAttrs: {
   pythonImportsCheck = [ "petsc4py" ];
 
   passthru = {
-    inherit mpiSupport pythonSupport;
+    inherit
+      mpiSupport
+      pythonSupport
+      fortranSupport
+      ;
     tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       fullDeps = petsc.override {
         withFullDeps = true;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -13,9 +13,9 @@
   python3Packages,
 
   # Build options
-  petsc-optimized ? true,
-  petsc-scalar-type ? "real",
-  petsc-precision ? "double",
+  debug ? false,
+  scalarType ? "real",
+  precision ? "double",
   mpiSupport ? true,
   fortranSupport ? true,
   pythonSupport ? false, # petsc python binding
@@ -161,8 +161,8 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "--with-blas=1"
       "--with-lapack=1"
-      "--with-scalar-type=${petsc-scalar-type}"
-      "--with-precision=${petsc-precision}"
+      "--with-scalar-type=${scalarType}"
+      "--with-precision=${precision}"
       "--with-mpi=${if mpiSupport then "1" else "0"}"
     ]
     ++ lib.optionals mpiSupport [
@@ -170,7 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-cxx=mpicxx"
       "--with-fc=mpif90"
     ]
-    ++ lib.optionals petsc-optimized [
+    ++ lib.optionals (!debug) [
       "--with-debugging=0"
       "COPTFLAGS=-O3"
       "FOPTFLAGS=-O3"
@@ -193,7 +193,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withFftw "--with-fftw=1"
     ++ lib.optional withSuitesparse "--with-suitesparse=1";
 
-  hardeningDisable = lib.optionals (!petsc-optimized) [
+  hardeningDisable = lib.optionals debug [
     "fortify"
     "fortify3"
   ];

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -122,37 +122,16 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-cxx=mpicxx"
       "--with-fc=mpif90"
     ]
-    ++ lib.optionals withMetis [
-      "--with-metis=1"
-      "--with-metis-dir=${metis}"
-    ]
-    ++ lib.optionals withParmetis [
-      "--with-parmetis=1"
-      "--with-parmetis-dir=${parmetis}"
-    ]
-    ++ lib.optionals withPtscotch [
-      "--with-ptscotch=1"
-      "--with-ptscotch-include=${lib.getDev scotch}/include"
-      "--with-ptscotch-lib=[-L${lib.getLib scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
-    ]
-    ++ lib.optionals withScalapack [
-      "--with-scalapack=1"
-      "--with-scalapack-dir=${scalapack}"
-    ]
-    ++ lib.optionals withMumps [
-      "--with-mumps=1"
-      "--with-mumps-dir=${mumps_par}"
-    ]
+    ++ lib.optional withMetis "--with-metis=1"
+    ++ lib.optional withParmetis "--with-parmetis=1"
+    ++ lib.optional withPtscotch "--with-ptscotch=1"
+    ++ lib.optional withScalapack "--with-scalapack=1"
+    ++ lib.optional withMumps "--with-mumps=1"
     ++ lib.optionals withP4est [
       "--with-p4est=1"
-      "--with-zlib-include=${lib.getDev zlib}/include"
-      "--with-zlib-lib=[-L${lib.getLib zlib}/lib,-lz]"
+      "--with-zlib=1"
     ]
-    ++ lib.optionals withHdf5 [
-      "--with-hdf5=1"
-      "--with-hdf5-include=${lib.getDev hdf5-fortran-mpi}/include"
-      "--with-hdf5-lib=[-L${lib.getLib hdf5-fortran-mpi}/lib,-lhdf5]"
-    ]
+    ++ lib.optional withHdf5 "--with-hdf5=1"
     ++ lib.optionals petsc-optimized [
       "--with-debugging=0"
       "COPTFLAGS=-O3"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -150,7 +150,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals withHdf5 [
       "--with-hdf5=1"
-      "--with-hdf5-fortran-bindings=1"
       "--with-hdf5-include=${lib.getDev hdf5-fortran-mpi}/include"
       "--with-hdf5-lib=[-L${lib.getLib hdf5-fortran-mpi}/lib,-lhdf5]"
     ]

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -41,6 +41,9 @@
   mumps_par,
   p4est,
   zlib, # propagated by p4est but required by petsc
+
+  # Used in passthru.tests
+  petsc,
 }:
 assert withFullDeps -> withCommonDeps;
 
@@ -199,6 +202,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit mpiSupport pythonSupport;
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      fullDeps = petsc.override {
+        withFullDeps = true;
+        withParmetis = false;
+      };
+    };
   };
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  sowing,
   python3,
   python3Packages,
   arpack-mpi,
@@ -17,13 +16,13 @@ assert petsc.mpiSupport;
 assert pythonSupport -> petsc.pythonSupport;
 stdenv.mkDerivation (finalAttrs: {
   pname = "slepc";
-  version = "3.22.2";
+  version = "3.23.0";
 
   src = fetchFromGitLab {
     owner = "slepc";
     repo = "slepc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a5DmsA7NAlhrEaS43TYPk7vtDfhXLEP+5sftu2A9Yt4=";
+    hash = "sha256-Z9CVZQ/Ezb1S2EkTb9amAPxaN4tiUnKrbvQIc3BnVuU=";
   };
 
   postPatch = ''
@@ -33,11 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
       "slepc.prefixdir,'${python3.sitePackages}'"
 
     patchShebangs lib/slepc/bin
-
-    # Use system bfort
-    substituteInPlace config/packages/sowing.py \
-      --replace-fail "bfort = os.path.join(archdir,'bin','bfort')" \
-      "bfort = '${sowing}/bin/bfort'"
   '';
 
   # Usually this project is being built as part of a `petsc` build or as part of


### PR DESCRIPTION
big changes in petsc.

1. Some cleanup to unnecessary flags.
2. Add two petsc variant 'serial' and 'fullDeps' in passthr.tests to valid combination of different build flags
3. Add a scope petscPackages
 
The third change 'Add a scope petscPackages' in commit https://github.com/NixOS/nixpkgs/pull/392392/commits/1458623a624403d52e5da7a8571e3552fee2174d
is very important to build petsc with appropriate buildInputs.

Petsc would like to passthrough its global override options to its buildInputs,
e.g.
petsc with mpiSupport/fortran require its dep to be built with mpiSupport/fortran too,
petsc with precision "single" require fftw use the same precision "single"
petsc built with mpich would like all its dep to be built with mpich

and in the future, i would like to introduce enableOpenMP,isILP64,cudaSupport as global override options to petsc.

This petscPackages is functional similar to nixpkgs overlay, but it allow us to override and test petsc varient simply, without ovelay the whole nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
