### PR TITLE
lcevcdec: fix pkg-config version data

### DIFF
--- a/pkgs/by-name/lc/lcevcdec/package.nix
+++ b/pkgs/by-name/lc/lcevcdec/package.nix
@@ -1,13 +1,11 @@
 {
   cmake,
-  copyPkgconfigItems,
   fetchFromGitHub,
   fmt,
   git,
   gitUpdater,
   gtest,
   lib,
-  makePkgconfigItem,
   pkg-config,
   python3,
   range-v3,
@@ -39,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "args.git_version" '"${finalAttrs.version}"' \
         --replace-fail "args.git_hash" '"${finalAttrs.src.rev}"' \
         --replace-fail "args.git_date" '"1970-01-01"'
+      substituteInPlace cmake/templates/lcevc_dec.pc.in \
+        --replace-fail "@GIT_SHORT_VERSION@" "${finalAttrs.version}"
 
     ''
     + lib.optionalString (!stdenv.hostPlatform.avxSupport) ''
@@ -55,35 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_CFLAGS_COMPILE = "-Wno-error=unused-variable";
   };
 
-  pkgconfigItems = [
-    (makePkgconfigItem rec {
-      name = "lcevc_dec";
-      inherit (finalAttrs) version;
-      libs = [
-        "-L${variables.libdir}"
-        "-llcevc_dec_api"
-      ];
-      libsPrivate = [
-        "-lpthread"
-        "-llcevc_dec_core"
-      ];
-      cflags = [
-        "-I${variables.includedir}"
-      ];
-      variables = {
-        prefix = "@dev@";
-        includedir = "@includedir@";
-        libdir = "@libdir@";
-      };
-    })
-  ];
-
   nativeBuildInputs = [
     cmake
     python3
     git
     pkg-config
-    copyPkgconfigItems
   ];
 
   buildInputs = [


### PR DESCRIPTION
Upstream now installs their own .pc file, which
we must patch to specify the correct version.

Fixes #392771

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
