### PR TITLE
postgresql{,TestHook}: avoid running postgresql during builds on darwin

### DIFF
--- a/pkgs/by-name/po/postgresqlTestHook/package.nix
+++ b/pkgs/by-name/po/postgresqlTestHook/package.nix
@@ -1,8 +1,14 @@
-{ callPackage, makeSetupHook }:
+{
+  callPackage,
+  makeSetupHook,
+  stdenv,
+}:
 
 makeSetupHook {
   name = "postgresql-test-hook";
   passthru.tests = {
     simple = callPackage ./test.nix { };
   };
+  # See comment in postgresql's generic.nix doInstallCheck section.
+  meta.broken = stdenv.hostPlatform.isDarwin;
 } ./postgresql-test-hook.sh

--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -42,6 +42,9 @@ buildPythonPackage rec {
     rm -rf asyncpg/
   '';
 
+  # https://github.com/MagicStack/asyncpg/issues/1236
+  disabledTests = [ "test_connect_params" ];
+
   pythonImportsCheck = [ "asyncpg" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   };
 
   # sandboxing issues on aarch64-darwin, see https://github.com/NixOS/nixpkgs/issues/198495
-  doCheck = postgresql.doCheck;
+  doCheck = postgresql.doInstallCheck;
 
   # required for compatibility with Python versions older than 3.11
   # see https://github.com/MagicStack/asyncpg/blob/v0.29.0/asyncpg/_asyncio_compat.py#L13

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -395,12 +395,15 @@ let
       doInstallCheck =
         !(stdenv'.hostPlatform.isStatic)
         &&
-          # Tests just get stuck on macOS 14.x for v13 and v14
-          !(stdenv'.hostPlatform.isDarwin && olderThan "15")
-        &&
-          # x86: Likely due to rosetta emulation:
+          # Tests currently can't be run on darwin, because of a Nix bug:
+          # https://github.com/NixOS/nix/issues/12548
+          # https://git.lix.systems/lix-project/lix/issues/691
+          # The error appears as this in the initdb logs:
           #   FATAL:  could not create shared memory segment: Cannot allocate memory
-          # aarch64: not sure why, e.g. https://hydra.nixos.org/build/292573408/nixlog/7
+          # Don't let yourself be fooled when trying to remove this condition: Running
+          # the tests works fine most of the time. But once the tests (or any package using
+          # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
+          # will be stuck around, and any future builds with the tests enabled *will* fail.
           !(stdenv'.hostPlatform.isDarwin);
       installCheckTarget = "check-world";
 

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -219,7 +219,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   # sandboxing issues on aarch64-darwin, see https://github.com/NixOS/nixpkgs/issues/198495
-  doCheck = postgresql.doCheck;
+  doCheck = !postgresqlTestHook.meta.broken;
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
This is related to #371242. TLDR: Because of a [nix](https://github.com/NixOS/nix/issues/12548) [bug](https://git.lix.systems/lix-project/lix/issues/691), we disabled postgresql's tests again in d0f329628446a532a54a0ed29d0e9470b4811dbf (thanks @vcunat, that makes total sense!).

This cleans up the situation a bit more:
- Expands the comments for why we disabled the checks, according to what we know now.
- Marks `postgresqlTestHook` as broken on darwin, because it leads to exactly the same problems again and again.
- Re-enables tests for some packages, which were accidentally disabled in 9869d7f7466d3d4e4c5bca289f6c0e6df74bd0c1, where we moved from `checkPhase` to `installCheckPhase`.

I'll probably target the last commit at `haskell-updates` after a test run here to avoid merge conflicts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
