### PR TITLE
nixos/gnome & nixos/gdm: migration out of x11

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -162,7 +162,7 @@
       - any-glob-to-any-file:
         - doc/languages-frameworks/gnome.section.md
         - nixos/modules/services/desktops/gnome/**/*
-        - nixos/modules/services/x11/desktop-managers/gnome.nix
+        - nixos/modules/services/desktop-managers/gnome.nix
         - nixos/tests/gnome-xorg.nix
         - nixos/tests/gnome.nix
         - pkgs/desktops/gnome/**/*

--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -29,7 +29,7 @@ Thus you should pick one or more of the following lines:
 {
   services.xserver.desktopManager.plasma5.enable = true;
   services.xserver.desktopManager.xfce.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
+  services.desktopManager.gnome.enable = true;
   services.xserver.desktopManager.mate.enable = true;
   services.xserver.windowManager.xmonad.enable = true;
   services.xserver.windowManager.twm.enable = true;
@@ -46,7 +46,7 @@ alternative one by picking one of the following lines:
 ```nix
 {
   services.displayManager.sddm.enable = true;
-  services.xserver.displayManager.gdm.enable = true;
+  services.displayManager.gdm.enable = true;
 }
 ```
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -20,7 +20,7 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 - GNOME has been updated to version 48.
 
   - `decibels` music player is now installed by default. You can disable it using [](#opt-environment.gnome.excludePackages).
-  - `gnome-shell-extensions` extension collection (which included GNOME Classic extensions, Apps Menu, and User Themes, among others) are no longer installed by default. You can install them again with [](#opt-services.xserver.desktopManager.gnome.sessionPath).
+  - `gnome-shell-extensions` extension collection (which included GNOME Classic extensions, Apps Menu, and User Themes, among others) are no longer installed by default. You can install them again with {option}`services.xserver.desktopManager.gnome.sessionPath`.
   - Option [](#opt-services.gnome.core-developer-tools.enable) now also installs `sysprof` and `d-spy`.
   - Option `services.gnome.core-utilities.enable` has been renamed to [](#opt-services.gnome.core-apps.enable).
   - `cantarell-fonts`, `source-code-pro` and `source-sans` fonts are no longer installed by default. They have been replaced by `adwaita-fonts`.

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
@@ -7,7 +7,7 @@
 
   isoImage.edition = lib.mkDefault "gnome";
 
-  services.xserver.desktopManager.gnome = {
+  services.desktopManager.gnome = {
     # Add Firefox and other tools useful for installation to the launcher
     favoriteAppsOverride = ''
       [org.gnome.shell]
@@ -35,7 +35,7 @@
     QT_QPA_PLATFORM = "$([[ $XDG_SESSION_TYPE = \"wayland\" ]] && echo \"wayland\")";
   };
 
-  services.xserver.displayManager.gdm = {
+  services.displayManager.gdm = {
     enable = true;
     # autoSuspend makes the machine automatically suspend after inactivity.
     # It's possible someone could/try to ssh'd into the machine and obviously

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -7,7 +7,7 @@
 
   isoImage.edition = lib.mkDefault "gnome";
 
-  services.xserver.desktopManager.gnome = {
+  services.desktopManager.gnome = {
     # Add Firefox and other tools useful for installation to the launcher
     favoriteAppsOverride = ''
       [org.gnome.shell]
@@ -16,7 +16,7 @@
     enable = true;
   };
 
-  services.xserver.displayManager.gdm = {
+  services.displayManager.gdm = {
     enable = true;
     # autoSuspend makes the machine automatically suspend after inactivity.
     # It's possible someone could/try to ssh'd into the machine and obviously

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -589,6 +589,7 @@
   ./services/development/zammad.nix
   ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/default.nix
+  ./services/display-managers/gdm.nix
   ./services/display-managers/greetd.nix
   ./services/display-managers/ly.nix
   ./services/display-managers/sddm.nix
@@ -1706,7 +1707,6 @@
   ./services/x11/colord.nix
   ./services/x11/desktop-managers/default.nix
   ./services/x11/display-managers/default.nix
-  ./services/x11/display-managers/gdm.nix
   ./services/x11/display-managers/lightdm.nix
   ./services/x11/display-managers/slim.nix
   ./services/x11/display-managers/startx.nix

--- a/nixos/modules/programs/gpaste.nix
+++ b/nixos/modules/programs/gpaste.nix
@@ -27,7 +27,7 @@
     services.dbus.packages = [ pkgs.gpaste ];
     systemd.packages = [ pkgs.gpaste ];
     # gnome-control-center crashes in Keyboard Shortcuts pane without the GSettings schemas.
-    services.xserver.desktopManager.gnome.sessionPath = [ pkgs.gpaste ];
+    services.desktopManager.gnome.sessionPath = [ pkgs.gpaste ];
     # gpaste-reloaded applet doesn't work without the typelib
     services.xserver.desktopManager.cinnamon.sessionPath = [ pkgs.gpaste ];
   };

--- a/nixos/modules/programs/nautilus-open-any-terminal.nix
+++ b/nixos/modules/programs/nautilus-open-any-terminal.nix
@@ -28,7 +28,7 @@ in
       nautilus-open-any-terminal
     ];
 
-    environment.sessionVariables = lib.mkIf (!config.services.xserver.desktopManager.gnome.enable) {
+    environment.sessionVariables = lib.mkIf (!config.services.desktopManager.gnome.enable) {
       NAUTILUS_4_EXTENSION_DIR = "${pkgs.nautilus-python}/lib/nautilus/extensions-4";
     };
 

--- a/nixos/modules/programs/zoom-us.nix
+++ b/nixos/modules/programs/zoom-us.nix
@@ -33,7 +33,7 @@
 
         # Support GNOME desktop environment if it's enabled on the system.
         gnomeXdgDesktopPortalSupport =
-          prev.gnomeXdgDesktopPortalSupport or config.services.xserver.desktopManager.gnome.enable;
+          prev.gnomeXdgDesktopPortalSupport or config.services.desktopManager.gnome.enable;
 
         # Support Hyprland desktop for Wayland if it's enabled on the system.
         hyprlandXdgDesktopPortalSupport =

--- a/nixos/modules/services/desktop-managers/gnome.md
+++ b/nixos/modules/services/desktop-managers/gnome.md
@@ -10,8 +10,8 @@ To enable the GNOME desktop use:
 
 ```nix
 {
-  services.xserver.desktopManager.gnome.enable = true;
-  services.xserver.displayManager.gdm.enable = true;
+  services.desktopManager.gnome.enable = true;
+  services.displayManager.gdm.enable = true;
 }
 ```
 
@@ -76,17 +76,17 @@ GNOME Flashback provides a desktop environment based on the classic GNOME 2 arch
 
 ```nix
 {
-  services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
+  services.desktopManager.gnome.flashback.enableMetacity = true;
 }
 ```
 
-It is also possible to create custom sessions that replace Metacity with a different window manager using [](#opt-services.xserver.desktopManager.gnome.flashback.customSessions).
+It is also possible to create custom sessions that replace Metacity with a different window manager using [](#opt-services.desktopManager.gnome.flashback.customSessions).
 
 The following example uses `xmonad` window manager:
 
 ```nix
 {
-  services.xserver.desktopManager.gnome.flashback.customSessions = [
+  services.desktopManager.gnome.flashback.customSessions = [
     {
       wmName = "xmonad";
       wmLabel = "XMonad";
@@ -143,10 +143,10 @@ Overrides really only change the default values for GSettings keys so if you or 
 :::
 
 You can override the default GSettings values using the
-[](#opt-services.xserver.desktopManager.gnome.extraGSettingsOverrides) option.
+[](#opt-services.desktopManager.gnome.extraGSettingsOverrides) option.
 
 Take note that whatever packages you want to override GSettings for, you need to add them to
-[](#opt-services.xserver.desktopManager.gnome.extraGSettingsOverridePackages).
+[](#opt-services.desktopManager.gnome.extraGSettingsOverridePackages).
 
 You can use `dconf-editor` tool to explore which GSettings you can set.
 
@@ -154,7 +154,7 @@ You can use `dconf-editor` tool to explore which GSettings you can set.
 
 ```nix
 {
-  services.xserver.desktopManager.gnome = {
+  services.desktopManager.gnome = {
     extraGSettingsOverrides = ''
       # Change default background
       [org.gnome.desktop.background]

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -15,7 +15,7 @@ let
     literalExpression
     ;
 
-  cfg = config.services.xserver.desktopManager.gnome;
+  cfg = config.services.desktopManager.gnome;
   serviceCfg = config.services.gnome;
 
   # Prioritize nautilus by default when opening directories
@@ -78,13 +78,45 @@ let
 in
 
 {
-
   meta = {
     doc = ./gnome.md;
     maintainers = lib.teams.gnome.members;
   };
 
   imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "enable" ]
+      [ "services" "desktopManager" "gnome" "enable" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "extraGSettingsOverrides" ]
+      [ "services" "desktopManager" "gnome" "extraGSettingsOverrides" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "extraGSettingsOverridePackages" ]
+      [ "services" "desktopManager" "gnome" "extraGSettingsOverridePackages" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "debug" ]
+      [ "services" "desktopManager" "gnome" "debug" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "sessionPath" ]
+      [ "services" "desktopManager" "gnome" "sessionPath" ]
+    )
+    # flashback options
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "flashback" "customSessions" ]
+      [ "services" "desktopManager" "gnome" "flashback" "customSessions" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "flashback" "enableMetacity" ]
+      [ "services" "desktopManager" "gnome" "flashback" "enableMetacity" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "xserver" "desktopManager" "gnome" "flashback" "panelModulePackages" ]
+      [ "services" "desktopManager" "gnome" "flashback" "panelModulePackages" ]
+    )
     (lib.mkRenamedOptionModule
       [ "services" "gnome" "core-utilities" "enable" ]
       [ "services" "gnome" "core-apps" "enable" ]
@@ -101,7 +133,7 @@ in
       games.enable = mkEnableOption "GNOME games";
     };
 
-    services.xserver.desktopManager.gnome = {
+    services.desktopManager.gnome = {
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -213,8 +245,8 @@ in
       system.nixos-generate-config.desktopConfiguration = [
         ''
           # Enable the GNOME Desktop Environment.
-          services.xserver.displayManager.gdm.enable = true;
-          services.xserver.desktopManager.gnome.enable = true;
+          services.displayManager.gdm.enable = true;
+          services.desktopManager.gnome.enable = true;
         ''
       ];
 
@@ -333,7 +365,7 @@ in
     })
 
     (lib.mkIf serviceCfg.core-shell.enable {
-      services.xserver.desktopManager.gnome.sessionPath = [
+      services.desktopManager.gnome.sessionPath = [
         pkgs.gnome-shell
       ];
 

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -257,7 +257,7 @@ in
         dmConf = config.services.xserver.displayManager;
         noDmUsed =
           !(
-            dmConf.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable
+            cfg.gdm.enable || cfg.sddm.enable || dmConf.xpra.enable || dmConf.lightdm.enable || cfg.ly.enable
           );
       in
       lib.mkIf noDmUsed (lib.mkDefault false);

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -31,7 +31,6 @@ in
     ./lumina.nix
     ./lxqt.nix
     ./enlightenment.nix
-    ./gnome.nix
     ./retroarch.nix
     ./kodi.nix
     ./mate.nix
@@ -43,6 +42,7 @@ in
     ./deepin.nix
     ../../desktop-managers/lomiri.nix
     ../../desktop-managers/cosmic.nix
+    ../../desktop-managers/gnome.nix
   ];
 
   options = {

--- a/nixos/modules/services/x11/terminal-server.nix
+++ b/nixos/modules/services/x11/terminal-server.nix
@@ -17,7 +17,7 @@ with lib;
     services.xserver.videoDrivers = [ ];
 
     # Enable GDM.  Any display manager will do as long as it supports XDMCP.
-    services.xserver.displayManager.gdm.enable = true;
+    services.displayManager.gdm.enable = true;
 
     systemd.sockets.terminal-server = {
       description = "Terminal Server Socket";

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -761,7 +761,7 @@ in
         dmConf = cfg.displayManager;
         default =
           !(
-            dmConf.gdm.enable
+            config.services.displayManager.gdm.enable
             || config.services.displayManager.sddm.enable
             || dmConf.xpra.enable
             || dmConf.sx.enable

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -610,8 +610,8 @@ rec {
       { ... }:
       {
         services.xserver.enable = true;
-        services.xserver.displayManager.gdm.enable = true;
-        services.xserver.desktopManager.gnome.enable = true;
+        services.displayManager.gdm.enable = true;
+        services.desktopManager.gnome.enable = true;
       }
     );
 

--- a/nixos/tests/gnome-extensions.nix
+++ b/nixos/tests/gnome-extensions.nix
@@ -34,8 +34,8 @@
       };
 
       # Configure Gnome
-      services.xserver.desktopManager.gnome.enable = true;
-      services.xserver.desktopManager.gnome.debug = true;
+      services.desktopManager.gnome.enable = true;
+      services.desktopManager.gnome.debug = true;
 
       systemd.user.services = {
         "org.gnome.Shell@wayland" = {

--- a/nixos/tests/gnome-flashback.nix
+++ b/nixos/tests/gnome-flashback.nix
@@ -14,9 +14,9 @@
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager = {
-        gdm.enable = true;
-        gdm.debug = true;
+      services.displayManager.gdm = {
+        enable = true;
+        debug = true;
       };
 
       services.displayManager.autoLogin = {
@@ -24,9 +24,9 @@
         user = user.name;
       };
 
-      services.xserver.desktopManager.gnome.enable = true;
-      services.xserver.desktopManager.gnome.debug = true;
-      services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
+      services.desktopManager.gnome.enable = true;
+      services.desktopManager.gnome.debug = true;
+      services.desktopManager.gnome.flashback.enableMetacity = true;
       services.displayManager.defaultSession = "gnome-flashback-metacity";
     };
 

--- a/nixos/tests/gnome-xorg.nix
+++ b/nixos/tests/gnome-xorg.nix
@@ -16,9 +16,9 @@
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager = {
-        gdm.enable = true;
-        gdm.debug = true;
+      services.displayManager.gdm = {
+        enable = true;
+        debug = true;
       };
 
       services.displayManager.autoLogin = {
@@ -26,8 +26,8 @@
         user = user.name;
       };
 
-      services.xserver.desktopManager.gnome.enable = true;
-      services.xserver.desktopManager.gnome.debug = true;
+      services.desktopManager.gnome.enable = true;
+      services.desktopManager.gnome.debug = true;
       services.displayManager.defaultSession = "gnome-xorg";
 
       systemd.user.services = {

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -11,9 +11,9 @@
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager = {
-        gdm.enable = true;
-        gdm.debug = true;
+      services.displayManager.gdm = {
+        enable = true;
+        debug = true;
       };
 
       services.displayManager.autoLogin = {
@@ -21,8 +21,8 @@
         user = "alice";
       };
 
-      services.xserver.desktopManager.gnome.enable = true;
-      services.xserver.desktopManager.gnome.debug = true;
+      services.desktopManager.gnome.enable = true;
+      services.desktopManager.gnome.debug = true;
 
       systemd.user.services = {
         "org.gnome.Shell@wayland" = {

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -15,8 +15,8 @@
     system.nixos-generate-config.desktopConfiguration = [
       ''
         # DESKTOP
-        services.xserver.displayManager.gdm.enable = true;
-        services.xserver.desktopManager.gnome.enable = true;
+        services.displayManager.gdm.enable = true;
+        services.desktopManager.gnome.enable = true;
       ''
     ];
   };
@@ -40,7 +40,7 @@
 
     # Test if the Perl variable $desktopConfiguration is spliced correctly
     machine.succeed(
-        "grep 'services\\.xserver\\.desktopManager\\.gnome\\.enable = true;' /etc/nixos/configuration.nix"
+        "grep 'services\\.desktopManager\\.gnome\\.enable = true;' /etc/nixos/configuration.nix"
     )
 
     machine.succeed("rm -rf /etc/nixos")

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # The following patches implement certain environment variables in GDM which are set by
-    # the gdm configuration module (nixos/modules/services/x11/display-managers/gdm.nix).
+    # the gdm configuration module (gdm.nix).
 
     ./gdm-x-session_extra_args.patch
 

--- a/pkgs/by-name/ne/nemo-seahorse/package.nix
+++ b/pkgs/by-name/ne/nemo-seahorse/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
           libcryptui
         ];
 
-        services.xserver.desktopManager.gnome.extraGSettingsOverridePackages = with pkgs; [
+        services.desktopManager.gnome.extraGSettingsOverridePackages = with pkgs; [
           nemo
           gcr
           libcryptui


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Reasons:
since DEs like KDE Plasma 6, GNOME and COMSIC are not designed to be x11-exclusive putting them under `services.xserver` is misleading; to confirm my point - [this PR](https://github.com/NixOS/nixpkgs/pull/292141) and [this PR](https://github.com/NixOS/nixpkgs/pull/291913) exist.
also, GNOME's default **is** `wayland`, and `x11` sessions is an option, that could be [dropped](https://gitlab.gnome.org/GNOME/gnome-session/-/merge_requests/99) in future. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
