### PR TITLE
jigasi: 1.1-311-g3de47d0 -> 1.1-374-g0ab957c, fix build

### DIFF
--- a/pkgs/by-name/ji/jigasi/package.nix
+++ b/pkgs/by-name/ji/jigasi/package.nix
@@ -9,10 +9,10 @@
 
 let
   pname = "jigasi";
-  version = "1.1-311-g3de47d0";
+  version = "1.1-374-g0ab957c";
   src = fetchurl {
     url = "https://download.jitsi.org/stable/${pname}_${version}-1_all.deb";
-    hash = "sha256-pwUgkId7AHFjbqYo02fBgm0gsiMqEz+wvwkdy6sgTD0=";
+    hash = "sha256-FLIIQbAjNNoCF6OBV8fpRSX/Xv5PfpP4ztvYElTfhXg=";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
jigasi: 1.1-311-g3de47d0 -> 1.1-374-g0ab957c, fix build

---

Fixes build failure of `jigasi` since `2025-02-07` (addition of `noBrokenSymlinks` hook #370750):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.jigasi.x86_64-linux
https://hydra.nixos.org/build/293018164

Error log:
```text
ERROR: noBrokenSymlinks: the symlink /nix/store/xshm74p1i8939bh23bjmh9kk8q3lqq5g-jigasi-1.1-311-g3de47d0/share/jigasi/lib/libunix-java.so points to a missing target: /nix/store/xshm74p1i8939bh23bjmh9kk8q3lqq5g-jigasi-1.1-311-g3de47d0/share/jigasi/lib/libunix-0.5.1.so
ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
```

`.deb` file from previous version (`1.1-311-g3de47d0`) had broken symlink inside:
```bash
dpkg-deb --contents /nix/store/aj8rfp6y5rykh2b7qaz0w1nks5h6yg17-jigasi_1.1-311-g3de47d0-1_all.deb | grep 'libunix'
lrwxrwxrwx root/root         0 2023-09-28 02:41 ./usr/share/jigasi/lib/libunix-java.so -> libunix-0.5.1.so
```

No symlinks in `.deb` of new version (`1.1-374-g0ab957c`):
```bash
dpkg-deb --contents /nix/store/c9azk4fxnbfrs2zhkqw4m0id2z7wncv2-jigasi_1.1-374-g0ab957c-1_all.deb | grep '\->'
# nothing
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
