### PR TITLE
windsurf: 1.5.6 -> 1.5.9

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.5.6",
+    "version": "1.5.9",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/164066c0badcfdea724847b1a24fd88eb96f9510/Windsurf-darwin-arm64-1.5.6.zip",
-    "sha256": "174fcd06dc73a760edf06105678af9b427303c8091cbe0f1454207107383076a"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/b3241b91445f79878ccc91626dfe190f90563e53/Windsurf-darwin-arm64-1.5.9.zip",
+    "sha256": "efe7638999179137525d38b523516a61ef4f19645d76cfd16c942724ff58c3d8"
   },
   "x86_64-darwin": {
-    "version": "1.5.6",
+    "version": "1.5.9",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/164066c0badcfdea724847b1a24fd88eb96f9510/Windsurf-darwin-x64-1.5.6.zip",
-    "sha256": "a3891e831ab43452f791a6856f0fd3c63535348583ae673bfcdae4466f36f8df"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/b3241b91445f79878ccc91626dfe190f90563e53/Windsurf-darwin-x64-1.5.9.zip",
+    "sha256": "d6b27ac0cf54c8554c021c5ed84515fef6ecca1612687d59927ea4993886da01"
   },
   "x86_64-linux": {
-    "version": "1.5.6",
+    "version": "1.5.9",
     "vscodeVersion": "1.94.0",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/164066c0badcfdea724847b1a24fd88eb96f9510/Windsurf-linux-x64-1.5.6.tar.gz",
-    "sha256": "5b01ce09139d7d8932be5c297a1c71a891a299825b2d5304f3fed22367188ecb"
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/b3241b91445f79878ccc91626dfe190f90563e53/Windsurf-linux-x64-1.5.9.tar.gz",
+    "sha256": "de33d2eb8ab5aa24ee45bcc0f8af6f973311f1b49a2c0e31c3f10e0c6374cf73"
   }
 }


### PR DESCRIPTION
Bumped version from 1.5.6 to 1.5.9

1.5.9 

Changes

    Gemini 2.5 Pro (Beta)
    Gemini 2.5 Pro is now available in beta!
    Gemini 2.5 Pro takes 1x user prompt credits on every message and 1x flow action credits on each tool call


Fixes

    Fixes to "Remote - SSH" extension, including custom SSH binary path setting

---

1.5.8 

Fixes

    Fixes for Cascade, which now better respects User-Defined Memories
    Improvements for Browser Previews
    Fixes for a few Cascade layout issues impacting icons

---

#Source: https://codeium.com/changelog
