### PR TITLE
zsv: 0.3.8-alpha -> 0.4.4-alpha

### DIFF
--- a/pkgs/by-name/zs/zsv/package.nix
+++ b/pkgs/by-name/zs/zsv/package.nix
@@ -6,15 +6,15 @@
   jq,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zsv";
-  version = "0.3.8-alpha";
+  version = "0.4.4-alpha";
 
   src = fetchFromGitHub {
     owner = "liquidaty";
     repo = "zsv";
-    rev = "v${version}";
-    hash = "sha256-+6oZvMlfLVTDLRlqOpgdZP2YxT6Zlt13wBMFlryBrXY=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XZE7jMQaPP2B1OIlkHucNrtiJy8wMEVY9gcc5X4FyNI=";
   };
 
   nativeBuildInputs = [ perl ];
@@ -25,13 +25,13 @@ stdenv.mkDerivation rec {
     "--jq-prefix=${lib.getLib jq}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "World's fastest (simd) CSV parser, with an extensible CLI";
     mainProgram = "zsv";
     homepage = "https://github.com/liquidaty/zsv";
-    changelog = "https://github.com/liquidaty/zsv/releases/tag/v${version}";
-    license = licenses.mit;
+    changelog = "https://github.com/liquidaty/zsv/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
     maintainers = [ ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
- update to latest tag (`0.4.4-alpha`), fixing build failure with GCC 14
- replace `with lib;` on `meta`
- replace `rec` with `finalAttrs`

---

Fixes build failure of `zsv` (fails since `2025-01-14`, GCC update to 14 #356812).
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.zsv.x86_64-linux
https://hydra.nixos.org/build/293113751

Error log:
```text
external/yajl_helper/yajl_helper.c: In function 'yajl_helper_callbacks_init':
external/yajl_helper/yajl_helper.c:435:5: error: initialization of 'int (*)(void *, const char *, size_t,  int)' {aka 'int (*)(void *, const char *, long unsigned int,  int)'} from incompatible pointer type 'int (*)(void *, const unsigned char *, unsigned int,  int)' []
  435 |     yajl_helper_error
      |     ^~~~~~~~~~~~~~~~~
external/yajl_helper/yajl_helper.c:435:5: note: (near initialization for 'x.yajl_helper_error')
```
Upstream commit fixing it: https://github.com/liquidaty/zsv/commit/badf65a4968c4f76aa8281c24e5f4da115c8c4ec

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
