### PR TITLE
nixos/dependency-track: fix nginx config for frontend

### DIFF
--- a/nixos/modules/services/web-apps/dependency-track.nix
+++ b/nixos/modules/services/web-apps/dependency-track.nix
@@ -509,9 +509,27 @@ in
       upstreams.dependency-track.servers."localhost:${toString cfg.port}" = { };
       virtualHosts.${cfg.nginx.domain} = {
         locations = {
-          "/".alias = "${cfg.package.frontend}/dist/";
+          "/" = {
+            alias = "${cfg.package.frontend}/dist/";
+            index = "index.html";
+            tryFiles = "$uri $uri/ /index.html";
+            extraConfig = ''
+              location ~ (index\.html)$ {
+                add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
+                add_header Pragma "no-cache";
+                add_header Expires 0;
+              }
+            '';
+          };
           "/api".proxyPass = "http://dependency-track";
-          "= /static/config.json".alias = frontendConfigFile;
+          "= /static/config.json" = {
+            alias = frontendConfigFile;
+            extraConfig = ''
+              add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
+              add_header Pragma "no-cache";
+              add_header Expires 0;
+            '';
+          };
         };
       };
     };

--- a/nixos/tests/dependency-track.nix
+++ b/nixos/tests/dependency-track.nix
@@ -45,22 +45,27 @@ import ./make-test-python.nix (
         };
     };
 
-    testScript = ''
-      import json
+    testScript =
+      # python
+      ''
+        import json
 
-      start_all()
+        start_all()
 
-      server.wait_for_unit("dependency-track.service")
-      server.wait_until_succeeds(
-        "journalctl -o cat -u dependency-track.service | grep 'Dependency-Track is ready'"
-      )
-      server.wait_for_open_port(${toString dependencyTrackPort})
-
-      with subtest("version api returns correct version"):
-        version = json.loads(
-          server.succeed("curl http://localhost/api/version")
+        server.wait_for_unit("dependency-track.service")
+        server.wait_until_succeeds(
+          "journalctl -o cat -u dependency-track.service | grep 'Dependency-Track is ready'"
         )
-        assert version["version"] == "${pkgs.dependency-track.version}"
-    '';
+        server.wait_for_open_port(${toString dependencyTrackPort})
+
+        with subtest("version api returns correct version"):
+          version = json.loads(
+            server.succeed("curl http://localhost/api/version")
+          )
+          assert version["version"] == "${pkgs.dependency-track.version}"
+
+        with subtest("nginx serves frontend"):
+          server.succeed("curl http://localhost/ | grep \"<title>Dependency-Track</title>\"")
+      '';
   }
 )


### PR DESCRIPTION
Apparend I fell for some browser cache when implementing this in the first place. This patch is based on the upstream nginx config.

https://github.com/DependencyTrack/frontend/blob/5f318aca10f85f1f5d7a91d7627883bd506cc48e/docker/etc/nginx/templates/default.conf.template


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
