### PR TITLE
otb: fix python support

### DIFF
--- a/pkgs/by-name/ot/otb/1-otb-swig-include-itk.diff
+++ b/pkgs/by-name/ot/otb/1-otb-swig-include-itk.diff
@@ -1,0 +1,17 @@
+diff --git a/Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt b/Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt
+index 1a33064..d791805 100644
+--- a/Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt
++++ b/Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt
+@@ -17,6 +17,12 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
++# Add ITK
++find_package(ITK REQUIRED)
++include(${ITK_USE_FILE})
++include_directories(${ITK_INCLUDE_DIRS})
++message(STATUS "ITK FOUND: ${ITK_INCLUDE_DIRS}")
++
+ include_directories( ${Python_INCLUDE_DIRS} )
+ include_directories ( ${CMAKE_CURRENT_SOURCE_DIR})
+ set_source_files_properties ( ../otbApplication.i PROPERTIES CPLUSPLUS ON )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Python support was broken because of missing header files for ITK and swig version [related issue](https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2451). Here I have added a patch to find ITK missing headers and switched to an older swig version until it is supported upstream.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
