### PR TITLE
squirreldisk: Fix displaying of results

### DIFF
--- a/pkgs/by-name/sq/squirreldisk/package.nix
+++ b/pkgs/by-name/sq/squirreldisk/package.nix
@@ -38,6 +38,12 @@ let
     '';
     distPhase = "true";
     dontInstall = true;
+
+    patches = [
+      # Update field names to work with pdu versions >=0.10.0
+      # https://github.com/adileo/squirreldisk/pull/47
+      ./update-pdu-json-format.patch
+    ];
   };
 in
 rustPlatform.buildRustPackage rec {

--- a/pkgs/by-name/sq/squirreldisk/update-pdu-json-format.patch
+++ b/pkgs/by-name/sq/squirreldisk/update-pdu-json-format.patch
@@ -1,0 +1,77 @@
+diff --git a/src/components/FileLine.tsx b/src/components/FileLine.tsx
+index e55f3bd..bd722d7 100644
+--- a/src/components/FileLine.tsx
++++ b/src/components/FileLine.tsx
+@@ -65,7 +65,7 @@ export const FileLine = ({
+             {/* {JSON.stringify(item.data)} */}
+             {item &&
+               item.data &&
+-              (item.data.data / mul / mul / mul).toFixed(2)}{" "}
++              (item.data.size / mul / mul / mul).toFixed(2)}{" "}
+             GB
+           </div>
+         </div>
+diff --git a/src/d3chart.ts b/src/d3chart.ts
+index 855886b..d85c682 100644
+--- a/src/d3chart.ts
++++ b/src/d3chart.ts
+@@ -191,7 +191,7 @@ const updateData = (
+           isDirectory: false,
+           name: "Smaller Items",
+           value: item.value || 0,
+-          data: item.value || 0,
++          size: item.value || 0,
+           children: [],
+         };
+         accumulator = d3.hierarchy(v) as D3HierarchyDiskItem;
+@@ -248,7 +248,7 @@ const updateData = (
+               .ancestors()
+               .map((d) => d.data.name)
+               .reverse()
+-              .join("/")}\n${((d.data.data || 0) / mul / mul / mul).toFixed(
++              .join("/")}\n${((d.data.size || 0) / mul / mul / mul).toFixed(
+               2
+             )} GB`
+         );
+diff --git a/src/index.d.ts b/src/index.d.ts
+index daa7233..81b5243 100644
+--- a/src/index.d.ts
++++ b/src/index.d.ts
+@@ -5,7 +5,7 @@ interface DiskItem {
+   id: string;
+   name: string;
+   value: number;
+-  data: number;
++  size: number;
+   isDirectory: boolean;
+   children: Array<DiskItem>;
+ }
+diff --git a/src/pruneData.ts b/src/pruneData.ts
+index 37e70d8..040e227 100644
+--- a/src/pruneData.ts
++++ b/src/pruneData.ts
+@@ -18,7 +18,7 @@ export const itemMap = (obj: any, parent: any = null) => {
+     //recursive call to scan property
+     if (obj["children"].length > 0) {
+       obj.isDirectory = true;
+-      obj.value = obj.data;
++      obj.value = obj.size;
+       obj["children"].forEach((element: any) => {
+         itemMap(element, obj);
+       });
+@@ -31,13 +31,13 @@ const partition = (data: DiskItem) => {
+   const hierarchy = d3
+     .hierarchy(data)
+     .sum(function (d) {
+-      return !d.children || d.children.length === 0 ? d.data : 0;
++      return !d.children || d.children.length === 0 ? d.size : 0;
+     })
+ 
+     // .sum(d => d.value)
+     // .sum((d: DiskItem) => (d.children ? d.data : d.data))
+     // .sum(d => d.data ? 0 : d.value)
+-    .sort((a: any, b: any) => (b.data || 0) - (a.data || 0));
++    .sort((a: any, b: any) => (b.size || 0) - (a.size || 0));
+   // debugger;
+   const partition = d3
+     .partition<DiskItem>()


### PR DESCRIPTION
Currently the squirreldisk package is broken - it scans the directory, but does not display the results correctly (i.e., no graph and no file sizes are displayed).
The reason is that parallel-disk-usage from nixpkgs has been updated to a version that does not work with squirreldisk anymore (i.e. changed JSON output format).
This commit adds a patch that updates the frontend code to work with pdu's new JSON output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
