### PR TITLE
sdns: init at 1.4.0

### DIFF
--- a/pkgs/by-name/sd/sdns/package.nix
+++ b/pkgs/by-name/sd/sdns/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "sdns";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "semihalev";
+    repo = "sdns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5YQnViBz5j/1Q7FG3Vh73kckNtyQp4FjNy1dydRuJc0=";
+  };
+
+  vendorHash = "sha256-Qv0YXROeRR39nzT4QcF1J7vJgMP5DW5id7gi5nM97tA=";
+
+  postPatch = ''
+    substituteInPlace dnsutil/dnsutil_test.go \
+        --replace-fail "TestExchange" "SkipExchange"
+    substituteInPlace middleware/cache/cache_test.go \
+        --replace-fail "Test_Cache_CNAME" "Skip_Cache_CNAME" \
+        --replace-fail "Test_Cache_ResponseWriter" "Skip_Cache_ResponseWriter"
+    substituteInPlace middleware/failover/failover_test.go \
+        --replace-fail "Test_Failover" "Skip_Failover"
+    substituteInPlace middleware/forwarder/forwarder_test.go \
+        --replace-fail "Test_Forwarder" "Skip_Forwarder"
+    substituteInPlace middleware/resolver/client_test.go \
+        --replace-fail "Test_Client" "Skip_Client"
+    substituteInPlace middleware/resolver/resolver_test.go \
+        --replace-fail "Test_resolver" "Skip_resolver"
+    substituteInPlace middleware/resolver/handler_test.go \
+        --replace-fail "Test_handler" "Skip_handler"
+    substituteInPlace server/doh/doh_test.go \
+        --replace-fail "Test_dohWire" "Skip_dohWire" \
+        --replace-fail "Test_dohJSON" "Skip_dohJSON"
+  '';
+
+  meta = {
+    description = "High-performance, recursive DNS resolver server with DNSSEC support, focused on preserving privacy.";
+    mainProgram = "sdns";
+    homepage = "https://sdns.dev";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [abbe];
+    changelog = "https://github.com/semihalev/sdns/releases/tag/v${finalAttrs.version}";
+  };
+})


### PR DESCRIPTION
A high-performance, recursive DNS resolver server with DNSSEC support, focused on preserving privacy.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
