### PR TITLE
postgresql.pg_config: add check to confirm output is correct

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -11,7 +11,7 @@
 - `squid` has been updated to version 7, this release includes multiple breaking changes, like ESI removal.
   For more information, [check the release notes](https://github.com/squid-cache/squid/releases/tag/SQUID_7_0_1).
 
-- `postgresql` and `libpq` don't provide `pg_config` by default anymore. Instead, `pg_config` is available via `postgresql.pg_config` or `libpq.pg_config`. This allowed implementing it as a shell script, which can be build for both the build and host systems when cross-compiling. If your build fails to find `pg_config`, add `postgresql.pg_config` or `libpq.pg_config` to `nativeBuildInputs`.
+- `postgresql` and `libpq` don't provide `pg_config` by default anymore. Instead, `pg_config` is available via `postgresql.pg_config` or `libpq.pg_config`. This allowed implementing it as a shell script, which can be built for both the build and host systems when cross-compiling. If your build fails to find `pg_config`, add `postgresql.pg_config` or `libpq.pg_config` to `nativeBuildInputs`.
 
 - The [`no-broken-symlinks` hook](https://nixos.org/manual/nixpkgs/unstable/#no-broken-symlinks.sh) was added to catch builds containing dangling or reflexive symlinks, as these are indicative of problems with packaging.
   The hook can be disabled by providing `dontCheckForBrokenSymlinks = true;` as an argument to `mkDerivation`.

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -366,6 +366,7 @@ let
 
       postPatch = ''
         substituteInPlace "src/Makefile.global.in" --subst-var out
+        substituteInPlace "src/common/config_info.c" --subst-var dev
         cat ${./pg_config.env.mk} >> src/common/Makefile
       '';
 
@@ -373,7 +374,12 @@ let
         ''
           moveToOutput "bin/ecpg" "$dev"
           moveToOutput "lib/pgxs" "$dev"
-
+        ''
+        + lib.optionalString (stdenv'.buildPlatform.canExecute stdenv'.hostPlatform) ''
+          mkdir -p "$dev/nix-support"
+          "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
+        ''
+        + ''
           rm "$out/bin/pg_config"
           make -C src/common pg_config.env
           install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"

--- a/pkgs/servers/sql/postgresql/pg_config.nix
+++ b/pkgs/servers/sql/postgresql/pg_config.nix
@@ -1,7 +1,9 @@
 {
+  diffutils,
   lib,
   replaceVarsWith,
   runtimeShell,
+  stdenv,
   # PostgreSQL package
   finalPackage,
 }:
@@ -15,4 +17,12 @@ replaceVarsWith {
     inherit runtimeShell;
     postgresql-dev = lib.getDev finalPackage;
   };
+  nativeCheckInputs = [
+    diffutils
+  ];
+  postCheck = ''
+    if [ -e ${lib.getDev finalPackage}/nix-support/pg_config.expected ]; then
+        diff ${lib.getDev finalPackage}/nix-support/pg_config.expected <($out/bin/pg_config)
+    fi
+  '';
 }


### PR DESCRIPTION
Adds a test for the new `pg_config` introduced in #388807, as discussed in 
https://github.com/NixOS/nixpkgs/pull/388807#discussion_r2008805812.

## Things done

Building this PR on current staging is only possible when temporarily applying the changes in #392267.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
  - [x] pkgsStatic (x86_64-linux)
  - [x] withJIT (x86_64-linux)
  - [x] FreeBSD cross
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
