### PR TITLE
Cups brother dcpt500wlpr package

### DIFF
--- a/pkgs/misc/cups/drivers/brother/dcpt500w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcpt500w/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cups,
+  dpkg,
+  gnused,
+  makeWrapper,
+  ghostscript,
+  file,
+  a2ps,
+  coreutils,
+  gnugrep,
+  which,
+  gawk,
+}:
+
+let
+  version = "3.0.2-0";
+  model = "dcpt500w";
+in
+rec {
+  driver = stdenv.mkDerivation {
+    pname = "${model}-lpr";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://download.brother.com/welcome/dlf101956/dcpt500wlpr-${version}.i386.deb";
+      sha256 = "+BvDELptQVYRd2clmZYTFea0cDtfJ62Dh8qGIcOzDTg=";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
+    buildInputs = [
+      cups
+      ghostscript
+      a2ps
+      gawk
+    ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter${model} \
+      --replace /opt "$out/opt"
+
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/${model}/lpd/br${model}filter
+
+      mkdir -p $out/lib/cups/filter/
+      ln -s $out/opt/brother/Printers/${model}/lpd/filter${model} $out/lib/cups/filter/brother_lpdwrapper_${model}
+
+      wrapProgram $out/opt/brother/Printers/${model}/lpd/filter${model} \
+        --prefix PATH ":" ${
+          lib.makeBinPath [
+            gawk
+            ghostscript
+            a2ps
+            file
+            gnused
+            gnugrep
+            coreutils
+            which
+          ]
+        }
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadhowto.aspx?c=br&lang=pt&prod=dcpt500w_all&os=128&dlid=dlf101957_000&flang=4&type3=561";
+      maintainers = with maintainers; [ pshirshov ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation {
+    pname = "${model}-cupswrapper";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://download.brother.com/welcome/dlf101957/dcpt500wcupswrapper-${version}.i386.deb";
+      sha256 = "mOT3pxYOeL+VBoVAW8yMUsF30UzlMDp3mRkXu1jyEDg=";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
+    buildInputs = [
+      cups
+      ghostscript
+      a2ps
+      gawk
+    ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      for f in $out/opt/brother/Printers/${model}/cupswrapper/cupswrapper${model}; do
+        wrapProgram $f --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            ghostscript
+            gnugrep
+            gnused
+          ]
+        }
+      done
+
+      mkdir -p $out/share/cups/model
+      ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer CUPS wrapper driver";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadhowto.aspx?c=br&lang=pt&prod=dcpt500w_all&os=128&dlid=dlf101957_000&flang=4&type3=561";
+      maintainers = with maintainers; [ pshirshov ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17023,6 +17023,10 @@ with pkgs;
 
   dcp9020cdw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).cupswrapper;
 
+  dcpt500wlpr = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcpt500w { }).driver;
+
+  dcpt500w-cupswrapper = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcpt500w { }).cupswrapper;
+
   cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };
 
   cups-brother-hl1210w = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1210w { };


### PR DESCRIPTION
<!--
Add cups-brother-dcpt500wlpr printer driver

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add support for the Brother DCP-T500W Network printer. https://support.brother.com/g/b/downloadhowto.aspx?c=br&lang=pt&prod=dcpt500w_all&os=128&dlid=dlf101957_000&flang=4&type3=561

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
