### PR TITLE
fp16: init at 0-unstable-2024-20-06

### DIFF
--- a/pkgs/by-name/fp/fp16/package.nix
+++ b/pkgs/by-name/fp/fp16/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fp16";
+  version = "0-unstable-2024-20-06";
+
+  src = fetchFromGitHub {
+    owner = "Maratyszcza";
+    repo = "FP16";
+    rev = "98b0a46bce017382a6351a19577ec43a715b6835";
+    sha256 = "sha256-aob776ZGjnH4k/xfsdIcN9+wiuDreUoRBpyzrWGuxKk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FP16_BUILD_TESTS" false)
+    (lib.cmakeBool "FP16_BUILD_BENCHMARKS" false)
+    (lib.cmakeBool "FP16_USE_SYSTEM_LIBS" true)
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Header-only library for conversion to/from half-precision floating point formats";
+    homepage = "https://github.com/Maratyszcza/FP16";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Header-only library for conversion to/from half-precision floating point formats.

https://github.com/luxonis/FP16

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
