### PR TITLE
nxios/cyrus-imap: fix cyrus-imap certs options

### DIFF
--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -72,6 +72,20 @@ let
     } cfg.imapdSettings;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "cyrus-imap" "sslServerCert" ]
+      [ "services" "cyrus-imap" "imapdSettings" "tls_server_cert" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "cyrus-imap" "sslServerKey" ]
+      [ "services" "cyrus-imap" "imapdSettings" "tls_server_key" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "cyrus-imap" "sslCACert" ]
+      [ "services" "cyrus-imap" "imapdSettings" "tls_client_ca_file" ]
+    )
+  ];
   options.services.cyrus-imap = {
     enable = mkEnableOption "Cyrus IMAP, an email, contacts and calendar server";
     debug = mkEnableOption "debugging messages for the Cyrus master process";
@@ -293,24 +307,6 @@ in
       default = null;
       description = "Path to the configuration file used for Cyrus.";
       apply = v: if v != null then v else pkgs.writeText "cyrus.conf" cyrusConfig;
-    };
-
-    sslCACert = mkOption {
-      type = nullOr str;
-      default = null;
-      description = "File path which containing one or more CA certificates to use.";
-    };
-
-    sslServerCert = mkOption {
-      type = nullOr str;
-      default = null;
-      description = "File containing the global certificate used for all services (IMAP, POP3, LMTP, Sieve)";
-    };
-
-    sslServerKey = mkOption {
-      type = nullOr str;
-      default = null;
-      description = "File containing the private key belonging to the global server certificate.";
     };
   };
 


### PR DESCRIPTION
I'm not sure why I kept these three options when I wrote the module at the time, as their values are actually not used within the module. The correct approach should have been to set `tls_{server_cert,key}` within `imapdSettings`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
