### PR TITLE
ausweiskopie: init at 0.1.5

### DIFF
--- a/pkgs/by-name/au/ausweiskopie/package.nix
+++ b/pkgs/by-name/au/ausweiskopie/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  makeDesktopItem,
+  copyDesktopItems,
+  desktopToDarwinBundle,
+  enableModern ? true,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "ausweiskopie";
+  version = "0.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Varbin";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-axy/cI5n2uvMKZ2Fkb0seFMRBKv6rpU01kgKSiQ10jE=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Meine Ausweiskopie";
+      exec = "ausweiskopie";
+      icon = "ausweiskopie";
+      desktopName = "Meine Ausweiskopie";
+      comment = "Create redacted copies of German identity cards";
+      categories = [
+        "Office"
+        "Viewer"
+      ];
+    })
+  ];
+
+  dependencies =
+    with python3Packages;
+    (
+      [
+        pillow
+        tkinter
+        importlib-resources
+      ]
+      ++ lib.optionals enableModern optional-dependencies.modern
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        dbus-next
+        pygobject3
+      ]
+    );
+
+  optional-dependencies.modern = [ python3Packages.ttkbootstrap ];
+
+  postInstall = ''
+    install -Dm644 ./src/ausweiskopie/resources/icon_colored.png $out/share/icons/hicolor/256x256/apps/ausweiskopie.png
+  '';
+
+  meta = {
+    description = "Create privacy friendly and legal copies of your Ausweisdokument";
+    homepage = "https://github.com/Varbin/ausweiskopie";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ e1mo ];
+    platforms = lib.platforms.unix;
+    mainProgram = "ausweiskopie";
+  };
+}

--- a/pkgs/development/python-modules/ttkbootstrap/default.nix
+++ b/pkgs/development/python-modules/ttkbootstrap/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pillow,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ttkbootstrap";
+  version = "1.10.1";
+
+  src = fetchFromGitHub {
+    owner = "israel-dryer";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-aUqr30Tgz3ZLjLbNIt9yi6bqhXj+31heZoOLOZHYUiU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pillow
+  ];
+
+  # As far as I can tell, all tests require a display and are not normal-ish pytests
+  # but appear to just be python scripts that run demos of components?
+  doCheck = false;
+
+  meta = {
+    description = "Supercharged theme extension for tkinter inspired by Bootstrap";
+    homepage = "https://github.com/israel-dryer/ttkbootstrap";
+    maintainers = with lib.maintainers; [ e1mo ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17476,6 +17476,8 @@ self: super: with self; {
 
   ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };
 
+  ttkbootstrap = callPackage ../development/python-modules/ttkbootstrap { };
+
   ttls = callPackage ../development/python-modules/ttls { };
 
   ttn-client = callPackage ../development/python-modules/ttn-client { };


### PR DESCRIPTION
Ausweiskopie is an application that makes it easy to watermark and redact details from scans of your id card.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
