### PR TITLE
python312Packages.docling-ibm-models: relax jsonlines dependency

### DIFF
--- a/pkgs/development/python-modules/docling-ibm-models/default.nix
+++ b/pkgs/development/python-modules/docling-ibm-models/default.nix
@@ -58,8 +58,9 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "transformers"
+    "jsonlines"
     "numpy"
+    "transformers"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/docling-ibm-models/default.nix
+++ b/pkgs/development/python-modules/docling-ibm-models/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -80,6 +81,12 @@ buildPythonPackage rec {
     "test_layoutpredictor"
     "test_readingorder"
     "test_tf_predictor"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
+    "tests/test_code_formula_predictor.py"
+    "tests/test_layout_predictor.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/docling/default.nix
+++ b/pkgs/development/python-modules/docling/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -158,6 +159,25 @@ buildPythonPackage rec {
 
     # AssertionError: pred_itxt==true_itxt
     "test_e2e_valid_csv_conversions"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
+    "tests/test_backend_csv.py"
+    "tests/test_backend_html.py"
+    "tests/test_backend_jats.py"
+    "tests/test_backend_msexcel.py"
+    "tests/test_backend_msword.py"
+    "tests/test_backend_pptx.py"
+    "tests/test_cli.py"
+    "tests/test_code_formula.py"
+    "tests/test_document_picture_classifier.py"
+    "tests/test_e2e_conversion.py"
+    "tests/test_e2e_ocr_conversion.py"
+    "tests/test_interfaces.py"
+    "tests/test_invalid_input.py"
+    "tests/test_legacy_format_transform.py"
+    "tests/test_options.py"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

cc @drupol

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
