### PR TITLE
python3Packages.waymax: init at 0-unstable-2025-03-25

### DIFF
--- a/pkgs/development/python-modules/waymax/default.nix
+++ b/pkgs/development/python-modules/waymax/default.nix
@@ -1,0 +1,70 @@
+{
+  absl-py,
+  buildPythonPackage,
+  chex,
+  dm-env,
+  dm-tree,
+  fetchFromGitHub,
+  flax,
+  immutabledict,
+  jax,
+  lib,
+  matplotlib,
+  mediapy,
+  numpy,
+  pillow,
+  pytestCheckHook,
+  setuptools,
+  tensorflow,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "waymax";
+  version = "0-unstable-2025-03-25";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "waymo-research";
+    repo = "waymax";
+    rev = "720f9214a9bf79b3da7926497f0cd0468ca3e630";
+    hash = "sha256-B1Rp5MATbEelp6G6K2wwV83QpINhOHgvAxb3mBN52Eg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    absl-py
+    chex
+    dm-env
+    dm-tree
+    flax
+    immutabledict
+    jax
+    matplotlib
+    mediapy
+    numpy
+    pillow
+    tensorflow
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "waymax" ];
+
+  disabledTestPaths = [
+    # Disable visualization tests that require a GUI
+    # waymax/visualization/viz_test.py Fatal Python error: Aborted
+    "waymax/visualization/viz_test.py"
+  ];
+
+  meta = {
+    description = "A JAX-based simulator for autonomous driving research";
+    homepage = "https://github.com/waymo-research/waymax";
+    changelog = "https://github.com/waymo-research/waymax/blob/main/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18905,6 +18905,8 @@ self: super: with self; {
 
   waybackpy = callPackage ../development/python-modules/waybackpy { };
 
+  waymax = callPackage ../development/python-modules/waymax { };
+
   wazeroutecalculator = callPackage ../development/python-modules/wazeroutecalculator { };
 
   wcag-contrast-ratio = callPackage ../development/python-modules/wcag-contrast-ratio { };


### PR DESCRIPTION
cc @justinfu distributing waymax!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
