### PR TITLE
teams: fix Darwin build (#377741)

### DIFF
--- a/pkgs/by-name/te/teams/package.nix
+++ b/pkgs/by-name/te/teams/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     zcat < Teams_osx_app.pkg/Payload | cpio -i
   '';
 
-  sourceRoot = "Microsoft\\ Teams.app";
+  sourceRoot = "Microsoft Teams.app";
   dontPatch = true;
   dontConfigure = true;
   dontBuild = true;


### PR DESCRIPTION
Fixes #377741

## Disclaimer

This is one-liner fix and due to depleted time budget for side things like this, I might not have followed `nixpkgs` PR rules, however I made sure the functionality has been fixed.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested:

due to package' need for `allowUnfree` and myself - having a private flake-based setup featuring teams, I did opinionated testing using minimal viable flake (below)

## Test Setup

```flake.nix
{
  inputs = {
    nixpkgs.url = "github:ink-splatters/nixpkgs/1b87a986ab65a0bb5cd790221fdbcbeaaa45fd84";
  };

  outputs = {nixpkgs, ...}: let
    system = "aarch64-darwin";
    pkgs = import nixpkgs {
      inherit system;
      config.allowUnfree = true;
    };
  in {
    packages.${system}.default = pkgs.teams;
  };
}
```

<details><summary>Click here for build log</summary>

```sh
❯ nix --experimental-features 'nix-command flakes' build -L --print-build-logs --verbose
fetching path input 'path:/private/tmp/teams'
this derivation will be built:
  /nix/store/sn8a8n9nad47571p0nixad57mcfh4bpk-teams-1.6.00.4464.drv
these 57 paths will be fetched (144.36 MiB download, 1059.55 MiB unpacked):
  /nix/store/3604krq5fl7n3lgidkh10ax4b7nli37i-apple-sdk-11.3
  /nix/store/ra9x0yp18yg1b3zj9avd1ksgb47bwr0j-bzip2-1.0.8
  /nix/store/h90yqfqg6ix09sv3xxjk83xywk9v6aki-bzip2-1.0.8-bin
  /nix/store/304zy0fxpbxrq1m9glfhyzmqsq1343zi-cctools-1010.6
  /nix/store/33nx9jvj9a204bibrr20hjk0myycc6iy-cctools-1010.6-libtool
  /nix/store/dmjdr9fc39gpq2izzqdiq7796pqla7an-cctools-binutils-darwin-1010.6
  /nix/store/11s2lx401bv3l8fx7jl69b25x4zvc9hz-cctools-binutils-darwin-wrapper-1010.6
  /nix/store/2rij3brrzn54mzd82hs496cqxdx82n2f-clang-19.1.7
  /nix/store/53l5h86r860jw07p2lx0j46wd11cy3xd-clang-19.1.7-lib
  /nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7
  /nix/store/0sc47pq4c79mxfh54fvb9ccd1gwvc8d7-compiler-rt-libc-19.1.7
  /nix/store/y5i8vcl2gpx6rjxcwmjwffrjvsf7g5gy-compiler-rt-libc-19.1.7-dev
  /nix/store/4idwmksk4s5bdmzl1sz1z17bj0yfqgkj-coreutils-9.6
  /nix/store/nyijnq2grg6yrmh1jjkn01n050adgsnv-cpio-2.15
  /nix/store/4njvhgcdm480224mh6yalh6mcf3nqx83-cups-headers-2.4.11
  /nix/store/kqxmarwy1y9m6ipr9r42gqdpxrxcsphm-die-hook
  /nix/store/ivq7lckmms63zb2kaqvh3yi0r3aw1292-diffutils-3.10
  /nix/store/6qhjq486j9zhkpp9kg7ynv3fvm7bi07f-ed-1.21
  /nix/store/3a1s510sz72pn10qiwvqq78c19lm4qhk-expand-response-params
  /nix/store/6dhmi0kl8i6vi3m1j6w23g70c2vhyj5b-file-5.46
  /nix/store/vsia946b1b3bqz3j9cznlibc5l834n5f-findutils-4.10.0
  /nix/store/js9jxkw9h2fw1qrsshlr6i518ih1dkcx-gawk-5.3.1
  /nix/store/frpmc324akwqf2zghwh2xpzcspvannrd-gmp-with-cxx-6.3.0
  /nix/store/ymhnmxjsc7kcqpd75d4pp0h2ggmwxmyq-gnu-config-2024-01-01
  /nix/store/zdx9494j3rsg81makrh09v8ln5f16gjr-gnugrep-3.11
  /nix/store/cnkfqpa3kyi3mgk0yd8lqbrdysq7j38q-gnumake-4.4.1
  /nix/store/pj9bj4cczgxwzgvgzjlgz5kzifwsh4ky-gnused-4.9
  /nix/store/xhp434ahjnbjp0r68y14zr1205712vpn-gnutar-1.35
  /nix/store/p4kmf6jzxpflwxzsiwl3rjvv6yzr21lm-gzip-1.13
  /nix/store/jza1b2n060p7qfm22y0nkxz6xjszys75-ld64-954.16
  /nix/store/vj9a04lhqfgw9a01q0vrhcfkwiw53wcl-ld64-954.16-lib
  /nix/store/j2slpwgyy4w7zjjfyhhpsc7fkg1s19z3-libSystem-B
  /nix/store/w9v3pg4gh8c9fwpm4g093w1awddw9n8h-libcxx-19.1.7-dev
  /nix/store/jgdagkhidk9frkd0rj2frgcd7ysnf6pk-libffi-39
  /nix/store/j57f2k37j99zypb8ilx576xgifm7q12h-libiconv-109-dev
  /nix/store/yndqbil329i51gqh9whzc5v2gsprbr1v-libresolv-83-dev
  /nix/store/dnmafb3a9iy48qjixknlyarhq6h09xqw-libsbuf-14.1.0
  /nix/store/scim78wb47y8sm3b5z01jq08g53cj78l-libsbuf-14.1.0-dev
  /nix/store/9kg4lh56kqk163gn2vckisfz25scaq6m-libutil-72
  /nix/store/kparya24h5rhd82lizx78arfxjdyml08-libxml2-2.13.6
  /nix/store/1irmdf3glbgggpzzz67mggzvnl3fq7fv-llvm-19.1.7
  /nix/store/pp5pxd3f4glid2qxbhwg4ngx54g6xi9d-llvm-19.1.7-lib
  /nix/store/s6mah0y143q3diyqr55dkc9lqz7yr3ya-locale-118
  /nix/store/1d2m7jng6vnrjgbns449jav9f7ismbzd-make-shell-wrapper-hook
  /nix/store/xfh6fy6pzmriw96yqcivxmi3d666nqci-ncurses-6.5
  /nix/store/3lk1wchnmf1878bhhc2gnqkcgg7jm5r2-ncurses-6.5-dev
  /nix/store/jgwrs391scrlyv9indwv7f4acmbzc8jq-ncurses-6.5-man
  /nix/store/7rxrg62dcclg6yaxxs0z4m8jzv0dzvxk-patch-2.7.6
  /nix/store/hjih3ih7wdq3cgqrlz3ry6dnbdjn04qv-stdenv-darwin
  /nix/store/k3hkrn1sjgb2bg146g0lcgwzrf80lyaa-update-autotools-gnu-config-scripts-hook
  /nix/store/ly2cymsm8zwzi4ibcpnczm1brvqi4fr3-xar-minimal-501
  /nix/store/pcrvhv0mbd7bawnvii1xcypp2lnsj7fj-xar-minimal-501-dev
  /nix/store/g929il81vvl1rwqh49j22mp073ljqxid-xar-minimal-501-lib
  /nix/store/5bwqjycc84gj6pk7f0pxc1sjjr48gsy8-xcbuild-0.1.1-unstable-2019-11-20
  /nix/store/l2j4vv991n0kl6w1926r1a7ydbk1s986-xcbuild-0.1.1-unstable-2019-11-20-xcrun
  /nix/store/gs163z7sl2j6divjv8gkb1l2ih7dpmms-xz-5.6.4
  /nix/store/l083ymlnrn8iqyf8l204kpp24cz6sshm-xz-5.6.4-bin
copying path '/nix/store/js9jxkw9h2fw1qrsshlr6i518ih1dkcx-gawk-5.3.1' from 'https://cache.nixos.org'...
copying path '/nix/store/pj9bj4cczgxwzgvgzjlgz5kzifwsh4ky-gnused-4.9' from 'https://cache.nixos.org'...
copying path '/nix/store/s6mah0y143q3diyqr55dkc9lqz7yr3ya-locale-118' from 'https://cache.nixos.org'...
copying path '/nix/store/kqxmarwy1y9m6ipr9r42gqdpxrxcsphm-die-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/ra9x0yp18yg1b3zj9avd1ksgb47bwr0j-bzip2-1.0.8' from 'https://cache.nixos.org'...
copying path '/nix/store/gs163z7sl2j6divjv8gkb1l2ih7dpmms-xz-5.6.4' from 'https://cache.nixos.org'...
copying path '/nix/store/4njvhgcdm480224mh6yalh6mcf3nqx83-cups-headers-2.4.11' from 'https://cache.nixos.org'...
copying path '/nix/store/3a1s510sz72pn10qiwvqq78c19lm4qhk-expand-response-params' from 'https://cache.nixos.org'...
copying path '/nix/store/j2slpwgyy4w7zjjfyhhpsc7fkg1s19z3-libSystem-B' from 'https://cache.nixos.org'...
copying path '/nix/store/xfh6fy6pzmriw96yqcivxmi3d666nqci-ncurses-6.5' from 'https://cache.nixos.org'...
copying path '/nix/store/jgwrs391scrlyv9indwv7f4acmbzc8jq-ncurses-6.5-man' from 'https://cache.nixos.org'...
copying path '/nix/store/dnmafb3a9iy48qjixknlyarhq6h09xqw-libsbuf-14.1.0' from 'https://cache.nixos.org'...
copying path '/nix/store/jgdagkhidk9frkd0rj2frgcd7ysnf6pk-libffi-39' from 'https://cache.nixos.org'...
copying path '/nix/store/p4kmf6jzxpflwxzsiwl3rjvv6yzr21lm-gzip-1.13' from 'https://cache.nixos.org'...
copying path '/nix/store/nyijnq2grg6yrmh1jjkn01n050adgsnv-cpio-2.15' from 'https://cache.nixos.org'...
copying path '/nix/store/cnkfqpa3kyi3mgk0yd8lqbrdysq7j38q-gnumake-4.4.1' from 'https://cache.nixos.org'...
copying path '/nix/store/6dhmi0kl8i6vi3m1j6w23g70c2vhyj5b-file-5.46' from 'https://cache.nixos.org'...
copying path '/nix/store/9kg4lh56kqk163gn2vckisfz25scaq6m-libutil-72' from 'https://cache.nixos.org'...
copying path '/nix/store/frpmc324akwqf2zghwh2xpzcspvannrd-gmp-with-cxx-6.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0sc47pq4c79mxfh54fvb9ccd1gwvc8d7-compiler-rt-libc-19.1.7' from 'https://cache.nixos.org'...
copying path '/nix/store/w9v3pg4gh8c9fwpm4g093w1awddw9n8h-libcxx-19.1.7-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/kparya24h5rhd82lizx78arfxjdyml08-libxml2-2.13.6' from 'https://cache.nixos.org'...
copying path '/nix/store/j57f2k37j99zypb8ilx576xgifm7q12h-libiconv-109-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/xhp434ahjnbjp0r68y14zr1205712vpn-gnutar-1.35' from 'https://cache.nixos.org'...
copying path '/nix/store/yndqbil329i51gqh9whzc5v2gsprbr1v-libresolv-83-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/6qhjq486j9zhkpp9kg7ynv3fvm7bi07f-ed-1.21' from 'https://cache.nixos.org'...
copying path '/nix/store/ymhnmxjsc7kcqpd75d4pp0h2ggmwxmyq-gnu-config-2024-01-01' from 'https://cache.nixos.org'...
copying path '/nix/store/zdx9494j3rsg81makrh09v8ln5f16gjr-gnugrep-3.11' from 'https://cache.nixos.org'...
copying path '/nix/store/vj9a04lhqfgw9a01q0vrhcfkwiw53wcl-ld64-954.16-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/1d2m7jng6vnrjgbns449jav9f7ismbzd-make-shell-wrapper-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/h90yqfqg6ix09sv3xxjk83xywk9v6aki-bzip2-1.0.8-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/scim78wb47y8sm3b5z01jq08g53cj78l-libsbuf-14.1.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/l083ymlnrn8iqyf8l204kpp24cz6sshm-xz-5.6.4-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/k3hkrn1sjgb2bg146g0lcgwzrf80lyaa-update-autotools-gnu-config-scripts-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/7rxrg62dcclg6yaxxs0z4m8jzv0dzvxk-patch-2.7.6' from 'https://cache.nixos.org'...
copying path '/nix/store/4idwmksk4s5bdmzl1sz1z17bj0yfqgkj-coreutils-9.6' from 'https://cache.nixos.org'...
copying path '/nix/store/3lk1wchnmf1878bhhc2gnqkcgg7jm5r2-ncurses-6.5-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/g929il81vvl1rwqh49j22mp073ljqxid-xar-minimal-501-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/5bwqjycc84gj6pk7f0pxc1sjjr48gsy8-xcbuild-0.1.1-unstable-2019-11-20' from 'https://cache.nixos.org'...
copying path '/nix/store/pp5pxd3f4glid2qxbhwg4ngx54g6xi9d-llvm-19.1.7-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/y5i8vcl2gpx6rjxcwmjwffrjvsf7g5gy-compiler-rt-libc-19.1.7-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/ly2cymsm8zwzi4ibcpnczm1brvqi4fr3-xar-minimal-501' from 'https://cache.nixos.org'...
copying path '/nix/store/ivq7lckmms63zb2kaqvh3yi0r3aw1292-diffutils-3.10' from 'https://cache.nixos.org'...
copying path '/nix/store/vsia946b1b3bqz3j9cznlibc5l834n5f-findutils-4.10.0' from 'https://cache.nixos.org'...
copying path '/nix/store/pcrvhv0mbd7bawnvii1xcypp2lnsj7fj-xar-minimal-501-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/l2j4vv991n0kl6w1926r1a7ydbk1s986-xcbuild-0.1.1-unstable-2019-11-20-xcrun' from 'https://cache.nixos.org'...
copying path '/nix/store/53l5h86r860jw07p2lx0j46wd11cy3xd-clang-19.1.7-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/1irmdf3glbgggpzzz67mggzvnl3fq7fv-llvm-19.1.7' from 'https://cache.nixos.org'...
copying path '/nix/store/jza1b2n060p7qfm22y0nkxz6xjszys75-ld64-954.16' from 'https://cache.nixos.org'...
copying path '/nix/store/33nx9jvj9a204bibrr20hjk0myycc6iy-cctools-1010.6-libtool' from 'https://cache.nixos.org'...
copying path '/nix/store/304zy0fxpbxrq1m9glfhyzmqsq1343zi-cctools-1010.6' from 'https://cache.nixos.org'...
copying path '/nix/store/2rij3brrzn54mzd82hs496cqxdx82n2f-clang-19.1.7' from 'https://cache.nixos.org'...
copying path '/nix/store/dmjdr9fc39gpq2izzqdiq7796pqla7an-cctools-binutils-darwin-1010.6' from 'https://cache.nixos.org'...
copying path '/nix/store/3604krq5fl7n3lgidkh10ax4b7nli37i-apple-sdk-11.3' from 'https://cache.nixos.org'...
copying path '/nix/store/11s2lx401bv3l8fx7jl69b25x4zvc9hz-cctools-binutils-darwin-wrapper-1010.6' from 'https://cache.nixos.org'...
copying path '/nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7' from 'https://cache.nixos.org'...
copying path '/nix/store/hjih3ih7wdq3cgqrlz3ry6dnbdjn04qv-stdenv-darwin' from 'https://cache.nixos.org'...
building '/nix/store/sn8a8n9nad47571p0nixad57mcfh4bpk-teams-1.6.00.4464.drv'...
teams> Running phase: unpackPhase
teams> 959142 blocks
teams> Running phase: updateAutotoolsGnuConfigScriptsPhase
teams> Running phase: installPhase
teams> Running phase: fixupPhase
teams> checking for references to /private/tmp/nix-build-teams-1.6.00.4464.drv-5/ in /nix/store/v3y2hzwz8qs82xx20jb56zzcgqh6ipkv-teams-1.6.00.4464...
teams> patching script interpreter paths in /nix/store/v3y2hzwz8qs82xx20jb56zzcgqh6ipkv-teams-1.6.00.4464
teams> stripping (with command strip and flags -S) in  /nix/store/v3y2hzwz8qs82xx20jb56zzcgqh6ipkv-teams-1.6.00.4464/bin /nix/store/v3y2hzwz8qs82xx20jb56zzcgqh6ipkv-teams-1.6.00.4464/Applications
```

</details>