### PR TITLE
nmh: 1.7.1 -> 1.8

### DIFF
--- a/pkgs/by-name/nm/nmh/package.nix
+++ b/pkgs/by-name/nm/nmh/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ShAdinvBA7guVBhjqTelBRiUzyo5KqHcawlQS9kXtqs=";
   };
 
+  patches = [ ./reproducible-build-date.patch ];
+
   postPatch = ''
     substituteInPlace \
       sbr/arglist.c \

--- a/pkgs/by-name/nm/nmh/package.nix
+++ b/pkgs/by-name/nm/nmh/package.nix
@@ -14,25 +14,25 @@
   openssl,
   readline,
   runtimeShell,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nmh";
-  version = "1.7.1";
+  version = "1.8";
   src = fetchFromSavannah {
     repo = "nmh";
     rev = finalAttrs.version;
-    hash = "sha256-sBftXl4hWs4bKw5weHkif1KIJBpheU/RCePx0WXuv9o=";
+    hash = "sha256-ShAdinvBA7guVBhjqTelBRiUzyo5KqHcawlQS9kXtqs=";
   };
 
   postPatch = ''
-    substituteInPlace config/config.c --replace /bin/cat ${coreutils}/bin/cat
     substituteInPlace \
       sbr/arglist.c \
       uip/mhbuildsbr.c \
       uip/whatnowsbr.c \
       uip/slocal.c \
-      --replace '"/bin/sh"' '"${runtimeShell}"'
+      --replace-fail '"/bin/sh"' '"${runtimeShell}"'
     # the "cleanup" pseudo-test makes diagnosing test failures a pain
     ln -s -f ${stdenv}/bin/true test/cleanup
   '';
@@ -56,6 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
   NIX_CFLAGS_COMPILE = "-Wno-stringop-truncation";
   doCheck = true;
   enableParallelBuilding = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/install-mh";
+  versionCheckProgramArg = "-version";
 
   meta = {
     description = "New MH Mail Handling System";

--- a/pkgs/by-name/nm/nmh/reproducible-build-date.patch
+++ b/pkgs/by-name/nm/nmh/reproducible-build-date.patch
@@ -1,0 +1,15 @@
+Index: config/version.sh
+===================================================================
+--- a/config/version.sh
++++ b/config/version.sh
+@@ -11,9 +11,9 @@
+     git=" `git -C $srcdir describe --long --dirty`"
+ else
+     git=
+ fi
+-date="`TZ=GMT0 date +'%Y-%m-%d %T'` +0000"
++date="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d)"
+ 
+ cat <<E
+ char *version_str = "nmh-$version$git built $date on $host";
+ char *version_num = "nmh-$version";


### PR DESCRIPTION
Update nmh to [1.8](https://savannah.nongnu.org/news/?id=10261). Make the build reproducible by replacing build timestamp.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
