### PR TITLE
nixosTests.forgejo{,-lts}: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -437,8 +437,14 @@ in {
   fluentd = handleTest ./fluentd.nix {};
   fluidd = handleTest ./fluidd.nix {};
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix {};
-  forgejo = handleTest ./forgejo.nix { forgejoPackage = pkgs.forgejo; };
-  forgejo-lts = handleTest ./forgejo.nix { forgejoPackage = pkgs.forgejo-lts; };
+  forgejo = import ./forgejo.nix {
+    inherit runTest;
+    forgejoPackage = pkgs.forgejo;
+  };
+  forgejo-lts = import ./forgejo.nix {
+    inherit runTest;
+    forgejoPackage = pkgs.forgejo-lts;
+  };
   freenet = handleTest ./freenet.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
   freetube = discoverTests (import ./freetube.nix);

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -1,12 +1,7 @@
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../.. { inherit system config; },
-  forgejoPackage ? pkgs.forgejo,
+  runTest,
+  forgejoPackage,
 }:
-
-with import ../lib/testing-python.nix { inherit system pkgs; };
-with pkgs.lib;
 
 let
   ## gpg --faked-system-time='20230301T010000!' --quick-generate-key snakeoil ed25519 sign
@@ -24,37 +19,19 @@ let
   '';
   signingPrivateKeyId = "4D642DE8B678C79D";
 
-  actionsWorkflowYaml = ''
-    run-name: dummy workflow
-    on:
-      push:
-    jobs:
-      cat:
-        runs-on: native
-        steps:
-          - uses: http://localhost:3000/test/checkout@main
-          - run: cat testfile
-  '';
-  # https://github.com/actions/checkout/releases
-  checkoutActionSource = pkgs.fetchFromGitHub {
-    owner = "actions";
-    repo = "checkout";
-    rev = "v4.1.1";
-    hash = "sha256-h2/UIp8IjPo3eE4Gzx52Fb7pcgG/Ww7u31w5fdKVMos=";
-  };
-
   metricSecret = "fakesecret";
 
-  supportedDbTypes = [
-    "mysql"
-    "postgres"
-    "sqlite3"
-  ];
-  makeForgejoTest =
-    type:
-    nameValuePair type (makeTest {
+  base =
+    {
+      lib,
+      pkgs,
+      type,
+      ...
+    }:
+
+    {
       name = "forgejo-${type}";
-      meta.maintainers = with maintainers; [
+      meta.maintainers = with lib.maintainers; [
         bendlas
         emilylange
       ];
@@ -141,6 +118,25 @@ let
             "${backupDir}/${file}";
           remoteUri = "forgejo@server:test/repo";
           remoteUriCheckoutAction = "forgejo@server:test/checkout";
+
+          actionsWorkflowYaml = ''
+            run-name: dummy workflow
+            on:
+              push:
+            jobs:
+              cat:
+                runs-on: native
+                steps:
+                  - uses: http://localhost:3000/test/checkout@main
+                  - run: cat testfile
+          '';
+          # https://github.com/actions/checkout/releases
+          checkoutActionSource = pkgs.fetchFromGitHub {
+            owner = "actions";
+            repo = "checkout";
+            rev = "v4.1.1";
+            hash = "sha256-h2/UIp8IjPo3eE4Gzx52Fb7pcgG/Ww7u31w5fdKVMos=";
+          };
         in
         ''
           import json
@@ -285,7 +281,19 @@ let
               assert "Zstandard compressed data" in server.succeed("file ${dumpFile}")
               server.copy_from_vm("${dumpFile}")
         '';
-    });
+    };
 in
-
-listToAttrs (map makeForgejoTest supportedDbTypes)
+{
+  mysql = runTest {
+    imports = [ base ];
+    _module.args.type = "mysql";
+  };
+  sqlite3 = runTest {
+    imports = [ base ];
+    _module.args.type = "sqlite3";
+  };
+  postgres = runTest {
+    imports = [ base ];
+    _module.args.type = "postgres";
+  };
+}


### PR DESCRIPTION
This is part of the bigger handleTest deprecation.

See #386873 and #383870 (7e3c66897a1c857dd68844fe7227dd078666fb11).

Figured we can drop the `listToAttrs (map makeForgejoTest supportedDbTypes)` and just list them one by one to increase readability and not having to awkwardly pass `listToAttrs` to the `import` in `all-tests.nix`.
If someone disagrees with this or has some better idea, let me know. Open to change it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
