### PR TITLE
librechat: init at 0.7.7

### DIFF
--- a/pkgs/by-name/li/librechat/0001-npm-pack.patch
+++ b/pkgs/by-name/li/librechat/0001-npm-pack.patch
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 2131951..91e4846 100644
+--- a/package.json
++++ b/package.json
+@@ -114,5 +114,15 @@
+       "admin/",
+       "packages/"
+     ]
++  },
++  "files": [
++    "api",
++    "client/dist",
++    "packages/data-provider",
++    "packages/data-schemas",
++    "packages/mcp"
++  ],
++  "bin": {
++    "librechat-server": "api/server/index.js"
+   }
+ }

--- a/pkgs/by-name/li/librechat/0002-logs.patch
+++ b/pkgs/by-name/li/librechat/0002-logs.patch
@@ -1,0 +1,26 @@
+diff --git a/api/config/meiliLogger.js b/api/config/meiliLogger.js
+index 195b387..d445e54 100644
+--- a/api/config/meiliLogger.js
++++ b/api/config/meiliLogger.js
+@@ -2,7 +2,7 @@ const path = require('path');
+ const winston = require('winston');
+ require('winston-daily-rotate-file');
+ 
+-const logDir = path.join(__dirname, '..', 'logs');
++const logDir = path.join('.', 'logs');
+ 
+ const { NODE_ENV } = process.env;
+ 
+diff --git a/api/config/winston.js b/api/config/winston.js
+index 8f51b99..2ebd041 100644
+--- a/api/config/winston.js
++++ b/api/config/winston.js
+@@ -3,7 +3,7 @@ const winston = require('winston');
+ require('winston-daily-rotate-file');
+ const { redactFormat, redactMessage, debugTraverse, jsonTruncateFormat } = require('./parsers');
+ 
+-const logDir = path.join(__dirname, '..', 'logs');
++const logDir = path.join('.', 'logs');
+ 
+ const { NODE_ENV, DEBUG_LOGGING = true, DEBUG_CONSOLE = false, CONSOLE_JSON = false } = process.env;
+ 

--- a/pkgs/by-name/li/librechat/0003-upload-paths.patch
+++ b/pkgs/by-name/li/librechat/0003-upload-paths.patch
@@ -1,0 +1,20 @@
+diff --git a/api/config/paths.js b/api/config/paths.js
+index 165e9e6..fc85083 100644
+--- a/api/config/paths.js
++++ b/api/config/paths.js
+@@ -2,13 +2,13 @@ const path = require('path');
+ 
+ module.exports = {
+   root: path.resolve(__dirname, '..', '..'),
+-  uploads: path.resolve(__dirname, '..', '..', 'uploads'),
++  uploads: path.resolve('.', 'uploads'),
+   clientPath: path.resolve(__dirname, '..', '..', 'client'),
+   dist: path.resolve(__dirname, '..', '..', 'client', 'dist'),
+   publicPath: path.resolve(__dirname, '..', '..', 'client', 'public'),
+   fonts: path.resolve(__dirname, '..', '..', 'client', 'public', 'fonts'),
+   assets: path.resolve(__dirname, '..', '..', 'client', 'public', 'assets'),
+-  imageOutput: path.resolve(__dirname, '..', '..', 'client', 'public', 'images'),
++  imageOutput: path.resolve('.', 'images'),
+   structuredTools: path.resolve(__dirname, '..', 'app', 'clients', 'tools', 'structured'),
+   pluginManifest: path.resolve(__dirname, '..', 'app', 'clients', 'tools', 'manifest.json'),
+ };

--- a/pkgs/by-name/li/librechat/package.nix
+++ b/pkgs/by-name/li/librechat/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  node-gyp,
+  vips,
+  nix-update-script,
+}:
+
+buildNpmPackage rec {
+  pname = "librechat";
+  version = "0.7.7";
+
+  src = fetchFromGitHub {
+    owner = "danny-avila";
+    repo = "LibreChat";
+    tag = "v${version}";
+    hash = "sha256-U0yIoJt7wE4a7WbryN7hheLRFTRVol5qawIrmKte41M=";
+  };
+
+  patches = [
+    # `buildNpmPackage` relies on `npm pack`, which only includes files explicitly
+    # listed in the project's package.json `files` array if this property is set.
+    # LibreChat does not set this property, but we can avoid packaging the whole
+    # workspace by simply adding the relevant paths here ourselves.
+    # Also, we set the `bin` property to the server script to benefit from the
+    # auto-generated wrapper.
+    ./0001-npm-pack.patch
+    # LibreChat tries writing logs to the package directory, which is immutable
+    # in our case. We patch the log directory to target the current working directory
+    # instead, which in case of NixOS will be the service's data directory.
+    ./0002-logs.patch
+    # Similarly to the logs, user uploads are by default written to the package
+    # directory as well. Again, we patch this to be relative to the current working
+    # directory instead.
+    ./0003-upload-paths.patch
+  ];
+
+  npmDepsHash = "sha256-r06Hcdxa7pYMqIvNWP4VclJ4woiPd9kJxEmQO88i8J8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    node-gyp
+  ];
+
+  buildInputs = [
+    vips
+  ];
+
+  # required for sharp
+  makeCacheWritable = true;
+
+  npmBuildScript = "frontend";
+  npmPruneFlags = [ "--omit=dev" ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v(\\d+\\.\\d+\\.\\d+)$"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Open-source app for all your AI conversations, fully customizable and compatible with any AI provider";
+    homepage = "https://github.com/danny-avila/LibreChat";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ niklaskorz ];
+    mainProgram = "librechat-server";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Implements the package part of #352044. The NixOS module will follow in a separate PR for easier review and to get the package in faster, as module reviews usually are more involved than package reviews.

This package has been in use for about five months, so it's been fairly well tested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
