### PR TITLE
clean: init at 3.1

### DIFF
--- a/pkgs/by-name/cl/clean/chroot-build-support-do-not-rebuild-equal-timestamps.patch
+++ b/pkgs/by-name/cl/clean/chroot-build-support-do-not-rebuild-equal-timestamps.patch
@@ -1,0 +1,21 @@
+The clean command line compiler clm uses timestamps of dcl, icl, abc and o files
+to decide what must be rebuild.  However as for chroot builds, all of the
+library files will have equal timestamps, this leads to clm trying to rebuild
+the library modules distributed with the Clean installation every time a user
+compiles any file, which fails ue to the absence of write permission on the Nix
+store.
+
+This patch changes the freshness check to use less than instead of less than or
+equal to in order to avoid this.
+
+--- b/src/clm/clm.c
++++ a/src/clm/clm.c
+@@ -250,7 +250,7 @@
+ 		|| (t1.dwHighDateTime==t2.dwHighDateTime && (unsigned)(t1.dwLowDateTime)<=(unsigned)(t2.dwLowDateTime)))
+ #else
+ 	typedef unsigned long FileTime;
+-#	define FILE_TIME_LE(t1,t2) (t1<=t2)
++#	define FILE_TIME_LE(t1,t2) (t1<t2)
+ #endif
+ 
+ typedef struct project_node {

--- a/pkgs/by-name/cl/clean/declare-functions-explicitly-for-gcc14.patch
+++ b/pkgs/by-name/cl/clean/declare-functions-explicitly-for-gcc14.patch
@@ -1,0 +1,22 @@
+--- a/src/RuntimeSystem/scon.c
++++ b/src/RuntimeSystem/scon.c
+@@ -858,6 +858,8 @@
+ int execution_aborted;
+ int return_code;
+ 
++extern void abc_main (void);
++
+ int main (int argc,char **argv)
+ {
+ 	int arg_n;
+
+--- a/src/clm/cachingcompiler.h
++++ b/src/clm/cachingcompiler.h
+@@ -1,6 +1,7 @@
+ Clean (:: *Thread :== Int)
+ int start_caching_compiler (CleanCharArray compiler_path);
+ Clean (start_caching_compiler :: {#Char} Thread -> (Int, Thread))
++int start_caching_compiler_with_args (CleanCharArray coc_path, char** cocl_argv, int cocl_argv_size);
+ int call_caching_compiler (CleanCharArray args);
+ Clean (call_caching_compiler :: {#Char} Thread -> (Int, Thread))
+ int stop_caching_compiler (void);

--- a/pkgs/by-name/cl/clean/package.nix
+++ b/pkgs/by-name/cl/clean/package.nix
@@ -1,0 +1,80 @@
+{
+  binutils,
+  fetchurl,
+  gcc,
+  lib,
+  runCommand,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "clean";
+  version = "3.1";
+
+  src =
+    if stdenv.hostPlatform.system == "i686-linux" then
+      (fetchurl {
+        url = "https://ftp.cs.ru.nl/Clean/Clean31/linux/clean3.1_32_boot.tar.gz";
+        sha256 = "Ls0IKf+o7yhRLhtSV61jzmnYukfh5x5fogHaP5ke/Ck=";
+      })
+    else if stdenv.hostPlatform.system == "x86_64-linux" then
+      (fetchurl {
+        url = "https://ftp.cs.ru.nl/Clean/Clean31/linux/clean3.1_64_boot.tar.gz";
+        sha256 = "Gg5CVZjrwDBtV7Vuw21Xj6Rn+qN1Mf6B3ls6r/16oBc=";
+      })
+    else
+      throw "Architecture not supported";
+
+  hardeningDisable = [ "pic" ];
+
+  patches = [
+    ./chroot-build-support-do-not-rebuild-equal-timestamps.patch
+    ./declare-functions-explicitly-for-gcc14.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'INSTALL_DIR = $(CURRENTDIR)' "INSTALL_DIR = $out"
+    substituteInPlace src/clm/clm.c \
+      --replace-fail /usr/bin/as ${binutils}/bin/as \
+      --replace-fail /usr/bin/gcc ${gcc}/bin/gcc
+  '';
+
+  buildFlags = [ "-C src/" ];
+
+  # do not strip libraries and executables since all symbols since they are
+  # required as is for compilation. Especially the labels of unused section need
+  # to be kept.
+  dontStrip = true;
+
+  passthru.tests.compile-hello-world = runCommand "compile-hello-world" { } ''
+    cat >HelloWorld.icl <<EOF
+    module HelloWorld
+    Start = "Hello, world!"
+    EOF
+    ${finalAttrs.finalPackage}/bin/clm HelloWorld -o hello-world
+    touch $out
+  '';
+
+  meta = {
+    description = "General purpose, state-of-the-art, pure and lazy functional programming language";
+    longDescription = ''
+      Clean is a general purpose, state-of-the-art, pure and lazy functional
+      programming language designed for making real-world applications. Some
+      of its most notable language features are uniqueness typing, dynamic typing,
+      and generic functions.
+    '';
+
+    homepage = "http://wiki.clean.cs.ru.nl/Clean";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      bmrips
+      erin
+    ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "clean";
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -436,7 +436,6 @@ mapAliases {
   citra = throw "citra has been removed from nixpkgs, as it has been taken down upstream"; # added 2024-03-04
   citra-nightly = throw "citra-nightly has been removed from nixpkgs, as it has been taken down upstream"; # added 2024-03-04
   citra-canary = throw "citra-canary has been removed from nixpkgs, as it has been taken down upstream"; # added 2024-03-04
-  clean = throw "'clean' has been removed from nixpkgs, as it is unmaintained and broken"; # Added 2025-05-18
   cloog = throw "cloog has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-13
   cloog_0_18_0 = throw "cloog_0_18_0 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-13
   cloogppl = throw "cloogppl has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-13


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update Clean to version 3.1 and fix the regressions incurred by GCC 14.

Since I do not have i686-linux machine, I can not test the corresponding variant of the derivation.

Also, `nixpkgs-review rev HEAD` started building thousands of derivation, so I aborted it. Hints on how to fix this problem or how to use it properly are welcome.

@ErinvanderVeen 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
