### PR TITLE
{zenmonitor,linuxPackages.zenpower}: Switch to new upstreams and update

### DIFF
--- a/pkgs/by-name/ze/zenmonitor/package.nix
+++ b/pkgs/by-name/ze/zenmonitor/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromGitLab,
   pkg-config,
   gtk3,
   wrapGAppsHook3,
@@ -9,11 +9,10 @@
 
 stdenv.mkDerivation rec {
   pname = "zenmonitor";
-  version = "unstable-2024-05-21";
+  version = "unstable-2024-12-19";
 
-  src = fetchFromGitea {
-    domain = "git.exozy.me";
-    owner = "a";
+  src = fetchFromGitLab {
+    owner = "shdwchn10";
     repo = "zenmonitor3";
     rev = "a09f0b25d33967fd32f3831304be049b008cdabf";
     sha256 = "sha256-5N1Hhv2s0cv4Rujw4wFGHyIy7NyKAFThVvAo+xXqSyk=";

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -2,17 +2,18 @@
   lib,
   stdenv,
   kernel,
-  fetchgit,
+  fetchFromGitLab,
 }:
 
 stdenv.mkDerivation rec {
   pname = "zenpower";
-  version = "unstable-2022-11-04";
+  version = "unstable-2025-02-28";
 
-  src = fetchgit {
-    url = "https://git.unnamed.website/zenpower3/";
-    rev = "c176fdb0d5bcba6ba2aba99ea36812e40f47751f";
-    sha256 = "sha256-d2WH8Zv7F0phZmEKcDiaak9On+Mo9bAFhMulT/N5FWI=";
+  src = fetchFromGitLab {
+    owner = "shdwchn10";
+    repo = "zenpower3";
+    rev = "138fa0637b46a0b0a087f2ba4e9146d2f9ba2475";
+    sha256 = "sha256-kLtkG97Lje+Fd5FoYf+UlSaEyxFaETtXrSjYzFnHkjY=";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -2,17 +2,15 @@
   lib,
   stdenv,
   kernel,
-  fetchFromGitea,
+  fetchgit,
 }:
 
 stdenv.mkDerivation rec {
   pname = "zenpower";
   version = "unstable-2022-11-04";
 
-  src = fetchFromGitea {
-    domain = "git.exozy.me";
-    owner = "a";
-    repo = "zenpower3";
+  src = fetchgit {
+    url = "https://git.unnamed.website/zenpower3/";
     rev = "c176fdb0d5bcba6ba2aba99ea36812e40f47751f";
     sha256 = "sha256-d2WH8Zv7F0phZmEKcDiaak9On+Mo9bAFhMulT/N5FWI=";
   };


### PR DESCRIPTION
- **linuxPackages.zenpower: Switch to renamed upstream**
- **linuxPackages.zenpower: unstable-2022-11-04 -> unstable-2025-02-28**
- **zenmonitor: unstable-2024-05-21 -> unstable-2024-12-19**
