### PR TITLE
nixos/archtika: fix module and package

### DIFF
--- a/nixos/modules/services/web-apps/archtika.nix
+++ b/nixos/modules/services/web-apps/archtika.nix
@@ -17,7 +17,7 @@ let
 in
 {
   options.services.archtika = {
-    enable = mkEnableOption "Whether to enable the archtika service";
+    enable = mkEnableOption "the archtika CMS";
 
     package = mkPackageOption pkgs "archtika" { };
 

--- a/pkgs/by-name/ar/archtika/package.nix
+++ b/pkgs/by-name/ar/archtika/package.nix
@@ -21,7 +21,7 @@ let
   web = buildNpmPackage {
     name = "web-app";
     src = "${src}/web-app";
-    npmDepsHash = "sha256-RTyo7K/Hr1hBGtcBKynrziUInl91JqZl84NkJg16ufA=";
+    npmDepsHash = "sha256-2udi8vLLvdoZxIyRKLOCfEpEMsooxsIrM1wiua1QPAI=";
     npmFlags = [ "--legacy-peer-deps" ];
     installPhase = ''
       mkdir -p $out/web-app
@@ -51,7 +51,7 @@ symlinkJoin {
   ];
 
   passthru = {
-    inherit src;
+    inherit src web;
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/ar/archtika/package.nix
+++ b/pkgs/by-name/ar/archtika/package.nix
@@ -9,13 +9,13 @@
 }:
 
 let
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "archtika";
     repo = "archtika";
     tag = "v${version}";
-    hash = "sha256-ba9da7LqCE/e2lhRVHD7GOhwOj1fNTBbN/pARPMzIg4=";
+    hash = "sha256-GffYAtLs12v2Lt1WoKJOG5dZsmzDcySZKFBQwCT9nnY=";
   };
 
   web = buildNpmPackage {
@@ -50,7 +50,10 @@ symlinkJoin {
     api
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    inherit src;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Modern, performant and lightweight CMS";


### PR DESCRIPTION
Adapt the description for `mkEnableOption` so that it does not repeat itself, and inherit `src` for `passthru` so that `nix-update-script` does not throw an error.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
