### PR TITLE
stdenv: fix propagatedUserEnvPkgs when __structuredAttrs is true again

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/wrapper-test.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test.nix
@@ -10,6 +10,7 @@ runCommand "test-emacs-withPackages-wrapper"
       (emacs.pkgs.withPackages (
         epkgs: with epkgs; [
           magit
+          flx-ido
         ]
       ))
       git # needed by magit
@@ -17,5 +18,10 @@ runCommand "test-emacs-withPackages-wrapper"
   }
   ''
     emacs --batch --eval="(require 'magit)"
+
+    emacs --batch --eval="(require 'flx-ido)"
+    # transitive dependencies should be made available
+    # https://github.com/NixOS/nixpkgs/issues/388829
+    emacs --batch --eval="(require 'flx)"
     touch $out
   ''

--- a/pkgs/stdenv/generic/builder.sh
+++ b/pkgs/stdenv/generic/builder.sh
@@ -18,6 +18,6 @@ mkdir $out
 # Allow the user to install stdenv using nix-env and get the packages
 # in stdenv.
 mkdir $out/nix-support
-if [ "$propagatedUserEnvPkgs" ]; then
+if [ "${propagatedUserEnvPkgs[*]}" ]; then
     printf '%s ' "${propagatedUserEnvPkgs[@]}" > $out/nix-support/propagated-user-env-packages
 fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1642,7 +1642,7 @@ fixupPhase() {
 
     # Propagate user-env packages into the output with binaries, TODO?
 
-    if [ -n "${propagatedUserEnvPkgs:-}" ]; then
+    if [ -n "${propagatedUserEnvPkgs[*]:-}" ]; then
         mkdir -p "${!outputBin}/nix-support"
         printWords "${propagatedUserEnvPkgs[@]}" > "${!outputBin}/nix-support/propagated-user-env-packages"
     fi


### PR DESCRIPTION
This is a follow-up of #388908.

Previously, `$out/nix-support/propagated-user-env-packages` was not created when `__structuredAttrs` was enabled, the first element of `propagatedUserEnvPkgs` was `null` and the length of `propagatedUserEnvPkgs` was at least 2.

Fixes #388829

With this patch applied, condition check result for each `propagatedUserEnvPkgs` is shown below.

| `propagatedUserEnvPkgs`  | `__structuredAttrs` enabled | `__structuredAttrs` disabled |
| ---------------- | ------------- | ----------- |
| `null`           | `false`  |        `false`     |
| `[ ]`            |  `false` |   `false`          |
| `[ null ]`       | `false`  |   `false`          |
| `[ null "foo" ]` | `true` ( previously was `false`)  |    `true`         |

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
