### PR TITLE
{llvm,triton-llvm}: fix nondeterministic hang

### DIFF
--- a/pkgs/by-name/tr/triton-llvm/llvm-exegesis-timeout.patch
+++ b/pkgs/by-name/tr/triton-llvm/llvm-exegesis-timeout.patch
@@ -1,0 +1,27 @@
+From 705ba309ccebb0f505107a83542ff13d555008e0 Mon Sep 17 00:00:00 2001
+From: Stephen Huan <stephen.huan@cgdct.moe>
+Date: Mon, 24 Mar 2025 21:35:42 -0400
+Subject: [PATCH] [llvm-exegesis] Timeout if subprocess executor hangs
+
+The call to llvm_exegesis_exe nondeterministically hangs, causing
+llvm's tests to block. Introduce a timeout when this happens.
+---
+ llvm/test/tools/llvm-exegesis/lit.local.cfg | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/test/tools/llvm-exegesis/lit.local.cfg b/llvm/test/tools/llvm-exegesis/lit.local.cfg
+index a51a2d73442fa..8b7c13f5eb1b6 100644
+--- a/llvm/test/tools/llvm-exegesis/lit.local.cfg
++++ b/llvm/test/tools/llvm-exegesis/lit.local.cfg
+@@ -24,9 +24,10 @@ def can_use_perf_counters(mode, extra_options=[]):
+             + extra_options,
+             stdout=subprocess.DEVNULL,
+             stderr=subprocess.DEVNULL,
++            timeout=1,
+         )
+         return return_code == 0
+-    except OSError:
++    except (OSError, subprocess.TimeoutExpired):
+         print("could not exec llvm-exegesis")
+         return False
+ 

--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -83,6 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "8957e64a20fc7f4277565c6cfe3e555c119783ce";
     hash = "sha256-ljdwHPLGZv72RBPBg5rs7pZczsB+WJhdCeHJxoi4gJQ=";
   };
+  patches = [
+    # fix tests nondeterministically hanging
+    # [llvm-exegesis] Timeout if subprocess executor hangs #132861
+    # https://github.com/llvm/llvm-project/pull/132861
+    ./llvm-exegesis-timeout.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/compilers/llvm/17/llvm/llvm-exegesis-timeout.patch
+++ b/pkgs/development/compilers/llvm/17/llvm/llvm-exegesis-timeout.patch
@@ -1,0 +1,27 @@
+From 705ba309ccebb0f505107a83542ff13d555008e0 Mon Sep 17 00:00:00 2001
+From: Stephen Huan <stephen.huan@cgdct.moe>
+Date: Mon, 24 Mar 2025 21:35:42 -0400
+Subject: [PATCH] [llvm-exegesis] Timeout if subprocess executor hangs
+
+The call to llvm_exegesis_exe nondeterministically hangs, causing
+llvm's tests to block. Introduce a timeout when this happens.
+---
+ llvm/test/tools/llvm-exegesis/lit.local.cfg | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/test/tools/llvm-exegesis/lit.local.cfg b/llvm/test/tools/llvm-exegesis/lit.local.cfg
+index a51a2d73442fa..8b7c13f5eb1b6 100644
+--- a/test/tools/llvm-exegesis/lit.local.cfg
++++ b/test/tools/llvm-exegesis/lit.local.cfg
+@@ -24,9 +24,10 @@ def can_use_perf_counters(mode, extra_options=[]):
+             + extra_options,
+             stdout=subprocess.DEVNULL,
+             stderr=subprocess.DEVNULL,
++            timeout=1,
+         )
+         return return_code == 0
+-    except OSError:
++    except (OSError, subprocess.TimeoutExpired):
+         print("could not exec llvm-exegesis")
+         return False
+ 

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -166,6 +166,10 @@ stdenv.mkDerivation (
         # on macOS (nothing about this _seems_ nix specific)..
         (getVersionFile "llvm/lit-shell-script-runner-set-dyld-library-path.patch")
       ]
+      # Fix tests nondeterministically hanging: https://github.com/llvm/llvm-project/pull/132861
+      ++ lib.optional (lib.versionAtLeast release_version "17") (
+        getVersionFile "llvm/llvm-exegesis-timeout.patch"
+      )
       ++
         lib.optional (lib.versionOlder release_version "19")
           # Add missing include headers to build against gcc-15:

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -45,6 +45,12 @@
       path = ../18;
     }
   ];
+  "llvm/llvm-exegesis-timeout.patch" = [
+    {
+      after = "17";
+      path = ../17;
+    }
+  ];
   "llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch" = [
     {
       path = ../18;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm experiencing a nondeterministic hang while running llvm's tests (it gets stuck on a lit test and doesn't finish, even after waiting for a long time). Other times it finishes fine. Seems to be more stable with 4 cores or less.

Possibly caused by https://github.com/llvm/llvm-project/issues/56336 (see https://github.com/llvm/llvm-project/commit/61708ec7547885ac5ef5421c64335e9c2c93946a and the [following comment](https://github.com/llvm/llvm-project/blob/ef3e521a2b34050d92a6b711c5df811a0bde84f4/llvm/utils/lit/tests/max-failures.py#L2-L5))

```python
# FIXME: This test is flaky and hangs randomly on multi-core systems.
# See https://github.com/llvm/llvm-project/issues/56336 for more
# details.
# REQUIRES:  less-than-4-cpu-cores-in-parallel
```

Not sure if this is the only flaky test as the hang is nondeterministic and llvm takes a long time to build.

Of course this could be fixed by `--cores 4` but that would slow down the build as well (and not just the tests).

Happy to change the PR to just disable this test (`rm llvm/utils/lit/tests/max-failures.py`) if that would be cleaner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
