### PR TITLE
bluespec: Fix `check-smoke` and `check-suite`

### DIFF
--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -22,11 +22,23 @@
   asciidoctor,
   texliveFull,
   which,
+  makeWrapper,
+  cctools,
+  targetPackages,
   # install -m 644 lib/libstp.dylib /private/tmp/nix-build-bluespec-2024.07.drv-5/source/inst/lib/SAT
   # install: cannot stat 'lib/libstp.dylib': No such file or directory
   # https://github.com/B-Lang-org/bsc/pull/600 might fix it
   stubStp ? !stdenv.hostPlatform.isDarwin,
   withDocs ? true,
+  # With 23 core parallel 10 mins on r9 5900x
+  # Broken on darwin currently
+  withSuiteCheck ? false,
+  gnugrep,
+  time,
+  dejagnu,
+  systemc,
+  glibcLocales,
+  buildPackages,
 }:
 
 let
@@ -76,22 +88,56 @@ stdenv.mkDerivation rec {
     chmod -R +rwX $sourceRoot/src/vendor/yices/v2.6/yices2
   '';
 
+  postPatch =
+    ''
+      patchShebangs \
+        src/vendor/stp/src/AST/genkinds.pl \
+        src/Verilog/copy_module.pl \
+        src/comp/update-build-version.sh \
+        src/comp/update-build-system.sh \
+        src/comp/wrapper.sh
+
+      substituteInPlace src/comp/Makefile \
+        --replace-fail 'install-bsc install-bluetcl' 'install-bsc install-bluetcl $(UTILEXES) $(SHOWRULESEXES) install-utils install-showrules'
+
+      # For darwin
+      # ld: library not found for -ltcl8.5
+      substituteInPlace ./platform.sh \
+        --replace-fail 'TCLSH=/usr/bin/tclsh' 'TCLSH=`which tclsh`'
+    ''
+    + lib.optionalString withSuiteCheck ''
+      substituteInPlace testsuite/bsc.options/verilog-e/verilog-e.exp \
+        --replace-fail "/bin/echo" "${lib.getExe' buildPackages.coreutils "echo"}"
+
+      substituteInPlace testsuite/test_list.sh testsuite/findfailures.csh \
+        --replace-fail "bin/csh" "${lib.getExe buildPackages.tcsh}"
+
+      patchShebangs \
+        testsuite/test_list.sh \
+        testsuite/findfailures.csh \
+        scripts/tool-find.sh \
+        testsuite/bsc.bluetcl/packages/expandPorts/compareOutput.pl \
+        testsuite/bsc.bsv_examples/AES/funcit.pl \
+        testsuite/bsc.bsv_examples/AES/makeVecs.pl \
+        testsuite/bsc.bsv_examples/AES/makeVecs192.pl \
+        testsuite/bsc.bsv_examples/AES/makeVecs256.pl \
+        testsuite/bsc.if/split/canonicalize.pl \
+        testsuite/bsc.interra/operators/Arith/generate/gen.pl \
+        testsuite/bsc.interra/operators/Arith/generate/sort.pl \
+        testsuite/bsc.interra/operators/BitSel/generate/gen.pl \
+        testsuite/bsc.interra/operators/BitSel/generate/sort.pl \
+        testsuite/bsc.interra/operators/Logic/generate/gen.pl \
+        testsuite/bsc.interra/operators/Logic/generate/sort.pl \
+        testsuite/bsc.preprocessor/ifdef/iftestcase-perl.pl \
+        testsuite/bsc.verilog/filter/basicinout.pl \
+        testsuite/scripts/collapse.pl \
+        testsuite/scripts/double-directory.pl \
+        testsuite/scripts/process-summary-file.pl \
+        testsuite/scripts/sort-by-time.pl \
+        testsuite/scripts/times-by-directory.pl
+    '';
+
   preBuild = ''
-    patchShebangs \
-      src/vendor/stp/src/AST/genkinds.pl \
-      src/Verilog/copy_module.pl \
-      src/comp/update-build-version.sh \
-      src/comp/update-build-system.sh \
-      src/comp/wrapper.sh
-
-    substituteInPlace src/comp/Makefile \
-      --replace-fail 'install-bsc install-bluetcl' 'install-bsc install-bluetcl $(UTILEXES) $(SHOWRULESEXES) install-utils install-showrules'
-
-    # For darwin
-    # ld: library not found for -ltcl8.5
-    substituteInPlace ./platform.sh \
-      --replace-fail 'TCLSH=/usr/bin/tclsh' 'TCLSH=`which tclsh`'
-
     # allow running bsc to bootstrap
     export LD_LIBRARY_PATH=$PWD/inst/lib/SAT
 
@@ -110,18 +156,26 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  nativeBuildInputs = [
-    automake
-    autoconf
-    asciidoctor
-    bison
-    flex
-    ghcWithPackages
-    perl
-    pkg-config
-    texliveFull
-    tcl
-  ];
+  nativeBuildInputs =
+    [
+      automake
+      autoconf
+      asciidoctor
+      bison
+      flex
+      ghcWithPackages
+      perl
+      pkg-config
+      texliveFull
+      tcl
+      makeWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # https://github.com/B-Lang-org/bsc/blob/main/src/comp/bsc.hs#L1838
+      # /nix/store/7y0vlsf6l8lr3vjsbrirqrsbx4mwqiwf-cctools-binutils-darwin-1010.6/bin/strip: error: unknown argument '-u'
+      # make[1]: *** [Makefile:97: smoke_test_bluesim] Error 1
+      cctools
+    ];
 
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals (stdenv.cc.isClang) [
@@ -141,17 +195,6 @@ stdenv.mkDerivation rec {
       "STP_STUB=1" # uses yices as a SMT solver and stub out STP
     ];
 
-  doCheck = true;
-
-  nativeCheckInputs = [
-    gmp-static
-    iverilog
-  ];
-
-  # /nix/store/7y0vlsf6l8lr3vjsbrirqrsbx4mwqiwf-cctools-binutils-darwin-1010.6/bin/strip: error: unknown argument '-u'
-  # make[1]: *** [Makefile:97: smoke_test_bluesim] Error 1
-  checkTarget = lib.optionalString (!stdenv.hostPlatform.isDarwin) "check-smoke"; # this is the shortest check but "check-suite" tests much more
-
   installPhase =
     ''
       mkdir -p $out
@@ -166,6 +209,72 @@ stdenv.mkDerivation rec {
       mv inst/ReleaseNotes.* $doc/share/doc/bsc
       mv inst/doc/*.pdf $doc/share/doc/bsc
     '';
+
+  postFixup = ''
+    # https://github.com/B-Lang-org/bsc/blob/65e3a87a17f6b9cf38cbb7b6ad7a4473f025c098/src/comp/bsc.hs#L1839
+    wrapProgram $out/bin/bsc --prefix PATH : ${
+      lib.makeBinPath (if stdenv.hostPlatform.isDarwin then [ cctools ] else [ targetPackages.stdenv.cc ])
+    }
+  '';
+
+  doCheck = true;
+
+  # TODO To fix check-suite:
+  # On darwin
+  # ```
+  # FAIL: `Cpreprocess_line.bsv.bsc-out' differs from `Cpreprocess_line.bsv.bsc-out.expected'
+
+  # FAIL: `sysGCD.bsc-vcomp-out.filtered' differs from `empty.expected'
+
+  # FAIL: module `' in `ImpArgConnect3.bsv' should compile to Verilog
+  # Caught error in sed: sed: can't read mkArgImpConnect3.v: No such file or directory
+  # FAIL: `mkArgImpConnect3.v.filtered' differs from `mkArgImpConnect3.v.expected.filtered'
+  # ```
+
+  checkTarget = if withSuiteCheck then "checkparallel" else "check-smoke"; # this is the shortest check but "check-suite" tests much more
+
+  # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+  LOCALE_ARCHIVE = lib.optionalString (
+    withSuiteCheck && stdenv.hostPlatform.isLinux
+  ) "${glibcLocales}/lib/locale/locale-archive";
+
+  nativeCheckInputs =
+    [
+      gmp-static
+      iverilog
+    ]
+    ++ lib.optionals withSuiteCheck [
+      time
+      dejagnu # for `/bin/runtest` in `check-suite`
+      gnugrep # `testsuite/bsc.interra/operators/Arith/arith.exp` and more
+    ];
+
+  checkInputs = lib.optionals withSuiteCheck [
+    systemc
+  ];
+
+  checkPhase = lib.optionalString withSuiteCheck ''
+    (
+      cd testsuite
+      set +e # disable exit on error
+      make -j $NIX_BUILD_CORES $checkTarget
+      test_exit_code=$?
+      set -e
+      failures=$(./findfailures.csh)
+      echo "$failures"
+      for failure in $failures; do
+        logpath="''${failure/%sum/log}"
+        echo "\nFAILURE LOG: $logpath"
+        cat "$logpath"
+        echo "END LOG: $logpath"
+      done
+
+      if [[ "$test_exit_code" != "0" || -n "$failures" ]]; then
+        echo "Some tests failed or the makefile failed to run"
+        exit 1
+      fi
+    )
+  '';
 
   meta = {
     description = "Toolchain for the Bluespec Hardware Definition Language";


### PR DESCRIPTION
The check suite is still broken on darwin with a few failures but check-smoke works

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
