### PR TITLE
k3s: source k3s version.sh in update script to get component versions

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_31/versions.nix
@@ -9,7 +9,7 @@
   k3sRootSha256 = "0svbi42agqxqh5q2ri7xmaw2a2c70s7q5y587ls0qkflw5vx4sl7";
   k3sCNIVersion = "1.6.0-k3s1";
   k3sCNISha256 = "0g7zczvwba5xqawk37b0v96xysdwanyf1grxn3l3lhxsgjjsmkd7";
-  containerdVersion = "1.7.23-k3s2";
-  containerdSha256 = "0lp9vxq7xj74wa7hbivvl5hwg2wzqgsxav22wa0p1l7lc1dqw8dm";
+  containerdVersion = "2.0.2-k3s2";
+  containerdSha256 = "1883srp3rlap0a6rx5dnbnxl67aijbymjrqdg7zg3a162j21xz3s";
   criCtlVersion = "1.31.0-k3s2";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
@@ -9,7 +9,7 @@
   k3sRootSha256 = "0svbi42agqxqh5q2ri7xmaw2a2c70s7q5y587ls0qkflw5vx4sl7";
   k3sCNIVersion = "1.6.0-k3s1";
   k3sCNISha256 = "0g7zczvwba5xqawk37b0v96xysdwanyf1grxn3l3lhxsgjjsmkd7";
-  containerdVersion = "1.7.23-k3s2";
-  containerdSha256 = "0lp9vxq7xj74wa7hbivvl5hwg2wzqgsxav22wa0p1l7lc1dqw8dm";
+  containerdVersion = "2.0.2-k3s2";
+  containerdSha256 = "1883srp3rlap0a6rx5dnbnxl67aijbymjrqdg7zg3a162j21xz3s";
   criCtlVersion = "1.31.0-k3s2";
 }

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -11,10 +11,6 @@ trap "rm -rf ${WORKDIR}" EXIT
 NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"/
 NIXPKGS_K3S_PATH=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)/
 OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_ROOT. {}; k3s_1_${MINOR_VERSION}.version or (builtins.parseDrvName k3s_1_${MINOR_VERSION}.name).version" | tr -d '"')"
-cd ${NIXPKGS_K3S_PATH}
-
-cd 1_${MINOR_VERSION}
-
 
 LATEST_TAG_RAWFILE=${WORKDIR}/latest_tag.json
 curl --silent -f ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
@@ -31,18 +27,24 @@ K3S_COMMIT=$(curl --silent -f ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/k3s-io/k3s/git/refs/tags \
     | jq -r "map(select(.ref == \"refs/tags/${LATEST_TAG_NAME}\")) | .[0] | .object.sha")
 
-K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/k3s-io/k3s/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
+PREFETCH_META=$(nix-prefetch-url --unpack --print-path https://github.com/k3s-io/k3s/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
+K3S_STORE_PATH=${PREFETCH_META#*$'\n'}
+K3S_REPO_SHA256=${PREFETCH_META%$'\n'*}
 
-FILE_SCRIPTS_DOWNLOAD=${WORKDIR}/scripts-download
-curl --silent -f https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/download > $FILE_SCRIPTS_DOWNLOAD
+cd "$K3S_STORE_PATH"
+# Set the DRONE variables as they are expected to be set in version.sh
+DRONE_TAG="$LATEST_TAG_NAME"
+DRONE_COMMIT="$K3S_COMMIT"
+source "${K3S_STORE_PATH}/scripts/version.sh"
 
-FILE_SCRIPTS_VERSION=${WORKDIR}/scripts-version.sh
-curl --silent -f https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts/version.sh > $FILE_SCRIPTS_VERSION
+K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/k3s-io/k3s-root/releases/download/${VERSION_ROOT}/k3s-root-amd64.tar")
+CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/rancher/plugins/archive/refs/tags/${VERSION_CNIPLUGINS}.tar.gz")
+CONTAINERD_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/k3s-io/containerd/archive/refs/tags/${VERSION_CONTAINERD}.tar.gz")
 
-FILE_TRAEFIK_MANIFEST=${WORKDIR}/traefik.yml
-curl --silent -f -o "$FILE_TRAEFIK_MANIFEST" https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/manifests/traefik.yaml
-
-CHART_FILES=( $(yq eval --no-doc .spec.chart "$FILE_TRAEFIK_MANIFEST" | xargs -n1 basename) )
+CHART_FILES=( $(yq eval --no-doc .spec.chart "${K3S_STORE_PATH}/manifests/traefik.yaml" | xargs -n1 basename) )
 # These files are:
 #   1. traefik-crd-20.3.1+up20.3.0.tgz
 #   2. traefik-20.3.1+up20.3.0.tgz
@@ -52,6 +54,8 @@ if [[ "${#CHART_FILES[@]}" != "2" ]]; then
     echo "New manifest charts added, the packaging scripts will need to be updated: ${CHART_FILES}"
     exit 1
 fi
+
+cd "${NIXPKGS_K3S_PATH}/1_${MINOR_VERSION}"
 
 CHARTS_URL=https://k3s.io/k3s-charts/assets
 # Get metadata for both files
@@ -95,39 +99,6 @@ while read -r name url; do
         '{$name: {"url": $url, "sha256": $sha256}}'
 done <<<"${IMAGES_ARCHIVES}" | jq --slurp 'reduce .[] as $item ({}; . * $item)' > images-versions.json
 
-FILE_GO_MOD=${WORKDIR}/go.mod
-curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/go.mod > $FILE_GO_MOD
-
-
-K3S_ROOT_VERSION=$(grep 'VERSION_ROOT=' ${FILE_SCRIPTS_VERSION} \
-    | cut -d'=' -f2 | sed -e 's/"//g' -e 's/^v//')
-K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
-    "https://github.com/k3s-io/k3s-root/releases/download/v${K3S_ROOT_VERSION}/k3s-root-amd64.tar")
-
-CNIPLUGINS_VERSION=$(grep 'VERSION_CNIPLUGINS=' ${FILE_SCRIPTS_VERSION} \
-    | cut -d'=' -f2 | sed -e 's/"//g' -e 's/^v//')
-CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
-    "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
-
-# mimics https://github.com/k3s-io/k3s/blob/v1.26.5%2Bk3s1/scripts/version.sh#L25
-CONTAINERD_VERSION=$(grep github.com/containerd/containerd ${FILE_GO_MOD} \
-    | head -n1 | awk '{print $4}' | sed -e 's/^v//')
-CONTAINERD_SHA256=$(nix-prefetch-url --quiet --unpack \
-    "https://github.com/k3s-io/containerd/archive/refs/tags/v${CONTAINERD_VERSION}.tar.gz")
-
-# The repository of "cri-tools" changes for 1.31.x, this can likely be removed in future releases
-if [ "$MINOR_VERSION" -gt 30 ]; then
-    CRI_CTL_REPO=sigs.k8s.io
-else
-    CRI_CTL_REPO=github.com/kubernetes-sigs
-fi
-CRI_CTL_VERSION=$(grep "$CRI_CTL_REPO/cri-tools" ${FILE_GO_MOD} \
-    | head -n1 | awk '{print $4}' | sed -e 's/"//g' -e 's/^v//')
-
-setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ${NIXPKGS_K3S_PATH}default.nix
-}
-
 FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
 cat >versions.nix <<EOF
@@ -138,13 +109,13 @@ cat >versions.nix <<EOF
   k3sVendorHash = "${FAKE_HASH}";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
-  k3sRootVersion = "${K3S_ROOT_VERSION}";
+  k3sRootVersion = "${VERSION_ROOT:1}";
   k3sRootSha256 = "${K3S_ROOT_SHA256}";
-  k3sCNIVersion = "${CNIPLUGINS_VERSION}";
+  k3sCNIVersion = "${VERSION_CNIPLUGINS:1}";
   k3sCNISha256 = "${CNIPLUGINS_SHA256}";
-  containerdVersion = "${CONTAINERD_VERSION}";
+  containerdVersion = "${VERSION_CONTAINERD:1}";
   containerdSha256 = "${CONTAINERD_SHA256}";
-  criCtlVersion = "${CRI_CTL_VERSION}";
+  criCtlVersion = "${VERSION_CRICTL:1}";
 }
 EOF
 


### PR DESCRIPTION
The containerd versions were wrong for `k3s_1_31` and `k3s_1_32`. These use containerd v2 and thus the update script failed to get the correct version. Sourcing `version.sh` fixes this, should adapt better to similar upstream changes and eliminates a lot of custom logic for version parsing. Additionally, the update script gets rid of several curls of single files, by using them directly from the prefetched k3s repo.

@NixOS/k3s 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
