### PR TITLE
{recon-ng,xdg-desktop-portal}: use replaceVars instead of substituteAll

### DIFF
--- a/pkgs/by-name/re/recon-ng/package.nix
+++ b/pkgs/by-name/re/recon-ng/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   python3,
-  substituteAll,
+  replaceVars,
   fetchpatch,
 }:
 python3.pkgs.buildPythonApplication rec {
@@ -49,8 +49,7 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch =
     let
-      setup = substituteAll {
-        src = ./setup.py;
+      setup = replaceVars ./setup.py {
         inherit pname version;
       };
     in

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -27,7 +27,7 @@
   gst_all_1,
   libgudev,
   umockdev,
-  substituteAll,
+  replaceVars,
   enableGeoLocation ? true,
   enableSystemd ? true,
 }:
@@ -51,14 +51,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # The icon validator copied from Flatpak needs to access the gdk-pixbuf loaders
     # in the Nix store and cannot bind FHS paths since those are not available on NixOS.
-    (substituteAll {
-      src = ./fix-icon-validation.patch;
+    (replaceVars ./fix-icon-validation.patch {
       inherit (builtins) storeDir;
     })
 
     # Same for the sound validator, except the gdk-pixbuf part.
-    (substituteAll {
-      src = ./fix-sound-validation.patch;
+    (replaceVars ./fix-sound-validation.patch {
       inherit (builtins) storeDir;
     })
 


### PR DESCRIPTION
Since `replaceVars` is more robust than `substituteAll`, `substituteAll` has been migrated away from in a treewide.
Some packages still get merged that use `substituteAll`.

Not sure how we can avoid people resorting to use `substituteAll`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
