### PR TITLE
fwupd: 2.0.6 -> 2.0.7

### DIFF
--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -84,17 +84,6 @@
 let
   isx86 = stdenv.hostPlatform.isx86;
 
-  # Dell isn't supported on Aarch64
-  haveDell = isx86;
-
-  # only redfish for x86_64
-  haveRedfish = stdenv.hostPlatform.isx86_64;
-
-  # only use msr if x86 (requires cpuid)
-  haveMSR = isx86;
-
-  # # Currently broken on Aarch64
-  # haveFlashrom = isx86;
   # Experimental
   haveFlashrom = isx86 && enableFlashrom;
 
@@ -141,7 +130,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.0.6";
+  version = "2.0.7";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -159,7 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     tag = finalAttrs.version;
-    hash = "sha256-//y2kkCrj6E3kKxZIEK2bBUiZezB9j4xzR6WrBdcpqQ=";
+    hash = "sha256-Rus/GaLdoxC1vZskcZeKYE26ys7iBq6szgl2dh1UPsM=";
   };
 
   patches = [
@@ -262,7 +251,6 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.mesonEnable "docs" true)
       # We are building the official releases.
       (lib.mesonEnable "supported_build" true)
-      (lib.mesonEnable "launchd" false)
       (lib.mesonOption "systemd_root_prefix" "${placeholder "out"}")
       (lib.mesonOption "installed_test_prefix" "${placeholder "installedTests"}")
       "--localstatedir=/var"
@@ -281,17 +269,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals (!enablePassim) [
       (lib.mesonEnable "passim" false)
     ]
-    ++ lib.optionals (!haveDell) [
-      (lib.mesonEnable "plugin_synaptics_mst" false)
-    ]
-    ++ lib.optionals (!haveRedfish) [
-      (lib.mesonEnable "plugin_redfish" false)
-    ]
     ++ lib.optionals (!haveFlashrom) [
       (lib.mesonEnable "plugin_flashrom" false)
-    ]
-    ++ lib.optionals (!haveMSR) [
-      (lib.mesonEnable "plugin_msr" false)
     ];
 
   # TODO: wrapGAppsHook3 wraps efi capsule even though it is not ELF


### PR DESCRIPTION
## Things done

Changelog: https://github.com/fwupd/fwupd/releases/tag/2.0.7

cc @R-VdP

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
