### PR TITLE
[24.11] signal-desktop(aarch64-linux): 7.36.0 -> 7.46.0-1 from COPR

### DIFF
--- a/pkgs/by-name/si/signal-desktop/generic.nix
+++ b/pkgs/by-name/si/signal-desktop/generic.nix
@@ -5,6 +5,7 @@
   autoPatchelfHook,
   noto-fonts-color-emoji,
   dpkg,
+  libarchive,
   asar,
   rsync,
   python3,
@@ -53,7 +54,9 @@
 
 {
   pname,
-  dir,
+  libdir,
+  bindir,
+  extractPkg,
   version,
   hash,
   url,
@@ -100,7 +103,7 @@ stdenv.mkDerivation rec {
     recursiveHash = true;
     downloadToTemp = true;
     nativeBuildInputs = [
-      dpkg
+      (if ARCH == "x64" then dpkg else libarchive)
       asar
     ];
     # Signal ships the Apple emoji set without a licence via an npm
@@ -117,10 +120,10 @@ stdenv.mkDerivation rec {
     # unlicensed emoji files, but the rest of the work is done in the
     # main derivation.
     postFetch = ''
-      dpkg-deb -x $downloadedFile $out
-      asar extract "$out/opt/${dir}/resources/app.asar" $out/asar-contents
+      ${extractPkg}
+      asar extract "$out/${libdir}/resources/app.asar" $out/asar-contents
       rm -r \
-        "$out/opt/${dir}/resources/app.asar"{,.unpacked} \
+        "$out/${libdir}/resources/app.asar"{,.unpacked} \
         $out/asar-contents/node_modules/emoji-datasource-apple
     '';
   };
@@ -196,14 +199,14 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib
 
     mv usr/share $out/share
-    mv "opt/${dir}" "$out/lib/${dir}"
+    mv "${libdir}" "$out/lib/signal-desktop"
 
     # Symlink to bin
     mkdir -p $out/bin
-    ln -s "$out/lib/${dir}/${pname}" $out/bin/${pname}
+    ln -s "$out/lib/signal-desktop/signal-desktop" $out/bin/${meta.mainProgram}
 
     # Create required symlinks:
-    ln -s libGLESv2.so "$out/lib/${dir}/libGLESv2.so.2"
+    ln -s libGLESv2.so "$out/lib/signal-desktop/libGLESv2.so.2"
 
     # Copy the Noto Color Emoji PNGs into the ASAR contents. See `src`
     # for the motivation, and the script for the technical details.
@@ -218,7 +221,7 @@ stdenv.mkDerivation rec {
     substituteInPlace asar-contents/preload.bundle.js \
       --replace-fail \
         'emoji://jumbo?emoji=' \
-        "file://$out/lib/${lib.escapeURL dir}/resources/app.asar/$emojiPrefix/"
+        "file://$out/lib/signal-desktop/resources/app.asar/$emojiPrefix/"
 
     # `asar(1)` copies files from the corresponding `.unpacked`
     # directory when extracting, and will put them back in the modified
@@ -227,7 +230,7 @@ stdenv.mkDerivation rec {
     asar pack \
       --unpack '*.node' \
       asar-contents \
-      "$out/lib/${dir}/resources/app.asar"
+      "$out/lib/signal-desktop/resources/app.asar"
 
     runHook postInstall
   '';
@@ -239,13 +242,13 @@ stdenv.mkDerivation rec {
     )
 
     # Fix the desktop link
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-fail "/opt/${dir}/${pname}" ${meta.mainProgram} \
+    substituteInPlace $out/share/applications/signal-desktop.desktop \
+      --replace-fail "/${bindir}/signal-desktop" ${meta.mainProgram} \
       --replace-fail "StartupWMClass=Signal" "StartupWMClass=signal"
 
     # Note: The following path contains bundled libraries:
-    # $out/lib/${dir}/resources/app.asar.unpacked/node_modules/
-    patchelf --add-needed ${libpulseaudio}/lib/libpulse.so "$out/lib/${dir}/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-${ARCH}.node"
+    # $out/lib/signal-desktop/resources/app.asar.unpacked/node_modules/
+    patchelf --add-needed ${libpulseaudio}/lib/libpulse.so "$out/lib/signal-desktop/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-${ARCH}.node"
   '';
 
   passthru = {

--- a/pkgs/by-name/si/signal-desktop/generic.nix
+++ b/pkgs/by-name/si/signal-desktop/generic.nix
@@ -240,7 +240,7 @@ stdenv.mkDerivation rec {
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-fail "/opt/${dir}/${pname}" $out/bin/${pname} \
+      --replace-fail "/opt/${dir}/${pname}" ${meta.mainProgram} \
       --replace-fail "StartupWMClass=Signal" "StartupWMClass=signal"
 
     # Note: The following path contains bundled libraries:

--- a/pkgs/by-name/si/signal-desktop/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-desktop-aarch64.nix
@@ -1,8 +1,15 @@
 { callPackage }:
-callPackage ./generic.nix { } rec {
+callPackage ./generic.nix { } {
   pname = "signal-desktop";
-  dir = "Signal";
-  version = "7.36.0";
-  url = "https://github.com/0mniteck/Signal-Desktop-Mobian/raw/${version}/builds/release/signal-desktop_${version}_arm64.deb";
-  hash = "sha256-nmAqFDw35pdZg5tiq9MUlqXnbRLRkSOX9SWhccnE2Xw=";
+  version = "7.46.0-1";
+
+  libdir = "usr/lib64/signal-desktop";
+  bindir = "usr/bin";
+  extractPkg = ''
+    mkdir -p $out
+    bsdtar -xf $downloadedFile -C "$out"
+  '';
+
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/08759579-signal-desktop/signal-desktop-7.46.0-1.fc42.aarch64.rpm";
+  hash = "sha256-kiNwaB+jNOgkfkJ4V5Fj23RNILP3IOZfKWKAehMmtZ0=";
 }

--- a/pkgs/by-name/si/signal-desktop/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-desktop.nix
@@ -1,8 +1,12 @@
 { callPackage }:
 callPackage ./generic.nix { } rec {
   pname = "signal-desktop";
-  dir = "Signal";
   version = "7.46.0";
+
+  libdir = "opt/Signal";
+  bindir = libdir;
+  extractPkg = "dpkg-deb -x $downloadedFile $out";
+
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
   hash = "sha256-HbmyivfhvZfXdtcL/Cjzl4v0Ck/fJCD517iTjIeidgc=";
 }

--- a/pkgs/by-name/si/signal-desktop/update.sh
+++ b/pkgs/by-name/si/signal-desktop/update.sh
@@ -1,39 +1,33 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash nix-update curl coreutils jq
+#!nix-shell -i bash -p bash common-updater-scripts curl coreutils jq
 
 set -ex
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-curl_github() {
-  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "$@"
-}
+latestTag=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+  "https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest" \
+  | jq -r ".tag_name")
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
 
-case "$UPDATE_NIX_ATTR_PATH" in
-signal-desktop)
-  latestTag=$(curl_github https://api.github.com/repos/signalapp/Signal-Desktop/releases/latest | jq -r ".tag_name")
-  latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
-  latestVersionAarch64=$(curl_github "https://api.github.com/repos/0mniteck/Signal-Desktop-Mobian/releases/latest" | jq -r ".tag_name")
+latestBuildInfoAarch64=$(curl \
+  "https://copr.fedorainfracloud.org/api_3/package/?ownername=useidel&projectname=signal-desktop&packagename=signal-desktop&with_latest_succeeded_build=true" \
+  | jq '.builds.latest_succeeded')
+latestBuildAarch64=$(jq '.id' <<< $latestBuildInfoAarch64)
+latestVersionAarch64=$(jq -r '.source_package.version' <<< $latestBuildInfoAarch64)
 
-  echo "Updating signal-desktop for x86_64-linux"
-  nix-update --version "$latestVersion" \
-    --system x86_64-linux \
-    --override-filename "$SCRIPT_DIR/signal-desktop.nix" \
-  signal-desktop
+echo "Updating signal-desktop for x86_64-linux"
+update-source-version signal-desktop "$latestVersion" \
+  --system=x86_64-linux \
+  --file="$SCRIPT_DIR/signal-desktop.nix"
 
-  echo "Updating signal-desktop for aarch64-linux"
-  nix-update --version "$latestVersionAarch64" \
-    --system aarch64-linux \
-    --override-filename "$SCRIPT_DIR/signal-desktop-aarch64.nix" \
-    signal-desktop
+echo "Updating signal-desktop for aarch64-linux"
+update-source-version signal-desktop "$latestVersionAarch64" "" \
+  "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/$(printf "%08d" $latestBuildAarch64)-signal-desktop/signal-desktop-$latestVersionAarch64.fc42.aarch64.rpm" \
+  --system=aarch64-linux \
+  --file="$SCRIPT_DIR/signal-desktop-aarch64.nix"
 
-  echo "Updating signal-desktop for darwin"
-  nix-update --version "$latestVersion" \
-    --system aarch64-darwin \
-    --override-filename "$SCRIPT_DIR/signal-desktop-darwin.nix" \
-    signal-desktop
-  ;;
-*)
-  echo "Unknown attr path $UPDATE_NIX_ATTR_PATH"
-  ;;
-esac
+echo "Updating signal-desktop for darwin"
+update-source-version signal-desktop "$latestVersion" \
+  --system=aarch64-darwin \
+  --file="$SCRIPT_DIR/signal-desktop-darwin.nix"


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/384032 with partial cherry-pick of https://github.com/NixOS/nixpkgs/pull/348601 to resolve a conflict.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
