### PR TITLE
nixVersions.nix_2_26: fix cross

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,21 +1,22 @@
-{ lib
-, config
-, stdenv
-, aws-sdk-cpp
-, boehmgc
-, callPackage
-, fetchFromGitHub
-, fetchpatch2
-, runCommand
-, Security
-, pkgs
-, pkgsi686Linux
-, pkgsStatic
-, nixosTests
+{
+  lib,
+  config,
+  stdenv,
+  aws-sdk-cpp,
+  boehmgc,
+  callPackage,
+  fetchFromGitHub,
+  fetchpatch2,
+  runCommand,
+  Security,
+  pkgs,
+  pkgsi686Linux,
+  pkgsStatic,
+  nixosTests,
 
-, storeDir ? "/nix/store"
-, stateDir ? "/nix/var"
-, confDir ? "/etc"
+  storeDir ? "/nix/store",
+  stateDir ? "/nix/var",
+  confDir ? "/etc",
 }:
 let
   boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
@@ -28,73 +29,90 @@ let
   });
 
   # old nix fails to build with newer aws-sdk-cpp and the patch doesn't apply
-  aws-sdk-cpp-old-nix = (aws-sdk-cpp.override {
-    apis = [ "s3" "transfer" ];
-    customMemoryManagement = false;
-  }).overrideAttrs (args: rec {
-    # intentionally overriding postPatch
-    version = "1.9.294";
+  aws-sdk-cpp-old-nix =
+    (aws-sdk-cpp.override {
+      apis = [
+        "s3"
+        "transfer"
+      ];
+      customMemoryManagement = false;
+    }).overrideAttrs
+      (args: rec {
+        # intentionally overriding postPatch
+        version = "1.9.294";
 
-    src = fetchFromGitHub {
-      owner = "aws";
-      repo = "aws-sdk-cpp";
-      rev = version;
-      hash = "sha256-Z1eRKW+8nVD53GkNyYlZjCcT74MqFqqRMeMc33eIQ9g=";
-    };
-    postPatch = ''
-      # Avoid blanket -Werror to evade build failures on less
-      # tested compilers.
-      substituteInPlace cmake/compiler_settings.cmake \
-        --replace '"-Werror"' ' '
+        src = fetchFromGitHub {
+          owner = "aws";
+          repo = "aws-sdk-cpp";
+          rev = version;
+          hash = "sha256-Z1eRKW+8nVD53GkNyYlZjCcT74MqFqqRMeMc33eIQ9g=";
+        };
+        postPatch =
+          ''
+            # Avoid blanket -Werror to evade build failures on less
+            # tested compilers.
+            substituteInPlace cmake/compiler_settings.cmake \
+              --replace '"-Werror"' ' '
 
-      # Missing includes for GCC11
-      sed '5i#include <thread>' -i \
-        aws-cpp-sdk-cloudfront-integration-tests/CloudfrontOperationTest.cpp \
-        aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp \
-        aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp \
-        aws-cpp-sdk-elasticfilesystem-integration-tests/ElasticFileSystemTest.cpp \
-        aws-cpp-sdk-lambda-integration-tests/FunctionTest.cpp \
-        aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp \
-        aws-cpp-sdk-queues/source/sqs/SQSQueue.cpp \
-        aws-cpp-sdk-redshift-integration-tests/RedshiftClientTest.cpp \
-        aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp \
-        aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp \
-        aws-cpp-sdk-s3control-integration-tests/S3ControlTest.cpp \
-        aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp \
-        aws-cpp-sdk-transfer-tests/TransferTests.cpp
-      # Flaky on Hydra
-      rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
-      # Includes aws-c-auth private headers, so only works with submodule build
-      rm aws-cpp-sdk-core-tests/aws/auth/AWSAuthSignerTest.cpp
-      # TestRandomURLMultiThreaded fails
-      rm aws-cpp-sdk-core-tests/http/HttpClientTest.cpp
-    '' + lib.optionalString aws-sdk-cpp.stdenv.hostPlatform.isi686 ''
-      # EPSILON is exceeded
-      rm aws-cpp-sdk-core-tests/aws/client/AdaptiveRetryStrategyTest.cpp
-    '';
+            # Missing includes for GCC11
+            sed '5i#include <thread>' -i \
+              aws-cpp-sdk-cloudfront-integration-tests/CloudfrontOperationTest.cpp \
+              aws-cpp-sdk-cognitoidentity-integration-tests/IdentityPoolOperationTest.cpp \
+              aws-cpp-sdk-dynamodb-integration-tests/TableOperationTest.cpp \
+              aws-cpp-sdk-elasticfilesystem-integration-tests/ElasticFileSystemTest.cpp \
+              aws-cpp-sdk-lambda-integration-tests/FunctionTest.cpp \
+              aws-cpp-sdk-mediastore-data-integration-tests/MediaStoreDataTest.cpp \
+              aws-cpp-sdk-queues/source/sqs/SQSQueue.cpp \
+              aws-cpp-sdk-redshift-integration-tests/RedshiftClientTest.cpp \
+              aws-cpp-sdk-s3-crt-integration-tests/BucketAndObjectOperationTest.cpp \
+              aws-cpp-sdk-s3-integration-tests/BucketAndObjectOperationTest.cpp \
+              aws-cpp-sdk-s3control-integration-tests/S3ControlTest.cpp \
+              aws-cpp-sdk-sqs-integration-tests/QueueOperationTest.cpp \
+              aws-cpp-sdk-transfer-tests/TransferTests.cpp
+            # Flaky on Hydra
+            rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
+            # Includes aws-c-auth private headers, so only works with submodule build
+            rm aws-cpp-sdk-core-tests/aws/auth/AWSAuthSignerTest.cpp
+            # TestRandomURLMultiThreaded fails
+            rm aws-cpp-sdk-core-tests/http/HttpClientTest.cpp
+          ''
+          + lib.optionalString aws-sdk-cpp.stdenv.hostPlatform.isi686 ''
+            # EPSILON is exceeded
+            rm aws-cpp-sdk-core-tests/aws/client/AdaptiveRetryStrategyTest.cpp
+          '';
 
-    patches = (args.patches or [ ]) ++ [ ./patches/aws-sdk-cpp-TransferManager-ContentEncoding.patch ];
+        patches = (args.patches or [ ]) ++ [ ./patches/aws-sdk-cpp-TransferManager-ContentEncoding.patch ];
 
-    # only a stripped down version is build which takes a lot less resources to build
-    requiredSystemFeatures = [ ];
-  });
+        # only a stripped down version is build which takes a lot less resources to build
+        requiredSystemFeatures = [ ];
+      });
 
-  aws-sdk-cpp-nix = (aws-sdk-cpp.override {
-    apis = [ "s3" "transfer" ];
-    customMemoryManagement = false;
-  }).overrideAttrs {
-    # only a stripped down version is build which takes a lot less resources to build
-    requiredSystemFeatures = [ ];
-  };
-
-  common = args:
-    callPackage
-      (import ./common.nix ({ inherit lib fetchFromGitHub; } // args))
+  aws-sdk-cpp-nix =
+    (aws-sdk-cpp.override {
+      apis = [
+        "s3"
+        "transfer"
+      ];
+      customMemoryManagement = false;
+    }).overrideAttrs
       {
-        inherit Security storeDir stateDir confDir;
-        boehmgc = boehmgc-nix;
-        aws-sdk-cpp = if lib.versionAtLeast args.version "2.12pre" then aws-sdk-cpp-nix else aws-sdk-cpp-old-nix;
+        # only a stripped down version is build which takes a lot less resources to build
+        requiredSystemFeatures = [ ];
       };
+
+  common =
+    args:
+    callPackage (import ./common.nix ({ inherit lib fetchFromGitHub; } // args)) {
+      inherit
+        Security
+        storeDir
+        stateDir
+        confDir
+        ;
+      boehmgc = boehmgc-nix;
+      aws-sdk-cpp =
+        if lib.versionAtLeast args.version "2.12pre" then aws-sdk-cpp-nix else aws-sdk-cpp-old-nix;
+    };
 
   # https://github.com/NixOS/nix/pull/7585
   patch-monitorfdhup = fetchpatch2 {
@@ -105,136 +123,173 @@ let
 
   # Intentionally does not support overrideAttrs etc
   # Use only for tests that are about the package relation to `pkgs` and/or NixOS.
-  addTestsShallowly = tests: pkg: pkg // {
-    tests = pkg.tests // tests;
-    # In case someone reads the wrong attribute
-    passthru.tests = pkg.tests // tests;
-  };
+  addTestsShallowly =
+    tests: pkg:
+    pkg
+    // {
+      tests = pkg.tests // tests;
+      # In case someone reads the wrong attribute
+      passthru.tests = pkg.tests // tests;
+    };
 
-  addFallbackPathsCheck = pkg: addTestsShallowly
-    { nix-fallback-paths =
-        runCommand "test-nix-fallback-paths-version-equals-nix-stable" {
-          paths = lib.concatStringsSep "\n" (builtins.attrValues (import ../../../../nixos/modules/installer/tools/nix-fallback-paths.nix));
-        } ''
-          # NOTE: name may contain cross compilation details between the pname
-          #       and version this is permitted thanks to ([^-]*-)*
-          if [[ "" != $(grep -vE 'nix-([^-]*-)*${lib.strings.replaceStrings ["."] ["\\."] pkg.version}$' <<< "$paths") ]]; then
-            echo "nix-fallback-paths not up to date with nixVersions.stable (nix-${pkg.version})"
-            echo "The following paths are not up to date:"
-            grep -v 'nix-${pkg.version}$' <<< "$paths"
-            echo
-            echo "Fix it by running in nixpkgs:"
-            echo
-            echo "curl https://releases.nixos.org/nix/nix-${pkg.version}/fallback-paths.nix >nixos/modules/installer/tools/nix-fallback-paths.nix"
-            echo
-            exit 1
-          else
-            echo "nix-fallback-paths versions up to date"
-            touch $out
-          fi
-        '';
-    }
-    pkg;
+  addFallbackPathsCheck =
+    pkg:
+    addTestsShallowly {
+      nix-fallback-paths =
+        runCommand "test-nix-fallback-paths-version-equals-nix-stable"
+          {
+            paths = lib.concatStringsSep "\n" (
+              builtins.attrValues (import ../../../../nixos/modules/installer/tools/nix-fallback-paths.nix)
+            );
+          }
+          ''
+            # NOTE: name may contain cross compilation details between the pname
+            #       and version this is permitted thanks to ([^-]*-)*
+            if [[ "" != $(grep -vE 'nix-([^-]*-)*${
+              lib.strings.replaceStrings [ "." ] [ "\\." ] pkg.version
+            }$' <<< "$paths") ]]; then
+              echo "nix-fallback-paths not up to date with nixVersions.stable (nix-${pkg.version})"
+              echo "The following paths are not up to date:"
+              grep -v 'nix-${pkg.version}$' <<< "$paths"
+              echo
+              echo "Fix it by running in nixpkgs:"
+              echo
+              echo "curl https://releases.nixos.org/nix/nix-${pkg.version}/fallback-paths.nix >nixos/modules/installer/tools/nix-fallback-paths.nix"
+              echo
+              exit 1
+            else
+              echo "nix-fallback-paths versions up to date"
+              touch $out
+            fi
+          '';
+    } pkg;
 
   # (meson based packaging)
   # Add passthru tests to the package, and re-expose package set overriding
   # functions. This will not incorporate the tests into the package set.
   # TODO (roberth): add package-set level overriding to the "everything" package.
-  addTests = selfAttributeName: pkg:
+  addTests =
+    selfAttributeName: pkg:
     let
       tests =
-        pkg.tests or {}
+        pkg.tests or { }
         // import ./tests.nix {
-          inherit runCommand lib stdenv pkgs pkgsi686Linux pkgsStatic nixosTests;
+          inherit
+            runCommand
+            lib
+            stdenv
+            pkgs
+            pkgsi686Linux
+            pkgsStatic
+            nixosTests
+            ;
           inherit (pkg) version src;
           nix = pkg;
           self_attribute_name = selfAttributeName;
         };
     in
     # preserve old pkg, including overrideSource, etc
-    pkg // {
-      tests = pkg.tests or {} // tests;
-      passthru = pkg.passthru or {} // {
-        tests = lib.warn "nix.passthru.tests is deprecated. Use nix.tests instead." pkg.passthru.tests or {} // tests;
+    pkg
+    // {
+      tests = pkg.tests or { } // tests;
+      passthru = pkg.passthru or { } // {
+        tests =
+          lib.warn "nix.passthru.tests is deprecated. Use nix.tests instead." pkg.passthru.tests or { }
+          // tests;
       };
     };
 
-in lib.makeExtensible (self: ({
-  nix_2_3 = ((common {
-    version = "2.3.18";
-    hash = "sha256-jBz2Ub65eFYG+aWgSI3AJYvLSghio77fWQiIW1svA9U=";
-    patches = [
-      patch-monitorfdhup
-    ];
-    self_attribute_name = "nix_2_3";
-    maintainers = with lib.maintainers; [ flokli ];
-  }).override { boehmgc = boehmgc-nix_2_3; }).overrideAttrs {
-    # https://github.com/NixOS/nix/issues/10222
-    # spurious test/add.sh failures
-    enableParallelChecking = false;
-  };
+in
+lib.makeExtensible (
+  self:
+  (
+    {
+      nix_2_3 =
+        (
+          (common {
+            version = "2.3.18";
+            hash = "sha256-jBz2Ub65eFYG+aWgSI3AJYvLSghio77fWQiIW1svA9U=";
+            patches = [
+              patch-monitorfdhup
+            ];
+            self_attribute_name = "nix_2_3";
+            maintainers = with lib.maintainers; [ flokli ];
+          }).override
+          { boehmgc = boehmgc-nix_2_3; }
+        ).overrideAttrs
+          {
+            # https://github.com/NixOS/nix/issues/10222
+            # spurious test/add.sh failures
+            enableParallelChecking = false;
+          };
 
-  nix_2_24 = common {
-    version = "2.24.12";
-    hash = "sha256-lPiheE0D146tstoUInOUf1451stezrd8j6H6w7+RCv8=";
-    self_attribute_name = "nix_2_24";
-  };
+      nix_2_24 = common {
+        version = "2.24.12";
+        hash = "sha256-lPiheE0D146tstoUInOUf1451stezrd8j6H6w7+RCv8=";
+        self_attribute_name = "nix_2_24";
+      };
 
-  nix_2_25 = common {
-    version = "2.25.5";
-    hash = "sha256-9xrQhrqHCSqWsQveykZvG/ZMu0se66fUQw3xVSg6BpQ=";
-    self_attribute_name = "nix_2_25";
-  };
+      nix_2_25 = common {
+        version = "2.25.5";
+        hash = "sha256-9xrQhrqHCSqWsQveykZvG/ZMu0se66fUQw3xVSg6BpQ=";
+        self_attribute_name = "nix_2_25";
+      };
 
-  components.nix_2_26 =
-    (callPackage ./vendor/2_26/componentized.nix {
-      inherit (self.nix_2_24.meta) maintainers;
-      selfAttributeName = "nix_2_26";
-    });
-  nix_2_26 = addTests "nix_2_26" self.components.nix_2_26.nix-everything;
+      components.nix_2_26 = (
+        callPackage ./vendor/2_26/componentized.nix {
+          inherit (self.nix_2_24.meta) maintainers;
+          selfAttributeName = "nix_2_26";
+        }
+      );
+      nix_2_26 = addTests "nix_2_26" self.components.nix_2_26.nix-everything;
 
-  git = common rec {
-    version = "2.25.0";
-    suffix = "pre20241101_${lib.substring 0 8 src.rev}";
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "nix";
-      rev = "2e5759e3778c460efc5f7cfc4cb0b84827b5ffbe";
-      hash = "sha256-E1Sp0JHtbD1CaGO3UbBH6QajCtOGqcrVfPSKL0n63yo=";
-    };
-    self_attribute_name = "git";
-  };
+      git = common rec {
+        version = "2.25.0";
+        suffix = "pre20241101_${lib.substring 0 8 src.rev}";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          rev = "2e5759e3778c460efc5f7cfc4cb0b84827b5ffbe";
+          hash = "sha256-E1Sp0JHtbD1CaGO3UbBH6QajCtOGqcrVfPSKL0n63yo=";
+        };
+        self_attribute_name = "git";
+      };
 
-  latest = self.nix_2_26;
+      latest = self.nix_2_26;
 
-  # The minimum Nix version supported by Nixpkgs
-  # Note that some functionality *might* have been backported into this Nix version,
-  # making this package an inaccurate representation of what features are available
-  # in the actual lowest minver.nix *patch* version.
-  minimum =
-    let
-      minver = import ../../../../lib/minver.nix;
-      major = lib.versions.major minver;
-      minor = lib.versions.minor minver;
-      attribute = "nix_${major}_${minor}";
-      nix = self.${attribute};
-    in
-    if ! self ? ${attribute} then
-      throw "The minimum supported Nix version is ${minver} (declared in lib/minver.nix), but pkgs.nixVersions.${attribute} does not exist."
-    else
-      nix;
+      # The minimum Nix version supported by Nixpkgs
+      # Note that some functionality *might* have been backported into this Nix version,
+      # making this package an inaccurate representation of what features are available
+      # in the actual lowest minver.nix *patch* version.
+      minimum =
+        let
+          minver = import ../../../../lib/minver.nix;
+          major = lib.versions.major minver;
+          minor = lib.versions.minor minver;
+          attribute = "nix_${major}_${minor}";
+          nix = self.${attribute};
+        in
+        if !self ? ${attribute} then
+          throw "The minimum supported Nix version is ${minver} (declared in lib/minver.nix), but pkgs.nixVersions.${attribute} does not exist."
+        else
+          nix;
 
-  # Read ./README.md before bumping a major release
-  stable = addFallbackPathsCheck self.nix_2_24;
-} // lib.optionalAttrs config.allowAliases (
-  lib.listToAttrs (map (
-    minor:
-    let
-      attr = "nix_2_${toString minor}";
-    in
-    lib.nameValuePair attr (throw "${attr} has been removed")
-  ) (lib.range 4 23))
-  // {
-    unstable = throw "nixVersions.unstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.";
-  }
-)))
+      # Read ./README.md before bumping a major release
+      stable = addFallbackPathsCheck self.nix_2_24;
+    }
+    // lib.optionalAttrs config.allowAliases (
+      lib.listToAttrs (
+        map (
+          minor:
+          let
+            attr = "nix_2_${toString minor}";
+          in
+          lib.nameValuePair attr (throw "${attr} has been removed")
+        ) (lib.range 4 23)
+      )
+      // {
+        unstable = throw "nixVersions.unstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.";
+      }
+    )
+  )
+)

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -186,7 +186,12 @@ in lib.makeExtensible (self: ({
     self_attribute_name = "nix_2_25";
   };
 
-  nix_2_26 = addTests "nix_2_26" (callPackage ./vendor/2_26/componentized.nix { inherit (self.nix_2_24.meta) maintainers; });
+  components.nix_2_26 =
+    (callPackage ./vendor/2_26/componentized.nix {
+      inherit (self.nix_2_24.meta) maintainers;
+      selfAttributeName = "nix_2_26";
+    });
+  nix_2_26 = addTests "nix_2_26" self.components.nix_2_26.nix-everything;
 
   git = common rec {
     version = "2.25.0";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -3,7 +3,6 @@
 , stdenv
 , aws-sdk-cpp
 , boehmgc
-, libgit2
 , callPackage
 , fetchFromGitHub
 , fetchpatch2

--- a/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
+++ b/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
@@ -7,6 +7,7 @@
   pkgs,
   stdenv,
   maintainers,
+  selfAttributeName,
   ...
 }:
 let
@@ -24,7 +25,7 @@ let
         inherit (nixDependencies) newScope;
       }
       {
-        otherSplices = generateSplicesForMkScope "nixComponents";
+        otherSplices = generateSplicesForMkScope [ "nixVersions" "components" selfAttributeName ];
         f = import ./packaging/components.nix {
           inherit
             lib
@@ -45,11 +46,13 @@ let
         inherit newScope; # layered directly on pkgs, unlike nixComponents above
       }
       {
-        otherSplices = generateSplicesForMkScope "nixDependencies";
+        # Technically this should point to the nixDependencies set only, but
+        # this is ok as long as the scopes don't intersect.
+        otherSplices = generateSplicesForMkScope ["nixVersions" "components" selfAttributeName ];
         f = import ./dependencies.nix {
           inherit pkgs;
           inherit stdenv;
         };
       };
 in
-(nixComponents.overrideSource src).nix-everything
+nixComponents.overrideSource src

--- a/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
+++ b/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
@@ -25,7 +25,11 @@ let
         inherit (nixDependencies) newScope;
       }
       {
-        otherSplices = generateSplicesForMkScope [ "nixVersions" "components" selfAttributeName ];
+        otherSplices = generateSplicesForMkScope [
+          "nixVersions"
+          "components"
+          selfAttributeName
+        ];
         f = import ./packaging/components.nix {
           inherit
             lib
@@ -48,7 +52,11 @@ let
       {
         # Technically this should point to the nixDependencies set only, but
         # this is ok as long as the scopes don't intersect.
-        otherSplices = generateSplicesForMkScope ["nixVersions" "components" selfAttributeName ];
+        otherSplices = generateSplicesForMkScope [
+          "nixVersions"
+          "components"
+          selfAttributeName
+        ];
         f = import ./dependencies.nix {
           inherit pkgs;
           inherit stdenv;


### PR DESCRIPTION
- Fixes #392783 
- Fixes #381952 

This contains a formatting commit, so best to review the commits individually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
