### PR TITLE
darwin.dtrace: init at 411

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13354,6 +13354,12 @@
     githubId = 13804737;
     keys = [ { fingerprint = "7FE2 113A A08B 695A C8B8  DDE6 AE53 B4C2 E58E DD45"; } ];
   };
+  lf- = {
+    name = "Jade Lovelace";
+    github = "lf-";
+    githubId = 6652840;
+    matrix = "@jade_:matrix.org";
+  };
   lgbishop = {
     email = "lachlan.bishop@hotmail.com";
     github = "lgbishop";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -805,6 +805,7 @@ with lib.maintainers;
     members = [
       _9999years
       Gabriella439
+      lf-
     ];
     scope = "Group registry for packages maintained by Mercury";
     shortName = "Mercury Employees";
@@ -825,6 +826,8 @@ with lib.maintainers;
     members = [
       raitobezarius
       qyriad
+      _9999years
+      lf-
     ];
     scope = "Maintain the Lix package manager inside of Nixpkgs.";
     shortName = "Lix ecosystem";

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/0001-Patches-for-building-externally-to-Apple.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/0001-Patches-for-building-externally-to-Apple.patch
@@ -1,0 +1,260 @@
+From 6be38fb19fffb058bbb12365aebda1e9918e5196 Mon Sep 17 00:00:00 2001
+From: Jade Lovelace <jadel@mercury.com>
+Date: Mon, 24 Mar 2025 15:20:13 -0700
+Subject: [PATCH] Patches for building externally to Apple
+
+---
+ cmd/dtrace/dtrace.c                     | 15 +++++++++++++--
+ lib/libdtrace/apple/dt_module_apple.c   |  2 +-
+ lib/libdtrace/apple/dt_provider_apple.c |  4 ++--
+ lib/libdtrace/apple/dt_subr_apple.c     |  2 +-
+ lib/libdtrace/common/dt_consume.c       |  1 +
+ lib/libdtrace/common/dt_grammar.h       |  2 +-
+ lib/libdtrace/common/dt_impl.h          |  3 ++-
+ lib/libdtrace/common/dt_lex.l           |  2 +-
+ lib/libdtrace/common/dt_print.c         |  1 -
+ lib/libdtrace/common/dt_proc.c          |  4 ++++
+ lib/libdtrace/common/dt_proc.h          |  1 +
+ lib/libproc/libproc.c                   |  4 ++--
+ 12 files changed, 29 insertions(+), 12 deletions(-)
+
+diff --git a/cmd/dtrace/dtrace.c b/cmd/dtrace/dtrace.c
+index b776708..e5c8924 100644
+--- a/cmd/dtrace/dtrace.c
++++ b/cmd/dtrace/dtrace.c
+@@ -47,11 +47,12 @@
+ #include <mach/machine.h>
+ #include <sys/sysctl.h>
+ #include <pthread.h>
+-#include <pthread/qos_private.h>
++/* #include <pthread/qos_private.h> */
+ 
+ #include <IOKit/IOKitLib.h>
+ 
+-#include <System/sys/csr.h>
++/* #include <System/sys/csr.h> */
++#include "procfs.h"
+ 
+ typedef struct dtrace_cmd {
+ 	void (*dc_func)(struct dtrace_cmd *);	/* function to compile arg */
+@@ -1082,10 +1083,12 @@ set_sched_policy() {
+ 		notice("could not set thread priority to %d", param.sched_priority);
+ 	}
+ 
++#if 0
+ 	err = pthread_set_fixedpriority_self();
+ 	if (err) {
+ 		notice("could not set thread scheduling priority to fixed");
+ 	}
++#endif
+ 
+ }
+ 
+@@ -1199,11 +1202,13 @@ main(int argc, char *argv[])
+ 				break;
+ 
+ 			case 'A':
++#if 0
+ #if DTRACE_TARGET_APPLE_MAC
+ 				if (csr_check(CSR_ALLOW_UNRESTRICTED_DTRACE) != 0 && csr_check(CSR_ALLOW_APPLE_INTERNAL) != 0) {
+ 					fatal("system integrity protection restricts the use of anonymous tracing");
+ 				}
+ #endif /* DTRACE_TARGET_APPLE_MAC */
++#endif
+ 				g_mode = DMODE_ANON;
+ 				g_exec = 0;
+ 				mode++;
+@@ -1297,11 +1302,13 @@ main(int argc, char *argv[])
+ 	if (g_mode == DMODE_VERS)
+ 		return (printf("%s: %s\n", g_pname, _dtrace_version) <= 0);
+ 
++#if 0
+ #if DTRACE_TARGET_APPLE_MAC
+ 	if (g_mode != DMODE_HEADER && csr_check(CSR_ALLOW_UNRESTRICTED_DTRACE) != 0) {
+ 		notice("system integrity protection is on, some features will not be available\n");
+ 	}
+ #endif /* DTRACE_TARGET_APPLE_MAC */
++#endif
+ 
+ 	/*
+ 	 * Open libdtrace.  If we are not actually going to be enabling any
+@@ -1640,6 +1647,10 @@ main(int argc, char *argv[])
+ 	(void) dtrace_getopt(g_dtp, "quiet", &opt);
+ 	g_quiet = opt != DTRACEOPT_UNSET;
+ 
++    if (g_mode != DMODE_VERS || g_mode != DMODE_HEADER) {
++        fputs("WARNING: nixpkgs' Apple DTrace package is only intended as a header generator and is likely arbitrarily broken for all other use cases, use /usr/sbin/dtrace instead\n", stderr);
++    }
++
+ 	/*
+ 	 * Now make a fifth and final pass over the options that have been
+ 	 * turned into programs and saved in g_cmdv[], performing any mode-
+diff --git a/lib/libdtrace/apple/dt_module_apple.c b/lib/libdtrace/apple/dt_module_apple.c
+index 617202f..8d56f09 100644
+--- a/lib/libdtrace/apple/dt_module_apple.c
++++ b/lib/libdtrace/apple/dt_module_apple.c
+@@ -10,10 +10,10 @@
+ #if DTRACE_USE_CORESYMBOLICATION
+ #include <CoreSymbolication/CoreSymbolication.h>
+ #include <CoreSymbolication/CoreSymbolicationPrivate.h>
++#include <sys/kas_info.h>
+ #endif /* DTRACE_USE_CORESYMBOLICATION */
+ 
+ #include <libkern/OSAtomic.h>
+-#include <sys/kas_info.h>
+ #include <sys/stat.h>
+ #include <sys/sysctl.h>
+ #include <sys/types.h>
+diff --git a/lib/libdtrace/apple/dt_provider_apple.c b/lib/libdtrace/apple/dt_provider_apple.c
+index de4c84a..f41c29b 100644
+--- a/lib/libdtrace/apple/dt_provider_apple.c
++++ b/lib/libdtrace/apple/dt_provider_apple.c
+@@ -8,7 +8,7 @@
+ #if DTRACE_TARGET_APPLE_EMBEDDED
+ #include <sys/sysctl.h>
+ #elif DTRACE_TARGET_APPLE_MAC
+-#include <sys/csr.h>
++// #include <sys/csr.h>
+ #endif
+ 
+ int
+@@ -35,7 +35,7 @@ dt_probe_noprobe_errno(dtrace_hdl_t *dtp, const dtrace_probedesc_t *pdp)
+ 	 * actually exist).
+ 	 */
+ 
+-#if DTRACE_TARGET_APPLE_MAC
++#if 0
+ 	if (csr_check(CSR_ALLOW_UNRESTRICTED_DTRACE) != 0) {
+ 		return EDT_PROBERESTRICTED;
+ 	}
+diff --git a/lib/libdtrace/apple/dt_subr_apple.c b/lib/libdtrace/apple/dt_subr_apple.c
+index cb615c2..00552c4 100644
+--- a/lib/libdtrace/apple/dt_subr_apple.c
++++ b/lib/libdtrace/apple/dt_subr_apple.c
+@@ -5,7 +5,7 @@
+ #include <string.h>
+ 
+ #include <sys/sysctl.h>
+-#include <os/assumes.h>
++/* #include <os/assumes.h> */
+ 
+ #if TARGET_OS_IPHONE && (TARGET_OS_SIMULATOR || !TARGET_OS_IOS)
+ #define TARGET_SUPPORTS_NATIVE_SYSTEM 0
+diff --git a/lib/libdtrace/common/dt_consume.c b/lib/libdtrace/common/dt_consume.c
+index b18afba..010d616 100644
+--- a/lib/libdtrace/common/dt_consume.c
++++ b/lib/libdtrace/common/dt_consume.c
+@@ -38,6 +38,7 @@
+ #include <ctype.h>
+ #include <alloca.h>
+ #include <dt_impl.h>
++#include <libproc.h>
+ 
+ #include "dt_printf.h"
+ 
+diff --git a/lib/libdtrace/common/dt_grammar.h b/lib/libdtrace/common/dt_grammar.h
+index 0194f29..6b56f23 100644
+--- a/lib/libdtrace/common/dt_grammar.h
++++ b/lib/libdtrace/common/dt_grammar.h
+@@ -1 +1 @@
+-#include "y.tab.h"
+\ No newline at end of file
++#include "dt_grammar.tab.h"
+diff --git a/lib/libdtrace/common/dt_impl.h b/lib/libdtrace/common/dt_impl.h
+index 9584acd..a8185a3 100644
+--- a/lib/libdtrace/common/dt_impl.h
++++ b/lib/libdtrace/common/dt_impl.h
+@@ -44,6 +44,7 @@
+ #endif
+ 
+ #include <sys/param.h>
++#include <sys/utsname.h>
+ 
+ #if defined(__APPLE__)
+ #define OS_LOG_SUPPORTED 1
+@@ -737,7 +738,7 @@ extern dt_pcb_t *yypcb;		/* pointer to current parser control block */
+ extern char yyintprefix;	/* int token prefix for macros (+/-) */
+ extern char yyintsuffix[4];	/* int token suffix ([uUlL]*) */
+ extern int yyintdecimal;	/* int token is decimal (1) or octal/hex (0) */
+-extern char yytext[];		/* lex input buffer */
++extern char * yytext;		/* lex input buffer */
+ extern int yylineno;		/* lex line number */
+ extern int yydebug;		/* lex debugging */
+ extern dt_node_t *yypragma;	/* lex token list for control lines */
+diff --git a/lib/libdtrace/common/dt_lex.l b/lib/libdtrace/common/dt_lex.l
+index 27f5ee1..cc3126b 100644
+--- a/lib/libdtrace/common/dt_lex.l
++++ b/lib/libdtrace/common/dt_lex.l
+@@ -699,7 +699,7 @@ if (yypcb->pcb_token != 0) {
+ void
+ yybegin(yystate_t state)
+ {
+-#ifdef	YYDEBUG
++#if	defined(YYDEBUG) && YYDEBUG
+ 	yydebug = _dtrace_debug;
+ #endif
+ 	if (yypcb->pcb_yystate == state)
+diff --git a/lib/libdtrace/common/dt_print.c b/lib/libdtrace/common/dt_print.c
+index 68e3cb2..6dc2c5f 100644
+--- a/lib/libdtrace/common/dt_print.c
++++ b/lib/libdtrace/common/dt_print.c
+@@ -77,7 +77,6 @@
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+-#include <arpa/nameser.h>
+ 
+ #include <dt_module.h>
+ #include <dt_printf.h>
+diff --git a/lib/libdtrace/common/dt_proc.c b/lib/libdtrace/common/dt_proc.c
+index 93a11c8..75f3044 100644
+--- a/lib/libdtrace/common/dt_proc.c
++++ b/lib/libdtrace/common/dt_proc.c
+@@ -92,6 +92,10 @@
+ #include <crt_externs.h>
+ #endif
+ 
++// NIX: private symbols from Darwin libproc
++int pid_suspend(int pid);
++int pid_resume(int pid);
++
+ dt_bkpt_t *
+ dt_proc_bpcreate(dt_proc_t *dpr, uintptr_t addr, dt_bkpt_f *func, void *data)
+ {
+diff --git a/lib/libdtrace/common/dt_proc.h b/lib/libdtrace/common/dt_proc.h
+index f3d62de..c15ddaa 100644
+--- a/lib/libdtrace/common/dt_proc.h
++++ b/lib/libdtrace/common/dt_proc.h
+@@ -33,6 +33,7 @@
+ #include <dt_list.h>
+ 
+ #include <sys/link.h>
++#include <rtld_db.h>
+ 
+ #ifdef	__cplusplus
+ extern "C" {
+diff --git a/lib/libproc/libproc.c b/lib/libproc/libproc.c
+index 352d49f..4b5bb63 100644
+--- a/lib/libproc/libproc.c
++++ b/lib/libproc/libproc.c
+@@ -36,7 +36,7 @@
+ #include <sys/sysctl.h>
+ 
+ #include <sys/proc_info.h>
+-#include <sys/codesign.h>
++// #include <sys/codesign.h>
+ #include <sys/fasttrap_isa.h>
+ 
+ #if DTRACE_TARGET_APPLE_MAC
+@@ -46,7 +46,7 @@
+ 
+ #include "libproc.h"
+ #include "libproc_apple.h"
+-#include "libproc_internal.h"
++// #include "libproc_internal.h"
+ 
+ #include <spawn.h>
+ #include <pthread.h>
+-- 
+2.48.1
+

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/cmd/dtrace/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/cmd/dtrace/meson.build
@@ -1,0 +1,15 @@
+dtrace = executable(
+  'dtrace',
+  files('dtrace.c'),
+  c_args : [ '-Wno-format-security' ],
+  dependencies : [
+    libdtrace_dep,
+    libproc_dep,
+    libelf_dep,
+    libctf_dep,
+    darwin_shim_dep,
+    corefoundation_dep,
+    iokit_dep,
+  ],
+  install : true,
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/compat/opensolaris/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/compat/opensolaris/meson.build
@@ -1,0 +1,11 @@
+darwin_shim = library(
+  'dtrace_darwinshim',
+  files('./darwin_shim.c'),
+  darwin_versions : '1',
+  install : true,
+)
+
+darwin_shim_dep = declare_dependency(
+  link_with : darwin_shim,
+  include_directories : include_directories('.', './sys'),
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libctf/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libctf/meson.build
@@ -1,0 +1,27 @@
+libctf_sources = files(
+  'common/ctf_labels.c',
+  'common/ctf_create.c',
+  'common/ctf_util.c',
+  'common/ctf_lib.c',
+  'common/ctf_hash.c',
+  'common/ctf_lookup.c',
+  'common/ctf_subr.c',
+  'common/ctf_decl.c',
+  'common/ctf_error.c',
+  'common/ctf_open.c',
+  'common/ctf_types.c',
+)
+
+libctf_incdir = include_directories('./common')
+libctf = library(
+  'dtrace_ctf',
+  libctf_sources,
+  dependencies : [ libelf_dep, darwin_shim_dep ],
+  include_directories : libctf_incdir,
+  darwin_versions : '1',
+  install : true,
+)
+libctf_dep = declare_dependency(
+  link_with : libctf,
+  include_directories : libctf_incdir,
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libdtrace/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libdtrace/meson.build
@@ -1,0 +1,69 @@
+libdtrace_lexer = lex.process('common/dt_lex.l')
+libdtrace_parser = yacc.process('common/dt_grammar.y')
+
+libdtrace_sources = files(
+  'apple/dt_ld.cpp',
+  'apple/dt_subr_apple.c',
+  'apple/dt_provider_apple.c',
+  'apple/dt_pid_apple.c',
+  'apple/dt_proc_apple.c',
+  'apple/dt_module_apple.c',
+  'i386/dt_isadep.c',
+  'i386/dis_tables.c',
+  'common/dt_consume.c',
+  'common/dt_parser.c',
+  'common/dt_dof.c',
+  'common/dt_program.c',
+  'common/dt_work.c',
+  'common/dt_errtags.c',
+  'common/dt_subr.c',
+  'common/dt_proc.c',
+  'common/dt_sugar.c',
+  'common/dt_decl.c',
+  'common/dt_pid.c',
+  'common/dt_names.c',
+  'common/dt_ident.c',
+  'common/dt_print.c',
+  'common/dt_open.c',
+  'common/dt_pcb.c',
+  'common/dt_pq.c',
+  'common/dt_list.c',
+  'common/dt_regset.c',
+  'common/dt_module.c',
+  'common/dt_as.c',
+  'common/dt_map.c',
+  'common/dt_dis.c',
+  'common/dt_string.c',
+  'common/dt_options.c',
+  'common/dt_cg.c',
+  'common/dt_error.c',
+  'common/dt_provider.c',
+  'common/dt_printf.c',
+  'common/dt_strtab.c',
+  'common/dt_cc.c',
+  'common/dt_inttab.c',
+  'common/dt_handle.c',
+  'common/dt_aggregate.c',
+  'common/dt_buf.c',
+  'common/dt_xlator.c',
+  'common/dt_pragma.c',
+  'arm/dt_isadep.c',
+)
+
+libdtrace_incdir = include_directories('./common')
+
+libdtrace = library(
+  'dtrace',
+  libdtrace_sources,
+  libdtrace_lexer,
+  libdtrace_parser,
+  dependencies : [ libctf_dep, libelf_dep, libproc_dep, darwin_shim_dep ],
+  include_directories : [ libdtrace_incdir ],
+  darwin_versions : '1',
+  install : true,
+)
+
+libdtrace_dep = declare_dependency(
+  link_with : libdtrace,
+  include_directories : [ libdtrace_incdir ],
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libelf/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libelf/meson.build
@@ -1,0 +1,37 @@
+libelf_sources = files(
+  'begin.c',
+  'clscook.c',
+  'clscook_ELF64.c',
+  'cntl.c',
+  'cook.c',
+  'data.c',
+  'end.c',
+  'error.c',
+  'gelf.c',
+  'getdata.c',
+  'getehdr.c',
+  'getident.c',
+  'getscn.c',
+  'getshdr.c',
+  'getshstrndx.c',
+  'input.c',
+  'kind.c',
+  'ndxscn.c',
+  'nextscn.c',
+  'strptr.c',
+  'xlate.c',
+  'xlate64.c',
+)
+libelf_incdir = include_directories('.')
+libelf = library(
+  'dtrace_elf',
+  libelf_sources,
+  dependencies : [ darwin_shim_dep ],
+  include_directories : [ libelf_incdir ],
+  darwin_versions : '1',
+  install : true,
+)
+libelf_dep = declare_dependency(
+  link_with : libelf,
+  include_directories : [ libelf_incdir ],
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libproc/meson.build
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/lib/libproc/meson.build
@@ -1,0 +1,18 @@
+libproc_sources = files(
+  'libproc.c',
+)
+libproc_incdir = include_directories('.')
+
+libproc = library(
+  'dtrace_proc',
+  libproc_sources,
+  dependencies : [ libelf_dep, darwin_shim_dep ],
+  include_directories : [ libproc_incdir ],
+  darwin_versions : '1',
+  install : true,
+)
+
+libproc_dep = declare_dependency(
+  link_with : libproc,
+  include_directories : [ libproc_incdir ],
+)

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/meson.build.in
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/meson/meson.build.in
@@ -1,0 +1,25 @@
+# Build settings based on the upstream Xcode project.
+# See: https://github.com/apple-oss-distributions/dtrace/blob/main/dtrace.xcodeproj/project.pbxproj
+
+project('dtrace', 'c', 'cpp', version : '@version@')
+
+flex_exe = find_program('flex')
+yacc_exe = find_program('bison')
+
+lex = generator(flex_exe,
+  output : '@PLAINNAME@.yy.c',
+  arguments : ['-o', '@OUTPUT@', '@INPUT@'])
+
+yacc = generator(yacc_exe,
+  output : ['@BASENAME@.tab.c', '@BASENAME@.tab.h'],
+  arguments : ['@INPUT@', '--defines=@OUTPUT1@', '--output=@OUTPUT0@'])
+
+corefoundation_dep = dependency('CoreFoundation')
+iokit_dep = dependency('IOKit')
+
+subdir('compat/opensolaris')
+subdir('lib/libelf')
+subdir('lib/libproc')
+subdir('lib/libctf')
+subdir('lib/libdtrace')
+subdir('cmd/dtrace')

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  mkAppleDerivation,
+  bison,
+  flex,
+}:
+
+mkAppleDerivation {
+  releaseName = "dtrace";
+
+  xcodeHash = "sha256-aiWh5M+qboE4i6lERvYqG/K2Gc4Nd8fz2pOY8zwJ97k=";
+
+  dontCopyMeson = true;
+  postUnpack = ''
+    substitute ${lib.escapeShellArg "${./meson/meson.build.in}"} "$sourceRoot/meson.build" --subst-var version
+    cp -R ${./meson}/* "$sourceRoot"
+    chmod -R +w "$sourceRoot"
+  '';
+
+  nativeBuildInputs = [
+    bison
+    flex
+  ];
+
+  patches = [
+    ./0001-Patches-for-building-externally-to-Apple.patch
+  ];
+
+  meta = {
+    description = "dtrace dynamic tracer";
+    longDescription = ''
+      The dtrace dynamic tracer. This packaging is just present for generating
+      stubs; there is no guarantee it actually works for tracing, use the
+      system version for that.
+    '';
+    maintainers = lib.teams.lix.members;
+  };
+}

--- a/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
@@ -66,13 +66,15 @@ lib.makeOverridable (
       // lib.optionalAttrs (super ? xcodeHash) {
         postUnpack =
           super.postUnpack or ""
-          + lib.concatMapStrings (
-            file:
-            if baseNameOf file == "meson.build.in" then
-              "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
-            else
-              "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
-          ) mesonFiles;
+          + lib.optionalString (!(super.dontCopyMeson or false)) (
+            lib.concatMapStrings (
+              file:
+              if baseNameOf file == "meson.build.in" then
+                "substitute ${lib.escapeShellArg "${file}"} \"$sourceRoot/meson.build\" --subst-var version\n"
+              else
+                "cp ${lib.escapeShellArg "${file}"} \"$sourceRoot/\"${lib.escapeShellArg (baseNameOf file)}\n"
+            ) mesonFiles
+          );
 
         xcodeProject = super.xcodeProject or "${releaseName}.xcodeproj";
 

--- a/pkgs/os-specific/darwin/apple-source-releases/versions.json
+++ b/pkgs/os-specific/darwin/apple-source-releases/versions.json
@@ -47,6 +47,10 @@
     "hash": "sha256-/Mf+RhaTU9O5i95gddZ2h9eDjLezwj3nP6FvryMF54E=",
     "version": "66"
   },
+  "dtrace": {
+    "hash": "sha256-iNEZyxK3DmEwO3gzrfvCaVZSEuuOMQm5IG/6FodPNdI=",
+    "version": "411"
+  },
   "dyld": {
     "hash": "sha256-DDhV7X81nhd3oeJuICEvF8FU43yE/afQ/LYgDNtXswA=",
     "version": "1241.17"

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -97,7 +97,6 @@ makeScopeWithSplicing' {
           "configd"
           "configdHeaders"
           "darwin-stubs"
-          "dtrace"
           "eap8021x"
           "hfs"
           "hfsHeaders"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is necessary to build probe header files. It's not intended for
anything else, and probably does not work for anything else.

I put a warning in it to stop anyone trying anything else.

There's a few things that may be contentious about how I did this, and I don't know if they are the right way:
- Multiple meson files (so I don't type file paths 100 times)
- Making it possible to override the meson file copying thing (also aaaaaaa the way that works by default is really magic and was confusing)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true` (sandbox = false tested also!)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
