### PR TITLE
update-source-version: update cargo hash if exists

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -283,8 +283,53 @@ if cmp -s "$nixFile" "$nixFile.cmp"; then
     die "Failed to replace temporary source hash of '$attr' to the final source hash!"
 fi
 
+cargoHashExists=$(nix-instantiate $systemArg --eval --strict -E "let pkgs = $importTree; in builtins.hasAttr \"cargoHash\" pkgs.$attr")
+
+if [[ "$cargoHashExists" = "true" ]]; then
+    # Get old cargo hash though $attr.cargoHash
+    oldCargoHash=$(nix-instantiate $systemArg --eval --strict -A "$attr.cargoHash" | tr -d '"')
+    if [[ -z "$oldCargoHash" ]]; then
+        die "Couldn't evaluate old cargo hash from '$attr.cargoHash'!"
+    fi
+    if [[ $(grep --count "$oldCargoHash" "$nixFile") != 1 ]]; then
+        die "Couldn't locate old cargo hash '$oldCargoHash' (or it appeared more than once) in '$nixFile'!"
+    fi
+
+    # Replace cargo hash with temporary hash
+    oldCargoHashEscaped=$(echo "$oldCargoHash" | sed -re 's|[+]|\\&|g')
+    tempCargoHash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    tempCargoHashEscaped=$(echo "$tempCargoHash" | sed -re 's|[+]|\\&|g')
+    sed -i.cargohash.cmp "$nixFile" -re "s|\"$oldCargoHashEscaped\"|\"$tempCargoHash\"|"
+    if cmp -s "$nixFile" "$nixFile.cargohash.cmp"; then
+        die "Failed to replace cargo hash of '$attr' to a temporary hash!"
+    fi
+
+    # Compute new cargo hash
+    nix-build $systemArg --no-out-link -A "$attr.cargoDeps" 2>"$attr.cargohash.fetchlog" >/dev/null || true
+    # FIXME: use nix-build --hash here once https://github.com/NixOS/nix/issues/1172 is fixed
+    newCargoHash=$(
+        sed '1,/hash mismatch in fixed-output derivation/d' "$attr.cargohash.fetchlog" \
+        | grep --perl-regexp --only-matching 'got: +[: ]\K.+'
+    )
+    if [[ -z "$newCargoHash" ]]; then
+        cat "$attr.cargohash.fetchlog" >&2
+        die "Couldn't figure out new cargo hash of '$attr'!"
+    fi
+
+    # Replace temporary cargo hash with the new one
+    sed -i.cargohash.cmp "$nixFile" -re "s|\"$tempCargoHashEscaped\"|\"$newCargoHash\"|"
+    if cmp -s "$nixFile" "$nixFile.cargohash.cmp"; then
+        die "Failed to replace temporary cargo hash of '$attr' to the final cargo hash!"
+    fi
+fi
+
 rm -f "$nixFile.cmp"
 rm -f "$attr.fetchlog"
+
+if [[ "$cargoHashExists" = "true" ]]; then
+    rm -f "$nixFile.cargohash.cmp"
+    rm -f "$attr.cargohash.fetchlog"
+fi
 
 if [ -n "$printChanges" ]; then
     printf '[{"attrPath":"%s","oldVersion":"%s","newVersion":"%s","files":["%s"]}]\n' "$attr" "$oldVersion" "$newVersion" "$nixFile"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Let `gitUpdater` work with `rustPlatform.buildRustPackage`; if `$attr.cargoHash` exists, update it. 

### Current behavior

If we do something like

```nix
rustPlatform.buildRustPackage {
  ...

  passthru.updateScript = gitUpdater {
    rev-prefix = "v";
  };

  ...
}
```

we would get error like

https://github.com/NixOS/nixpkgs/blob/97dc21f791250738292997703f42e8ff49363367/pkgs/build-support/rust/hooks/cargo-setup-hook.sh#L68-L76

because `cargoHash` was never updated.

### Why now?

Since https://github.com/NixOS/nixpkgs/pull/349360 is here, rust packages no longer bundle their `flake.lock` inside nixpkgs and now their `cargoDeps` only depend on `cargoHash`, making updates much easier to automate.

### Difference from original hash replacing logic

I copied most of the hash updating behavior from the original script, but 1) default to replacing a fake sha256 hash as I see no one using sha512 in `cargoHash`; and 2) skipped non-SRI-style hash handling since `cargoSha256` is deprecated:

https://github.com/NixOS/nixpkgs/blob/fb65bbfb1d7cb509a998239f8bd31fc07fae9a3e/doc/languages-frameworks/rust.section.md?plain=1#L52-L59

### Testing

I only tested this against `firecracker` so far. Appreciate if other maintainers can test on their rust packages also. 🙏 

```diff
diff --git a/pkgs/by-name/fi/firecracker/package.nix b/pkgs/by-name/fi/firecracker/package.nix
index 293c9057a..8adab8d0b 100644
--- a/pkgs/by-name/fi/firecracker/package.nix
+++ b/pkgs/by-name/fi/firecracker/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gitUpdater,
   cmake,
   gcc,
   rust-bindgen,
@@ -75,6 +76,11 @@ rustPlatform.buildRustPackage rec {
     runHook postInstall
   '';

+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    ignoredVersions = "dev";
+  };
+
   meta = with lib; {
     description = "Secure, fast, minimal micro-container virtualization";
     homepage = "http://firecracker-microvm.io";
```

Open to suggestions, whether this is something needed or not; or if this should be implemented somewhere else and not polluting the `update-source-version`.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
