### PR TITLE
python3Packages.mcp: 1.3.0 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -10,6 +10,7 @@
   pydantic,
   pydantic-settings,
   pytest-asyncio,
+  pytest-examples,
   pytestCheckHook,
   python-dotenv,
   rich,
@@ -17,21 +18,25 @@
   starlette,
   typer,
   uvicorn,
+  websockets,
 }:
 
 buildPythonPackage rec {
   pname = "mcp";
-  version = "1.3.0";
+  version = "1.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "python-sdk";
     tag = "v${version}";
-    hash = "sha256-DbRXD4o/uFfpGvrux8lm7/t2utdFDEFg2G7CiraCJd0=";
+    hash = "sha256-Z2NN6k4mD6NixDON1MUOELpBZW9JvMvFErcCbFPdg2o=";
   };
 
   postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "uv-dynamic-versioning"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
     substituteInPlace tests/client/test_stdio.py \
       --replace '/usr/bin/tee' '${lib.getExe' coreutils "tee"}'
   '';
@@ -61,18 +66,24 @@ buildPythonPackage rec {
     rich = [
       rich
     ];
+    ws = [
+      websockets
+    ];
   };
 
   pythonImportsCheck = [ "mcp" ];
 
   nativeCheckInputs = [
     pytest-asyncio
+    pytest-examples
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTests = [
     # attempts to run the package manager uv
     "test_command_execution"
+    # performance-dependent test
+    "test_messages_are_executed_concurrently"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Address https://github.com/NixOS/nixpkgs/issues/392681#issuecomment-2752539821

cc @gaelj. It was easier to just fix it, turns out there was no prior example in python-modules.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).