### PR TITLE
field-monitor: init at 49.1

### DIFF
--- a/pkgs/by-name/fi/field-monitor/package.nix
+++ b/pkgs/by-name/fi/field-monitor/package.nix
@@ -1,0 +1,102 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cargo,
+  meson,
+  ninja,
+  rustPlatform,
+  rustc,
+  pkg-config,
+  glib,
+  gsettings-desktop-schemas,
+  gtk4,
+  libadwaita,
+  libvirt,
+  gst_all_1,
+  desktop-file-utils,
+  appstream,
+  appstream-glib,
+  wrapGAppsHook4,
+  xdg-desktop-portal,
+  blueprint-compiler,
+  libxml2,
+  spice-protocol,
+  spice-gtk,
+  vte-gtk4,
+  gtk-vnc,
+  usbredir,
+  libepoxy,
+  libGL,
+  openssl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "field-monitor";
+  version = "49.1";
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "theCapypara";
+    repo = "field-monitor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vtRubZwIQRV3ySFwdPgZ1Eyxh32FPsAvissxjrV3JcE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-zBCt/ptxAQ3TAzklmjbajQZ4Ou1+xlvH/k74yW34t9g=";
+  };
+
+  mesonBuildType = "release";
+
+  nativeBuildInputs = [
+    appstream
+    appstream-glib
+    blueprint-compiler
+    cargo
+    desktop-file-utils
+    libxml2
+    meson
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gsettings-desktop-schemas
+    gtk-vnc
+    gtk4
+    libadwaita
+    libepoxy
+    libGL
+    libvirt
+    openssl
+    spice-gtk
+    spice-protocol
+    usbredir
+    vte-gtk4
+    xdg-desktop-portal
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+  ]);
+
+  postInstall = ''
+    wrapProgram $out/bin/de.capypara.FieldMonitor --prefix PATH ':' "$out/libexec"
+  '';
+
+  meta = {
+    description = "Viewer for virtual machines and other external screens";
+    homepage = "https://github.com/theCapypara/field-monitor";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ theCapypara ];
+    platforms = lib.platforms.linux;
+    mainProgram = "de.capypara.FieldMonitor";
+  };
+})


### PR DESCRIPTION
This adds my app Field Monitor to nixpkgs:

> Field Monitor is a remote-desktop client designed for the GNOME platform.
> 
> It is focused on connecting to virtual machines, but can connect to any server
> supporting the RDP, SPICE or VNC protocols.
> 
> It has support for directly connecting to VMs of the following hypervisors:
> 
> - Proxmox
> - QEMU/KVM via libvirt
> 
> For supported VM hypervisors Field Monitor also offers options to manage the basic
> power state of VMs, such as starting, stopping, rebooting, etc.
> 
> Additionally, Field Monitor supports opening RDP and Virt Viewer connection files
> and quickly connecting to RDP, SPICE or VNC servers via URI.

Upstream URL: https://github.com/theCapypara/field-monitor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
