### PR TITLE
lilypond: modernise, enable docs

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -124,8 +124,12 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Music typesetting system";
-    homepage = "http://lilypond.org/";
-    license = lib.licenses.gpl3;
+    homepage = "https://lilypond.org/";
+    license = with lib.licenses; [
+      gpl3Plus # most code
+      gpl3Only # ly/articulate.ly
+      ofl # mf/
+    ];
     maintainers = with lib.maintainers; [
       marcweber
       yurrriq

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
-    sha256 = "sha256-6W+gNXHHnyDhl5ZTr6vb5O5Cdlo9n9FJU/DNnupReBw=";
+    hash = "sha256-6W+gNXHHnyDhl5ZTr6vb5O5Cdlo9n9FJU/DNnupReBw=";
   };
 
   postInstall = ''
@@ -76,7 +76,8 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    sed -e "s@mem=mf2pt1@mem=$PWD/mf/mf2pt1@" -i scripts/build/mf2pt1.pl
+    substituteInPlace scripts/build/mf2pt1.pl \
+      --replace-fail "mem=mf2pt1" "mem=$PWD/mf/mf2pt1"
     export HOME=$TMPDIR/home
   '';
 
@@ -121,15 +122,15 @@ stdenv.mkDerivation rec {
     supportedFeatures = [ "commit" ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Music typesetting system";
     homepage = "http://lilypond.org/";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
       marcweber
       yurrriq
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 
   FONTCONFIG_FILE = lib.optional stdenv.hostPlatform.isDarwin (makeFontsConf {

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchzip,
   ghostscript,
   gyre-fonts,
   texinfo,
@@ -46,9 +46,9 @@ stdenv.mkDerivation rec {
   pname = "lilypond";
   version = "2.24.4";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "http://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
-    hash = "sha256-6W+gNXHHnyDhl5ZTr6vb5O5Cdlo9n9FJU/DNnupReBw=";
+    hash = "sha256-UYdORvodrVchxslOxpMiXrAh7DtB9sWp9yqZU/jeB9Y=";
   };
 
   postInstall = ''

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -34,10 +34,11 @@
   texliveSmall,
   tex ? texliveSmall.withPackages (
     ps: with ps; [
-      lh
-      metafont
       epsf
       fontinst
+      fontware
+      lh
+      metafont
     ]
   ),
 }:
@@ -69,7 +70,6 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
-    "--disable-documentation"
     # FIXME: these URW fonts are not OTF, configure reports "URW++ OTF files... no".
     "--with-urwotf-dir=${ghostscript.fonts}/share/fonts"
     "--with-texgyre-dir=${gyre-fonts}/share/fonts/truetype/"
@@ -129,12 +129,16 @@ stdenv.mkDerivation rec {
     supportedFeatures = [ "commit" ];
   };
 
+  # documentation makefile uses "out" for different purposes, hence we explicitly set it to an empty string
+  makeFlags = [ "out=" ];
+
   meta = {
     description = "Music typesetting system";
     homepage = "https://lilypond.org/";
     license = with lib.licenses; [
       gpl3Plus # most code
       gpl3Only # ly/articulate.ly
+      fdl13Plus # docs
       ofl # mf/
     ];
     maintainers = with lib.maintainers; [

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -7,9 +7,12 @@
   texinfo,
   imagemagick,
   texi2html,
+  extractpdfmark,
   guile,
   python3,
   gettext,
+  glib,
+  gmp,
   flex,
   perl,
   bison,
@@ -21,9 +24,6 @@
   pango,
   fontforge,
   help2man,
-  zip,
-  netpbm,
-  groff,
   freefont_ttf,
   makeFontsConf,
   makeWrapper,
@@ -81,36 +81,43 @@ stdenv.mkDerivation rec {
     export HOME=$TMPDIR/home
   '';
 
-  nativeBuildInputs = [
-    autoreconfHook
-    bison
-    flex
-    makeWrapper
+  strictDeps = true;
+
+  depsBuildBuild = [
     pkg-config
   ];
 
-  buildInputs = [
-    ghostscript
-    texinfo
-    imagemagick
-    texi2html
-    guile
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
     dblatex
-    tex
-    zip
-    netpbm
-    python3
-    gettext
-    perl
+    extractpdfmark
+    flex # for flex binary
     fontconfig
-    freetype
-    pango
     fontforge
+    gettext
+    ghostscript
+    guile
     help2man
-    groff
-    t1utils
-    boehmgc
+    imagemagick
+    makeWrapper
+    perl
+    pkg-config
+    python3
     rsync
+    t1utils
+    tex
+    texi2html
+    texinfo
+  ];
+
+  buildInputs = [
+    boehmgc
+    flex # FlexLexer.h
+    freetype
+    glib
+    gmp
+    pango
   ];
 
   autoreconfPhase = "NOCONFIGURE=1 sh autogen.sh";

--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -3,7 +3,6 @@
   lib,
   fetchzip,
   ghostscript,
-  gyre-fonts,
   texinfo,
   imagemagick,
   texi2html,
@@ -69,16 +68,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  configureFlags = [
-    # FIXME: these URW fonts are not OTF, configure reports "URW++ OTF files... no".
-    "--with-urwotf-dir=${ghostscript.fonts}/share/fonts"
-    "--with-texgyre-dir=${gyre-fonts}/share/fonts/truetype/"
-  ];
-
   preConfigure = ''
     substituteInPlace scripts/build/mf2pt1.pl \
       --replace-fail "mem=mf2pt1" "mem=$PWD/mf/mf2pt1"
-    export HOME=$TMPDIR/home
   '';
 
   strictDeps = true;

--- a/pkgs/misc/lilypond/unstable.nix
+++ b/pkgs/misc/lilypond/unstable.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  fetchurl,
+  fetchzip,
   lilypond,
 }:
 
 lilypond.overrideAttrs (oldAttrs: rec {
-  version = "2.25.24";
-  src = fetchurl {
+  version = "2.25.25";
+  src = fetchzip {
     url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor version}/lilypond-${version}.tar.gz";
-    hash = "sha256-1n6mJBbZcfQYsmrjWxcG/EtIyF9uHNRVT7fX3+zoXc4=";
+    hash = "sha256-OO3yXA2PgOuUUR4Bo5wP4PieBvIxV1N9hPiapOB6cAE=";
   };
 
   passthru.updateScript = {

--- a/pkgs/misc/lilypond/update.sh
+++ b/pkgs/misc/lilypond/update.sh
@@ -21,5 +21,5 @@ echo "[{\"commitMessage\":\"$ATTR: $PREV -> $NEXT\"}]"
 
 # update hash
 PREV=$(nix eval --raw -f default.nix $ATTR.src.outputHash)
-NEXT=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 $(nix eval --raw -f default.nix $ATTR.src.url)))
+NEXT=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 --unpack $(nix eval --raw -f default.nix $ATTR.src.url)))
 sed -i "s|$PREV|$NEXT|" "$FILE"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **lilypond: modernise**
- **lilypond: fix metadata**
- **lilypond: enable strictDeps**
- **lilypond-unstable: 2.25.24 -> 2.25.25; lilypond: switch to fetchzip**
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

fixes #392943

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
