### PR TITLE
libblake3: use older tbb version on macOS

### DIFF
--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   cmake,
   fetchFromGitHub,
-  tbb_2022_0,
+  tbb_2021_11,
   useTBB ? true,
 }:
 
@@ -22,7 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = lib.optionals useTBB [ tbb_2022_0 ];
+  buildInputs = lib.optionals useTBB [
+    # 2022.0 crashes on macOS at the moment
+    tbb_2021_11
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "BLAKE3_USE_TBB" useTBB)


### PR DESCRIPTION
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               nix [69105]
Path:                  /Users/USER/*/nix
Identifier:            nix
Version:               ???
Code Type:             ARM-64 (Native)
Parent Process:        Exited process [69036]
Responsible:           ghostty [609]
User ID:               501

Date/Time:             2025-03-24 10:28:36.3531 +0100
OS Version:            macOS 15.1.1 (24B91)
Report Version:        12
Anonymous UUID:        43196E0E-30B7-6E8A-68F3-0C573FEA61E3

Sleep/Wake UUID:       C4FFF3A0-095A-4AE0-935B-60B5E7DE7522

Time Awake Since Boot: 130000 seconds
Time Since Wake:       78381 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x000000010d7d3ff4
Exception Codes:       0x0000000000000001, 0x000000010d7d3ff4

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [69105]

VM Region Info: 0x10d7d3ff4 is not in any region.  Bytes after previous region: 49141  Bytes before following region: 196620
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      __LINKEDIT                  10d7c0000-10d7c8000    [   32K] r--/rwx SM=COW  /Volumes/VOLUME/*/liblowdown.1.dylib
--->  GAP OF 0x3c000 BYTES
      VM_ALLOCATE                 10d804000-10d854000    [  320K] rw-/rwx SM=PRV

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   ???                           	       0x10d7d3ff4 ???
1   libtbb.12.14.dylib            	       0x106abd4f8 tbb::detail::r1::__TBB_InitOnce::~__TBB_InitOnce() + 60
2   libsystem_c.dylib             	       0x1939f2998 __cxa_finalize_ranges + 476
3   libsystem_c.dylib             	       0x1939f275c exit + 44
4   libdyld.dylib                 	       0x193b5a94c dyld4::LibSystemHelpers::exit(int) const + 20
5   dyld                          	       0x1937b42c8 start + 2924

Thread 1:
0   libsystem_pthread.dylib       	       0x193b320e8 start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	       0x193b320e8 start_wqthread + 0

Thread 3:
0   libsystem_kernel.dylib        	       0x193b01840 __sigwait + 8
1   libsystem_pthread.dylib       	       0x193b37a9c sigwait + 40
2   libnixutil.dylib              	       0x106fae034 nix::signalHandlerThread(unsigned int) + 36 (signals.cc:62)
3   libnixutil.dylib              	       0x106fb0730 decltype(std::declval<void (*)(unsigned int)>()(std::declval<unsigned int>())) std::__1::__invoke[abi:fe190107]<void (*)(unsigned int), unsigned int>(void (*&&)(unsigned int), unsigned int&&) + 40 (invoke.h:149)
4   libnixutil.dylib              	       0x106fb06f4 void std::__1::__thread_execute[abi:fe190107]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(unsigned int), unsigned int, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(unsigned int), unsigned int>&, std::__1::__tuple_indices<2ul>) + 48 (thread.h:192)
5   libnixutil.dylib              	       0x106fb0340 void* std::__1::__thread_proxy[abi:fe190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (*)(unsigned int), unsigned int>>(void*) + 100 (thread.h:201)
6   libsystem_pthread.dylib       	       0x193b372e4 _pthread_start + 136
7   libsystem_pthread.dylib       	       0x193b320fc thread_start + 8

Thread 0 crashed with ARM Thread State (64-bit):
    x0: 0x000000010dc8bf80   x1: 0x000000010d7d3ff4   x2: 0x0000000000000103   x3: 0x00000001f9b12978
    x4: 0x0000000000000000   x5: 0x0000000000000000   x6: 0x0000000000000000   x7: 0x0000000000000000
    x8: 0x0000000000000000   x9: 0x0000000000000000  x10: 0x000000016b68dc40  x11: 0x000000016b68ded0
   x12: 0x0000000000000000  x13: 0x0000000000018000  x14: 0x0000000000004af0  x15: 0x00000001111477df
   x16: 0x0000000193b693b4  x17: 0x0000000200eaa590  x18: 0x0000000000000000  x19: 0x0000000106af0838
   x20: 0x0000000106af0388  x21: 0x0000000000000002  x22: 0x0000000106158030  x23: 0x0000000000000000
   x24: 0x0000000000000008  x25: 0x00000001f8c54000  x26: 0x0000000000000004  x27: 0x0000000000000003
   x28: 0x0000000000000003   fp: 0x000000016b68f7a0   lr: 0x0000000106abc110
    sp: 0x000000016b68f790   pc: 0x000000010d7d3ff4 cpsr: 0x60001000
   far: 0x000000010d7d3ff4  esr: 0x82000007 (Instruction Abort) Translation fault


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
