### PR TITLE
lttv: fix build with gcc14

### DIFF
--- a/pkgs/by-name/lt/lttv/package.nix
+++ b/pkgs/by-name/lt/lttv/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   pkg-config,
   glib,
   gtk2,
@@ -17,6 +18,15 @@ stdenv.mkDerivation rec {
     url = "https://lttng.org/files/packages/${pname}-${version}.tar.bz2";
     sha256 = "1faldxnh9dld5k0vxckwpqw241ya1r2zv286l6rpgqr500zqw7r1";
   };
+
+  patches = [
+    # fix build with gcc14:
+    (fetchpatch {
+      name = "lttv-c99-compatibility-fix.patch";
+      url = "https://git.lttng.org/?p=lttv.git;a=patch;h=6b9d59fe4cc1dc943501ab6ede93856b2f06c3ce";
+      hash = "sha256-zcLHBri0i10NGkgiZT6QRZbixffYvkzLaFBeC/ESF/U=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
lttv: fix build with gcc14

- add patch from upstream fixing compilation error:
```
state.c: In function 'check_expand':
state.c:274:14: error: type of 'nb' defaults to 'int' []
  274 | static guint check_expand(nb, id)
      |              ^~~~~~~~~~~~
```

---

Fixes build failure of `lttv`, fails since `2025-01-14` (update to GCC14 - #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.lttv.x86_64-linux
https://hydra.nixos.org/build/293035073

Error log:
```text
state.c: In function 'check_expand':
state.c:274:14: error: type of 'nb' defaults to 'int' []
  274 | static guint check_expand(nb, id)
      |              ^~~~~~~~~~~~
```

Tracking issue: #388196

---

For future ref package is unmaintained upstream, but git repo is still up (thought there is no link on homepage anymore):
`git://git.lttng.org/lttv.git`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
