### PR TITLE
nlopt: fix build, python3Packages.nlopt: init, nlopt: 2.7.1 -> 2.10.0

### DIFF
--- a/pkgs/development/libraries/nlopt/default.nix
+++ b/pkgs/development/libraries/nlopt/default.nix
@@ -2,32 +2,89 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   nix-update-script,
   # Optionally build Python bindings
   withPython ? false,
   python3,
   python3Packages,
-  swig,
   # Optionally build Octave bindings
   withOctave ? false,
   octave,
+  # Optionally build Java bindings
+  withJava ? false,
+  jdk,
+  # Required for building the Python and Java bindings
+  swig,
+  # Optionally exclude Luksan solvers to allow licensing under MIT
+  withoutLuksanSolvers ? false,
   # Build static on-demand
   withStatic ? stdenv.hostPlatform.isStatic,
+
+  # v2.8.0 introduced a regression where testing on Linux platforms fails with a buffer overflow
+  # when compiled with -D_FORTIFY_SOURCE=3.
+  # This was deemed to be a compiler false positive by the library's author in https://github.com/stevengj/nlopt/issues/563.
+  # Building with `clangStdenv` prevents this from occurring.
+  clangStdenv,
 }:
 let
   buildPythonBindingsEnv = python3.withPackages (p: [ p.numpy ]);
+  buildDocsEnv = python3.withPackages (p: [
+    p.mkdocs
+    p.python-markdown-math
+  ]);
 in
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "nlopt";
-  version = "2.7.1";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "stevengj";
     repo = "nlopt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TgieCX7yUdTAEblzXY/gCN0r6F9TVDh4RdNDjQdXZ1o=";
+    hash = "sha256-mZRmhXrApxfiJedk+L/poIP2DR/BkV04c5fiwPGAyjI=";
   };
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  patches = [
+    # 26-03-2025: `mkdocs.yml` is missing a link for the subpage related to the Java bindings.
+    # 26-03-2025: This commit was merged after v2.10.0 was released, and has not been made
+    # 26-03-2025: part of a release.
+    (fetchpatch {
+      name = "missing-java-reference-mkdocs";
+      url = "https://github.com/stevengj/nlopt/commit/7e34f1a6fe82ed27daa6111d83c4d5629555454b.patch";
+      hash = "sha256-XivfZtgIGLyTtU+Zo2jSQAx2mVdGLJ8PD7VSSvGR/5Q=";
+    })
+
+    # 26-03-2025: The docs pages still list v2.7.1 as the newest version.
+    # 26-03-2025: This commit was merged after v2.10.0 was released, and has not been made
+    # 26-03-2025: part of a release.
+    (fetchpatch {
+      name = "update-index-md";
+      url = "https://github.com/stevengj/nlopt/commit/2c4147832eff7ea15d0536c82351a9e169f85e43.patch";
+      hash = "sha256-BXcbNUyu20f3N146v6v9cpjSj5CwuDtesp6lAqOK2KY=";
+    })
+
+    # 26-03-2025: There is an off-by-one error in the test/CMakeLists.txt
+    # 26-03-2025: that causes the tests to attempt to run disabled Luksan solver code,
+    # 26-03-2025: which in turn causes the test suite to fail.
+    # 26-03-2025: See https://github.com/stevengj/nlopt/pull/605
+    (fetchpatch {
+      name = "fix-nondisabled-luksan-algorithm";
+      url = "https://github.com/stevengj/nlopt/commit/7817ec19f21be6877a4b79777fc5315a52c6850b.patch";
+      hash = "sha256-KgdAMSYKOQuraun4HNr9GOx48yjyeQk6W3IgWRA44oo=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace nlopt.pc.in \
+      --replace-fail 'libdir=''${exec_prefix}/@NLOPT_INSTALL_LIBDIR@' 'libdir=@NLOPT_INSTALL_LIBDIR@'
+  '';
 
   nativeBuildInputs =
     [ cmake ]
@@ -36,6 +93,11 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withPython [
       swig
       buildPythonBindingsEnv
+    ]
+    ## Building the java bindings requires SWIG, C++, JNI and Java
+    ++ lib.optionals withJava [
+      swig
+      jdk
     ]
     ## Building octave bindings requires `mkoctfile` to be installed.
     ++ lib.optional withOctave octave;
@@ -49,15 +111,24 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "NLOPT_CXX" true)
       (lib.cmakeBool "NLOPT_PYTHON" withPython)
       (lib.cmakeBool "NLOPT_OCTAVE" withOctave)
-      (lib.cmakeBool "NLOPT_SWIG" withPython)
+      (lib.cmakeBool "NLOPT_JAVA" withJava)
+      (lib.cmakeBool "NLOPT_SWIG" (withPython || withJava))
       (lib.cmakeBool "NLOPT_FORTRAN" false)
       (lib.cmakeBool "NLOPT_MATLAB" false)
       (lib.cmakeBool "NLOPT_GUILE" false)
+      (lib.cmakeBool "NLOPT_LUKSAN" (!withoutLuksanSolvers))
       (lib.cmakeBool "NLOPT_TESTS" finalAttrs.doCheck)
     ]
     ++ lib.optional withPython (
       lib.cmakeFeature "Python_EXECUTABLE" "${buildPythonBindingsEnv.interpreter}"
     );
+
+  postBuild = ''
+    ${buildDocsEnv.interpreter} -m mkdocs build \
+      --config-file ../mkdocs.yml \
+      --site-dir $doc \
+      --no-directory-urls
+  '';
 
   doCheck = true;
 
@@ -72,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://nlopt.readthedocs.io/en/latest/";
     changelog = "https://github.com/stevengj/nlopt/releases/tag/v${finalAttrs.version}";
     description = "Free open-source library for nonlinear optimization";
-    license = lib.licenses.lgpl21Plus;
+    license = if withoutLuksanSolvers then lib.licenses.mit else lib.licenses.lgpl21Plus;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.bengsparks ];
   };

--- a/pkgs/development/libraries/nlopt/default.nix
+++ b/pkgs/development/libraries/nlopt/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  nix-update-script,
   # Optionally build Python bindings
   withPython ? false,
   python3,
@@ -64,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/lib/cmake/nlopt/NLoptLibraryDepends.cmake --replace-fail \
       'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/' 'INTERFACE_INCLUDE_DIRECTORIES "'
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://nlopt.readthedocs.io/en/latest/";

--- a/pkgs/development/python-modules/nlopt/default.nix
+++ b/pkgs/development/python-modules/nlopt/default.nix
@@ -1,0 +1,5 @@
+{
+  toPythonModule,
+  pkgs,
+}:
+toPythonModule (pkgs.nlopt.override { withPython = true; })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4298,7 +4298,7 @@ with pkgs;
 
   nifskope = libsForQt5.callPackage ../tools/graphics/nifskope { };
 
-  nlopt = callPackage ../development/libraries/nlopt { octave = null; };
+  nlopt = callPackage ../development/libraries/nlopt { };
 
   notation = callPackage ../by-name/no/notation/package.nix {
     buildGoModule = buildGo123Module;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10547,6 +10547,8 @@ self: super: with self; {
 
   nkdfu = callPackage ../development/python-modules/nkdfu { };
 
+  nlopt = callPackage ../development/python-modules/nlopt { };
+
   nlpcloud = callPackage ../development/python-modules/nlpcloud { };
 
   nlpo3 = callPackage ../development/python-modules/nlpo3 { };


### PR DESCRIPTION
## Summary

The `nlopt` package shifted from autoconf to CMake quite some time ago. The first commit updates the package to reflect this.
The second commit makes use of the Python bindings to add a suitable Python module.

The third commit updates nlopt to the latest version v2.10.0, adding support for building Java bindings on request, documentation by default, and disabling Luksan solvers to allow for an MIT-licensed release.
It adds three patches (two doc-related, one testing related) to ensure everything is output as expected, including fixing an off-by-one error in a CMakeLists.txt.

The last two commits reintroduce automatic updates and add support for separating debug info.

The final result is a new healthy package, and two more packages now building correctly, namely
`haskellPackages.hmatrix-nlopt` and `haskellPackages.nlopt-haskell`.


### Changelog:

https://github.com/stevengj/nlopt/releases/tag/v2.8.0
https://github.com/stevengj/nlopt/releases/tag/v2.9.0
https://github.com/stevengj/nlopt/releases/tag/v2.9.1
https://github.com/stevengj/nlopt/releases/tag/v2.10.0

### Checks done for v2.7.1
<details>
<summary>Successfully build and test nlopt</summary>

```console
$ nix-build -A nlopt
100% tests passed, 0 tests failed out of 57
```
</details>

<details>
<summary>Successfully build and test Python bindings</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withPython = true; })"
58/58 Test #58: test_python ......................   Passed    0.28 sec
100% tests passed, 0 tests failed out of 58
```
</details>

<details>
<summary>Successfully build and test Octave bindings</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withOctave = true; })"
58/58 Test #58: test_octave ......................   Passed    1.96 sec
100% tests passed, 0 tests failed out of 58
```
</details>

<details>
<summary>Successfully build and test both bindings at the same time</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withOctave = true; withPython = true; })"
58/59 Test #58: test_python ......................   Passed    0.44 sec
59/59 Test #59: test_octave ......................   Passed    0.47 sec
100% tests passed, 0 tests failed out of 59
```
</details>




### Checks done for v2.10.0:
<details>
<summary>Successfully build and test nlopt</summary>

```console
$ nix-build -A nlopt
100% tests passed, 0 tests failed out of 77
```
</details>

<details>
<summary>Successfully build and test Python bindings</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withPython = true; })"
78/82 Test #78: test_python24 ....................   Passed    0.50 sec
79/82 Test #81: test_python40 ....................   Passed    0.45 sec
80/82 Test #80: test_python31 ....................   Passed    0.51 sec
81/82 Test #79: test_python25 ....................   Passed    0.54 sec
82/82 Test #82: test_memoize .....................   Passed    0.99 sec
100% tests passed, 0 tests failed out of 82
```

</details>

<details>
<summary>Successfully build and test Octave bindings</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withOctave = true; })"
78/78 Test #78: test_octave ......................   Passed    0.55 sec
100% tests passed, 0 tests failed out of 78
```
</details>

<details>
<summary>Successfully build and test Java bindings</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withJava = true; })"
78/81 Test #81: test_java40 ......................   Passed    0.20 sec
79/81 Test #78: test_java24 ......................   Passed    0.24 sec
80/81 Test #79: test_java25 ......................   Passed    0.27 sec
81/81 Test #80: test_java31 ......................   Passed    0.27 sec
100% tests passed, 0 tests failed out of 81
```
</details>

<details>
<summary>Successfully build and test nlopt without Luksan solvers</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withoutLuksanSolvers = true; })"
100% tests passed, 0 tests failed out of 61

The following tests did not run:
         42 - testopt_algo11_obj0 (Disabled)
         43 - testopt_algo11_obj1 (Disabled)
         44 - testopt_algo12_obj0 (Disabled)
         45 - testopt_algo12_obj1 (Disabled)
         46 - testopt_algo13_obj0 (Disabled)
         47 - testopt_algo13_obj1 (Disabled)
         48 - testopt_algo14_obj0 (Disabled)
         49 - testopt_algo14_obj1 (Disabled)
         50 - testopt_algo15_obj0 (Disabled)
         51 - testopt_algo15_obj1 (Disabled)
         52 - testopt_algo16_obj0 (Disabled)
         53 - testopt_algo16_obj1 (Disabled)
         54 - testopt_algo17_obj0 (Disabled)
         55 - testopt_algo17_obj1 (Disabled)
         56 - testopt_algo18_obj0 (Disabled)
         57 - testopt_algo18_obj1 (Disabled)
```
</details>

<details>
<summary>Successfully build and test all bindings at the same time while disabling Luksan solvers</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { withoutLuksanSolvers = true; withPython = true; withJava = true; withOctave = true; })"`

80/87 Test #85: test_java31 ......................   Passed    0.31 sec
81/87 Test #86: test_java40 ......................   Passed    0.19 sec
82/87 Test #78: test_python24 ....................   Passed    0.61 sec
83/87 Test #79: test_python25 ....................   Passed    0.62 sec
84/87 Test #81: test_python40 ....................   Passed    0.54 sec
85/87 Test #80: test_python31 ....................   Passed    0.62 sec
86/87 Test #87: test_octave ......................   Passed    0.55 sec
87/87 Test #82: test_memoize .....................   Passed    1.29 sec
100% tests passed, 0 tests failed out of 71

The following tests did not run:
         42 - testopt_algo11_obj0 (Disabled)
         43 - testopt_algo11_obj1 (Disabled)
         44 - testopt_algo12_obj0 (Disabled)
         45 - testopt_algo12_obj1 (Disabled)
         46 - testopt_algo13_obj0 (Disabled)
         47 - testopt_algo13_obj1 (Disabled)
         48 - testopt_algo14_obj0 (Disabled)
         49 - testopt_algo14_obj1 (Disabled)
         50 - testopt_algo15_obj0 (Disabled)
         51 - testopt_algo15_obj1 (Disabled)
         52 - testopt_algo16_obj0 (Disabled)
         53 - testopt_algo16_obj1 (Disabled)
         54 - testopt_algo17_obj0 (Disabled)
         55 - testopt_algo17_obj1 (Disabled)
         56 - testopt_algo18_obj0 (Disabled)
         57 - testopt_algo18_obj1 (Disabled)
```

</details>

### Checks done for both v2.7.1 and v2.10.0:
<details>
<summary>Skip checks</summary>

```console
$ nix-build -E "with import <nixpkgs> {}; (callPackage pkgs/development/libraries/nlopt/default.nix { }).overrideAttrs { doCheck = false; }"
```
</details>

<details>
<summary>Usage of dynamic and statically linked nlopt (continues) to function</summary>

```console
$ nixpkgs-review pr 392544
```
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
