### PR TITLE
catppuccin-sddm-corners: 0-unstable-2024-05-07 -> 0-unstable-2025-03-25

### DIFF
--- a/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  unstableGitUpdater,
+  nix-update-script,
   qt6,
 }:
 
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Soothing pastel theme for SDDM based on corners theme";

--- a/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
@@ -2,37 +2,31 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  libsForQt5,
   unstableGitUpdater,
+  qt6,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "catppuccin-sddm-corners";
-  version = "0-unstable-2024-05-07";
+  version = "0-unstable-2025-03-25";
 
   src = fetchFromGitHub {
     owner = "khaneliman";
     repo = "catppuccin-sddm-corners";
-    rev = "aca5af5ce0c9dff56e947938697dec40ea101e3e";
-    hash = "sha256-xtcNcjNQSG7SwlNw/EkAU93wFaku+cE1/r6c8c4FrBg=";
+    rev = "10831dea7298bd1c3262a7f48417b5af1b92ed99";
+    hash = "sha256-nQImL5eDMENNDCXEqgrL2eszWXtBpbVlzjMxNdpxZlQ=";
   };
 
   dontConfigure = true;
   dontBuild = true;
   dontWrapQtApps = true;
 
-  propagatedBuildInputs = with libsForQt5.qt5; [
-    qtgraphicaleffects
-    qtquickcontrols2
+  propagatedUserEnvPkgs = with qt6; [
+    qt5compat
+    qtwayland
+    qtquick3d
     qtsvg
   ];
-
-  postFixup = ''
-    mkdir -p $out/nix-support
-    echo ${libsForQt5.qt5.qtgraphicaleffects}  >> $out/nix-support/propagated-user-env-packages
-    echo ${libsForQt5.qt5.qtquickcontrols2}  >> $out/nix-support/propagated-user-env-packages
-    echo ${libsForQt5.qt5.qtsvg}  >> $out/nix-support/propagated-user-env-packages
-  '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Migrated sddm theme from qt5 to qt6 since qt5 is becoming EOL soon. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
