### PR TITLE
copilot-language-server: add fhs version

### DIFF
--- a/pkgs/by-name/co/copilot-language-server/package.nix
+++ b/pkgs/by-name/co/copilot-language-server/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  buildFHSEnv,
   fetchzip,
   nix-update-script,
 }:
@@ -24,30 +25,48 @@ let
     }
     ."${stdenvNoCC.hostPlatform.system}"
       or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
-in
 
+  executableName = "copilot-language-server";
+  fhs =
+    { package }:
+    buildFHSEnv {
+      name = package.meta.mainProgram;
+      version = package.version;
+      targetPkgs = pkgs: [ pkgs.stdenv.cc.cc.lib ];
+      runScript = lib.getExe package;
+
+      meta = package.meta // {
+        description =
+          package.meta.description
+          + " (FHS-wrapped, expand package details for further information when to use it)";
+        longDescription = "Use this version if you encounter an error like `Could not start dynamically linked executable` or `SyntaxError: Invalid or unexpected token` (see nixpkgs issue [391730](https://github.com/NixOS/nixpkgs/issues/391730)).";
+      };
+    };
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "copilot-language-server";
-  version = "1.290.0";
+  version = "1.294.0";
 
   src = fetchzip {
     url = "https://github.com/github/copilot-language-server-release/releases/download/${finalAttrs.version}/copilot-language-server-native-${finalAttrs.version}.zip";
-    hash = "sha256-ELOSeb3Z7AI8pjDhtUIRoaf+4UXjXKEu/OJ2CLQno6A=";
+    hash = "sha256-8nB8vlrSy+949HiJRCa9yFqu/GAaluFH1VzE63AUUs8=";
     stripRoot = false;
   };
 
-  npmDepsHash = "sha256-PLX/mN7xu8gMh2BkkyTncP3+rJ3nBmX+pHxl0ONXbe4=";
   installPhase = ''
     runHook preInstall
 
-    install -Dt "$out"/bin "${os}-${arch}"/copilot-language-server
+    install "${os}-${arch}/${executableName}" -Dm755 -t "$out"/bin
 
     runHook postInstall
   '';
 
   dontStrip = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    fhs = fhs { package = finalAttrs.finalPackage; };
+  };
 
   meta = {
     description = "Use GitHub Copilot with any editor or IDE via the Language Server Protocol";
@@ -60,7 +79,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       shortName = "GitHub Copilot License";
       url = "https://github.com/customer-terms/github-copilot-product-specific-terms";
     };
-    mainProgram = "copilot-language-server";
+    mainProgram = executableName;
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -294,6 +294,8 @@ with pkgs;
 
   coolercontrol = recurseIntoAttrs (callPackage ../applications/system/coolercontrol { });
 
+  copilot-language-server-fhs = copilot-language-server.fhs;
+
   curv = callPackage ../by-name/cu/curv/package.nix {
     openexr = openexr_3;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Solves issue #391730 and closes the PR #391748.

The main inspiration for the FHS environment were the vscode and zed-editor packages. An `fhs` passthru has been created and later referenced in `pkgs/top-level/all-packages.nix`.
I am not quite sure, if this is the correct of doing this, but it was the only reference I had.

This PR will provide an additional package `copilot-language-server-fhs`, which should solve the issue addressed in #391730. The "normal" package is kept, since it works on stable releases so far. It is possible, when `25.05` is released, that the normal package will break. The FHS package will then become the default one in the future.

I would be happy if someone could provide a better solution or a fix to the underlying problem. I guess it isn't packages correctly or the package needs additional information?

As for the PR #391748: using the auto patch hook breaks the binary and AFAIK it can't be fixed afterwards, which makes FHS environments the only solution.

If someone has the same problem as addressed in the issue, please test this PR and see if it solves your problem. Looking forward for your feedback.

**For those who have a merge/commit bit**: please only merge this PR after some testing has been done!

TODO:
- It would be nice to have a [`versionCheckHook`](https://nixos.org/manual/nixpkgs/stable/#versioncheckhook) too, but I am not sure if I should introduce this in this PR or make a separate one.

Ping: @wattmto @drupol @brianmcgillion 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
