### PR TITLE
nitter: 0-unstable-2024-02-26 -> 0-unstable-2025-02-25; nixos/nitter: rename guestAccounts to sessionsFile

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -462,6 +462,8 @@
 
 - `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
+- `services.nitter.guestAccounts` has been renamed to `services.nitter.sessionsFile`, for consistency with upstream. The file format is unchanged.
+
 - `virtualisation.azure.agent` option provided by `azure-agent.nix` is replaced by `services.waagent`, and will be removed in a future release.
 
 - `matomo` now defaults to version 5 (previously available as `matomo_5`). Version 4 has been removed as it reached EOL on December 19, 2024.

--- a/nixos/modules/services/misc/nitter.nix
+++ b/nixos/modules/services/misc/nitter.nix
@@ -64,6 +64,10 @@ in
       "nitter"
       "replaceInstagram"
     ] "Nitter no longer supports this option as Bibliogram has been discontinued.")
+    (lib.mkRenamedOptionModule
+      [ "services" "nitter" "guestAccounts" ]
+      [ "services" "nitter" "sessionsFile" ]
+    )
   ];
 
   options = {
@@ -322,20 +326,20 @@ in
         '';
       };
 
-      guestAccounts = lib.mkOption {
+      sessionsFile = lib.mkOption {
         type = lib.types.path;
-        default = "/var/lib/nitter/guest_accounts.jsonl";
+        default = "/var/lib/nitter/sessions.jsonl";
         description = ''
-          Path to the guest accounts file.
+          Path to the session tokens file.
 
-          This file contains a list of guest accounts that can be used to
+          This file contains a list of session tokens that can be used to
           access the instance without logging in. The file is in JSONL format,
           where each line is a JSON object with the following fields:
 
           {"oauth_token":"some_token","oauth_token_secret":"some_secret_key"}
 
-          See <https://github.com/zedeus/nitter/wiki/Guest-Account-Branch-Deployment>
-          for more information on guest accounts and how to generate them.
+          See <https://github.com/zedeus/nitter/wiki/Creating-session-tokens>
+          for more information on session tokens and how to generate them.
         '';
       };
 
@@ -369,11 +373,11 @@ in
       after = [ "network-online.target" ];
       serviceConfig = {
         DynamicUser = true;
-        LoadCredential = "guestAccountsFile:${cfg.guestAccounts}";
+        LoadCredential = "sessionsFile:${cfg.sessionsFile}";
         StateDirectory = "nitter";
         Environment = [
           "NITTER_CONF_FILE=/var/lib/nitter/nitter.conf"
-          "NITTER_ACCOUNTS_FILE=%d/guestAccountsFile"
+          "NITTER_SESSIONS_FILE=%d/sessionsFile"
         ];
         # Some parts of Nitter expect `public` folder in working directory,
         # see https://github.com/zedeus/nitter/issues/414

--- a/nixos/tests/nitter.nix
+++ b/nixos/tests/nitter.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix (
     # These credentials are from the nitter wiki and are expired. We must provide
     # credentials in the correct format, otherwise nitter fails to start. They
     # must not be valid, as unauthorized errors are handled gracefully.
-    guestAccountFile = pkgs.writeText "guest_accounts.jsonl" ''
+    sessionsFile = pkgs.writeText "sessions.jsonl" ''
       {"oauth_token":"1719213587296620928-BsXY2RIJEw7fjxoNwbBemgjJhueK0m","oauth_token_secret":"N0WB0xhL4ng6WTN44aZO82SUJjz7ssI3hHez2CUhTiYqy"}
     '';
   in
@@ -22,7 +22,7 @@ import ./make-test-python.nix (
         # Test CAP_NET_BIND_SERVICE
         server.port = 80;
         # Provide dummy guest accounts
-        guestAccounts = guestAccountFile;
+        inherit sessionsFile;
       };
     };
 

--- a/pkgs/by-name/ni/nitter/lock.json
+++ b/pkgs/by-name/ni/nitter/lock.json
@@ -16,12 +16,12 @@
       "packages": [
         "dotenv"
       ],
-      "path": "/nix/store/9hxi0hvds11agbmpaha8zp1bgzf7vypv-source",
-      "ref": "2.0.1",
-      "rev": "48315332fe79ffce87c81b9d0bec992ba19b6966",
-      "sha256": "08y8xvpiqk75v0hxhgbhxfbxz7l95vavh1lv8kxkid8rb9p92zr4",
+      "path": "/nix/store/jkf2p6sp0506crd1awpq2x98m527v4mb-source",
+      "ref": "2.0.2",
+      "rev": "19bb965ef04f57128f4f4ea2e690ff9f7d6a81b1",
+      "sha256": "0dk0ixgpxmaz2kf12a3fvzdaknn38qnwgdhp7yag0m5fbhhz2kjc",
       "srcDir": "src",
-      "url": "https://github.com/euantorano/dotenv.nim/archive/48315332fe79ffce87c81b9d0bec992ba19b6966.tar.gz"
+      "url": "https://github.com/euantorano/dotenv.nim/archive/19bb965ef04f57128f4f4ea2e690ff9f7d6a81b1.tar.gz"
     },
     {
       "method": "fetchzip",

--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -10,13 +10,13 @@
 buildNimPackage (
   finalAttrs: prevAttrs: {
     pname = "nitter";
-    version = "0-unstable-2024-02-26";
+    version = "0-unstable-2025-02-25";
 
     src = fetchFromGitHub {
       owner = "zedeus";
       repo = "nitter";
-      rev = "c6edec04901d0a37799499ed4c6921db640fb5a4";
-      hash = "sha256-N3d63nyVzUTa2+UemA1REFfVsw6iOVU8xUlYraR55m4=";
+      rev = "41fa47bfbf3917e9b3ac4f7b49c89a75a7a2bd44";
+      hash = "sha256-cmYlmzCJl1405TuYExGw3AOmjdY0r7ObmmLCAom+Fyw=";
     };
 
     lockFile = ./lock.json;
@@ -41,7 +41,7 @@ buildNimPackage (
 
     passthru = {
       tests = { inherit (nixosTests) nitter; };
-      updateScript = unstableGitUpdater { branch = "guest_accounts"; };
+      updateScript = unstableGitUpdater { };
     };
 
     meta = with lib; {


### PR DESCRIPTION
Simple version bump. We are tracking `master` again for sources, as guest account/sessions support was merged.
Upstream diff: https://github.com/zedeus/nitter/compare/c6edec04901d0a37799499ed4c6921db640fb5a4...41fa47bfbf3917e9b3ac4f7b49c89a75a7a2bd44

I also took the liberty to rename the guestAccounts option for consistency with upstream, see https://github.com/zedeus/nitter/commit/6fcd849eff51ad1ee6e6078e3236896ab97803b6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
