### PR TITLE
oprofile: fix build with gcc14

### DIFF
--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -11,12 +11,12 @@
   libiberty_static,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "oprofile";
   version = "1.4.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/oprofile/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/oprofile/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "04m46ni0ryk4sqmzd6mahwzp7iwhwqzfbmfi42fki261sycnz83v";
   };
 
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace opjitconv/opjitconv.c \
-      --replace "/bin/rm" "${buildPackages.coreutils}/bin/rm" \
-      --replace "/bin/cp" "${buildPackages.coreutils}/bin/cp"
+      --replace-fail "/bin/rm" "${buildPackages.coreutils}/bin/rm" \
+      --replace-fail "/bin/cp" "${buildPackages.coreutils}/bin/cp"
   '';
 
   nativeBuildInputs = [ pkg-config ];
@@ -66,4 +66,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/tools/profiling/oprofile/default.nix
+++ b/pkgs/development/tools/profiling/oprofile/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "04m46ni0ryk4sqmzd6mahwzp7iwhwqzfbmfi42fki261sycnz83v";
   };
 
+  patches = [
+    # fix configurePhase with gcc14:
+    # https://sourceforge.net/p/oprofile/oprofile/ci/b0acf9f0c0aac93bf6f3e196d7a52c9632ff4475/
+    ./fix-autoconf-detection-of-perf_events.patch
+  ];
+
   postPatch = ''
     substituteInPlace opjitconv/opjitconv.c \
       --replace "/bin/rm" "${buildPackages.coreutils}/bin/rm" \

--- a/pkgs/development/tools/profiling/oprofile/fix-autoconf-detection-of-perf_events.patch
+++ b/pkgs/development/tools/profiling/oprofile/fix-autoconf-detection-of-perf_events.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index cf36d5ea43..bb59613ef6 100755
+--- a/configure
++++ b/configure
+@@ -17215,6 +17215,7 @@
+ 		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <linux/perf_event.h>
++				#include <unistd.h>
+ 				#include <asm/unistd.h>
+ 				#include <sys/types.h>
+ 				#include <string.h>


### PR DESCRIPTION
oprofile: fix build with gcc14

- add patch similar to upstream commit
https://sourceforge.net/p/oprofile/oprofile/ci/b0acf9f0c0aac93bf6f3e196d7a52c9632ff4475
patch from commit does not work as is because tarball used for build
has `configure` inside and changes to `configure.ac` do not affect it
---
oprofile: cleanup

- replace `--replace` with `--replace-fail`
- replace `rec` with `finalAttrs`
---

Fixes build failure of `oprofile`, fails since `2025-01-14` (update to GCC14 #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.oprofile.x86_64-linux
https://hydra.nixos.org/build/293043082

Error log:
```text
checking kernel supports perf_events... no
ERROR: You requested to build oprofile with '--with-kernel=/nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7',
but your kernel does not appear to have the necessary support to run oprofile.
configure: error: Unable to build oprofile. Exiting.
```

More logs from inside `./configure` with `set -x`:
```text
+ eval test '"x$ac_cv_header__nix_store_js4nk0ps39v0km1c11sprg4wmb57l883_linux_headers_6_12_7_include_linux_perf_event_h"' = xyes
++ test xyes = xyes
+ :
+ PERF_EVENT_H_EXISTS=yes
+ printf '%s\n' 'configure:17211: checking kernel supports perf_events'
+ printf %s 'checking kernel supports perf_events... '
checking kernel supports perf_events... + test yes = yes
+ rm -f test-for-PERF_EVENT_OPEN
+ cat confdefs.h -
+ gcc conftest.c -g -O2 -I/nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7/include -o test-for-PERF_EVENT_OPEN
+ test -f test-for-PERF_EVENT_OPEN
+ printf '%s\n' 'configure:17244: result: no'
+ printf '%s\n' no
no
+ kernel_has_perf_events_support=no
+ rm -f test-for-PERF_EVENT_OPEN
+ test no '!=' yes
+ test /nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7 '!=' ''
+ echo 'ERROR: You requested to build oprofile with '\''--with-kernel=/nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7'\'','
ERROR: You requested to build oprofile with '--with-kernel=/nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7',
+ test -d /nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7
+ test yes '!=' yes
+ echo 'but your kernel does not appear to have the necessary support to run oprofile.'
but your kernel does not appear to have the necessary support to run oprofile.
```

Line that fails (does not produce output that is checked after):
```text
gcc conftest.c -g -O2 -I/nix/store/js4nk0ps39v0km1c11sprg4wmb57l883-linux-headers-6.12.7/include -o test-for-PERF_EVENT_OPEN
```

From manual build of C code inside `./configure` (same error as in upstream commit message):
```text
conftest.c: In function ‘main’:
conftest.c:14:39: error: implicit declaration of function ‘getpid’ [-Wimplicit-function-declaration]
   14 |                                 pid = getpid();
      |                                       ^~~~~~
conftest.c:15:33: error: implicit declaration of function ‘syscall’ [-Wimplicit-function-declaration]
   15 |                                 syscall(__NR_perf_event_open, &attr, pid, 0, -1, 0);
      |                                 ^~~~~~~
```

Upstream commit patch is based on:
https://sourceforge.net/p/oprofile/oprofile/ci/b0acf9f0c0aac93bf6f3e196d7a52c9632ff4475
Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
