### PR TITLE
buildPgrxExtension: mark packages as broken on darwin

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
@@ -178,6 +178,11 @@ let
       (args.checkFeatures or [ ])
       ++ (lib.optionals usePgTestCheckFeature [ "pg_test" ])
       ++ [ "pg${pgrxPostgresMajor}" ];
+
+    meta = (args.meta or { }) // {
+      # See comment in postgresql's generic.nix doInstallCheck section
+      broken = (args.meta.broken or false) || stdenv.hostPlatform.isDarwin;
+    };
   };
 in
 rustPlatform.buildRustPackage finalArgs


### PR DESCRIPTION
Follow up to #392430, potentially controversial, because it marks those pgrx packages as broken on darwin, when they technically build fine - sometimes.

Because of [1], we can't run initdb / postgres inside the darwin sandbox, even though it succeeds most of the time. It will lead to hard to debug build failures eventually.

Since pgrx runs initdb as part of the build... there seems to be no other way than marking those packages as broken for now. This could be relaxed once [2] is available, because we could then disable the checkPhase and all "initdb" for pgrx on darwin.

[1]:
https://github.com/NixOS/nixpkgs/issues/371242#issuecomment-2672697582
[2]: https://github.com/pgcentralfoundation/pgrx/pull/1994

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
