### PR TITLE
duplicity: disable test_black due to Black version conflict

### DIFF
--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -56,6 +56,7 @@ let
       # ************* Module duplicity.backends.swiftbackend
       # duplicity/backends/swiftbackend.py:176: [E0401(import-error), SwiftBackend._put] Unable to import 'swiftclient.service'
       "test_pylint"
+      "test_black"
     ];
 
     nativeBuildInputs = [
@@ -65,7 +66,6 @@ let
       wrapGAppsNoGuiHook
       python3.pkgs.setuptools-scm
       python3.pkgs.pycodestyle
-      python3.pkgs.black
       python3.pkgs.pylint
     ];
 


### PR DESCRIPTION
The error occurs because the test enforces Black 24.x while Nixpkgs provides 25.1.0. 
This PR disables the failing test using `pytestFlagsArray` to allow the build to succeed until upstream fixes the version requirement.

Closes #392506
Maintainer: @corngood