### PR TITLE
 treewide: drop copumpkin from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4869,12 +4869,6 @@
     githubId = 32609395;
     name = "B YI";
   };
-  copumpkin = {
-    email = "pumpkingod@gmail.com";
-    github = "copumpkin";
-    githubId = 2623;
-    name = "Dan Peebles";
-  };
   corbanr = {
     email = "corban@raunco.co";
     github = "CorbanR";

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -447,8 +447,7 @@ let
     mkdir -p $root
 
     # Copy arbitrary other files into the image
-    # Semi-shamelessly copied from make-etc.sh. I (@copumpkin) shall factor this stuff out as part of
-    # https://github.com/NixOS/nixpkgs/issues/23052.
+    # Semi-shamelessly copied from make-etc.sh.
     set -f
     sources_=(${lib.concatStringsSep " " sources})
     targets_=(${lib.concatStringsSep " " targets})

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -1,7 +1,7 @@
 /*
   Technical details
 
-  `make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine.
+  `make-disk-image` has a bit of magic to minimize the amount of work to do in a virtual machine. It also might arguably have too much, or at least too specific magic, so please consider to work towards the effort of unifying our image builders, as outlined in https://github.com/NixOS/nixpkgs/issues/324817 before adding more.
 
   It relies on the [LKL (Linux Kernel Library) project](https://github.com/lkl/linux) which provides Linux kernel as userspace library.
 

--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -80,7 +80,6 @@ buildGoModule rec {
     license = licenses.asl20;
     maintainers = with maintainers; [
       ebzzry
-      copumpkin
       vdemeester
       atkinschang
       Chili-Man

--- a/pkgs/applications/virtualization/lkl/default.nix
+++ b/pkgs/applications/virtualization/lkl/default.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation {
     platforms = platforms.linux; # Darwin probably works too but I haven't tested it
     license = licenses.gpl2;
     maintainers = with maintainers; [
-      copumpkin
       raitobezarius
     ];
   };

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -176,7 +176,6 @@ buildGoModule rec {
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [
-      copumpkin
       manveru
       anthonyroussel
       arianvp

--- a/pkgs/by-name/co/commonsBcel/package.nix
+++ b/pkgs/by-name/co/commonsBcel/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     homepage = "https://commons.apache.org/proper/commons-bcel/";
     description = "Gives users a convenient way to analyze, create, and manipulate (binary) Java class files";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/by-name/co/commonsCompress/package.nix
+++ b/pkgs/by-name/co/commonsCompress/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://commons.apache.org/proper/commons-compress";
     description = "Allows manipulation of ar, cpio, Unix dump, tar, zip, gzip, XZ, Pack200, bzip2, 7z, arj, lzma, snappy, DEFLATE and Z files";
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/co/commonsFileUpload/package.nix
+++ b/pkgs/by-name/co/commonsFileUpload/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://commons.apache.org/proper/commons-fileupload";
     description = "Makes it easy to add robust, high-performance, file upload capability to your servlets and web applications";
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/co/commonsIo/package.nix
+++ b/pkgs/by-name/co/commonsIo/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://commons.apache.org/proper/commons-io";
     description = "Library of utilities to assist with developing IO functionality";
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/co/commonsLang/package.nix
+++ b/pkgs/by-name/co/commonsLang/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Provides additional methods to manipulate standard Java library classes";
     homepage = "https://commons.apache.org/proper/commons-lang";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
   };

--- a/pkgs/by-name/co/commonsMath/package.nix
+++ b/pkgs/by-name/co/commonsMath/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://commons.apache.org/proper/commons-math/";
     description = "Library of lightweight, self-contained mathematics and statistics components";
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/cr/createrepo_c/package.nix
+++ b/pkgs/by-name/cr/createrepo_c/package.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "https://rpm-software-management.github.io/createrepo_c/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ec/ecs-agent/package.nix
+++ b/pkgs/by-name/ec/ecs-agent/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
     changelog = "https://github.com/aws/amazon-ecs-agent/raw/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
     mainProgram = "agent";
   };
 }

--- a/pkgs/by-name/js/jsonnet/package.nix
+++ b/pkgs/by-name/js/jsonnet/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     description = "Purely-functional configuration language that helps you define JSON data";
     maintainers = with lib.maintainers; [
       benley
-      copumpkin
     ];
     license = lib.licenses.asl20;
     homepage = "https://github.com/google/jsonnet";

--- a/pkgs/by-name/li/libsolv/package.nix
+++ b/pkgs/by-name/li/libsolv/package.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/openSUSE/libsolv";
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/mi/micro-httpd/package.nix
+++ b/pkgs/by-name/mi/micro-httpd/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
     description = "Really small HTTP server";
     license = licenses.bsd2;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
     mainProgram = "micro_httpd";
   };
 }

--- a/pkgs/by-name/os/ostree/package.nix
+++ b/pkgs/by-name/os/ostree/package.nix
@@ -161,6 +161,6 @@ in stdenv.mkDerivation rec {
     homepage = "https://ostreedev.github.io/ostree/";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/pa/paxtest/package.nix
+++ b/pkgs/by-name/pa/paxtest/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      copumpkin
       joachifm
     ];
   };

--- a/pkgs/by-name/rp/rpm-ostree/package.nix
+++ b/pkgs/by-name/rp/rpm-ostree/package.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
     description = "Hybrid image/package system. It uses OSTree as an image format, and uses RPM as a component model";
     homepage = "https://coreos.github.io/rpm-ostree/";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
     platforms = platforms.linux;
     mainProgram = "rpm-ostree";
   };

--- a/pkgs/by-name/so/souffle/package.nix
+++ b/pkgs/by-name/so/souffle/package.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [
       thoughtpolice
-      copumpkin
       wchresta
       markusscherer
     ];

--- a/pkgs/by-name/xa/xar/package.nix
+++ b/pkgs/by-name/xa/xar/package.nix
@@ -183,9 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/apple-oss-distributions/xar";
     description = "An easily extensible archive format";
     license = lib.licenses.bsd3;
-    maintainers =
-      lib.teams.darwin.members
-      ++ lib.attrValues { inherit (lib.maintainers) copumpkin tie; };
+    maintainers = lib.teams.darwin.members ++ lib.attrValues { inherit (lib.maintainers) tie; };
     platforms = lib.platforms.unix;
     mainProgram = "xar";
   };

--- a/pkgs/development/python-modules/ansicolors/default.nix
+++ b/pkgs/development/python-modules/ansicolors/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/verigak/colors/";
     description = "ANSI colors for Python";
     license = licenses.isc;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/lmdb/default.nix
+++ b/pkgs/development/python-modules/lmdb/default.nix
@@ -40,7 +40,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/jnwatson/py-lmdb/blob/py-lmdb_${version}/ChangeLog";
     license = lib.licenses.openldap;
     maintainers = with lib.maintainers; [
-      copumpkin
       ivan
     ];
   };

--- a/pkgs/development/python-modules/pathspec/default.nix
+++ b/pkgs/development/python-modules/pathspec/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/cpburnz/python-path-specification";
     changelog = "https://github.com/cpburnz/python-pathspec/blob/v${version}/CHANGES.rst";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pex/default.nix
+++ b/pkgs/development/python-modules/pex/default.nix
@@ -64,8 +64,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pantsbuild/pex";
     changelog = "https://github.com/pantsbuild/pex/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [
-      copumpkin
-    ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/vsajip/python-gnupg";
     changelog = "https://github.com/vsajip/python-gnupg/releases/tag/${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -292,6 +292,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    maintainers = [ lib.maintainers.copumpkin ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/stdenv-bootstrap-tools.nix
@@ -292,6 +292,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    maintainers = [ ];
+    maintainers = lib.teams.darwin.members;
   };
 })

--- a/pkgs/tools/package-management/librepo/default.nix
+++ b/pkgs/tools/package-management/librepo/default.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation rec {
     homepage = "https://rpm-software-management.github.io/librepo/";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation rec {
       lgpl21Plus
     ];
     description = "RPM Package Manager";
-    maintainers = with maintainers; [ copumpkin ];
+    maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
second iteration of https://github.com/NixOS/nixpkgs/pull/392354 after that one was merged a bit too early. Drafted in order to avoid merging this too quickly for a second time. Good to merge after two weeks or so, I'd say.

---

@copumpkin's last commit is from March 28th 2019, about 6 years ago.

This PR is in no way intended to diminish Daniels's accomplishments, and they're welcome to just say so if they'd prefer this PR not to be merged. Also, even if it's merged, of course they're always welcome to return to activity and be added back. The intent of this PR is to give more realistic expectations around the maintainership of these packages, and to invite others to step up for maintainership if they rely on those packages.

If this is merged, they should probably also be removed from the list of committers for the time being.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
