### PR TITLE
dockerTools: Support mounting images with more than 16 layers (#392421)

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -297,7 +297,7 @@ rec {
           fi
 
           # Unpack all of the parent layers into the image.
-          lowerdir=""
+          lowerdirs=()
           extractionID=0
           for layerTar in $(cat layer-list); do
             echo "Unpacking layer $layerTar"
@@ -310,7 +310,7 @@ rec {
             find image/$extractionID/layer -name ".wh.*" -exec bash -c 'name="$(basename {}|sed "s/^.wh.//")"; mknod "$(dirname {})/$name" c 0 0; rm {}' \;
 
             # Get the next lower directory and continue the loop.
-            lowerdir=image/$extractionID/layer''${lowerdir:+:}$lowerdir
+            lowerdirs=( "image/$extractionID/layer"  "''${lowerdirs[@]}" )
           done
 
           mkdir work
@@ -323,11 +323,25 @@ rec {
             ${preMount}
           ''}
 
-          if [ -n "$lowerdir" ]; then
-            mount -t overlay overlay -olowerdir=$lowerdir,workdir=work,upperdir=layer mnt
-          else
-            mount --bind layer mnt
-          fi
+          mountDirs() {
+            local IFS=:
+            declare -g layerNum
+            if [ "$#" -eq 0 ]; then
+              mount --bind layer mnt
+              return
+            elif [ "$#" -lt 16 ]; then
+              mount -t overlay overlay -olowerdir="$*",workdir=work,upperdir=layer mnt
+              return
+            fi
+
+            # tough case: we have too many layers to mount at once; recurse
+            : layerNum=''${layerNum:=0}
+            mkdir -p "work$layerNum" "layer$layerNum" "mnt$layerNum" || return
+            mount -t overlay overlay -o "lowerdir=''${*:1:16},workdir=work$layerNum,upperdir=layer$layerNum" "mnt$layerNum" || return
+            mountDirs "mnt$layerNum" "''${@:17}"
+          }
+
+          mountDirs "''${lowerdirs[@]}"
 
           ${lib.optionalString (postMount != "") ''
             # Execute post-mount steps
@@ -352,6 +366,7 @@ rec {
 
       postMount = ''
         echo "Packing raw image..."
+        mkdir -p -- "$out"
         tar -C mnt --hard-dereference --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cf $out/layer.tar .
       '';
 


### PR DESCRIPTION
Resolves #392421

When a Docker image contains more than 16 layers, the `mount -t overlay` command run to combine those into a single filesystem view fails.

To address this, we now loop in batches of 16 mount points until we've combined all layers into a single mount.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
