### PR TITLE
[DRAFT] code-cursor: fix updateScript

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -100,45 +100,43 @@ stdenvNoCC.mkDerivation {
     inherit sources;
     updateScript = writeScript "update.sh" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl yq coreutils gnused trurl common-updater-scripts
+      #!nix-shell -i bash -p curl jq coreutils gnused trurl common-updater-scripts
       set -eu -o pipefail
 
-      baseUrl="https://download.todesktop.com/230313mzl4w4u92"
-      latestLinux="$(curl -s $baseUrl/latest-linux.yml)"
-      latestDarwin="$(curl -s $baseUrl/latest-mac.yml)"
-      linuxVersion="$(echo "$latestLinux" | yq -r .version)"
+      baseUrl="https://www.cursor.com/api/download"
 
+      latestLinux="$(curl -s "''${baseUrl}?releaseTrack=stable&platform=linux-x64")"
+      latestDarwin="$(curl -s "''${baseUrl}?releaseTrack=stable&platform=darwin-arm64")"
+
+      linuxVersion="$(echo "$latestLinux" | jq -r .version)"
       currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
 
       if [[ "$linuxVersion" != "$currentVersion" ]]; then
-          darwinVersion="$(echo "$latestDarwin" | yq -r .version)"
+          darwinVersion="$(echo "$latestDarwin" | jq -r .version)"
           if [ "$linuxVersion" != "$darwinVersion" ]; then
               echo "Linux version ($linuxVersion) and Darwin version ($darwinVersion) do not match"
               exit 1
           fi
           version="$linuxVersion"
 
-          linuxFilename="$(echo "$latestLinux" | yq -r '.files[] | .url | select(. | endswith(".AppImage"))' | head -n 1)"
-          linuxStem="$(echo "$linuxFilename" | sed -E s/^\(.+build.+\)-[^-]+AppImage$/\\1/)"
-
-          darwinFilename="$(echo "$latestDarwin" | yq -r '.files[] | .url | select(. | endswith(".dmg"))' | head -n 1)"
-          darwinStem="$(echo "$darwinFilename" | sed -E s/^\(.+Build[^-]+\)-.+dmg$/\\1/)"
-
-          for platform in  "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"; do
+          # For each platform, get the download URL directly from the API
+          for platform in "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"; do
               if [ $platform = "x86_64-linux" ]; then
-                  url="$baseUrl/$linuxStem-x86_64.AppImage"
+                  apiPlatform="linux-x64"
               elif [ $platform = "aarch64-linux" ]; then
-                  url="$baseUrl/$linuxStem-arm64.AppImage"
+                  apiPlatform="linux-arm64"
               elif [ $platform = "x86_64-darwin" ]; then
-                  url="$baseUrl/$darwinStem-x64.dmg"
+                  apiPlatform="darwin-x64"
               elif [ $platform = "aarch64-darwin" ]; then
-                  url="$baseUrl/$darwinStem-arm64.dmg"
+                  apiPlatform="darwin-arm64"
               else
                   echo "Unsupported platform: $platform"
                   exit 1
               fi
 
-              url=$(trurl --accept-space "$url")
+              response="$(curl -s "''${baseUrl}?releaseTrack=stable&platform=''${apiPlatform}")"
+              url="$(echo "$response" | jq -r .downloadUrl)"
+
               hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$url" --name "cursor-$version")")
               update-source-version code-cursor $version $hash $url --system=$platform --ignore-same-version --source-key="sources.$platform"
           done


### PR DESCRIPTION
The unstable channel currently has cursor `0.45.14`, but `0.47.8` is the latest. I've tried to update the package and noticed the update script was out of date, so I tried fixing that first.

Upstream changed their update api, that's why the old script stopped working. This PR fixes the script.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
