### PR TITLE
nixos/boot.kernelPatches: description update

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -91,32 +91,7 @@ in
         ]
       '';
       description = ''
-        A list of additional patches to apply to the kernel.
-
-        Every item should be an attribute set with the following attributes:
-
-        ```nix
-        {
-          name = "foo";                 # descriptive name, required
-
-          patch = ./foo.patch;          # path or derivation that contains the patch source
-                                        # (required, but can be null if only config changes
-                                        # are needed)
-
-          extraStructuredConfig = {     # attrset of extra configuration parameters without the CONFIG_ prefix
-            FOO = lib.kernel.yes;       # (optional)
-          };                            # values should generally be lib.kernel.yes,
-                                        # lib.kernel.no or lib.kernel.module
-
-          features = {                  # attrset of extra "features" the kernel is considered to have
-            foo = true;                 # (may be checked by other NixOS modules, optional)
-          };
-
-          extraConfig = "FOO y";        # extra configuration options in string form without the CONFIG_ prefix
-                                        # (optional, multiple lines allowed to specify multiple options)
-                                        # (deprecated, use extraStructuredConfig instead)
-        }
-        ```
+        A list of additional patches to apply to the kernel. Every item should be an attribute set as shown in the example below.
 
         There's a small set of existing kernel patches in Nixpkgs, available as `pkgs.kernelPatches`,
         that follow this format and can be used directly.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -91,7 +91,13 @@ in
         ]
       '';
       description = ''
-        A list of additional patches to apply to the kernel. Every item should be an attribute set as shown in the example below.
+        A list of additional patches to apply to the kernel. Every item should be an attribute set as shown below.
+
+        * **`name`**: (Required) Descriptive name (e.g., `"foo"`).
+        * **`patch`**: (Required, or `null`) Path to patch source (e.g., `./foo.patch`).
+        * **`extraStructuredConfig`**: (Optional) Configuration options (e.g., `{ FOO = lib.kernel.yes; }`).
+        * **`features`**: (Optional) Kernel "features" (e.g., `{ foo = true; }`).
+        * **`extraConfig`**: (Optional, deprecated) String config options (e.g., `"FOO y"`).
 
         There's a small set of existing kernel patches in Nixpkgs, available as `pkgs.kernelPatches`,
         that follow this format and can be used directly.


### PR DESCRIPTION
can we remove the big chunk of example as isn't [formatted correctly](https://search.nixos.org/options?channel=24.11&show=boot.kernelPatches&from=0&size=50&sort=relevance&type=packages&query=kernel+parameters) on the search page and we already show it as an example


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
