### PR TITLE
tabby: add support for vulkan

### DIFF
--- a/pkgs/by-name/ta/tabby/package.nix
+++ b/pkgs/by-name/ta/tabby/package.nix
@@ -21,7 +21,8 @@
   cudaSupport ? config.cudaSupport,
   rocmSupport ? config.rocmSupport,
   metalSupport ? stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64,
-  # one of [ null "cpu" "rocm" "cuda" "metal" ];
+  vulkanSupport ? false,
+  # one of [ null "cpu" "rocm" "cuda" "metal" "vulkan"];
   acceleration ? null,
 }:
 
@@ -38,6 +39,7 @@ let
     (optional cudaSupport "cuda")
     (optional rocmSupport "rocm")
     (optional metalSupport "metal")
+    (optional vulkanSupport "vulkan")
   ];
 
   warnIfMultipleAccelerationMethods =
@@ -82,6 +84,7 @@ let
     "rocm"
     "cuda"
     "metal"
+    "vulkan"
   ];
 
   # TODO(ghthor): there is a bug here where featureDevice could be cuda, but enableCuda is false
@@ -89,6 +92,7 @@ let
   enableRocm = validAccel && (featureDevice == "rocm") && (warnIfNotLinux "rocm");
   enableCuda = validAccel && (featureDevice == "cuda") && (warnIfNotLinux "cuda");
   enableMetal = validAccel && (featureDevice == "metal") && (warnIfNotDarwinAarch64 "metal");
+  enableVulkan = validAccel && (featureDevice == "vulkan");
 
   # We have to use override here because tabby doesn't actually tell llama-cpp
   # to use a specific device type as it is relying on llama-cpp only being
@@ -100,6 +104,7 @@ let
     rocmSupport = enableRocm;
     cudaSupport = enableCuda;
     metalSupport = enableMetal;
+    vulkanSupport = enableVulkan;
   };
 
   # TODO(ghthor): some of this can be removed

--- a/pkgs/by-name/ta/tabby/package.nix
+++ b/pkgs/by-name/ta/tabby/package.nix
@@ -164,7 +164,7 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     # NOTE: Project contains a subproject for building llama-server
     # But, we already have a derivation for this
-    ln -s ${lib.getExe' llama-cpp "llama-server"} $out/bin/llama-server
+    ln -s ${lib.getExe' llamaccpPackage "llama-server"} $out/bin/llama-server
   '';
 
   env = {


### PR DESCRIPTION
This adds vulkan support for tabby and fixes #306157

Just llama-cpp needs to be overridden for this to work.
Vulkan will be enabled by default, but other accelerations will get precedence.

Currently if another Acceleration is enabled, there will be a warning, that multiple accelerations are targeted if no acceleration was defined.
I don't know if there is a better way to handle the situation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
