### PR TITLE
libnop: init at 0-unstable-2022-09-04

### DIFF
--- a/pkgs/by-name/li/libnop/001-system-install.patch
+++ b/pkgs/by-name/li/libnop/001-system-install.patch
@@ -1,0 +1,89 @@
+From ae29a8772f38fdb1efc24af9ec2e3f6814eb2158 Mon Sep 17 00:00:00 2001
+From: Petr Hodina <petr.hodina@luxonis.com>
+Date: Sun, 4 May 2025 09:30:55 +0200
+Subject: [PATCH] Makefile: Add install into the system
+
+---
+ Makefile     | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ libnop.pc.in |  7 +++++++
+ 2 files changed, 51 insertions(+)
+ create mode 100644 libnop.pc.in
+
+diff --git a/Makefile b/Makefile
+index 84cb459..e5b8a67 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,7 @@
+ what_to_build:: all
+ 
++VERSION ?= 0-unstable-2022-09-04
++
+ -include local.mk
+ 
+ TOOLCHAIN ?=
+@@ -17,6 +19,12 @@ HOST_CFLAGS := -g -O2 -Wall -Werror -Wextra -Iinclude
+ HOST_CXXFLAGS := -std=c++14
+ HOST_LDFLAGS :=
+ 
++# Define install locations in the system
++INSTALL_PREFIX ?= /usr/local
++INCLUDE_INSTALL_DIR ?= $(INSTALL_PREFIX)/include/
++PKGCONFIG_INSTALL_DIR ?= $(INSTALL_PREFIX)/lib/pkgconfig
++CMAKE_CONFIG_INSTALL_DIR ?= $(INSTALL_PREFIX)/lib/cmake/libnop
++
+ ifeq ($(HOST_OS),Linux)
+ HOST_LDFLAGS := -lpthread
+ endif
+@@ -138,3 +146,39 @@ all:: $(ALL)
+ # we generate .d as a side-effect of compiling. override generic rule:
+ %.d:
+ -include $(DEPS)
++
++# Handle install into the system
++.PHONY: install install-pkgconfig install-cmake
++
++install: install-headers install-pkgconfig install-cmake
++
++install-headers:
++	@echo "Installing headers to $(INCLUDE_INSTALL_DIR)"
++	mkdir -p $(INCLUDE_INSTALL_DIR)
++	cp -r include/* $(INCLUDE_INSTALL_DIR)
++
++install-pkgconfig: $(OUT)/libnop.pc
++	@echo "Installing pkg-config file to $(PKGCONFIG_INSTALL_DIR)"
++	mkdir -p $(PKGCONFIG_INSTALL_DIR)
++	cp $< $(PKGCONFIG_INSTALL_DIR)
++
++PC_TEMPLATE := libnop.pc.in
++
++$(OUT)/libnop.pc: $(PC_TEMPLATE)
++	mkdir -p $(dir $@)
++	sed \
++		-e 's|@prefix@|$(INSTALL_PREFIX)|g' \
++		-e 's|@includedir@|$(INSTALL_PREFIX)/include|g' \
++		-e 's|@version@|$(VERSION)|g' \
++		$< > $@
++
++install-cmake: $(OUT)/libnopConfig.cmake
++	@echo "Installing CMake config to $(CMAKE_CONFIG_INSTALL_DIR)"
++	mkdir -p $(CMAKE_CONFIG_INSTALL_DIR)
++	cp $< $(CMAKE_CONFIG_INSTALL_DIR)
++
++$(OUT)/libnopConfig.cmake:
++	mkdir -p $(dir $@)
++	echo "set(LIBNOP_INCLUDE_DIR \"$(INCLUDE_INSTALL_DIR)\")" > $@
++	echo "set(LIBNOP_FOUND TRUE)" >> $@
++	echo "mark_as_advanced(LIBNOP_INCLUDE_DIR)" >> $@
+diff --git a/libnop.pc.in b/libnop.pc.in
+new file mode 100644
+index 0000000..8c5475b
+--- /dev/null
++++ b/libnop.pc.in
+@@ -0,0 +1,7 @@
++prefix=@prefix@
++includedir=@includedir@
++
++Name: libnop
++Description: Header-only C++ Native Object Protocols library
++Version: @version@
++Cflags: -I${includedir}

--- a/pkgs/by-name/li/libnop/002-fix-template-warning.patch
+++ b/pkgs/by-name/li/libnop/002-fix-template-warning.patch
@@ -1,0 +1,54 @@
+From 199978a0fb0dc31de43b80f7504b53958fd202ee Mon Sep 17 00:00:00 2001
+From: Petr Hodina <petr.hodina@luxonis.com>
+Date: Sun, 4 May 2025 09:58:20 +0200
+Subject: [PATCH] C++: Fix compilation issue
+ -Wno-missing-template-arg-list-after-template-kw
+
+---
+ include/nop/rpc/interface.h | 2 +-
+ include/nop/types/variant.h | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/nop/rpc/interface.h b/include/nop/rpc/interface.h
+index 167d203..9772d06 100644
+--- a/include/nop/rpc/interface.h
++++ b/include/nop/rpc/interface.h
+@@ -245,7 +245,7 @@ struct InterfaceMethod {
+     template <typename Sender>
+     static void Invoke(Sender* sender, Status<Return>* return_value,
+                        Args... args) {
+-      sender->NOP_TEMPLATE SendMethod(InterfaceMethod::Selector, return_value,
++      sender->NOP_TEMPLATE SendMethod<>(InterfaceMethod::Selector, return_value,
+                                   std::forward_as_tuple(args...));
+     }
+ 
+diff --git a/include/nop/types/variant.h b/include/nop/types/variant.h
+index fdf8e03..af8c81e 100644
+--- a/include/nop/types/variant.h
++++ b/include/nop/types/variant.h
+@@ -239,7 +239,7 @@ class Variant {
+   // resulting type.
+   template <typename... Args>
+   void Construct(Args&&... args) {
+-    index_ = value_.NOP_TEMPLATE Construct(std::forward<Args>(args)...);
++    index_ = value_.NOP_TEMPLATE Construct<>(std::forward<Args>(args)...);
+   }
+   void Construct(EmptyVariant) {}
+ 
+@@ -256,14 +256,14 @@ class Variant {
+   // multiple element types.
+   template <typename T, typename U>
+   void Assign(TypeTag<T>, U&& value) {
+-    if (!value_.NOP_TEMPLATE Assign(TypeTag<T>{}, index_, std::forward<U>(value))) {
++    if (!value_.NOP_TEMPLATE Assign<>(TypeTag<T>{}, index_, std::forward<U>(value))) {
+       Destruct();
+       Construct(TypeTag<T>{}, std::forward<U>(value));
+     }
+   }
+   template <typename T>
+   void Assign(T&& value) {
+-    if (!value_.NOP_TEMPLATE Assign(index_, std::forward<T>(value))) {
++    if (!value_.NOP_TEMPLATE Assign<>(index_, std::forward<T>(value))) {
+       Destruct();
+       Construct(std::forward<T>(value));
+     }

--- a/pkgs/by-name/li/libnop/package.nix
+++ b/pkgs/by-name/li/libnop/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  fetchFromGitHub,
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libnop";
+  version = "0-unstable-2022-09-04";
+
+  src = fetchFromGitHub {
+    owner = "luxonis";
+    repo = "libnop";
+    rev = "ab842f51dc2eb13916dc98417c2186b78320ed10";
+    sha256 = "sha256-d2z/lDI9pe5TR82MxGkR9bBMNXPvzqb9Gsd5jOv6x1A=";
+  };
+
+  patches = [
+    # System install
+    # https://github.com/luxonis/libnop/pull/6/commits/ae29a8772f38fdb1efc24af9ec2e3f6814eb2158.patch
+    ./001-system-install.patch
+    # Fix template warning
+    # https://github.com/luxonis/libnop/pull/6/commits/199978a0fb0dc31de43b80f7504b53958fd202ee.patch
+    ./002-fix-template-warning.patch
+  ];
+
+  nativeBuildInputs = [ gtest ];
+
+  # Add optimization flags to address _FORTIFY_SOURCE warning
+  NIX_CFLAGS_COMPILE = [ "-O1" ];
+
+  installPhase = ''
+    runHook preInstall
+    make INSTALL_PREFIX=$out install
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A fast, header-only C++ serialization library";
+    homepage = "https://github.com/google/libnop";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Add header-only library for serializing and deserializing C++ data types.

https://github.com/luxonis/libnop/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
