### PR TITLE
readest: 0.9.23 -> 0.9.28

### DIFF
--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -19,13 +19,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "readest";
-  version = "0.9.23";
+  version = "0.9.25";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${version}";
-    hash = "sha256-MveWZ+9SSd6mPw580U8d8aP7c4rl4861VzCKHpOKiXU=";
+    hash = "sha256-AHPSkrCmtoM7K8v6+vu+jeKJ7u2srro1d7vn5oSIHX8=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -98,7 +98,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/readest/readest/releases/tag/v${finalAttrs.version}";
     mainProgram = "readest";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ eljamm ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -19,13 +19,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.9.27";
+  version = "0.9.28";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p6aMIhvSQx81YtBHdp3YXkeEeJCTaIrePDizuKIGAxM=";
+    hash = "sha256-jIAvpppOB50KA+4jmx8QN/4e1Dkn6V9Oo3lHUWb5cyI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -19,13 +19,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.9.26";
+  version = "0.9.27";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gNhuxbHnCT31VHVQfhep4oCyaLf5N9y4vQXIaZzvL8Y=";
+    hash = "sha256-p6aMIhvSQx81YtBHdp3YXkeEeJCTaIrePDizuKIGAxM=";
     fetchSubmodules = true;
   };
 
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   useFetchCargoVendor = true;
 
-  cargoHash = "sha256-0eyG9qmSuH2QCvl1L0+jgzRI136hDYLuq/2ZkQ/IofE=";
+  cargoHash = "sha256-guUe2liie2x87VXNo8UeJhVLgvfPViKJKQol1XWA3fw=";
 
   cargoRoot = "../..";
 

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -17,14 +17,14 @@
   jq,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
   version = "0.9.26";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gNhuxbHnCT31VHVQfhep4oCyaLf5N9y4vQXIaZzvL8Y=";
     fetchSubmodules = true;
   };
@@ -34,10 +34,10 @@ rustPlatform.buildRustPackage rec {
     chmod -R +w .
   '';
 
-  sourceRoot = "${src.name}/apps/readest-app";
+  sourceRoot = "${finalAttrs.src.name}/apps/readest-app";
 
   pnpmDeps = pnpm_9.fetchDeps {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-VcPxhCpDrKaqKtGMsvPwXwniPy0rbJ/i03gbZ3i87aE=";
   };
 
@@ -95,10 +95,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Modern, feature-rich ebook reader";
     homepage = "https://github.com/readest/readest";
-    changelog = "https://github.com/readest/readest/releases/tag/v${version}";
+    changelog = "https://github.com/readest/readest/releases/tag/v${finalAttrs.version}";
     mainProgram = "readest";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -19,13 +19,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "readest";
-  version = "0.9.25";
+  version = "0.9.26";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${version}";
-    hash = "sha256-AHPSkrCmtoM7K8v6+vu+jeKJ7u2srro1d7vn5oSIHX8=";
+    hash = "sha256-gNhuxbHnCT31VHVQfhep4oCyaLf5N9y4vQXIaZzvL8Y=";
     fetchSubmodules = true;
   };
 
@@ -38,14 +38,14 @@ rustPlatform.buildRustPackage rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-faLytJLMlWs80HZpN0TnCCEWPe9SPP9QH0bx3HLDO5o=";
+    hash = "sha256-VcPxhCpDrKaqKtGMsvPwXwniPy0rbJ/i03gbZ3i87aE=";
   };
 
   pnpmRoot = "../..";
 
   useFetchCargoVendor = true;
 
-  cargoHash = "sha256-5E+3Hpa6hiOORtZ5ykrXVOPucbppwO5KVVS1mb9mVXY=";
+  cargoHash = "sha256-0eyG9qmSuH2QCvl1L0+jgzRI136hDYLuq/2ZkQ/IofE=";
 
   cargoRoot = "../..";
 


### PR DESCRIPTION
Changelog: https://github.com/readest/readest/releases/tag/v0.9.28
Diff: https://github.com/readest/readest/compare/v0.9.23...v0.9.28

also switching to `final.Attrs`

add @eljamm as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
