### PR TITLE
nixos/recyclarr: add settings configuration option

### DIFF
--- a/nixos/modules/services/misc/recyclarr.nix
+++ b/nixos/modules/services/misc/recyclarr.nix
@@ -14,6 +14,7 @@ let
   secretsReplacement = utils.genJqSecretsReplacement {
     loadCredential = true;
   } cfg.configuration configPath;
+  settingsPath = "${stateDir}/settings.yml";
 in
 {
   options.services.recyclarr = {
@@ -52,6 +53,61 @@ in
 
         The configuration is processed using [utils.genJqSecretsReplacement](https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/utils.nix#L232-L331) to handle secret substitution.
         ```
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = {
+        enable_ssl_certificate_validation = true;
+        git_path = lib.literalExpression "\${lib.getExe pkgs.git}";
+
+        log_janitor = {
+          max_files = 20;
+        };
+
+        notifications = {
+          verbosity = "normal";
+          apprise = {
+            mode = "stateful";
+            base_url = "http://localhost:8000";
+            key = "recyclarr";
+            tags = "foo bar, baz";
+          };
+        };
+
+        resource_providers = [
+          # Git-based provider (trash-guides or config-templates)
+          {
+            name = "trash_guides";
+            type = "trash-guides";
+            clone_url = "https://github.com/TRaSH-/Guides.git";
+            reference = "master";
+            replace_default = true;
+          }
+          {
+            name = "config-templates";
+            type = "config-templates";
+            clone_url = "https://github.com/recyclarr/config-templates.git";
+            reference = "master";
+            replace_default = true;
+          }
+          # Local directory provider (custom-formats)
+          {
+            name = "my-language-cfs";
+            type = "custom-formats";
+            path = lib.literalExpression "./path/to/custom-radarr-formats";
+            service = "radarr";
+            replace_default = false;
+          }
+        ];
+      };
+      description = ''
+        Recyclarr YAML settings as a Nix attribute set.
+
+        For detailed settings options and examples, see the
+        [official settings reference](https://recyclarr.dev/reference/settings/).
       '';
     };
 
@@ -98,7 +154,10 @@ in
     systemd.services.recyclarr = {
       description = "Recyclarr Service";
 
-      preStart = secretsReplacement.script;
+      preStart = ''
+        ${secretsReplacement.script}
+        ${pkgs.coreutils}/bin/ln -fs ${format.generate "settings.yaml" cfg.settings} ${settingsPath}
+      '';
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
Creates the settings file used by recyclarr, allowing for alternative git repos to be referenced for custom formats and other services such as logs and notifications

https://recyclarr.dev/wiki/yaml/settings-reference/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
