### PR TITLE
libtickit: split package in dev, man and out outputs and fix cross compilation

### DIFF
--- a/pkgs/by-name/li/libtickit/002-use-pkg-config-env-var.patch
+++ b/pkgs/by-name/li/libtickit/002-use-pkg-config-env-var.patch
@@ -1,0 +1,61 @@
+diff --git a/Makefile b/Makefile
+index a5b810f..8b18467 100644
+--- a/Makefile
++++ b/Makefile
+@@ -19,18 +19,18 @@ ifeq ($(PROFILE),1)
+   override LDFLAGS+=-pg
+ endif
+ 
+-ifeq ($(shell pkg-config --atleast-version=1.1.0 unibilium && echo 1),1)
+-  override CFLAGS +=$(shell pkg-config --cflags unibilium) -DHAVE_UNIBILIUM
+-  override LDFLAGS+=$(shell pkg-config --libs   unibilium)
+-else ifeq ($(shell pkg-config ncursesw && echo 1),1)
+-  override CFLAGS +=$(shell pkg-config --cflags ncursesw)
+-  override LDFLAGS+=$(shell pkg-config --libs   ncursesw)
++ifeq ($(shell $(PKG_CONFIG) --atleast-version=1.1.0 unibilium && echo 1),1)
++  override CFLAGS +=$(shell $(PKG_CONFIG) --cflags unibilium) -DHAVE_UNIBILIUM
++  override LDFLAGS+=$(shell $(PKG_CONFIG) --libs   unibilium)
++else ifeq ($(shell $(PKG_CONFIG) ncursesw && echo 1),1)
++  override CFLAGS +=$(shell $(PKG_CONFIG) --cflags ncursesw)
++  override LDFLAGS+=$(shell $(PKG_CONFIG) --libs   ncursesw)
+ else
+   override LDFLAGS+=-lncurses
+ endif
+ 
+-override CFLAGS +=$(shell pkg-config --cflags termkey)
+-override LDFLAGS+=$(shell pkg-config --libs   termkey)
++override CFLAGS +=$(shell $(PKG_CONFIG) --cflags termkey)
++override LDFLAGS+=$(shell $(PKG_CONFIG) --libs   termkey)
+ 
+ CFILES=$(sort $(wildcard src/*.c))
+ HFILES=$(sort $(wildcard include/*.h))
+@@ -44,11 +44,11 @@ TESTFILES=$(TESTSOURCES:.c=.t)
+ 
+ EXAMPLESOURCES=$(sort $(wildcard examples/*.c))
+ 
+-ifneq ($(shell pkg-config glib-2.0 && echo 1),1)
++ifneq ($(shell $(PKG_CONFIG) glib-2.0 && echo 1),1)
+   EXAMPLESOURCES:=$(filter-out examples/evloop-glib.c, $(EXAMPLESOURCES))
+ endif
+ 
+-ifneq ($(shell pkg-config libuv && echo 1),1)
++ifneq ($(shell $(PKG_CONFIG) libuv && echo 1),1)
+   EXAMPLESOURCES:=$(filter-out examples/evloop-libuv.c, $(EXAMPLESOURCES))
+ endif
+ 
+@@ -107,11 +107,11 @@ clean: clean-test
+ 	$(LIBTOOL) --mode=clean rm -f $(EXAMPLEOBJECTS) $(EXAMPLES)
+ 	$(LIBTOOL) --mode=clean rm -f $(LIBRARY)
+ 
+-examples/evloop-glib.lo: CFLAGS +=$(shell pkg-config --cflags glib-2.0)
+-examples/evloop-glib:    LDFLAGS+=$(shell pkg-config --libs   glib-2.0)
++examples/evloop-glib.lo: CFLAGS +=$(shell $(PKG_CONFIG) --cflags glib-2.0)
++examples/evloop-glib:    LDFLAGS+=$(shell $(PKG_CONFIG) --libs   glib-2.0)
+ 
+-examples/evloop-libuv.lo: CFLAGS +=$(shell pkg-config --cflags libuv)
+-examples/evloop-libuv:    LDFLAGS+=$(shell pkg-config --libs   libuv)
++examples/evloop-libuv.lo: CFLAGS +=$(shell $(PKG_CONFIG) --cflags libuv)
++examples/evloop-libuv:    LDFLAGS+=$(shell $(PKG_CONFIG) --libs   libuv)
+ 
+ .PHONY: examples
+ examples: $(EXAMPLES)

--- a/pkgs/by-name/li/libtickit/package.nix
+++ b/pkgs/by-name/li/libtickit/package.nix
@@ -8,28 +8,36 @@
   libtermkey,
   unibilium,
 }:
-let
-  version = "0.4.5";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtickit";
-  inherit version;
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "leonerd";
     repo = "libtickit";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-q8JMNFxmnyOiUso4nXLZjJIBFYR/EF6g45lxVeY0f1s=";
   };
+
+  outputs = [
+    "dev"
+    "man"
+    "out"
+  ];
 
   patches = [
     # Disabled on darwin, since test assumes TERM=linux
     ./001-skip-test-18term-builder-on-macos.patch
+    # Make the Makefile use $(PKG_CONFIG) instead of pkg-config, allowing for
+    # cross compilation.
+    ./002-use-pkg-config-env-var.patch
   ];
 
   nativeBuildInputs = [
     pkg-config
     libtool
+    libtermkey
+    unibilium
   ];
 
   buildInputs = [
@@ -49,7 +57,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  doCheck = !stdenv.hostPlatform.isStatic;
 
   meta = with lib; {
     description = "Terminal interface construction kit";
@@ -63,4 +71,4 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ onemoresuza ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Split package in dev, man and out outputs

Change `doCheck` to `stdenv.hostPlatform.isStaic`, since the tests
fail on static builds.

Patch `pkg-config` to become `$(PKG_CONFIG)`, allowing for cross
compilation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
