### PR TITLE
python313Packages.albumentations: 2.0.0 -> 2.0.5

### DIFF
--- a/pkgs/development/python-modules/albumentations/default.nix
+++ b/pkgs/development/python-modules/albumentations/default.nix
@@ -9,29 +9,29 @@
 
   # dependencies
   albucore,
-  eval-type-backport,
   numpy,
   opencv-python,
   pydantic,
   pyyaml,
-  scikit-image,
   scipy,
 
   # optional dependencies
   huggingface-hub,
   pillow,
+  torch,
 
   # tests
   deepdiff,
   pytestCheckHook,
   pytest-mock,
-  torch,
+  scikit-image,
+  scikit-learn,
   torchvision,
 }:
 
 buildPythonPackage rec {
   pname = "albumentations";
-  version = "2.0.0";
+  version = "2.0.5";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = "albumentations-team";
     repo = "albumentations";
     tag = version;
-    hash = "sha256-8WEOI2J2H4PNhyb9LoIUMofGKx9AHPiPddkQCSdh8/A=";
+    hash = "sha256-WqU25I1DxBqZAXd2+sNMUv/HOL4towlGTnFnpCGmMgY=";
   };
 
   patches = [
@@ -53,17 +53,16 @@ buildPythonPackage rec {
 
   dependencies = [
     albucore
-    eval-type-backport
     numpy
     opencv-python
     pydantic
     pyyaml
-    scikit-image
     scipy
   ];
 
   optional-dependencies = {
     hub = [ huggingface-hub ];
+    pytorch = [ torch ];
     text = [ pillow ];
   };
 
@@ -71,14 +70,16 @@ buildPythonPackage rec {
     deepdiff
     pytestCheckHook
     pytest-mock
+    scikit-image
+    scikit-learn
     torch
     torchvision
   ];
 
   disabledTests = [
     "test_pca_inverse_transform"
-    # this test hangs up
-    "test_transforms"
+    # test hangs
+    "test_keypoint_remap_methods"
   ];
 
   pythonImportsCheck = [ "albumentations" ];

--- a/pkgs/development/python-modules/albumentations/dont-check-for-updates.patch
+++ b/pkgs/development/python-modules/albumentations/dont-check-for-updates.patch
@@ -1,11 +1,11 @@
 diff --git a/albumentations/__init__.py b/albumentations/__init__.py
-index 0b3b531..7c69c65 100644
+index 44ee9b9..ea3bc50 100644
 --- a/albumentations/__init__.py
 +++ b/albumentations/__init__.py
-@@ -7,7 +7,3 @@ from .augmentations import *
- from .core.composition import *
- from .core.serialization import *
- from .core.transforms_interface import *
+@@ -22,7 +22,3 @@ from .core.transforms_interface import *
+ 
+ with suppress(ImportError):
+     from .pytorch import *
 -
 -# Perform the version check after all other initializations
 -if os.getenv("NO_ALBUMENTATIONS_UPDATE", "").lower() not in {"true", "1"}:


### PR DESCRIPTION
Diff: https://github.com/albumentations-team/albumentations/compare/refs/tags/2.0.0...2.0.5

Changelog: https://github.com/albumentations-team/albumentations/releases/tag/2.0.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
