### PR TITLE
qr-backup: init at 1.1.4

### DIFF
--- a/pkgs/by-name/qr/qr-backup/package.nix
+++ b/pkgs/by-name/qr/qr-backup/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pkgs,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+  dejavu_fonts,
+  fetchpatch,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "qr-backup";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "za3k";
+    repo = "qr-backup";
+    tag = "v${version}";
+    hash = "sha256-Sre8cHbrRqJTX6+3HiLj6Ky8Bw+hg6UXItwRUtLzHZA=";
+  };
+
+  pyproject = false;
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  dependencies = with pkgs; [
+    python3Packages.pillow
+    python3Packages.qrcode
+    python3Packages.reedsolo
+    which
+    zbar
+    imagemagickBig
+    gnupg
+  ];
+
+  patches = [
+    # Backported from the upstream master branch so we can `doCheck` on
+    # the latest release version without needing to vendor a patch to
+    # disable the fragile regression tests
+    (fetchpatch {
+      name = "0001-Rename-from-regression-to-reproducibility-tests.patch";
+      url = "https://github.com/za3k/qr-backup/commit/ec8ab373110de62d2e1f6f47c9a34e9e1a73c571.patch";
+      hash = "sha256-93wxmCeH3qxZkDLZa9giMGUmVHdXSitXzet6WnAbQRw=";
+    })
+    (fetchpatch {
+      name = "0002-Add-fast-option-to-tests.patch";
+      url = "https://github.com/za3k/qr-backup/commit/e7d028eb4fddaa7f8628c88e1604d5e64f546389.patch";
+      hash = "sha256-5Ib+bs+ciqH1z0kvHBD7PrefTTwD6nWk+6pEPqxc9uU=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace qr-backup \
+      --replace-fail '"DejaVuSansMono.ttf"' "'${dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf'" \
+      --replace-fail '"python3", sys.argv[0]' "'$out/bin/qr-backup'"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 755 qr-backup "$out/bin/qr-backup"
+    mv docs/qr-backup.1{.man,} # remove .man suffix
+    installManPage docs/qr-backup.1
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+  doInstallCheck = true;
+  nativeCheckInputs = with pkgs; [
+    versionCheckHook
+    which
+    zbar
+  ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    substituteInPlace tests/test.py \
+      --replace-fail '"python3", "qr-backup"' "'$out/bin/qr-backup'"
+    export GNUPGHOME="$(mktemp -d)"
+    make test-fast
+
+    runHook postInstallCheck
+  '';
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Utility to generate paper backup of files using QR codes";
+    homepage = "https://github.com/za3k/qr-backup";
+    changelog = "https://github.com/za3k/qr-backup/blob/v${version}/docs/CHANGELOG";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [
+      acuteaangle
+    ];
+    mainProgram = "qr-backup";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds [qr-backup](https://github.com/za3k/qr-backup/), a utility to create paper backups of files using QR codes.

Homepage: https://github.com/za3k/qr-backup
License: `CC0-1.0`

~~Currently blocked by upstream issues:~~ Resolved
- https://github.com/za3k/qr-backup/issues/63
- https://github.com/za3k/qr-backup/issues/60

Closes: gh-343799 ("Package request: qr-backup")
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
