### PR TITLE
sequoia-sq: 1.1.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -14,14 +14,14 @@
   sqlite,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sequoia-sq";
   version = "1.3.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sq";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1jssSlyjbrGgkxGC1gieZooVVI42Qvz0q+pIfcZRIj0=";
   };
 
@@ -74,7 +74,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Cool new OpenPGP implementation";
     homepage = "https://sequoia-pgp.org/";
-    changelog = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v${version}/NEWS";
+    changelog = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       minijackson
@@ -83,4 +83,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "sq";
   };
-}
+})

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -10,22 +10,23 @@
   capnproto,
   installShellFiles,
   openssl,
+  cacert,
   sqlite,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sequoia-sq";
-  version = "1.1.0";
+  version = "1.3.0";
 
   src = fetchFromGitLab {
     owner = "sequoia-pgp";
     repo = "sequoia-sq";
     rev = "v${version}";
-    hash = "sha256-m6uUqTXswzdtIabNgijdU54VGQSk0SkSqdh+7m1Q7RU=";
+    hash = "sha256-1jssSlyjbrGgkxGC1gieZooVVI42Qvz0q+pIfcZRIj0=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-a+3oKORX88SfMw4/QA6+Ls12koZIw0iadTulCzGlr6U=";
+  cargoHash = "sha256-tATxGaoF/+cUDywvlnW1N2sKo/FbKhJM7yUb74mxB5s=";
 
   nativeBuildInputs = [
     pkg-config
@@ -48,14 +49,11 @@ rustPlatform.buildRustPackage rec {
       ]
     );
 
-  checkFlags = [
-    # https://gitlab.com/sequoia-pgp/sequoia-sq/-/issues/297
-    "--skip=sq_autocrypt_import"
-  ];
-
   # Needed for tests to be able to create a ~/.local/share/sequoia directory
+  # Needed for avoiding "OpenSSL error" since 1.2.0
   preCheck = ''
     export HOME=$(mktemp -d)
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
   '';
 
   env.ASSET_OUT_DIR = "/tmp/";

--- a/pkgs/by-name/se/sequoia-sq/package.nix
+++ b/pkgs/by-name/se/sequoia-sq/package.nix
@@ -72,10 +72,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Cool new OpenPGP implementation";
+    description = "Command line application exposing a useful set of OpenPGP functionality for common tasks";
     homepage = "https://sequoia-pgp.org/";
     changelog = "https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/v${finalAttrs.version}/NEWS";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.lgpl2Plus;
     maintainers = with lib.maintainers; [
       minijackson
       doronbehar


### PR DESCRIPTION
- Diff: https://gitlab.com/sequoia-pgp/sequoia-sq/-/compare/v1.1.0...v1.3.0
- Changelog: https://gitlab.com/sequoia-pgp/sequoia-sq/-/blob/f942696665bd845933066591291286a2b51f66ce/NEWS#L5-32

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Remove outdated skipping test
* Prefer tag rather than rev in fetcher
* Add missing SSL_CERT_FILE to pass tests since 1.2.0

This PR aims to fix [failing automatic updates](https://nixpkgs-update-logs.nix-community.org/sequoia-sq/2025-03-16.log) and might supersede #380960.

Without adding $SSL_CERT_FILE, it makes following error. Thanks for posting to upstream https://gitlab.com/sequoia-pgp/sequoia-sq/-/issues/545

```
command=`cd "/build/.tmpZt2hxU" && SEQUOIA_CERT_STORE="/build/.tmpZt2hxU/cert-store" SEQUOIA_CRYPTO_POLICY="/build/.tmpZt2hxU/empty-policy.toml" SEQUOIA_HOME="/build/.tmpZt2hxU/home" SEQUOIA_KEY_STORE="/build/.tmpZt2hxU/key-store" "/build/source/target/x86_64-unknown-linux-gnu/release/sq" "--batch" "download" "--url=file://debian/SHA512SUMS" "--signature-url=file://debian/SHA512SUMS.sign" "--signer=DF9B9C49EAA9298432589D76DA87E80D6294BE9B" "--output=SHA512SUMS"`
code=1
stdout=""
stderr=```

  Error: builder error
because: OpenSSL error
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @dvn0 Thanks for your work :pray:

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
