### PR TITLE
python313Packages.unity-test-parser: init at 0.1.1 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4819,6 +4819,12 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  concatime = {
+    email = "issam.e.maghni@mailbox.org";
+    github = "concatime";
+    githubId = 26262387;
+    name = "Issam E. Maghni";
+  };
   confus = {
     email = "con-f-use@gmx.net";
     github = "con-f-use";

--- a/pkgs/development/python-modules/unity-test-parser/default.nix
+++ b/pkgs/development/python-modules/unity-test-parser/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  junit-xml,
+  approvaltests,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "unity-test-parser";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ETCLabs";
+    repo = "unity-test-parser";
+    tag = "v${version}";
+    hash = "sha256-x5kbNvQn1RxGaHGnXWKAkaBfwCpGW7lHlkHaYRGqCyE=";
+  };
+
+  patches = [
+    # https://github.com/ETCLabs/unity-test-parser/pull/4
+    (fetchpatch {
+      url = "https://github.com/ETCLabs/unity-test-parser/commit/7f0a7bcacdffd1b89c7c87bc1be3e37482344d21.patch";
+      hash = "sha256-IWGSXFj+ZtAz9X6KTMuZ670m/2WifQfSCi5jqxegP6s=";
+    })
+
+    # https://github.com/ETCLabs/unity-test-parser/pull/5
+    (fetchpatch {
+      url = "https://github.com/ETCLabs/unity-test-parser/commit/6ac6de19ccd7e42d0da1a7b05031528fd1491e57.patch";
+      hash = "sha256-3xAuKRJyJgzVdzIIosFW5DnAczdGcxM3il5uLsvzyfs=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ junit-xml ];
+
+  nativeCheckInputs = [
+    approvaltests
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "unity_test_parser" ];
+
+  meta = {
+    description = "Unity test parser written in Python";
+    homepage = "https://github.com/ETCLabs/unity-test-parser";
+    changelog = "https://github.com/ETCLabs/unity-test-parser/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ concatime ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18124,6 +18124,8 @@ self: super: with self; {
 
   unittest-xml-reporting = callPackage ../development/python-modules/unittest-xml-reporting { };
 
+  unity-test-parser = callPackage ../development/python-modules/unity-test-parser { };
+
   univers = callPackage ../development/python-modules/univers { };
 
   universal-pathlib = callPackage ../development/python-modules/universal-pathlib { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add new unity-test-parser Python package. We use it in our CI to parse the output of Unity.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
