### PR TITLE
zenmap: init at 7.95

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16452,6 +16452,13 @@
     githubId = 6295090;
     name = "Mats";
   };
+  mymindstorm = {
+    name = "Brendan Early";
+    email = "mymindstorm@evermiss.net";
+    github = "mymindstorm";
+    githubId = 27789806;
+    keys = [ { fingerprint = "52B9 A09F 788F 4D1F 0C94  9EBE EE39 A9F3 0C9D 72B5"; } ];
+  };
   mynacol = {
     github = "Mynacol";
     githubId = 26695166;

--- a/pkgs/by-name/ze/zenmap/package.nix
+++ b/pkgs/by-name/ze/zenmap/package.nix
@@ -1,0 +1,81 @@
+{
+  gobject-introspection,
+  gtk3,
+  lib,
+  nmap,
+  python3Packages,
+  wrapGAppsHook3,
+  xterm,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "zenmap";
+  version = nmap.version;
+  pyproject = true;
+
+  src = nmap.src;
+
+  prePatch = ''
+    cd zenmap
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  buildInputs = [
+    nmap
+    gtk3
+    xterm
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  nativeCheckInputs = [
+    nmap
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ nmap ]})
+  '';
+  postInstall = ''
+    # Icons
+    install -Dm 644 "zenmapCore/data/pixmaps/zenmap.png" -t "$out/share/pixmaps/"
+    # Desktop-files for application
+    install -Dm 644 "install_scripts/unix/zenmap.desktop" -t "$out/share/applications/"
+    install -Dm 644 "install_scripts/unix/zenmap-root.desktop" -t "$out/share/applications/"
+    install -Dm 755 "install_scripts/unix/su-to-zenmap.sh" -t "$out/bin/"
+    substituteInPlace "$out/bin/su-to-zenmap.sh" \
+        --replace-fail 'COMMAND="zenmap"' \
+                      'COMMAND="'"$out/bin/zenmap"'"' \
+        --replace-fail 'xterm' \
+                      '"${xterm}/bin/xterm"'
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    cd test
+    ${python3Packages.python.interpreter} run_tests.py 2>&1 | tee /dev/stderr | tail -n1 | grep '^OK$'
+
+    runHook postCheck
+  '';
+
+  meta = nmap.meta // {
+    description = "Offical nmap Security Scanner GUI";
+    homepage = "https://nmap.org/zenmap/";
+    maintainers = with lib.maintainers; [
+      dvaerum
+      mymindstorm
+    ];
+  };
+}


### PR DESCRIPTION
Fixes #287288

Zenmap is the offical GUI for nmap, a network scanner. It was previously included in nixpkgs, but disabled due to requiring python 2. Since then, upstream has migrated to python 3.

Zenmap is also a bit strange to package because its source code lives in a subdirectory of nmap's source code. A new package seemed most appropriate because I felt that adding an option to nmap would overcomplicate things. I was also unable to build it using nmap's makefile, whereas `buildPythonPackage` works perfectly. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
