### PR TITLE
xorg.xf86videovmware: fix 3d support with mesa

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -200,7 +200,11 @@ in stdenv.mkDerivation {
 
     (lib.mesonBool "gallium-nine" false) # Direct3D9 in Wine, largely supplanted by DXVK
     (lib.mesonBool "osmesa" false) # deprecated upstream
-    (lib.mesonEnable "gallium-xa" false) # old and mostly dead
+
+    # Only used by xf86-video-vmware, which has more features than VMWare's KMS driver,
+    # so we're keeping it for now. Should be removed when that's no longer the case.
+    # See: https://github.com/NixOS/nixpkgs/pull/392492
+    (lib.mesonEnable "gallium-xa" true)
 
     (lib.mesonBool "teflon" true) # TensorFlow frontend
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -604,6 +604,7 @@ self: super:
   });
 
   xf86videovmware = super.xf86videovmware.overrideAttrs (attrs: {
+    buildInputs = attrs.buildInputs ++ [ mesa ];
     env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=address" ]; # gcc12
     meta = attrs.meta // {
       platforms = ["i686-linux" "x86_64-linux"];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/390737.

## Context

The xf86videovmware driver needs the gallium-xa driver for 3d support. Otherwise the X server crashes if you have 3d acceleration enabled in vmware workstation/player:

```log
17.628] (II) vmware(0): Driver was compiled without KMS- and 3D support.
[    17.628] (WW) vmware(0): Disabling 3D support.
[    17.628] (WW) vmware(0): Disabling Render Acceleration.
[    17.628] (WW) vmware(0): Disabling RandR12+ support.
...
  19.086] (EE) Backtrace:
[    19.086] (EE) 0: /nix/store/8lfqzlmg0cddfz9j22050mcmw34is7jc-xorg-server-21.1.16/bin/X (OsSigHandler+0x33) [0x5cc453]
[    19.086] (EE) unw_get_proc_name failed: no unwind info found [-10]
[    19.086] (EE) 1: /nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66/lib/libc.so.6 (?+0x0) [0x7f7ae43a4f30]
[    19.086] (EE) 2: /nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66/lib/libc.so.6 (__memset_avx2_unaligned_erms+0x49) [0x7f7ae44d9b89]
[    19.086] (EE) 3: /nix/store/1l8f8g1q4nczssafpsmzh0mjv75y4ic5-xf86-video-vmware-13.4.0/lib/xorg/modules/drivers/vmware_drv.so (VMWAREScreenInit+0x15c) [0x7f7ae3d7169c]
[    19.086] (EE) 4: /nix/store/8lfqzlmg0cddfz9j22050mcmw34is7jc-xorg-server-21.1.16/bin/X (AddScreen+0xd7) [0x4473c7]
[    19.086] (EE) 5: /nix/store/8lfqzlmg0cddfz9j22050mcmw34is7jc-xorg-server-21.1.16/bin/X (InitOutput+0x27b) [0x48d15b]
[    19.086] (EE) 6: /nix/store/8lfqzlmg0cddfz9j22050mcmw34is7jc-xorg-server-21.1.16/bin/X (dix_main+0x190) [0x44b390]
[    19.086] (EE) 7: /nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66/lib/libc.so.6 (__libc_start_call_main+0x7e) [0x7f7ae438e1fe]
[    19.086] (EE) 8: /nix/store/cmpyglinc9xl9pr4ymx8akl286ygl64x-glibc-2.40-66/lib/libc.so.6 (__libc_start_main+0x89) [0x7f7ae438e2b9]
[    19.086] (EE) 9: /nix/store/8lfqzlmg0cddfz9j22050mcmw34is7jc-xorg-server-21.1.16/bin/X (_start+0x25) [0x433245]
[    19.086] (EE) 
[    19.086] (EE) Segmentation fault at address 0x0
[    19.086] (EE) 
Fatal server error:
[    19.086] (EE) Caught signal 11 (Segmentation fault). Server aborting
```

@K900 Hope one more mesa rebuild is ok despite your hard work to reduce them :smiley:.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
