### PR TITLE
Add Xen multiboot kernel to bootspec and package, refactor boot options, add xen bootspec support to Limine

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -51,7 +51,7 @@ let
         gnused
         jq
       ])
-      ++ optionals (cfg.efi.bootBuilderVerbosity == "info") (
+      ++ optionals (cfg.boot.builderVerbosity == "info") (
         with pkgs;
         [
           bat
@@ -146,6 +146,48 @@ in
         "path"
       ]
     )
+    (mkRenamedOptionModule
+      [
+        "virtualisation"
+        "xen"
+        "efi"
+        "bootBuilderVerbosity"
+      ]
+      [
+        "virtualisation"
+        "xen"
+        "boot"
+        "builderVerbosity"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "virtualisation"
+        "xen"
+        "bootParams"
+      ]
+      [
+        "virtualisation"
+        "xen"
+        "boot"
+        "params"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "virtualisation"
+        "xen"
+        "efi"
+        "path"
+      ]
+      [
+        "virtualisation"
+        "xen"
+        "boot"
+        "efi"
+        "path"
+      ]
+    )
   ];
 
   ## Interface ##
@@ -178,25 +220,24 @@ in
       };
     };
 
-    bootParams = mkOption {
-      default = [ ];
-      example = ''
-        [
-          "iommu=force:true,qinval:true,debug:true"
-          "noreboot=true"
-          "vga=ask"
-        ]
-      '';
-      type = listOf str;
-      description = ''
-        Xen Command Line parameters passed to Domain 0 at boot time.
-        Note: these are different from `boot.kernelParams`. See
-        the [Xen documentation](https://xenbits.xenproject.org/docs/unstable/misc/xen-command-line.html) for more information.
-      '';
-    };
-
-    efi = {
-      bootBuilderVerbosity = mkOption {
+    boot = {
+      params = mkOption {
+        default = [ ];
+        example = ''
+          [
+            "iommu=force:true,qinval:true,debug:true"
+            "noreboot=true"
+            "vga=ask"
+          ]
+        '';
+        type = listOf str;
+        description = ''
+          Xen Command Line parameters passed to Domain 0 at boot time.
+          Note: these are different from `boot.kernelParams`. See
+          the [Xen documentation](https://xenbits.xenproject.org/docs/unstable/misc/xen-command-line.html) for more information.
+        '';
+      };
+      builderVerbosity = mkOption {
         type = enum [
           "default"
           "info"
@@ -206,7 +247,7 @@ in
         default = "default";
         example = "info";
         description = ''
-          The EFI boot entry builder script should be called with exactly one of the following arguments in order to specify its verbosity:
+          The boot entry builder script should be called with exactly one of the following arguments in order to specify its verbosity:
 
           - `quiet` supresses all messages.
 
@@ -220,19 +261,33 @@ in
           This option does not alter the actual functionality of the script, just the number of messages printed when rebuilding the system.
         '';
       };
-
-      path = mkOption {
-        type = path;
-        default = "${cfg.package.boot}/${cfg.package.efi}";
-        defaultText = literalExpression "\${config.virtualisation.xen.package.boot}/\${config.virtualisation.xen.package.efi}";
-        example = literalExpression "\${config.virtualisation.xen.package}/boot/efi/efi/nixos/xen-\${config.virtualisation.xen.package.version}.efi";
-        description = ''
-          Path to xen.efi. `pkgs.xen` is patched to install the xen.efi file
-          on `$boot/boot/xen.efi`, but an unpatched Xen build may install it
-          somewhere else, such as `$out/boot/efi/efi/nixos/xen.efi`. Unless
-          you're building your own Xen derivation, you should leave this
-          option as the default value.
-        '';
+      bios = {
+        path = mkOption {
+          type = path;
+          default = "${cfg.package.boot}/${cfg.package.multiboot}";
+          defaultText = literalExpression "\${config.virtualisation.xen.package.boot}/\${config.virtualisation.xen.package.multiboot}";
+          example = literalExpression "\${config.virtualisation.xen.package}/boot/xen-\${config.virtualisation.xen.package.version}";
+          description = ''
+            Path to the Xen `multiboot` binary used for BIOS booting.
+            Unless you're building your own Xen derivation, you should leave this
+            option as the default value.
+          '';
+        };
+      };
+      efi = {
+        path = mkOption {
+          type = path;
+          default = "${cfg.package.boot}/${cfg.package.efi}";
+          defaultText = literalExpression "\${config.virtualisation.xen.package.boot}/\${config.virtualisation.xen.package.efi}";
+          example = literalExpression "\${config.virtualisation.xen.package}/boot/efi/efi/nixos/xen-\${config.virtualisation.xen.package.version}.efi";
+          description = ''
+            Path to xen.efi. `pkgs.xen` is patched to install the xen.efi file
+            on `$boot/boot/xen.efi`, but an unpatched Xen build may install it
+            somewhere else, such as `$out/boot/efi/efi/nixos/xen.efi`. Unless
+            you're building your own Xen derivation, you should leave this
+            option as the default value.
+          '';
+        };
       };
     };
 
@@ -612,8 +667,9 @@ in
       {
         assertion =
           config.boot.loader.systemd-boot.enable
-          || (config.boot ? lanzaboote) && config.boot.lanzaboote.enable;
-        message = "Xen only supports booting on systemd-boot or Lanzaboote.";
+          || (config.boot ? lanzaboote) && config.boot.lanzaboote.enable
+          || config.boot.loader.limine.enable;
+        message = "Xen only supports booting on systemd-boot, Lanzaboote or Limine.";
       }
       {
         assertion = config.boot.initrd.systemd.enable;
@@ -639,7 +695,7 @@ in
       }
     ];
 
-    virtualisation.xen.bootParams =
+    virtualisation.xen.boot.params =
       optionals cfg.trace [
         "loglvl=all"
         "guest_loglvl=all"
@@ -692,17 +748,28 @@ in
       '';
 
       # Xen Bootspec extension. This extension allows NixOS bootloaders to
-      # fetch the `xen.efi` path and access the `cfg.bootParams` option.
+      # fetch the dom0 kernel paths and access the `cfg.boot.params` option.
       bootspec.extensions = {
+        # Bootspec extension v1 is deprecated, and will be removed in 26.05
+        # It is present for backwards compatibility
         "org.xenproject.bootspec.v1" = {
-          xen = cfg.efi.path;
-          xenParams = cfg.bootParams;
+          xen = cfg.boot.efi.path;
+          xenParams = cfg.boot.params;
+        };
+        # Bootspec extension v2 includes more detail,
+        # including supporting multiboot, and is the current supported
+        # bootspec extension
+        "org.xenproject.bootspec.v2" = {
+          efiPath = cfg.boot.efi.path;
+          multibootPath = cfg.boot.bios.path;
+          version = cfg.package.version;
+          params = cfg.boot.params;
         };
       };
 
       # See the `xenBootBuilder` script in the main `let...in` statement of this file.
       loader.systemd-boot.extraInstallCommands = ''
-        ${getExe xenBootBuilder} ${cfg.efi.bootBuilderVerbosity}
+        ${getExe xenBootBuilder} ${cfg.boot.builderVerbosity}
       '';
     };
 


### PR DESCRIPTION
This PR aims to re-introduce support for booting the multiboot binary we build as part of the Xen package so that compatible bootloaders may use the Xen bootspec extension to build BIOS-bootable Xen dom0 configurations for a NixOS system. This change does not interfere in any way with the current ability to build and boot EFI-based Xen dom0 nixos systems.

It also includes changes to the Limine bootloader module to support the Xen bootspec extension, allowing booting on BIOS-based systems.

In summary, these changes:
 - Add an uncompressed multiboot binary for the Xen dom0 kernel to the `boot` output of the `xen-<version>` package
 - Extend the existing Xen bootspec extension to include EFI, Multiboot, version and parameter information
 - Refactors the options pertaining to the dom0 kernel build and configuration to not be EFI-specific.
 - Updates the existing boot builder to use the updated bootspec extension schema when fetching the EFI binary path
 - Make some small tweaks to formatting suggested by the `nixd` language server
 - Extend the Limine install script to detect and build boot entries for the Xen dom0 kernel if the bootspec extension is present for a generation

Configuration changes summary:
 - The `virtualisation.xen.boot` configuration object has been introduced
 - Several non-EFI-specific settings have been moved under `virtualisation.xen.boot` instead of `virtualisation.xen.efi`
 - The `virtualisation.xen.biosBoot` and `virtualisation.xen.efiBoot` objects have been added to the configuration, and multiboot/BIOS-specific and EFI-specific options moved under these keys
 - No Limine configuration options are modified

Bootspec extension changes summary:
 - Added `version` to the bootspec extension to make it easier to generate menus and labels in compatible bootloader modules 
 - Renamed `xen` to `efiPath` for the EFI-specific binary in the `boot` output, and updated the boot builder to use this key
 - Added `multibootPath` for the uncompressed multiboot binary within the `boot` output of the package

Limine install script changes summary:
 - Adds a helper function to generate one or more "Xen" entries for booting a Xen hypervisor, using NixOS as dom0
 - Supports both EFI (untested on hardware) and BIOS boot (tested on hardware - Coreboot+SeaBIOS)
 - The Xen helper function is called for each generation and only produces additional multiboot entires if BIOS and/or EFI booting is configured, and the relevant Hypervisor binary is present in the bootspec extension

Packaging (build support) changes for Xen summary:
 - Post-build, decompress the gzip-compressed multiboot binary as not all bootloaders (i.e Limine) support compressed multiboot kernels
 - Add the decompressed multiboot binary to the package outputs as `multiboot`

These changes do not:
- Enable GRUB to be used for booting Xen dom0 kernels. The grub support has been deprecated and we now have Limine as a maintained option for booting BIOS-based systems.
 - Interfere with existing NixOS configurations. Any changed settings in the dom0 module have been configured with `mkRenamedOptionModule` so that users are notified on the change but their existing configuration will still work with the previous EFI-specific configuration options.
 - Remove any existing functionality or configuration options. All renamed options have counterparts in the non-EFI-specific configuration schema proposed in this PR.
 - Modify any Limine module options, or interfere with existing menu generation code. All Xen code is in a separate function called when the Xen bootspec extension is present

Things I have tested:
 - End-to-end build of a BIOS-based Xen dom0 system using this module and the modified Limine install script, running on Coreboot+SeaBIOS, including general Xen functionality on the booted system. No problems were found.

**Limine Install script note!**

This one is mostly only interesting for Limine maintainers.

For some odd reason, I noticed that the first entry in the cmdline and module_string seems to be ignored when using the multiboot module. I've worked around this in the script, but also want to investigate if this is a bug in the script or the limine host binary. It seems from the logs it is being correctly passed, but when booting the first argument seems to be ignored or not received by the relevant multiboot kernel or Linux kernel (which is loaded as the second module, the Xen kernel being the first). I've worked around this by adding a -- as the first argument, as this is a no-op and everything works correctly with this in place.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
