### PR TITLE
[staging] python3.pkgs.sphinx-issues: avoid use of pandoc in build closure (riscv64-fix)

### DIFF
--- a/pkgs/development/python-modules/sphinx-issues/default.nix
+++ b/pkgs/development/python-modules/sphinx-issues/default.nix
@@ -3,17 +3,11 @@
   buildPythonPackage,
   sphinx,
   fetchFromGitHub,
-  pandoc,
 }:
-
 buildPythonPackage rec {
   pname = "sphinx-issues";
   version = "3.0.1";
   format = "setuptools";
-  outputs = [
-    "out"
-    "doc"
-  ];
 
   src = fetchFromGitHub {
     owner = "sloria";
@@ -25,17 +19,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "sphinx_issues" ];
 
   propagatedBuildInputs = [ sphinx ];
-
-  nativeBuildInputs = [ pandoc ];
-
-  postBuild = ''
-    pandoc -f rst -t html --standalone < README.rst > README.html
-  '';
-
-  postInstall = ''
-    mkdir -p $doc/share/doc/$name/html
-    cp README.html $doc/share/doc/$name/html
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/sloria/sphinx-issues";


### PR DESCRIPTION
Shipping an HTML version of the Readme for a library is a bit uncommon in nixpkgs.
We don't do this for any other package because it will also a bit
awkward to access directly (libraries don't get included into
environment.systemPackages directly for instance).
Including pandoc in the build closure makes this derivation unusuable on riscv64 and other platforms
that are not supported by ghc.
Since this package is now part of NixOS integration tests this break
evaluation of all riscv64-based NixOS tests.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
