### PR TITLE
fetchurl: add `unpacked` passthru

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -399,6 +399,17 @@ If `pname` and `version` are specified, `fetchurl` will use those values and wil
 
 : The same `url` attribute passed in the argument to `fetchurl`.
 
+`unpacked` (Derivation)
+
+: A convenience derivation for quick access to downloaded archives, as unpacked by the standard [`unpackPhase`](#ssec-unpack-phase) in [`stdenv`](#chap-stdenv).
+  If `recursiveHash` is set to `true` then this output will avoid unnecessary builds and reference the `fetchurl` result directly.
+
+  This attribute can be quickly built with e.g. `nix-build . -A hello.src.unpacked`.
+  Internally it makes use of `pkgs.srcOnly`, but it will not apply any patches since it is not aware of any.
+
+  Using this will push duplicate data to the store.
+  As such it will raise a warning on instantiation, primarily to disallow use within Nixpkgs.
+
 ### Examples {#ssec-pkgs-fetchers-fetchurl-examples}
 
 :::{.example #ex-fetchers-fetchurl-nixpkgs-version}
@@ -928,4 +939,3 @@ fetchtorrent {
 
 - `config`: When using `transmission` as the `backend`, a json configuration can
   be supplied to transmission. Refer to the [upstream documentation](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md) for information on how to configure.
-

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -100,7 +100,7 @@ lib.makeOverridable (
       throw
         "Please provide directories/patterns for sparse checkout as a list of strings. Passing a (multi-line) string is not supported any more."
     else
-      stdenvNoCC.mkDerivation {
+      stdenvNoCC.mkDerivation (finalAttrs: {
         name = if name != null then name else urlToName url revWithTag;
 
         builder = ./builder.sh;
@@ -160,7 +160,10 @@ lib.makeOverridable (
         passthru = {
           gitRepoUrl = url;
           inherit tag;
+          unpacked = lib.removeAttrs finalAttrs.finalPackage [ "unpacked" ] // {
+            passthru = removeAttrs finalAttrs.finalPackage.passthru [ "unpacked" ];
+          };
         };
-      }
+      })
   )
 )

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -17,7 +17,7 @@ if hash != null && sha256 != null then
   throw "Only one of sha256 or hash can be set"
 else
   # TODO: statically check if mercurial as the https support if the url starts with https.
-  stdenvNoCC.mkDerivation {
+  stdenvNoCC.mkDerivation (finalAttrs: {
     name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
     builder = ./builder.sh;
     nativeBuildInputs = [ mercurial ];
@@ -38,4 +38,10 @@ else
 
     inherit url rev;
     inherit preferLocalBuild;
-  }
+
+    passthru = {
+      unpacked = lib.removeAttrs finalAttrs.finalPackage [ "unpacked" ] // {
+        passthru = removeAttrs finalAttrs.finalPackage.passthru [ "unpacked" ];
+      };
+    };
+  })

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -52,7 +52,7 @@ in
 if hash != "" && sha256 != "" then
   throw "Only one of sha256 or hash can be set"
 else
-  stdenvNoCC.mkDerivation {
+  stdenvNoCC.mkDerivation (finalAttrs: {
     name = name_;
     builder = ./builder.sh;
     nativeBuildInputs = [
@@ -82,4 +82,10 @@ else
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars;
     inherit preferLocalBuild;
-  }
+
+    passthru = {
+      unpacked = lib.removeAttrs finalAttrs.finalPackage [ "unpacked" ] // {
+        passthru = removeAttrs finalAttrs.finalPackage.passthru [ "unpacked" ];
+      };
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -643,6 +643,7 @@ with pkgs;
       makeOverridable (import ../build-support/fetchurl) {
         inherit lib stdenvNoCC buildPackages;
         inherit cacert;
+        inherit srcOnly;
         curl = buildPackages.curlMinimal.override (old: rec {
           # break dependency cycles
           fetchurl = stdenv.fetchurlBoot;


### PR DESCRIPTION
`some-package.src.unpacked` is great convenience to have when you want to for example view the `setup.py` or `pyproject.toml` file in the `src` of a `fetchPypi` package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
