### PR TITLE
helm-sops: init at 20250205-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16199,6 +16199,11 @@
     githubId = 48406064;
     keys = [ { fingerprint = "6FAD DB43 D5A5 FE52 6835  0943 5B33 79E9 81EF 48B1"; } ];
   };
+  mrupnikm = {
+    github = "mrupnikm";
+    githubId = 93078189;
+    name = "Matic Rupnik";
+  };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";

--- a/pkgs/by-name/he/helm-sops/package.nix
+++ b/pkgs/by-name/he/helm-sops/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  helm,
+  sops,
+}:
+
+buildGoModule rec {
+  pname = "helm-sops";
+  version = "20250205-1";
+  src = fetchFromGitHub {
+    owner = "camptocamp";
+    repo = "helm-sops";
+    rev = "20250205-1";
+    sha256 = "sha256-xkHv+PM2acwk9uwAHlVgBbJKhofAU60KJykMEx7Zq8I=";
+  };
+
+  vendorHash = "sha256-jynNpi9XRaLLW1rbvFTgX5CHDoJxagFpx9nGK0F2H0Y=";
+
+  nativeBuildInputs = [
+    helm
+    sops
+  ];
+
+  meta = with lib; {
+    description = "A Helm plugin to encrypt secrets with SOPS";
+    homepage = "https://github.com/camptocamp/helm-sops";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mrupnikm ];
+  };
+}

--- a/pkgs/by-name/he/helm-sops/package.nix
+++ b/pkgs/by-name/he/helm-sops/package.nix
@@ -27,7 +27,8 @@ buildGoModule rec {
   meta = with lib; {
     description = "A Helm plugin to encrypt secrets with SOPS";
     homepage = "https://github.com/camptocamp/helm-sops";
+    changelog = "https://github.com/camptocamp/helm-sops/releases/tag/${version}";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ mrupnikm ];
+    maintainers = [ maintainers.mrupnikm ];
   };
 }


### PR DESCRIPTION
Added helm-sops binary

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).