### PR TITLE
nixos/syncthing: Add GUI password tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1337,6 +1337,7 @@ in
   syncthing = runTest ./syncthing.nix;
   syncthing-no-settings = runTest ./syncthing-no-settings.nix;
   syncthing-guiPassword = runTest ./syncthing-guiPassword.nix;
+  syncthing-guiPasswordFile = runTest ./syncthing-guiPasswordFile.nix;
   syncthing-init = runTest ./syncthing-init.nix;
   syncthing-many-devices = runTest ./syncthing-many-devices.nix;
   syncthing-folders = runTest ./syncthing-folders.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1336,6 +1336,7 @@ in
   sympa = runTest ./sympa.nix;
   syncthing = runTest ./syncthing.nix;
   syncthing-no-settings = runTest ./syncthing-no-settings.nix;
+  syncthing-guiPassword = runTest ./syncthing-guiPassword.nix;
   syncthing-init = runTest ./syncthing-init.nix;
   syncthing-many-devices = runTest ./syncthing-many-devices.nix;
   syncthing-folders = runTest ./syncthing-folders.nix;

--- a/nixos/tests/syncthing-guiPassword.nix
+++ b/nixos/tests/syncthing-guiPassword.nix
@@ -1,0 +1,56 @@
+{ lib, pkgs, ... }:
+{
+  name = "syncthing-guiPassword";
+  meta.maintainers = with lib.maintainers; [ nullcube ];
+  enableOCR = true;
+
+  nodes.machine = {
+    imports = [ ./common/x11.nix ];
+    environment.systemPackages = with pkgs; [
+      syncthing
+      xdotool
+    ];
+
+    programs.firefox = {
+      enable = true;
+      preferences = {
+        # Prevent firefox from asking to save the password
+        "signon.rememberSignons" = false;
+      };
+    };
+
+    services.syncthing = {
+      enable = true;
+      settings.options.urAccepted = -1;
+      settings.gui = {
+        insecureAdminAccess = false;
+        user = "alice";
+        password = "alice_password";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("syncthing.service")
+    machine.wait_for_x()
+    machine.execute("xterm -e 'firefox 127.0.0.1:8384' >&2 &")
+    machine.wait_for_window("Syncthing")
+    machine.screenshot("pre-login")
+
+    with subtest("Syncthing requests authentication"):
+      machine.wait_for_text("Authentication Required", 10)
+
+    with subtest("Syncthing password is valid"):
+      machine.execute("xdotool type \"alice\"")
+      machine.execute("xdotool key Tab")
+      machine.execute("xdotool type \"alice_password\"")
+      machine.execute("xdotool key Enter")
+      machine.sleep(2)
+      machine.wait_for_text("This Device", 10)
+      machine.screenshot("post-login")
+
+    with subtest("Plaintext Syncthing password is not in final config"):
+      config = machine.succeed("cat /var/lib/syncthing/.config/syncthing/config.xml")
+      assert "alice_password" not in config
+  '';
+}

--- a/nixos/tests/syncthing-guiPasswordFile.nix
+++ b/nixos/tests/syncthing-guiPasswordFile.nix
@@ -1,0 +1,56 @@
+{ lib, pkgs, ... }:
+{
+  name = "syncthing-guiPasswordFile";
+  meta.maintainers = with lib.maintainers; [ nullcube ];
+  enableOCR = true;
+
+  nodes.machine = {
+    imports = [ ./common/x11.nix ];
+    environment.systemPackages = with pkgs; [
+      syncthing
+      xdotool
+    ];
+
+    programs.firefox = {
+      enable = true;
+      preferences = {
+        # Prevent firefox from asking to save the password
+        "signon.rememberSignons" = false;
+      };
+    };
+
+    services.syncthing = {
+      enable = true;
+      settings.options.urAccepted = -1;
+      settings.gui = {
+        insecureAdminAccess = false;
+        user = "alice";
+      };
+      guiPasswordFile = (pkgs.writeText "syncthing-password-file" ''alice_password'').outPath;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("syncthing.service")
+    machine.wait_for_x()
+    machine.execute("xterm -e 'firefox 127.0.0.1:8384' >&2 &")
+    machine.wait_for_window("Syncthing")
+    machine.screenshot("pre-login")
+
+    with subtest("Syncthing requests authentication"):
+      machine.wait_for_text("Authentication Required", 10)
+
+    with subtest("Syncthing password is valid"):
+      machine.execute("xdotool type \"alice\"")
+      machine.execute("xdotool key Tab")
+      machine.execute("xdotool type \"alice_password\"")
+      machine.execute("xdotool key Enter")
+      machine.sleep(2)
+      machine.wait_for_text("This Device", 10)
+      machine.screenshot("post-login")
+
+    with subtest("Plaintext Syncthing password is not in final config"):
+      config = machine.succeed("cat /var/lib/syncthing/.config/syncthing/config.xml")
+      assert "alice_password" not in config
+  '';
+}


### PR DESCRIPTION
Requires: #290485

While reviewing and testing said PR I realized it would probably be good to actually have a nixos test to verify the password options are working correctly.

There are currently two tests, one for the method of setting the password directly that is currently in Nixpkgs, and then one for testing the new guiPasswordFile option being added in the PR mentioned above. With the existing nixpkgs method I am only setting the option to a plain text password, even though you can add a pre-hashed password, so you could say that is an area these tests don't cover but in practice I'm not sure if it makes much of a difference. These could all in theory be combined into a single test with multiple nodes, but I felt like one test per method was probably best, even though they do share most of their code. This could be changed if desired.

There is also a check to make sure the plain text version of the password doesn't appear in the final syncthing config but I'm not sure if that is strictly necessary, or if the check works properly. Not sure how to best test that.

To check if the password succeeded I check to see if `This Device` appears on screen, which is a part of the normal Syncthing web interface when you're authenticated. I did notice as well the window title also changes from `(unknown device) | Syncthing` to the hostname of the machine, which is a faster check, but I'm assuming that checking for "This Device" would be more robust?

You might be able to curl or query the config of syncthing via commands instead, which might be a better approach, but I wanted to check if the web interface was working properly with everything as well, so I'm just using the full xorg session for the test.

This is my first time writing NixOS tests, so any feedback or advice is appreciated.

Final sidenote: It might be worth moving the syncthing tests into their own folder, but I'm not sure if there's any specific criteria for which get their own folder or not, and that might fall outside the scope of this PR anyways. 

Tagging test maintainers:
@chkno @Lassulus

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
