### PR TITLE
cen64: unstable-2022-10-02 -> 0-unstable-2023-05-29, fix build with gcc14

### DIFF
--- a/pkgs/by-name/ce/cen64/cast-mi_regs-callbacks.patch
+++ b/pkgs/by-name/ce/cen64/cast-mi_regs-callbacks.patch
@@ -1,0 +1,22 @@
+From f13bdf94c00a9da3b152ed9fe20001e240215b96 Mon Sep 17 00:00:00 2001
+From: James Lambert <lambertjamesd@gmail.com>
+Date: Tue, 9 Feb 2021 11:49:51 -0700
+Subject: [PATCH] Cast mi_regs callbacks
+
+---
+ bus/controller.c   | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/bus/controller.c b/bus/controller.c
+index 1f0cdfccf..24b3df260 100644
+--- a/bus/controller.c
++++ b/bus/controller.c
+@@ -44,7 +44,7 @@ int bus_init(struct bus_controller *bus, int dd_present) {
+   static const struct bus_controller_mapping mappings[NUM_MAPPINGS] = {
+     {read_ai_regs, write_ai_regs, AI_REGS_BASE_ADDRESS, AI_REGS_ADDRESS_LEN},
+     {read_dp_regs, write_dp_regs, DP_REGS_BASE_ADDRESS, DP_REGS_ADDRESS_LEN},
+-    {read_mi_regs, write_mi_regs, MI_REGS_BASE_ADDRESS, MI_REGS_ADDRESS_LEN},
++    {(memory_rd_function)read_mi_regs, (memory_wr_function)write_mi_regs, MI_REGS_BASE_ADDRESS, MI_REGS_ADDRESS_LEN},
+     {read_pi_regs, write_pi_regs, PI_REGS_BASE_ADDRESS, PI_REGS_ADDRESS_LEN},
+     {read_ri_regs, write_ri_regs, RI_REGS_BASE_ADDRESS, RI_REGS_ADDRESS_LEN},
+     {read_si_regs, write_si_regs, SI_REGS_BASE_ADDRESS, SI_REGS_ADDRESS_LEN},

--- a/pkgs/by-name/ce/cen64/fix-thread-arg-type-for-pthread_setname_np.patch
+++ b/pkgs/by-name/ce/cen64/fix-thread-arg-type-for-pthread_setname_np.patch
@@ -1,0 +1,137 @@
+From 41ad58ab1953835313ad2b89686931b08b5b47e8 Mon Sep 17 00:00:00 2001
+From: ghpzin <ghpzin@gmail.com>
+Date: Tue, 25 Mar 2025 15:26:07 +0300
+Subject: [PATCH] Fix thread arg type for pthread_setname_np
+
+- change `thread` arg type to `cen64_thread` instead of `cen64_thread *`
+(`pthread_t` instead of `pthread_t *`) according to definition of
+`pthread_setname_np` from `<pthread.h>`:
+`int pthread_setname_np(pthread_t thread, const char *name);`
+fixes gcc14 errors:
+```
+/build/source/cen64.c:475:24: error: passing argument 1 of 'cen64_thread_setname' makes pointer from integer without a cast [-Wint-conversion]
+  475 |   cen64_thread_setname(thread, "device");
+      |                        ^~~~~~
+      |                        |
+      |                        cen64_thread {aka long unsigned int}
+In file included from /build/source/device/device.h:26,
+                 from /build/source/cen64.c:15:
+/build/source/os/posix/thread.h:59:54: note: expected 'cen64_thread *' {aka 'long unsigned int *'} but argument is of type 'cen64_thread' {aka 'lo>
+   59 | static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
+      |                                        ~~~~~~~~~~~~~~^
+```
+
+- add cast to `cen64_thread` from NULL where `cen64_thread` is called
+with it, fixes gcc14 errors:
+```
+/build/source/gdb/gdb.c:82:24: error: passing argument 1 of 'cen64_thread_setname' makes integer from pointer without a cast [-Wint-conversion]
+   82 |   cen64_thread_setname(NULL, "gdb");
+      |                        ^~~~
+      |                        |
+      |                        void *
+/build/source/os/posix/thread.h:59:53: note: expected 'cen64_thread' {aka 'long unsigned int'} but argument is of type 'void *'
+   59 | static inline int cen64_thread_setname(cen64_thread t, const char *name) {
+      |                                        ~~~~~~~~~~~~~^
+```
+---
+ cen64.c            | 2 +-
+ device/device.c    | 4 ++--
+ gdb/gdb.c          | 4 ++--
+ os/posix/thread.h  | 6 +++---
+ os/winapi/thread.h | 2 +-
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/cen64.c b/cen64.c
+index 51014a4..ca6bda1 100644
+--- a/cen64.c
++++ b/cen64.c
+@@ -483,7 +483,7 @@ int run_device(struct cen64_device *device, bool no_video) {
+ }
+ 
+ CEN64_THREAD_RETURN_TYPE run_device_thread(void *opaque) {
+-  cen64_thread_setname(NULL, "device");
++  cen64_thread_setname((cen64_thread)NULL, "device");
+   struct cen64_device *device = (struct cen64_device *) opaque;
+ 
+   device_run(device);
+diff --git a/device/device.c b/device/device.c
+index cd5a046..c915846 100644
+--- a/device/device.c
++++ b/device/device.c
+@@ -224,7 +224,7 @@ CEN64_THREAD_RETURN_TYPE run_rcp_thread(void *opaque) {
+ }
+ 
+ CEN64_THREAD_RETURN_TYPE run_vr4300_thread(void *opaque) {
+-  cen64_thread_setname(NULL, "vr4300");
++  cen64_thread_setname((cen64_thread)NULL, "vr4300");
+   struct cen64_device *device = (struct cen64_device *) opaque;
+ 
+   while (likely(device->running)) {
+@@ -351,4 +351,4 @@ int device_debug_spin(struct cen64_device *device) {
+ 
+ cen64_cold void device_connect_debugger(struct cen64_device *device, void* break_handler_data, vr4300_debug_break_handler break_handler) {
+   vr4300_connect_debugger(device->vr4300, break_handler_data, break_handler);
+-}
+\ No newline at end of file
++}
+diff --git a/gdb/gdb.c b/gdb/gdb.c
+index 021784d..0e8d188 100644
+--- a/gdb/gdb.c
++++ b/gdb/gdb.c
+@@ -79,7 +79,7 @@ bool gdb_parse_packet(const char* input, int len, const char** command_start, co
+ }
+ 
+ CEN64_THREAD_RETURN_TYPE gdb_thread(void *opaque) {
+-  cen64_thread_setname(NULL, "gdb");
++  cen64_thread_setname((cen64_thread)NULL, "gdb");
+   struct gdb *gdb = (struct gdb *) opaque;
+ 
+   cen64_mutex_lock(&gdb->client_mutex);
+@@ -257,4 +257,4 @@ cen64_cold void gdb_destroy(struct gdb* gdb) {
+ 
+   gdb->device = NULL;
+   free(gdb);
+-}
+\ No newline at end of file
++}
+diff --git a/os/posix/thread.h b/os/posix/thread.h
+index 2a261c6..e8e6144 100644
+--- a/os/posix/thread.h
++++ b/os/posix/thread.h
+@@ -45,9 +45,9 @@ static inline int cen64_thread_join(cen64_thread *t) {
+ #ifdef __APPLE__
+ int pthread_setname_np(const char*);
+ #elif __NETBSD__
+-int pthread_setname_np(cen64_thread*, const char*, const char*);
++int pthread_setname_np(cen64_thread, const char*, const char*);
+ #else
+-int pthread_setname_np(cen64_thread*, const char*);
++int pthread_setname_np(cen64_thread, const char*);
+ #endif
+ 
+ // Sets the name of the thread to a specific value
+@@ -56,7 +56,7 @@ int pthread_setname_np(cen64_thread*, const char*);
+ // If you call it at the wrong time or your OS doesn't support custom thread names
+ // the return value will be non-zero.
+ // If cen64_thread is not set the name of the current thread will be changed.
+-static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
++static inline int cen64_thread_setname(cen64_thread t, const char *name) {
+   #ifdef __APPLE__
+     if (t == NULL)
+       return pthread_setname_np(name);
+diff --git a/os/winapi/thread.h b/os/winapi/thread.h
+index d7c162a..128d935 100644
+--- a/os/winapi/thread.h
++++ b/os/winapi/thread.h
+@@ -57,7 +57,7 @@ static inline int cen64_thread_join(cen64_thread *t) {
+ //
+ // Windows isn't supported for the moment.
+ //
+-static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
++static inline int cen64_thread_setname(cen64_thread t, const char *name) {
+   return ENOSYS;
+ }
+ 
+-- 
+2.48.1
+

--- a/pkgs/by-name/ce/cen64/package.nix
+++ b/pkgs/by-name/ce/cen64/package.nix
@@ -20,6 +20,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-vFk29KESATcEY0eRNbS+mHLD9T1phJiG1fqjOlI19/w=";
   };
 
+  patches = [
+    # fix build with gcc14:
+    # https://github.com/n64dev/cen64/pull/191/commits/f13bdf94c00a9da3b152ed9fe20001e240215b96
+    ./cast-mi_regs-callbacks.patch
+    # https://github.com/n64dev/cen64/pull/237
+    ./fix-thread-arg-type-for-pthread_setname_np.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     libGL

--- a/pkgs/by-name/ce/cen64/package.nix
+++ b/pkgs/by-name/ce/cen64/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cen64";
-  version = "unstable-2022-10-02";
+  version = "0-unstable-2023-05-29";
 
   src = fetchFromGitHub {
     owner = "n64dev";
     repo = "cen64";
-    rev = "ee6db7d803a77b474e73992fdc25d76b9723d806";
-    sha256 = "sha256-/CraSu/leNA0dl8NVgFjvKdOWrC9/namAz5NSxtPr+I=";
+    rev = "1c1118462bd9d9b8ceb4c556a647718072477aab";
+    sha256 = "sha256-vFk29KESATcEY0eRNbS+mHLD9T1phJiG1fqjOlI19/w=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
cen64: unstable-2022-10-02 -> 0-unstable-2023-05-29

---

cen64: fix build with gcc14
- add patch from unmerged upstream PR (only `bus/controller.c`, other changes are already applied in master):
https://github.com/n64dev/cen64/pull/191/commits/f13bdf94c00a9da3b152ed9fe20001e240215b96
fixes error from gcc14:
`error: initialization of ... from incompatible pointer type`

- add patch from unmerged upstream PR:
https://github.com/n64dev/cen64/pull/237
fixes errors from gcc14:
`error: passing argument 1 of 'cen64_thread_setname' makes pointer from integer without a cast [-Wint-conversion]`
`error: passing argument 1 of 'cen64_thread_setname' makes integer from pointer without a cast [-Wint-conversion]`

---

Fixes build failure of `cen64` since `2025-01-14` (update to GCC14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.cen64.x86_64-linux
https://hydra.nixos.org/build/292986743

Error log (fixed with `cast-mi_regs-callbacks.patch`):
```text
/build/source/bus/controller.c: In function 'bus_init':
/build/source/bus/controller.c:47:6: error: initialization of 'int (*)(void *, uint32_t,  uint32_t *)' {aka 'int (*)(void *, unsigned int,  unsigned int *)'} from incompatible pointer type 'int (*)(struct vr4300 *, uint32_t,  uint32_t *)' {aka 'int (*)(struct vr4300 *, unsigned int,  unsigned int *)'} []
   47 |     {read_mi_regs, write_mi_regs, MI_REGS_BASE_ADDRESS, MI_REGS_ADDRESS_LEN},
      |      ^~~~~~~~~~~~
/build/source/bus/controller.c:47:6: note: (near initialization for 'mappings[2].read')
/build/source/bus/controller.c:47:20: error: initialization of 'int (*)(void *, uint32_t,  uint32_t,  uint32_t)' {aka 'int (*)(void *, unsigned int,  unsigned int,  unsigned int)'} from incompatible pointer type 'int (*)(struct vr4300 *, uint32_t,  uint32_t,  uint32_t)' {aka 'int (*)(struct vr4300 *, unsigned int,  unsigned int,  unsigned int)'} []
   47 |     {read_mi_regs, write_mi_regs, MI_REGS_BASE_ADDRESS, MI_REGS_ADDRESS_LEN},
      |                    ^~~~~~~~~~~~~
/build/source/bus/controller.c:47:20: note: (near initialization for 'mappings[2].write')
```


After applying first patch other errors come up (fixed with `fix-thread-arg-type-for-pthread_setname_np.patch`):
```text
/build/source/cen64.c:475:24: error: passing argument 1 of 'cen64_thread_setname' makes pointer from integer without a cast [-Wint-conversion]
  475 |   cen64_thread_setname(thread, "device");
      |                        ^~~~~~
      |                        |
      |                        cen64_thread {aka long unsigned int}
In file included from /build/source/device/device.h:26,
                 from /build/source/cen64.c:15:
/build/source/os/posix/thread.h:59:54: note: expected 'cen64_thread *' {aka 'long unsigned int *'} but argument is of type 'cen64_thread' {aka 'lo>
   59 | static inline int cen64_thread_setname(cen64_thread *t, const char *name) {
      |                                        ~~~~~~~~~~~~~~^
```
```text
/build/source/gdb/gdb.c:82:24: error: passing argument 1 of 'cen64_thread_setname' makes integer from pointer without a cast [-Wint-conversion]
   82 |   cen64_thread_setname(NULL, "gdb");
      |                        ^~~~
      |                        |
      |                        void *
/build/source/os/posix/thread.h:59:53: note: expected 'cen64_thread' {aka 'long unsigned int'} but argument is of type 'void *'
   59 | static inline int cen64_thread_setname(cen64_thread t, const char *name) {
      |                                        ~~~~~~~~~~~~~^
```

Upstream PRs with included patches:
https://github.com/n64dev/cen64/pull/191
https://github.com/n64dev/cen64/pull/237

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
