### PR TITLE
nixos/spacetimedb: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -536,6 +536,7 @@
   ./services/databases/postgrest.nix
   ./services/databases/redis.nix
   ./services/databases/rethinkdb.nix
+  ./services/databases/spacetimedb.nix
   ./services/databases/surrealdb.nix
   ./services/databases/tigerbeetle.nix
   ./services/databases/victorialogs.nix

--- a/nixos/modules/services/databases/spacetimedb.nix
+++ b/nixos/modules/services/databases/spacetimedb.nix
@@ -1,0 +1,236 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.spacetimedb;
+
+  listenAddr = "${cfg.server.bindAddress}:${toString cfg.server.port}";
+
+  executable = "${lib.getExe cfg.package} --root-dir=${cfg.rootDir} start --listen-addr='${listenAddr}' ${lib.optionalString cfg.server.enableTracy "--enable-tracy"} ${
+    lib.optionalString (
+      cfg.server.jwtPublicKeyPath != null
+    ) "--jwt-pub-key-path=${cfg.server.jwtPublicKeyPath}"
+  } ${
+    lib.optionalString (
+      cfg.server.jwtPrivateKeyPath != null
+    ) "--jwt-priv-key-path=${cfg.server.jwtPrivateKeyPath}"
+  } ${lib.optionalString cfg.server.inMemory "--in-memory"}";
+in
+{
+  options.services.spacetimedb = {
+    enable = lib.mkEnableOption "spacetimedb";
+
+    package = lib.mkPackageOption pkgs "spacetimedb" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "spacetimedb";
+      description = "The user to run SpacetimeDB as.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "spacetimedb";
+      description = "The group to run SpacetimeDB as.";
+    };
+
+    rootDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/spacetime";
+      description = "The root directory for SpacetimeDB.";
+    };
+
+    openFirewall = lib.mkEnableOption "" // {
+      description = "Whether to open the firewall for the SpacetimeDB server.";
+    };
+
+    server = {
+      bindAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "The address to listen on";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 3000;
+        description = "The port to listen on.";
+      };
+
+      enableTracy = lib.mkEnableOption "tracy profiling";
+
+      jwtPublicKeyPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "The path to the public jwt key for verifying identities";
+      };
+
+      jwtPrivateKeyPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "The path to the private jwt key for issuing identities";
+      };
+
+      inMemory = lib.mkEnableOption "" // {
+        description = "If enabled the database will run entirely in memory. After the process exits, all data will be lost.";
+      };
+    };
+
+    nginx = {
+      enable = lib.mkEnableOption "Nginx";
+
+      domain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          The domain used by the nginx virtualHost.
+        '';
+      };
+
+      forceSSL = lib.mkEnableOption "" // {
+        description = "Whether to force the use of SSL.";
+      };
+
+      useACMEHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          A host of an existing Let's Encrypt certificate to use.
+
+          *Note that this still requires services.spacetimedb.nginx.domain to be set.
+        '';
+      };
+
+      restrictPublish = lib.mkEnableOption "" // {
+        description = "Whether to restrict the publish database route to local connections.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.nginx.enable || (cfg.nginx.domain != null);
+        message = "To use services.spacetimedb.nginx, you need to set services.spacetimedb.nginx.domain";
+      }
+    ];
+
+    users.groups = lib.mkIf (cfg.group == "spacetimedb") { spacetimedb = { }; };
+
+    users.users = lib.mkIf (cfg.user == "spacetimedb") {
+      spacetimedb = {
+        group = cfg.group;
+        home = cfg.rootDir;
+        description = "SpacetimeDB Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.tmpfiles.settings."10-spacetimedb" = {
+      ${cfg.rootDir}.d = {
+        inherit (cfg) user group;
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.spacetimedb = {
+      description = "SpacetimeDB Server";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      unitConfig.RequiresMountsFor = cfg.rootDir;
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        Type = "simple";
+        ExecStart = executable;
+        Restart = "always";
+        RestartSec = "15";
+
+        WorkingDirectory = cfg.rootDir;
+
+        # Capabilities
+        CapabilityBoundingSet = "";
+
+        # Security
+        NoNewPrivileges = true;
+
+        # Filesystem Protection
+        ProtectSystem = "full";
+        ProtectHome = true;
+        PrivateTmp = true;
+
+        # Device and System Protection
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+
+        # Network Restriction
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+
+        # Security Hardening
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+
+        # System Call Filtering
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    services.nginx = lib.mkIf cfg.nginx.enable {
+      enable = true;
+      recommendedTlsSettings = true;
+      recommendedOptimisation = true;
+      recommendedGzipSettings = true;
+
+      virtualHosts.${cfg.nginx.domain} = {
+        forceSSL = cfg.nginx.forceSSL;
+
+        enableACME = lib.mkDefault (cfg.nginx.forceSSL && cfg.nginx.useACMEHost == null);
+        useACMEHost = cfg.nginx.useACMEHost;
+
+        locations = {
+          "/" = {
+            proxyPass = "http://${listenAddr}";
+            recommendedProxySettings = true;
+            proxyWebsockets = true;
+          };
+
+          "/v1/publish" = lib.mkIf cfg.nginx.restrictPublish {
+            proxyPass = "http://${listenAddr}";
+            recommendedProxySettings = true;
+            proxyWebsockets = true;
+
+            extraConfig = ''
+              allow 127.0.0.1;
+              deny all;
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  meta.maintainers = [
+    lib.maintainers.akotro
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1368,6 +1368,7 @@ in
   sonarr = runTest ./sonarr.nix;
   sonic-server = runTest ./sonic-server.nix;
   spacecookie = runTest ./spacecookie.nix;
+  spacetimedb = handleTest ./spacetimedb.nix { };
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark { };
   spiped = runTest ./spiped.nix;
   sqlite3-to-mysql = runTest ./sqlite3-to-mysql.nix;

--- a/nixos/tests/spacetimedb.nix
+++ b/nixos/tests/spacetimedb.nix
@@ -1,0 +1,64 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  let
+    allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "spacetimedb" ];
+    port1 = 3000;
+    port2 = 3005;
+  in
+  {
+    name = "spacetimedb";
+    meta.maintainers = [ lib.maintainers.akotro ];
+
+    nodes = {
+      machine1 =
+        { ... }:
+        {
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+
+          services.spacetimedb = {
+            enable = true;
+            nginx = {
+              enable = true;
+              domain = "localhost";
+            };
+          };
+        };
+
+      machine2 =
+        { ... }:
+        {
+          nixpkgs.config.allowUnfreePredicate = allowUnfreePredicate;
+
+          services.spacetimedb = {
+            enable = true;
+            server.port = port2;
+            nginx = {
+              enable = true;
+              domain = "localhost";
+            };
+          };
+        };
+    };
+
+    testScript = ''
+      start_all()
+
+      machine1.wait_for_unit("spacetimedb.service")
+      machine1.wait_for_unit("nginx.service")
+      machine1.wait_for_open_port(${toString port1})
+
+      machine2.wait_for_unit("spacetimedb.service")
+      machine2.wait_for_unit("nginx.service")
+      machine2.wait_for_open_port(${toString port2})
+
+      with subtest("Ping spacetimedb on machine1 (default port: ${toString port1})"):
+        machine1.succeed("curl --fail --show-error --silent http://localhost:${toString port1}/v1/ping")
+        machine1.succeed("spacetime server ping local | grep 'Server is online'")
+
+      with subtest("Ping spacetimedb on machine2 (non-default port: ${toString port2})"):
+        machine2.succeed("spacetime server edit local --url http://localhost:${toString port2} --yes")
+        machine2.succeed("curl --fail --show-error --silent http://localhost:${toString port2}/v1/ping")
+        machine2.succeed("spacetime server ping local | grep 'Server is online'")
+    '';
+  }
+)

--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -10,6 +10,7 @@
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
   },
+  nixosTests,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spacetimedb";
@@ -48,6 +49,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     mv $out/bin/spacetimedb-cli $out/bin/spacetime
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) spacetimedb;
+  };
 
   meta = {
     description = "Full-featured relational database system that lets you run your application logic inside the database";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a module for running a standalone [SpacetimeDB](https://github.com/clockworklabs/SpacetimeDB) server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
