### PR TITLE
nixos/bitbox-bridge: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -212,6 +212,7 @@
 
 - [ipfs-cluster](https://ipfscluster.io/), Pinset orchestration for IPFS. Available as [services.ipfs-cluster](#opt-services.ipfs-cluster.enable)
 
+- [bitbox-bridge](https://github.com/BitBoxSwiss/bitbox-bridge), a bridge software that connects BitBox hardware wallets to computers & web wallets like [Rabby](https://rabby.io/). Allows one to interact & transact with smart contracts, Web3 websites & financial services without storing private keys anywhere other than the hardware wallet. Available as [services.bitbox-bridge](#opt-services.bitbox-bridge.enable).
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -613,6 +613,7 @@
   ./services/hardware/asusd.nix
   ./services/hardware/auto-cpufreq.nix
   ./services/hardware/auto-epp.nix
+  ./services/hardware/bitbox-bridge.nix
   ./services/hardware/bluetooth.nix
   ./services/hardware/bolt.nix
   ./services/hardware/brltty.nix

--- a/nixos/modules/services/hardware/bitbox-bridge.nix
+++ b/nixos/modules/services/hardware/bitbox-bridge.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.bitbox-bridge;
+in
+{
+  options = {
+    services.bitbox-bridge = {
+      enable = lib.mkEnableOption "Bitbox bridge daemon, for use with Bitbox hardware wallets.";
+
+      package = lib.mkPackageOption pkgs "bitbox-bridge" { };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8178;
+        description = ''
+          Listening port for the bitbox-bridge.
+        '';
+      };
+
+      runOnMount = lib.mkEnableOption null // {
+        default = true;
+        description = ''
+          Run bitbox-bridge.service only when hardware wallet is plugged, also registers the systemd device unit.
+          This option is enabled by default to save power, when false, bitbox-bridge service runs all the time instead.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages =
+      [ cfg.package ]
+      ++ lib.optionals (cfg.runOnMount) [
+        (pkgs.writeTextFile {
+          name = "bitbox-bridge-run-on-mount-udev-rules";
+          destination = "/etc/udev/rules.d/99-bitbox-bridge-run-on-mount.rules";
+          text = ''
+            SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", MODE="0660", GROUP="bitbox", TAG+="systemd", SYMLINK+="bitbox02", ENV{SYSTEMD_WANTS}="bitbox-bridge.service"
+          '';
+        })
+      ];
+
+    systemd.services.bitbox-bridge = {
+      description = "BitBox Bridge";
+      wantedBy = [ "multi-user.target" ];
+
+      bindsTo = lib.optionals (cfg.runOnMount) [ "dev-bitbox02.device" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/bitbox-bridge -p ${builtins.toString cfg.port}";
+        User = "bitbox";
+      };
+    };
+
+    users.groups.bitbox = { };
+    users.users.bitbox = {
+      group = "bitbox";
+      description = "bitbox-bridge daemon user";
+      isSystemUser = true;
+      extraGroups = [ "bitbox" ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -214,6 +214,7 @@ in {
   bind = handleTest ./bind.nix {};
   bird = handleTest ./bird.nix {};
   birdwatcher = handleTest ./birdwatcher.nix {};
+  bitbox-bridge = runTest ./bitbox-bridge.nix;
   bitcoind = handleTest ./bitcoind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
   blockbook-frontend = handleTest ./blockbook-frontend.nix {};

--- a/nixos/tests/bitbox-bridge.nix
+++ b/nixos/tests/bitbox-bridge.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+
+let
+  testPort = 8179;
+in
+{
+  name = "bitbox-bridge";
+  meta = {
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      izelnakri
+      tensor5
+    ];
+  };
+
+  nodes.machine = {
+    services.bitbox-bridge = {
+      enable = true;
+      port = testPort;
+      runOnMount = false;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("bitbox-bridge.service")
+    machine.wait_for_open_port(${toString testPort})
+    machine.wait_until_succeeds("curl -fL http://localhost:${toString testPort}/api/info | grep version")
+  '';
+}

--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p $out/lib/systemd/user
     substitute bitbox-bridge/release/linux/bitbox-bridge.service $out/lib/systemd/user/bitbox-bridge.service \
       --replace-fail /opt/bitbox-bridge/bin/bitbox-bridge $out/bin/bitbox-bridge
-    install -Dm644 bitbox-bridge/release/linux/hid-digitalbitbox.rules $out/lib/udev/rules.d/50-hid-digitalbitbox.rules
+    install -Dm644 bitbox-bridge/release/linux/hid-digitalbitbox.rules $out/etc/udev/rules.d/50-hid-digitalbitbox.rules
   '';
 
   meta = {

--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -5,6 +5,8 @@
   rustPlatform,
   pkg-config,
   libudev-zero,
+  nixosTests,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -40,6 +42,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail /opt/bitbox-bridge/bin/bitbox-bridge $out/bin/bitbox-bridge
     install -Dm644 bitbox-bridge/release/linux/hid-digitalbitbox.rules $out/etc/udev/rules.d/50-hid-digitalbitbox.rules
   '';
+
+  passthru = {
+    tests.basic = nixosTests.bitbox-bridge;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "A bridge service that connects web wallets like Rabby to BitBox02";


### PR DESCRIPTION
This PR adds `config.services.bitbox-bridge` to NixOS.

Previous PR could be found here: https://github.com/NixOS/nixpkgs/pull/391415 

## Things done

- Adds the most basic service configuration for `config.services.bitbox-bridge`.
- Adds a nix test to check `bitbox-bridge` can be built & run.
- Adds `config.services.bitbox-bridge.runOnMount` to run the systemd service only on mount. It does proper systemd device unit registration when hardware wallet is plugged via udev.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
