### PR TITLE
nixos/cosmic-greeter: init; nixos/cosmic: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -10,6 +10,8 @@
   Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
   If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
 
+- Initial support for the [COSMIC DE](https://system76.com/cosmic), a Rust-based desktop environment by System76, makers of Pop!_OS. Toggle the greeter (login manager) using `services.displayManager.cosmic-greeter.enable` and the DE itself with `services.desktopManager.cosmic.enable`. Mostly stable but still experimental. Please report any issues to the [COSMIC DE tracker in Nixpkgs](https://github.com/NixOS/nixpkgs/issues/259641) instead of upstream.
+
 - The default kernel package has been updated from 6.6 to 6.12. All supported kernels remain available.
 
 - GCC has been updated from GCC 13 to GCC 14.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -577,6 +577,7 @@
   ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix
   ./services/display-managers/default.nix
+  ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/greetd.nix
   ./services/display-managers/sddm.nix
   ./services/display-managers/ly.nix

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Lily Foster <lily@lily.flowers>
+# Portions of this code are adapted from nixos-cosmic
+# https://github.com/lilyinstarlight/nixos-cosmic
+
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.desktopManager.cosmic;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    thefossguy
+    HeitorAugustoLN
+    nyabinary
+    ahoneybun
+  ];
+
+  options = {
+    services.desktopManager.cosmic = {
+      enable = lib.mkEnableOption "Enable the COSMIC desktop environment";
+
+      xwayland.enable = lib.mkEnableOption "Xwayland support for the COSMIC compositor" // {
+        default = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Environment packages
+    environment.pathsToLink = [
+      "/share/backgrounds"
+      "/share/cosmic"
+    ];
+    environment.systemPackages =
+      with pkgs;
+      [
+        adwaita-icon-theme
+        alsa-utils
+        cosmic-applets
+        cosmic-applibrary
+        cosmic-bg
+        (cosmic-comp.override { useXWayland = false; })
+        cosmic-edit
+        cosmic-files
+        config.services.displayManager.cosmic-greeter.package
+        cosmic-icons
+        cosmic-idle
+        cosmic-launcher
+        cosmic-notifications
+        cosmic-osd
+        cosmic-panel
+        cosmic-player
+        cosmic-randr
+        cosmic-screenshot
+        cosmic-session
+        cosmic-settings
+        cosmic-settings-daemon
+        cosmic-term
+        cosmic-wallpapers
+        cosmic-workspaces-epoch
+        hicolor-icon-theme
+        playerctl
+        pop-icon-theme
+        pop-launcher
+        xdg-user-dirs
+      ]
+      ++ lib.optionals cfg.xwayland.enable [
+        xwayland
+      ]
+      ++ lib.optionals config.services.flatpak.enable [
+        cosmic-store
+      ];
+
+    # Distro-wide defaults for graphical sessions
+    services.graphical-desktop.enable = true;
+
+    xdg = {
+      icons.fallbackCursorThemes = lib.mkDefault [ "Cosmic" ];
+
+      portal = {
+        enable = true;
+        extraPortals = with pkgs; [
+          xdg-desktop-portal-cosmic
+          xdg-desktop-portal-gtk
+        ];
+        configPackages = lib.mkDefault [ pkgs.xdg-desktop-portal-cosmic ];
+      };
+    };
+
+    systemd = {
+      packages = [ pkgs.cosmic-session ];
+      user.targets = {
+        cosmic-session = {
+          wants = [ "xdg-desktop-autostart.target" ];
+          before = [ "xdg-desktop-autostart.target" ];
+        };
+        tray = {
+          description = "Cosmic Tray Target";
+          requires = [ "graphical-session-pre.target" ];
+        };
+      };
+    };
+
+    fonts.packages = with pkgs; [
+      fira
+      noto-fonts
+      open-sans
+    ];
+
+    # Required options for the COSMIC DE
+    environment.sessionVariables.X11_BASE_RULES_XML = "${config.services.xserver.xkb.dir}/rules/base.xml";
+    environment.sessionVariables.X11_EXTRA_RULES_XML = "${config.services.xserver.xkb.dir}/rules/base.extras.xml";
+    programs.dconf.enable = true;
+    programs.dconf.packages = [ pkgs.cosmic-session ];
+    security.polkit.enable = true;
+    security.rtkit.enable = true;
+    services.accounts-daemon.enable = true;
+    services.displayManager.sessionPackages = [ pkgs.cosmic-session ];
+    services.libinput.enable = true;
+    services.upower.enable = true;
+    # Setup PAM authentication for the `cosmic-greeter` user
+    security.pam.services.cosmic-greeter = { };
+
+    # Good to have defaults
+    hardware.bluetooth.enable = lib.mkDefault true;
+    networking.networkmanager.enable = lib.mkDefault true;
+    services.acpid.enable = lib.mkDefault true;
+    services.avahi.enable = lib.mkDefault true;
+    services.gnome.gnome-keyring.enable = lib.mkDefault true;
+    services.gvfs.enable = lib.mkDefault true;
+    services.power-profiles-daemon.enable = lib.mkDefault (
+      !config.hardware.system76.power-daemon.enable
+    );
+  };
+}

--- a/nixos/modules/services/display-managers/cosmic-greeter.nix
+++ b/nixos/modules/services/display-managers/cosmic-greeter.nix
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Lily Foster <lily@lily.flowers>
+# Portions of this code are adapted from nixos-cosmic
+# https://github.com/lilyinstarlight/nixos-cosmic
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.displayManager.cosmic-greeter;
+in
+
+{
+  meta.maintainers = with lib.maintainers; [
+    thefossguy
+    HeitorAugustoLN
+    nyabinary
+    ahoneybun
+  ];
+
+  options.services.displayManager.cosmic-greeter = {
+    enable = lib.mkEnableOption "COSMIC greeter";
+    package = lib.mkPackageOption pkgs "cosmic-greeter" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.greetd = {
+      enable = true;
+      settings = {
+        default_session = {
+          user = "cosmic-greeter";
+          command = ''${lib.getExe' pkgs.coreutils "env"} XCURSOR_THEME="''${XCURSOR_THEME:-Pop}" systemd-cat -t cosmic-greeter ${lib.getExe pkgs.cosmic-comp} ${lib.getExe cfg.package}'';
+        };
+      };
+    };
+
+    # Daemon for querying background state and such
+    systemd.services.cosmic-greeter-daemon = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "greetd.service" ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "com.system76.CosmicGreeter";
+        ExecStart = lib.getExe' cfg.package "cosmic-greeter-daemon";
+        Restart = "on-failure";
+      };
+    };
+
+    # The greeter user is hardcoded in `cosmic-greeter`
+    users.groups.cosmic-greeter = { };
+    users.users.cosmic-greeter = {
+      description = "COSMIC login greeter user";
+      isSystemUser = true;
+      home = "/var/lib/cosmic-greeter";
+      createHome = true;
+      group = "cosmic-greeter";
+    };
+    # Setup PAM authentication for the `cosmic-greeter` user
+    security.pam.services.cosmic-greeter = { };
+
+    hardware.graphics.enable = true;
+    services.accounts-daemon.enable = true;
+    services.dbus.packages = [ cfg.package ];
+    services.libinput.enable = true;
+  };
+}

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -21,6 +21,7 @@ in
     ./lxqt.nix ./enlightenment.nix ./gnome.nix ./retroarch.nix ./kodi.nix
     ./mate.nix ./pantheon.nix ./surf-display.nix ./cde.nix
     ./cinnamon.nix ./budgie.nix ./deepin.nix ../../desktop-managers/lomiri.nix
+    ../../desktop-managers/cosmic.nix
   ];
 
   options = {


### PR DESCRIPTION
Initialize the cosmic modules so the state of broken-ness (or not) of any packages in nixpkgs can be tested.

This will help test the packages and bring out bugs like following:
```
Mar 25 01:18:22 matsya cosmic-session[1923]: thread 'main' panicked at 'failed to start cosmic-idle': src/main.rs:560
[---snip---]
Mar 25 01:18:23 matsya .cosmic-comp-wrapped[2045]: Unable to parse your locale: ParserError(InvalidLanguage)
Mar 25 01:18:23 matsya .cosmic-comp-wrapped[2045]: Failed to read config 'workspaces'
[---snip---]
Mar 25 01:18:23 matsya .cosmic-comp-wrapped[2045]: shortcuts custom config error: GetKey("custom", Os { code: 2, kind: NotFound, message: "No such file or directory" })
```
Closes https://github.com/NixOS/nixpkgs/pull/369113.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
