### PR TITLE
python3Packages.fast-hadamard-transform: init at 1.0.4

### DIFF
--- a/pkgs/development/python-modules/fast-hadamard-transform/default.nix
+++ b/pkgs/development/python-modules/fast-hadamard-transform/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cudaPackages,
+  config,
+  setuptools,
+  torch,
+  cudaSupport ? config.cudaSupport,
+
+}:
+
+assert cudaSupport -> torch.cudaSupport;
+
+buildPythonPackage rec {
+  pname = "fast-hadamard-transform";
+  version = "1.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "fast-hadamard-transform";
+    tag = "v${version}";
+    hash = "sha256-WFrjTQac+mUcVqW1QmDxbcXzYLU/YSgTnjgQHImpoTc=";
+  };
+
+  nativeBuildInputs = lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ];
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    torch
+  ];
+
+
+  env =
+    {
+      FORCE_CUDA = cudaSupport;
+    }
+    // lib.optionalAttrs cudaSupport {
+      TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
+    };
+
+
+
+  pythonImportsCheck = [ "fast_hadamard_transform" ];
+
+  meta = {
+    description = "Fast Hadamard transform in CUDA";
+    homepage = "https://github.com/Dao-AILab/fast-hadamard-transform";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ osbm ];
+    broken = !cudaSupport;
+  };
+}

--- a/pkgs/development/python-modules/fast-hadamard-transform/default.nix
+++ b/pkgs/development/python-modules/fast-hadamard-transform/default.nix
@@ -6,8 +6,10 @@
   config,
   setuptools,
   torch,
+  ninja,
+  wheel,
   cudaSupport ? config.cudaSupport,
-
+  autoAddDriverRunpath,
 }:
 
 assert cudaSupport -> torch.cudaSupport;
@@ -24,9 +26,14 @@ buildPythonPackage rec {
     hash = "sha256-WFrjTQac+mUcVqW1QmDxbcXzYLU/YSgTnjgQHImpoTc=";
   };
 
-  nativeBuildInputs = lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ];
+  nativeBuildInputs = lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+    autoAddDriverRunpath
+  ];
   build-system = [
     setuptools
+    ninja
+    wheel
   ];
 
   dependencies = [
@@ -39,6 +46,7 @@ buildPythonPackage rec {
       FORCE_CUDA = cudaSupport;
     }
     // lib.optionalAttrs cudaSupport {
+      CUDA_HOME = "${lib.getDev cudaPackages.cuda_nvcc}";
       TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4686,6 +4686,8 @@ self: super: with self; {
 
   farama-notifications = callPackage ../development/python-modules/farama-notifications { };
 
+  fast-hadamard-transform = callPackage ../development/python-modules/fast-hadamard-transform { };
+
   fast-histogram = callPackage ../development/python-modules/fast-histogram { };
 
   fastai = callPackage ../development/python-modules/fastai { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done 
Fixes #376944 

This package Contains Pytorch and CUDA codes.
 I am trying to contribute fast-hadamard-transform to the nixpkgs but the CUDA compilation is killing me.

I am adamant on learning how the CUDA-python hooks and packages works. So please if you see something wrong, just tell me.

If at any point the compilation becomes successful, i will squash these commits.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
