### PR TITLE
Add wsdd2 NixOS service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1026,6 +1026,7 @@
   ./services/network-filesystems/orangefs/server.nix
   ./services/network-filesystems/rsyncd.nix
   ./services/network-filesystems/samba-wsdd.nix
+  ./services/network-filesystems/samba-wsdd2.nix
   ./services/network-filesystems/samba.nix
   ./services/network-filesystems/saunafs.nix
   ./services/network-filesystems/tahoe.nix

--- a/nixos/modules/services/network-filesystems/samba-wsdd2.nix
+++ b/nixos/modules/services/network-filesystems/samba-wsdd2.nix
@@ -1,0 +1,167 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.samba-wsdd2;
+  repeatFlag = flag: level:
+    lib.concatStrings (builtins.genList (_: flag) level);
+  args = lib.concatStringsSep " " ([
+    (lib.optionalString cfg.ipv4Only "-4")
+    (lib.optionalString cfg.ipv6Only "-6")
+    (lib.optionalString cfg.udpOnly "-u")
+    (lib.optionalString cfg.tcpOnly "-t")
+    (lib.optionalString cfg.llmnrOnly "-l")
+    (lib.optionalString cfg.wsddOnly "-w")
+    (repeatFlag "-L" cfg.llmnrDebugLevel)
+    (repeatFlag "-W" cfg.wsddDebugLevel)
+    (lib.optionalString (cfg.interface != null) "-i ${cfg.interface}")
+    (lib.optionalString (cfg.hostname != null) "-H ${cfg.hostname}")
+    (lib.optionalString (cfg.aliases != null)
+      ''-A "${lib.concatStringsSep "," cfg.aliases}"'')
+    (lib.optionalString (cfg.netbiosName != null) "-N ${cfg.netbiosName}")
+    (lib.optionalString (cfg.netbiosAliases != null)
+      ''-B "${lib.concatStringsSep "," cfg.netbiosAliases}"'')
+    (lib.optionalString (cfg.workgroup != null) "-G ${cfg.workgroup}")
+    (lib.optionalString (cfg.bootParameters != null)
+      ''-b "${cfg.bootParameters}"'')
+  ]);
+in {
+  options.services.samba-wsdd2 = {
+    enable = lib.mkEnableOption "Web Services Dynamic Discovery Daemon (wsdd2)";
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open required firewall ports for WSDD2.";
+    };
+    ipv4Only = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Run wsdd2 as a daemon.";
+    };
+    ipv6Only = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable IPv6-only mode.";
+    };
+    udpOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Use UDP-only mode.";
+    };
+    tcpOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Use TCP-only mode.";
+    };
+    llmnrOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable LLMNR-only mode.";
+    };
+    wsddOnly = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable WSDD-only mode.";
+    };
+    llmnrDebugLevel = lib.mkOption {
+      type = lib.types.int;
+      default = 0;
+      description = "Set LLMNR debug level (e.g., 1 = -L, 2 = -LL, etc.).";
+    };
+    wsddDebugLevel = lib.mkOption {
+      type = lib.types.int;
+      default = 0;
+      description = "Set WSDD debug level (e.g., 1 = -W, 2 = -WW, etc.).";
+    };
+    interface = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Network interface to bind to (e.g., br0).";
+    };
+    hostname = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Set host name for WSDD.";
+    };
+    aliases = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      description = "Set host aliases.";
+    };
+    netbiosName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "NetBIOS name to advertise.";
+    };
+    netbiosAliases = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      description = "NetBIOS aliases.";
+    };
+    workgroup = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "HOME";
+      description = "Set workgroup name.";
+    };
+    bootParameters = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Boot parameters in the format key1:val1,key2:val2,...";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.samba-wsdd2 = {
+      description = "Web Services Dynamic Discovery Daemon (wsdd2)";
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.wsdd2}/bin/wsdd2 ${args}";
+        Restart = "always";
+        RestartSec = "5s";
+        # Security Hardening Options
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = false;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies =
+          [ "AF_UNIX" "AF_INET" "AF_INET6" "AF_NETLINK" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RuntimeDirectoryMode = "0750";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@cpu-emulation"
+          "~@debug"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0027";
+      };
+    };
+    environment.systemPackages = [ pkgs.wsdd2 ];
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedUDPPorts = [ 3702 5355 ]; # WS-Discovery + LLMNR multicast UDP
+      allowedTCPPorts = [ 5355 ]; # LLMNR unicast TCP
+      extraCommands = ''
+        ip6tables -A INPUT -p udp -m udp --dport 3702 -d ff02::c -j ACCEPT
+        ip6tables -A INPUT -p udp -m udp --dport 5355 -d ff02::1:3 -j ACCEPT
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1046,6 +1046,7 @@ in {
   sabnzbd = handleTest ./sabnzbd.nix {};
   samba = handleTest ./samba.nix {};
   samba-wsdd = handleTest ./samba-wsdd.nix {};
+  samba-wsdd2 = handleTest ./samba-wsdd2.nix {};
   sane = handleTest ./sane.nix {};
   sanoid = handleTest ./sanoid.nix {};
   saunafs = handleTest ./saunafs.nix {};

--- a/nixos/tests/samba-wsdd2.nix
+++ b/nixos/tests/samba-wsdd2.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+  {
+    name = "samba-wsdd2";
+    meta.maintainers = with pkgs.lib.maintainers; [ izorkin ];
+
+    nodes = {
+      server_wsdd2 = { ... }: {
+        services.samba-wsdd2 = {
+          enable = true;
+          openFirewall = true;
+          interface = "eth1";
+          workgroup = "WORKGROUP";
+          hostname = "SERVER-WSDD";
+        };
+      };
+    };
+
+    testScript = ''
+      server_wsdd2.start()
+      server_wsdd2.wait_for_unit("samba-wsdd2")
+    '';
+  })

--- a/pkgs/by-name/ws/wsdd2/package.nix
+++ b/pkgs/by-name/ws/wsdd2/package.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, makeWrapper, lib }:
+stdenv.mkDerivation rec {
+  pname = "wsdd2";
+  version = "1.8.7";
+  src = fetchFromGitHub {
+    owner = "Netgear";
+    repo = "wsdd2";
+    rev = "${version}";
+    hash = "sha256-K0pGqcWzTgJGdQOIvrkXUPosgaOSL1lm81MEevK8YXk=";
+  };
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ];
+  buildPhase = ''
+    make
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m755 wsdd2 $out/bin/wsdd2
+  '';
+  meta = with lib; {
+    description = "WSD/LLMNR Discovery/Name Service Daemon";
+    homepage = "https://github.com/Netgear/wsdd2";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
Creation of the service samba-wsdd2 (evolution of samba-wsdd) service and the pkg wsdd2 

The WSDD service helps Windows machines discover SMB servers. This is the updated version from https://github.com/Netgear/wsdd2?tab=readme-ov-file with works better on Windows 11 machines than the previous versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
