### PR TITLE
`fetchurl`: improve error messages

### DIFF
--- a/pkgs/build-support/dotnet/fetchnuget/default.nix
+++ b/pkgs/build-support/dotnet/fetchnuget/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchurl,
   buildDotnetPackage,
   unzip,
@@ -14,10 +15,12 @@ attrs@{
   ...
 }:
 if md5 != "" then
-  throw "fetchnuget does not support md5 anymore, please use 'hash' attribute with SRI hash"
+  throw "fetchnuget does not support md5 anymore, please use 'hash' attribute with SRI hash: ${
+    lib.generators.toPretty { } attrs
+  }"
 # This is also detected in fetchurl, but we just throw here to avoid confusion
 else if (sha256 != "" && hash != "") then
-  throw "multiple hashes passed to fetchNuGet"
+  throw "multiple hashes passed to fetchNuGet: ${lib.generators.toPretty { } url}"
 else
   buildDotnetPackage (
     {

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -119,16 +119,23 @@ in
 
   # Additional packages needed as part of a fetch
   nativeBuildInputs ? [ ],
-}:
+}@args:
 
 let
   urls_ =
     if urls != [ ] && url == "" then
-      (if lib.isList urls then urls else throw "`urls` is not a list")
+      (
+        if lib.isList urls then urls else throw "`urls` is not a list: ${lib.generators.toPretty { } urls}"
+      )
     else if urls == [ ] && url != "" then
-      (if lib.isString url then [ url ] else throw "`url` is not a string")
+      (
+        if lib.isString url then
+          [ url ]
+        else
+          throw "`url` is not a string: ${lib.generators.toPretty { } urls}"
+      )
     else
-      throw "fetchurl requires either `url` or `urls` to be set";
+      throw "fetchurl requires either `url` or `urls` to be set: ${lib.generators.toPretty { } args}";
 
   hash_ =
     if
@@ -143,7 +150,7 @@ let
         ]
       ) > 1
     then
-      throw "multiple hashes passed to fetchurl"
+      throw "multiple hashes passed to fetchurl: ${lib.generators.toPretty { } urls_}"
     else
 
     if hash != "" then
@@ -155,7 +162,7 @@ let
       if outputHashAlgo != "" then
         { inherit outputHashAlgo outputHash; }
       else
-        throw "fetchurl was passed outputHash without outputHashAlgo"
+        throw "fetchurl was passed outputHash without outputHashAlgo: ${lib.generators.toPretty { } urls_}"
     else if sha512 != "" then
       {
         outputHashAlgo = "sha512";
@@ -177,7 +184,7 @@ let
         outputHash = "";
       }
     else
-      throw "fetchurl requires a hash for fixed-output derivation: ${lib.concatStringsSep ", " urls_}";
+      throw "fetchurl requires a hash for fixed-output derivation: ${lib.generators.toPretty urls_}";
 in
 
 assert


### PR DESCRIPTION
I recently saw this error message, which I needed to use the `--debugger` to locate:

```
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: multiple hashes passed to fetchurl
```

This patch improves the error message, and other error messages from `fetchurl`:

```
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while calling the 'derivationStrict' builtin
         at «internal»:1:208:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: multiple hashes passed to fetchurl: [
         "https://github.com/reorg/pg_repack/archive/refs/tags/ver_1.5.0.tar.gz"
       ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
