### PR TITLE
nixos/tailscale-auth: restart on-failure and wait for tailscaled

### DIFF
--- a/nixos/modules/services/networking/tailscale-auth.nix
+++ b/nixos/modules/services/networking/tailscale-auth.nix
@@ -68,6 +68,7 @@ in
     systemd.services.tailscale-nginx-auth = {
       description = "Tailscale NGINX Authentication service";
       requires = [ "tailscale-nginx-auth.socket" ];
+      after = [ "tailscaled.service" ];
 
       serviceConfig = {
         ExecStart = getExe cfg.package;
@@ -107,6 +108,8 @@ in
           "~@privileged"
           "~@setuid"
         ];
+
+        Restart = "on-failure";
       };
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I observed the following:

```
Mar 25 11:01:59 systemd Started Tailscale NGINX Authentication service.
Mar 25 11:01:59 (inx-auth) tailscale-nginx-auth.service: Failed to set up mount namespacing: /run/tailscale/tailscaled.sock: No such file or directory
Mar 25 11:01:59 (inx-auth) tailscale-nginx-auth.service: Failed at step NAMESPACE spawning /nix/store/gzlgb9bxxzikif2r6hllvgnr7gjqrrl3-tailscale-nginx-auth-1.80.3/bin/tailscale.nginx-auth: No such file or directory
Mar 25 11:02:00 systemd tailscale-nginx-auth.service: Main process exited, code=exited, status=226/NAMESPACE
Mar 25 11:02:00 systemd tailscale-nginx-auth.service: Failed with result 'exit-code'.
```

This happened while updating, because the service started before tailscaled was available. It also didn't restart after the failure. Here I'm adding a restart `on-failure` and making it start after `tailscaled`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
