### PR TITLE
ws-protocol: init at 1.4.0

### DIFF
--- a/pkgs/by-name/ws/ws-protocol/package.nix
+++ b/pkgs/by-name/ws/ws-protocol/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  boost186,
+  libwebsockets,
+  nlohmann_json,
+  websocketpp,
+  openssl,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ws-protocol";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "foxglove";
+    repo = "ws-protocol";
+    tag = "releases/cpp/v${finalAttrs.version}";
+    hash = "sha256-JMCwxShOOv1PSrlKiPGtsCgKJVR+7ds9otKrlPHfIio=";
+  };
+
+  patches = [
+    # Install cmake and pkg-config files to out
+    (fetchpatch {
+      url = "https://github.com/foxglove/ws-protocol/commit/2d44d39f1a7156b9e19cd9e283e891e1908042e1.patch";
+      hash = "sha256-y61o6HHzPLesUm2aJB7RC0GuuUJyU9AQ2V3DHQntlkQ=";
+    })
+    # Missing libraries for Darwin
+    (fetchpatch {
+      url = "https://github.com/foxglove/ws-protocol/commit/336b3eaffd2369b255e3e66cfebaca3655e7c085.patch";
+      hash = "sha256-Y4V8B6+rt+e27U7LH5/j46u7L1Je3tSdaeG1Ui53b6A=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost186
+    libwebsockets
+    websocketpp
+    nlohmann_json
+    openssl
+    zlib
+  ];
+
+  # NOTE: Switch back once the patches are merged
+  # sourceRoot = "${finalAttrs.src.name}/cpp/foxglove-websocket";
+
+  postPatch = ''
+    cd cpp/foxglove-websocket
+  '';
+
+  cmakeFlags = [ (lib.cmakeBool "BUILD_SHARED_LIBS" true) ];
+
+  meta = {
+    description = "WebSocket protocol implementation";
+    homepage = "https://github.com/foxglove/ws-protocol";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Foxglove WebSocket protocol specification and libraries

https://foxglove.dev/

NOTE: The patch is for Darwin where the `openssl` and `zlib` are not found during linking
 
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).