### PR TITLE
python313Packages.gradio-client: 1.7.2 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "gradio-client";
-  version = "1.8.0";
+  version = "1.10.0";
   pyproject = true;
 
   # no tests on pypi
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     # not to be confused with @gradio/client@${version}
     tag = "gradio_client@${version}";
     sparseCheckout = [ "client/python" ];
-    hash = "sha256-Z/+oY2fURVE+KpQtXrpdOGlq9tmiovFqzYm7dq/QFCI=";
+    hash = "sha256-6sfY8a6CCfkczsF4yvjOuUZOcyiXx1zK7pUHUtYMq/Q=";
   };
 
   sourceRoot = "${src.name}/client/python";

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "gradio-client";
-  version = "1.7.2";
+  version = "1.8.0";
   pyproject = true;
 
   # no tests on pypi
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     # not to be confused with @gradio/client@${version}
     tag = "gradio_client@${version}";
     sparseCheckout = [ "client/python" ];
-    hash = "sha256-9hEls6f3aBNg7W2RGhu68mJSGlUScpNqMGsdHxTGyRY=";
+    hash = "sha256-Z/+oY2fURVE+KpQtXrpdOGlq9tmiovFqzYm7dq/QFCI=";
   };
 
   sourceRoot = "${src.name}/client/python";

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   writeShellScriptBin,
   gradio,
+  nix-update-script,
 
   # build-system
   hatchling,
@@ -71,19 +72,19 @@
 
 buildPythonPackage rec {
   pname = "gradio";
-  version = "5.20.0";
+  version = "5.22.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${version}";
-    hash = "sha256-gAAyhsnc1LUcAvlUC5hftsWN1kSiRWqcQ4iKGpSIL+U=";
+    hash = "sha256-pHmeS9wnhS8lAQ2lnzGXLVGKZwzHkKA0tAF2t/nDmt8=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-y0Bdupn19gEtwatc6Q3KD7aekXDk0xrq04LaG7gxMFI=";
+    hash = "sha256-HjJxd2dzBGEE9dxWIi9dI28J7rOA6iidJmoAGDYM/Zw=";
   };
 
   pythonRelaxDeps = [
@@ -348,11 +349,20 @@ buildPythonPackage rec {
         dontCheckRuntimeDeps = true;
       });
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^gradio@(.*)"
+    ];
+  };
+
   meta = {
     homepage = "https://www.gradio.app/";
     changelog = "https://github.com/gradio-app/gradio/releases/tag/gradio@${version}";
     description = "Python library for easily interacting with trained machine learning models";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
+    # unexplained timeout during preBuild
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -61,6 +61,7 @@
   ffmpeg,
   ipython,
   pytest-asyncio,
+  mcp,
   respx,
   scikit-image,
   torch,
@@ -72,19 +73,19 @@
 
 buildPythonPackage rec {
   pname = "gradio";
-  version = "5.22.0";
+  version = "5.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${version}";
-    hash = "sha256-pHmeS9wnhS8lAQ2lnzGXLVGKZwzHkKA0tAF2t/nDmt8=";
+    hash = "sha256-hgK1zA7jEH7DVAgXJuT/lsnE/J3B/cmPnj4BJ4rlxms=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-HjJxd2dzBGEE9dxWIi9dI28J7rOA6iidJmoAGDYM/Zw=";
+    hash = "sha256-h3ulPik0Uf8X687Se3J7h3+8jYzwXtbO6obsO27zyfA=";
   };
 
   pythonRelaxDeps = [
@@ -156,6 +157,7 @@ buildPythonPackage rec {
       ffmpeg
       ipython
       pytest-asyncio
+      mcp
       respx
       scikit-image
       # shap is needed as well, but breaks too often
@@ -308,6 +310,8 @@ buildPythonPackage rec {
     "client/python/test/test_client.py"
     # makes pytest freeze 50% of the time
     "test/test_interfaces.py"
+    # requires docker
+    "test/test_docker/"
 
     # Local network tests dependant on port availability (port 7860-7959)
     "test/test_routes.py"


### PR DESCRIPTION
- **python313Packages.gradio-client: 1.7.2 -> 1.8.0**
- **python313Packages.gradio: 5.20.0 -> 5.22.0**

~~To get gradio to build I had to apply a [dirty hack](https://gist.github.com/pbsds/475cfae99e56784c5d1aea7be6954624) to pydub, due to some error in ffmpeg-full which I believe https://github.com/NixOS/nixpkgs/pull/392115 could have played a part in. This build failure have yet to become visible on hydra however, so it may be an issue on my infra~~


closes https://github.com/NixOS/nixpkgs/pull/392452

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
