### PR TITLE
zabbix64, zabbix50: remove due to EOL

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -14,7 +14,6 @@ import ./versions.nix (
   {
     version,
     hash,
-    vendorHash ? throw "unsupported version ${version} for zabbix-agent2",
     ...
   }:
   buildGoModule {
@@ -28,7 +27,7 @@ import ./versions.nix (
 
     modRoot = "src/go";
 
-    inherit vendorHash;
+    vendorHash = null;
 
     nativeBuildInputs = [
       autoreconfHook

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -91,10 +91,6 @@ import ./versions.nix (
       ++ optional postgresqlSupport "--with-postgresql"
       ++ optional ipmiSupport "--with-openipmi=${openipmi.dev}";
 
-    env.NIX_CFLAGS_COMPILE = lib.optionalString (
-      lib.versions.major version <= "5"
-    ) "-Wno-error=incompatible-pointer-types";
-
     prePatch = ''
       find database -name data.sql -exec sed -i 's|/usr/bin/||g' {} +
     '';

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -9,11 +9,6 @@ generic: {
     hash = "sha256-r9VNy3bRuFvJAL+ZQEbKjCAS3+AvetnWAwFjLxFVuGU=";
     vendorHash = null;
   };
-  v64 = generic {
-    version = "6.4.20";
-    hash = "sha256-tFsg2Jq8Uaa5YULGUu1kXLkxyJuA3YGeSfJ4DPfOHkk=";
-    vendorHash = null;
-  };
   v60 = generic {
     version = "6.0.36";
     hash = "sha256-Ne0OY6NGzTYOn3sDVd+5tfawBu5VBjxNRtlxasubGCk=";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -2,16 +2,13 @@ generic: {
   v72 = generic {
     version = "7.2.5";
     hash = "sha256-DQGzk90isqYLNvs3qY/PEIHGg62Ygyot3YeUOhIAg54=";
-    vendorHash = null;
   };
   v70 = generic {
     version = "7.0.11";
     hash = "sha256-r9VNy3bRuFvJAL+ZQEbKjCAS3+AvetnWAwFjLxFVuGU=";
-    vendorHash = null;
   };
   v60 = generic {
     version = "6.0.36";
     hash = "sha256-Ne0OY6NGzTYOn3sDVd+5tfawBu5VBjxNRtlxasubGCk=";
-    vendorHash = null;
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -19,10 +19,4 @@ generic: {
     hash = "sha256-Ne0OY6NGzTYOn3sDVd+5tfawBu5VBjxNRtlxasubGCk=";
     vendorHash = null;
   };
-
-  v50 = generic {
-    version = "5.0.46";
-    hash = "sha256-p6OZALpOQG6v70Y20cC2bdlzTINz3JBd9qGWZACfcl4=";
-    vendorHash = "sha256-NgSi6usIbss3WEZCYht46WjxcrdOO3qv8KwwUZwtkk0=";
-  };
 }

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -24,7 +24,7 @@ import ./versions.nix (
 
     installPhase = ''
       mkdir -p $out/share/zabbix/
-      cp -a ${if lib.versionAtLeast version "5.0.0" then "ui/." else "frontends/php/."} $out/share/zabbix/
+      cp -a ui/. $out/share/zabbix/
       cp ${phpConfig} $out/share/zabbix/conf/zabbix.conf.php
     '';
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1929,6 +1929,7 @@ mapAliases {
   ### Z ###
 
   zabbix50 = throw "'zabbix50' has been removed, it would have reached its End of Life a few days after the release of NixOS 25.05. Consider upgrading to 'zabbix60' or 'zabbix70'.";
+  zabbix64 = throw "'zabbix64' has been removed because it reached its End of Life. Consider upgrading to 'zabbix70'.";
   zeroadPackages = recurseIntoAttrs {
     zeroad = lib.warnOnInstantiate "'zeroadPackages.zeroad' has been renamed to 'zeroad'" zeroad; # Added 2025-03-22
     zeroad-data = lib.warnOnInstantiate "'zeroadPackages.zeroad-data' has been renamed to 'zeroad-data'" zeroad-data; # Added 2025-03-22

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1928,6 +1928,7 @@ mapAliases {
 
   ### Z ###
 
+  zabbix50 = throw "'zabbix50' has been removed, it would have reached its End of Life a few days after the release of NixOS 25.05. Consider upgrading to 'zabbix60' or 'zabbix70'.";
   zeroadPackages = recurseIntoAttrs {
     zeroad = lib.warnOnInstantiate "'zeroadPackages.zeroad' has been renamed to 'zeroad'" zeroad; # Added 2025-03-22
     zeroad-data = lib.warnOnInstantiate "'zeroadPackages.zeroad-data' has been renamed to 'zeroad-data'" zeroad-data; # Added 2025-03-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12578,7 +12578,6 @@ with pkgs;
   zabbix70 = recurseIntoAttrs (zabbixFor "v70");
   zabbix60 = recurseIntoAttrs (zabbixFor "v60");
   zabbix64 = recurseIntoAttrs (zabbixFor "v64");
-  zabbix50 = recurseIntoAttrs (zabbixFor "v50");
 
   zabbix = zabbix60;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12577,7 +12577,6 @@ with pkgs;
   zabbix72 = recurseIntoAttrs (zabbixFor "v72");
   zabbix70 = recurseIntoAttrs (zabbixFor "v70");
   zabbix60 = recurseIntoAttrs (zabbixFor "v60");
-  zabbix64 = recurseIntoAttrs (zabbixFor "v64");
 
   zabbix = zabbix60;
 


### PR DESCRIPTION
Both are either already EOL or will be before the end of the current release cycle.

https://www.zabbix.com/life_cycle_and_release_policy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
