### PR TITLE
cpr: init at 1.11.0

### DIFF
--- a/pkgs/by-name/cp/cpr/package.nix
+++ b/pkgs/by-name/cp/cpr/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl,
+  curl,
+  zlib,
+  gtest,
+  cppcheck,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpr";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "libcpr";
+    repo = "cpr";
+    tag = finalAttrs.version;
+    hash = "sha256-jWyss0krj8MVFqU1LAig+4UbXO5pdcWIT+hCs9DxemM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    gtest
+    cppcheck
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+    curl
+  ];
+
+  cmakeFlags = [
+    # NOTE: Does not build with CPPCHECK
+    # (lib.cmakeBool "CPR_ENABLE_CPPCHECK" true)
+    (lib.cmakeBool "CPR_BUILD_TEST" true)
+    (lib.cmakeBool "CURL_ZLIB" false)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "CPR_USE_SYSTEM_CURL" true)
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+  ];
+
+  # Install headers
+  postInstall = ''
+    mkdir -p $out/include
+    cp -r $src/include/* $out/include/
+  '';
+
+  meta = {
+    description = "C++ Requests: Curl for People, a spiritual port of Python Requests";
+    homepage = "https://github.com/libcpr/cpr";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Wrapper around libcurl

https://github.com/luxonis/cpr

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).