### PR TITLE
twitch-drops-miner: init at 0-unstable-2025-3-24

### DIFF
--- a/pkgs/by-name/tw/twitch-drops-miner/0001-data-paths.patch
+++ b/pkgs/by-name/tw/twitch-drops-miner/0001-data-paths.patch
@@ -1,0 +1,14 @@
+diff --git a/build.spec b/build.spec
+index 58ff4f7..b351e4c 100755
+--- a/build.spec
++++ b/build.spec
+@@ -60,6 +60,9 @@ if sys.platform == "linux":
+             "gi_typelibs",
+         )
+     )
++    datas.append((Path("@gtk3@/lib/girepository-1.0/Gtk-3.0.typelib"), "gi_typelibs"))
++    datas.append((Path("@tcl@/lib"), "_tcl_data"))
++    datas.append((Path("@tk@/lib"), "_tk_data"))
+     binaries.append((Path(f"/usr/lib/{arch}-linux-gnu/libayatana-appindicator3.so.1"), "."))
+ 
+     hiddenimports.extend([

--- a/pkgs/by-name/tw/twitch-drops-miner/0002-path-constants.patch
+++ b/pkgs/by-name/tw/twitch-drops-miner/0002-path-constants.patch
@@ -1,0 +1,29 @@
+diff --git a/constants.py b/constants.py
+index df20268..fe632a9 100644
+--- a/constants.py
++++ b/constants.py
+@@ -46,14 +46,7 @@ def _resource_path(relative_path: Path | str) -> Path:
+ 
+     Works for dev and for PyInstaller.
+     """
+-    if IS_APPIMAGE:
+-        base_path = Path(sys.argv[0]).resolve().parent
+-    elif IS_PACKAGED:
+-        # PyInstaller's folder where the one-file app is unpacked
+-        meipass: str = getattr(sys, "_MEIPASS")
+-        base_path = Path(meipass)
+-    else:
+-        base_path = WORKING_DIR
++    base_path = Path("@out@/share")
+     return base_path.joinpath(relative_path)
+ 
+ 
+@@ -91,7 +84,7 @@ else:
+     SELF_PATH = Path(sys.argv[0]).resolve()
+     if SELF_PATH.stem == "pyinstaller" or SELF_PATH.name == "gui.py":
+         SELF_PATH = Path(__file__).with_name("main.py").resolve()
+-WORKING_DIR = SELF_PATH.parent
++WORKING_DIR = Path(os.path.expanduser("~/.local/share/twitch-drops-miner"))
+ # Development paths
+ VENV_PATH = Path(WORKING_DIR, "env")
+ SITE_PACKAGES_PATH = Path(VENV_PATH, SYS_SITE_PACKAGES)

--- a/pkgs/by-name/tw/twitch-drops-miner/0003-create-runtime-directory.patch
+++ b/pkgs/by-name/tw/twitch-drops-miner/0003-create-runtime-directory.patch
@@ -1,0 +1,30 @@
+diff --git a/main.py b/main.py
+index 00d536f..119b514 100644
+--- a/main.py
++++ b/main.py
+@@ -7,6 +7,7 @@ from multiprocessing import freeze_support
+ if __name__ == "__main__":
+     freeze_support()
+     import io
++    import os
+     import sys
+     import signal
+     import asyncio
+@@ -27,7 +28,7 @@ if __name__ == "__main__":
+     from version import __version__
+     from exceptions import CaptchaRequired
+     from utils import lock_file, resource_path, set_root_icon
+-    from constants import LOGGING_LEVELS, SELF_PATH, FILE_FORMATTER, LOG_PATH, LOCK_PATH
++    from constants import LOGGING_LEVELS, SELF_PATH, FILE_FORMATTER, LOG_PATH, LOCK_PATH, WORKING_DIR
+ 
+     warnings.simplefilter("default", ResourceWarning)
+ 
+@@ -186,6 +187,8 @@ if __name__ == "__main__":
+ 
+     try:
+         # use lock_file to check if we're not already running
++        if not os.path.isdir(WORKING_DIR):
++            os.makedirs(WORKING_DIR)
+         success, file = lock_file(LOCK_PATH)
+         if not success:
+             # already running - exit

--- a/pkgs/by-name/tw/twitch-drops-miner/package.nix
+++ b/pkgs/by-name/tw/twitch-drops-miner/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+
+  libayatana-appindicator,
+  tcl,
+  tk,
+  gtk3,
+
+  unstableGitUpdater,
+}:
+python3Packages.buildPythonApplication {
+  pname = "twitchdropsminer";
+  version = "0-unstable-2025-3-24";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "DevilXD";
+    repo = "TwitchDropsMiner";
+    rev = "714558965fce217005ef5ad2c11da90a6834e0b1";
+    hash = "sha256-2SrPXddWbNjh7F+mkrqFu9q1JVSJLVE6uajGFQbErU8=";
+  };
+
+  patches = [
+    ./0001-data-paths.patch
+    ./0002-path-constants.patch
+    ./0003-create-runtime-directory.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace build.spec \
+      --subst-var-by "gtk3" "${gtk3}" \
+      --subst-var-by "tcl" "${tcl}" \
+      --subst-var-by "tk" "${tk}" \
+      --replace-fail "/usr/lib/{arch}-linux-gnu" "${libayatana-appindicator}/lib"
+
+    substituteInPlace constants.py \
+      --subst-var "out"
+  '';
+
+  dependencies = with python3Packages; [
+    tkinter
+    aiohttp
+    pillow
+    pystray
+    pygobject3
+    truststore
+  ];
+
+  buildInputs = [
+    libayatana-appindicator
+    gtk3
+  ];
+
+  nativeBuildInputs = [
+    python3Packages.pyinstaller
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pyinstaller --clean --noconfirm build.spec
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    mv dist/Twitch\ Drops\ Miner\ \(by\ DevilXD\) $out/bin/twitch-drops-miner
+    mv icons $out/share/icons
+    mv lang $out/share/lang
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "GUI App to automine twitch drops";
+    homepage = "https://github.com/DevilXD/TwitchDropsMiner";
+    mainProgram = "twitch-drops-miner";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nyukuru ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

An app that allows you to AFK mine timed Twitch drops, with automatic drop claiming and channel switching. 

Fixes #390510

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
