### PR TITLE
python3Packages.weasyprint: 64.1 -> 65.0

### DIFF
--- a/pkgs/development/python-modules/cssselect2/default.nix
+++ b/pkgs/development/python-modules/cssselect2/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "cssselect2";
-  version = "0.7.0";
+  version = "0.8.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-HM2YTauJ/GiVUEOspOGwPgzynK2YgPbijjunp0sUqlo=";
+    hash = "sha256-dnT/uVSjtGFiOSruKjoK7bLhTs+Z/MKGRJAPTm4+nTo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,6 +1,4 @@
 {
-  lib,
-  stdenv,
   buildPythonPackage,
   cffi,
   cssselect2,
@@ -11,6 +9,7 @@
   ghostscript,
   glib,
   harfbuzz,
+  lib,
   pango,
   pillow,
   pydyf,
@@ -19,6 +18,7 @@
   pytestCheckHook,
   pythonOlder,
   replaceVars,
+  stdenv,
   tinycss2,
   tinyhtml5,
 }:
@@ -26,7 +26,7 @@
 buildPythonPackage rec {
   pname = "weasyprint";
   version = "65.0";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -39,11 +39,11 @@ buildPythonPackage rec {
   patches = [
     (replaceVars ./library-paths.patch {
       fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";
-      pangoft2 = "${pango.out}/lib/libpangoft2-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       gobject = "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}";
-      pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz_subset = "${harfbuzz.out}/lib/libharfbuzz-subset${stdenv.hostPlatform.extensions.sharedLibrary}";
+      pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
+      pangoft2 = "${pango.out}/lib/libpangoft2-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];
 
@@ -61,30 +61,30 @@ buildPythonPackage rec {
   ] ++ fonttools.optional-dependencies.woff;
 
   nativeCheckInputs = [
+    ghostscript
     pytest-cov-stub
     pytestCheckHook
-    ghostscript
   ];
 
   disabledTests = [
     # needs the Ahem font (fails on macOS)
     "test_font_stretch"
     # sensitive to sandbox environments
+    "test_linear_gradients_12"
+    "test_linear_gradients_5"
     "test_tab_size"
     "test_tabulation_character"
-    "test_linear_gradients_5"
-    "test_linear_gradients_12"
     # rounding issues in sandbox
+    "test_empty_inline_auto_margins"
     "test_images_transparent_text"
+    "test_layout_table_auto_44"
+    "test_layout_table_auto_45"
+    "test_margin_boxes_element"
+    "test_running_elements"
+    "test_vertical_align_4"
     "test_visibility_1"
     "test_visibility_3"
     "test_visibility_4"
-    "test_empty_inline_auto_margins"
-    "test_vertical_align_4"
-    "test_margin_boxes_element"
-    "test_running_elements"
-    "test_layout_table_auto_44"
-    "test_layout_table_auto_45"
     "test_woff_simple"
   ];
 
@@ -100,12 +100,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "weasyprint" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/Kozea/WeasyPrint/releases/tag/v${version}";
     description = "Converts web documents to PDF";
     mainProgram = "weasyprint";
     homepage = "https://weasyprint.org/";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = lib.teams.apm.members;
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -106,5 +106,6 @@ buildPythonPackage rec {
     mainProgram = "weasyprint";
     homepage = "https://weasyprint.org/";
     license = licenses.bsd3;
+    maintainers = lib.teams.apm.members;
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "weasyprint";
-  version = "64.1";
+  version = "65.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.9";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "weasyprint";
-    hash = "sha256-KLAvLGQJuvzhsSINnXanNFh1vTvQjE9t+/UQu5KpR1c=";
+    hash = "sha256-PGed6Wp8hxrgDwjNHncgDzPipJ014gnHIRWTJ1eN+Yg=";
   };
 
   patches = [
@@ -48,8 +48,6 @@ buildPythonPackage rec {
   ];
 
   build-system = [ flit-core ];
-
-  pythonRelaxDeps = [ "tinycss2" ];
 
   dependencies = [
     cffi


### PR DESCRIPTION
Updating weasyprint to 65.0. Changelog: https://github.com/Kozea/WeasyPrint/releases/tag/v65.0

Needs an update to `python3Packages.cssselect2` as well, so included. Changelog: https://github.com/Kozea/cssselect2/releases/tag/0.8.0

Also adopt weasyprint and "modernize" the package (although most of that is sorting stuff nicely).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of direct reverse dependencies.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
